### PR TITLE
fix(but): prevent `but discard` from failing on most multi-hunk files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1757,6 +1757,7 @@ dependencies = [
  "gitbutler-repo",
  "gitbutler-stack",
  "gix",
+ "indexmap 2.13.0",
  "insta",
  "itertools",
  "md5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,6 +264,7 @@ rust-embed = { version = "8", features = ["axum"] }
 mime_guess = "2"
 chrono = { version = "0.4.42", default-features = false, features = ["std"] }
 hex = "0.4.3"
+indexmap = "2"
 md5 = "0.8.0"
 sha2 = "0.10"
 base64 = "0.22"

--- a/crates/but-workspace/Cargo.toml
+++ b/crates/but-workspace/Cargo.toml
@@ -45,6 +45,7 @@ anyhow.workspace = true
 bstr.workspace = true
 git2 = { workspace = true, optional = true }
 gix = { workspace = true, features = ["worktree-mutation"] }
+indexmap.workspace = true
 serde.workspace = true
 itertools.workspace = true
 url = { version = "2.5.4", features = ["serde"] }

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -22,8 +22,6 @@
 //! * **DiffSpec**
 //!   - A type that identifies changes, either as whole file, or as hunks in the file.
 //!   - It doesn't specify if the change is in a commit, or in the worktree, so that information must be provided separately.
-use std::collections::HashMap;
-
 use but_core::DiffSpec;
 
 /// **Do not use!**
@@ -38,6 +36,7 @@ pub mod ui;
 pub mod commit_engine;
 /// Tools for manipulating trees
 pub mod tree_manipulation;
+use indexmap::IndexMap;
 pub use tree_manipulation::discard_worktree_changes::discard_workspace_changes;
 
 /// 🚧utilities for applying and unapplying branches 🚧.
@@ -166,8 +165,16 @@ pub struct WorkspaceCommit<'repo> {
 }
 
 /// If there are multiple diffs spces where path and previous_path are the same, collapse them into one.
-pub fn flatten_diff_specs(input: Vec<DiffSpec>) -> Vec<DiffSpec> {
-    let mut output: HashMap<String, DiffSpec> = HashMap::new();
+///
+/// This flattening preserves the initial order of each (path, previous_path) pair. The output order
+/// is relative to the _first_ occurrence in the input. As a simplified example using, an input of
+/// `[2, 1, 2, 3]` deterministically produces an output ordered as `[2, 1, 3]`.
+///
+/// This is an important property as there are applications of [`DiffSpec`] sequences that are
+/// currently very sensitive to ordering, such as when discarding file renamings, additions and
+/// deletions of intersecting paths.
+pub fn flatten_diff_specs(input: impl IntoIterator<Item = DiffSpec>) -> Vec<DiffSpec> {
+    let mut output: IndexMap<String, DiffSpec> = IndexMap::new();
     for spec in input {
         let key = format!(
             "{}:{}",

--- a/crates/but-workspace/src/tree_manipulation/discard_worktree_changes.rs
+++ b/crates/but-workspace/src/tree_manipulation/discard_worktree_changes.rs
@@ -2,6 +2,8 @@ use anyhow::{Context as _, bail};
 use bstr::ByteSlice;
 use but_core::{ChangeState, DiffSpec, TreeStatus};
 
+use crate::flatten_diff_specs;
+
 /// Discard the given `changes` in the worktree of `repo`. If a change could not be matched with an actual worktree change, for
 /// instance due to a race, that's not an error, instead it will be returned in the result Vec, along with all hunks that couldn't
 /// be matched.
@@ -50,7 +52,8 @@ pub fn discard_workspace_changes(
     let mut path_check = gix::status::plumbing::SymlinkCheck::new(
         repo.workdir().context("non-bare repository")?.into(),
     );
-    for mut spec in changes {
+
+    for mut spec in flatten_diff_specs(changes) {
         let Some(wt_change) = wt_changes.changes.iter().find(|c| {
             c.path == spec.path
                 && c.previous_path() == spec.previous_path.as_ref().map(|p| p.as_bstr())

--- a/crates/but-workspace/tests/workspace/tree_manipulation/hunk.rs
+++ b/crates/but-workspace/tests/workspace/tree_manipulation/hunk.rs
@@ -318,6 +318,61 @@ fn from_selections() -> anyhow::Result<()> {
 }
 
 #[test]
+/// Regression test reproducing a bug where multiple DiffSpecs for the same file would be applied
+/// independently, making DiffSpecs with a net positive or negative amount of lines cause
+/// misalignment for subsequent DiffSpecs.
+fn handles_multiple_diffspecs_for_same_file() -> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario("mixed-hunk-modifications");
+    let filename = "file-in-index";
+    let (change, hunks) = changed_file_in_worktree_with_hunks(&repo, filename, CONTEXT_LINES)?;
+    insta::assert_debug_snapshot!(hunks.iter().map(|h| &h.diff).collect::<Vec<_>>(), @r#"
+    [
+        "@@ -1,0 +1,4 @@\n+1\n+2\n+3\n+4\n",
+        "@@ -2,2 +6,1 @@\n-6\n-7\n+6-7\n",
+        "@@ -6,2 +9,2 @@\n-10\n-11\n+ten\n+eleven\n",
+        "@@ -9,2 +12,3 @@\n-13\n-14\n+20\n+21\n+22\n",
+        "@@ -13,2 +17,0 @@\n-17\n-18\n",
+    ]
+    "#);
+
+    // First spec contains a hunk that displaces all lines in the rest of the file. With the bug in
+    // place where the specs are applied independently, this causes the second spec's hunk to not
+    // align with the worktree hunk that's resolved after the first spec's application.
+    let first_spec = DiffSpec {
+        previous_path: None,
+        path: change.path.clone(),
+        hunk_headers: vec![hunk_header("-1,0", "+1,4")],
+    };
+    let second_spec = DiffSpec {
+        previous_path: None,
+        path: change.path.clone(),
+        hunk_headers: vec![hunk_header("-13,2", "+17,0")],
+    };
+    let dropped = discard_workspace_changes(&repo, vec![first_spec, second_spec], CONTEXT_LINES)?;
+    assert_eq!(dropped, [], "all sub-hunks could be associated");
+
+    let file_content: BString = std::fs::read(repo.workdir().unwrap().join(filename))?.into();
+    insta::assert_snapshot!(file_content, @"
+    5
+    6-7
+    8
+    9
+    ten
+    eleven
+    12
+    20
+    21
+    22
+    15
+    16
+    17
+    18
+    ");
+
+    Ok(())
+}
+
+#[test]
 fn from_selections_with_context() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario("mixed-hunk-modifications");
     let filename = "file-in-index";

--- a/crates/but/tests/but/command/discard.rs
+++ b/crates/but/tests/but/command/discard.rs
@@ -1,4 +1,5 @@
 use bstr::ByteSlice;
+use snapbox::str;
 
 use crate::{command::util, utils::Sandbox};
 
@@ -78,6 +79,47 @@ fn concurrent_discard_to_independent_files_succeeds() -> anyhow::Result<()> {
         0,
         "both discarded files should be removed from the workspace"
     );
+
+    Ok(())
+}
+
+#[test]
+/// Reproduces a bug where hunks from the same file were separated into different DiffSpecs and
+/// applied one at a time in order. Existing hunks in the workspace were resolved again in between
+/// each DiffSpec being applied. If any hunk caused line displacement by adding or removing
+/// lines, any subsequent hunks become displaced from the DiffSpecs and trigger an error.
+fn can_discard_multiple_hunks_from_same_file() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-with-large-file")?;
+    env.setup_metadata(&["large-file"])?;
+
+    let initiale_file_content =
+        std::fs::read_to_string(env.projects_root().join("large_file.txt"))?;
+
+    // We prepend a new line to the beggining of the file and append a line to the end. These two
+    // edits end up in different hunks, and naively discarding these hunks in order with a "disc
+    // materialization" in between fails as the second hunk ends up outside the initially computed
+    // DiffSpec once the first has been discarded.
+    let new_large_file_content = format!("New first line\n{initiale_file_content}\nNew last line");
+    env.file("large_file.txt", new_large_file_content);
+
+    let status = util::status_json(&env)?;
+    let large_file_id = find_unassigned_cli_id(&status, "large_file.txt")
+        .expect("should find CLI ID of large file");
+
+    env.but("discard")
+        .arg(large_file_id)
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Successfully discarded changes to 2 items
+
+"#]])
+        .stderr_eq("");
+
+    let file_content_after_discard =
+        std::fs::read_to_string(env.projects_root().join("large_file.txt"))?;
+
+    assert_eq!(file_content_after_discard, initiale_file_content);
 
     Ok(())
 }

--- a/crates/but/tests/fixtures/scenario/one-stack-with-large-file.sh
+++ b/crates/but/tests/fixtures/scenario/one-stack-with-large-file.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+### General Description
+#
+# A single-stack workspace with a single relatively large file that can be used to (among other things) create independent diff hunks.
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git-init-frozen
+commit-file initial-commit-file.txt
+setup_target_to_match_main
+
+git checkout -b large-file
+# POSIX-compliant way to do the equivalent of `seq 100 > large_file.txt`
+for i in {1..100}; do
+  echo "$i" >> large_file.txt
+done
+git add large_file.txt && git commit -m 'Add large file'
+
+create_workspace_commit_once large-file

--- a/crates/but/tests/fixtures/scenario/one-stack-with-large-file.sh
+++ b/crates/but/tests/fixtures/scenario/one-stack-with-large-file.sh
@@ -13,7 +13,7 @@ commit-file initial-commit-file.txt
 setup_target_to_match_main
 
 git checkout -b large-file
-# POSIX-compliant way to do the equivalent of `seq 100 > large_file.txt`
+# simulating `seq 100 > large_file.txt`
 for i in {1..100}; do
   echo "$i" >> large_file.txt
 done


### PR DESCRIPTION
## 🧢 Changes
Fixes `but discard` failing on (most) multi-hunk files by flattening DiffSpecs before discarding.

The gist of it is that every hunk was (well, _is still_) naively added into a DiffSpec of its own. So a file with 2 hunks gets 2 DiffSpecs. We then applied these diffspecs in order, one at a time, independently. We resolve the hunks from the worktree again between each application so a preceeding DiffSpec with a hunk that displaces lines causes any succeeding DiffSpec to not line up anymore, triggering the bug.

This is trivial to reproduce: prepend a line to any moderately sized file, and then append a line to the same file s.t. the edits end up in different hunks. Discarding the first hunk displaces the rest of the lines of the file, so discarding the second hunk fails.

Here's a reproduction of the error: https://github.com/gitbutlerapp/gitbutler/actions/runs/24852478421/job/72756448821?pr=13505#step:5:2080

The fix I'm proposing here is to flatten the DiffSpecs on the level of the `but-workspace` crate so this kind of mistake cannot be reproduced in other places.

There's still an issue with DiffSpecs requiring certain ordering to be successful (see comments on commits and in code), so I've also updated the flattening to preserve order. It's still the responsibility of the caller to pass in specs in the correct order, though, which is not optimal as it's easy to get it wrong.

## Potential TODO
`but discard` is still passing in one `DiffSpec` per hunk, which is not very efficient. It would be better to just pass empty DiffSpecs for the file(s) to be restored, if the target is a file.