### PR TITLE
Add an add_edge operation to the rebase engine

### DIFF
--- a/crates/but-rebase/src/graph_rebase/mutate.rs
+++ b/crates/but-rebase/src/graph_rebase/mutate.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashSet;
 
-use anyhow::{Result, anyhow};
+use anyhow::{Result, anyhow, bail};
 use but_core::RefMetadata;
 use petgraph::{Direction, visit::EdgeRef};
 use serde::{Deserialize, Serialize};
@@ -742,6 +742,59 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
                 })
             }
         }
+    }
+
+    /// Add an edge to the graph with a desired order.
+    ///
+    /// Bails if there is already an edge from the child to the parent with the
+    /// same order.
+    pub fn add_edge(
+        &mut self,
+        child: impl ToSelector,
+        parent: impl ToSelector,
+        desired_order: usize,
+    ) -> Result<()> {
+        let child = self.history.normalize_selector(child.to_selector(self)?)?;
+        let parent = self.history.normalize_selector(parent.to_selector(self)?)?;
+
+        if cfg!(debug_assertions) {
+            let mut seen = HashSet::from([parent.id]);
+            let mut tips = vec![parent.id];
+
+            while let Some(tip) = tips.pop() {
+                for parent in self
+                    .graph
+                    .edges_directed(tip, Direction::Outgoing)
+                    .map(|e| e.target())
+                {
+                    if seen.insert(parent) {
+                        tips.push(parent);
+                    }
+                }
+            }
+
+            if seen.contains(&child.id) {
+                bail!("BUG: Add edge introduces a cycle");
+            }
+        }
+
+        if self
+            .graph
+            .edges_directed(child.id, Direction::Outgoing)
+            .any(|edge| edge.weight().order == desired_order)
+        {
+            bail!("An edge with desired order {desired_order} already exists");
+        }
+
+        self.graph.add_edge(
+            child.id,
+            parent.id,
+            Edge {
+                order: desired_order,
+            },
+        );
+
+        Ok(())
     }
 }
 

--- a/crates/but-rebase/tests/rebase/graph_rebase/add_edge.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/add_edge.rs
@@ -1,0 +1,91 @@
+//! These tests exercise the add_edge operation.
+
+use anyhow::Result;
+use but_graph::Graph;
+use but_rebase::graph_rebase::{Editor, testing::Testing as _};
+
+use crate::utils::{fixture, standard_options};
+
+#[test]
+fn adding_an_existing_edge_causes_an_error() -> Result<()> {
+    let (repo, mut meta) = fixture("four-commits")?;
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let b = repo.rev_parse_single("HEAD~")?.detach();
+    let a = repo.rev_parse_single("HEAD~2")?.detach();
+    let b_selector = editor.select_commit(b)?;
+    let a_selector = editor.select_commit(a)?;
+
+    let err = editor
+        .add_edge(b_selector, a_selector, 0)
+        .expect_err("adding an existing edge order should fail");
+
+    assert_eq!(
+        err.to_string(),
+        "An edge with desired order 0 already exists"
+    );
+
+    Ok(())
+}
+
+#[test]
+#[cfg(debug_assertions)]
+fn adding_an_edge_that_introduces_a_cycle_causes_an_error() -> Result<()> {
+    let (repo, mut meta) = fixture("four-commits")?;
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let c = repo.rev_parse_single("HEAD")?.detach();
+    let a = repo.rev_parse_single("HEAD~2")?.detach();
+    let c_selector = editor.select_commit(c)?;
+    let a_selector = editor.select_commit(a)?;
+
+    let err = editor
+        .add_edge(a_selector, c_selector, 1)
+        .expect_err("adding an edge to an existing descendant should fail");
+
+    assert_eq!(err.to_string(), "BUG: Add edge introduces a cycle");
+
+    Ok(())
+}
+
+#[test]
+fn adding_a_valid_edge_is_successful() -> Result<()> {
+    let (repo, mut meta) = fixture("merge-in-the-middle")?;
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let a = repo.rev_parse_single("A")?.detach();
+    let b = repo.rev_parse_single("B")?.detach();
+    let a_selector = editor.select_commit(a)?;
+    let b_selector = editor.select_commit(b)?;
+
+    editor.add_edge(a_selector, b_selector, 1)?;
+
+    insta::assert_snapshot!(editor.steps_ascii(), @r"
+    ◎ refs/heads/with-inner-merge
+    ● e8ee978 on top of inner merge
+    ● 2fc288c Merge branch 'B' into with-inner-merge
+    ├─╮
+    ◎ │ refs/heads/A
+    ● │ add59d2 A: 10 lines on top
+    ├─╪─╮
+    │ ◎ │ refs/heads/B
+    │ ├─╯
+    │ ● 984fd1c C: new file with 10 lines
+    ├─╯
+    ◎ refs/heads/main
+    ◎ refs/tags/base
+    ● 8f0d338 base
+    ╵
+    ");
+
+    Ok(())
+}

--- a/crates/but-rebase/tests/rebase/graph_rebase/mod.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/mod.rs
@@ -5,6 +5,7 @@ use but_meta::{
 };
 use but_testsupport::StackState;
 
+mod add_edge;
 mod cherry_pick;
 mod conflictable_restriction;
 mod disconnect;


### PR DESCRIPTION
I’ve gone back and forth as to whether we should have / need to have a cycle check.

Our algorithms using the `Editor` should never introduce a cycle as part of their definition.

I ended up falling into the middle ground of making it a check that will run in non-release builds.