### PR TITLE
Cache forge user profiles for offline support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,6 +1264,7 @@ dependencies = [
  "but-utils",
  "serde",
  "serde_json",
+ "tempfile",
  "tracing",
 ]
 
@@ -1298,6 +1299,8 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -1312,6 +1315,8 @@ dependencies = [
  "reqwest 0.12.28",
  "schemars 1.2.1",
  "serde",
+ "thiserror 2.0.18",
+ "tracing",
  "urlencoding",
 ]
 

--- a/crates/but-forge-storage/Cargo.toml
+++ b/crates/but-forge-storage/Cargo.toml
@@ -21,5 +21,8 @@ anyhow.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [lints]
 workspace = true

--- a/crates/but-forge-storage/src/controller.rs
+++ b/crates/but-forge-storage/src/controller.rs
@@ -46,21 +46,46 @@ impl Controller {
             .iter()
             .map(|account| account.access_token_key().to_string())
             .collect::<Vec<String>>();
+        for key in &access_tokens_to_delete {
+            settings.cached_profiles.remove(key);
+        }
         settings.github.known_accounts.clear();
         self.save_settings(&settings)?;
 
         Ok(access_tokens_to_delete)
     }
 
-    /// Remove a GitHub account.
+    /// Get the cached profile for an account by its `access_token_key`.
+    pub fn cached_profile(
+        &self,
+        key: &str,
+    ) -> anyhow::Result<Option<crate::settings::CachedProfile>> {
+        let settings = self.read_settings()?;
+        Ok(settings.cached_profiles.get(key).cloned())
+    }
+
+    /// Set or clear the cached profile for an account by its `access_token_key`.
+    pub fn set_cached_profile(
+        &self,
+        key: &str,
+        profile: Option<crate::settings::CachedProfile>,
+    ) -> anyhow::Result<()> {
+        let mut settings = self.read_settings()?;
+        match profile {
+            Some(p) => settings.cached_profiles.insert(key.to_owned(), p),
+            None => settings.cached_profiles.remove(key),
+        };
+        self.save_settings(&settings)
+    }
+
+    /// Remove a GitHub account and its cached profile.
     pub fn remove_github_account(
         &self,
         account: &crate::settings::GitHubAccount,
     ) -> anyhow::Result<()> {
         let mut settings = self.read_settings()?;
-
+        settings.cached_profiles.remove(account.access_token_key());
         settings.github.known_accounts.retain(|a| a != account);
-
         self.save_settings(&settings)
     }
 
@@ -95,21 +120,23 @@ impl Controller {
             .iter()
             .map(|account| account.access_token_key().to_string())
             .collect::<Vec<String>>();
+        for key in &access_tokens_to_delete {
+            settings.cached_profiles.remove(key);
+        }
         settings.gitlab.known_accounts.clear();
         self.save_settings(&settings)?;
 
         Ok(access_tokens_to_delete)
     }
 
-    /// Remove a GitLab account.
+    /// Remove a GitLab account and its cached profile.
     pub fn remove_gitlab_account(
         &self,
         account: &crate::settings::GitLabAccount,
     ) -> anyhow::Result<()> {
         let mut settings = self.read_settings()?;
-
+        settings.cached_profiles.remove(account.access_token_key());
         settings.gitlab.known_accounts.retain(|a| a != account);
-
         self.save_settings(&settings)
     }
 
@@ -119,5 +146,111 @@ impl Controller {
 
     fn save_settings(&self, settings: &crate::settings::ForgeSettings) -> anyhow::Result<()> {
         self.settings_storage.save(settings)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::{CachedProfile, GitHubAccount, GitLabAccount};
+
+    fn test_controller() -> (Controller, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let controller = Controller::from_path(dir.path());
+        (controller, dir)
+    }
+
+    #[test]
+    fn remove_github_account_clears_cached_profile() {
+        let (controller, _dir) = test_controller();
+        let account = GitHubAccount::Pat {
+            username: "testuser".into(),
+            access_token_key: "github_pat_testuser".into(),
+        };
+        controller.add_github_account(&account).unwrap();
+        controller
+            .set_cached_profile(
+                "github_pat_testuser",
+                Some(CachedProfile {
+                    name: Some("Test".into()),
+                    ..Default::default()
+                }),
+            )
+            .unwrap();
+
+        assert!(
+            controller
+                .cached_profile("github_pat_testuser")
+                .unwrap()
+                .is_some()
+        );
+        controller.remove_github_account(&account).unwrap();
+        assert!(
+            controller
+                .cached_profile("github_pat_testuser")
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn clear_all_github_accounts_clears_cached_profiles() {
+        let (controller, _dir) = test_controller();
+        let account = GitHubAccount::OAuth {
+            username: "user1".into(),
+            access_token_key: "github_oauth_user1".into(),
+        };
+        controller.add_github_account(&account).unwrap();
+        controller
+            .set_cached_profile(
+                "github_oauth_user1",
+                Some(CachedProfile {
+                    name: Some("User 1".into()),
+                    ..Default::default()
+                }),
+            )
+            .unwrap();
+
+        let keys = controller.clear_all_github_accounts().unwrap();
+        assert_eq!(keys, vec!["github_oauth_user1"]);
+        assert!(
+            controller
+                .cached_profile("github_oauth_user1")
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn remove_gitlab_account_clears_cached_profile() {
+        let (controller, _dir) = test_controller();
+        let account = GitLabAccount::Pat {
+            username: "gluser".into(),
+            access_token_key: "gitlab_pat_gluser".into(),
+        };
+        controller.add_gitlab_account(&account).unwrap();
+        controller
+            .set_cached_profile(
+                "gitlab_pat_gluser",
+                Some(CachedProfile {
+                    email: Some("gl@test.com".into()),
+                    ..Default::default()
+                }),
+            )
+            .unwrap();
+
+        assert!(
+            controller
+                .cached_profile("gitlab_pat_gluser")
+                .unwrap()
+                .is_some()
+        );
+        controller.remove_gitlab_account(&account).unwrap();
+        assert!(
+            controller
+                .cached_profile("gitlab_pat_gluser")
+                .unwrap()
+                .is_none()
+        );
     }
 }

--- a/crates/but-forge-storage/src/settings.rs
+++ b/crates/but-forge-storage/src/settings.rs
@@ -1,4 +1,18 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Deserializer, Serialize, de::DeserializeOwned};
+
+/// Cached user profile data fetched from the forge API.
+///
+/// Stored separately from account credentials so the cache can evolve
+/// independently and be easily swapped for a different storage backend.
+#[derive(Clone, Debug, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CachedProfile {
+    pub avatar_url: Option<String>,
+    pub name: Option<String>,
+    pub email: Option<String>,
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
@@ -8,6 +22,9 @@ pub struct ForgeSettings {
     /// GitLab-specific settings.
     #[serde(default)]
     pub gitlab: GitLabSettings,
+    /// Cached user profiles, keyed by account `access_token_key`.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub cached_profiles: HashMap<String, CachedProfile>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
@@ -18,7 +35,7 @@ pub struct GitHubSettings {
     pub known_accounts: Vec<GitHubAccount>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type")]
 pub enum GitHubAccount {
     OAuth {
@@ -67,51 +84,6 @@ impl GitHubAccount {
     }
 }
 
-impl PartialEq for GitHubAccount {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (
-                GitHubAccount::OAuth {
-                    username: u1,
-                    access_token_key: k1,
-                },
-                GitHubAccount::OAuth {
-                    username: u2,
-                    access_token_key: k2,
-                },
-            ) => u1 == u2 && k1 == k2,
-            (
-                GitHubAccount::Pat {
-                    username: u1,
-                    access_token_key: k1,
-                },
-                GitHubAccount::Pat {
-                    username: u2,
-                    access_token_key: k2,
-                },
-            ) => u1 == u2 && k1 == k2,
-            (
-                GitHubAccount::Enterprise {
-                    host: h1,
-                    username: u1,
-                    access_token_key: k1,
-                },
-                GitHubAccount::Enterprise {
-                    host: h2,
-                    username: u2,
-                    access_token_key: k2,
-                },
-            ) => h1 == h2 && u1 == u2 && k1 == k2,
-            (GitHubAccount::OAuth { .. }, GitHubAccount::Pat { .. }) => false,
-            (GitHubAccount::Pat { .. }, GitHubAccount::OAuth { .. }) => false,
-            (GitHubAccount::Enterprise { .. }, GitHubAccount::OAuth { .. }) => false,
-            (GitHubAccount::OAuth { .. }, GitHubAccount::Enterprise { .. }) => false,
-            (GitHubAccount::Pat { .. }, GitHubAccount::Enterprise { .. }) => false,
-            (GitHubAccount::Enterprise { .. }, GitHubAccount::Pat { .. }) => false,
-        }
-    }
-}
-
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct GitLabSettings {
@@ -120,7 +92,7 @@ pub struct GitLabSettings {
     pub known_accounts: Vec<GitLabAccount>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type")]
 pub enum GitLabAccount {
     Pat {
@@ -155,37 +127,6 @@ impl GitLabAccount {
         match self {
             GitLabAccount::Pat { username, .. } => username,
             GitLabAccount::SelfHosted { username, .. } => username,
-        }
-    }
-}
-
-impl PartialEq for GitLabAccount {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (
-                GitLabAccount::Pat {
-                    username: u1,
-                    access_token_key: k1,
-                },
-                GitLabAccount::Pat {
-                    username: u2,
-                    access_token_key: k2,
-                },
-            ) => u1 == u2 && k1 == k2,
-            (
-                GitLabAccount::SelfHosted {
-                    host: h1,
-                    username: u1,
-                    access_token_key: k1,
-                },
-                GitLabAccount::SelfHosted {
-                    host: h2,
-                    username: u2,
-                    access_token_key: k2,
-                },
-            ) => h1 == h2 && u1 == u2 && k1 == k2,
-            (GitLabAccount::Pat { .. }, GitLabAccount::SelfHosted { .. }) => false,
-            (GitLabAccount::SelfHosted { .. }, GitLabAccount::Pat { .. }) => false,
         }
     }
 }
@@ -266,6 +207,7 @@ mod tests {
                     access_token_key: "gitlab_pat_gltest".into(),
                 }],
             },
+            cached_profiles: HashMap::new(),
         };
         let json = serde_json::to_string(&settings).unwrap();
         let roundtripped: ForgeSettings = serde_json::from_str(&json).unwrap();

--- a/crates/but-github/Cargo.toml
+++ b/crates/but-github/Cargo.toml
@@ -24,6 +24,8 @@ but-error.workspace = true
 
 serde.workspace = true
 anyhow.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
 serde_json.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 schemars = { workspace = true, optional = true }

--- a/crates/but-github/src/client.rs
+++ b/crates/but-github/src/client.rs
@@ -10,6 +10,15 @@ use crate::graphql::{
 
 const GITHUB_API_BASE_URL: &str = "https://api.github.com";
 
+/// An HTTP error with a status code, returned when the API responds with a non-success status.
+///
+/// This can be downcasted from `anyhow::Error` to distinguish auth failures (401/403) from other errors.
+#[derive(Debug, thiserror::Error)]
+#[error("HTTP {status}")]
+pub struct HttpStatusError {
+    pub status: reqwest::StatusCode,
+}
+
 pub struct GitHubClient {
     client: reqwest::Client,
     base_url: String,
@@ -109,7 +118,10 @@ impl GitHubClient {
         let response = self.client.get(&url).send().await?;
 
         if !response.status().is_success() {
-            bail!("Failed to get authenticated user: {}", response.status());
+            return Err(HttpStatusError {
+                status: response.status(),
+            }
+            .into());
         }
 
         let user: User = response.json().await?;

--- a/crates/but-github/src/lib.rs
+++ b/crates/but-github/src/lib.rs
@@ -111,6 +111,27 @@ pub async fn check_github_auth_status(
     })
 }
 
+/// Cache the user profile so it's available offline.
+fn cache_user_profile(
+    account: &GithubAccountIdentifier,
+    user: &client::AuthenticatedUser,
+    storage: &but_forge_storage::Controller,
+) {
+    let profile = but_forge_storage::settings::CachedProfile {
+        avatar_url: user.avatar_url.clone(),
+        name: user.name.clone(),
+        email: user.email.clone(),
+    };
+    let key = account.cache_key();
+    let existing = storage.cached_profile(&key).ok().flatten();
+    if existing.as_ref() == Some(&profile) {
+        return;
+    }
+    if let Err(err) = storage.set_cached_profile(&key, Some(profile)) {
+        tracing::warn!(?account, "Failed to update cached GitHub profile: {err}");
+    }
+}
+
 /// Fetch the authenticated user data from GitHub and persist the access token. (OAuth)
 async fn fetch_and_persist_oauth_user_data(
     access_token: &Sensitive<String>,
@@ -121,12 +142,10 @@ async fn fetch_and_persist_oauth_user_data(
         .get_authenticated()
         .await
         .context("Failed to get authenticated user")?;
-    token::persist_gh_access_token(
-        &token::GithubAccountIdentifier::oauth(&user.login),
-        access_token,
-        storage,
-    )
-    .context("Failed to persist access token")?;
+    let account_id = token::GithubAccountIdentifier::oauth(&user.login);
+    token::persist_gh_access_token(&account_id, access_token, storage)
+        .context("Failed to persist access token")?;
+    cache_user_profile(&account_id, &user, storage);
     Ok(user)
 }
 
@@ -155,12 +174,10 @@ async fn fetch_and_persist_pat_user_data(
         .get_authenticated()
         .await
         .context("Failed to get authenticated user")?;
-    token::persist_gh_access_token(
-        &token::GithubAccountIdentifier::pat(&user.login),
-        access_token,
-        storage,
-    )
-    .context("Failed to persist access token")?;
+    let account_id = token::GithubAccountIdentifier::pat(&user.login);
+    token::persist_gh_access_token(&account_id, access_token, storage)
+        .context("Failed to persist access token")?;
+    cache_user_profile(&account_id, &user, storage);
     Ok(user)
 }
 
@@ -192,12 +209,10 @@ async fn fetch_and_persist_enterprise_user_data(
         .get_authenticated()
         .await
         .context("Failed to get authenticated user")?;
-    token::persist_gh_access_token(
-        &token::GithubAccountIdentifier::enterprise(&user.login, host),
-        access_token,
-        storage,
-    )
-    .context("Failed to persist access token")?;
+    let account_id = token::GithubAccountIdentifier::enterprise(&user.login, host);
+    token::persist_gh_access_token(&account_id, access_token, storage)
+        .context("Failed to persist access token")?;
+    cache_user_profile(&account_id, &user, storage);
     Ok(user)
 }
 
@@ -225,28 +240,56 @@ pub async fn get_gh_user(
         let gh = account
             .client(&access_token)
             .context("Failed to create GitHub client")?;
-        let user = match gh.get_authenticated().await {
-            Ok(user) => user,
+        match gh.get_authenticated().await {
+            Ok(user) => {
+                cache_user_profile(account, &user, storage);
+                Ok(Some(AuthenticatedUser {
+                    access_token,
+                    login: user.login,
+                    avatar_url: user.avatar_url,
+                    name: user.name,
+                    email: user.email,
+                }))
+            }
             Err(client_err) => {
-                // Check if this is a network error
+                let cache_key = account.cache_key();
+                // Check if this is a network error — return cached data if available.
                 if let Some(reqwest_err) = client_err.downcast_ref::<reqwest::Error>()
                     && is_network_error(reqwest_err)
                 {
+                    match storage.cached_profile(&cache_key) {
+                        Ok(Some(cached)) => {
+                            return Ok(Some(AuthenticatedUser {
+                                access_token,
+                                login: account.username().to_owned(),
+                                avatar_url: cached.avatar_url,
+                                name: cached.name,
+                                email: cached.email,
+                            }));
+                        }
+                        Ok(None) => {}
+                        Err(err) => {
+                            tracing::warn!("Failed to read cached GitHub profile: {err}");
+                        }
+                    }
                     return Err(client_err.context(but_error::Context::new_static(
                         but_error::Code::NetworkError,
                         "Unable to connect to GitHub.",
                     )));
                 }
-                return Err(client_err.context("Failed to get authenticated user"));
+                // Check if this is an auth error (401/403) — clear cached profile.
+                if let Some(http_err) = client_err.downcast_ref::<client::HttpStatusError>()
+                    && matches!(
+                        http_err.status,
+                        reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN
+                    )
+                    && let Err(err) = storage.set_cached_profile(&cache_key, None)
+                {
+                    tracing::warn!("Failed to clear cached GitHub profile: {err}");
+                }
+                Err(client_err.context("Failed to get authenticated user"))
             }
-        };
-        Ok(Some(AuthenticatedUser {
-            access_token,
-            login: user.login,
-            avatar_url: user.avatar_url,
-            name: user.name,
-            email: user.email,
-        }))
+        }
     } else {
         Ok(None)
     }

--- a/crates/but-github/src/token.rs
+++ b/crates/but-github/src/token.rs
@@ -90,6 +90,21 @@ impl GithubAccountIdentifier {
         }
     }
 
+    /// The key used to store and look up the cached profile for this account.
+    pub fn cache_key(&self) -> String {
+        match self {
+            GithubAccountIdentifier::OAuthUsername { username } => {
+                format!("github_oauth_{username}")
+            }
+            GithubAccountIdentifier::PatUsername { username } => {
+                format!("github_pat_{username}")
+            }
+            GithubAccountIdentifier::Enterprise { host, .. } => {
+                format!("github_enterprise_{host}")
+            }
+        }
+    }
+
     pub fn client(&self, access_token: &Sensitive<String>) -> Result<GitHubClient> {
         match self {
             GithubAccountIdentifier::OAuthUsername { .. }
@@ -209,9 +224,15 @@ impl GitHubAccount {
 
     fn secret_key(&self) -> String {
         match self {
-            GitHubAccount::OAuth { username, .. } => format!("github_oauth_{username}"),
-            GitHubAccount::Pat { username, .. } => format!("github_pat_{username}"),
-            GitHubAccount::Enterprise { host, .. } => format!("github_enterprise_{host}"),
+            GitHubAccount::OAuth { username, .. } => {
+                GithubAccountIdentifier::oauth(username).cache_key()
+            }
+            GitHubAccount::Pat { username, .. } => {
+                GithubAccountIdentifier::pat(username).cache_key()
+            }
+            GitHubAccount::Enterprise { host, username, .. } => {
+                GithubAccountIdentifier::enterprise(username, host).cache_key()
+            }
         }
     }
 

--- a/crates/but-gitlab/Cargo.toml
+++ b/crates/but-gitlab/Cargo.toml
@@ -22,6 +22,8 @@ but-forge-storage.workspace = true
 but-error.workspace = true
 serde.workspace = true
 anyhow.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 urlencoding.workspace = true
 schemars = { workspace = true, optional = true }

--- a/crates/but-gitlab/src/client.rs
+++ b/crates/but-gitlab/src/client.rs
@@ -7,6 +7,15 @@ use crate::GitLabProjectId;
 
 const GITLAB_API_BASE_URL: &str = "https://gitlab.com/api/v4";
 
+/// An HTTP error with a status code, returned when the API responds with a non-success status.
+///
+/// This can be downcasted from `anyhow::Error` to distinguish auth failures (401/403) from other errors.
+#[derive(Debug, thiserror::Error)]
+#[error("HTTP {status}")]
+pub struct HttpStatusError {
+    pub status: reqwest::StatusCode,
+}
+
 pub struct GitLabClient {
     client: reqwest::Client,
     base_url: String,
@@ -89,7 +98,10 @@ impl GitLabClient {
         let response = self.client.get(&url).send().await?;
 
         if !response.status().is_success() {
-            bail!("Failed to get authenticated user: {}", response.status());
+            return Err(HttpStatusError {
+                status: response.status(),
+            }
+            .into());
         }
 
         let user: User = response.json().await?;

--- a/crates/but-gitlab/src/lib.rs
+++ b/crates/but-gitlab/src/lib.rs
@@ -41,6 +41,27 @@ pub async fn store_pat(
     })
 }
 
+/// Cache the user profile so it's available offline.
+fn cache_user_profile(
+    account: &GitlabAccountIdentifier,
+    user: &client::AuthenticatedUser,
+    storage: &but_forge_storage::Controller,
+) {
+    let profile = but_forge_storage::settings::CachedProfile {
+        avatar_url: user.avatar_url.clone(),
+        name: user.name.clone(),
+        email: user.email.clone(),
+    };
+    let key = account.cache_key();
+    let existing = storage.cached_profile(&key).ok().flatten();
+    if existing.as_ref() == Some(&profile) {
+        return;
+    }
+    if let Err(err) = storage.set_cached_profile(&key, Some(profile)) {
+        tracing::warn!(?account, "Failed to update cached GitLab profile: {err}");
+    }
+}
+
 /// Fetch the authenticated user data from GitLab and persist the access token. (PAT)
 async fn fetch_and_persist_pat_user_data(
     access_token: &Sensitive<String>,
@@ -51,12 +72,10 @@ async fn fetch_and_persist_pat_user_data(
         .get_authenticated()
         .await
         .context("Failed to get authenticated user")?;
-    token::persist_gl_access_token(
-        &token::GitlabAccountIdentifier::pat(&user.username),
-        access_token,
-        storage,
-    )
-    .context("Failed to persist access token")?;
+    let account_id = token::GitlabAccountIdentifier::pat(&user.username);
+    token::persist_gl_access_token(&account_id, access_token, storage)
+        .context("Failed to persist access token")?;
+    cache_user_profile(&account_id, &user, storage);
     Ok(user)
 }
 
@@ -88,12 +107,10 @@ async fn fetch_and_persist_selfhosted_user_data(
         .get_authenticated()
         .await
         .context("Failed to get authenticated user")?;
-    token::persist_gl_access_token(
-        &token::GitlabAccountIdentifier::selfhosted(&user.username, host),
-        access_token,
-        storage,
-    )
-    .context("Failed to persist access token")?;
+    let account_id = token::GitlabAccountIdentifier::selfhosted(&user.username, host);
+    token::persist_gl_access_token(&account_id, access_token, storage)
+        .context("Failed to persist access token")?;
+    cache_user_profile(&account_id, &user, storage);
     Ok(user)
 }
 
@@ -112,29 +129,56 @@ pub async fn get_gl_user(
         let gl = account
             .client(&access_token)
             .context("Failed to create GitLab client")?;
-        let user = match gl.get_authenticated().await {
-            Ok(user) => user,
+        match gl.get_authenticated().await {
+            Ok(user) => {
+                cache_user_profile(account, &user, storage);
+                Ok(Some(AuthenticatedUser {
+                    access_token,
+                    username: user.username,
+                    name: user.name,
+                    email: user.email,
+                    avatar_url: user.avatar_url,
+                }))
+            }
             Err(client_err) => {
-                println!("Error fetching authenticated user: {client_err:?}");
-                // Check if this is a network error
+                let cache_key = account.cache_key();
+                // Check if this is a network error — return cached data if available.
                 if let Some(reqwest_err) = client_err.downcast_ref::<reqwest::Error>()
                     && is_network_error(reqwest_err)
                 {
+                    match storage.cached_profile(&cache_key) {
+                        Ok(Some(cached)) => {
+                            return Ok(Some(AuthenticatedUser {
+                                access_token,
+                                username: account.username().to_owned(),
+                                avatar_url: cached.avatar_url,
+                                name: cached.name,
+                                email: cached.email,
+                            }));
+                        }
+                        Ok(None) => {}
+                        Err(err) => {
+                            tracing::warn!("Failed to read cached GitLab profile: {err}");
+                        }
+                    }
                     return Err(client_err.context(but_error::Context::new_static(
                         but_error::Code::NetworkError,
                         "Unable to connect to GitLab.",
                     )));
                 }
-                return Err(client_err.context("Failed to get authenticated user"));
+                // Check if this is an auth error (401/403) — clear cached profile.
+                if let Some(http_err) = client_err.downcast_ref::<client::HttpStatusError>()
+                    && matches!(
+                        http_err.status,
+                        reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN
+                    )
+                    && let Err(err) = storage.set_cached_profile(&cache_key, None)
+                {
+                    tracing::warn!("Failed to clear cached GitLab profile: {err}");
+                }
+                Err(client_err.context("Failed to get authenticated user"))
             }
-        };
-        Ok(Some(AuthenticatedUser {
-            access_token,
-            username: user.username,
-            name: user.name,
-            email: user.email,
-            avatar_url: user.avatar_url,
-        }))
+        }
     } else {
         Ok(None)
     }

--- a/crates/but-gitlab/src/token.rs
+++ b/crates/but-gitlab/src/token.rs
@@ -83,6 +83,18 @@ impl GitlabAccountIdentifier {
         }
     }
 
+    /// The key used to store and look up the cached profile for this account.
+    pub fn cache_key(&self) -> String {
+        match self {
+            GitlabAccountIdentifier::PatUsername { username } => {
+                format!("gitlab_pat_{username}")
+            }
+            GitlabAccountIdentifier::SelfHosted { host, .. } => {
+                format!("gitlab_selfhosted_{host}")
+            }
+        }
+    }
+
     pub fn client(&self, access_token: &Sensitive<String>) -> Result<GitLabClient> {
         match self {
             GitlabAccountIdentifier::PatUsername { .. } => GitLabClient::new(access_token),
@@ -180,8 +192,12 @@ impl GitLabAccount {
 
     fn secret_key(&self) -> String {
         match self {
-            GitLabAccount::Pat { username, .. } => format!("gitlab_pat_{username}"),
-            GitLabAccount::SelfHosted { host, .. } => format!("gitlab_selfhosted_{host}"),
+            GitLabAccount::Pat { username, .. } => {
+                GitlabAccountIdentifier::pat(username).cache_key()
+            }
+            GitLabAccount::SelfHosted { host, username, .. } => {
+                GitlabAccountIdentifier::selfhosted(username, host).cache_key()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Cache forge user profiles so the app can display user info (avatar, name, email) without requiring an active network connection.

- Cached profiles are stored in a top-level `cachedProfiles` map in `forge_settings.json`, keyed by `access_token_key` — separate from account credentials so the cache can evolve independently
- On successful API calls, the cache is updated (writes are skipped when data is unchanged to avoid unnecessary disk I/O)
- On network errors, the cached profile is returned so the app works offline
- On auth errors (401/403), the cache is cleared so stale data isn't shown for revoked tokens
- Fixes a pre-existing bug where `GitHubAccount::username()` / `GitLabAccount::username()` incorrectly returned the `host` field for Enterprise/SelfHosted variants

## Frontend changes (uncommitted)

Adds graceful offline handling to the PR card UI:
- `ReduxResult` gets an `errorOverrides` prop for custom error rendering by error type
- `PullRequestCard` shows "{forgeName} not available" on network errors instead of a generic error
- `ghQuery.ts` maps network errors to `code: "NetworkError"`