### PR TITLE
chore: remove dummy `gitbutler-git-setsid` binary

### DIFF
--- a/crates/gitbutler-git/Cargo.toml
+++ b/crates/gitbutler-git/Cargo.toml
@@ -14,11 +14,6 @@ name = "gitbutler-git-askpass"
 path = "src/bin/askpass.rs"
 test = false
 
-[[bin]] # we need this binary only for backwards compatibility with old bundled CLI installers that validate that it's there
-name = "gitbutler-git-setsid"
-path = "src/bin/noop.rs"
-test = false
-
 [features]
 default = ["tokio"]
 tokio = ["dep:tokio"]

--- a/crates/gitbutler-git/src/bin/noop.rs
+++ b/crates/gitbutler-git/src/bin/noop.rs
@@ -1,4 +1,0 @@
-//! This is just a dummy NOOP implementation that is used to produce an effectively empty binary
-//! for backwards compatibility with old installers.
-
-pub fn main() {}

--- a/crates/gitbutler-git/src/repository.rs
+++ b/crates/gitbutler-git/src/repository.rs
@@ -279,8 +279,7 @@ where
 /// for the CLI, as the child process simply inherits stdin from the parent process and therefore
 /// doesn't need the askpass mechanism.
 ///
-/// It's doubly useful in the sense that the CLI then does not need the askpass and setsid
-/// binaries.
+/// It's doubly useful in the sense that the CLI then does not need the askpass binary.
 async fn execute_direct<P, E>(
     harness_env: HarnessEnv<P>,
     executor: &E,

--- a/crates/gitbutler-tauri/inject-git-binaries.sh
+++ b/crates/gitbutler-tauri/inject-git-binaries.sh
@@ -20,20 +20,17 @@ CRATE_ROOT="$ROOT/crates/gitbutler-tauri"
 
 # BINARIES
 ASKPASS="gitbutler-git-askpass"
-SETSID="gitbutler-git-setsid"
 BUT="but"
 
-if [ -f "$TARGET_ROOT/$ASKPASS.exe" ] && [ -f "$TARGET_ROOT/$SETSID.exe" ]; then
+if [ -f "$TARGET_ROOT/$ASKPASS.exe" ]; then
     log injecting windows gitbutler-git binaries into crates/gitbutler-tauri "(TRIPLE=${TRIPLE})"
     cp -v "$TARGET_ROOT/$ASKPASS.exe" "$CRATE_ROOT/$ASKPASS-${TRIPLE}.exe"
-    cp -v "$TARGET_ROOT/$SETSID.exe" "$CRATE_ROOT/$SETSID-${TRIPLE}.exe"
     if [ -f "$TARGET_ROOT/$BUT.exe" ]; then
       cp -v "$TARGET_ROOT/$BUT.exe" "$CRATE_ROOT/$BUT-${TRIPLE}.exe"
     fi
-elif [ -f "$TARGET_ROOT/$ASKPASS" ] && [ -f "$TARGET_ROOT/$SETSID" ]; then
+elif [ -f "$TARGET_ROOT/$ASKPASS" ]; then
     log injecting gitbutler-git binaries into crates/gitbutler-tauri "(TRIPLE=${TRIPLE})"
     cp -v "$TARGET_ROOT/$ASKPASS" "$CRATE_ROOT/$ASKPASS-${TRIPLE}"
-    cp -v "$TARGET_ROOT/$SETSID" "$CRATE_ROOT/$SETSID-${TRIPLE}"
 else
     log gitbutler-git binaries are not built
     exit 1

--- a/crates/gitbutler-tauri/tauri.conf.nightly-local.json
+++ b/crates/gitbutler-tauri/tauri.conf.nightly-local.json
@@ -13,7 +13,7 @@
 			"icons/nightly/icon.icns",
 			"icons/nightly/icon.ico"
 		],
-		"externalBin": ["gitbutler-git-askpass", "gitbutler-git-setsid"]
+		"externalBin": ["gitbutler-git-askpass"]
 	},
 	"plugins": {
 		"updater": {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -185,15 +185,13 @@ if [ "$OS" = "windows" ]; then
 	#          Should it be re-added, please ensure that `but` is built
 	#          as part of the 'beforeBuildCommand' in tauri.conf AND it must be injected
 	#          via 'inject-git-binaries.sh'.
-	EXTERNAL_BIN='["gitbutler-git-askpass", "gitbutler-git-setsid", "but"]'
+	EXTERNAL_BIN='["gitbutler-git-askpass", "but"]'
 	FEATURES="windows"
 elif [ "$OS" = "linux" ]; then
 	EXTERNAL_BIN='["gitbutler-git-askpass"]'
 	FEATURES="builtin-but packaged-but-distribution"
 elif [ "$OS" = "macos" ]; then
-	# we need to include the gitbutler-git-setsid dummy binary as
-	# installers bundled with version <=0.19.3 will validate that it's there for macOS.
-	EXTERNAL_BIN='["gitbutler-git-askpass", "gitbutler-git-setsid"]'
+	EXTERNAL_BIN='["gitbutler-git-askpass"]'
 	FEATURES="builtin-but"
 else
 	echo "Unsupported OS: $OS"


### PR DESCRIPTION
The functionality of the setsid binary was removed quite a while back, but we had to keep a dummy binary around as the then-version of the macOS `but-installer` would verify the existence of said binary. So, old versions of the CLI would fail to upgrade to new versions.

Now it's been sufficiently long that I think we can get rid of this relic. For the very few people that may still be on a super-duper old version of the installer, they can repair the install by downloading the standalone `but-installer` (e.g. using the `install.sh` shell script).