### PR TITLE
feat(but): apply theme to remaining `but` commands

### DIFF
--- a/crates/but/src/command/alias.rs
+++ b/crates/but/src/command/alias.rs
@@ -7,11 +7,13 @@ use std::collections::HashMap;
 use anyhow::{Context as _, Result};
 use bstr::ByteSlice;
 use but_ctx::Context;
-use colored::Colorize;
 use serde::Serialize;
 
 use super::git_config::{EditGlobalConfig, edit_git_config};
-use crate::utils::OutputChannel;
+use crate::{
+    theme::{self, Paint},
+    utils::OutputChannel,
+};
 
 /// Represents where an alias is configured
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -64,6 +66,7 @@ pub fn list(repo: &gix::Repository, out: &mut OutputChannel) -> Result<()> {
     }
 
     if let Some(out) = out.for_human() {
+        let t = theme::get();
         // Calculate max name length for alignment
         let max_name_len = user_aliases
             .iter()
@@ -74,21 +77,21 @@ pub fn list(repo: &gix::Repository, out: &mut OutputChannel) -> Result<()> {
 
         // Show user-configured aliases first
         if !user_aliases.is_empty() {
-            writeln!(out, "{}:", "User aliases".bold())?;
+            writeln!(out, "{}:", t.important.paint("User aliases"))?;
             writeln!(out)?;
 
             for alias in &user_aliases {
                 let scope_indicator = match alias.scope {
-                    AliasScope::Local => "(local)".dimmed(),
-                    AliasScope::Global => "(global)".dimmed(),
-                    AliasScope::Both => "(local+global)".dimmed(),
+                    AliasScope::Local => t.hint.paint("(local)"),
+                    AliasScope::Global => t.hint.paint("(global)"),
+                    AliasScope::Both => t.hint.paint("(local+global)"),
                 };
                 writeln!(
                     out,
                     "  {:<width$}  {}  {} {}",
-                    alias.name.green(),
-                    "→".dimmed(),
-                    alias.value.cyan(),
+                    t.config_key.paint(&alias.name),
+                    t.sym().arrow,
+                    t.config_value.paint(&alias.value),
                     scope_indicator,
                     width = max_name_len
                 )?;
@@ -101,8 +104,8 @@ pub fn list(repo: &gix::Repository, out: &mut OutputChannel) -> Result<()> {
             writeln!(
                 out,
                 "{} {}:",
-                "Default aliases".bold(),
-                "(overridable)".dimmed()
+                t.important.paint("Default aliases"),
+                t.hint.paint("(overridable)")
             )?;
             writeln!(out)?;
 
@@ -114,19 +117,19 @@ pub fn list(repo: &gix::Repository, out: &mut OutputChannel) -> Result<()> {
                     writeln!(
                         out,
                         "  {:<width$}  {}  {}  {}",
-                        name.dimmed(),
-                        "→".dimmed(),
-                        value.dimmed(),
-                        "(overridden)".dimmed(),
+                        t.hint.paint(name),
+                        t.sym().arrow,
+                        t.hint.paint(value),
+                        t.hint.paint("(overridden)"),
                         width = max_name_len
                     )?;
                 } else {
                     writeln!(
                         out,
                         "  {:<width$}  {}  {}",
-                        name.green(),
-                        "→".dimmed(),
-                        value.cyan(),
+                        t.config_key.paint(name),
+                        t.sym().arrow,
+                        t.config_value.paint(value),
                         width = max_name_len
                     )?;
                 }
@@ -260,13 +263,14 @@ pub fn add(
     })?;
 
     if let Some(out) = out.for_human() {
+        let t = theme::get();
         writeln!(
             out,
             "{} Alias '{}' {} '{}'",
-            "✓".green(),
-            name.green(),
-            "→".dimmed(),
-            value.cyan()
+            t.sym().success,
+            t.config_key.paint(name),
+            t.sym().arrow,
+            t.config_value.paint(value)
         )?;
         if is_global {
             writeln!(out, "  (configured globally)")?;
@@ -297,11 +301,17 @@ pub fn remove(
     })?;
 
     if let Some(out) = out.for_human() {
+        let t = theme::get();
         if !success {
-            writeln!(out, "{} Alias '{}' not found", "✗".red(), name.green())?;
+            writeln!(
+                out,
+                "{} Alias '{}' not found",
+                t.sym().error,
+                t.config_key.paint(name)
+            )?;
             return Ok(());
         } else {
-            writeln!(out, "Alias '{}' removed", name.green())?;
+            writeln!(out, "Alias '{}' removed", t.config_key.paint(name))?;
             if is_global {
                 writeln!(out, "  (globally)")?;
             }

--- a/crates/but/src/command/commit/move.rs
+++ b/crates/but/src/command/commit/move.rs
@@ -206,7 +206,7 @@ pub fn move_commit_to_commit_with_perm(
                 "Moved {} → {} {}",
                 t.cli_id.paint(shorten_object_id(&repo, source)),
                 action,
-                t.local_branch.paint(shorten_object_id(&repo, target)),
+                t.commit_id.paint(shorten_object_id(&repo, target)),
             )?;
         } else {
             writeln!(
@@ -214,7 +214,7 @@ pub fn move_commit_to_commit_with_perm(
                 "Moved {} commits → {} {}",
                 t.cli_id.paint(sources.len().to_string()),
                 action,
-                t.local_branch.paint(shorten_object_id(&repo, target)),
+                t.commit_id.paint(shorten_object_id(&repo, target)),
             )?;
         }
     } else if let Some(out) = out.for_json() {

--- a/crates/but/src/command/commit/move.rs
+++ b/crates/but/src/command/commit/move.rs
@@ -1,13 +1,12 @@
+use crate::{
+    CliId,
+    theme::{self, Paint},
+    utils::{OutputChannel, shorten_object_id},
+};
 use anyhow::bail;
 use but_core::{DryRun, sync::RepoExclusive};
 use but_ctx::Context;
 use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
-use colored::Colorize;
-
-use crate::{
-    CliId,
-    utils::{OutputChannel, shorten_object_id},
-};
 
 pub(crate) fn handle_resolved_with_perm(
     ctx: &mut Context,
@@ -17,6 +16,7 @@ pub(crate) fn handle_resolved_with_perm(
     after: bool,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<()> {
+    let t = theme::get();
     // Validate --after flag usage
     if after {
         // Check if target is a branch (--after only makes sense for commit-to-commit moves)
@@ -42,10 +42,10 @@ pub(crate) fn handle_resolved_with_perm(
         bail!(
             "Cannot move {} ({}) to {} ({}).\n\
             Valid moves: commit→commit, commit→branch, or committed-file→commit",
-            source_id.to_short_string().blue().bold(),
-            source_id.kind_for_humans().yellow(),
-            target_id.to_short_string().blue().bold(),
-            target_id.kind_for_humans().yellow()
+            t.cli_id.paint(source_id.to_short_string()),
+            t.attention.paint(source_id.kind_for_humans()),
+            t.cli_id.paint(target_id.to_short_string()),
+            t.attention.paint(target_id.kind_for_humans())
         );
     };
 
@@ -60,6 +60,7 @@ pub(crate) fn handle_multiple_resolved_with_perm(
     after: bool,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<()> {
+    let t = theme::get();
     if source_ids.is_empty() {
         bail!("No source commits provided.");
     }
@@ -70,7 +71,7 @@ pub(crate) fn handle_multiple_resolved_with_perm(
             CliId::Commit { commit_id, .. } => Ok(*commit_id),
             _ => bail!(
                 "Cannot move {} as part of a multi-commit operation. Only commits are supported.",
-                id.to_short_string().blue().bold()
+                t.cli_id.paint(id.to_short_string())
             ),
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
@@ -92,8 +93,8 @@ pub(crate) fn handle_multiple_resolved_with_perm(
         _ => bail!(
             "Cannot move multiple commits to {} ({}).\n\
             Valid multi-commit moves: commit→commit or commit→branch",
-            target_id.to_short_string().blue().bold(),
-            target_id.kind_for_humans().yellow()
+            t.cli_id.paint(target_id.to_short_string()),
+            t.attention.paint(target_id.kind_for_humans())
         ),
     }
 }
@@ -194,6 +195,7 @@ pub fn move_commit_to_commit_with_perm(
         perm,
     )?;
 
+    let t = theme::get();
     if let Some(out) = out.for_human() {
         let repo = ctx.repo.get()?;
         let action = if after { "after" } else { "before" };
@@ -202,17 +204,17 @@ pub fn move_commit_to_commit_with_perm(
             writeln!(
                 out,
                 "Moved {} → {} {}",
-                shorten_object_id(&repo, source).blue(),
+                t.cli_id.paint(shorten_object_id(&repo, source)),
                 action,
-                shorten_object_id(&repo, target).green(),
+                t.local_branch.paint(shorten_object_id(&repo, target)),
             )?;
         } else {
             writeln!(
                 out,
                 "Moved {} commits → {} {}",
-                sources.len().to_string().blue(),
+                t.cli_id.paint(sources.len().to_string()),
                 action,
-                shorten_object_id(&repo, target).green(),
+                t.local_branch.paint(shorten_object_id(&repo, target)),
             )?;
         }
     } else if let Some(out) = out.for_json() {
@@ -238,6 +240,7 @@ pub fn move_commit_to_branch_with_perm(
         perm,
     )?;
 
+    let t = theme::get();
     if let Some(out) = out.for_human() {
         let repo = ctx.repo.get()?;
         if sources.len() == 1 {
@@ -245,15 +248,15 @@ pub fn move_commit_to_branch_with_perm(
             writeln!(
                 out,
                 "Moved {} → {}",
-                shorten_object_id(&repo, source).blue(),
-                format!("[{target_branch}]").green()
+                t.cli_id.paint(shorten_object_id(&repo, source)),
+                t.local_branch.paint(format!("[{target_branch}]"))
             )?;
         } else {
             writeln!(
                 out,
                 "Moved {} commits → {}",
-                sources.len().to_string().blue(),
-                format!("[{target_branch}]").green()
+                t.cli_id.paint(sources.len().to_string()),
+                t.local_branch.paint(format!("[{target_branch}]"))
             )?;
         }
     } else if let Some(out) = out.for_json() {

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -1893,7 +1893,8 @@ fn format_scope(scope: Option<gix::config::Source>) -> String {
     match scope {
         Some(source) => theme::get()
             .hint
-            .paint(format!("({})", config_source_scope(source))),
+            .paint(format!("({})", config_source_scope(source)))
+            .to_string(),
         None => String::new(),
     }
 }

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -18,7 +18,6 @@ use but_llm::{
 use but_secret::{Sensitive, secret};
 use but_settings::{AppSettingsWithDiskSync, api::TelemetryUpdate};
 use cfg_if::cfg_if;
-use colored::Colorize;
 use gix::bstr::ByteSlice as _;
 use serde::Serialize;
 
@@ -28,6 +27,7 @@ use crate::{
         AiKeyOption, AiSubcommand, ForgeSubcommand, MetricsStatus, Subcommands, UiSubcommand,
         UserSubcommand,
     },
+    theme::{self, Paint},
     tui,
     utils::{ConfirmOrEmpty, InputOutputChannel, OutputChannel},
 };
@@ -117,6 +117,7 @@ pub(crate) fn ai_config(
 
 /// Show overview of important settings
 async fn show_overview(ctx: &mut Context, out: &mut OutputChannel) -> Result<()> {
+    let t = theme::get();
     #[derive(Serialize)]
     struct ConfigOverview {
         name: Option<String>,
@@ -160,34 +161,39 @@ async fn show_overview(ctx: &mut Context, out: &mut OutputChannel) -> Result<()>
         .collect();
 
     if let Some(out) = out.for_human() {
-        writeln!(out, "\n{}", "GitButler Configuration".bold())?;
+        writeln!(out, "\n{}", t.important.paint("GitButler Configuration"))?;
         writeln!(out)?;
 
         // User section
-        writeln!(out, "{}:", "User".bold())?;
+        writeln!(out, "{}:", t.important.paint("User"))?;
         write_user_config_human(out, &user_info)?;
 
         // Target branch
-        writeln!(out, "{}:", "Target Branch".bold())?;
+        writeln!(out, "{}:", t.important.paint("Target Branch"))?;
         if let Some(branch) = &target_branch {
-            writeln!(out, "    {}", branch.cyan())?;
+            writeln!(out, "    {}", t.config_value.paint(branch))?;
         } else {
-            writeln!(out, "    {}", "(not set)".dimmed())?;
+            writeln!(out, "    {}", t.hint.paint("(not set)"))?;
         }
         writeln!(out)?;
 
         // Forge
-        writeln!(out, "{}:", "Forge".bold())?;
+        writeln!(out, "{}:", t.important.paint("Forge"))?;
         if forge_accounts.is_empty() {
             writeln!(
                 out,
                 "  {}    Run {} to authenticate to a forge",
-                "✗ Not configured\n".red(),
-                "but config forge auth".blue()
+                t.sym().error.to_string() + " Not configured\n",
+                t.command_suggestion.paint("but config forge auth")
             )?;
         } else {
             for account in &forge_accounts {
-                writeln!(out, "  • {} {}", account.provider.cyan(), account.username)?;
+                writeln!(
+                    out,
+                    "  • {} {}",
+                    t.config_value.paint(&account.provider),
+                    account.username
+                )?;
             }
         }
         writeln!(out)?;
@@ -197,51 +203,51 @@ async fn show_overview(ctx: &mut Context, out: &mut OutputChannel) -> Result<()>
             let repo = ctx.repo.get()?;
             let config = repo.config_snapshot();
             let tui_enabled = get_tui_enabled(&config);
-            writeln!(out, "{}:", "UI".bold())?;
+            writeln!(out, "{}:", t.important.paint("UI"))?;
             writeln!(
                 out,
                 "  {}: {}",
-                "TUI mode".dimmed(),
+                t.hint.paint("TUI mode"),
                 if tui_enabled {
-                    "enabled".green()
+                    t.success.paint("enabled")
                 } else {
-                    "disabled".dimmed()
+                    t.hint.paint("disabled")
                 }
             )?;
             writeln!(out)?;
         }
 
         // Hints
-        writeln!(out, "{}", "Available subcommands:".dimmed())?;
+        writeln!(out, "{}", t.hint.paint("Available subcommands:"))?;
         writeln!(
             out,
             "  {}    - User settings (name, email, editor)",
-            "but config user".blue().dimmed()
+            t.command_suggestion.paint("but config user")
         )?;
         writeln!(
             out,
             "  {}   - Forge settings (GitHub, etc)",
-            "but config forge".blue().dimmed()
+            t.command_suggestion.paint("but config forge")
         )?;
         writeln!(
             out,
             "  {}  - Target branch settings",
-            "but config target".blue().dimmed()
+            t.command_suggestion.paint("but config target")
         )?;
         writeln!(
             out,
             "  {} - Metrics settings",
-            "but config metrics".blue().dimmed()
+            t.command_suggestion.paint("but config metrics")
         )?;
         writeln!(
             out,
             "  {}      - AI provider settings",
-            "but config ai".blue().dimmed()
+            t.command_suggestion.paint("but config ai")
         )?;
         writeln!(
             out,
             "  {}      - UI preferences (TUI mode)",
-            "but config ui".blue().dimmed()
+            t.command_suggestion.paint("but config ui")
         )?;
     } else if let Some(out) = out.for_json() {
         out.write_value(serde_json::json!(ConfigOverview {
@@ -261,41 +267,51 @@ pub(crate) async fn metrics_config(
     out: &mut OutputChannel,
     status: Option<MetricsStatus>,
 ) -> Result<()> {
+    let t = theme::get();
     let app_settings_sync = load_app_settings_sync()?;
 
     match status {
         None => {
             let enabled = app_settings_sync.get()?.telemetry.app_metrics_enabled;
             if let Some(out) = out.for_human() {
-                writeln!(out, "\n{}:", "Metrics Configuration".bold())?;
+                writeln!(out, "\n{}:", t.important.paint("Metrics Configuration"))?;
                 writeln!(out)?;
                 writeln!(
                     out,
                     "  {}",
-                    "GitButler uses metrics to help us know what is useful and improve it."
-                        .dimmed()
+                    t.hint.paint(
+                        "GitButler uses metrics to help us know what is useful and improve it."
+                    )
                 )?;
                 writeln!(
                     out,
                     "  {} {}",
-                    "Privacy policy:".dimmed(),
-                    "https://gitbutler.com/privacy".dimmed()
+                    t.hint.paint("Privacy policy:"),
+                    t.hint.paint("https://gitbutler.com/privacy")
                 )?;
                 writeln!(out)?;
                 writeln!(
                     out,
                     "  {}: {}",
-                    "Metrics".dimmed(),
+                    t.hint.paint("Metrics"),
                     if enabled {
-                        "enabled".green()
+                        t.success.paint("enabled")
                     } else {
-                        "disabled".red()
+                        t.error.paint("disabled")
                     }
                 )?;
                 writeln!(out)?;
-                writeln!(out, "{}:", "To change metrics".dimmed())?;
-                writeln!(out, "  {}", "but config metrics enable".blue().dimmed())?;
-                writeln!(out, "  {}", "but config metrics disable".blue().dimmed())?;
+                writeln!(out, "{}:", t.hint.paint("To change metrics"))?;
+                writeln!(
+                    out,
+                    "  {}",
+                    t.command_suggestion.paint("but config metrics enable")
+                )?;
+                writeln!(
+                    out,
+                    "  {}",
+                    t.command_suggestion.paint("but config metrics disable")
+                )?;
             } else if let Some(out) = out.for_shell() {
                 writeln!(out, "{enabled}")?;
             } else if let Some(out) = out.for_json() {
@@ -316,11 +332,11 @@ pub(crate) async fn metrics_config(
                 writeln!(
                     out,
                     "{} Metrics are now {}",
-                    "✓".green(),
+                    t.sym().success,
                     if enabled {
-                        "enabled".green()
+                        t.success.paint("enabled")
                     } else {
-                        "disabled".red()
+                        t.error.paint("disabled")
                     }
                 )?;
             } else if let Some(out) = out.for_shell() {
@@ -373,31 +389,33 @@ fn get_user_config_info(config: &gix::config::Snapshot<'_>) -> UserConfigInfo {
 
 /// Write user config info in human-readable format
 fn write_user_config_human(out: &mut dyn std::fmt::Write, info: &UserConfigInfo) -> Result<()> {
+    let t = theme::get();
     writeln!(
         out,
         "    {}: {} {}",
-        "Name".dimmed(),
+        t.hint.paint("Name"),
         info.name
             .as_deref()
-            .map(|n| n.cyan())
-            .unwrap_or_else(|| "(not set)".red()),
+            .map(|n| t.config_value.paint(n))
+            .unwrap_or_else(|| t.error.paint("(not set)")),
         format_scope(info.name_scope)
     )?;
     writeln!(
         out,
         "   {}: {} {}",
-        "Email".dimmed(),
+        t.hint.paint("Email"),
         info.email
             .as_deref()
-            .map(|e| e.cyan())
-            .unwrap_or_else(|| "(not set)".red()),
+            .map(|e| t.config_value.paint(e))
+            .unwrap_or_else(|| t.error.paint("(not set)")),
         format_scope(info.email_scope)
     )?;
     writeln!(
         out,
         "  {}: {} {}",
-        "Editor".dimmed(),
-        info.editor.as_deref().unwrap_or("(built-in)").cyan(),
+        t.hint.paint("Editor"),
+        t.config_value
+            .paint(info.editor.as_deref().unwrap_or("(built-in)")),
         format_scope(info.editor_scope)
     )?;
     writeln!(out)?;
@@ -410,6 +428,7 @@ async fn user_config(
     out: &mut OutputChannel,
     cmd: Option<UserSubcommand>,
 ) -> Result<()> {
+    let t = theme::get();
     let repo = ctx.repo.get()?;
 
     match cmd {
@@ -419,21 +438,21 @@ async fn user_config(
             let user_info = get_user_config_info(&config);
 
             if let Some(out) = out.for_human() {
-                writeln!(out, "{}:", "\nUser Configuration".bold())?;
+                writeln!(out, "{}:", t.important.paint("\nUser Configuration"))?;
                 writeln!(out)?;
                 write_user_config_human(out, &user_info)?;
-                writeln!(out, "{}:", "To set values".dimmed())?;
+                writeln!(out, "{}:", t.hint.paint("To set values"))?;
                 writeln!(
                     out,
                     "  {}",
-                    "but config user set name \"Your Name\"".blue().dimmed()
+                    t.command_suggestion
+                        .paint("but config user set name \"Your Name\"")
                 )?;
                 writeln!(
                     out,
                     "  {}",
-                    "but config user set --global email your@email.com"
-                        .blue()
-                        .dimmed()
+                    t.command_suggestion
+                        .paint("but config user set --global email your@email.com")
                 )?;
             } else if let Some(out) = out.for_json() {
                 out.write_value(serde_json::json!(user_info))?;
@@ -451,10 +470,10 @@ async fn user_config(
                 writeln!(
                     out,
                     "{} Set {} {} {}",
-                    "✓".green(),
-                    git_key.green(),
-                    "→".dimmed(),
-                    value.cyan()
+                    t.sym().success,
+                    t.config_key.paint(git_key),
+                    t.hint.paint("→"),
+                    t.config_value.paint(&value)
                 )?;
                 if global {
                     writeln!(out, "  (configured globally)")?;
@@ -476,7 +495,12 @@ async fn user_config(
             })?;
 
             if let Some(out) = out.for_human() {
-                writeln!(out, "{} Removed {}", "✓".green(), git_key.green(),)?;
+                writeln!(
+                    out,
+                    "{} Removed {}",
+                    t.sym().success,
+                    t.config_key.paint(git_key),
+                )?;
                 if global {
                     writeln!(out, "  (removed from global config)")?;
                 }
@@ -508,17 +532,18 @@ pub(crate) async fn forge_config(
 
 /// Show overview of forge configuration (same as list-users)
 async fn forge_show_overview(out: &mut OutputChannel) -> Result<()> {
+    let t = theme::get();
     let known_gh_accounts = but_api::github::list_known_github_accounts()?;
     let known_gl_accounts = but_api::gitlab::list_known_gitlab_accounts()?;
 
     if let Some(out) = out.for_human() {
         if known_gh_accounts.is_empty() && known_gl_accounts.is_empty() {
-            writeln!(out, "\n{}", "No forge accounts configured".dimmed())?;
+            writeln!(out, "\n{}", t.hint.paint("No forge accounts configured"))?;
             writeln!(out)?;
             writeln!(
                 out,
                 "Run {} to authenticate with GitHub or GitLab.",
-                "but config forge auth".cyan()
+                t.command_suggestion.paint("but config forge auth")
             )?;
         } else {
             let mut some_accounts_invalid =
@@ -530,26 +555,28 @@ async fn forge_show_overview(out: &mut OutputChannel) -> Result<()> {
                 writeln!(
                     out,
                     "{}",
-                    "Some accounts have invalid or missing credentials.".yellow()
+                    t.attention
+                        .paint("Some accounts have invalid or missing credentials.")
                 )?;
                 writeln!(
                     out,
                     "Re-authenticate using: {}",
-                    "but config forge auth".cyan()
+                    t.command_suggestion.paint("but config forge auth")
                 )?;
                 writeln!(out)?;
             }
 
-            writeln!(out, "{}:", "Available commands".dimmed())?;
+            writeln!(out, "{}:", t.hint.paint("Available commands"))?;
             writeln!(
                 out,
                 "  {} - Authenticate with a forge",
-                "but config forge auth".blue().dimmed()
+                t.command_suggestion.paint("but config forge auth")
             )?;
             writeln!(
                 out,
                 "  {} - Forget an authenticated account",
-                "but config forge forget [username]".blue().dimmed()
+                t.command_suggestion
+                    .paint("but config forge forget [username]")
             )?;
         }
     } else if let Some(out) = out.for_shell() {
@@ -856,7 +883,12 @@ async fn display_authenticated_github_accounts(
     known_gh_accounts: &Vec<but_github::GithubAccountIdentifier>,
     out: &mut (dyn Write + 'static),
 ) -> Result<bool, anyhow::Error> {
-    writeln!(out, "\n{}:", "Authenticated GitHub accounts".bold())?;
+    let t = theme::get();
+    writeln!(
+        out,
+        "\n{}:",
+        t.important.paint("Authenticated GitHub accounts")
+    )?;
     writeln!(out)?;
 
     let mut some_accounts_invalid = false;
@@ -867,16 +899,18 @@ async fn display_authenticated_github_accounts(
             .ok();
 
         let message = match account_status {
-            Some(but_github::CredentialCheckResult::Valid) => "(valid credentials)".green().bold(),
+            Some(but_github::CredentialCheckResult::Valid) => {
+                t.success.paint("(valid credentials)")
+            }
             Some(but_github::CredentialCheckResult::Invalid) => {
                 some_accounts_invalid = true;
-                "(invalid credentials)".bold().yellow()
+                t.attention.paint("(invalid credentials)")
             }
             Some(but_github::CredentialCheckResult::NoCredentials) => {
                 some_accounts_invalid = true;
-                "(no credentials)".bold().yellow()
+                t.attention.paint("(no credentials)")
             }
-            None => "(unknown status)".bold().red(),
+            None => t.error.paint("(unknown status)"),
         };
 
         writeln!(out, "  • {account} {message}")?;
@@ -889,11 +923,16 @@ async fn display_authenticated_gitlab_accounts(
     known_gl_accounts: &Vec<but_gitlab::GitlabAccountIdentifier>,
     out: &mut (dyn Write + 'static),
 ) -> Result<bool, anyhow::Error> {
+    let t = theme::get();
     if known_gl_accounts.is_empty() {
         return Ok(false);
     }
 
-    writeln!(out, "\n{}:", "Authenticated GitLab accounts".bold())?;
+    writeln!(
+        out,
+        "\n{}:",
+        t.important.paint("Authenticated GitLab accounts")
+    )?;
     writeln!(out)?;
 
     let mut some_accounts_invalid = false;
@@ -904,16 +943,18 @@ async fn display_authenticated_gitlab_accounts(
             .ok();
 
         let message = match account_status {
-            Some(but_gitlab::CredentialCheckResult::Valid) => "(valid credentials)".green().bold(),
+            Some(but_gitlab::CredentialCheckResult::Valid) => {
+                t.success.paint("(valid credentials)")
+            }
             Some(but_gitlab::CredentialCheckResult::Invalid) => {
                 some_accounts_invalid = true;
-                "(invalid credentials)".bold().yellow()
+                t.attention.paint("(invalid credentials)")
             }
             Some(but_gitlab::CredentialCheckResult::NoCredentials) => {
                 some_accounts_invalid = true;
-                "(no credentials)".bold().yellow()
+                t.attention.paint("(no credentials)")
             }
-            None => "(unknown status)".bold().red(),
+            None => t.error.paint("(unknown status)"),
         };
 
         writeln!(out, "  • {account} {message}")?;
@@ -1055,96 +1096,88 @@ fn show_ai_config(
     out: &mut OutputChannel,
     scope: AiScope,
 ) -> Result<()> {
+    let t = theme::get();
     let info = get_ai_config_info(repo, scope)?;
 
     if let Some(out) = out.for_human() {
         writeln!(
             out,
             "{} ({})",
-            "AI Configuration".bold(),
-            scope.as_str().dimmed()
+            t.important.paint("AI Configuration"),
+            t.hint.paint(scope.as_str())
         )?;
         writeln!(out)?;
         writeln!(
             out,
             "  {}: {}",
-            "Provider".dimmed(),
+            t.hint.paint("Provider"),
             info.provider
                 .as_deref()
-                .map(|provider| provider.cyan().to_string())
-                .unwrap_or_else(|| "(not set)".red().to_string())
+                .map(|provider| t.config_value.paint(provider))
+                .unwrap_or_else(|| t.error.paint("(not set)"))
         )?;
         writeln!(
             out,
             "  {}: {}",
-            "OpenAI key option".dimmed(),
-            info.openai_key_option
-                .as_deref()
-                .unwrap_or("(not set)")
-                .cyan()
+            t.hint.paint("OpenAI key option"),
+            t.config_value
+                .paint(info.openai_key_option.as_deref().unwrap_or("(not set)"))
         )?;
         writeln!(
             out,
             "  {}: {}",
-            "OpenAI model".dimmed(),
-            info.openai_model.as_deref().unwrap_or("(not set)").cyan()
+            t.hint.paint("OpenAI model"),
+            t.config_value
+                .paint(info.openai_model.as_deref().unwrap_or("(not set)"))
         )?;
         writeln!(
             out,
             "  {}: {}",
-            "OpenAI endpoint".dimmed(),
-            info.openai_endpoint
-                .as_deref()
-                .unwrap_or("(not set)")
-                .cyan()
+            t.hint.paint("OpenAI endpoint"),
+            t.config_value
+                .paint(info.openai_endpoint.as_deref().unwrap_or("(not set)"))
         )?;
         writeln!(
             out,
             "  {}: {}",
-            "Anthropic key option".dimmed(),
-            info.anthropic_key_option
-                .as_deref()
-                .unwrap_or("(not set)")
-                .cyan()
+            t.hint.paint("Anthropic key option"),
+            t.config_value
+                .paint(info.anthropic_key_option.as_deref().unwrap_or("(not set)"))
         )?;
         writeln!(
             out,
             "  {}: {}",
-            "Anthropic model".dimmed(),
-            info.anthropic_model
-                .as_deref()
-                .unwrap_or("(not set)")
-                .cyan()
+            t.hint.paint("Anthropic model"),
+            t.config_value
+                .paint(info.anthropic_model.as_deref().unwrap_or("(not set)"))
         )?;
         writeln!(
             out,
             "  {}: {}",
-            "Ollama endpoint".dimmed(),
-            info.ollama_endpoint
-                .as_deref()
-                .unwrap_or("(not set)")
-                .cyan()
+            t.hint.paint("Ollama endpoint"),
+            t.config_value
+                .paint(info.ollama_endpoint.as_deref().unwrap_or("(not set)"))
         )?;
         writeln!(
             out,
             "  {}: {}",
-            "Ollama model".dimmed(),
-            info.ollama_model.as_deref().unwrap_or("(not set)").cyan()
+            t.hint.paint("Ollama model"),
+            t.config_value
+                .paint(info.ollama_model.as_deref().unwrap_or("(not set)"))
         )?;
         writeln!(
             out,
             "  {}: {}",
-            "LM Studio endpoint".dimmed(),
-            info.lmstudio_endpoint
-                .as_deref()
-                .unwrap_or("(not set)")
-                .cyan()
+            t.hint.paint("LM Studio endpoint"),
+            t.config_value
+                .paint(info.lmstudio_endpoint.as_deref().unwrap_or("(not set)"))
         )?;
         writeln!(
             out,
             "  {}: {}",
-            "LM Studio model".dimmed(),
-            info.lmstudio_model.as_deref().unwrap_or("(not set)").cyan()
+            t.hint.paint("LM Studio model"),
+            t.config_value
+                .paint(info.lmstudio_model.as_deref().unwrap_or("(not set)"))
         )?;
     } else if let Some(out) = out.for_shell() {
         writeln!(out, "{}", info.provider.as_deref().unwrap_or(""))?;
@@ -1221,6 +1254,7 @@ fn ai_config_interactive(
     out: &mut OutputChannel,
     scope: AiScope,
 ) -> Result<()> {
+    let t = theme::get();
     use cli_prompts::DisplayPrompt;
 
     let mut inout = out
@@ -1315,9 +1349,9 @@ fn ai_config_interactive(
     writeln!(
         inout,
         "{} AI provider set to {} ({})",
-        "✓".green(),
-        provider.display_name().cyan(),
-        scope.as_str().dimmed()
+        t.sym().success,
+        t.config_value.paint(provider.display_name()),
+        t.hint.paint(scope.as_str())
     )?;
     Ok(())
 }
@@ -1327,13 +1361,14 @@ fn write_ai_config_success(
     scope: AiScope,
     provider: LLMProviderKind,
 ) -> Result<()> {
+    let t = theme::get();
     if let Some(out) = out.for_human() {
         writeln!(
             out,
             "{} AI provider set to {} ({})",
-            "✓".green(),
-            provider.display_name().cyan(),
-            scope.as_str().dimmed()
+            t.sym().success,
+            t.config_value.paint(provider.display_name()),
+            t.hint.paint(scope.as_str())
         )?;
     } else if let Some(out) = out.for_shell() {
         writeln!(out, "{}", provider.as_git_config_value())?;
@@ -1593,6 +1628,7 @@ async fn target_config(
     out: &mut OutputChannel,
     branch: Option<String>,
 ) -> Result<()> {
+    let t = theme::get();
     match branch {
         None => {
             #[cfg(feature = "legacy")]
@@ -1601,17 +1637,32 @@ async fn target_config(
 
                 if let Some(target_branch) = target {
                     if let Some(out) = out.for_human() {
-                        writeln!(out, "{}", "Used to determine common base to calculate commits unique to each branch (not yet integrated)\n".dimmed())?;
-                        writeln!(out, "{}:", "Target Branch".bold())?;
-                        writeln!(out, "\n  {}", target_branch.branch_name.to_string().cyan())?;
+                        writeln!(out, "{}", t.hint.paint("Used to determine common base to calculate commits unique to each branch (not yet integrated)\n"))?;
+                        writeln!(out, "{}:", t.important.paint("Target Branch"))?;
+                        writeln!(
+                            out,
+                            "\n  {}",
+                            t.config_value.paint(&target_branch.branch_name)
+                        )?;
                         writeln!(out)?;
-                        writeln!(out, "  {}: {}", "Remote".dimmed(), target_branch.remote_url)?;
-                        writeln!(out, "  {}:    {}", "SHA".dimmed(), target_branch.base_sha)?;
-                        writeln!(out, "\n{}:", "To change target branch".dimmed())?;
+                        writeln!(
+                            out,
+                            "  {}: {}",
+                            t.hint.paint("Remote"),
+                            target_branch.remote_url
+                        )?;
+                        writeln!(
+                            out,
+                            "  {}:    {}",
+                            t.hint.paint("SHA"),
+                            target_branch.base_sha
+                        )?;
+                        writeln!(out, "\n{}:", t.hint.paint("To change target branch"))?;
                         writeln!(
                             out,
                             "  {}",
-                            "but config target <branch_name>".blue().dimmed()
+                            t.command_suggestion
+                                .paint("but config target <branch_name>")
                         )?;
                     } else if let Some(out) = out.for_json() {
                         out.write_value(serde_json::json!({
@@ -1632,21 +1683,19 @@ async fn target_config(
                     writeln!(
                         out,
                         "{}",
-                        "\nThe following branches are currently applied:\n".bold()
+                        t.important
+                            .paint("\nThe following branches are currently applied:\n")
                     )?;
                     ws.stacks.iter().for_each(|stack| {
                         {
                             writeln!(
                                 out,
                                 "{} Applied branch: {}",
-                                "•".dimmed(),
-                                stack
-                                    .ref_name()
-                                    .map_or_else(
-                                        || "ANONYMOUS".to_string(),
-                                        |rn| rn.shorten().to_string()
-                                    )
-                                    .cyan()
+                                t.hint.paint("•"),
+                                t.config_value.paint(stack.ref_name().map_or_else(
+                                    || "ANONYMOUS".to_string(),
+                                    |rn| rn.shorten().to_string()
+                                ))
                             )
                             .ok();
                         };
@@ -1654,7 +1703,9 @@ async fn target_config(
                     writeln!(
                         out,
                         "\n{}\n",
-                        "Please unapply all branches before changing the target branch.".yellow()
+                        t.attention.paint(
+                            "Please unapply all branches before changing the target branch."
+                        )
                     )
                     .ok();
                 }
@@ -1667,8 +1718,8 @@ async fn target_config(
                 writeln!(
                     out,
                     "{} Changing target branch to '{}'",
-                    "✓".green(),
-                    new_branch.cyan()
+                    t.sym().success,
+                    t.config_value.paint(&new_branch)
                 )?;
             }
 
@@ -1693,6 +1744,7 @@ async fn target_config(
 
 /// Handle UI config subcommand
 fn ui_config(ctx: &mut Context, out: &mut OutputChannel, cmd: Option<UiSubcommand>) -> Result<()> {
+    let t = theme::get();
     let repo = ctx.repo.get()?;
 
     match cmd {
@@ -1702,23 +1754,31 @@ fn ui_config(ctx: &mut Context, out: &mut OutputChannel, cmd: Option<UiSubcomman
             let tui_scope = get_config_scope(&config, "but.ui.tui");
 
             if let Some(out) = out.for_human() {
-                writeln!(out, "{}:", "\nUI Configuration".bold())?;
+                writeln!(out, "{}:", t.important.paint("\nUI Configuration"))?;
                 writeln!(out)?;
                 writeln!(
                     out,
                     "  {}: {} {}",
-                    "Prefer TUI mode".dimmed(),
+                    t.hint.paint("Prefer TUI mode"),
                     if tui_enabled {
-                        "enabled".green()
+                        t.success.paint("enabled")
                     } else {
-                        "disabled".red()
+                        t.error.paint("disabled")
                     },
                     format_scope(tui_scope)
                 )?;
                 writeln!(out)?;
-                writeln!(out, "{}:", "To change".dimmed())?;
-                writeln!(out, "  {}", "but config ui set tui true".blue().dimmed())?;
-                writeln!(out, "  {}", "but config ui set tui false".blue().dimmed())?;
+                writeln!(out, "{}:", t.hint.paint("To change"))?;
+                writeln!(
+                    out,
+                    "  {}",
+                    t.command_suggestion.paint("but config ui set tui true")
+                )?;
+                writeln!(
+                    out,
+                    "  {}",
+                    t.command_suggestion.paint("but config ui set tui false")
+                )?;
             } else if let Some(out) = out.for_shell() {
                 writeln!(out, "{tui_enabled}")?;
             } else if let Some(out) = out.for_json() {
@@ -1742,13 +1802,13 @@ fn ui_config(ctx: &mut Context, out: &mut OutputChannel, cmd: Option<UiSubcomman
                 writeln!(
                     out,
                     "{} Set {} {} {}",
-                    "✓".green(),
-                    git_key.green(),
-                    "→".dimmed(),
+                    t.sym().success,
+                    t.config_key.paint(git_key),
+                    t.hint.paint("→"),
                     if bool_value {
-                        "true".cyan()
+                        t.config_value.paint("true")
                     } else {
-                        "false".cyan()
+                        t.config_value.paint("false")
                     }
                 )?;
                 if global {
@@ -1770,7 +1830,12 @@ fn ui_config(ctx: &mut Context, out: &mut OutputChannel, cmd: Option<UiSubcomman
             })?;
 
             if let Some(out) = out.for_human() {
-                writeln!(out, "{} Removed {}", "✓".green(), git_key.green())?;
+                writeln!(
+                    out,
+                    "{} Removed {}",
+                    t.sym().success,
+                    t.config_key.paint(git_key)
+                )?;
                 if global {
                     writeln!(out, "  (removed from global config)")?;
                 }
@@ -1826,9 +1891,9 @@ fn config_source_scope(source: gix::config::Source) -> &'static str {
 /// Format the scope for display
 fn format_scope(scope: Option<gix::config::Source>) -> String {
     match scope {
-        Some(source) => format!("({})", config_source_scope(source))
-            .dimmed()
-            .to_string(),
+        Some(source) => theme::get()
+            .hint
+            .paint(format!("({})", config_source_scope(source))),
         None => String::new(),
     }
 }

--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -17,28 +17,28 @@ pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
 
     let groups = [
         (
-            t.attention.paint("Inspection"),
+            t.important.paint("Inspection"),
             vec!["status", "diff", "show"],
         ),
         (
-            t.attention.paint("Branching and Committing"),
+            t.important.paint("Branching and Committing"),
             vec![
                 "commit", "stage", "new", "branch", "merge", "discard", "resolve",
             ],
         ),
-        (t.attention.paint("Rules"), vec!["mark", "unmark"]),
+        (t.important.paint("Rules"), vec!["mark", "unmark"]),
         (
-            t.attention.paint("Server Interactions"),
+            t.important.paint("Server Interactions"),
             vec!["push", "pull", "base", "pr", "forge"],
         ),
         (
-            t.attention.paint("Editing Commits"),
+            t.important.paint("Editing Commits"),
             vec![
                 "rub", "absorb", "reword", "uncommit", "amend", "squash", "move",
             ],
         ),
         (
-            t.attention.paint("Operation History"),
+            t.important.paint("Operation History"),
             vec!["oplog", "undo", "restore"],
         ),
     ];
@@ -106,7 +106,7 @@ pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
 
     // Print MISC section if there are any ungrouped commands
     if !misc_commands.is_empty() {
-        writeln!(out, "{}:", t.attention.paint("Other Commands"))?;
+        writeln!(out, "{}:", t.important.paint("Other Commands"))?;
         for subcmd in misc_commands {
             let about = subcmd.get_about().unwrap_or_default().to_string();
             // Calculate available width: terminal_width - indent (2) - command column (10) - buffer (1)
@@ -140,7 +140,7 @@ pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
     )?;
     writeln!(out)?;
 
-    writeln!(out, "{}:", t.attention.paint("Options"))?;
+    writeln!(out, "{}:", t.important.paint("Options"))?;
     // Truncate long option descriptions if needed
     let option_descriptions = [
         (

--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -1,6 +1,5 @@
-use colored::Colorize;
-
 use crate::args::Args;
+use crate::theme::{self, Paint};
 use crate::tui::text::{terminal_width, truncate_text};
 
 pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
@@ -14,32 +13,41 @@ pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
     let subcommands: Vec<_> = cmd.get_subcommands().collect();
 
     // Define command groupings and their order (excluding MISC)
+    let t = theme::get();
+
     let groups = [
-        ("Inspection".yellow(), vec!["status", "diff", "show"]),
         (
-            "Branching and Committing".yellow(),
+            t.attention.paint("Inspection"),
+            vec!["status", "diff", "show"],
+        ),
+        (
+            t.attention.paint("Branching and Committing"),
             vec![
                 "commit", "stage", "new", "branch", "merge", "discard", "resolve",
             ],
         ),
-        ("Rules".yellow(), vec!["mark", "unmark"]),
+        (t.attention.paint("Rules"), vec!["mark", "unmark"]),
         (
-            "Server Interactions".yellow(),
+            t.attention.paint("Server Interactions"),
             vec!["push", "pull", "base", "pr", "forge"],
         ),
         (
-            "Editing Commits".yellow(),
+            t.attention.paint("Editing Commits"),
             vec![
                 "rub", "absorb", "reword", "uncommit", "amend", "squash", "move",
             ],
         ),
         (
-            "Operation History".yellow(),
+            t.attention.paint("Operation History"),
             vec!["oplog", "undo", "restore"],
         ),
     ];
 
-    writeln!(out, "{}", "The GitButler CLI change control system".red())?;
+    writeln!(
+        out,
+        "{}",
+        t.error.paint("The GitButler CLI change control system")
+    )?;
     writeln!(out)?;
     writeln!(out, "Usage: but [OPTIONS] <COMMAND>")?;
     writeln!(out, "       but [OPTIONS] [RUB-SOURCE] [RUB-TARGET]")?;
@@ -81,7 +89,7 @@ pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
                 writeln!(
                     out,
                     "  {:<LONGEST_COMMAND_LEN$}{}",
-                    cmd_name.green(),
+                    t.success.paint(cmd_name),
                     truncated_about,
                 )?;
                 printed_commands.insert(cmd_name.to_string());
@@ -98,7 +106,7 @@ pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
 
     // Print MISC section if there are any ungrouped commands
     if !misc_commands.is_empty() {
-        writeln!(out, "{}:", "Other Commands".yellow())?;
+        writeln!(out, "{}:", t.attention.paint("Other Commands"))?;
         for subcmd in misc_commands {
             let about = subcmd.get_about().unwrap_or_default().to_string();
             // Calculate available width: terminal_width - indent (2) - command column (10) - buffer (1)
@@ -107,7 +115,7 @@ pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
             writeln!(
                 out,
                 "  {:<LONGEST_COMMAND_LEN$}{}",
-                subcmd.get_name().green(),
+                t.success.paint(subcmd.get_name()),
                 truncated_about
             )?;
         }
@@ -132,7 +140,7 @@ pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
     )?;
     writeln!(out)?;
 
-    writeln!(out, "{}:", "Options".yellow())?;
+    writeln!(out, "{}:", t.attention.paint("Options"))?;
     // Truncate long option descriptions if needed
     let option_descriptions = [
         (

--- a/crates/but/src/command/legacy/absorb.rs
+++ b/crates/but/src/command/legacy/absorb.rs
@@ -1,12 +1,12 @@
 use std::path::Path;
 
+use crate::theme::{self, Paint};
 use but_core::{RepositoryExt, sync::RepoExclusive};
 use but_ctx::Context;
 use but_hunk_assignment::{
     AbsorptionTarget, CommitAbsorption, HunkAssignment, JsonAbsorbOutput, JsonCommitAbsorption,
     JsonFileAbsorption,
 };
-use colored::Colorize;
 use gitbutler_branch_actions::update_workspace_commit;
 use gitbutler_oplog::{
     OplogExt,
@@ -90,7 +90,8 @@ pub(crate) fn handle(
     if dry_run {
         // Nothing more to do
         if let Some(out) = out.for_human() {
-            let message = "Dry run complete. No changes were made.".green();
+            let t = theme::get();
+            let message = t.success.paint("Dry run complete. No changes were made.");
             writeln!(out, "{message}")?;
         }
         return Ok(());
@@ -149,13 +150,14 @@ fn absorb_assignments(
     update_workspace_commit(ctx, false)?;
 
     // Display completion message
+    let t = theme::get();
     if let Some(out) = out.for_human() {
         writeln!(out)?;
         if total_rejected > 0 {
             writeln!(
                 out,
                 "{}: Failed to absorb {} file{}",
-                "Warning".yellow(),
+                t.attention.paint("Warning"),
                 total_rejected,
                 if total_rejected == 1 { "" } else { "s" }
             )?;
@@ -163,7 +165,7 @@ fn absorb_assignments(
         writeln!(
             out,
             "{}: you can run `but undo` to undo these changes",
-            "Hint".cyan()
+            t.info.paint("Hint")
         )?;
     } else if let Some(out) = out.for_json() {
         // Combine plan and result into a single JSON write to avoid overwriting
@@ -280,6 +282,7 @@ fn display_absorption_plan(
         json_out.write_value(&plan_output)?;
     }
 
+    let t = theme::get();
     if let Some(out) = out.for_human() {
         writeln!(
             out,
@@ -301,16 +304,16 @@ fn display_absorption_plan(
                 out,
                 "{}: {} {}",
                 verb,
-                short_hash.cyan(),
+                t.commit_id.paint(&short_hash),
                 absorption.commit_summary
             )?;
-            writeln!(out, "  ({})", absorption.reason.description().dimmed())?;
+            writeln!(out, "  ({})", t.hint.paint(absorption.reason.description()))?;
 
             for file in &absorption.files {
                 let hunks = get_hunk_ranges(&file.assignment);
                 let hunk_display = hunks.join(", ");
 
-                writeln!(out, "    {} {}", file.path, hunk_display.dimmed())?;
+                writeln!(out, "    {} {}", file.path, t.hint.paint(&hunk_display))?;
             }
             writeln!(out)?;
         }

--- a/crates/but/src/command/legacy/ai.rs
+++ b/crates/but/src/command/legacy/ai.rs
@@ -7,10 +7,12 @@ use std::fmt::Write as _;
 
 use anyhow::{Context, Result};
 use but_llm::{ChatMessage, LLMProvider};
-use colored::Colorize;
 use schemars::JsonSchema;
 
-use crate::utils::OutputChannel;
+use crate::{
+    theme::{self, Paint},
+    utils::OutputChannel,
+};
 
 /// Generate a commit message using AI based on the unified diff and optional user summary.
 ///
@@ -40,7 +42,11 @@ pub fn generate_commit_message(
 ) -> Result<String> {
     let mut progress = out.progress_channel();
 
-    writeln!(progress, "{}", "Generating commit message...".bright_cyan())?;
+    writeln!(
+        progress,
+        "{}",
+        theme::get().progress.paint("Generating commit message...")
+    )?;
     let llm = LLMProvider::default_openai()
         .ok_or_else(|| anyhow::anyhow!("Failed to initialize default OpenAI LLM provider"))?;
     let system_message =
@@ -102,7 +108,11 @@ pub fn generate_commit_message_from_multiple_messages(
     user_summary: Option<String>,
 ) -> Result<String> {
     let mut progress = out.progress_channel();
-    writeln!(progress, "{}", "Generating commit message...".bright_cyan())?;
+    writeln!(
+        progress,
+        "{}",
+        theme::get().progress.paint("Generating commit message...")
+    )?;
     let llm = LLMProvider::default_openai()
         .ok_or_else(|| anyhow::anyhow!("Failed to initialize default OpenAI LLM provider"))?;
     let system_message =

--- a/crates/but/src/command/legacy/branch/list.rs
+++ b/crates/but/src/command/legacy/branch/list.rs
@@ -654,7 +654,7 @@ fn print_applied_branches_table(
                     .join(", ");
                 t.info.paint(format!(" ({review_numbers})"))
             } else {
-                String::new()
+                t.default.paint("")
             };
 
             let branch_str = format!("{branch_with_prefix}{reviews_str}");
@@ -662,9 +662,9 @@ fn print_applied_branches_table(
             table.add_row(vec![
                 Cell::new(type_str),
                 Cell::new(branch_str),
-                Cell::new(ahead_str),
-                Cell::new(t.hint.paint(date_str)),
-                Cell::new(t.hint.paint(author_str)),
+                Cell::new(ahead_str.to_string()),
+                Cell::new(t.hint.paint(date_str).to_string()),
+                Cell::new(t.hint.paint(author_str).to_string()),
             ]);
         }
     }
@@ -739,12 +739,12 @@ fn print_branches_table(
                 .join(", ");
             t.info.paint(format!(" ({review_numbers})"))
         } else {
-            String::new()
+            t.default.paint("")
         };
 
         let (type_str, branch_name) = if branch.has_local {
             (
-                "local".to_string(),
+                t.default.paint("local"),
                 t.local_branch.paint(branch.name.to_string()),
             )
         } else {
@@ -756,11 +756,11 @@ fn print_branches_table(
         let branch_str = format!("{merge_status_str}{branch_name}{reviews_str}");
 
         table.add_row(vec![
-            Cell::new(type_str),
+            Cell::new(type_str.to_string()),
             Cell::new(branch_str),
             Cell::new(ahead_str),
-            Cell::new(t.hint.paint(date_str)),
-            Cell::new(t.hint.paint(author_str)),
+            Cell::new(t.hint.paint(date_str).to_string()),
+            Cell::new(t.hint.paint(author_str).to_string()),
         ]);
     }
 

--- a/crates/but/src/command/legacy/branch/show.rs
+++ b/crates/but/src/command/legacy/branch/show.rs
@@ -504,7 +504,7 @@ fn output_human(
             .join(", ");
         t.info.paint(format!(" ({review_numbers})"))
     } else {
-        String::new()
+        t.default.paint("")
     };
 
     writeln!(
@@ -554,7 +554,7 @@ fn output_human(
                         "added" => t.addition.paint(&file.path),
                         "deleted" => t.deletion.paint(&file.path),
                         "modified" => t.modification.paint(&file.path),
-                        _ => file.path.to_string(),
+                        _ => t.default.paint(&file.path),
                     };
 
                     let change_str = if file.status == "added" {

--- a/crates/but/src/command/legacy/clean.rs
+++ b/crates/but/src/command/legacy/clean.rs
@@ -1,13 +1,15 @@
 use std::collections::HashSet;
 
 use but_core::ref_metadata::StackId;
-use colored::Colorize;
 use gitbutler_oplog::{
     OplogExt,
     entry::{OperationKind, SnapshotDetails},
 };
 
-use crate::utils::OutputChannel;
+use crate::{
+    theme::{self, Paint},
+    utils::OutputChannel,
+};
 
 /// Options for the clean command.
 pub struct CleanOptions {
@@ -73,10 +75,16 @@ pub fn handle(
             })?;
         } else if let Some(out) = out.for_human() {
             for (_, name) in &empty_branches {
-                writeln!(out, "Would delete branch: {}", name.yellow())?;
+                let t = theme::get();
+                writeln!(out, "Would delete branch: {}", t.attention.paint(name))?;
             }
             let count = empty_branches.len();
-            writeln!(out, "Found {} empty branch(es)", count.to_string().bold())?;
+            let t = theme::get();
+            writeln!(
+                out,
+                "Found {} empty branch(es)",
+                t.important.paint(count.to_string())
+            )?;
         } else if let Some(out) = out.for_shell() {
             for (_, name) in &empty_branches {
                 writeln!(out, "{name}")?;
@@ -122,22 +130,27 @@ pub fn handle(
             dry_run: false,
         })?;
     } else if let Some(out) = out.for_human() {
+        let t = theme::get();
         for branch in &deleted {
-            writeln!(out, "  Deleted branch: {}", branch.name.green())?;
+            writeln!(
+                out,
+                "  Deleted branch: {}",
+                t.local_branch.paint(&branch.name)
+            )?;
         }
         if !deleted.is_empty() {
             writeln!(
                 out,
                 "{} Deleted {} empty branch(es)",
-                "✓".green().bold(),
-                deleted.len().to_string().bold()
+                t.sym().success,
+                t.important.paint(deleted.len().to_string())
             )?;
         }
         for f in &failed {
             writeln!(
                 out,
                 "{} Failed to delete branch '{}': {}",
-                "!".red().bold(),
+                t.sym().error,
                 f.name,
                 f.error
             )?;

--- a/crates/but/src/command/legacy/diff/display.rs
+++ b/crates/but/src/command/legacy/diff/display.rs
@@ -1,6 +1,5 @@
 use but_core::{UnifiedPatch, ui, unified_diff::DiffHunk};
 use but_hunk_assignment::HunkAssignment;
-use colored::Colorize;
 
 use crate::command::legacy::status::status_letter_ui;
 use crate::theme::Paint as _;
@@ -45,6 +44,7 @@ impl TreeChangeWithPatch {
 
 impl DiffDisplay for TreeChangeWithPatch {
     fn print_diff(&self, _cli_id: Option<&str>) -> String {
+        let t = crate::theme::get();
         // Note: CLI IDs are per-hunk, so we don't display them for TreeChangeWithPatch
         // which shows file-level diffs with potentially multiple hunks.
         let mut output = String::new();
@@ -62,9 +62,9 @@ impl DiffDisplay for TreeChangeWithPatch {
         // M file  │
         // ────────╯
         let render_header = |out: &mut String| {
-            out.push_str(&format!("{}╮\n", "─".repeat(content_width).dimmed()));
+            out.push_str(&format!("{}╮\n", t.hint.paint("─".repeat(content_width))));
             out.push_str(&format!("{status} {path}│\n"));
-            out.push_str(&format!("{}╯\n", "─".repeat(content_width).dimmed()));
+            out.push_str(&format!("{}╯\n", t.hint.paint("─".repeat(content_width))));
         };
 
         if let Some(patch) = &self.patch {
@@ -81,20 +81,23 @@ impl DiffDisplay for TreeChangeWithPatch {
 /// This is a helper function for consistent patch formatting.
 /// The `render_header` function is called before each hunk to render the file header.
 fn format_patch(patch: &UnifiedPatch, render_header: impl Fn(&mut String)) -> String {
+    let t = crate::theme::get();
     let mut output = String::new();
     match patch {
         UnifiedPatch::Binary => {
             render_header(&mut output);
             output.push_str(&format!(
                 "   {}\n",
-                "Binary file - no diff available".dimmed()
+                t.hint.paint("Binary file - no diff available")
             ));
         }
         UnifiedPatch::TooLarge { size_in_bytes } => {
             render_header(&mut output);
             output.push_str(&format!(
                 "   {}\n",
-                format!("File too large ({size_in_bytes} bytes) - no diff available").dimmed()
+                t.hint.paint(format!(
+                    "File too large ({size_in_bytes} bytes) - no diff available"
+                ))
             ));
         }
         UnifiedPatch::Patch {
@@ -106,7 +109,8 @@ fn format_patch(patch: &UnifiedPatch, render_header: impl Fn(&mut String)) -> St
                 render_header(&mut output);
                 output.push_str(&format!(
                     "   {}\n",
-                    "(diff generated from binary-to-text conversion)".yellow()
+                    t.attention
+                        .paint("(diff generated from binary-to-text conversion)")
                 ));
             }
 
@@ -121,6 +125,7 @@ fn format_patch(patch: &UnifiedPatch, render_header: impl Fn(&mut String)) -> St
 
 fn fmt_hunk(hunk: &DiffHunk) -> String {
     use bstr::ByteSlice;
+    let t = crate::theme::get();
 
     let mut output = String::new();
 
@@ -177,7 +182,11 @@ fn fmt_hunk(hunk: &DiffHunk) -> String {
             ' ' => {
                 // Context line: show both line numbers
                 let line_nums = format!("{old_line:>width$} {new_line:>width$}");
-                output.push_str(&format!("   {}│ {}\n", line_nums.dimmed(), content_str));
+                output.push_str(&format!(
+                    "   {}│ {}\n",
+                    t.hint.paint(&line_nums),
+                    content_str
+                ));
                 old_line += 1;
                 new_line += 1;
             }
@@ -190,6 +199,7 @@ fn fmt_hunk(hunk: &DiffHunk) -> String {
 
 impl DiffDisplay for HunkAssignment {
     fn print_diff(&self, short_id: Option<&str>) -> String {
+        let t = crate::theme::get();
         let mut output = String::new();
 
         // Calculate the width needed for the box (id + space + filename)
@@ -199,7 +209,7 @@ impl DiffDisplay for HunkAssignment {
         // ─────────╮
         // <id> file│
         // ─────────╯
-        output.push_str(&format!("{}╮\n", "─".repeat(content_width).dimmed()));
+        output.push_str(&format!("{}╮\n", t.hint.paint("─".repeat(content_width))));
         if let Some(id) = &short_id {
             output.push_str(&format!(
                 "{} {}│\n",
@@ -212,7 +222,7 @@ impl DiffDisplay for HunkAssignment {
                 crate::theme::get().important.paint(&self.path)
             ));
         }
-        output.push_str(&format!("{}╯\n", "─".repeat(content_width).dimmed()));
+        output.push_str(&format!("{}╯\n", t.hint.paint("─".repeat(content_width))));
 
         // Check if we have diff data to display
         if let (Some(diff), Some(header)) = (&self.diff, &self.hunk_header) {
@@ -227,7 +237,10 @@ impl DiffDisplay for HunkAssignment {
             output.push_str(&fmt_hunk(&hunk));
         } else if self.hunk_header.is_none() {
             // Binary, too large, or whole file without detailed diff
-            output.push_str(&format!("   {}\n", "(no detailed diff available)".dimmed()));
+            output.push_str(&format!(
+                "   {}\n",
+                t.hint.paint("(no detailed diff available)")
+            ));
         }
 
         output

--- a/crates/but/src/command/legacy/diff/display.rs
+++ b/crates/but/src/command/legacy/diff/display.rs
@@ -1,10 +1,11 @@
 use but_core::{UnifiedPatch, ui, unified_diff::DiffHunk};
 use but_hunk_assignment::HunkAssignment;
+use colored::ColoredString;
 
 use crate::command::legacy::status::status_letter_ui;
 use crate::theme::Paint as _;
 
-fn path_with_color_ui(status: &ui::TreeStatus, path: String) -> String {
+fn path_with_color_ui(status: &ui::TreeStatus, path: String) -> ColoredString {
     let t = crate::theme::get();
     match status {
         ui::TreeStatus::Addition { .. } => t.addition.paint(&path),

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -681,7 +681,7 @@ async fn publish_reviews_for_branch_and_dependents(
                 "Creating {}review for {} {} {}...",
                 draftiness,
                 t.local_branch.paint(head.name.to_string()),
-                t.sym().info_right,
+                t.sym().arrow.info(),
                 t.remote_branch.paint(current_target_branch)
             )?;
         }

--- a/crates/but/src/command/legacy/merge.rs
+++ b/crates/but/src/command/legacy/merge.rs
@@ -45,7 +45,7 @@ pub async fn handle(
         writeln!(
             progress,
             "Merging branch {} into target {}",
-            t.remote_branch.paint(&branch_name),
+            t.local_branch.paint(&branch_name),
             t.remote_branch
                 .paint(format!("{}/{}", target_remote, base_branch.branch_name))
         )?;
@@ -74,10 +74,10 @@ pub async fn handle(
         writeln!(
             progress,
             "Merging {} ({}) into {} ({})",
-            t.remote_branch.paint(&branch_name),
+            t.local_branch.paint(&branch_name),
             t.hint
                 .paint(shorten_object_id(&repo, merge_in_branch_head_oid)),
-            t.remote_branch.paint(&local_branch_name),
+            t.local_branch.paint(&local_branch_name),
             t.hint
                 .paint(shorten_object_id(&repo, local_branch_head_oid))
         )?;

--- a/crates/but/src/command/legacy/merge.rs
+++ b/crates/but/src/command/legacy/merge.rs
@@ -1,13 +1,12 @@
 use std::fmt::Write;
 
-use anyhow::bail;
-use but_ctx::Context;
-use colored::Colorize;
-
 use crate::{
     CliId, IdMap,
+    theme::{self, Paint},
     utils::{OutputChannel, shorten_object_id},
 };
+use anyhow::bail;
+use but_ctx::Context;
 
 pub async fn handle(
     ctx: &mut Context,
@@ -15,6 +14,7 @@ pub async fn handle(
     branch_id: &str,
 ) -> anyhow::Result<()> {
     let mut progress = out.progress_channel();
+    let t = theme::get();
     let guard = ctx.exclusive_worktree_access();
 
     let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
@@ -45,8 +45,9 @@ pub async fn handle(
         writeln!(
             progress,
             "Merging branch {} into target {}",
-            branch_name.bright_cyan(),
-            format!("{}/{}", target_remote, base_branch.branch_name).bright_cyan()
+            t.remote_branch.paint(&branch_name),
+            t.remote_branch
+                .paint(format!("{}/{}", target_remote, base_branch.branch_name))
         )?;
 
         // Extract the local branch name from the base branch
@@ -73,10 +74,12 @@ pub async fn handle(
         writeln!(
             progress,
             "Merging {} ({}) into {} ({})",
-            branch_name.bright_cyan(),
-            shorten_object_id(&repo, merge_in_branch_head_oid).bright_black(),
-            local_branch_name.bright_cyan(),
-            shorten_object_id(&repo, local_branch_head_oid).bright_black()
+            t.remote_branch.paint(&branch_name),
+            t.hint
+                .paint(shorten_object_id(&repo, merge_in_branch_head_oid)),
+            t.remote_branch.paint(&local_branch_name),
+            t.hint
+                .paint(shorten_object_id(&repo, local_branch_head_oid))
         )?;
 
         // do the merge
@@ -108,7 +111,11 @@ pub async fn handle(
             vec![merge_in_branch_head_oid, local_branch_head_oid],
         )?;
 
-        writeln!(progress, "\nUpdating {}", local_branch_name.blue())?;
+        writeln!(
+            progress,
+            "\nUpdating {}",
+            t.local_branch.paint(&local_branch_name)
+        )?;
 
         // update the local branch
         let branch_ref_name: gix::refs::FullName =
@@ -127,7 +134,7 @@ pub async fn handle(
         writeln!(
             progress,
             "\n{}",
-            "Merge and update complete!".green().bold()
+            t.success.paint("Merge and update complete!")
         )?;
     } else {
         bail!(

--- a/crates/but/src/command/legacy/oplog.rs
+++ b/crates/but/src/command/legacy/oplog.rs
@@ -149,7 +149,7 @@ pub(crate) fn show_oplog(
                 "BRANCH" | "CHECKOUT" => t.remote_branch.paint(operation_type),
                 "MOVE" | "REORDER" | "MOVE_HUNK" => t.info.paint(operation_type),
                 "SNAPSHOT" => t.remote_branch.paint(operation_type),
-                _ => operation_type.to_string(),
+                _ => t.default.paint(operation_type),
             };
 
             writeln!(

--- a/crates/but/src/command/legacy/oplog.rs
+++ b/crates/but/src/command/legacy/oplog.rs
@@ -146,9 +146,9 @@ pub(crate) fn show_oplog(
                 "AMEND" | "REWORD" => t.attention.paint(operation_type),
                 "UNDO" | "RESTORE" => t.error.paint(operation_type),
                 "DISCARD" => t.error.paint(operation_type),
-                "BRANCH" | "CHECKOUT" => t.remote_branch.paint(operation_type),
+                "BRANCH" | "CHECKOUT" => t.local_branch.paint(operation_type),
                 "MOVE" | "REORDER" | "MOVE_HUNK" => t.info.paint(operation_type),
-                "SNAPSHOT" => t.remote_branch.paint(operation_type),
+                "SNAPSHOT" => t.hint.paint(operation_type),
                 _ => t.default.paint(operation_type),
             };
 
@@ -205,7 +205,7 @@ pub(crate) fn restore_to_oplog(
         writeln!(
             out,
             "  Target: {} ({})",
-            t.success.paint(target_operation),
+            t.important.paint(target_operation),
             t.time.paint(&target_time)
         )?;
         writeln!(out, "  Snapshot: {}", t.commit_id.paint(&commit_short))?;
@@ -278,7 +278,7 @@ pub(crate) fn undo_last_operation(
         writeln!(
             out,
             "  Reverting to: {} ({})",
-            t.success.paint(target_operation),
+            t.important.paint(target_operation),
             t.time.paint(&target_time)
         )?;
     }
@@ -323,7 +323,7 @@ pub(crate) fn create_snapshot(
         writeln!(out, "{}", t.success.paint("Snapshot created successfully!"))?;
 
         if let Some(msg) = message {
-            writeln!(out, "  Message: {}", t.config_value.paint(msg))?;
+            writeln!(out, "  Message: {}", t.info.paint(msg))?;
         }
 
         writeln!(out, "  Snapshot ID: {}", t.cli_id.paint(&short))?;

--- a/crates/but/src/command/legacy/oplog.rs
+++ b/crates/but/src/command/legacy/oplog.rs
@@ -1,9 +1,11 @@
 use but_core::RepositoryExt;
-use colored::Colorize;
 use gitbutler_oplog::entry::{OperationKind, Snapshot};
 use gix::{date::time::CustomFormat, prelude::ObjectIdExt};
 
-use crate::utils::{Confirm, ConfirmDefault, OutputChannel, shorten_object_id};
+use crate::{
+    theme::{self, Paint},
+    utils::{Confirm, ConfirmDefault, OutputChannel, shorten_object_id},
+};
 
 pub const ISO8601_NO_TZ: CustomFormat = CustomFormat::new("%Y-%m-%d %H:%M:%S");
 
@@ -58,8 +60,9 @@ pub(crate) fn show_oplog(
         out.write_value(&snapshots)?;
     } else if let Some(out) = out.for_human() {
         let repo = ctx.repo.get()?.clone().for_commit_shortening();
-        writeln!(out, "{}", "Operations History".blue().bold())?;
-        writeln!(out, "{}", "─".repeat(50).dimmed())?;
+        let t = theme::get();
+        writeln!(out, "{}", t.important.paint("Operations History"))?;
+        writeln!(out, "{}", t.hint.paint("─".repeat(50)))?;
         // Find the longest short ID length to keep all lines aligned.
         let longest_short_id_len = snapshots
             .iter()
@@ -74,7 +77,7 @@ pub(crate) fn show_oplog(
             let time_string = snapshot_time_string(&snapshot);
             let short = snapshot.commit_id;
             let short = short.to_hex_with_len(longest_short_id_len);
-            let commit_id = short.to_string().blue().bold();
+            let commit_id = t.cli_id.paint(short.to_string());
 
             let (operation_type, title) = if let Some(details) = &snapshot.details {
                 let op_type = match details.operation {
@@ -139,21 +142,21 @@ pub(crate) fn show_oplog(
             };
 
             let operation_colored = match operation_type {
-                "CREATE" => operation_type.green(),
-                "AMEND" | "REWORD" => operation_type.yellow(),
-                "UNDO" | "RESTORE" => operation_type.red(),
-                "DISCARD" => operation_type.red().bold(),
-                "BRANCH" | "CHECKOUT" => operation_type.purple(),
-                "MOVE" | "REORDER" | "MOVE_HUNK" => operation_type.cyan(),
-                "SNAPSHOT" => operation_type.bright_magenta(),
-                _ => operation_type.normal(),
+                "CREATE" => t.success.paint(operation_type),
+                "AMEND" | "REWORD" => t.attention.paint(operation_type),
+                "UNDO" | "RESTORE" => t.error.paint(operation_type),
+                "DISCARD" => t.error.paint(operation_type),
+                "BRANCH" | "CHECKOUT" => t.remote_branch.paint(operation_type),
+                "MOVE" | "REORDER" | "MOVE_HUNK" => t.info.paint(operation_type),
+                "SNAPSHOT" => t.remote_branch.paint(operation_type),
+                _ => operation_type.to_string(),
             };
 
             writeln!(
                 out,
                 "{} {} [{}] {}",
                 commit_id,
-                time_string.dimmed(),
+                t.time.paint(&time_string),
                 operation_colored,
                 title
             )?;
@@ -193,23 +196,27 @@ pub(crate) fn restore_to_oplog(
 
     if let Some(mut out) = out.prepare_for_terminal_input() {
         use std::fmt::Write;
-        writeln!(out, "{}", "Restoring to oplog snapshot...".blue().bold())?;
+        let t = theme::get();
+        writeln!(
+            out,
+            "{}",
+            t.progress.paint("Restoring to oplog snapshot...")
+        )?;
         writeln!(
             out,
             "  Target: {} ({})",
-            target_operation.green(),
-            target_time.dimmed()
+            t.success.paint(target_operation),
+            t.time.paint(&target_time)
         )?;
-        writeln!(out, "  Snapshot: {}", commit_short.cyan().bold())?;
+        writeln!(out, "  Snapshot: {}", t.commit_id.paint(&commit_short))?;
 
         // Confirm the restoration (safety check)
         if !force {
             writeln!(
                 out,
                 "\n{}",
-                "⚠️  This will overwrite your current workspace state."
-                    .yellow()
-                    .bold()
+                t.attention
+                    .paint("⚠️  This will overwrite your current workspace state.")
             )?;
             if out.confirm("Continue with restore?", ConfirmDefault::No)? == Confirm::No {
                 return Ok(());
@@ -221,16 +228,14 @@ pub(crate) fn restore_to_oplog(
     but_api::legacy::oplog::restore_snapshot(ctx, commit_id)?;
 
     if let Some(out) = out.for_human() {
-        writeln!(
-            out,
-            "\n{} Restore completed successfully!",
-            "✓".green().bold(),
-        )?;
+        let t = theme::get();
+        writeln!(out, "\n{} Restore completed successfully!", t.sym().success,)?;
 
         writeln!(
             out,
             "{}",
-            "\nWorkspace has been restored to the selected snapshot.".green()
+            t.success
+                .paint("\nWorkspace has been restored to the selected snapshot.")
         )?;
     }
 
@@ -246,7 +251,12 @@ pub(crate) fn undo_last_operation(
 
     if snapshots.len() < 2 {
         if let Some(out) = out.for_human() {
-            writeln!(out, "{}", "No previous operations to undo.".yellow())?;
+            let t = theme::get();
+            writeln!(
+                out,
+                "{}",
+                t.attention.paint("No previous operations to undo.")
+            )?;
         }
         return Ok(());
     }
@@ -263,12 +273,13 @@ pub(crate) fn undo_last_operation(
     let target_time = snapshot_time_string(target_snapshot);
 
     if let Some(out) = out.for_human() {
-        writeln!(out, "{}", "Undoing operation...".blue().bold())?;
+        let t = theme::get();
+        writeln!(out, "{}", t.progress.paint("Undoing operation..."))?;
         writeln!(
             out,
             "  Reverting to: {} ({})",
-            target_operation.green(),
-            target_time.dimmed()
+            t.success.paint(target_operation),
+            t.time.paint(&target_time)
         )?;
     }
 
@@ -277,14 +288,15 @@ pub(crate) fn undo_last_operation(
     but_api::legacy::oplog::restore_snapshot(ctx, target_snapshot.commit_id)?;
 
     if let Some(out) = out.for_human() {
+        let t = theme::get();
         let repo = ctx.repo.get()?;
         let short = shorten_object_id(&repo, target_snapshot.commit_id);
 
         writeln!(
             out,
             "{} Undo completed successfully! Restored to snapshot: {}",
-            "✓".green().bold(),
-            short.blue().bold()
+            t.sym().success,
+            t.cli_id.paint(&short)
         )?;
     }
 
@@ -307,17 +319,18 @@ pub(crate) fn create_snapshot(
     } else if let Some(out) = out.for_human() {
         let repo = ctx.repo.get()?;
         let short = shorten_object_id(&repo, snapshot_id);
-        writeln!(out, "{}", "Snapshot created successfully!".green().bold())?;
+        let t = theme::get();
+        writeln!(out, "{}", t.success.paint("Snapshot created successfully!"))?;
 
         if let Some(msg) = message {
-            writeln!(out, "  Message: {}", msg.cyan())?;
+            writeln!(out, "  Message: {}", t.config_value.paint(msg))?;
         }
 
-        writeln!(out, "  Snapshot ID: {}", short.blue().bold(),)?;
+        writeln!(out, "  Snapshot ID: {}", t.cli_id.paint(&short))?;
         writeln!(
             out,
             "\n{} Use 'but oplog restore {}' to restore to this snapshot later.",
-            "💡".bright_blue(),
+            t.info.paint("💡"),
             short
         )?;
     }

--- a/crates/but/src/command/legacy/pick.rs
+++ b/crates/but/src/command/legacy/pick.rs
@@ -106,7 +106,7 @@ pub fn handle(
                 out,
                 "{} {} {} {}",
                 t.success.paint("Picked commit"),
-                t.attention.paint(&commit_short),
+                t.commit_id.paint(&commit_short),
                 t.success.paint("into branch"),
                 t.local_branch.paint(target_branch_name)
             )?;

--- a/crates/but/src/command/legacy/pick.rs
+++ b/crates/but/src/command/legacy/pick.rs
@@ -1,5 +1,6 @@
 //! Cherry-pick commits from unapplied branches into applied virtual branches.
 
+use crate::theme::{self, Paint};
 use anyhow::{Context as _, Result, bail};
 use bstr::ByteSlice;
 use but_api::legacy::{cherry_apply, virtual_branches, workspace};
@@ -8,7 +9,6 @@ use but_core::{RepositoryExt, ref_metadata::StackId, sync::RepoShared};
 use but_ctx::Context;
 use but_workspace::legacy::{StacksFilter, ui::StackEntry};
 use cli_prompts::DisplayPrompt;
-use colored::Colorize;
 use gitbutler_branch_actions::BranchListingFilter;
 use gitbutler_oplog::{
     OplogExt,
@@ -97,6 +97,7 @@ pub fn handle(
     }
 
     // Output results
+    let t = theme::get();
     let repo = ctx.repo.get()?.clone().for_commit_shortening();
     for (commit_hex, target_branch_name, _) in &picked {
         let commit_short = shorten_hex_object_id(&repo, commit_hex);
@@ -104,10 +105,10 @@ pub fn handle(
             writeln!(
                 out,
                 "{} {} {} {}",
-                "Picked commit".green(),
-                commit_short.yellow(),
-                "into branch".green(),
-                target_branch_name.cyan()
+                t.success.paint("Picked commit"),
+                t.attention.paint(&commit_short),
+                t.success.paint("into branch"),
+                t.local_branch.paint(target_branch_name)
             )?;
         }
     }
@@ -385,12 +386,13 @@ fn handle_locked_to_stack(
             h.name.to_str_lossy() == target || h.name.to_string().to_lowercase() == target_lower
         });
 
+        let t = theme::get();
         if !target_matches && let Some(out) = out.for_human() {
             writeln!(
                 out,
                 "{} Commit is locked to '{}' due to conflicts. Ignoring specified target.",
-                "Warning:".yellow(),
-                locked_branch_name.cyan()
+                t.attention.paint("Warning:"),
+                t.local_branch.paint(&locked_branch_name)
             )?;
         }
     }

--- a/crates/but/src/command/legacy/pull/mod.rs
+++ b/crates/but/src/command/legacy/pull/mod.rs
@@ -155,7 +155,7 @@ async fn handle_check(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<
             out,
             "\n{}\t{}",
             t.hint.paint("Base branch:"),
-            t.config_value.paint(&base_branch.branch_name)
+            t.remote_branch.paint(&base_branch.branch_name)
         )?;
         let upstream_label = format!(
             "{} new commits on {}",
@@ -188,7 +188,7 @@ async fn handle_check(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<
                 writeln!(
                     out,
                     "  {} {}",
-                    t.attention.paint(&commit_short),
+                    t.commit_id.paint(&commit_short),
                     t.hint.paint(&msg)
                 )?;
             }
@@ -299,7 +299,7 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
     }
 
     if let Some(out) = out.for_human() {
-        writeln!(progress, "   Checking: {}", t.info.paint(&upstream_url))?;
+        writeln!(progress, "   Checking: {}", t.link.paint(&upstream_url))?;
 
         if base_branch.behind > 0 {
             writeln!(
@@ -601,7 +601,7 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
                             out,
                             "{} of {} {}",
                             t.important.paint("Rebase"),
-                            t.remote_branch.paint(branch_name.as_str()),
+                            t.local_branch.paint(branch_name.as_str()),
                             t.success.paint("successful")
                         )?;
                     }
@@ -612,7 +612,7 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
                             out,
                             "{} of {} {}",
                             t.important.paint("Rebase"),
-                            t.remote_branch.paint(branch_name.as_str()),
+                            t.local_branch.paint(branch_name.as_str()),
                             t.attention.paint("resulted in conflicts")
                         )?;
                     }
@@ -639,7 +639,7 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
                         writeln!(
                             out,
                             "  {} - {}",
-                            t.remote_branch.paint(branch),
+                            t.local_branch.paint(branch),
                             t.success.paint("rebased")
                         )?;
                     }
@@ -648,7 +648,7 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
                         writeln!(
                             out,
                             "  {} - {}",
-                            t.remote_branch.paint(branch),
+                            t.local_branch.paint(branch),
                             t.info.paint("integrated")
                         )?;
                     }
@@ -657,7 +657,7 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
                         writeln!(
                             out,
                             "  {} - {}",
-                            t.remote_branch.paint(branch),
+                            t.local_branch.paint(branch),
                             t.error.paint("conflicted")
                         )?;
                     }

--- a/crates/but/src/command/legacy/pull/mod.rs
+++ b/crates/but/src/command/legacy/pull/mod.rs
@@ -4,7 +4,6 @@ use std::{collections::HashMap, fmt::Write};
 
 use but_core::RepositoryExt;
 use but_ctx::Context;
-use colored::Colorize;
 use gitbutler_branch_actions::upstream_integration::{
     BranchStatus::{self, Conflicted, Empty, Integrated, SafelyUpdatable},
     Resolution, ResolutionApproach,
@@ -14,7 +13,10 @@ use gitbutler_branch_actions::upstream_integration::{
 use json::{BaseBranchInfo, BranchStatusInfo, PullCheckOutput, UpstreamCommit, UpstreamInfo};
 use serde::{Deserialize, Serialize};
 
-use crate::utils::{OutputChannel, shorten_hex_object_id};
+use crate::{
+    theme::{self, Paint},
+    utils::{OutputChannel, shorten_hex_object_id},
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -76,6 +78,7 @@ pub async fn handle(
 }
 
 async fn handle_check(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<()> {
+    let t = theme::get();
     let mut progress = out.progress_channel();
 
     writeln!(progress, "Fetching from upstream remotes...")?;
@@ -143,12 +146,16 @@ async fn handle_check(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<
         };
         out.write_value(output)?;
     } else if let Some(out) = out.for_human() {
-        writeln!(progress, "{}", "Checking base branch status...".bold())?;
+        writeln!(
+            progress,
+            "{}",
+            t.important.paint("Checking base branch status...")
+        )?;
         writeln!(
             out,
             "\n{}\t{}",
-            "Base branch:".dimmed(),
-            base_branch.branch_name.cyan()
+            t.hint.paint("Base branch:"),
+            t.config_value.paint(&base_branch.branch_name)
         )?;
         let upstream_label = format!(
             "{} new commits on {}",
@@ -157,11 +164,11 @@ async fn handle_check(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<
         writeln!(
             out,
             "{}\t{}",
-            "Upstream:".dimmed(),
+            t.hint.paint("Upstream:"),
             if base_branch.behind > 0 {
-                upstream_label.yellow()
+                t.attention.paint(&upstream_label)
             } else {
-                upstream_label.green()
+                t.success.paint(&upstream_label)
             }
         )?;
 
@@ -171,29 +178,33 @@ async fn handle_check(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<
             let commits = base_branch.upstream_commits.iter().take(3);
             for commit in commits {
                 let commit_short = shorten_hex_object_id(&repo, &commit.id);
+                let msg: String = commit
+                    .description
+                    .to_string()
+                    .replace('\n', " ")
+                    .chars()
+                    .take(72)
+                    .collect();
                 writeln!(
                     out,
                     "  {} {}",
-                    commit_short.yellow(),
-                    commit
-                        .description
-                        .to_string()
-                        .replace('\n', " ")
-                        .chars()
-                        .take(72)
-                        .collect::<String>()
-                        .dimmed()
+                    t.attention.paint(&commit_short),
+                    t.hint.paint(&msg)
                 )?;
             }
             let hidden_commits = base_branch.behind.saturating_sub(3);
             if hidden_commits > 0 {
-                writeln!(out, "  {}", format!("... ({hidden_commits} more)").dimmed())?;
+                writeln!(
+                    out,
+                    "  {}",
+                    t.hint.paint(format!("... ({hidden_commits} more)"))
+                )?;
             }
         }
 
         match status {
             UpToDate => {
-                writeln!(out, "\n{}", "Up to date".green().bold())?;
+                writeln!(out, "\n{}", t.success.paint("Up to date"))?;
             }
             UpdatesRequired {
                 worktree_conflicts,
@@ -203,26 +214,25 @@ async fn handle_check(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<
                     writeln!(
                         out,
                         "\n{}",
-                        "Warning: uncommitted changes may conflict with updates."
-                            .yellow()
-                            .bold()
+                        t.attention
+                            .paint("Warning: uncommitted changes may conflict with updates.")
                     )?;
                 }
                 if !statuses.is_empty() {
-                    writeln!(out, "\n{}", "Branch Status".bold())?;
+                    writeln!(out, "\n{}", t.important.paint("Branch Status"))?;
                     for (_id, status) in statuses {
                         for bs in status.branch_statuses {
                             let status_text = match bs.status {
-                                SafelyUpdatable => "[ok]".green(),
-                                Integrated => "[integrated]".blue(),
+                                SafelyUpdatable => t.success.paint("[ok]"),
+                                Integrated => t.info.paint("[integrated]"),
                                 Conflicted { rebasable } => {
                                     if rebasable {
-                                        "[conflict - rebasable]".yellow()
+                                        t.attention.paint("[conflict - rebasable]")
                                     } else {
-                                        "[conflict]".red()
+                                        t.error.paint("[conflict]")
                                     }
                                 }
-                                Empty => "[empty]".dimmed(),
+                                Empty => t.hint.paint("[empty]"),
                             };
                             writeln!(out, "  {} {}", status_text, bs.name)?;
                         }
@@ -231,7 +241,7 @@ async fn handle_check(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<
                 writeln!(
                     out,
                     "\n{}",
-                    "Run `but pull` to update your branches".dimmed()
+                    t.hint.paint("Run `but pull` to update your branches")
                 )?;
             }
         }
@@ -240,6 +250,7 @@ async fn handle_check(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<
 }
 
 async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<()> {
+    let t = theme::get();
     let mut pull_result = PullResult {
         status: String::new(),
         upstream_url: None,
@@ -263,7 +274,7 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
     writeln!(
         progress,
         "{}",
-        "Fetching newest data from remotes...".bright_cyan()
+        t.progress.paint("Fetching newest data from remotes...")
     )?;
 
     // Fetch from remotes to get latest upstream info
@@ -288,15 +299,15 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
     }
 
     if let Some(out) = out.for_human() {
-        writeln!(progress, "   Checking: {}", upstream_url.bright_cyan())?;
+        writeln!(progress, "   Checking: {}", t.info.paint(&upstream_url))?;
 
         if base_branch.behind > 0 {
             writeln!(
                 out,
                 "\n{} {} upstream commits on {}",
-                "Found".bold(),
-                base_branch.behind.to_string().bright_yellow(),
-                base_branch.branch_name.bright_cyan()
+                t.important.paint("Found"),
+                t.attention.paint(base_branch.behind.to_string()),
+                t.remote_branch.paint(&base_branch.branch_name)
             )?;
 
             // Show upstream commits (actual new commits to integrate)
@@ -311,15 +322,19 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
                     .take(65)
                     .collect::<String>();
                 let commit_short = shorten_hex_object_id(&repo, &commit_info.id);
-                writeln!(out, "   {} {}", commit_short.bright_black(), msg)?;
+                writeln!(out, "   {} {}", t.hint.paint(&commit_short), msg)?;
             }
 
             let hidden = base_branch.behind.saturating_sub(commits_to_show);
             if hidden > 0 {
-                writeln!(out, "   ... and {} more", hidden.to_string().bright_black())?;
+                writeln!(out, "   ... and {} more", t.hint.paint(hidden.to_string()))?;
             }
         } else {
-            writeln!(out, "\n{}", "No new upstream commits found".green())?;
+            writeln!(
+                out,
+                "\n{}",
+                t.success.paint("No new upstream commits found")
+            )?;
         }
 
         writeln!(progress, "   Checking integration statuses...")?;
@@ -334,7 +349,7 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
         UpToDate => {
             pull_result.status = "up_to_date".to_string();
             if let Some(out) = out.for_human() {
-                writeln!(out, "\n{}", "Everything is up to date".green())?;
+                writeln!(out, "\n{}", t.success.paint("Everything is up to date"))?;
             }
             if let Some(out) = out.for_json() {
                 out.write_value(&pull_result)?;
@@ -351,12 +366,13 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
                     writeln!(
                         out,
                         "\n{}",
-                        "There are uncommitted changes in the worktree that may conflict with the updates.".red()
+                        t.error.paint("There are uncommitted changes in the worktree that may conflict with the updates.")
                     )?;
                     writeln!(
                         out,
                         "   {}",
-                        "Please commit or stash them and try again.".yellow()
+                        t.attention
+                            .paint("Please commit or stash them and try again.")
                     )?;
                 }
                 if let Some(out) = out.for_json() {
@@ -377,7 +393,8 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
                             writeln!(
                                 out,
                                 "\n{}",
-                                "No stack ID, assuming we're on single-branch mode...".yellow()
+                                t.attention
+                                    .paint("No stack ID, assuming we're on single-branch mode...")
                             )?;
                         }
                         continue;
@@ -435,8 +452,8 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
                     writeln!(
                         out,
                         "\n{} {} active branches...",
-                        "Updating".bright_cyan(),
-                        branches_to_update.to_string().bright_yellow()
+                        t.progress.paint("Updating"),
+                        t.attention.paint(branches_to_update.to_string())
                     )?;
                 }
 
@@ -583,9 +600,9 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
                         writeln!(
                             out,
                             "{} of {} {}",
-                            "Rebase".bold(),
-                            branch_name.as_str().bright_cyan(),
-                            "successful".green()
+                            t.important.paint("Rebase"),
+                            t.remote_branch.paint(branch_name.as_str()),
+                            t.success.paint("successful")
                         )?;
                     }
 
@@ -594,9 +611,9 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
                         writeln!(
                             out,
                             "{} of {} {}",
-                            "Rebase".bright_white(),
-                            branch_name.as_str().bright_cyan(),
-                            "resulted in conflicts".yellow()
+                            t.important.paint("Rebase"),
+                            t.remote_branch.paint(branch_name.as_str()),
+                            t.attention.paint("resulted in conflicts")
                         )?;
                     }
 
@@ -607,59 +624,69 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
                             writeln!(
                                 out,
                                 "{} {} has been integrated upstream and removed locally",
-                                "Branch".bold(),
-                                branch.bright_green()
+                                t.important.paint("Branch"),
+                                t.local_branch.paint(branch)
                             )?;
                         }
                     }
 
                     // Final summary
-                    writeln!(out, "\n{}", "Summary".bold())?;
+                    writeln!(out, "\n{}", t.important.paint("Summary"))?;
                     writeln!(out, "────────")?;
 
                     // List each branch with color-coded status
                     for branch in &successful_rebases {
-                        writeln!(out, "  {} - {}", branch.bright_cyan(), "rebased".green())?;
+                        writeln!(
+                            out,
+                            "  {} - {}",
+                            t.remote_branch.paint(branch),
+                            t.success.paint("rebased")
+                        )?;
                     }
 
                     for branch in &pull_result.integrated_branches {
                         writeln!(
                             out,
                             "  {} - {}",
-                            branch.bright_cyan(),
-                            "integrated".bright_purple()
+                            t.remote_branch.paint(branch),
+                            t.info.paint("integrated")
                         )?;
                     }
 
                     for branch in &conflicted_rebases {
-                        writeln!(out, "  {} - {}", branch.bright_cyan(), "conflicted".red())?;
+                        writeln!(
+                            out,
+                            "  {} - {}",
+                            t.remote_branch.paint(branch),
+                            t.error.paint("conflicted")
+                        )?;
                     }
 
                     // Conflict resolution instructions
                     if has_conflicts {
                         writeln!(out)?;
-                        writeln!(out, "{}", "To resolve conflicts:".bold())?;
+                        writeln!(out, "{}", t.important.paint("To resolve conflicts:"))?;
                         writeln!(
                             out,
                             "  1. Run {} to see conflicted commits",
-                            "`but status`".bright_cyan()
+                            t.command_suggestion.paint("`but status`")
                         )?;
                         writeln!(
                             out,
                             "  2. Run {} to enter resolution mode on any conflicted commit",
-                            "`but resolve <commit>`".bright_cyan()
+                            t.command_suggestion.paint("`but resolve <commit>`")
                         )?;
                         writeln!(out, "  3. Edit files to resolve the conflicts")?;
                         writeln!(
                             out,
                             "  4. Run {} to finalize the resolution",
-                            "`but resolve finish`".bright_cyan()
+                            t.command_suggestion.paint("`but resolve finish`")
                         )?;
                     }
 
                     // Undo instructions
                     writeln!(out)?;
-                    writeln!(out, "{}", "To undo this operation:".bold())?;
+                    writeln!(out, "{}", t.important.paint("To undo this operation:"))?;
                     writeln!(out, "  Run `but undo`")?;
                 }
 
@@ -671,7 +698,12 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
             Err(e) => {
                 pull_result.status = "error".to_string();
                 if let Some(out) = out.for_human() {
-                    writeln!(out, "\n{} {}", "Error during integration:".red(), e)?;
+                    writeln!(
+                        out,
+                        "\n{} {}",
+                        t.error.paint("Error during integration:"),
+                        e
+                    )?;
                 }
                 if let Some(out) = out.for_json() {
                     out.write_value(&pull_result)?;

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -337,7 +337,7 @@ fn handle_dry_run(
     writeln!(
         progress,
         "{} {}",
-        t.progress.paint("Dry run:"),
+        t.important.paint("Dry run:"),
         t.hint.paint("Showing what would be pushed")
     )?;
     writeln!(progress)?;
@@ -451,7 +451,7 @@ fn handle_dry_run(
                 t.hint.paint(line_prefix),
                 t.success.paint("→"),
                 t.hint.paint("Would push to:"),
-                t.attention
+                t.remote_branch
                     .paint(format!("{}/{}", info.remote, branch_name))
             )?;
             writeln!(
@@ -552,7 +552,7 @@ fn handle_dry_run(
     writeln!(
         progress,
         "{} Would push {} {} across {} {}",
-        t.progress.paint("Summary:"),
+        t.important.paint("Summary:"),
         t.attention.paint(total_commits.to_string()),
         if total_commits == 1 {
             "commit"
@@ -623,7 +623,7 @@ fn push_single_branch(
                 t.local_branch.paint(branch),
                 t.hint.paint(&remote_ref),
                 t.hint.paint(&before_str),
-                t.success.paint(&after_str)
+                t.commit_id.paint(&after_str)
             )?;
         }
     }
@@ -784,7 +784,7 @@ fn push_all_branches(
                     t.local_branch.paint(branch),
                     t.hint.paint(&remote_ref),
                     t.hint.paint(&before_str),
-                    t.success.paint(&after_str)
+                    t.commit_id.paint(&after_str)
                 )?;
             }
         }

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -3,7 +3,6 @@ use std::fmt::Write;
 use but_core::{RepositoryExt, ref_metadata::StackId};
 use but_ctx::Context;
 use cli_prompts::DisplayPrompt;
-use colored::Colorize;
 use gitbutler_git::PushResult;
 use serde::Serialize;
 
@@ -11,6 +10,7 @@ use crate::{
     CliId, IdMap,
     args::{push, push::Command},
     command::legacy::workspace_target,
+    theme::{self, Paint},
     utils::{OutputChannel, shorten_hex_object_id, shorten_object_id},
 };
 
@@ -149,6 +149,7 @@ fn handle_dry_run(
     branch_id: &Option<String>,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
+    let t = theme::get();
     let mut progress = out.progress_channel();
 
     // Fetch from remote first to get latest state
@@ -185,7 +186,7 @@ fn handle_dry_run(
         writeln!(
             progress,
             "{}",
-            "No branches have unpushed commits.".dimmed()
+            t.hint.paint("No branches have unpushed commits.")
         )?;
         return Ok(());
     }
@@ -336,8 +337,8 @@ fn handle_dry_run(
     writeln!(
         progress,
         "{} {}",
-        "Dry run:".bright_blue().bold(),
-        "Showing what would be pushed".dimmed()
+        t.progress.paint("Dry run:"),
+        t.hint.paint("Showing what would be pushed")
     )?;
     writeln!(progress)?;
 
@@ -362,9 +363,9 @@ fn handle_dry_run(
             writeln!(
                 progress,
                 "{} {} {}",
-                "Stack:".yellow().bold(),
-                stack_name.cyan(),
-                format!("({} branches)", branches.len()).dimmed()
+                t.attention.paint("Stack:"),
+                t.local_branch.paint(stack_name),
+                t.hint.paint(format!("({} branches)", branches.len()))
             )?;
         }
 
@@ -393,7 +394,7 @@ fn handle_dry_run(
             let has_next = is_in_stack && !is_last;
 
             if is_in_stack && !is_first {
-                writeln!(progress, "{}", "│".dimmed())?;
+                writeln!(progress, "{}", t.hint.paint("│"))?;
             } else {
                 writeln!(progress)?;
             }
@@ -416,19 +417,19 @@ fn handle_dry_run(
                 writeln!(
                     progress,
                     "{} {} {} {} {}",
-                    gutter.dimmed(),
-                    "Branch:".bold(),
-                    info.branch_name.cyan().bold(),
-                    "↑".dimmed(),
-                    format!("(on top of {stacked_on})").blue()
+                    t.hint.paint(gutter),
+                    t.important.paint("Branch:"),
+                    t.local_branch.paint(&info.branch_name),
+                    t.hint.paint("↑"),
+                    t.info.paint(format!("(on top of {stacked_on})"))
                 )?;
             } else {
                 writeln!(
                     progress,
                     "{} {} {}",
-                    gutter.dimmed(),
-                    "Branch:".bold(),
-                    info.branch_name.cyan().bold()
+                    t.hint.paint(gutter),
+                    t.important.paint("Branch:"),
+                    t.local_branch.paint(&info.branch_name)
                 )?;
             }
 
@@ -447,27 +448,24 @@ fn handle_dry_run(
             writeln!(
                 progress,
                 "{}  {} {} {}",
-                line_prefix.dimmed(),
-                "→".green(),
-                "Would push to:".dimmed(),
-                format!("{}/{}", info.remote, branch_name).yellow()
+                t.hint.paint(line_prefix),
+                t.success.paint("→"),
+                t.hint.paint("Would push to:"),
+                t.attention
+                    .paint(format!("{}/{}", info.remote, branch_name))
             )?;
             writeln!(
                 progress,
-                "{}  {} {}",
-                line_prefix.dimmed(),
-                "Commits:".dimmed(),
-                format!(
-                    "{} unpushed commit{}",
-                    info.unpushed_commits,
-                    if info.unpushed_commits == 1 { "" } else { "s" }
-                )
-                .yellow()
+                "{}  {} {} unpushed commit{}",
+                t.hint.paint(line_prefix),
+                t.hint.paint("Commits:"),
+                info.unpushed_commits,
+                if info.unpushed_commits == 1 { "" } else { "s" }
             )?;
 
             if !info.commits.is_empty() {
                 if is_in_stack {
-                    writeln!(progress, "{}", line_prefix.dimmed())?;
+                    writeln!(progress, "{}", t.hint.paint(line_prefix))?;
                 } else {
                     writeln!(progress)?;
                 }
@@ -475,22 +473,18 @@ fn handle_dry_run(
                     writeln!(
                         progress,
                         "{}    {} {}",
-                        line_prefix.dimmed(),
-                        commit.sha_short.green(),
-                        commit.message.dimmed()
+                        t.hint.paint(line_prefix),
+                        t.commit_id.paint(&commit.sha_short),
+                        t.hint.paint(&commit.message)
                     )?;
                 }
 
                 if info.unpushed_commits > info.commits.len() {
                     writeln!(
                         progress,
-                        "{}    {}",
-                        line_prefix.dimmed(),
-                        format!(
-                            "... and {} more",
-                            info.unpushed_commits - info.commits.len()
-                        )
-                        .dimmed()
+                        "{}    ... and {} more",
+                        t.hint.paint(line_prefix),
+                        info.unpushed_commits - info.commits.len()
                     )?;
                 }
             }
@@ -500,29 +494,25 @@ fn handle_dry_run(
                 writeln!(progress)?;
                 writeln!(
                     progress,
-                    "{}  {} {} {}",
-                    line_prefix.dimmed(),
-                    "⚠".yellow(),
-                    "Upstream commits (on remote):".yellow(),
-                    format!(
-                        "{} commit{}",
-                        info.upstream_commits.len(),
-                        if info.upstream_commits.len() == 1 {
-                            ""
-                        } else {
-                            "s"
-                        }
-                    )
-                    .yellow()
+                    "{}  {} {} {} commit{}",
+                    t.hint.paint(line_prefix),
+                    t.sym().warning,
+                    t.attention.paint("Upstream commits (on remote):"),
+                    info.upstream_commits.len(),
+                    if info.upstream_commits.len() == 1 {
+                        ""
+                    } else {
+                        "s"
+                    }
                 )?;
                 writeln!(progress)?;
                 for commit in &info.upstream_commits {
                     writeln!(
                         progress,
                         "{}    {} {}",
-                        line_prefix.dimmed(),
-                        commit.sha_short.red(),
-                        commit.message.dimmed()
+                        t.hint.paint(line_prefix),
+                        t.error.paint(&commit.sha_short),
+                        t.hint.paint(&commit.message)
                     )?;
                 }
             }
@@ -533,9 +523,9 @@ fn handle_dry_run(
                 writeln!(
                     progress,
                     "{}  {} {}",
-                    line_prefix.dimmed(),
-                    "⚠".red().bold(),
-                    warning.red()
+                    t.hint.paint(line_prefix),
+                    t.sym().warning.error(),
+                    t.error.paint(warning)
                 )?;
             }
 
@@ -545,9 +535,9 @@ fn handle_dry_run(
                 writeln!(
                     progress,
                     "{}  {} {}",
-                    line_prefix.dimmed(),
-                    "⚡".yellow(),
-                    "Force push required".yellow()
+                    t.hint.paint(line_prefix),
+                    t.sym().lightning,
+                    t.attention.paint("Force push required")
                 )?;
             }
         }
@@ -562,14 +552,14 @@ fn handle_dry_run(
     writeln!(
         progress,
         "{} Would push {} {} across {} {}",
-        "Summary:".bright_blue().bold(),
-        total_commits.to_string().yellow().bold(),
+        t.progress.paint("Summary:"),
+        t.attention.paint(total_commits.to_string()),
         if total_commits == 1 {
             "commit"
         } else {
             "commits"
         },
-        total_branches.to_string().cyan().bold(),
+        t.info.paint(total_branches.to_string()),
         if total_branches == 1 {
             "branch"
         } else {
@@ -580,7 +570,7 @@ fn handle_dry_run(
     writeln!(
         progress,
         "{}",
-        "Run without --dry-run to push these changes.".dimmed()
+        t.hint.paint("Run without --dry-run to push these changes.")
     )?;
 
     Ok(())
@@ -603,6 +593,7 @@ fn push_single_branch(
     gerrit_mode: bool,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
+    let t = theme::get();
     let result = push_single_branch_impl(ctx, branch_name, args, gerrit_mode)?;
     let mut progress = out.progress_channel();
 
@@ -611,11 +602,7 @@ fn push_single_branch(
     }
 
     writeln!(progress)?;
-    writeln!(
-        progress,
-        "{} Push completed successfully",
-        "✓".green().bold()
-    )?;
+    writeln!(progress, "{} Push completed successfully", t.sym().success)?;
     writeln!(progress)?;
     if !result.branch_sha_updates.is_empty() {
         let repo = ctx.repo.get()?.clone().for_commit_shortening();
@@ -633,10 +620,10 @@ fn push_single_branch(
             writeln!(
                 progress,
                 "  {} -> {} ({} -> {})",
-                branch.cyan(),
-                remote_ref.dimmed(),
-                before_str.dimmed(),
-                after_str.green()
+                t.local_branch.paint(branch),
+                t.hint.paint(&remote_ref),
+                t.hint.paint(&before_str),
+                t.success.paint(&after_str)
             )?;
         }
     }
@@ -680,6 +667,7 @@ fn push_all_branches(
     gerrit_mode: bool,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
+    let t = theme::get();
     let mut progress = out.progress_channel();
     let branches_with_info = get_branches_with_unpushed_info(ctx)?;
 
@@ -702,13 +690,13 @@ fn push_all_branches(
         writeln!(
             progress,
             "{}",
-            "No branches have unpushed commits.".dimmed()
+            t.hint.paint("No branches have unpushed commits.")
         )?;
         return Ok(());
     }
 
     writeln!(progress)?;
-    writeln!(progress, "{}", "Pushing branches...".bright_blue().bold())?;
+    writeln!(progress, "{}", t.progress.paint("Pushing branches..."))?;
     writeln!(progress)?;
 
     let mut total_commits_pushed = 0;
@@ -716,7 +704,12 @@ fn push_all_branches(
     let mut failed_branches = Vec::new();
 
     for (branch_name, unpushed_count, _) in branches_to_push {
-        write!(progress, "  {} {}... ", "→".cyan(), branch_name.bold())?;
+        write!(
+            progress,
+            "  {} {}... ",
+            t.info.paint("→"),
+            t.important.paint(&branch_name)
+        )?;
 
         match push_single_branch_impl(ctx, &branch_name, args, gerrit_mode) {
             Ok(result) => {
@@ -724,8 +717,8 @@ fn push_all_branches(
                 writeln!(
                     progress,
                     "{} ({} commit{})",
-                    "✓".green(),
-                    unpushed_count.to_string().yellow(),
+                    t.sym().success,
+                    t.attention.paint(unpushed_count.to_string()),
                     if unpushed_count == 1 { "" } else { "s" }
                 )?;
                 pushed_results.push(result);
@@ -735,7 +728,12 @@ fn push_all_branches(
                     branch_name: branch_name.clone(),
                     error: e.to_string(),
                 });
-                writeln!(progress, "{} {}", "✗".red(), e.to_string().red())?;
+                writeln!(
+                    progress,
+                    "{} {}",
+                    t.sym().error,
+                    t.error.paint(e.to_string())
+                )?;
             }
         }
     }
@@ -755,9 +753,9 @@ fn push_all_branches(
         writeln!(
             progress,
             "{} {} {} {}",
-            "✓".green().bold(),
-            "Successfully pushed".green().bold(),
-            total_commits_pushed.to_string().yellow().bold(),
+            t.sym().success,
+            t.success.paint("Successfully pushed"),
+            t.attention.paint(total_commits_pushed.to_string()),
             if total_commits_pushed == 1 {
                 "commit"
             } else {
@@ -783,10 +781,10 @@ fn push_all_branches(
                 writeln!(
                     progress,
                     "  {} -> {} ({} -> {})",
-                    branch.cyan(),
-                    remote_ref.dimmed(),
-                    before_str.dimmed(),
-                    after_str.green()
+                    t.local_branch.paint(branch),
+                    t.hint.paint(&remote_ref),
+                    t.hint.paint(&before_str),
+                    t.success.paint(&after_str)
                 )?;
             }
         }
@@ -797,8 +795,8 @@ fn push_all_branches(
         writeln!(
             progress,
             "{} Failed to push {} {}:",
-            "✗".red().bold(),
-            failed_branches.len().to_string().red().bold(),
+            t.sym().error,
+            t.error.paint(failed_branches.len().to_string()),
             if failed_branches.len() == 1 {
                 "branch"
             } else {
@@ -809,8 +807,8 @@ fn push_all_branches(
             writeln!(
                 progress,
                 "    {} - {}",
-                failed.branch_name.red(),
-                failed.error.dimmed()
+                t.error.paint(&failed.branch_name),
+                t.hint.paint(&failed.error)
             )?;
         }
     }
@@ -822,6 +820,7 @@ fn handle_no_branch_specified(
     ctx: &Context,
     out: &mut OutputChannel,
 ) -> anyhow::Result<BranchSelection> {
+    let t = theme::get();
     let branches_with_info = get_branches_with_unpushed_info(ctx)?;
 
     if branches_with_info.is_empty() {
@@ -852,7 +851,8 @@ fn handle_no_branch_specified(
         writeln!(
             progress,
             "{}",
-            "✓ All branches are up to date with the remote.".green()
+            t.success
+                .paint("✓ All branches are up to date with the remote.")
         )?;
         return Ok(BranchSelection::None);
     }

--- a/crates/but/src/command/legacy/resolve.rs
+++ b/crates/but/src/command/legacy/resolve.rs
@@ -10,7 +10,6 @@ use but_api::legacy::modes::{
     save_edit_and_return_to_workspace_with_output,
 };
 use but_ctx::Context;
-use colored::Colorize;
 use gitbutler_commit::commit_ext::{CommitExt, CommitMessageBstr};
 use gitbutler_edit_mode::commands::changes_from_initial;
 use gitbutler_operating_modes::OperatingMode;
@@ -19,6 +18,7 @@ use crate::{
     IdMap,
     args::resolve::Subcommands,
     id::CliId,
+    theme::{self, Paint},
     utils::{Confirm, ConfirmDefault, OutputChannel, shorten_object_id},
 };
 
@@ -52,6 +52,7 @@ pub(crate) fn handle(
 }
 
 fn enter_resolution(ctx: &mut Context, out: &mut OutputChannel, commit_id_str: &str) -> Result<()> {
+    let t = theme::get();
     use gix::{prelude::ObjectIdExt as _, revision::walk::Sorting};
 
     // Create an IdMap to resolve commit IDs (supports both CLI IDs and partial SHAs)
@@ -134,8 +135,8 @@ fn enter_resolution(ctx: &mut Context, out: &mut OutputChannel, commit_id_str: &
         writeln!(
             out,
             "{} {}",
-            "Checking out conflicted commit".bold(),
-            shorten_object_id(&repo, commit_gix_oid).cyan()
+            t.important.paint("Checking out conflicted commit"),
+            t.commit_id.paint(shorten_object_id(&repo, commit_gix_oid))
         )?;
     }
 
@@ -157,6 +158,7 @@ fn show_status_impl(
     out: &mut OutputChannel,
     prompt_to_finalize: bool,
 ) -> Result<()> {
+    let t = theme::get();
     // Check if we're in edit mode
     let mode = operating_mode(ctx)?.operating_mode;
     if !matches!(mode, OperatingMode::Edit(_)) {
@@ -169,9 +171,10 @@ fn show_status_impl(
     writeln!(
         progress,
         "{}\n - resolve all conflicts \n - finalize with {} \n - OR cancel with {}\n",
-        "You are currently in conflict resolution mode.".bold(),
-        "but resolve finish".green().bold(),
-        "but resolve cancel".red().bold()
+        t.important
+            .paint("You are currently in conflict resolution mode."),
+        t.success.paint("but resolve finish"),
+        t.error.paint("but resolve cancel")
     )?;
 
     let all_resolved = show_conflicted_files(ctx, out)?;
@@ -182,7 +185,7 @@ fn show_status_impl(
         writeln!(
             progress,
             "{}",
-            "All conflicts have been resolved!".green().bold()
+            t.success.paint("All conflicts have been resolved!")
         )?;
 
         let should_finalize = if let Some(mut inout) = out.prepare_for_terminal_input() {
@@ -193,7 +196,7 @@ fn show_status_impl(
                 writeln!(
                     progress,
                     "Resolution not finalized. Run {} when ready.",
-                    "but resolve finish".green().bold()
+                    t.success.paint("but resolve finish")
                 )?;
                 false
             }
@@ -210,6 +213,7 @@ fn show_status_impl(
 }
 
 fn show_conflicted_files(ctx: &mut Context, out: &mut OutputChannel) -> Result<bool> {
+    let t = theme::get();
     let conflicted_files =
         edit_initial_index_state(ctx).context("Failed to get conflicted files")?;
 
@@ -251,15 +255,19 @@ fn show_conflicted_files(ctx: &mut Context, out: &mut OutputChannel) -> Result<b
     let all_resolved = still_conflicted.is_empty();
 
     if all_resolved {
-        writeln!(progress, "{}", "No conflicted files remaining!".green())?;
+        writeln!(
+            progress,
+            "{}",
+            t.success.paint("No conflicted files remaining!")
+        )?;
         if !resolved.is_empty() {
-            writeln!(progress, "{} resolved:", "Files".green())?;
+            writeln!(progress, "{} resolved:", t.success.paint("Files"))?;
             for change in &resolved {
                 writeln!(
                     progress,
                     "  {} {}",
-                    "✓".green(),
-                    change.path.to_str_lossy().green()
+                    t.sym().success,
+                    t.success.paint(change.path.to_str_lossy())
                 )?;
             }
         }
@@ -267,24 +275,24 @@ fn show_conflicted_files(ctx: &mut Context, out: &mut OutputChannel) -> Result<b
         writeln!(
             progress,
             "{}:",
-            "Conflicted files remaining".yellow().bold()
+            t.attention.paint("Conflicted files remaining")
         )?;
         for change in &still_conflicted {
             writeln!(
                 progress,
                 "  {} {}",
-                "✗".red(),
-                change.path.to_str_lossy().yellow()
+                t.sym().error,
+                t.attention.paint(change.path.to_str_lossy())
             )?;
         }
         if !resolved.is_empty() {
-            writeln!(progress, "\n{} resolved:", "Files".green())?;
+            writeln!(progress, "\n{} resolved:", t.success.paint("Files"))?;
             for change in &resolved {
                 writeln!(
                     progress,
                     "  {} {}",
-                    "✓".green(),
-                    change.path.to_str_lossy().green()
+                    t.sym().success,
+                    t.success.paint(change.path.to_str_lossy())
                 )?;
             }
         }
@@ -318,6 +326,7 @@ fn has_conflict_markers(content: &str) -> bool {
 }
 
 fn finish_resolution(ctx: &mut Context, out: &mut OutputChannel) -> Result<()> {
+    let t = theme::get();
     // Check if we're in edit mode
     let mode = operating_mode(ctx)?.operating_mode;
     if !matches!(mode, OperatingMode::Edit(_)) {
@@ -336,9 +345,8 @@ fn finish_resolution(ctx: &mut Context, out: &mut OutputChannel) -> Result<()> {
         writeln!(
             human_out,
             "{}",
-            "✓ Conflict resolution finalized successfully!"
-                .green()
-                .bold()
+            t.success
+                .paint("✓ Conflict resolution finalized successfully!")
         )?;
         writeln!(
             human_out,
@@ -353,6 +361,7 @@ fn finish_resolution(ctx: &mut Context, out: &mut OutputChannel) -> Result<()> {
 }
 
 fn cancel_resolution(ctx: &mut Context, out: &mut OutputChannel, force: bool) -> Result<()> {
+    let t = theme::get();
     // Check if we're in edit mode
     let mode = operating_mode(ctx)?.operating_mode;
     if !matches!(mode, OperatingMode::Edit(_)) {
@@ -371,7 +380,11 @@ fn cancel_resolution(ctx: &mut Context, out: &mut OutputChannel, force: bool) ->
         .context("Failed to cancel resolution and return to workspace")?;
 
     if let Some(out) = out.for_human() {
-        writeln!(out, "{}", "Conflict resolution cancelled.".yellow())?;
+        writeln!(
+            out,
+            "{}",
+            t.attention.paint("Conflict resolution cancelled.")
+        )?;
         writeln!(
             out,
             "All changes made during resolution have been discarded."
@@ -395,6 +408,7 @@ fn check_for_new_conflicts_after_rebase(
     out: &mut OutputChannel,
     conflicts_before: BTreeMap<String, Vec<ConflictedCommit>>,
 ) -> Result<()> {
+    let t = theme::get();
     // Get the current list of conflicted commits after the rebase
     let conflicts_after = find_conflicted_commits(ctx)?;
 
@@ -423,9 +437,8 @@ fn check_for_new_conflicts_after_rebase(
             writeln!(
                 human_out,
                 "{}",
-                "⚠ Warning: New conflicts were introduced during the rebase:"
-                    .yellow()
-                    .bold()
+                t.attention
+                    .paint("⚠ Warning: New conflicts were introduced during the rebase:")
             )?;
             writeln!(human_out)?;
 
@@ -433,8 +446,8 @@ fn check_for_new_conflicts_after_rebase(
                 writeln!(
                     human_out,
                     "  {} {} {}",
-                    "●".red(),
-                    commit.commit_short_id.dimmed(),
+                    t.sym().dot.error(),
+                    t.hint.paint(&commit.commit_short_id),
                     commit.commit_message
                 )?;
             }
@@ -443,8 +456,8 @@ fn check_for_new_conflicts_after_rebase(
             writeln!(
                 human_out,
                 "Run {} to see all conflicted commits, or {} to resolve them.",
-                "but status".green(),
-                "but resolve <commit>".green()
+                t.command_suggestion.paint("but status"),
+                t.command_suggestion.paint("but resolve <commit>")
             )?;
         } else if let Some(json_out) = out.for_json() {
             let newly_conflicted_json: Vec<serde_json::Value> = newly_conflicted
@@ -530,6 +543,7 @@ fn find_conflicted_commits(ctx: &mut Context) -> Result<BTreeMap<String, Vec<Con
 
 /// Check for conflicted commits and prompt user to resolve them
 fn check_and_prompt_for_conflicts(ctx: &mut Context, out: &mut OutputChannel) -> Result<()> {
+    let t = theme::get();
     // Find all conflicted commits
     let conflicts_by_branch = find_conflicted_commits(ctx)?;
 
@@ -542,19 +556,28 @@ fn check_and_prompt_for_conflicts(ctx: &mut Context, out: &mut OutputChannel) ->
 
     // We have conflicts - show them grouped by branch
     if out.for_human().is_some() {
-        writeln!(progress, "{}", "Found conflicted commits:".yellow().bold())?;
+        writeln!(
+            progress,
+            "{}",
+            t.attention.paint("Found conflicted commits:")
+        )?;
         writeln!(progress)?;
 
         let mut all_commits: Vec<&ConflictedCommit> = vec![];
 
         for (branch_name, commits) in &conflicts_by_branch {
-            writeln!(progress, "{} {}", "Branch:".bold(), branch_name.green())?;
+            writeln!(
+                progress,
+                "{} {}",
+                t.important.paint("Branch:"),
+                t.local_branch.paint(branch_name)
+            )?;
             for commit in commits {
                 writeln!(
                     progress,
                     "  {} {} {}",
-                    "●".red(),
-                    commit.commit_short_id.dimmed(),
+                    t.sym().dot.error(),
+                    t.hint.paint(&commit.commit_short_id),
                     commit.commit_message
                 )?;
                 all_commits.push(commit);
@@ -566,7 +589,8 @@ fn check_and_prompt_for_conflicts(ctx: &mut Context, out: &mut OutputChannel) ->
         writeln!(
             progress,
             "{}",
-            "Would you like to start resolving these conflicts?".bold()
+            t.important
+                .paint("Would you like to start resolving these conflicts?")
         )?;
 
         // Find the bottom-most commit (first in topological order) on the first branch
@@ -579,7 +603,7 @@ fn check_and_prompt_for_conflicts(ctx: &mut Context, out: &mut OutputChannel) ->
             inout
                 .prompt(format!(
                     "Enter commit ID to resolve [default: {}]",
-                    default.commit_short_id.cyan()
+                    t.commit_id.paint(&default.commit_short_id)
                 ))?
                 .unwrap_or_else(|| default.commit_short_id.clone())
                 .into()
@@ -621,66 +645,99 @@ fn check_and_prompt_for_conflicts(ctx: &mut Context, out: &mut OutputChannel) ->
 }
 
 fn show_workflow_help(out: &mut OutputChannel) -> Result<()> {
+    let t = theme::get();
     if let Some(out) = out.for_human() {
-        writeln!(out, "{}", "Conflict Resolution Workflow".bold().underline())?;
+        writeln!(out, "{}", t.important.paint("Conflict Resolution Workflow"))?;
         writeln!(out)?;
         writeln!(
             out,
             "This command is used when you have a commit in a conflicted state"
         )?;
         writeln!(out)?;
-        writeln!(out, "{}", "To resolve conflicts in a commit:".bold())?;
+        writeln!(
+            out,
+            "{}",
+            t.important.paint("To resolve conflicts in a commit:")
+        )?;
         writeln!(out)?;
         writeln!(
             out,
             "  {} Enter resolution mode for a conflicted commit:",
-            "1.".bold()
+            t.important.paint("1.")
         )?;
-        writeln!(out, "     {}", "but resolve <commit>".green())?;
+        writeln!(
+            out,
+            "     {}",
+            t.command_suggestion.paint("but resolve <commit>")
+        )?;
         writeln!(out)?;
         writeln!(
             out,
             "  {} Resolve conflicts in the conflicted files",
-            "2.".bold()
+            t.important.paint("2.")
         )?;
         writeln!(
             out,
             "     Edit the files to remove conflict markers ({}, {}, {})",
-            "<<<<<<<".red(),
-            "=======".yellow(),
-            ">>>>>>>".red()
+            t.error.paint("<<<<<<<"),
+            t.attention.paint("======="),
+            t.error.paint(">>>>>>>")
         )?;
         writeln!(out)?;
         writeln!(
             out,
             "  {} Check which files are still conflicted:",
-            "3.".bold()
+            t.important.paint("3.")
         )?;
-        writeln!(out, "     {}", "but resolve status".green())?;
+        writeln!(
+            out,
+            "     {}",
+            t.command_suggestion.paint("but resolve status")
+        )?;
         writeln!(out)?;
-        writeln!(out, "  {} Finalize or cancel the resolution:", "4.".bold())?;
-        writeln!(out, "     {}", "but resolve finish".green())?;
-        writeln!(out, "     {}", "OR".dimmed())?;
-        writeln!(out, "     {}", "but resolve cancel".green())?;
+        writeln!(
+            out,
+            "  {} Finalize or cancel the resolution:",
+            t.important.paint("4.")
+        )?;
+        writeln!(
+            out,
+            "     {}",
+            t.command_suggestion.paint("but resolve finish")
+        )?;
+        writeln!(out, "     {}", t.hint.paint("OR"))?;
+        writeln!(
+            out,
+            "     {}",
+            t.command_suggestion.paint("but resolve cancel")
+        )?;
         writeln!(out)?;
-        writeln!(out, "{}", "Example:".bold())?;
-        writeln!(out, "  {} (find conflicted commits)", "but status".green())?;
+        writeln!(out, "{}", t.important.paint("Example:"))?;
+        writeln!(
+            out,
+            "  {} (find conflicted commits)",
+            t.command_suggestion.paint("but status")
+        )?;
         writeln!(
             out,
             "  {} (enter resolution mode)",
-            "but resolve 55".green()
+            t.command_suggestion.paint("but resolve 55")
         )?;
         writeln!(
             out,
             "  {} (edit files to resolve conflicts)",
-            "vim src/file.rs".dimmed()
+            t.hint.paint("vim src/file.rs")
         )?;
         writeln!(
             out,
             "  {} (check remaining conflicts)",
-            "but resolve status".green()
+            t.command_suggestion.paint("but resolve status")
         )?;
-        writeln!(out, "  {} (finalize)", "but resolve finish".green())?;
+        writeln!(
+            out,
+            "  {} (finalize)",
+            t.command_suggestion.paint("but resolve finish")
+        )?;
     } else if let Some(out) = out.for_json() {
         out.write_value(serde_json::json!({
             "workflow": [

--- a/crates/but/src/command/legacy/rub/amend.rs
+++ b/crates/but/src/command/legacy/rub/amend.rs
@@ -2,12 +2,14 @@ use but_core::{DiffSpec, ref_metadata::StackId};
 use but_ctx::{Context, access::RepoExclusive};
 use but_hunk_assignment::HunkAssignment;
 use but_workspace::commit_engine::{self, CreateCommitOutcome};
-use colored::Colorize;
 use gitbutler_branch_actions::update_workspace_commit;
 use gix::ObjectId;
 use nonempty::NonEmpty;
 
-use crate::utils::{OutputChannel, shorten_object_id, split_short_id};
+use crate::{
+    theme::{self, Paint},
+    utils::{OutputChannel, shorten_object_id, split_short_id},
+};
 
 pub(crate) fn uncommitted_to_commit_with_perm(
     ctx: &mut Context,
@@ -34,7 +36,8 @@ pub(crate) fn uncommitted_to_commit_with_perm(
             .map(|c| {
                 let short = shorten_object_id(&repo, c);
                 let (lead, rest) = split_short_id(&short, 2);
-                format!("{}{}", lead.blue().bold(), rest.blue())
+                let t = theme::get();
+                format!("{}{}", t.cli_id.paint(lead), t.cli_id.paint(rest))
             })
             .unwrap_or_default();
         writeln!(out, "Amended {description} → {new_commit}")?;

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use crate::theme::{self, Paint};
 use anyhow::{Context as _, bail};
 use bstr::BStr;
 use but_api::commit::types::{
@@ -9,7 +10,6 @@ use but_core::{DiffSpec, DryRun, ref_metadata::StackId, sync::RepoExclusive};
 use but_ctx::Context;
 use but_hunk_assignment::{HunkAssignment, HunkAssignmentRequest, HunkAssignmentTarget};
 use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
-use colored::Colorize;
 mod amend;
 mod assign;
 pub(crate) mod squash;
@@ -286,7 +286,10 @@ impl<'a> UncommittedToCommitOperation<'a> {
                 .map(|c| {
                     let short = shorten_object_id(&repo, c);
                     let (lead, rest) = split_short_id(&short, 2);
-                    format!("{}{}", lead.blue().bold(), rest.blue())
+                    {
+                        let t = theme::get();
+                        format!("{}{}", t.cli_id.paint(lead), t.cli_id.paint(rest))
+                    }
                 })
                 .unwrap_or_default();
             writeln!(out, "Amended {} → {new_commit}", self.description)?;
@@ -318,11 +321,12 @@ impl<'a> UncommittedToBranchOperation<'a> {
     pub(crate) fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
         self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
+            let t = theme::get();
             writeln!(
                 out,
                 "Staged {} → {}.",
                 self.description,
-                format!("[{}]", self.name).green()
+                t.local_branch.paint(format!("[{}]", self.name))
             )?;
         } else if let Some(out) = out.for_json() {
             out.write_value(serde_json::json!({"ok": true}))?;
@@ -344,11 +348,12 @@ impl<'a> UncommittedToStackOperation<'a> {
     pub(crate) fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
         self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
+            let t = theme::get();
             writeln!(
                 out,
                 "Staged {} → stack {}.",
                 self.description,
-                format!("[{}]", self.stack_id).green()
+                t.local_branch.paint(format!("[{}]", self.stack_id))
             )?;
         } else if let Some(out) = out.for_json() {
             out.write_value(serde_json::json!({"ok": true}))?;
@@ -371,12 +376,13 @@ impl StackToUnassignedOperation {
     pub(crate) fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
         self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
+            let t = theme::get();
             writeln!(
                 out,
                 "Unstaged all {} changes.",
                 stack_id_to_branch_name(ctx, self.stack_id)
-                    .map(|b| format!("[{b}]").green())
-                    .unwrap_or_else(|| "stack".to_string().bold())
+                    .map(|b| t.local_branch.paint(format!("[{b}]")))
+                    .unwrap_or_else(|| t.important.paint("stack"))
             )?;
         } else if let Some(out) = out.for_json() {
             out.write_value(serde_json::json!({"ok": true}))?;
@@ -395,15 +401,16 @@ impl StackToStackOperation {
     pub(crate) fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
         self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
+            let t = theme::get();
             writeln!(
                 out,
                 "Staged all {} changes to {}.",
                 stack_id_to_branch_name(ctx, self.from)
-                    .map(|b| format!("[{b}]").green())
-                    .unwrap_or_else(|| "stack".to_string().bold()),
+                    .map(|b| t.local_branch.paint(format!("[{b}]")))
+                    .unwrap_or_else(|| t.important.paint("stack")),
                 stack_id_to_branch_name(ctx, self.to)
-                    .map(|b| format!("[{b}]").green())
-                    .unwrap_or_else(|| "stack".to_string().bold())
+                    .map(|b| t.local_branch.paint(format!("[{b}]")))
+                    .unwrap_or_else(|| t.important.paint("stack"))
             )?;
         } else if let Some(out) = out.for_json() {
             out.write_value(serde_json::json!({"ok": true}))?;
@@ -422,13 +429,14 @@ impl<'a> StackToBranchOperation<'a> {
     pub(crate) fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
         self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
+            let t = theme::get();
             writeln!(
                 out,
                 "Staged all {} changes to {}.",
                 stack_id_to_branch_name(ctx, self.from)
-                    .map(|b| format!("[{b}]").green())
-                    .unwrap_or_else(|| "stack".to_string().bold()),
-                format!("[{}]", self.to).green(),
+                    .map(|b| t.local_branch.paint(format!("[{b}]")))
+                    .unwrap_or_else(|| t.important.paint("stack")),
+                t.local_branch.paint(format!("[{}]", self.to)),
             )?;
         } else if let Some(out) = out.for_json() {
             out.write_value(serde_json::json!({"ok": true}))?;
@@ -449,21 +457,25 @@ impl StackToCommitOperation {
     pub(crate) fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
         let result = self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
+            let t = theme::get();
             let repo = ctx.repo.get()?;
             let new_commit = result
                 .new_commit
                 .map(|c| {
                     let short = shorten_object_id(&repo, c);
                     let (lead, rest) = split_short_id(&short, 2);
-                    format!("{}{}", lead.blue().bold(), rest.blue())
+                    {
+                        let t = theme::get();
+                        format!("{}{}", t.cli_id.paint(lead), t.cli_id.paint(rest))
+                    }
                 })
                 .unwrap_or_default();
             writeln!(
                 out,
                 "Amended files assigned to {} → {}",
                 stack_id_to_branch_name(ctx, self.from)
-                    .map(|b| format!("[{b}]").green())
-                    .unwrap_or_else(|| "stack".to_string().bold()),
+                    .map(|b| t.local_branch.paint(format!("[{b}]")))
+                    .unwrap_or_else(|| t.important.paint("stack")),
                 new_commit,
             )?;
         } else if let Some(out) = out.for_json() {
@@ -493,7 +505,10 @@ impl UnassignedToCommitOperation {
                 .map(|c| {
                     let short = shorten_object_id(&repo, c);
                     let (lead, rest) = split_short_id(&short, 2);
-                    format!("{}{}", lead.blue().bold(), rest.blue())
+                    {
+                        let t = theme::get();
+                        format!("{}{}", t.cli_id.paint(lead), t.cli_id.paint(rest))
+                    }
                 })
                 .unwrap_or_default();
             writeln!(out, "Amended unassigned files → {new_commit}")?;
@@ -518,11 +533,12 @@ impl<'a> UnassignedToBranchOperation<'a> {
     pub(crate) fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
         self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
+            let t = theme::get();
             writeln!(
                 out,
                 "Staged all {} changes to {}.",
-                "unstaged".to_string().bold(),
-                format!("[{}]", self.to).green(),
+                t.important.paint("unstaged"),
+                t.local_branch.paint(format!("[{}]", self.to)),
             )?;
         } else if let Some(out) = out.for_json() {
             out.write_value(serde_json::json!({"ok": true}))?;
@@ -542,13 +558,14 @@ impl UnassignedToStackOperation {
     pub(crate) fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
         self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
+            let t = theme::get();
             writeln!(
                 out,
                 "Staged all {} changes to {}.",
-                "unstaged".bold(),
+                t.important.paint("unstaged"),
                 stack_id_to_branch_name(ctx, self.to)
-                    .map(|b| format!("[{b}]").green())
-                    .unwrap_or_else(|| "stack".bold())
+                    .map(|b| t.local_branch.paint(format!("[{b}]")))
+                    .unwrap_or_else(|| t.important.paint("stack"))
             )?;
         } else if let Some(out) = out.for_json() {
             out.write_value(serde_json::json!({"ok": true}))?;
@@ -567,11 +584,12 @@ impl CommitToUnassignedOperation {
     pub(crate) fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
         self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
+            let t = theme::get();
             let repo = ctx.repo.get()?;
             writeln!(
                 out,
                 "Uncommitted {}",
-                shorten_object_id(&repo, self.oid).blue()
+                t.cli_id.paint(shorten_object_id(&repo, self.oid))
             )?;
         } else if let Some(out) = out.for_json() {
             out.write_value(serde_json::json!({"ok": true}))?;
@@ -590,14 +608,15 @@ impl CommitToStackOperation {
     pub(crate) fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
         self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
+            let t = theme::get();
             let repo = ctx.repo.get()?;
             writeln!(
                 out,
                 "Uncommitted {} to {}",
-                shorten_object_id(&repo, self.oid).blue(),
+                t.cli_id.paint(shorten_object_id(&repo, self.oid)),
                 stack_id_to_branch_name(ctx, self.stack)
-                    .map(|b| format!("[{b}]").green())
-                    .unwrap_or_else(|| "stack".bold()),
+                    .map(|b| t.local_branch.paint(format!("[{b}]")))
+                    .unwrap_or_else(|| t.important.paint("stack")),
             )?;
         } else if let Some(out) = out.for_json() {
             out.write_value(serde_json::json!({"ok": true}))?;
@@ -616,12 +635,13 @@ impl SquashCommitsOperation {
     pub(crate) fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
         let result = self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
+            let t = theme::get();
             let repo = ctx.repo.get()?;
             writeln!(
                 out,
                 "Squashed {} → {}",
-                shorten_object_id(&repo, self.source).blue(),
-                shorten_object_id(&repo, result.new_commit).blue(),
+                t.cli_id.paint(shorten_object_id(&repo, self.source)),
+                t.cli_id.paint(shorten_object_id(&repo, result.new_commit)),
             )?;
         } else if let Some(out) = out.for_json() {
             out.write_value(serde_json::json!({
@@ -644,12 +664,13 @@ impl<'a> MoveCommitToBranchOperation<'a> {
     pub(crate) fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
         self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
+            let t = theme::get();
             let repo = ctx.repo.get()?;
             writeln!(
                 out,
                 "Moved {} → {}",
-                shorten_object_id(&repo, self.oid).blue(),
-                format!("[{}]", self.name).green()
+                t.cli_id.paint(shorten_object_id(&repo, self.oid)),
+                t.local_branch.paint(format!("[{}]", self.name))
             )?;
         } else if let Some(out) = out.for_json() {
             out.write_value(serde_json::json!({"ok": true}))?;
@@ -675,10 +696,11 @@ impl<'a> BranchToUnassignedOperation<'a> {
     pub(crate) fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
         self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
+            let t = theme::get();
             writeln!(
                 out,
                 "Unstaged all {} changes.",
-                format!("[{}]", self.from).green(),
+                t.local_branch.paint(format!("[{}]", self.from)),
             )?;
         } else if let Some(out) = out.for_json() {
             out.write_value(serde_json::json!({"ok": true}))?;
@@ -698,13 +720,14 @@ impl<'a> BranchToStackOperation<'a> {
     pub(crate) fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
         self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
+            let t = theme::get();
             writeln!(
                 out,
                 "Staged all {} changes to {}.",
-                format!("[{}]", self.from).green(),
+                t.local_branch.paint(format!("[{}]", self.from)),
                 stack_id_to_branch_name(ctx, self.to)
-                    .map(|b| format!("[{b}]").green())
-                    .unwrap_or_else(|| "stack".to_string().bold()),
+                    .map(|b| t.local_branch.paint(format!("[{b}]")))
+                    .unwrap_or_else(|| t.important.paint("stack")),
             )?;
         } else if let Some(out) = out.for_json() {
             out.write_value(serde_json::json!({"ok": true}))?;
@@ -724,19 +747,23 @@ impl<'a> BranchToCommitOperation<'a> {
     pub(crate) fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
         let result = self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
+            let t = theme::get();
             let repo = ctx.repo.get()?;
             let new_commit = result
                 .new_commit
                 .map(|c| {
                     let short = shorten_object_id(&repo, c);
                     let (lead, rest) = split_short_id(&short, 2);
-                    format!("{}{}", lead.blue().bold(), rest.blue())
+                    {
+                        let t = theme::get();
+                        format!("{}{}", t.cli_id.paint(lead), t.cli_id.paint(rest))
+                    }
                 })
                 .unwrap_or_default();
             writeln!(
                 out,
                 "Amended assigned files {} → {}",
-                format!("[{}]", self.name).green(),
+                t.local_branch.paint(format!("[{}]", self.name)),
                 new_commit,
             )?;
         } else if let Some(out) = out.for_json() {
@@ -764,11 +791,12 @@ impl<'a> BranchToBranchOperation<'a> {
     pub(crate) fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
         self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
+            let t = theme::get();
             writeln!(
                 out,
                 "Staged all {} changes to {}.",
-                format!("[{}]", self.from).green(),
-                format!("[{}]", self.to).green(),
+                t.local_branch.paint(format!("[{}]", self.from)),
+                t.local_branch.paint(format!("[{}]", self.to)),
             )?;
         } else if let Some(out) = out.for_json() {
             out.write_value(serde_json::json!({"ok": true}))?;
@@ -1166,12 +1194,13 @@ pub(crate) fn handle(
 }
 
 fn makes_no_sense_error(source: &CliId, target: &CliId) -> String {
+    let t = theme::get();
     format!(
         "Operation doesn't make sense. Source {} is {} and target {} is {}.",
-        source.to_short_string().blue().bold(),
-        source.kind_for_humans().yellow(),
-        target.to_short_string().blue().bold(),
-        target.kind_for_humans().yellow()
+        t.cli_id.paint(source.to_short_string()),
+        t.attention.paint(source.kind_for_humans()),
+        t.cli_id.paint(target.to_short_string()),
+        t.attention.paint(target.kind_for_humans())
     )
 }
 
@@ -1294,6 +1323,7 @@ pub(crate) fn handle_uncommit(
     source_str: &str,
     discard: bool,
 ) -> anyhow::Result<()> {
+    let t = theme::get();
     let id_map = IdMap::legacy_new_from_context(ctx, None)?;
     let sources = parse_sources_with_disambiguation(ctx, &id_map, source_str, out)?;
 
@@ -1306,8 +1336,8 @@ pub(crate) fn handle_uncommit(
             _ => {
                 bail!(
                     "Cannot uncommit {} - it is {}. Only commits and files-in-commits can be uncommitted.",
-                    source_str.blue().bold(),
-                    source.kind_for_humans().yellow()
+                    t.cli_id.paint(source_str),
+                    t.attention.paint(source.kind_for_humans())
                 );
             }
         }
@@ -1326,7 +1356,7 @@ pub(crate) fn handle_uncommit(
                         writeln!(
                             out,
                             "Discarded {}",
-                            shorten_object_id(&repo, commit_id).blue()
+                            t.cli_id.paint(shorten_object_id(&repo, commit_id))
                         )?;
                     }
                 }
@@ -1366,6 +1396,7 @@ pub(crate) fn handle_amend(
     file_str: &str,
     commit_str: &str,
 ) -> anyhow::Result<()> {
+    let t = theme::get();
     let mut guard = ctx.exclusive_worktree_access();
     let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
     let files = parse_sources_with_disambiguation(ctx, &id_map, file_str, out)?;
@@ -1380,8 +1411,8 @@ pub(crate) fn handle_amend(
             _ => {
                 bail!(
                     "Cannot amend {} - it is {}. Only uncommitted files and hunks can be amended.",
-                    file.to_short_string().blue().bold(),
-                    file.kind_for_humans().yellow()
+                    t.cli_id.paint(file.to_short_string()),
+                    t.attention.paint(file.kind_for_humans())
                 );
             }
         }
@@ -1417,8 +1448,8 @@ pub(crate) fn handle_amend(
         other => {
             bail!(
                 "Cannot amend into {} - it is {}. Target must be a commit.",
-                other.to_short_string().blue().bold(),
-                other.kind_for_humans().yellow()
+                t.cli_id.paint(other.to_short_string()),
+                t.attention.paint(other.kind_for_humans())
             );
         }
     }
@@ -1433,6 +1464,7 @@ pub(crate) fn handle_stage(
     file_or_hunk_str: &str,
     branch_str: &str,
 ) -> anyhow::Result<()> {
+    let t = theme::get();
     let id_map = IdMap::legacy_new_from_context(ctx, None)?;
     let files = parse_sources_with_disambiguation(ctx, &id_map, file_or_hunk_str, out)?;
     let branch = resolve_single_id(ctx, &id_map, branch_str, "Branch", out)?;
@@ -1446,8 +1478,8 @@ pub(crate) fn handle_stage(
             _ => {
                 bail!(
                     "Cannot stage {} - it is {}. Only uncommitted files and hunks can be staged.",
-                    file.to_short_string().blue().bold(),
-                    file.kind_for_humans().yellow()
+                    t.cli_id.paint(file.to_short_string()),
+                    t.attention.paint(file.kind_for_humans())
                 );
             }
         }
@@ -1461,8 +1493,8 @@ pub(crate) fn handle_stage(
         other => {
             bail!(
                 "Cannot stage to {} - it is {}. Target must be a branch.",
-                other.to_short_string().blue().bold(),
-                other.kind_for_humans().yellow()
+                t.cli_id.paint(other.to_short_string()),
+                t.attention.paint(other.kind_for_humans())
             );
         }
     }
@@ -1478,6 +1510,7 @@ pub(crate) fn handle_stage_tui(
     out: &mut OutputChannel,
     branch_str: Option<&str>,
 ) -> anyhow::Result<()> {
+    let t = theme::get();
     use crate::tui::stage_viewer::{StageFileEntry, StageResult};
 
     let id_map = IdMap::legacy_new_from_context(ctx, None)?;
@@ -1490,8 +1523,8 @@ pub(crate) fn handle_stage_tui(
             other => {
                 bail!(
                     "Cannot stage to {} - it is {}. Target must be a branch.",
-                    other.to_short_string().blue().bold(),
-                    other.kind_for_humans().yellow()
+                    t.cli_id.paint(other.to_short_string()),
+                    t.attention.paint(other.kind_for_humans())
                 );
             }
         }
@@ -1563,10 +1596,11 @@ pub(crate) fn handle_stage_tui(
             )?);
             assign::do_assignments(ctx, reqs)?;
             if let Some(out) = out.for_human() {
+                let t = theme::get();
                 writeln!(
                     out,
                     "Staged selected hunks → {}.",
-                    format!("[{branch_name}]").green()
+                    t.local_branch.paint(format!("[{branch_name}]"))
                 )?;
             }
             Ok(())
@@ -1589,6 +1623,7 @@ pub(crate) fn handle_unstage(
     file_or_hunk_str: &str,
     branch_str: Option<&str>,
 ) -> anyhow::Result<()> {
+    let t = theme::get();
     let id_map = IdMap::legacy_new_from_context(ctx, None)?;
     let files = parse_sources_with_disambiguation(ctx, &id_map, file_or_hunk_str, out)?;
 
@@ -1601,8 +1636,8 @@ pub(crate) fn handle_unstage(
             _ => {
                 bail!(
                     "Cannot unstage {} - it is {}. Only uncommitted files and hunks can be unstaged.",
-                    file.to_short_string().blue().bold(),
-                    file.kind_for_humans().yellow()
+                    t.cli_id.paint(file.to_short_string()),
+                    t.attention.paint(file.kind_for_humans())
                 );
             }
         }
@@ -1618,8 +1653,8 @@ pub(crate) fn handle_unstage(
             other => {
                 bail!(
                     "Cannot unstage from {} - it is {}. Target must be a branch.",
-                    other.to_short_string().blue().bold(),
-                    other.kind_for_humans().yellow()
+                    t.cli_id.paint(other.to_short_string()),
+                    t.attention.paint(other.kind_for_humans())
                 );
             }
         }

--- a/crates/but/src/command/legacy/rub/squash.rs
+++ b/crates/but/src/command/legacy/rub/squash.rs
@@ -4,12 +4,13 @@ use anyhow::{Context as _, bail};
 use bstr::BString;
 use but_core::{DryRun, ref_metadata::StackId, sync::RepoExclusive};
 use but_ctx::Context;
-use colored::Colorize;
 use gitbutler_oplog::{
     OplogExt,
     entry::{OperationKind, SnapshotDetails},
 };
 use gix::ObjectId;
+
+use crate::theme::{self, Paint};
 
 use super::undo::stack_id_by_commit_id;
 use crate::{
@@ -166,8 +167,8 @@ fn handle_multi_commit_squash(
             other => {
                 bail!(
                     "Cannot squash {} - it is {}. All arguments must be commits.",
-                    other.to_short_string().blue().bold(),
-                    other.kind_for_humans().yellow()
+                    theme::get().cli_id.paint(other.to_short_string()),
+                    theme::get().attention.paint(other.kind_for_humans())
                 );
             }
         }
@@ -343,6 +344,7 @@ fn squash_commits_internal(
     };
 
     // Output message based on context
+    let t = theme::get();
     if let Some(out) = out.for_human() {
         let repo = ctx.repo.get()?;
         let final_short = shorten_object_id(&repo, final_commit_oid);
@@ -351,8 +353,8 @@ fn squash_commits_internal(
             writeln!(
                 out,
                 "Squashed {} → {}",
-                shorten_object_id(&repo, source_oids[0]).blue(),
-                final_short.blue()
+                t.cli_id.paint(shorten_object_id(&repo, source_oids[0])),
+                t.cli_id.paint(&final_short)
             )?
         } else {
             // Multiple commits squash
@@ -360,7 +362,7 @@ fn squash_commits_internal(
                 out,
                 "Squashed {} commits → {}",
                 source_oids.len(),
-                final_short.blue()
+                t.cli_id.paint(&final_short)
             )?
         }
     } else if let Some(out) = out.for_json() {
@@ -435,11 +437,12 @@ fn squash_branch_commits(
     )?;
 
     // Add branch-specific output message
+    let t = theme::get();
     if let Some(out) = out.for_human() {
         writeln!(
             out,
             "Squashed all commits in branch '{}'",
-            branch_name.blue()
+            t.local_branch.paint(branch_name)
         )?
     }
     Ok(())

--- a/crates/but/src/command/legacy/setup.rs
+++ b/crates/but/src/command/legacy/setup.rs
@@ -50,7 +50,7 @@ fn display_splash_screen(out: &mut dyn std::fmt::Write) -> anyhow::Result<()> {
     writeln!(
         out,
         "{}",
-        t.progress.paint(
+        t.info.paint(
             r#"
  ██████▄      ▄██████    ██████╗ ██╗   ██╗████████╗
  ██▀▀▀▀██▄  ▄██▀▀▀▀██    ██╔══██╗██║   ██║╚══██╔══╝

--- a/crates/but/src/command/legacy/setup.rs
+++ b/crates/but/src/command/legacy/setup.rs
@@ -5,10 +5,12 @@ use but_core::{
     sync::{RepoExclusive, RepoShared},
 };
 use but_ctx::Context;
-use colored::Colorize;
 use serde::Serialize;
 
-use crate::utils::OutputChannel;
+use crate::{
+    theme::{self, Paint},
+    utils::OutputChannel,
+};
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -43,64 +45,66 @@ struct TargetInfo {
 
 /// Display a colorful splash screen with GitButler branding and helpful commands
 fn display_splash_screen(out: &mut dyn std::fmt::Write) -> anyhow::Result<()> {
+    let t = theme::get();
     writeln!(out)?;
     writeln!(
         out,
         "{}",
-        r#"
+        t.progress.paint(
+            r#"
  ██████▄      ▄██████    ██████╗ ██╗   ██╗████████╗
  ██▀▀▀▀██▄  ▄██▀▀▀▀██    ██╔══██╗██║   ██║╚══██╔══╝
  ██     ▀████▀     ██    ██████╔╝██║   ██║   ██║
  ██▄▄▄▄██▀  ▀██▄▄▄▄██    ██╔══██╗██║   ██║   ██║
  ██████▀      ▀██████    ██████╔╝╚██████╔╝   ██║
 "#
-        .cyan()
-        .bold()
+        )
     )?;
 
     writeln!(
         out,
         "{}",
-        "The command-line interface for GitButler".dimmed()
+        t.hint.paint("The command-line interface for GitButler")
     )?;
     writeln!(out)?;
 
     writeln!(
         out,
         "{:<45} {}",
-        "$ but branch new <name>".bright_blue(),
-        "Create a new branch".dimmed()
+        t.command_suggestion.paint("$ but branch new <name>"),
+        t.hint.paint("Create a new branch")
     )?;
     writeln!(
         out,
         "{:<45} {}",
-        "$ but status".bright_blue(),
-        "View workspace status".dimmed()
+        t.command_suggestion.paint("$ but status"),
+        t.hint.paint("View workspace status")
     )?;
     writeln!(
         out,
         "{:<45} {}",
-        "$ but commit -m <message>".bright_blue(),
-        "Commit changes to current branch".dimmed()
+        t.command_suggestion.paint("$ but commit -m <message>"),
+        t.hint.paint("Commit changes to current branch")
     )?;
     writeln!(
         out,
         "{:<45} {}",
-        "$ but push".bright_blue(),
-        "Push all branches".dimmed()
+        t.command_suggestion.paint("$ but push"),
+        t.hint.paint("Push all branches")
     )?;
     writeln!(
         out,
         "{:<45} {}",
-        "$ but teardown".bright_blue(),
-        "Return to normal Git mode".dimmed()
+        t.command_suggestion.paint("$ but teardown"),
+        t.hint.paint("Return to normal Git mode")
     )?;
     writeln!(out)?;
 
     writeln!(
         out,
         "{}",
-        "Learn more at https://docs.gitbutler.com/cli-overview".dimmed()
+        t.hint
+            .paint("Learn more at https://docs.gitbutler.com/cli-overview")
     )?;
     writeln!(out)?;
 
@@ -113,6 +117,7 @@ pub fn find_or_initialize_repo(
     out: &mut OutputChannel,
     init: bool,
 ) -> anyhow::Result<gix::Repository> {
+    let t = theme::get();
     match gix::open(repo_path) {
         Ok(repo) => Ok(repo),
         Err(_) => {
@@ -122,7 +127,8 @@ pub fn find_or_initialize_repo(
                     writeln!(
                         out,
                         "{}",
-                        "No git repository found. Initializing new repository...".dimmed()
+                        t.hint
+                            .paint("No git repository found. Initializing new repository...")
                     )?;
                 }
                 let repo = gix::init(repo_path)?;
@@ -131,7 +137,8 @@ pub fn find_or_initialize_repo(
                     writeln!(
                         out,
                         "{}",
-                        "✓ Initialized repository with empty commit".green()
+                        t.success
+                            .paint("✓ Initialized repository with empty commit")
                     )?;
                     writeln!(out)?;
                 }
@@ -146,7 +153,8 @@ pub fn find_or_initialize_repo(
                             writeln!(
                                 out,
                                 "{}",
-                                format!("Failed to initialize repository: {e}").red()
+                                t.error
+                                    .paint(format!("Failed to initialize repository: {e}"))
                             )?;
                         }
                         anyhow::bail!(
@@ -168,6 +176,7 @@ pub(crate) fn repo(
     out: &mut OutputChannel,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<()> {
+    let t = theme::get();
     let mut target_info: Option<TargetInfo> = None;
 
     // what branch is head() pointing to?
@@ -182,14 +191,17 @@ pub(crate) fn repo(
 
     // find or setup the gitbutler project
     if let Some(out) = out.for_human() {
-        writeln!(out, "{}", "Setting up GitButler project...".cyan())?;
+        writeln!(
+            out,
+            "{}",
+            t.progress.paint("Setting up GitButler project...")
+        )?;
         writeln!(out)?;
         writeln!(
             out,
             "{}",
-            "→ Adding repository to GitButler project registry"
-                .to_string()
-                .dimmed()
+            t.hint
+                .paint("→ Adding repository to GitButler project registry")
         )?;
     }
 
@@ -202,7 +214,7 @@ pub(crate) fn repo(
                 writeln!(
                     out,
                     "  {}",
-                    "✓ Repository added to project registry".green()
+                    t.success.paint("✓ Repository added to project registry")
                 )?;
             }
             Ok(ProjectStatus::Added)
@@ -212,7 +224,7 @@ pub(crate) fn repo(
                 writeln!(
                     out,
                     "  {}",
-                    "✓ Repository already in project registry".green()
+                    t.success.paint("✓ Repository already in project registry")
                 )?;
             }
             Ok(ProjectStatus::AlreadyExists)
@@ -261,7 +273,11 @@ pub(crate) fn repo(
         // Step 2: Determine remote
         if let Some(out) = out.for_human() {
             writeln!(out)?;
-            writeln!(out, "{}", "→ Configuring default target branch".dimmed())?;
+            writeln!(
+                out,
+                "{}",
+                t.hint.paint("→ Configuring default target branch")
+            )?;
         }
 
         let mut repo = ctx.repo.get_mut()?;
@@ -271,7 +287,8 @@ pub(crate) fn repo(
                     writeln!(
                         out,
                         "  {}",
-                        format!("✓ Using existing push remote: {name}").green()
+                        t.success
+                            .paint(format!("✓ Using existing push remote: {name}"))
                     )?;
                 }
                 name.to_string()
@@ -301,8 +318,9 @@ pub(crate) fn repo(
                         writeln!(
                             out,
                             "  {}",
-                            format!("✓ No remote HEAD found, using {remote_name}/{branch}")
-                                .yellow()
+                            t.attention.paint(format!(
+                                "✓ No remote HEAD found, using {remote_name}/{branch}"
+                            ))
                         )?;
                     }
                     format!("{remote_name}/{branch}")
@@ -332,16 +350,16 @@ pub(crate) fn repo(
             writeln!(
                 out,
                 "  {}",
-                format!("✓ Set default target to: {name}").green()
+                t.success.paint(format!("✓ Set default target to: {name}"))
             )?;
             writeln!(out)?;
             writeln!(
                 out,
                 "{}",
-                "GitButler project setup complete!".green().bold()
+                t.success.paint("GitButler project setup complete!")
             )?;
-            writeln!(out, "{}", format!("Target branch: {name}").dimmed())?;
-            writeln!(out, "{}", format!("Remote: {remote_name}").dimmed())?;
+            writeln!(out, "{}", t.hint.paint(format!("Target branch: {name}")))?;
+            writeln!(out, "{}", t.hint.paint(format!("Remote: {remote_name}")))?;
             writeln!(out)?;
         }
     } else {
@@ -359,13 +377,14 @@ pub(crate) fn repo(
             writeln!(
                 out,
                 "{}",
-                "GitButler project is already set up!".green().bold()
+                t.success.paint("GitButler project is already set up!")
             )?;
             if let Some(target) = target {
                 writeln!(
                     out,
                     "{}",
-                    format!("Target branch: {}", target.branch_name).dimmed()
+                    t.hint
+                        .paint(format!("Target branch: {}", target.branch_name))
                 )?;
             }
             writeln!(out)?;
@@ -393,7 +412,9 @@ pub(crate) fn repo(
         writeln!(
             out,
             "  {}",
-            format!("Warning: Failed to install GitButler managed hooks: {e}").yellow()
+            t.attention.paint(format!(
+                "Warning: Failed to install GitButler managed hooks: {e}"
+            ))
         )?;
     }
 
@@ -404,7 +425,7 @@ pub(crate) fn repo(
         writeln!(
             out,
             "{}",
-            format!(
+            t.attention.paint(format!(
                 r#"
 Setting up your project for GitButler tooling. Some things to note:
 
@@ -418,8 +439,7 @@ To undo these changes and return to normal Git mode, either:
 
 More info: https://docs.gitbutler.com/workspace-branch
 "#
-            )
-            .yellow()
+            ))
         )?;
     }
 
@@ -492,6 +512,7 @@ pub fn check_project_setup(ctx: &Context, perm: &RepoShared) -> anyhow::Result<b
 
 /// Creates a 'gb-local' remote pointing to this repository and creates tracking refs for the default branch.
 fn setup_local_remote(repo: &gix::Repository, out: &mut OutputChannel) -> anyhow::Result<String> {
+    let t = theme::get();
     let repo_url = repo
         .workdir()
         .ok_or_else(|| anyhow::anyhow!("Repository has no working directory"))?
@@ -502,7 +523,8 @@ fn setup_local_remote(repo: &gix::Repository, out: &mut OutputChannel) -> anyhow
         writeln!(
             out,
             "  {}",
-            "No push remote found, creating gb-local remote...".blue()
+            t.info
+                .paint("No push remote found, creating gb-local remote...")
         )?;
     }
 
@@ -557,7 +579,9 @@ fn setup_local_remote(repo: &gix::Repository, out: &mut OutputChannel) -> anyhow
         writeln!(
             out,
             "  {}",
-            format!("✓ Created gb-local remote tracking {default_branch_name}").green()
+            t.success.paint(format!(
+                "✓ Created gb-local remote tracking {default_branch_name}"
+            ))
         )?;
     }
 
@@ -566,6 +590,7 @@ fn setup_local_remote(repo: &gix::Repository, out: &mut OutputChannel) -> anyhow
 
 /// Sets up a new git repository and creates an initial empty commit.
 fn setup_new_repo(current_dir: &Path, out: &mut OutputChannel) -> anyhow::Result<gix::Repository> {
+    let t = theme::get();
     use std::fmt::Write as FmtWrite;
 
     let mut progress = out.progress_channel();
@@ -573,18 +598,20 @@ fn setup_new_repo(current_dir: &Path, out: &mut OutputChannel) -> anyhow::Result
         writeln!(
             &mut progress as &mut dyn FmtWrite,
             "{}",
-            "No git repository found.".red()
+            t.error.paint("No git repository found.")
         )?;
 
         let input = inout.prompt(format!(
             "Would you like to initialize a new one?\n{}\n[y/N]",
-            "(this will also create an empty first commit)".dimmed()
+            t.hint
+                .paint("(this will also create an empty first commit)")
         ))?;
         if input.as_deref() == Some("y") {
             writeln!(
                 &mut progress as &mut dyn FmtWrite,
                 "{}",
-                "Initializing new repository and creating an empty first commit...".dimmed()
+                t.hint
+                    .paint("Initializing new repository and creating an empty first commit...")
             )?;
             let repo = gix::init(current_dir)?;
 
@@ -593,7 +620,8 @@ fn setup_new_repo(current_dir: &Path, out: &mut OutputChannel) -> anyhow::Result
             writeln!(
                 &mut progress as &mut dyn FmtWrite,
                 "{}",
-                "Initialized a new repository and created an empty first commit.\n".green()
+                t.success
+                    .paint("Initialized a new repository and created an empty first commit.\n")
             )?;
             return Ok(repo);
         }

--- a/crates/but/src/command/legacy/teardown.rs
+++ b/crates/but/src/command/legacy/teardown.rs
@@ -1,11 +1,13 @@
 use anyhow::Context as _;
 use but_ctx::Context;
 use but_workspace::legacy::StacksFilter;
-use colored::Colorize;
 use gix::refs::transaction::PreviousValue;
 use serde::Serialize;
 
-use crate::utils::{OutputChannel, shorten_object_id};
+use crate::{
+    theme::{self, Paint},
+    utils::{OutputChannel, shorten_object_id},
+};
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -15,6 +17,7 @@ struct TeardownResult {
 }
 
 pub(crate) fn teardown(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
+    let t = theme::get();
     // Check that we're on gitbutler/workspace
     let head_name = {
         let repo = ctx.repo.get()?;
@@ -29,26 +32,29 @@ pub(crate) fn teardown(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Re
             writeln!(
                 out,
                 "{}",
-                format!("Not currently on gitbutler/workspace branch (on: {head_name}).").red()
+                t.error.paint(format!(
+                    "Not currently on gitbutler/workspace branch (on: {head_name})."
+                ))
             )?;
             writeln!(out)?;
             writeln!(
                 out,
                 "{}",
-                "Teardown can only be run while on the gitbutler/workspace branch.".dimmed()
+                t.hint
+                    .paint("Teardown can only be run while on the gitbutler/workspace branch.")
             )?;
         }
         anyhow::bail!("Not on gitbutler/workspace branch");
     }
 
     if let Some(out) = out.for_human() {
-        writeln!(out, "{}", "Exiting GitButler mode...".cyan().bold())?;
+        writeln!(out, "{}", t.progress.paint("Exiting GitButler mode..."))?;
         writeln!(out)?;
     }
 
     // Create an oplog snapshot
     if let Some(out) = out.for_human() {
-        writeln!(out, "{}", "→ Creating snapshot...".dimmed())?;
+        writeln!(out, "{}", t.hint.paint("→ Creating snapshot..."))?;
     }
 
     let snapshot = but_api::legacy::oplog::create_snapshot(
@@ -64,7 +70,8 @@ pub(crate) fn teardown(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Re
         writeln!(
             out,
             "  {}",
-            format!("✓ Snapshot created: {snapshot_short}").green()
+            t.success
+                .paint(format!("✓ Snapshot created: {snapshot_short}"))
         )?;
         writeln!(out)?;
     }
@@ -74,7 +81,7 @@ pub(crate) fn teardown(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Re
         writeln!(
             out,
             "{}",
-            "→ Finding active branch to check out...".dimmed()
+            t.hint.paint("→ Finding active branch to check out...")
         )?;
     }
 
@@ -107,7 +114,8 @@ pub(crate) fn teardown(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Re
         writeln!(
             out,
             "  {}",
-            format!("✓ Will check out: {target_branch_name}").green()
+            t.success
+                .paint(format!("✓ Will check out: {target_branch_name}"))
         )?;
         writeln!(out)?;
     }
@@ -120,7 +128,8 @@ pub(crate) fn teardown(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Re
         writeln!(
             out,
             "  {}",
-            format!("Warning: Failed to uninstall Git hooks: {e}").yellow()
+            t.attention
+                .paint(format!("Warning: Failed to uninstall Git hooks: {e}"))
         )?;
     }
 
@@ -129,7 +138,8 @@ pub(crate) fn teardown(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Re
         writeln!(
             out,
             "{}",
-            format!("→ Checking out {target_branch_name}...").dimmed()
+            t.hint
+                .paint(format!("→ Checking out {target_branch_name}..."))
         )?;
     }
 
@@ -153,7 +163,7 @@ pub(crate) fn teardown(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Re
             writeln!(
                 out,
                 "  {}",
-                "⚠ Checkout failed, trying soft reset...\n  ⚠ This will leave changes from multiple branches in your working directory.\n  ⚠ You will have to manually remove, stash or re-commit the changes.".yellow()
+                t.attention.paint("⚠ Checkout failed, trying soft reset...\n  ⚠ This will leave changes from multiple branches in your working directory.\n  ⚠ You will have to manually remove, stash or re-commit the changes.")
             )?;
         }
 
@@ -174,7 +184,8 @@ pub(crate) fn teardown(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Re
         writeln!(
             out,
             "  {}",
-            format!("✓ Checked out: {target_branch_name}").green()
+            t.success
+                .paint(format!("✓ Checked out: {target_branch_name}"))
         )?;
         writeln!(out)?;
     }
@@ -184,17 +195,18 @@ pub(crate) fn teardown(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Re
         writeln!(
             out,
             "{}",
-            "✓ Successfully exited GitButler mode!".green().bold()
+            t.success.paint("✓ Successfully exited GitButler mode!")
         )?;
         writeln!(out)?;
         writeln!(
             out,
             "{}",
-            format!("You are now on branch: {target_branch_name}").dimmed()
+            t.hint
+                .paint(format!("You are now on branch: {target_branch_name}"))
         )?;
         writeln!(out)?;
-        writeln!(out, "{}", "To return to GitButler mode, run:".blue())?;
-        writeln!(out, "  {}", "but setup".cyan())?;
+        writeln!(out, "{}", t.info.paint("To return to GitButler mode, run:"))?;
+        writeln!(out, "  {}", t.command_suggestion.paint("but setup"))?;
         writeln!(out)?;
     }
 
@@ -212,11 +224,12 @@ pub(crate) fn teardown(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Re
 // a call to get stacks failed, which could be because someone committed on top
 // of gitbutler/workspace. Try to fix that.
 fn try_stack_fixes(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
+    let t = theme::get();
     if let Some(out) = out.for_human() {
         writeln!(
             out,
             "\n{}",
-            "Attempting to fix workspace stacks...".yellow()
+            t.attention.paint("Attempting to fix workspace stacks...")
         )?;
     }
 
@@ -225,7 +238,11 @@ fn try_stack_fixes(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result
 
     // Look for dangling commits on gitbutler/workspace
     if let Some(out) = out.for_human() {
-        writeln!(out, "{}", "→ Checking for dangling commits...".dimmed())?;
+        writeln!(
+            out,
+            "{}",
+            t.hint.paint("→ Checking for dangling commits...")
+        )?;
     }
 
     let mut workspace_ref = repo.find_reference("refs/heads/gitbutler/workspace")?;
@@ -257,7 +274,7 @@ fn try_stack_fixes(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result
 
     if dangling_commits.is_empty() {
         if let Some(out) = out.for_human() {
-            writeln!(out, "  {}", "✓ No dangling commits found".green())?;
+            writeln!(out, "  {}", t.success.paint("✓ No dangling commits found"))?;
             writeln!(out)?;
         }
     } else {
@@ -268,7 +285,8 @@ fn try_stack_fixes(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result
             writeln!(
                 out,
                 "{}",
-                format!("→ Resetting gitbutler/workspace to {target_short}").dimmed()
+                t.hint
+                    .paint(format!("→ Resetting gitbutler/workspace to {target_short}"))
             )?;
         }
         repo.reference(
@@ -281,7 +299,8 @@ fn try_stack_fixes(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result
             writeln!(
                 out,
                 "  {}",
-                format!("✓ gitbutler/workspace reset to {target_short}").green()
+                t.success
+                    .paint(format!("✓ gitbutler/workspace reset to {target_short}"))
             )?;
         }
 
@@ -292,11 +311,12 @@ fn try_stack_fixes(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result
             writeln!(
                 out,
                 "\n  {}",
-                format!(
-                    "⚠ Non-GitButler created commits found.\n  ⚠ Undoing these commits but keeping the changes in your working directory.\n  ⚠ Uncommitted {} dangling commit(s):",
+                t.attention.paint(format!(
+                    "⚠ Non-GitButler created commits found.
+  ⚠ Undoing these commits but keeping the changes in your working directory.
+  ⚠ Uncommitted {} dangling commit(s):",
                     dangling_commits.len()
-                )
-                .yellow()
+                ))
             )?;
             for commit in &dangling_commits {
                 let message = String::from_utf8_lossy(commit.message_raw().unwrap_or((&[]).into()));

--- a/crates/but/src/command/skill.rs
+++ b/crates/but/src/command/skill.rs
@@ -3,10 +3,13 @@ use std::{fmt::Write as _, path::PathBuf};
 use anyhow::{Context as _, Result};
 use but_ctx::Context;
 use cli_prompts::{DisplayPrompt, prompts::AbortReason};
-use colored::Colorize;
 use serde::Serialize;
 
-use crate::{args::skill, utils::OutputChannel};
+use crate::{
+    args::skill,
+    theme::{self, Paint},
+    utils::OutputChannel,
+};
 
 /// Error type for user-initiated cancellation
 #[derive(Debug, Clone, Copy)]
@@ -493,6 +496,7 @@ fn check_skills(
     local_only: bool,
     auto_update: bool,
 ) -> Result<()> {
+    let t = theme::get();
     // Determine scope
     let (check_global, check_local) = match (global_only, local_only) {
         (true, false) => (true, false),
@@ -523,7 +527,11 @@ fn check_skills(
     // Auto-update if requested (do this before displaying results)
     if auto_update && !outdated_paths.is_empty() {
         let mut progress = out.progress_channel();
-        writeln!(progress, "{}", "Updating outdated skills...".bold())?;
+        writeln!(
+            progress,
+            "{}",
+            t.important.paint("Updating outdated skills...")
+        )?;
         writeln!(progress)?;
 
         for path_str in &outdated_paths {
@@ -548,7 +556,7 @@ fn check_skills(
             writeln!(
                 writer,
                 "{} Run 'but skill check --update' to update outdated skills",
-                "→".yellow().bold()
+                t.sym().arrow.attention()
             )?;
         }
     } else if let Some(json_out) = out.for_json() {
@@ -567,8 +575,13 @@ fn print_human_check_output(
     writer: &mut dyn std::fmt::Write,
     result: &SkillCheckResult,
 ) -> Result<(), anyhow::Error> {
+    let t = theme::get();
     writeln!(writer)?;
-    writeln!(writer, "CLI version: {}", result.cli_version.cyan())?;
+    writeln!(
+        writer,
+        "CLI version: {}",
+        t.config_value.paint(&result.cli_version)
+    )?;
     writeln!(writer)?;
 
     if result.skills.is_empty() {
@@ -587,18 +600,18 @@ fn print_human_check_output(
 
     for skill in &result.skills {
         let status_icon = if skill.up_to_date {
-            "✓".green()
+            t.sym().success.to_string()
         } else {
-            "✗".red()
+            t.sym().error.to_string()
         };
 
         let version_display = if skill.up_to_date {
-            skill.installed_version.green().to_string()
+            t.success.paint(&skill.installed_version)
         } else {
             format!(
                 "{} → {}",
-                skill.installed_version.red(),
-                result.cli_version.green()
+                t.error.paint(&skill.installed_version),
+                t.success.paint(&result.cli_version)
             )
         };
 
@@ -608,7 +621,7 @@ fn print_human_check_output(
             status_icon,
             skill.format_name,
             skill.scope,
-            skill.path.display().to_string().dimmed(),
+            t.hint.paint(skill.path.display().to_string()),
             version_display
         )?;
     }
@@ -616,12 +629,12 @@ fn print_human_check_output(
     writeln!(writer)?;
 
     if result.outdated_count == 0 {
-        writeln!(writer, "{} All skills are up to date!", "✓".green().bold())?;
+        writeln!(writer, "{} All skills are up to date!", t.sym().success)?;
     } else {
         writeln!(
             writer,
             "{} {} skill(s) are outdated",
-            "!".yellow().bold(),
+            t.sym().warning,
             result.outdated_count
         )?;
     }
@@ -714,8 +727,13 @@ fn detect_install_path(ctx: Option<&mut Context>, global: bool) -> Result<PathBu
 }
 
 fn prompt_for_install_scope(progress: &mut impl std::io::Write) -> Result<InstallScope> {
+    let t = theme::get();
     writeln!(progress)?;
-    writeln!(progress, "{}", "Select installation scope:".bold())?;
+    writeln!(
+        progress,
+        "{}",
+        t.important.paint("Select installation scope:")
+    )?;
     writeln!(progress)?;
 
     let prompt = cli_prompts::prompts::Selection::new(
@@ -740,6 +758,7 @@ fn prompt_for_install_path(
     out: &mut OutputChannel,
     progress: &mut impl std::io::Write,
 ) -> Result<PathBuf> {
+    let t = theme::get();
     if out.for_human().is_none() {
         anyhow::bail!(
             "In non-interactive mode, you must specify --path or --detect. Use --path <path> to specify where to install the skill, or --detect to update an existing installation."
@@ -774,13 +793,13 @@ fn prompt_for_install_path(
             writeln!(
                 progress,
                 "{} Not in a git repository. Installing globally in your home directory.",
-                "ℹ".blue()
+                t.info.paint("ℹ")
             )?;
         } else {
             writeln!(
                 progress,
                 "{} Local installs require a repository workdir. Installing globally in your home directory.",
-                "ℹ".blue()
+                t.info.paint("ℹ")
             )?;
         }
         writeln!(progress)?;
@@ -789,7 +808,11 @@ fn prompt_for_install_path(
     let base_dir = get_base_dir(ctx, scope.is_global())?;
 
     writeln!(progress)?;
-    writeln!(progress, "{}", "Select a skill folder format:".bold())?;
+    writeln!(
+        progress,
+        "{}",
+        t.important.paint("Select a skill folder format:")
+    )?;
     writeln!(progress)?;
 
     let available_formats: Vec<&SkillFormat> = SKILL_FORMATS
@@ -809,7 +832,7 @@ fn prompt_for_install_path(
                 "{} - {} ({})",
                 format.name,
                 format.description,
-                full_path.display().to_string().dimmed()
+                t.hint.paint(full_path.display().to_string())
             )
         })
         .collect();
@@ -872,6 +895,7 @@ fn install_skill(
     custom_path: Option<String>,
     detect: bool,
 ) -> Result<()> {
+    let t = theme::get();
     // Validate that embedded files are not empty (catches build issues)
     if SKILL_FILES.iter().any(|f| f.content.is_empty()) {
         anyhow::bail!(
@@ -949,8 +973,8 @@ fn install_skill(
         writeln!(
             progress,
             "{} Skill files already exist at {}",
-            "⚠".yellow(),
-            install_path.display().to_string().cyan()
+            t.sym().warning,
+            t.config_value.paint(install_path.display().to_string())
         )?;
         writeln!(progress, "  Overwriting existing files...")?;
         writeln!(progress)?;
@@ -986,13 +1010,13 @@ fn install_skill(
     writeln!(
         progress,
         "{} GitButler skill installed successfully!",
-        "✓".green().bold()
+        t.sym().success
     )?;
     writeln!(progress)?;
     writeln!(
         progress,
         "  Location: {}",
-        install_path.display().to_string().cyan()
+        t.config_value.paint(install_path.display().to_string())
     )?;
     writeln!(progress)?;
     writeln!(progress, "  Files installed:")?;

--- a/crates/but/src/command/skill.rs
+++ b/crates/but/src/command/skill.rs
@@ -606,7 +606,7 @@ fn print_human_check_output(
         };
 
         let version_display = if skill.up_to_date {
-            t.success.paint(&skill.installed_version)
+            t.success.paint(&skill.installed_version).to_string()
         } else {
             format!(
                 "{} → {}",

--- a/crates/but/src/command/update.rs
+++ b/crates/but/src/command/update.rs
@@ -1,11 +1,13 @@
+use crate::{
+    args::update,
+    theme::{self, Paint},
+    utils::OutputChannel,
+};
 use anyhow::Result;
 #[cfg(all(unix, not(feature = "packaged-but-distribution")))]
 use but_installer::VersionRequest;
 use but_settings::AppSettings;
 use but_update::{AppName, CheckUpdateStatus, check_status};
-use colored::Colorize;
-
-use crate::{args::update, theme, utils::OutputChannel};
 
 pub fn handle(
     cmd: update::Subcommands,
@@ -38,7 +40,7 @@ fn check_for_updates(out: &mut OutputChannel, app_settings: &AppSettings) -> Res
         writeln!(
             writer,
             "{} Another process is currently checking for updates",
-            "→".yellow().bold()
+            theme::get().attention.paint("→")
         )?;
     }
 
@@ -52,7 +54,7 @@ fn print_human_output(writer: &mut dyn std::fmt::Write, status: &CheckUpdateStat
             writer,
             "{} You're running the latest version ({})",
             t.sym().success,
-            status.latest_version.bold()
+            t.important.paint(&status.latest_version)
         )?;
     } else {
         let current_version = option_env!("VERSION").unwrap_or("0.0.0");
@@ -71,10 +73,10 @@ fn print_human_output(writer: &mut dyn std::fmt::Write, status: &CheckUpdateStat
         writeln!(
             writer,
             "{} A new version is available: {} {} {}. {}",
-            "→".yellow().bold(),
-            current_version.dimmed(),
-            "→".dimmed(),
-            status.latest_version.green().bold(),
+            t.attention.paint("→"),
+            t.hint.paint(current_version),
+            t.hint.paint("→"),
+            t.success.paint(&status.latest_version),
             install_hint,
         )?;
 
@@ -90,7 +92,7 @@ fn print_human_output(writer: &mut dyn std::fmt::Write, status: &CheckUpdateStat
         #[cfg(not(target_os = "linux"))]
         if let Some(url) = &status.url {
             writeln!(writer)?;
-            writeln!(writer, "Download: {}", url.cyan())?;
+            writeln!(writer, "Download: {}", t.link.paint(url.as_str()))?;
         }
     }
 
@@ -169,11 +171,13 @@ fn install(out: &mut OutputChannel, target: Option<String>) -> Result<()> {
 
     // Show change log link
     if let Some(writer) = out.for_human() {
+        let t = theme::get();
         writeln!(
             writer,
             "{} {}",
-            "→".cyan().bold(),
-            "View release notes: https://gitbutler.com/releases".bold()
+            t.info.paint("→"),
+            t.link
+                .paint("View release notes: https://gitbutler.com/releases")
         )?;
         writeln!(writer)?;
     }

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -61,6 +61,15 @@ const CLI_DATE: CustomFormat = gix::date::time::format::ISO8601;
 
 /// Handle `args` which must be what's passed by `std::env::args_os()`.
 pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
+    {
+        let theme = dirs::config_dir()
+            .map(|dir| dir.join("gitbutler").join("but-theme.json"))
+            .filter(|p| p.exists())
+            .and_then(|p| theme::load(&p).ok())
+            .unwrap_or_default();
+        theme::init(theme);
+    }
+
     let args: Vec<_> = args.collect();
 
     // Check if version is requested
@@ -136,15 +145,6 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
 
     // If no subcommand is provided, but we have source and target, default to rub
     let mut out = OutputChannel::new_with_optional_pager(output_format, use_pager);
-    // Initialize the global color theme, loading from a user config file if present.
-    {
-        let theme = dirs::config_dir()
-            .map(|dir| dir.join("gitbutler").join("but-theme.json"))
-            .filter(|p| p.exists())
-            .and_then(|p| theme::load(&p).ok())
-            .unwrap_or_default();
-        theme::init(theme);
-    }
 
     match args.cmd.take() {
         None if args.source_or_path.is_some() && args.target.is_some() => {

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -34,8 +34,8 @@ use args::{
     metrics, update as update_args, worktree,
 };
 use but_settings::AppSettings;
-use colored::Colorize;
 use gix::date::time::CustomFormat;
+use theme::Paint;
 
 #[cfg(feature = "legacy")]
 use crate::command::legacy::ShowDiffInEditor;
@@ -537,18 +537,20 @@ async fn match_subcommand(
                                 // For human-readable output, show timestamp and message
                                 println!(
                                     "{} {}",
-                                    "Timestamp:".bold(),
-                                    msg.created_at()
-                                        .format("%Y-%m-%d %H:%M:%S")
-                                        .to_string()
-                                        .cyan()
+                                    theme::get().important.paint("Timestamp:"),
+                                    theme::get().time.paint(
+                                        msg.created_at().format("%Y-%m-%d %H:%M:%S").to_string()
+                                    )
                                 );
                                 match msg.content() {
                                     but_claude::MessagePayload::User(input) => {
                                         println!("{}", input.message);
                                     }
                                     _ => {
-                                        println!("{}", "Not a user input message".red());
+                                        println!(
+                                            "{}",
+                                            theme::get().error.paint("Not a user input message")
+                                        );
                                     }
                                 }
                             }
@@ -594,8 +596,9 @@ async fn match_subcommand(
             writeln!(
                 progress,
                 "{}",
-                "Assuming you meant to check for upstream work, running `but pull --check`"
-                    .yellow()
+                theme::get().attention.paint(
+                    "Assuming you meant to check for upstream work, running `but pull --check`"
+                )
             )?;
             let ctx = setup::init_ctx(&args, InitCtxOptions::default(), out)?;
             command::legacy::pull::handle(&ctx, out, true)

--- a/crates/but/src/setup.rs
+++ b/crates/but/src/setup.rs
@@ -1,8 +1,8 @@
 use std::fmt::Write;
 
+use crate::theme::{self, Paint};
 use but_core::sync::LockScope;
 use but_ctx::Context;
-use colored::Colorize;
 use command_group::AsyncCommandGroup;
 
 use crate::{
@@ -387,7 +387,9 @@ fn spawn_background_sync(
         writeln!(
             out,
             "{}",
-            format!("{msg}Initiated a background sync...").dimmed()
+            theme::get()
+                .hint
+                .paint(format!("{msg}Initiated a background sync..."))
         )
         .ok();
     }
@@ -410,7 +412,7 @@ fn prompt_for_setup(out: &mut OutputChannel, message: &str) -> SetupPromptResult
         progress,
         "The current project is not configured to be managed by GitButler.\n"
     );
-    writeln!(progress, "{}\n", message.red()).ok();
+    writeln!(progress, "{}\n", theme::get().error.paint(message)).ok();
 
     // Check if we have an interactive terminal and prompt the user
     let user_declined_in_interactive_mode = if let Some(mut inout) =
@@ -438,7 +440,9 @@ fn prompt_for_setup(out: &mut OutputChannel, message: &str) -> SetupPromptResult
         _ = writeln!(
             progress,
             "{}",
-            "Please run `but setup` to switch to GitButler management.\n".yellow()
+            theme::get()
+                .attention
+                .paint("Please run `but setup` to switch to GitButler management.\n")
         );
     }
 
@@ -453,7 +457,9 @@ fn prompt_for_setup(out: &mut OutputChannel, message: &str) -> SetupPromptResult
         _ = writeln!(
             progress,
             "{}",
-            "Please run `but setup` to switch to GitButler management.\n".yellow()
+            theme::get()
+                .attention
+                .paint("Please run `but setup` to switch to GitButler management.\n")
         );
     };
     SetupPromptResult::Declined
@@ -490,15 +496,15 @@ fn check_workspace_commits_before_init(
             writeln!(
                 writer,
                 "{}",
-                "⚠ Detected commits on top of gitbutler/workspace"
-                    .yellow()
-                    .bold()
+                theme::get()
+                    .attention
+                    .paint("⚠ Detected commits on top of gitbutler/workspace")
             )?;
             writeln!(writer)?;
             writeln!(
                 writer,
                 "{}",
-                "GitButler detected that you have committed directly on the\ngitbutler/workspace branch. To preserve your work and\nfix up things, please run `but teardown`.".dimmed()
+                theme::get().hint.paint("GitButler detected that you have committed directly on the\ngitbutler/workspace branch. To preserve your work and\nfix up things, please run `but teardown`.")
             )?;
             writeln!(writer)?;
         }

--- a/crates/but/src/theme.rs
+++ b/crates/but/src/theme.rs
@@ -274,6 +274,8 @@ pub struct Theme {
     pub user: Style,
     /// Time-related information
     pub time: Style,
+    /// In-progress action labels (e.g. "Pushing...", "Fetching...", "Setting up...").
+    pub progress: Style,
 
     // Layout
     /// Default border style
@@ -395,6 +397,7 @@ impl Theme {
             default: Style::new(),
             user: style_fg(Color::LightYellow),
             time: style_fg(Color::Cyan),
+            progress: style_fg(Color::DarkGray),
 
             // Layout
             border: Style::new().fg(Color::DarkGray),
@@ -463,8 +466,14 @@ pub struct ThemeSymbols {
     pub success: StyledSymbol,
     /// Error state.
     pub error: StyledSymbol,
-    /// Info to the right.
-    pub info_right: StyledSymbol,
+    /// Warning indicator.
+    pub warning: StyledSymbol,
+    /// Generic dot marker — use `.success()`/`.attention()`/`.error()`/`.info()` for context.
+    pub dot: StyledSymbol,
+    /// Arrow indicator.
+    pub arrow: StyledSymbol,
+    /// Force / lightning indicator.
+    pub lightning: StyledSymbol,
 }
 
 impl ThemeSymbols {
@@ -472,7 +481,10 @@ impl ThemeSymbols {
         Self {
             success: StyledSymbol::new("✓", t.success.add_modifier(Modifier::BOLD)),
             error: StyledSymbol::new("✗", t.error.add_modifier(Modifier::BOLD)),
-            info_right: StyledSymbol::new("→", t.info),
+            warning: StyledSymbol::new("⚠", t.attention.add_modifier(Modifier::BOLD)),
+            dot: StyledSymbol::new("●", t.default),
+            arrow: StyledSymbol::new("→", t.hint),
+            lightning: StyledSymbol::new("⚡", t.attention.add_modifier(Modifier::BOLD)),
         }
     }
 }
@@ -497,6 +509,30 @@ impl StyledSymbol {
     /// Convert the [`StyledSymbol`] into a styled [`Span`].
     pub fn span(&self) -> Span<'_> {
         Span::styled(&self.content, self.style)
+    }
+
+    /// Return a new symbol styled for success.
+    pub fn success(&self) -> StyledSymbol {
+        let t = get();
+        StyledSymbol::new(&self.content, t.success.add_modifier(Modifier::BOLD))
+    }
+
+    /// Return a new symbol styled for attention / warning.
+    pub fn attention(&self) -> StyledSymbol {
+        let t = get();
+        StyledSymbol::new(&self.content, t.attention.add_modifier(Modifier::BOLD))
+    }
+
+    /// Return a new symbol styled for error.
+    pub fn error(&self) -> StyledSymbol {
+        let t = get();
+        StyledSymbol::new(&self.content, t.error.add_modifier(Modifier::BOLD))
+    }
+
+    /// Return a new symbol styled for info.
+    pub fn info(&self) -> StyledSymbol {
+        let t = get();
+        StyledSymbol::new(&self.content, t.info.add_modifier(Modifier::BOLD))
     }
 }
 

--- a/crates/but/src/theme.rs
+++ b/crates/but/src/theme.rs
@@ -83,24 +83,25 @@ pub fn load(path: &Path) -> anyhow::Result<Theme> {
 /// writeln!(out, "{}", t.local_branch.paint(&name))?;
 /// ```
 pub trait Paint {
-    /// Apply this style to `text`, producing a [`String`] with ANSI escape codes baked in.
+    /// Apply this style to `text`, producing a [`ColoredString`] which can be used by the one-shot
+    /// CLI to output ANSI escape code formatted strings.
     ///
-    /// Each paint application produces an independently styled [`String`] in the sense that it is
-    /// terminated with a reset code.
+    /// Each paint application produces an independently styled [`ColoredString`] that respects its
+    /// surrounding during formatting. That is to say, you can nest paint applications and it will
+    /// work as expected, with the outer style resuming where the nested style ends.
     ///
-    /// Note that at this time, any implementation _must_ respect the control mechanisms via
-    /// [`colored::control::SHOULD_COLORIZE`] for enabling/disabling styled output. If we require
-    /// multiple implementations of this trait in the future, we'll probably want to roll our own
-    /// control mechanism.
-    fn paint<S: AsRef<str>>(&self, text: S) -> String;
+    /// Note: The reason we return [`ColoredString`] here instead of directly formatting a
+    /// [`String`] is that the former allows for formatting without accounting for the escape codes,
+    /// making it much easier to align with padding and the like.
+    fn paint<S: AsRef<str>>(&self, text: S) -> ColoredString;
 }
 
 impl Paint for Style {
-    fn paint<S: AsRef<str>>(&self, text: S) -> String {
+    fn paint<S: AsRef<str>>(&self, text: S) -> ColoredString {
         // This is technically unnecessary as `colored` performs this check internally, it's just
         // here for clarity of intent
         if !colored::control::SHOULD_COLORIZE.should_colorize() {
-            return text.as_ref().to_string();
+            return text.as_ref().into();
         }
 
         let mut styled = text.as_ref().normal();
@@ -113,7 +114,7 @@ impl Paint for Style {
         }
         styled = apply_modifiers(styled, self.add_modifier);
 
-        styled.to_string()
+        styled
     }
 }
 

--- a/crates/but/tests/theme.rs
+++ b/crates/but/tests/theme.rs
@@ -14,7 +14,7 @@ fn paint_produces_self_contained_string_styling() {
     let style = ratatui::style::Style::new()
         .fg(ratatui::style::Color::Green)
         .add_modifier(ratatui::style::Modifier::BOLD);
-    let result = but::theme::Paint::paint(&style, "hello");
+    let result = but::theme::Paint::paint(&style, "hello").to_string();
 
     let bold_green = "\x1b[1;32m";
     let reset = "\x1b[0m";
@@ -34,7 +34,7 @@ fn paint_respects_colored_control_disable() {
     let style = ratatui::style::Style::new()
         .fg(ratatui::style::Color::Green)
         .add_modifier(ratatui::style::Modifier::BOLD);
-    let result = but::theme::Paint::paint(&style, "hello");
+    let result = but::theme::Paint::paint(&style, "hello").to_string();
 
     assert_eq!(result, "hello");
 


### PR DESCRIPTION
## 🧢 Changes
Applies the theme to the remaining commands.

I had to revert `Paint::paint()` to return a `colored::ColoredString` as it is formatting-aware, and let's you easily format output without needing to consider the ANSI escape codes. With raw strings directly embedding the ANSI escape codes, they become part of the string lengths, making it difficult to align them precisely.

## ☕️ Reasoning