### PR TITLE
ci: remove duplicated `but` test run and unify `but-server` tests

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -282,11 +282,9 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Dependencies for 'keyring'
         run: sudo ./scripts/install-minimal-debian-dependencies.sh
-      - run: cargo test --workspace --exclude gitbutler-tauri --exclude but-server --exclude but-api-macros-tests
+      - run: cargo test --workspace --exclude gitbutler-tauri --exclude but-api-macros-tests
       # It's intentional to use 'name equals run-script' so it's easy to re-run locally on failure.
-      - run: cargo test -p but
       - run: make test-modern-but
-      - run: cargo test -p but-server
       - name: test vendored
         run: |
           set -x


### PR DESCRIPTION
## 🧢 Changes
Removes some test redundancy and unnecessary test separation.

This speeds up the test execution by ~30%, cutting down running times from ~13-14 to ~9-10 minutes.