### PR TITLE
feat(but): make progress output more visible in dark color scheme

### DIFF
--- a/crates/but/src/theme.rs
+++ b/crates/but/src/theme.rs
@@ -398,7 +398,7 @@ impl Theme {
             default: Style::new(),
             user: style_fg(Color::LightYellow),
             time: style_fg(Color::Cyan),
-            progress: style_fg(Color::DarkGray),
+            progress: Style::new().add_modifier(Modifier::DIM),
 
             // Layout
             border: Style::new().fg(Color::DarkGray),
@@ -450,6 +450,7 @@ impl Theme {
 
             // General purpose
             hint: style_fg(Color::DarkGray),
+            progress: style_fg(Color::DarkGray),
 
             // Layout
             selection_highlight: Style::new().fg(Color::Black).bg(Color::Indexed(252)),


### PR DESCRIPTION
## 🧢 Changes
Progress text (at least that which is colored as progress text) was almost unreadable with several dark themes. Basically, stay away from `Color::DarkGray` in the dark theme :)