### PR TITLE
but: replace misleading `--run-hooks` with `--no-hooks` on push/pr

### DIFF
--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -420,7 +420,7 @@ but push <branch-id>          # Push specific branch
 but push --dry-run            # Preview what would be pushed
 but push --with-force         # Force push (use carefully!)
 but push -s                   # Skip force push protection checks
-but push -r                   # Run pre-push hooks
+but push --no-hooks           # Bypass pre-push hooks
 ```
 
 ### `but pull`
@@ -443,11 +443,13 @@ but pr new <branch-id>        # Push branch and create PR (recommended)
 but pr new <branch-id> -F pr_message.txt    # Use file: first line is title, rest is description
 but pr new <branch-id> -m "Title..."        # Inline message: first line is title, rest is description
 but pr new <branch-id> -t     # Use default content (commit message), skip prompts
+but pr new <branch-id> --no-hooks  # Bypass pre-push hooks
 but pr                        # Create PR (prompts for branch)
 but pr template               # Configure PR description template
 ```
 
-**Key behavior:** `but pr new` automatically pushes the branch to remote before creating the PR. No need to run `but push` first. Force push (`--with-force`) and pre-push hooks (`--run-hooks`) are enabled by default.
+**Key behavior:** `but pr new` automatically pushes the branch to remote before creating the PR. No need to run `but push` first. Force push (`--with-force`) and pre-push hooks run by default.
+Use `--no-hooks` to bypass pre-push hooks when needed.
 
 In non-interactive environments, use `--message (-m)`, `--file (-F)`, or `--default (-t)` to avoid editor prompts. The `-t` flag uses the commit message as title/description for single-commit branches; for multi-commit branches it falls back to the branch name as the title.
 

--- a/crates/but/src/args/forge.rs
+++ b/crates/but/src/args/forge.rs
@@ -28,9 +28,9 @@ pub mod pr {
             /// Skip force push protection checks
             #[clap(long, short = 's')]
             skip_force_push_protection: bool,
-            /// Run pre-push hooks (defaults to true).
-            #[clap(long, short = 'r', default_value_t = true)]
-            run_hooks: bool,
+            /// Bypass pre-push hooks.
+            #[clap(long = "no-hooks", visible_alias = "no-verify")]
+            no_hooks: bool,
             /// Use the default content for the review title and description, skipping any prompts.
             /// If the branch contains only a single commit, the commit message will be used.
             #[clap(long, short = 't', default_value_t = false)]

--- a/crates/but/src/args/push.rs
+++ b/crates/but/src/args/push.rs
@@ -8,9 +8,9 @@ pub struct Command {
     /// Skip force push protection checks
     #[clap(long, short = 's')]
     pub skip_force_push_protection: bool,
-    /// Run pre-push hooks
-    #[clap(long, short = 'r', default_value_t = true)]
-    pub run_hooks: bool,
+    /// Bypass pre-push hooks
+    #[clap(long = "no-hooks", visible_alias = "no-verify")]
+    pub no_hooks: bool,
     /// Mark change as work-in-progress (Gerrit). Mutually exclusive with --ready.
     #[clap(long, short = 'w', conflicts_with = "ready", hide = true)]
     pub wip: bool,

--- a/crates/but/src/args/tests.rs
+++ b/crates/but/src/args/tests.rs
@@ -136,7 +136,10 @@ fn clap() {
     Args::command().debug_assert();
 }
 
+#[cfg(feature = "legacy")]
 mod push {
+    use clap::Parser;
+
     #[cfg(feature = "legacy")]
     mod get_gerrit_flags {
         use crate::{args::push::Command as Args, command::legacy::push::get_gerrit_flags};
@@ -147,7 +150,7 @@ mod push {
                 branch_id: Some("test".to_string()),
                 with_force: true,
                 skip_force_push_protection: false,
-                run_hooks: true,
+                no_hooks: false,
                 wip: false,
                 ready: false,
                 hashtag: vec![],
@@ -168,7 +171,7 @@ mod push {
                 branch_id: Some("test".to_string()),
                 with_force: true,
                 skip_force_push_protection: false,
-                run_hooks: true,
+                no_hooks: false,
                 wip: true,
                 ready: false,
                 hashtag: vec![],
@@ -194,7 +197,7 @@ mod push {
                 branch_id: Some("test".to_string()),
                 with_force: true,
                 skip_force_push_protection: false,
-                run_hooks: true,
+                no_hooks: false,
                 wip: false,
                 ready: false,
                 hashtag: vec![],
@@ -217,7 +220,7 @@ mod push {
                 branch_id: Some("test".to_string()),
                 with_force: true,
                 skip_force_push_protection: false,
-                run_hooks: true,
+                no_hooks: false,
                 wip: true,
                 ready: false,
                 hashtag: vec![],
@@ -240,7 +243,7 @@ mod push {
                 branch_id: Some("test".to_string()),
                 with_force: true,
                 skip_force_push_protection: false,
-                run_hooks: true,
+                no_hooks: false,
                 wip: false,
                 ready: false,
                 hashtag: vec!["tag1".to_string(), "tag2".to_string(), "tag3".to_string()],
@@ -274,7 +277,7 @@ mod push {
                 branch_id: Some("test".to_string()),
                 with_force: true,
                 skip_force_push_protection: false,
-                run_hooks: true,
+                no_hooks: false,
                 wip: false,
                 ready: false,
                 hashtag: vec![],
@@ -305,7 +308,7 @@ mod push {
                 branch_id: Some("test".to_string()),
                 with_force: true,
                 skip_force_push_protection: false,
-                run_hooks: true,
+                no_hooks: false,
                 wip: false,
                 ready: false,
                 hashtag: vec![],
@@ -336,7 +339,7 @@ mod push {
                 branch_id: Some("test".to_string()),
                 with_force: true,
                 skip_force_push_protection: false,
-                run_hooks: true,
+                no_hooks: false,
                 wip: false,
                 ready: false,
                 hashtag: vec![],
@@ -364,7 +367,7 @@ mod push {
                 branch_id: Some("test".to_string()),
                 with_force: true,
                 skip_force_push_protection: false,
-                run_hooks: true,
+                no_hooks: false,
                 wip: true,
                 ready: false,
                 hashtag: vec!["tag1".to_string(), "tag2".to_string()],
@@ -410,7 +413,7 @@ mod push {
                 branch_id: Some("test".to_string()),
                 with_force: true,
                 skip_force_push_protection: false,
-                run_hooks: true,
+                no_hooks: false,
                 wip: false,
                 ready: false,
                 hashtag: vec!["  ".to_string()],
@@ -436,7 +439,7 @@ mod push {
                 branch_id: Some("test".to_string()),
                 with_force: true,
                 skip_force_push_protection: false,
-                run_hooks: true,
+                no_hooks: false,
                 wip: false,
                 ready: false,
                 hashtag: vec![],
@@ -454,6 +457,78 @@ mod push {
                     .to_string()
                     .contains("Topic cannot be empty")
             );
+        }
+    }
+
+    #[test]
+    fn defaults_to_running_hooks() {
+        let args = crate::args::Args::try_parse_from(["but", "push", "topic"]).expect("parse args");
+
+        let cmd = args.cmd.expect("subcommand");
+        match cmd {
+            crate::args::Subcommands::Push(crate::args::push::Command { no_hooks, .. }) => {
+                assert!(!no_hooks);
+            }
+            _ => panic!("unexpected command shape"),
+        }
+    }
+
+    #[test]
+    fn parses_no_hooks_and_alias() {
+        for argv in [
+            ["but", "push", "topic", "--no-hooks"],
+            ["but", "push", "topic", "--no-verify"],
+        ] {
+            let args = crate::args::Args::try_parse_from(argv).expect("parse args");
+            let cmd = args.cmd.expect("subcommand");
+            match cmd {
+                crate::args::Subcommands::Push(crate::args::push::Command { no_hooks, .. }) => {
+                    assert!(no_hooks);
+                }
+                _ => panic!("unexpected command shape"),
+            }
+        }
+    }
+}
+
+#[cfg(feature = "legacy")]
+mod pr {
+    use clap::Parser;
+
+    #[test]
+    fn defaults_to_running_hooks() {
+        let args =
+            crate::args::Args::try_parse_from(["but", "pr", "new", "topic"]).expect("parse args");
+
+        let cmd = args.cmd.expect("subcommand");
+        match cmd {
+            crate::args::Subcommands::Pr(crate::args::forge::pr::Platform {
+                cmd: Some(crate::args::forge::pr::Subcommands::New { no_hooks, .. }),
+                ..
+            }) => {
+                assert!(!no_hooks);
+            }
+            _ => panic!("unexpected command shape"),
+        }
+    }
+
+    #[test]
+    fn parses_no_hooks_and_alias() {
+        for argv in [
+            ["but", "pr", "new", "topic", "--no-hooks"],
+            ["but", "pr", "new", "topic", "--no-verify"],
+        ] {
+            let args = crate::args::Args::try_parse_from(argv).expect("parse args");
+            let cmd = args.cmd.expect("subcommand");
+            match cmd {
+                crate::args::Subcommands::Pr(crate::args::forge::pr::Platform {
+                    cmd: Some(crate::args::forge::pr::Subcommands::New { no_hooks, .. }),
+                    ..
+                }) => {
+                    assert!(no_hooks);
+                }
+                _ => panic!("unexpected command shape"),
+            }
         }
     }
 }

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -654,7 +654,7 @@ fn push_single_branch_impl(
         args.with_force,
         args.skip_force_push_protection,
         branch_name.to_string(),
-        args.run_hooks,
+        !args.no_hooks,
         gerrit_flags,
     )?;
 

--- a/crates/but/src/command/push.rs
+++ b/crates/but/src/command/push.rs
@@ -60,7 +60,7 @@ pub mod help {
         )?;
         writeln!(
             out,
-            "  -r, --run-hooks                   Run pre-push hooks"
+            "      --no-hooks, --no-verify       Bypass pre-push hooks"
         )?;
 
         // Check if gerrit mode is enabled and show gerrit options

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -1168,7 +1168,7 @@ async fn match_subcommand(
                     file,
                     skip_force_push_protection,
                     with_force,
-                    run_hooks,
+                    no_hooks,
                     default,
                     draft,
                 }) => {
@@ -1208,7 +1208,7 @@ async fn match_subcommand(
                         branch,
                         skip_force_push_protection,
                         with_force,
-                        run_hooks,
+                        !no_hooks,
                         default,
                         draft,
                         review_message,


### PR DESCRIPTION
Motivated by https://github.com/gitbutlerapp/gitbutler/discussions/13464.

### Tasks

* [x] refackiew
* [x] ~~update docs~~ - docs are generally out of date and should be updated in bulk

## Summary

`but push` and `but pr new` exposed `--run-hooks` as if it were a boolean option with a default, but clap treated it as an enable-only presence flag. In practice there was no supported way to turn hooks off, while both local docs and published command pages implied that `--run-hooks=false` should work.

This change removes that misleading surface and replaces it with an explicit opt-out flag:

- add `--no-hooks` to `but push`
- add `--no-hooks` to `but pr new`
- add `--no-verify` as an alias for both commands
- keep the default behavior unchanged: hooks still run unless explicitly bypassed
- remove `--run-hooks` from the public CLI/help/docs
- add parser coverage for default behavior, aliases, and rejection of the removed flag

## Reasoning

The old flag shape was worse than just awkward documentation. It created a public interface that looked configurable while not actually being configurable. That is a sharp edge for both users and generated docs, because any tooling that inspects the clap metadata will naturally infer a defaulted boolean and document it that way.

Using `--no-hooks` matches the existing `but commit --no-hooks` naming, which keeps the CLI more internally consistent and makes the "hooks run by default, opt out explicitly" model obvious.

## Shortcomings

- `--run-hooks` is now removed rather than kept as a compatibility shim. That is intentional, but it does mean callers using the old spelling will now get an unknown-argument error instead of silent acceptance.
- this only addresses hook toggling for `push` and `pr new`
- `--with-force` still uses the same misleading clap pattern of a defaulted boolean presence flag, but was left unchanged to keep this fix narrowly scoped

## Future Work

- normalize `--with-force` to the same style of interface, likely with an explicit negative form if we want it to be user-configurable
- consider auditing other defaulted bool flags in `but` for the same clap/docs mismatch
- if we want a softer transition, we could later add a targeted error message for `--run-hooks` that points users to `--no-hooks`
