### PR TITLE
fix: But discard renames previous path

### DIFF
--- a/crates/but-testsupport/src/sandbox.rs
+++ b/crates/but-testsupport/src/sandbox.rs
@@ -7,6 +7,7 @@ use but_core::{
 use but_meta::VirtualBranchesTomlMetadata;
 #[cfg(feature = "sandbox-but-api")]
 use but_settings::AppSettings;
+use gix::bstr::ByteVec;
 use gix_testtools::{Creation, tempfile};
 use snapbox::{Assert, Redactions};
 
@@ -323,6 +324,13 @@ impl Sandbox {
             .write_all(data.as_ref())
             .expect("writes should work");
         self
+    }
+
+    /// Read a file at `path` from our projects root.
+    pub fn read_file(&self, path: impl AsRef<Path>) -> Result<String, gix::bstr::FromUtf8Error> {
+        std::fs::read(self.projects_root().join(path))
+            .expect("File exists and can be read")
+            .into_string()
     }
 
     /// Append `data` to `path` in our projects root.

--- a/crates/but/src/command/legacy/discard.rs
+++ b/crates/but/src/command/legacy/discard.rs
@@ -3,10 +3,11 @@
 //! This module provides functionality to discard uncommitted changes from the worktree.
 
 use anyhow::{Context as _, Result, bail};
-use bstr::ByteSlice;
+use bstr::{BStr, ByteSlice};
 use but_api::diff;
 use but_core::{DiffSpec, sync::RepoExclusive};
 use but_ctx::Context;
+use but_hunk_assignment::HunkAssignment;
 use gitbutler_oplog::{
     OplogExt,
     entry::{OperationKind, SnapshotDetails},
@@ -47,61 +48,18 @@ pub fn handle(ctx: &mut Context, out: &mut OutputChannel, id: &str) -> Result<()
     for resolved_id in resolved_ids {
         match resolved_id {
             CliId::Uncommitted(uncommitted) => {
-                // Convert hunk assignments to DiffSpecs
-                for assignment in uncommitted.hunk_assignments {
-                    let is_addition_or_deletion = path_status
-                        .get(assignment.path_bytes.as_bstr())
-                        .map(|status| {
-                            matches!(
-                                status,
-                                but_core::ui::TreeStatus::Addition { .. }
-                                    | but_core::ui::TreeStatus::Deletion { .. }
-                            )
-                        })
-                        .unwrap_or(false);
-
-                    diff_specs.push(DiffSpec {
-                        previous_path: None, // HunkAssignment doesn't track previous path (renames)
-                        path: assignment.path_bytes,
-                        // For additions/deletions, use empty hunk_headers to signal whole-file mode
-                        hunk_headers: if is_addition_or_deletion {
-                            Vec::new()
-                        } else {
-                            assignment.hunk_header.into_iter().collect()
-                        },
-                    });
-                }
+                collect_diff_specs_from_assignments(
+                    uncommitted.hunk_assignments,
+                    &path_status,
+                    &mut diff_specs,
+                );
             }
             CliId::PathPrefix { .. } => todo!(),
             CliId::Unassigned { .. } => {
                 // Discard all uncommitted changes
                 let assignments = worktree_changes.assignments.clone();
 
-                // Convert all assignments to DiffSpecs
-                // For file additions and deletions, we must use whole-file mode (empty hunk_headers)
-                for assignment in assignments {
-                    let is_addition_or_deletion = path_status
-                        .get(assignment.path_bytes.as_bstr())
-                        .map(|status| {
-                            matches!(
-                                status,
-                                but_core::ui::TreeStatus::Addition { .. }
-                                    | but_core::ui::TreeStatus::Deletion { .. }
-                            )
-                        })
-                        .unwrap_or(false);
-
-                    diff_specs.push(DiffSpec {
-                        previous_path: None,
-                        path: assignment.path_bytes,
-                        // For additions/deletions, use empty hunk_headers to signal whole-file mode
-                        hunk_headers: if is_addition_or_deletion {
-                            Vec::new()
-                        } else {
-                            assignment.hunk_header.into_iter().collect()
-                        },
-                    });
-                }
+                collect_diff_specs_from_assignments(assignments, &path_status, &mut diff_specs);
             }
             CliId::Branch { .. } => {
                 bail!("Cannot discard a branch. Use a file or hunk ID instead.");
@@ -200,6 +158,46 @@ pub fn handle(ctx: &mut Context, out: &mut OutputChannel, id: &str) -> Result<()
     Ok(())
 }
 
+fn collect_diff_specs_from_assignments(
+    assignments: impl IntoIterator<Item = HunkAssignment>,
+    path_status: &std::collections::HashMap<&BStr, &but_core::ui::TreeStatus>,
+    diff_specs: &mut Vec<DiffSpec>,
+) {
+    for assignment in assignments {
+        let spec = assignment_to_diff_spec(assignment, path_status);
+        diff_specs.push(spec);
+    }
+}
+
+fn assignment_to_diff_spec(
+    assignment: HunkAssignment,
+    path_status: &std::collections::HashMap<&BStr, &but_core::ui::TreeStatus>,
+) -> DiffSpec {
+    let (is_addition_or_deletion, previous_path) = path_status
+        .get(assignment.path_bytes.as_bstr())
+        .map(|status| match status {
+            but_core::ui::TreeStatus::Addition { .. } => (true, None),
+            but_core::ui::TreeStatus::Deletion { .. } => (true, None),
+            but_core::ui::TreeStatus::Modification { .. } => (false, None),
+            but_core::ui::TreeStatus::Rename {
+                previous_path_bytes,
+                ..
+            } => (false, Some(previous_path_bytes.to_owned())),
+        })
+        .unwrap_or((false, None));
+
+    DiffSpec {
+        previous_path,
+        path: assignment.path_bytes,
+        // For additions/deletions, use empty hunk_headers to signal whole-file mode.
+        hunk_headers: if is_addition_or_deletion {
+            Vec::new()
+        } else {
+            assignment.hunk_header.into_iter().collect()
+        },
+    }
+}
+
 /// Create a snapshot in the oplog before performing an operation
 fn create_snapshot(
     ctx: &mut Context,
@@ -220,4 +218,90 @@ fn create_snapshot(
 
     let details = SnapshotDetails::new(operation).with_trailers(trailers);
     let _snapshot = ctx.create_snapshot(details, perm).ok();
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use bstr::{BStr, BString};
+    use but_core::HunkHeader;
+    use but_hunk_assignment::HunkAssignment;
+
+    use super::{assignment_to_diff_spec, collect_diff_specs_from_assignments};
+
+    #[test]
+    fn assignment_to_diff_spec_keeps_hunk_for_non_filewide_case() {
+        let assignment = make_assignment("a.txt", Some(hunk(1, 2, 3, 4)));
+        let path_status: HashMap<&BStr, &but_core::ui::TreeStatus> = HashMap::new();
+
+        let spec = assignment_to_diff_spec(assignment, &path_status);
+
+        assert_eq!(spec.path, BString::from("a.txt"));
+        assert_eq!(spec.hunk_headers, vec![hunk(1, 2, 3, 4)]);
+        assert!(spec.previous_path.is_none());
+    }
+
+    #[test]
+    fn collect_diff_specs_from_assignments_preserves_input_granularity() {
+        let assignments = vec![
+            make_assignment("a.txt", Some(hunk(1, 2, 3, 4))),
+            make_assignment("a.txt", Some(hunk(5, 6, 7, 8))),
+            make_assignment("b.txt", Some(hunk(9, 1, 10, 1))),
+        ];
+        let path_status: HashMap<&BStr, &but_core::ui::TreeStatus> = HashMap::new();
+        let mut diff_specs = Vec::new();
+
+        collect_diff_specs_from_assignments(assignments, &path_status, &mut diff_specs);
+
+        assert_eq!(diff_specs.len(), 3);
+
+        assert_eq!(diff_specs[0].path, BString::from("a.txt"));
+        assert_eq!(diff_specs[0].hunk_headers, vec![hunk(1, 2, 3, 4)]);
+
+        assert_eq!(diff_specs[1].path, BString::from("a.txt"));
+        assert_eq!(diff_specs[1].hunk_headers, vec![hunk(5, 6, 7, 8)]);
+
+        assert_eq!(diff_specs[2].path, BString::from("b.txt"));
+        assert_eq!(diff_specs[2].hunk_headers, vec![hunk(9, 1, 10, 1)]);
+    }
+
+    #[test]
+    fn collect_diff_specs_from_assignments_keeps_filewide_and_hunk_entries() {
+        let assignments = vec![
+            make_assignment("a.txt", Some(hunk(1, 2, 3, 4))),
+            make_assignment("a.txt", None),
+        ];
+        let path_status: HashMap<&BStr, &but_core::ui::TreeStatus> = HashMap::new();
+        let mut diff_specs = Vec::new();
+
+        collect_diff_specs_from_assignments(assignments, &path_status, &mut diff_specs);
+
+        assert_eq!(diff_specs.len(), 2);
+        assert_eq!(diff_specs[0].hunk_headers, vec![hunk(1, 2, 3, 4)]);
+        assert!(diff_specs[1].hunk_headers.is_empty());
+    }
+
+    fn make_assignment(path: &str, hunk_header: Option<HunkHeader>) -> HunkAssignment {
+        HunkAssignment {
+            id: None,
+            hunk_header,
+            path: path.to_string(),
+            path_bytes: BString::from(path),
+            stack_id: None,
+            branch_ref_bytes: None,
+            line_nums_added: None,
+            line_nums_removed: None,
+            diff: None,
+        }
+    }
+
+    fn hunk(old_start: u32, old_lines: u32, new_start: u32, new_lines: u32) -> HunkHeader {
+        HunkHeader {
+            old_start,
+            old_lines,
+            new_start,
+            new_lines,
+        }
+    }
 }

--- a/crates/but/tests/but/command/discard.rs
+++ b/crates/but/tests/but/command/discard.rs
@@ -1,5 +1,4 @@
 use bstr::ByteSlice;
-use snapbox::str;
 
 use crate::{command::util, utils::Sandbox};
 
@@ -84,42 +83,174 @@ fn concurrent_discard_to_independent_files_succeeds() -> anyhow::Result<()> {
 }
 
 #[test]
-/// Reproduces a bug where hunks from the same file were separated into different DiffSpecs and
-/// applied one at a time in order. Existing hunks in the workspace were resolved again in between
-/// each DiffSpec being applied. If any hunk caused line displacement by adding or removing
-/// lines, any subsequent hunks become displaced from the DiffSpecs and trigger an error.
-fn can_discard_multiple_hunks_from_same_file() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-with-large-file")?;
-    env.setup_metadata(&["large-file"])?;
+fn discard_reverts_simple_rename() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
 
-    let initiale_file_content =
-        std::fs::read_to_string(env.projects_root().join("large_file.txt"))?;
+    env.file("src/rename-source.ts", "export const source = true;\n");
+    env.but("commit A -m 'seed rename source'")
+        .assert()
+        .success();
 
-    // We prepend a new line to the beggining of the file and append a line to the end. These two
-    // edits end up in different hunks, and naively discarding these hunks in order with a "disc
-    // materialization" in between fails as the second hunk ends up outside the initially computed
-    // DiffSpec once the first has been discarded.
-    let new_large_file_content = format!("New first line\n{initiale_file_content}\nNew last line");
-    env.file("large_file.txt", new_large_file_content);
+    std::fs::rename(
+        env.projects_root().join("src/rename-source.ts"),
+        env.projects_root().join("src/rename-target.ts"),
+    )?;
 
     let status = util::status_json(&env)?;
-    let large_file_id = find_unassigned_cli_id(&status, "large_file.txt")
-        .expect("should find CLI ID of large file");
+    let cli_id =
+        find_unassigned_cli_id(&status, "rename-target").expect("should find renamed file CLI ID");
 
-    env.but("discard")
-        .arg(large_file_id)
+    env.but(format!("discard {cli_id}")).assert().success();
+
+    assert!(
+        env.projects_root().join("src/rename-source.ts").exists(),
+        "discarding a rename should restore the source path"
+    );
+    assert!(
+        !env.projects_root().join("src/rename-target.ts").exists(),
+        "discarding a rename should remove the target path"
+    );
+    assert_eq!(
+        env.invoke_git("status --porcelain"),
+        "",
+        "discarding a rename should leave a clean worktree"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn discard_rename_does_not_discard_unrelated_changes() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.file("src/rename-source-only.ts", "export const source = 1;\n");
+    env.but("commit A -m 'seed rename source only'")
         .assert()
-        .success()
-        .stdout_eq(str![[r#"
-Successfully discarded changes to 2 items
+        .success();
 
-"#]])
-        .stderr_eq("");
+    std::fs::rename(
+        env.projects_root().join("src/rename-source-only.ts"),
+        env.projects_root().join("src/rename-target-only.ts"),
+    )?;
+    env.file("src/keep-me.ts", "export const keep = true;\n");
 
-    let file_content_after_discard =
-        std::fs::read_to_string(env.projects_root().join("large_file.txt"))?;
+    let status_before = util::status_json(&env)?;
+    let cli_id = find_unassigned_cli_id(&status_before, "rename-target-only")
+        .expect("should find renamed file CLI ID");
 
-    assert_eq!(file_content_after_discard, initiale_file_content);
+    env.but(format!("discard {cli_id}")).assert().success();
+
+    assert!(
+        env.projects_root()
+            .join("src/rename-source-only.ts")
+            .exists(),
+        "discarding rename should restore source path"
+    );
+    assert!(
+        !env.projects_root()
+            .join("src/rename-target-only.ts")
+            .exists(),
+        "discard should remove renamed target path"
+    );
+
+    let status_after = util::status_json(&env)?;
+    assert!(
+        find_unassigned_cli_id(&status_after, "rename-target-only").is_none(),
+        "discarded renamed file should no longer appear in unassigned changes"
+    );
+    assert!(
+        find_unassigned_cli_id(&status_after, "keep-me").is_some(),
+        "discarding a rename should not discard unrelated unassigned changes"
+    );
+
+    let git_status = env.invoke_git("status --porcelain");
+    assert!(
+        git_status.contains("src/keep-me.ts"),
+        "expected unrelated unassigned file to remain, got:\n{git_status}"
+    );
+    assert!(
+        !git_status.contains("rename-target-only") && !git_status.contains("rename-source-only"),
+        "rename paths should no longer be dirty, got:\n{git_status}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn discard_the_whole_unassigned_changes() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.file("src/rename-source-only.ts", "export const source = 1;\n");
+    env.but("commit A -m 'seed rename source only'")
+        .assert()
+        .success();
+
+    std::fs::rename(
+        env.projects_root().join("src/rename-source-only.ts"),
+        env.projects_root().join("src/rename-target-only.ts"),
+    )?;
+    env.file("src/keep-me.ts", "export const keep = true;\n");
+
+    env.but("discard zz").assert().success();
+
+    assert!(
+        env.projects_root()
+            .join("src/rename-source-only.ts")
+            .exists(),
+        "discarding rename should restore source path"
+    );
+    assert!(
+        !env.projects_root()
+            .join("src/rename-target-only.ts")
+            .exists(),
+        "discard should remove renamed target path"
+    );
+
+    let status_after = util::status_json(&env)?;
+    assert!(
+        find_unassigned_cli_id(&status_after, "rename-target-only").is_none(),
+        "discarded renamed file should no longer appear in unassigned changes"
+    );
+    assert!(
+        find_unassigned_cli_id(&status_after, "keep-me").is_none(),
+        "the added file should be gone as well"
+    );
+
+    assert_eq!(
+        env.invoke_git("status --porcelain"),
+        "",
+        "discarding a rename should leave a clean worktree"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn discarding_multiple_hunks_in_a_file_works() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    let content = "1\n2\n3\n4\n5\n6\n7";
+    let file_path = "src/some_file.txt";
+
+    env.file(file_path, content);
+    env.but("commit A -m 'seed rename source only'")
+        .assert()
+        .success();
+
+    env.file(file_path, "a\nb\nc\n1\n2\n3\n4\n5\n6\n7\nd\ne\nf");
+    env.but("discard zz").assert().success();
+
+    assert!(
+        env.projects_root().join("src/some_file.txt").exists(),
+        "discarding multiple hunks should keep the tracked file present"
+    );
+
+    let content_after_discard = env.read_file(file_path)?;
+    assert_eq!(content_after_discard, content);
 
     Ok(())
 }


### PR DESCRIPTION
Pass the previous path into the diff spec as expected

- Add tests for renaming and for multi-hunk discards
