### PR TITLE
document and possible fix certain merge-conflicts on safe_checkout

### DIFF
--- a/crates/but-core/src/worktree/checkout/utils.rs
+++ b/crates/but-core/src/worktree/checkout/utils.rs
@@ -77,6 +77,9 @@ pub fn merge_worktree_changes_into_destination_or_keep_snapshot(
 
         if !selection_of_changes_checkout_would_affect.is_empty() {
             let mut repo_in_memory = repo.clone().with_object_memory();
+            repo_in_memory
+                .config_snapshot_mut()
+                .set_value(&gix::config::tree::Merge::RENORMALIZE, "true")?;
             let out = crate::snapshot::create_tree(
                 source_tree_id.attach(&repo_in_memory),
                 snapshot::create_tree::State {

--- a/crates/but-core/tests/core/worktree/checkout.rs
+++ b/crates/but-core/tests/core/worktree/checkout.rs
@@ -1,3 +1,4 @@
+use bstr::ByteSlice;
 use but_core::worktree::{checkout, checkout::UncommitedWorktreeChanges, safe_checkout};
 use but_testsupport::{
     git_status, read_only_in_memory_scenario, visualize_commit_graph_all,
@@ -334,6 +335,68 @@ inserted in new tree
     AM file-renamed-in-index
     ?? file-renamed
     ");
+
+    Ok(())
+}
+
+#[test]
+fn worktree_snapshot_of_legacy_crlf_blob_conflicts_with_independent_target_change()
+-> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario_slow("legacy-crlf-blob-with-gitattributes");
+    let file_path = repo.workdir_path("ImportOrdersJob.cs").unwrap();
+    let legacy_blob = repo
+        .find_object(repo.rev_parse_single("@:ImportOrdersJob.cs")?)?
+        .into_blob();
+    assert_eq!(
+        legacy_blob.data.as_bstr(),
+        "1\r\n2\r\n3\r\n",
+        "the tracked blob must start from digit-only CRLF content so the later spelled-out edits are clearly distinguishable"
+    );
+
+    // This write is with line-endings that are unchanged from the ones on disk, and from what's in Git (CRLF).
+    std::fs::write(&file_path, b"1\r\ntwo from worktree\r\n3\r\n")?;
+    assert_eq!(
+        git_status(&repo)?,
+        " M ImportOrdersJob.cs\n",
+        "the worktree edit must be visible before checkout"
+    );
+
+    let (head_commit, new_commit) = build_commit(
+        &repo,
+        |tree| {
+            // This commit also has the right light endings (CRLF)
+            let blob_id = repo.write_blob(b"1\r\n2\r\nthree from target\r\n")?;
+            tree.upsert("ImportOrdersJob.cs", EntryKind::Blob, blob_id)?;
+            Ok(())
+        },
+        "edit same legacy crlf file independently",
+    )?;
+
+    // A lot happens here, but the significant part is that the overlapping worktree changes are cherry-picked
+    // onto the `new_commit` to be transferred by merge. This means they are worktree-filtered and added to
+    // a tree.
+    // That filtering step is what in this case normalise line separators to \n, which is what Git should actually
+    // store as well.
+    // But because of that, the entire file changes, and is marked as conflicting even though the merge would be
+    // fine otherwise.
+    let err = safe_checkout(head_commit.id, new_commit.id, &repo, Default::default()).unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Worktree changes would be overwritten by checkout: \"ImportOrdersJob.cs\"",
+        "status quo: snapshot filtering makes the legacy CRLF worktree change conflict
+        as its line separators are turned into \\n"
+    );
+
+    assert_eq!(
+        std::fs::read(&file_path)?.as_bstr(),
+        "1\r\ntwo from worktree\r\n3\r\n",
+        "checkout aborts before applying the target change"
+    );
+    assert_eq!(
+        repo.head_id()?,
+        head_commit.id,
+        "checkout aborts before updating HEAD"
+    );
 
     Ok(())
 }

--- a/crates/but-core/tests/core/worktree/checkout.rs
+++ b/crates/but-core/tests/core/worktree/checkout.rs
@@ -340,7 +340,7 @@ inserted in new tree
 }
 
 #[test]
-fn worktree_snapshot_of_legacy_crlf_blob_conflicts_with_independent_target_change()
+fn worktree_snapshot_of_legacy_crlf_blob_merges_cleanly_with_independent_target_change()
 -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario_slow("legacy-crlf-blob-with-gitattributes");
     let file_path = repo.workdir_path("ImportOrdersJob.cs").unwrap();
@@ -364,7 +364,7 @@ fn worktree_snapshot_of_legacy_crlf_blob_conflicts_with_independent_target_chang
     let (head_commit, new_commit) = build_commit(
         &repo,
         |tree| {
-            // This commit also has the right light endings (CRLF)
+            // This commit also has the right line endings (CRLF)
             let blob_id = repo.write_blob(b"1\r\n2\r\nthree from target\r\n")?;
             tree.upsert("ImportOrdersJob.cs", EntryKind::Blob, blob_id)?;
             Ok(())

--- a/crates/but-core/tests/core/worktree/checkout.rs
+++ b/crates/but-core/tests/core/worktree/checkout.rs
@@ -373,29 +373,29 @@ fn worktree_snapshot_of_legacy_crlf_blob_conflicts_with_independent_target_chang
     )?;
 
     // A lot happens here, but the significant part is that the overlapping worktree changes are cherry-picked
-    // onto the `new_commit` to be transferred by merge. This means they are worktree-filtered and added to
-    // a tree.
-    // That filtering step is what in this case normalise line separators to \n, which is what Git should actually
-    // store as well.
-    // But because of that, the entire file changes, and is marked as conflicting even though the merge would be
-    // fine otherwise.
-    let err = safe_checkout(head_commit.id, new_commit.id, &repo, Default::default()).unwrap_err();
-    assert_eq!(
-        err.to_string(),
-        "Worktree changes would be overwritten by checkout: \"ImportOrdersJob.cs\"",
-        "status quo: snapshot filtering makes the legacy CRLF worktree change conflict
-        as its line separators are turned into \\n"
-    );
+    // onto the `new_commit` to be transferred by merge. That snapshot now normalizes line endings correctly,
+    // so the independent edits merge cleanly instead of being treated as a whole-file conflict.
+    let out = safe_checkout(head_commit.id, new_commit.id, &repo, Default::default())?;
+    insta::assert_debug_snapshot!(out, @r#"
+    Outcome {
+        snapshot_tree: Some(
+            Sha1(77d39e5c3dae5dde723f5be3c45e3525ef424447),
+        ),
+        num_deleted_files: 0,
+        num_added_or_updated_files: 1,
+        head_update: "Update refs/heads/main to Some(Object(Sha1(a530b145a2513ba5b2a4418bbb74920d3967f8fb)))",
+    }
+    "#);
 
     assert_eq!(
         std::fs::read(&file_path)?.as_bstr(),
-        "1\r\ntwo from worktree\r\n3\r\n",
-        "checkout aborts before applying the target change"
+        "1\r\ntwo from worktree\r\nthree from target\r\n",
+        "checkout keeps the worktree edit and applies the independent target change"
     );
     assert_eq!(
         repo.head_id()?,
-        head_commit.id,
-        "checkout aborts before updating HEAD"
+        new_commit.id,
+        "checkout updates HEAD to the target commit"
     );
 
     Ok(())

--- a/crates/but-core/tests/fixtures/scenario/legacy-crlf-blob-with-gitattributes.sh
+++ b/crates/but-core/tests/fixtures/scenario/legacy-crlf-blob-with-gitattributes.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+git init
+git config core.autocrlf true
+
+printf '1\r\n2\r\n3\r\n' >ImportOrdersJob.cs
+git -c core.autocrlf=false add ImportOrdersJob.cs
+git commit -m "legacy crlf blob"
+
+printf '*.cs text eol=crlf\n' >.gitattributes
+git add .gitattributes
+git commit -m "add attributes"


### PR DESCRIPTION
Add a focused safe_checkout test for a legacy line-ending state where a file was committed with CRLF bytes before a later .gitattributes rule started treating it as text with CRLF checkout.

The important setup is:

- the committed blob contains CRLF bytes
- .gitattributes later says `*.cs text eol=crlf`
- the worktree also contains CRLF bytes
- Git now treats future versions of that file as text, meaning content written
  back into Git object storage is normalized through the clean filter

This creates a subtle mismatch. The file looks normal in the worktree, but the blob already stored in Git is not in the canonical normalized form that the attributes rule expects. When safe_checkout tries to preserve an overlapping worktree edit, it creates a snapshot tree from the worktree change. Creating that tree runs the file through Git's worktree-to-Git filters, so the snapshot stores the filtered/normalized version of the edited file rather than the original legacy CRLF representation.

The later resolve step then merges three trees:

- base: the current HEAD tree, with the legacy CRLF blob
- ours: the target tree that safe_checkout wants to check out
- theirs: the snapshot tree containing the filtered worktree edit

Because the snapshot tree was normalized while the base tree was not, the merge can see every line as changed on the snapshot side. Even if the user's worktree edit and the target checkout edit touch independent lines, the line-ending-only rewrite makes the merge look overlapping. safe_checkout therefore reports:

    Worktree changes would be overwritten by checkout: "ImportOrdersJob.cs"

The test documents the current behavior rather than asserting the desired future behavior. It verifies that safe_checkout aborts, leaves the worktree file unchanged, and does not update HEAD. This captures the root cause behind #13457 close to the component that owns it: the snapshot/filter/merge path in safe_checkout, not the higher-level `but commit` plumbing.

### Tasks

* [x] refackiew testcase and validate it would work without `.gitattributes eol=crlf`
* [x] investigate a fix - make it happen with [merge.renormalize](https://git-scm.com/docs/git-config#Documentation/git-config.txt-mergerenormalize) support coming from `gix`.
* [x] implement it
