### PR TITLE
update gix to the latest hardened version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -2184,7 +2184,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2920,7 +2920,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3152,7 +3152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4342,7 +4342,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.81.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "gix-actor",
  "gix-archive",
@@ -4385,7 +4385,7 @@ dependencies = [
  "gix-status",
  "gix-submodule",
  "gix-tempfile",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
  "gix-transport",
  "gix-traverse",
  "gix-url",
@@ -4403,7 +4403,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.40.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "gix-date",
@@ -4415,7 +4415,7 @@ dependencies = [
 [[package]]
 name = "gix-archive"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "gix-date",
@@ -4427,13 +4427,13 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "gix-glob",
  "gix-path 0.11.2",
  "gix-quote",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
  "kstring",
  "serde",
  "smallvec",
@@ -4444,7 +4444,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.3.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "gix-error",
 ]
@@ -4452,7 +4452,7 @@ dependencies = [
 [[package]]
 name = "gix-blame"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -4461,7 +4461,7 @@ dependencies = [
  "gix-hash",
  "gix-object",
  "gix-revwalk",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
  "gix-traverse",
  "gix-worktree",
  "smallvec",
@@ -4471,7 +4471,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.7.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "gix-error",
 ]
@@ -4479,19 +4479,19 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.8.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "gix-path 0.11.2",
  "gix-quote",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
  "shell-words",
 ]
 
 [[package]]
 name = "gix-commitgraph"
 version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -4505,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.54.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -4524,7 +4524,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.17.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4536,7 +4536,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.37.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4545,7 +4545,7 @@ dependencies = [
  "gix-path 0.11.2",
  "gix-prompt",
  "gix-sec",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
  "gix-url",
  "serde",
  "thiserror 2.0.18",
@@ -4554,7 +4554,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.15.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "gix-error",
@@ -4567,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.61.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -4581,7 +4581,7 @@ dependencies = [
  "gix-path 0.11.2",
  "gix-pathspec",
  "gix-tempfile",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
  "gix-traverse",
  "gix-worktree",
  "thiserror 2.0.18",
@@ -4590,7 +4590,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.23.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "gix-discover",
@@ -4600,7 +4600,7 @@ dependencies = [
  "gix-object",
  "gix-path 0.11.2",
  "gix-pathspec",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
  "gix-utils",
  "gix-worktree",
  "thiserror 2.0.18",
@@ -4609,7 +4609,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.49.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "dunce",
@@ -4623,7 +4623,7 @@ dependencies = [
 [[package]]
 name = "gix-error"
 version = "0.2.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
 ]
@@ -4631,13 +4631,13 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.46.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bytes",
  "crc32fast",
  "crossbeam-channel",
  "gix-path 0.11.2",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
  "gix-utils",
  "libc",
  "once_cell",
@@ -4651,7 +4651,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -4662,7 +4662,7 @@ dependencies = [
  "gix-packetline",
  "gix-path 0.11.2",
  "gix-quote",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
  "gix-utils",
  "smallvec",
  "thiserror 2.0.18",
@@ -4671,7 +4671,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.19.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4684,7 +4684,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.24.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4696,7 +4696,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.23.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -4708,7 +4708,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "gix-hash",
  "hashbrown 0.16.1",
@@ -4718,12 +4718,12 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "gix-glob",
  "gix-path 0.11.2",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
  "serde",
  "unicode-bom",
 ]
@@ -4731,7 +4731,7 @@ dependencies = [
 [[package]]
 name = "gix-imara-diff"
 version = "0.2.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "hashbrown 0.16.1",
@@ -4741,7 +4741,7 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.49.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4769,7 +4769,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "21.0.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -4779,7 +4779,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.32.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4791,7 +4791,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.14.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4807,7 +4807,7 @@ dependencies = [
  "gix-revision",
  "gix-revwalk",
  "gix-tempfile",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
  "gix-worktree",
  "nonempty",
  "thiserror 2.0.18",
@@ -4816,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bitflags 2.11.0",
  "gix-commitgraph",
@@ -4829,7 +4829,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.58.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4849,7 +4849,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.78.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "arc-swap",
  "gix-features",
@@ -4860,6 +4860,7 @@ dependencies = [
  "gix-pack",
  "gix-path 0.11.2",
  "gix-quote",
+ "memmap2",
  "parking_lot",
  "serde",
  "tempfile",
@@ -4869,7 +4870,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.68.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "clru",
  "gix-chunk",
@@ -4891,11 +4892,11 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.21.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
  "thiserror 2.0.18",
 ]
 
@@ -4914,10 +4915,10 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.11.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
  "gix-validate 0.11.0",
  "thiserror 2.0.18",
 ]
@@ -4925,7 +4926,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.16.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4939,7 +4940,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.14.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -4951,7 +4952,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.59.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -4965,7 +4966,7 @@ dependencies = [
  "gix-refspec",
  "gix-revwalk",
  "gix-shallow",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
  "gix-transport",
  "gix-utils",
  "maybe-async",
@@ -4978,7 +4979,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.7.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "gix-error",
@@ -4988,7 +4989,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.61.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -5009,7 +5010,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.39.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "gix-error",
@@ -5024,7 +5025,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.43.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -5035,7 +5036,7 @@ dependencies = [
  "gix-hashtable",
  "gix-object",
  "gix-revwalk",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
  "nonempty",
  "serde",
 ]
@@ -5043,7 +5044,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -5058,7 +5059,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.13.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bitflags 2.11.0",
  "gix-path 0.11.2",
@@ -5070,7 +5071,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.10.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -5083,7 +5084,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "filetime",
@@ -5105,7 +5106,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "gix-config",
@@ -5119,7 +5120,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "21.0.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "dashmap",
  "gix-fs",
@@ -5133,7 +5134,7 @@ dependencies = [
 [[package]]
 name = "gix-testtools"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "crc",
@@ -5162,7 +5163,7 @@ checksum = "f69a13643b8437d4ca6845e08143e847a36ca82903eed13303475d0ae8b162e0"
 [[package]]
 name = "gix-trace"
 version = "0.1.18"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "tracing",
 ]
@@ -5170,7 +5171,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.55.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -5189,7 +5190,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.55.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bitflags 2.11.0",
  "gix-commitgraph",
@@ -5205,7 +5206,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.35.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "gix-path 0.11.2",
@@ -5217,7 +5218,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "fastrand",
@@ -5237,7 +5238,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
 ]
@@ -5245,7 +5246,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.50.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -5263,7 +5264,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "bstr",
  "gix-features",
@@ -5280,7 +5281,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-stream"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
 dependencies = [
  "gix-attributes",
  "gix-error",
@@ -6088,7 +6089,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6163,7 +6164,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7069,7 +7070,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7613,7 +7614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8382,7 +8383,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9096,7 +9097,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9154,7 +9155,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10694,7 +10695,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10724,7 +10725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12166,7 +12167,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,10 +214,10 @@ backoff = "0.4.0"
 bstr = "1.12.1"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
 # When adjusting this, update `gix-testtools` as well!
-gix = { version = "0.81.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "172bd22b8241aba9187fc6e5134e3f454053c2be", default-features = false, features = [
+gix = { version = "0.81.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "63b841907ce30b36bb50da5aae3a9e1a06eadf64", default-features = false, features = [
     "sha1",
 ] }
-gix-testtools = { version = "0.19.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "172bd22b8241aba9187fc6e5134e3f454053c2be" }
+gix-testtools = { version = "0.19.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "63b841907ce30b36bb50da5aae3a9e1a06eadf64" }
 
 
 insta = { version = "1.45.1", features = ["json"] }

--- a/crates/but-core/src/worktree/checkout/function.rs
+++ b/crates/but-core/src/worktree/checkout/function.rs
@@ -61,8 +61,8 @@ pub fn safe_checkout(
 
     let mut delegate = super::utils::Delegate::default();
     gix::diff::tree(
-        TreeRefIter::from_bytes(&source_tree.data),
-        TreeRefIter::from_bytes(&destination_tree.data),
+        TreeRefIter::from_bytes(&source_tree.data, repo.object_hash()),
+        TreeRefIter::from_bytes(&destination_tree.data, repo.object_hash()),
         &mut gix::diff::tree::State::default(),
         repo,
         &mut delegate,

--- a/crates/but-workspace/src/changeset.rs
+++ b/crates/but-workspace/src/changeset.rs
@@ -664,8 +664,11 @@ fn id_for_tree_diff(
     let mut state = Default::default();
     let mut delegate = Delegate::default();
     gix::diff::tree(
-        gix::objs::TreeRefIter::from_bytes(&lhs_tree.unwrap_or(empty_tree).data),
-        gix::objs::TreeRefIter::from_bytes(&rhs_tree.data),
+        gix::objs::TreeRefIter::from_bytes(
+            &lhs_tree.unwrap_or(empty_tree).data,
+            repo.object_hash(),
+        ),
+        gix::objs::TreeRefIter::from_bytes(&rhs_tree.data, repo.object_hash()),
         &mut state,
         repo.objects.deref(),
         &mut delegate,


### PR DESCRIPTION
This version comes with a bunch of security related fixes and has added fuzzers for all major parsers with a lot of parsing-related problems fixed, that could cause crashes or OOM-kills when parsing attacker controlled files.