### PR TITLE
multi squash

### DIFF
--- a/apps/lite/electron/src/ipc.ts
+++ b/apps/lite/electron/src/ipc.ts
@@ -119,7 +119,7 @@ export interface CommitRewordParams {
 
 export interface CommitSquashParams {
 	projectId: string;
-	sourceCommitId: string;
+	sourceCommitIds: Array<string>;
 	destinationCommitId: string;
 	dryRun: boolean;
 }

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -173,8 +173,8 @@ const registerIpcHandlers = (): void => {
 	);
 	ipcMain.handle(
 		liteIpcChannels.commitSquash,
-		(_e, { projectId, sourceCommitId, destinationCommitId, dryRun }: CommitSquashParams) =>
-			commitSquash(projectId, sourceCommitId, destinationCommitId, "KeepBoth", dryRun),
+		(_e, { projectId, sourceCommitIds, destinationCommitId, dryRun }: CommitSquashParams) =>
+			commitSquash(projectId, sourceCommitIds, destinationCommitId, "KeepBoth", dryRun),
 	);
 	ipcMain.handle(
 		liteIpcChannels.commitReword,

--- a/apps/lite/ui/src/operations/operation.ts
+++ b/apps/lite/ui/src/operations/operation.ts
@@ -241,7 +241,7 @@ export const useRunOperation = () => {
 				CommitSquash: (operation) => {
 					commitSquash.mutate({
 						projectId,
-						sourceCommitId: operation.sourceCommitId,
+						sourceCommitIds: operation.sourceCommitIds,
 						destinationCommitId: operation.destinationCommitId,
 						dryRun: false,
 					});
@@ -376,7 +376,7 @@ const rubOperation = ({ source, target }: { source: Operand; target: Operand }):
 			},
 			({ source, target }) =>
 				commitSquashOperation({
-					sourceCommitId: source.commitId,
+					sourceCommitIds: [source.commitId],
 					destinationCommitId: target.commitId,
 				}),
 		),

--- a/crates/but-api/src/commit/squash.rs
+++ b/crates/but-api/src/commit/squash.rs
@@ -1,14 +1,15 @@
-use crate::WorkspaceState;
 use but_api_macros::but_api;
 use but_core::{DryRun, sync::RepoExclusive};
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
 use but_rebase::graph_rebase::{Editor, LookupStep as _};
-use but_workspace::commit::squash_commits::MessageCombinationStrategy;
+use but_workspace::commit::{SquashCommitsOutcome, squash_commits::MessageCombinationStrategy};
 use tracing::instrument;
+
+use crate::WorkspaceState;
 
 use super::types::CommitSquashResult;
 
-/// Squash `subject_commit_id` into `target_commit_id`.
+/// Squash `subject_commit_ids` into `target_commit_id`.
 ///
 /// This acquires exclusive worktree access from `ctx` before rewriting the
 /// commits.
@@ -20,7 +21,7 @@ use super::types::CommitSquashResult;
 #[instrument(err(Debug))]
 pub fn commit_squash_only(
     ctx: &mut but_ctx::Context,
-    subject_commit_id: gix::ObjectId,
+    subject_commit_ids: Vec<gix::ObjectId>,
     target_commit_id: gix::ObjectId,
     how_to_combine_messages: MessageCombinationStrategy,
     dry_run: DryRun,
@@ -28,7 +29,7 @@ pub fn commit_squash_only(
     let mut guard = ctx.exclusive_worktree_access();
     commit_squash_only_with_perm(
         ctx,
-        subject_commit_id,
+        subject_commit_ids,
         target_commit_id,
         how_to_combine_messages,
         dry_run,
@@ -36,22 +37,23 @@ pub fn commit_squash_only(
     )
 }
 
-/// Squash `subject_commit_id` into `target_commit_id` under caller-held
+/// Squash `subject_commit_ids` into `target_commit_id` under caller-held
 /// exclusive repository access.
 ///
-/// This materializes the squash rebase and returns the resulting squashed
-/// commit ID together with rewritten commit mappings. This variant does not
-/// create an oplog entry. When `dry_run` is enabled, it returns a preview of
-/// the resulting workspace state without materializing the rebase.
-/// For lower-level implementation details, see [`but_workspace::commit::squash_commits()`].
+/// This variant does not create an oplog entry. When `dry_run` is enabled, it
+/// returns a preview of the resulting workspace state without materializing the rebases.
 pub fn commit_squash_only_with_perm(
     ctx: &mut but_ctx::Context,
-    subject_commit_id: gix::ObjectId,
+    subject_commit_ids: Vec<gix::ObjectId>,
     target_commit_id: gix::ObjectId,
     how_to_combine_messages: MessageCombinationStrategy,
     dry_run: DryRun,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitSquashResult> {
+    if subject_commit_ids.is_empty() {
+        anyhow::bail!("No commits were provided to squash")
+    }
+
     let mut meta = ctx.meta()?;
     let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
@@ -67,12 +69,12 @@ pub fn commit_squash_only_with_perm(
     let workspace = WorkspaceState::from_successful_rebase(outcome.rebase, &repo, dry_run)?;
 
     Ok(CommitSquashResult {
-        new_commit,
+        new_commit: outcome.new_commit,
         workspace,
     })
 }
 
-/// Squash `subject_commit_id` into `target_commit_id` and record an oplog
+/// Squash `subject_commit_ids` into `target_commit_id` and record an oplog
 /// snapshot on success.
 ///
 /// This acquires exclusive worktree access from `ctx` before rewriting the
@@ -84,7 +86,7 @@ pub fn commit_squash_only_with_perm(
 #[instrument(err(Debug))]
 pub fn commit_squash(
     ctx: &mut but_ctx::Context,
-    subject_commit_id: gix::ObjectId,
+    subject_commit_ids: Vec<gix::ObjectId>,
     target_commit_id: gix::ObjectId,
     how_to_combine_messages: MessageCombinationStrategy,
     dry_run: DryRun,
@@ -92,7 +94,7 @@ pub fn commit_squash(
     let mut guard = ctx.exclusive_worktree_access();
     commit_squash_with_perm(
         ctx,
-        subject_commit_id,
+        subject_commit_ids,
         target_commit_id,
         how_to_combine_messages,
         dry_run,
@@ -100,17 +102,16 @@ pub fn commit_squash(
     )
 }
 
-/// Squash `subject_commit_id` into `target_commit_id` under caller-held
+/// Squash `subject_commit_ids` into `target_commit_id` under caller-held
 /// exclusive repository access and record an oplog snapshot on success.
 ///
 /// It prepares a best-effort `SquashCommit` oplog snapshot, performs the
-/// squash, and commits the snapshot only if the operation succeeds. When
+/// squashes, and commits the snapshot only if the operation succeeds. When
 /// `dry_run` is enabled, it returns a preview of the resulting workspace state
-/// and skips oplog persistence. For lower-level implementation details, see
-/// [`but_workspace::commit::squash_commits()`].
+/// and skips oplog persistence.
 pub fn commit_squash_with_perm(
     ctx: &mut but_ctx::Context,
-    subject_commit_id: gix::ObjectId,
+    subject_commit_ids: Vec<gix::ObjectId>,
     target_commit_id: gix::ObjectId,
     how_to_combine_messages: MessageCombinationStrategy,
     dry_run: DryRun,
@@ -125,7 +126,7 @@ pub fn commit_squash_with_perm(
 
     let res = commit_squash_only_with_perm(
         ctx,
-        subject_commit_id,
+        subject_commit_ids,
         target_commit_id,
         how_to_combine_messages,
         dry_run,

--- a/crates/but-api/src/commit/squash.rs
+++ b/crates/but-api/src/commit/squash.rs
@@ -57,19 +57,20 @@ pub fn commit_squash_only_with_perm(
     let mut meta = ctx.meta()?;
     let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
-
-    let outcome = but_workspace::commit::squash_commits(
+    let SquashCommitsOutcome {
+        rebase,
+        commit_selector,
+    } = but_workspace::commit::squash_commits(
         editor,
-        subject_commit_id,
+        subject_commit_ids,
         target_commit_id,
         how_to_combine_messages,
     )?;
-
-    let new_commit = outcome.rebase.lookup_pick(outcome.commit_selector)?;
-    let workspace = WorkspaceState::from_successful_rebase(outcome.rebase, &repo, dry_run)?;
+    let new_commit = rebase.lookup_pick(commit_selector)?;
+    let workspace = WorkspaceState::from_successful_rebase(rebase, &repo, dry_run)?;
 
     Ok(CommitSquashResult {
-        new_commit: outcome.new_commit,
+        new_commit,
         workspace,
     })
 }

--- a/crates/but-workspace/src/commit/mod.rs
+++ b/crates/but-workspace/src/commit/mod.rs
@@ -17,7 +17,7 @@ pub use move_changes::{MoveChangesOutcome, move_changes_between_commits};
 pub mod uncommit_changes;
 pub use uncommit_changes::{UncommitChangesOutcome, uncommit_changes};
 pub mod move_commit;
-pub use move_commit::move_commit;
+pub use move_commit::{move_commit, move_commit_no_rebase};
 pub mod discard_commit;
 pub use discard_commit::discard_commits;
 pub mod squash_commits;

--- a/crates/but-workspace/src/commit/move_commit.rs
+++ b/crates/but-workspace/src/commit/move_commit.rs
@@ -19,11 +19,35 @@ use but_rebase::graph_rebase::{
 /// The subject commit will be detached from the source segment, and inserted relative
 /// to a given anchor (branch or commit).
 pub fn move_commit<'ws, 'meta, M: RefMetadata>(
-    mut editor: Editor<'ws, 'meta, M>,
+    editor: Editor<'ws, 'meta, M>,
     subject_commit: impl ToCommitSelector,
     anchor: impl ToSelector,
     side: InsertSide,
 ) -> anyhow::Result<SuccessfulRebase<'ws, 'meta, M>> {
+    let editor = move_commit_no_rebase(editor, subject_commit, anchor, side)?;
+    editor.rebase()
+}
+
+/// Move a commit without rebasing.
+///
+/// `editor` is assumed to be aligned with the graph being mutated.
+///
+/// `subject_commit` - The commit to be moved.
+///
+/// `anchor` - A git graph node selector to move the subject commit relative to.
+///
+/// `side` - The side relative to the anchor at which to insert the subject commit.
+///
+/// The subject commit will be detached from the source segment, and inserted relative
+/// to a given anchor (branch or commit).
+///
+/// This function mutates the editor graph but does not execute a rebase.
+pub fn move_commit_no_rebase<'ws, 'meta, M: RefMetadata>(
+    mut editor: Editor<'ws, 'meta, M>,
+    subject_commit: impl ToCommitSelector,
+    anchor: impl ToSelector,
+    side: InsertSide,
+) -> anyhow::Result<Editor<'ws, 'meta, M>> {
     let (subject_commit_selector, _) = editor.find_selectable_commit(subject_commit)?;
 
     let commit_delimiter = SegmentDelimiter {
@@ -44,7 +68,7 @@ pub fn move_commit<'ws, 'meta, M: RefMetadata>(
 
     // Step 3: Insert
     editor.insert_segment(anchor, commit_delimiter, side)?;
-    editor.rebase()
+    Ok(editor)
 }
 
 /// Determine which parent to disconnect from the subject commit.

--- a/crates/but-workspace/src/commit/squash_commits.rs
+++ b/crates/but-workspace/src/commit/squash_commits.rs
@@ -16,8 +16,6 @@ pub struct SquashCommitsOutcome<'ws, 'meta, M: RefMetadata> {
     pub rebase: SuccessfulRebase<'ws, 'meta, M>,
     /// Selector pointing to the squashed replacement commit.
     pub commit_selector: Selector,
-    /// The final squashed commit ID after remapping through all rewrites.
-    pub new_commit: gix::ObjectId,
 }
 
 /// Append `message` to `combined`, inserting enough newlines so there are at
@@ -43,20 +41,6 @@ fn push_message_with_spacing(combined: &mut Vec<u8>, message: &[u8]) {
     }
 
     combined.extend_from_slice(message);
-}
-
-fn resolve_mapped_commit_id(
-    commit_id: gix::ObjectId,
-    rewritten_commits: &BTreeMap<gix::ObjectId, gix::ObjectId>,
-) -> gix::ObjectId {
-    let mut current = commit_id;
-    while let Some(next) = rewritten_commits.get(&current).copied() {
-        if next == current {
-            break;
-        }
-        current = next;
-    }
-    current
 }
 
 /// Reorder commits around `target_commit` so all selected commits become
@@ -111,7 +95,7 @@ fn construct_new_squashed_commit<'ws, 'meta, M: RefMetadata>(
     top_most_commit_id: Selector,
     bottom_most_commit_id: Selector,
     combined_message: Vec<u8>,
-) -> Result<(Editor<'ws, 'meta, M>, Selector, gix::ObjectId)> {
+) -> Result<(Editor<'ws, 'meta, M>, Selector)> {
     let (_, top_most_commit) = editor.find_selectable_commit(top_most_commit_id)?;
     let (bottom_most_selector, bottom_most_commit) =
         editor.find_selectable_commit(bottom_most_commit_id)?;
@@ -125,7 +109,7 @@ fn construct_new_squashed_commit<'ws, 'meta, M: RefMetadata>(
 
     editor.replace(bottom_most_selector, Step::new_pick(new_commit))?;
 
-    Ok((editor, bottom_most_selector, new_commit))
+    Ok((editor, bottom_most_selector))
 }
 
 /// How to combine messages of commits being squashed.
@@ -167,20 +151,20 @@ but_schemars::register_sdk_type!(MessageCombinationStrategy);
 ///
 pub fn squash_commits<'ws, 'meta, M: RefMetadata, S: ToCommitSelector, T: ToCommitSelector>(
     editor: Editor<'ws, 'meta, M>,
-    subject_commit_ids: Vec<S>,
+    subjects: Vec<S>,
     target_commit: T,
     how_to_combine_messages: MessageCombinationStrategy,
 ) -> Result<SquashCommitsOutcome<'ws, 'meta, M>> {
-    if subject_commit_ids.is_empty() {
+    if subjects.is_empty() {
         bail!("Need at least 2 commits to squash")
     }
 
     let (target_commit_selector, target_commit_obj) =
         editor.find_selectable_commit(target_commit)?;
 
-    let mut all_commits = Vec::with_capacity(subject_commit_ids.len() + 1);
+    let mut all_commits = Vec::with_capacity(subjects.len() + 1);
     all_commits.push(target_commit_selector);
-    for subject_commit in subject_commit_ids {
+    for subject_commit in subjects {
         let (subject_commit_selector, _) = editor.find_selectable_commit(subject_commit)?;
         if subject_commit_selector == target_commit_selector {
             bail!("Cannot squash a commit into itself")
@@ -236,21 +220,14 @@ pub fn squash_commits<'ws, 'meta, M: RefMetadata, S: ToCommitSelector, T: ToComm
         }
     }
 
-    let top_most_commit_id = above_anchor;
-    let bottom_most_commit_id = below_anchor;
-
-    let (editor, bottom_most_selector, new_commit) = construct_new_squashed_commit(
-        editor,
-        top_most_commit_id,
-        bottom_most_commit_id,
-        combined_message,
-    )?;
+    let (editor, bottom_most_selector) =
+        construct_new_squashed_commit(editor, above_anchor, below_anchor, combined_message)?;
 
     let rebase = editor.rebase()?;
     let mut editor = rebase.into_editor();
 
     for commit_selector in ordered_selectors {
-        if commit_selector == bottom_most_commit_id {
+        if commit_selector == below_anchor {
             continue;
         }
         let Ok((selector, _)) = editor.find_selectable_commit(commit_selector) else {
@@ -259,14 +236,9 @@ pub fn squash_commits<'ws, 'meta, M: RefMetadata, S: ToCommitSelector, T: ToComm
         editor.replace(selector, Step::None)?;
     }
 
-    let rebase = editor.rebase()?;
-    let final_rewritten_commits = rebase.history.commit_mappings();
-    let final_new_commit = resolve_mapped_commit_id(new_commit, &final_rewritten_commits);
-
     Ok(SquashCommitsOutcome {
-        rebase,
+        rebase: editor.rebase()?,
         commit_selector: bottom_most_selector,
-        new_commit: final_new_commit,
     })
 }
 

--- a/crates/but-workspace/src/commit/squash_commits.rs
+++ b/crates/but-workspace/src/commit/squash_commits.rs
@@ -1,73 +1,13 @@
-//! An action to squash one commit into another.
+//! An action to squash multiple commits into a target commit.
 
 use anyhow::{Result, bail};
 use but_core::RefMetadata;
-use but_graph::{SegmentRelation, projection::Workspace};
 use but_rebase::{
     commit::DateMode,
     graph_rebase::{
-        Editor, Selector, Step, SuccessfulRebase, ToCommitSelector,
-        mutate::{SegmentDelimiter, SelectorSet},
+        Editor, Selector, Step, SuccessfulRebase, ToCommitSelector, mutate::InsertSide,
     },
 };
-
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-enum ReorderDirection {
-    MoveSubjectAboveTarget,
-    MoveSubjectBelowTarget,
-}
-
-fn determine_reorder_direction(
-    workspace: &Workspace,
-    repo: &gix::Repository,
-    subject: &but_core::CommitOwned,
-    target: &but_core::CommitOwned,
-) -> Result<ReorderDirection> {
-    let subject_segment = workspace
-        .find_commit_segment_index(subject.id)
-        .ok_or_else(|| anyhow::anyhow!("Couldn't resolve subject commit segment"))?;
-    let target_segment = workspace
-        .find_commit_segment_index(target.id)
-        .ok_or_else(|| anyhow::anyhow!("Couldn't resolve target commit segment"))?;
-
-    match workspace
-        .graph
-        .relation_between(subject_segment, target_segment)
-    {
-        SegmentRelation::Descendant => return Ok(ReorderDirection::MoveSubjectAboveTarget),
-        SegmentRelation::Ancestor => return Ok(ReorderDirection::MoveSubjectBelowTarget),
-        SegmentRelation::Disjoint | SegmentRelation::Diverged => {
-            return Ok(ReorderDirection::MoveSubjectAboveTarget);
-        }
-        SegmentRelation::Identity => {
-            // Commits can differ while still belonging to the same segment, so use commit-level
-            // ancestry in this case.
-        }
-    }
-
-    let merge_base = match repo.merge_base(subject.id, target.id) {
-        Ok(base) => base,
-        // If commits don't have a merge-base (or merge-base resolution fails),
-        // we still allow squashing by using a deterministic default ordering.
-        Err(error) => match error {
-            gix::repository::merge_base::Error::FindMergeBase(_)
-            | gix::repository::merge_base::Error::NotFound { .. } => {
-                return Ok(ReorderDirection::MoveSubjectAboveTarget);
-            }
-            _ => return Err(error.into()),
-        },
-    };
-
-    if merge_base == target.id {
-        return Ok(ReorderDirection::MoveSubjectAboveTarget);
-    }
-
-    if merge_base == subject.id {
-        return Ok(ReorderDirection::MoveSubjectBelowTarget);
-    }
-
-    Ok(ReorderDirection::MoveSubjectAboveTarget)
-}
 
 /// The result of a squash_commits operation.
 #[derive(Debug)]
@@ -76,6 +16,116 @@ pub struct SquashCommitsOutcome<'ws, 'meta, M: RefMetadata> {
     pub rebase: SuccessfulRebase<'ws, 'meta, M>,
     /// Selector pointing to the squashed replacement commit.
     pub commit_selector: Selector,
+    /// The final squashed commit ID after remapping through all rewrites.
+    pub new_commit: gix::ObjectId,
+}
+
+/// Append `message` to `combined`, inserting enough newlines so there are at
+/// least two `\n` bytes between existing and appended non-empty blocks.
+///
+/// Empty `message` values are ignored.
+fn push_message_with_spacing(combined: &mut Vec<u8>, message: &[u8]) {
+    if message.is_empty() {
+        return;
+    }
+
+    if !combined.is_empty() {
+        let trailing_newlines = combined
+            .iter()
+            .rev()
+            .take_while(|byte| **byte == b'\n')
+            .count();
+        if trailing_newlines < 2 {
+            for _ in trailing_newlines..2 {
+                combined.push(b'\n');
+            }
+        }
+    }
+
+    combined.extend_from_slice(message);
+}
+
+fn resolve_mapped_commit_id(
+    commit_id: gix::ObjectId,
+    rewritten_commits: &BTreeMap<gix::ObjectId, gix::ObjectId>,
+) -> gix::ObjectId {
+    let mut current = commit_id;
+    while let Some(next) = rewritten_commits.get(&current).copied() {
+        if next == current {
+            break;
+        }
+        current = next;
+    }
+    current
+}
+
+/// Reorder commits around `target_commit` so all selected commits become
+/// adjacent around the target in parentage order.
+///
+/// Returns the rewritten editor together with the original below/above anchor
+/// commit IDs used for remapping after the first rebase.
+fn reorder_commits_around_target<'ws, 'meta, M: RefMetadata>(
+    mut editor: Editor<'ws, 'meta, M>,
+    ordered_all_commits: &[Selector],
+    target_commit: Selector,
+) -> Result<(Editor<'ws, 'meta, M>, Selector, Selector)> {
+    let target_pos = ordered_all_commits
+        .iter()
+        .position(|id| *id == target_commit)
+        .expect("target commit must be in ordered commit list");
+
+    let (below_commits, target_and_above_commits) = ordered_all_commits.split_at(target_pos);
+
+    let mut below_anchor = target_commit;
+    for source_id in below_commits.iter().rev().copied() {
+        editor = crate::commit::move_commit_no_rebase(
+            editor,
+            source_id,
+            below_anchor,
+            InsertSide::Below,
+        )?;
+        below_anchor = source_id;
+    }
+
+    let mut above_anchor = target_commit;
+    for source_id in target_and_above_commits.iter().skip(1).copied() {
+        editor = crate::commit::move_commit_no_rebase(
+            editor,
+            source_id,
+            above_anchor,
+            InsertSide::Above,
+        )?;
+        above_anchor = source_id;
+    }
+
+    Ok((editor, below_anchor, above_anchor))
+}
+
+/// Build the squashed commit from the mapped top/bottom commits and replace the
+/// bottom selector with the newly created commit.
+///
+/// Returns the updated editor and the selector that now points to the squashed
+/// commit.
+fn construct_new_squashed_commit<'ws, 'meta, M: RefMetadata>(
+    mut editor: Editor<'ws, 'meta, M>,
+    top_most_commit_id: Selector,
+    bottom_most_commit_id: Selector,
+    combined_message: Vec<u8>,
+) -> Result<(Editor<'ws, 'meta, M>, Selector, gix::ObjectId)> {
+    let (_, top_most_commit) = editor.find_selectable_commit(top_most_commit_id)?;
+    let (bottom_most_selector, bottom_most_commit) =
+        editor.find_selectable_commit(bottom_most_commit_id)?;
+
+    let new_commit = {
+        let mut squashed_commit = bottom_most_commit.clone();
+        squashed_commit.tree = top_most_commit.tree;
+        squashed_commit.message = combined_message.into();
+        editor.new_commit(squashed_commit, DateMode::CommitterUpdateAuthorKeep)?
+    };
+
+    editor.replace(bottom_most_selector, Step::new_pick(new_commit))?;
+
+    Ok((editor, bottom_most_selector, new_commit))
 }
 
 /// How to combine messages of commits being squashed.
@@ -84,7 +134,7 @@ pub struct SquashCommitsOutcome<'ws, 'meta, M: RefMetadata> {
 pub enum MessageCombinationStrategy {
     /// Keep both messages.
     KeepBoth,
-    /// Only keep the message of the subject.
+    /// Only keep the messages of subject commits.
     ///
     /// Target message will be discarded.
     KeepSubject,
@@ -97,113 +147,172 @@ pub enum MessageCombinationStrategy {
 #[cfg(feature = "export-schema")]
 but_schemars::register_sdk_type!(MessageCombinationStrategy);
 
-/// Squash `subject_commit` into `target_commit`.
+/// Squash `subjects` into `target_commit`.
 ///
-/// Depending on the ancestry relationship between the two commits, this operation may
-/// reorder them so that the subject ends up either above or below the target.
+/// `subjects` may be provided in any order. They are ordered by
+/// parentage internally together with `target_commit` before reordering and
+/// squashing.
 ///
-/// After any reordering, one of the two original commit positions (either the subject or
-/// the target) is replaced by a single squashed commit that has:
-/// - The tree of the commit that was top-most after reordering (subject or target)
-/// - A message determined by `how_to_combine_messages`: either the subject message, the
-///   target message, or both messages as `target\n\nsubject`
+/// The `target_commit` must not also appear in `subjects`.
 ///
-/// The other original commit (subject or target, depending on the chosen ordering) is
-/// removed from history.
-pub fn squash_commits<'ws, 'meta, M: RefMetadata>(
+/// After reordering and squashing, the resulting squashed commit has:
+/// - The tree of the commit that is top-most after reordering.
+/// - A message determined by `how_to_combine_messages`:
+///   - `KeepTarget`: target message only.
+///   - `KeepSubject`: subject messages only.
+///   - `KeepBoth`: target message followed by subject messages.
+///
+/// Subject messages are appended in squash order (top-most first after
+/// reordering), with at least one blank line between non-empty message blocks.
+///
+pub fn squash_commits<'ws, 'meta, M: RefMetadata, S: ToCommitSelector, T: ToCommitSelector>(
     editor: Editor<'ws, 'meta, M>,
-    subject_commit: impl ToCommitSelector,
-    target_commit: impl ToCommitSelector,
+    subject_commit_ids: Vec<S>,
+    target_commit: T,
     how_to_combine_messages: MessageCombinationStrategy,
 ) -> Result<SquashCommitsOutcome<'ws, 'meta, M>> {
-    let repo = editor.repo().clone();
-    let successful_rebase = editor.rebase()?;
-    let workspace = successful_rebase.overlayed_graph()?.into_workspace()?;
-    let mut editor = successful_rebase.into_editor();
-
-    let (subject_selector, subject) = editor.find_selectable_commit(subject_commit)?;
-    let (target_selector, target) = editor.find_selectable_commit(target_commit)?;
-
-    if subject.id == target.id {
-        bail!("Cannot squash a commit into itself")
+    if subject_commit_ids.is_empty() {
+        bail!("Need at least 2 commits to squash")
     }
 
-    if subject.clone().attach(editor.repo()).is_conflicted() {
-        bail!("Subject commit must not be conflicted")
+    let (target_commit_selector, target_commit_obj) =
+        editor.find_selectable_commit(target_commit)?;
+
+    let mut all_commits = Vec::with_capacity(subject_commit_ids.len() + 1);
+    all_commits.push(target_commit_selector);
+    for subject_commit in subject_commit_ids {
+        let (subject_commit_selector, _) = editor.find_selectable_commit(subject_commit)?;
+        if subject_commit_selector == target_commit_selector {
+            bail!("Cannot squash a commit into itself")
+        }
+        all_commits.push(subject_commit_selector);
     }
 
-    if target.clone().attach(editor.repo()).is_conflicted() {
-        bail!("Target commit must not be conflicted")
-    }
+    let ordered_selectors = editor.order_commit_selectors_by_parentage(all_commits)?;
 
-    let direction = determine_reorder_direction(&workspace, &repo, &subject, &target)?;
+    let (editor, below_anchor, above_anchor) =
+        reorder_commits_around_target(editor, &ordered_selectors, target_commit_selector)?;
+
+    let rebase = editor.rebase()?;
+    let editor = rebase.into_editor();
+
+    for commit_selector in &ordered_selectors {
+        let (_, commit) = editor.find_selectable_commit(*commit_selector)?;
+        if commit.clone().attach(editor.repo()).is_conflicted() {
+            bail!(
+                "Commit {} became conflicted after reordering. Can't continue with squash.",
+                commit.id
+            );
+        }
+    }
 
     let mut combined_message = Vec::new();
     match how_to_combine_messages {
         MessageCombinationStrategy::KeepSubject => {
-            combined_message.extend_from_slice(subject.message.as_ref());
+            for source_id in ordered_selectors
+                .iter()
+                .rev()
+                .copied()
+                .filter(|commit_selector| *commit_selector != target_commit_selector)
+            {
+                let (_, source_commit) = editor.find_selectable_commit(source_id)?;
+                push_message_with_spacing(&mut combined_message, source_commit.message.as_ref());
+            }
         }
         MessageCombinationStrategy::KeepTarget => {
-            combined_message.extend_from_slice(target.message.as_ref());
+            push_message_with_spacing(&mut combined_message, target_commit_obj.message.as_ref());
         }
         MessageCombinationStrategy::KeepBoth => {
-            match (subject.message.is_empty(), target.message.is_empty()) {
-                (true, true) => {
-                    // both messages are empty, leave combined message as empty
-                }
-                (true, false) => {
-                    // subject has no message, target does
-                    combined_message.extend_from_slice(target.message.as_ref());
-                }
-                (false, true) => {
-                    // subject has message, target doesn't
-                    combined_message.extend_from_slice(subject.message.as_ref());
-                }
-                (false, false) => {
-                    // both commits have messages, keep both
-                    combined_message.extend_from_slice(target.message.as_ref());
-                    if !combined_message.ends_with(b"\n") {
-                        combined_message.push(b'\n');
-                    }
-                    combined_message.push(b'\n');
-                    combined_message.extend_from_slice(subject.message.as_ref());
-                }
+            push_message_with_spacing(&mut combined_message, target_commit_obj.message.as_ref());
+            for source_id in ordered_selectors
+                .iter()
+                .rev()
+                .copied()
+                .filter(|commit_selector| *commit_selector != target_commit_selector)
+            {
+                let (_, source_commit) = editor.find_selectable_commit(source_id)?;
+                push_message_with_spacing(&mut combined_message, source_commit.message.as_ref());
             }
         }
     }
 
-    let (replace_selector, dropped_selector, mut commit_to_replace, top_tree_id) = match direction {
-        ReorderDirection::MoveSubjectAboveTarget => (
-            target_selector,
-            subject_selector,
-            target.clone(),
-            subject.tree,
-        ),
-        ReorderDirection::MoveSubjectBelowTarget => (
-            subject_selector,
-            target_selector,
-            subject.clone(),
-            target.tree,
-        ),
-    };
+    let top_most_commit_id = above_anchor;
+    let bottom_most_commit_id = below_anchor;
 
-    let new_commit_id = {
-        commit_to_replace.tree = top_tree_id;
-        commit_to_replace.message = combined_message.into();
-        editor.new_commit(commit_to_replace, DateMode::CommitterUpdateAuthorKeep)?
-    };
+    let (editor, bottom_most_selector, new_commit) = construct_new_squashed_commit(
+        editor,
+        top_most_commit_id,
+        bottom_most_commit_id,
+        combined_message,
+    )?;
 
-    let dropped_delimiter = SegmentDelimiter {
-        child: dropped_selector,
-        parent: dropped_selector,
-    };
-    editor.disconnect_segment_from(dropped_delimiter, SelectorSet::All, SelectorSet::All, false)?;
+    let rebase = editor.rebase()?;
+    let mut editor = rebase.into_editor();
 
-    editor.replace(replace_selector, Step::new_pick(new_commit_id))?;
-    editor.replace(dropped_selector, Step::None)?;
+    for commit_selector in ordered_selectors {
+        if commit_selector == bottom_most_commit_id {
+            continue;
+        }
+        let Ok((selector, _)) = editor.find_selectable_commit(commit_selector) else {
+            continue;
+        };
+        editor.replace(selector, Step::None)?;
+    }
+
+    let rebase = editor.rebase()?;
+    let final_rewritten_commits = rebase.history.commit_mappings();
+    let final_new_commit = resolve_mapped_commit_id(new_commit, &final_rewritten_commits);
 
     Ok(SquashCommitsOutcome {
-        rebase: editor.rebase()?,
-        commit_selector: replace_selector,
+        rebase,
+        commit_selector: bottom_most_selector,
+        new_commit: final_new_commit,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::push_message_with_spacing;
+
+    #[test]
+    fn push_message_with_spacing_adds_first_message_without_padding() {
+        let mut combined = Vec::new();
+        push_message_with_spacing(&mut combined, b"target");
+        assert_eq!(combined, b"target");
+    }
+
+    #[test]
+    fn push_message_with_spacing_ignores_empty_message() {
+        let mut combined = b"target".to_vec();
+        push_message_with_spacing(&mut combined, b"");
+        assert_eq!(combined, b"target");
+    }
+
+    #[test]
+    fn push_message_with_spacing_inserts_two_newlines_when_none_present() {
+        let mut combined = b"target".to_vec();
+        push_message_with_spacing(&mut combined, b"source");
+        assert_eq!(combined, b"target\n\nsource");
+    }
+
+    #[test]
+    fn push_message_with_spacing_inserts_one_newline_when_one_present() {
+        let mut combined = b"target\n".to_vec();
+        push_message_with_spacing(&mut combined, b"source");
+        assert_eq!(combined, b"target\n\nsource");
+    }
+
+    #[test]
+    fn push_message_with_spacing_keeps_existing_two_newlines() {
+        let mut combined = b"target\n\n".to_vec();
+        push_message_with_spacing(&mut combined, b"source");
+        assert_eq!(combined, b"target\n\nsource");
+    }
+
+    #[test]
+    fn push_message_with_spacing_keeps_existing_three_newlines() {
+        let mut combined = b"target\n\n\n".to_vec();
+        push_message_with_spacing(&mut combined, b"source");
+        assert_eq!(combined, b"target\n\n\nsource");
+    }
 }

--- a/crates/but-workspace/tests/fixtures/scenario/three-stacks.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/three-stacks.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A ws-ref points to a workspace commit with three stacks inside.
+# Stack A prepends lines to `file`.
+# Stack B appends lines to `file` in two commits.
+# Stack C creates `new-file` and extends it in two more commits.
+git init
+
+seq 50 60 >file && git add . && git commit -m "base" && git tag base
+setup_target_to_match_main
+
+git branch B
+git branch C
+
+git checkout -b A
+{ seq 10; seq 50 60; } >file && git add . && git commit -m "A: 10 lines on top"
+
+git checkout B
+{ seq 50 60; seq 61 70; } >file && git add . && git commit -m "B: 10 lines at the bottom"
+{ seq 50 60; seq 61 80; } >file && git add . && git commit -m "B: another 10 lines at the bottom"
+
+git checkout C
+seq 10 >new-file && git add . && git commit -m "C: new file with 10 lines"
+seq 20 >new-file && git add . && git commit -m "C: add 10 lines to new file"
+seq 30 >new-file && git add . && git commit -m "C: add another 10 lines to new file"
+
+create_workspace_commit_once A B C

--- a/crates/but-workspace/tests/workspace/commit/squash_commits.rs
+++ b/crates/but-workspace/tests/workspace/commit/squash_commits.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use bstr::ByteSlice as _;
-use but_rebase::graph_rebase::{Editor, LookupStep as _};
+use but_rebase::graph_rebase::{Editor, LookupStep};
 use but_testsupport::{graph_workspace, visualize_commit_graph_all};
 use but_workspace::commit::squash_commits;
 
@@ -28,7 +28,7 @@ fn squash_top_commit_into_parent() -> Result<()> {
     let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     let outcome = squash_commits(
         editor,
-        subject_id,
+        vec![subject_id],
         target_id,
         squash_commits::MessageCombinationStrategy::KeepBoth,
     )?;
@@ -87,7 +87,7 @@ fn squash_top_commit_into_parent_keeping_target_message() -> Result<()> {
     let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     let outcome = squash_commits(
         editor,
-        subject_id,
+        vec![subject_id],
         target_id,
         squash_commits::MessageCombinationStrategy::KeepTarget,
     )?;
@@ -123,7 +123,7 @@ fn squash_top_commit_into_parent_keeping_subject_message() -> Result<()> {
     let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     let outcome = squash_commits(
         editor,
-        subject_id,
+        vec![subject_id],
         target_id,
         squash_commits::MessageCombinationStrategy::KeepSubject,
     )?;
@@ -152,7 +152,7 @@ fn squash_reorders_when_subject_is_not_on_top() -> Result<()> {
     * 8b426d0 (one) commit one
     ");
 
-    // Subject starts below target in history and needs internal reorder first.
+    // Explicitly place the subject below the target before squashing.
     let subject_id = repo.rev_parse_single("two")?.detach();
     let target_id = repo.rev_parse_single("three")?.detach();
     let target_tree = repo.find_commit(target_id)?.tree_id()?.detach();
@@ -161,7 +161,7 @@ fn squash_reorders_when_subject_is_not_on_top() -> Result<()> {
     let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     let outcome = squash_commits(
         editor,
-        subject_id,
+        vec![subject_id],
         target_id,
         squash_commits::MessageCombinationStrategy::KeepBoth,
     )?;
@@ -182,10 +182,10 @@ fn squash_reorders_when_subject_is_not_on_top() -> Result<()> {
     );
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * 6426178 (HEAD -> three, two) commit three
+    * 6426178 (HEAD -> three) commit three
     | * 16fd221 (origin/two) commit two
     |/  
-    * 8b426d0 (one) commit one
+    * 8b426d0 (two, one) commit one
     ");
 
     Ok(())
@@ -209,7 +209,7 @@ fn squash_same_commit_is_rejected() -> Result<()> {
 
     let err = squash_commits(
         editor,
-        commit_id,
+        vec![commit_id],
         commit_id,
         squash_commits::MessageCombinationStrategy::KeepBoth,
     )
@@ -225,6 +225,33 @@ fn squash_same_commit_is_rejected() -> Result<()> {
     * 16fd221 (origin/two, two) commit two
     * 8b426d0 (one) commit one
     ");
+
+    Ok(())
+}
+
+#[test]
+fn squash_rejects_target_in_subject_commit_ids() -> Result<()> {
+    let (_tmp, graph, repo, mut _meta, _description) =
+        writable_scenario("reword-three-commits", |_| {})?;
+
+    let subject_id = repo.rev_parse_single("three")?.detach();
+    let target_id = repo.rev_parse_single("two")?.detach();
+
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
+
+    let err = squash_commits(
+        editor,
+        vec![subject_id, target_id],
+        target_id,
+        squash_commits::MessageCombinationStrategy::KeepBoth,
+    )
+    .expect_err("must fail");
+    assert!(
+        err.to_string()
+            .contains("Cannot squash a commit into itself"),
+        "error should explain that target cannot be one of the source commits"
+    );
 
     Ok(())
 }
@@ -247,7 +274,7 @@ fn squash_down_keeps_topmost_tree_for_shared_file_lineage() -> Result<()> {
     let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     let outcome = squash_commits(
         editor,
-        subject_id,
+        vec![subject_id],
         target_id,
         squash_commits::MessageCombinationStrategy::KeepBoth,
     )?;
@@ -268,7 +295,7 @@ fn squash_down_keeps_topmost_tree_for_shared_file_lineage() -> Result<()> {
 }
 
 #[test]
-fn squash_up_reorders_subject_below_target_for_shared_file_lineage() -> Result<()> {
+fn squash_move_subject_below_target_for_shared_file_lineage() -> Result<()> {
     let (_tmp, graph, repo, mut _meta, _description) =
         writable_scenario("squash-shared-file-three-commits", |_| {})?;
 
@@ -285,7 +312,7 @@ fn squash_up_reorders_subject_below_target_for_shared_file_lineage() -> Result<(
     let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     let outcome = squash_commits(
         editor,
-        subject_id,
+        vec![subject_id],
         target_id,
         squash_commits::MessageCombinationStrategy::KeepBoth,
     )?;
@@ -304,15 +331,15 @@ fn squash_up_reorders_subject_below_target_for_shared_file_lineage() -> Result<(
     );
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * 4fbac4b (HEAD -> three, two) commit three
-    * 8df0fa3 (one) commit one
+    * 4fbac4b (HEAD -> three) commit three
+    * 8df0fa3 (two, one) commit one
     ");
 
     Ok(())
 }
 
 #[test]
-fn squash_down_out_of_order_reorders_subject_below_target_for_shared_file_lineage() -> Result<()> {
+fn squash_move_subject_above_target_out_of_order_for_shared_file_lineage_fails() -> Result<()> {
     let (_tmp, graph, repo, mut _meta, _description) =
         writable_scenario("squash-shared-file-three-commits", |_| {})?;
 
@@ -327,29 +354,24 @@ fn squash_down_out_of_order_reorders_subject_below_target_for_shared_file_lineag
 
     let mut ws = graph.into_workspace()?;
     let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
-    let outcome = squash_commits(
+    let err = squash_commits(
         editor,
-        subject_id,
+        vec![subject_id],
         target_id,
         squash_commits::MessageCombinationStrategy::KeepBoth,
-    )?;
+    )
+    .expect_err("must fail when reordering produces conflicts");
 
-    let materialized = outcome.rebase.materialize()?;
-    let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
-
-    let spec = format!("{squashed_id}:shared.txt");
-    let object = repo.rev_parse_single(spec.as_str())?.object()?;
-    assert_eq!(object.data.as_bstr(), "v3\n");
-
-    let squashed_commit = repo.find_commit(squashed_id)?;
-    assert_eq!(
-        squashed_commit.message_raw()?,
-        "commit one\n\ncommit three\n"
+    assert!(
+        err.to_string()
+            .contains("became conflicted after reordering"),
+        "error should explain that conflicted commits cannot be squashed"
     );
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * 85f51d5 (HEAD -> three, two) [conflict] commit two
-    * f3ac68e (one) commit one
+    * a209f1b (HEAD -> three) commit three
+    * c0570de (two) commit two
+    * 8df0fa3 (one) commit one
     ");
 
     Ok(())
@@ -364,12 +386,13 @@ fn squash_across_stacks_subject_into_target() -> Result<()> {
         })?;
 
     let mut ws = graph.into_workspace()?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    let normalized = visualize_commit_graph_all(&repo)?.replace("  \n", "\n");
+    insta::assert_snapshot!(normalized, @r"
     *   c49e4d8 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    |\  
+    |\
     | * 09d8e52 (A) A
     * | c813d8d (B) B
-    |/  
+    |/
     * 85efbe4 (origin/main, main) M
     ");
     insta::assert_snapshot!(graph_workspace(&ws), @"
@@ -389,7 +412,7 @@ fn squash_across_stacks_subject_into_target() -> Result<()> {
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let outcome = squash_commits(
         editor,
-        subject_id,
+        vec![subject_id],
         target_id,
         squash_commits::MessageCombinationStrategy::KeepBoth,
     )?;
@@ -430,12 +453,13 @@ fn squash_across_stacks_target_into_subject() -> Result<()> {
 
     let mut ws = graph.into_workspace()?;
 
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    let normalized = visualize_commit_graph_all(&repo)?.replace("  \n", "\n");
+    insta::assert_snapshot!(normalized, @r"
     *   c49e4d8 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    |\  
+    |\
     | * 09d8e52 (A) A
     * | c813d8d (B) B
-    |/  
+    |/
     * 85efbe4 (origin/main, main) M
     ");
 
@@ -456,7 +480,7 @@ fn squash_across_stacks_target_into_subject() -> Result<()> {
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let outcome = squash_commits(
         editor,
-        subject_id,
+        vec![subject_id],
         target_id,
         squash_commits::MessageCombinationStrategy::KeepBoth,
     )?;
@@ -482,6 +506,70 @@ fn squash_across_stacks_target_into_subject() -> Result<()> {
     └── ≡📙:3:A on 85efbe4 {1}
         └── 📙:3:A
             └── ·17e27b0 (🏘️)
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn squash_all_c_commits_into_second_commit_of_b_keeps_new_file_content() -> Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) = writable_scenario("three-stacks", |meta| {
+        add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+        add_stack_with_segments(meta, 2, "B", StackState::InWorkspace, &[]);
+        add_stack_with_segments(meta, 3, "C", StackState::InWorkspace, &[]);
+    })?;
+
+    let c_top = repo.rev_parse_single("C")?.detach();
+    let c_second = repo.rev_parse_single("C~1")?.detach();
+    let c_third = repo.rev_parse_single("C~2")?.detach();
+    let target_id = repo.rev_parse_single("B~1")?.detach();
+
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+    let outcome = squash_commits(
+        editor,
+        vec![c_top, c_second, c_third],
+        target_id,
+        squash_commits::MessageCombinationStrategy::KeepBoth,
+    )?;
+
+    let materialized = outcome.rebase.materialize()?;
+    let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
+
+    let new_file_blob = repo
+        .rev_parse_single(format!("{squashed_id}:new-file").as_str())?
+        .object()?;
+    insta::assert_snapshot!(new_file_blob.data.as_bstr(), @r"
+    1
+    2
+    3
+    4
+    5
+    6
+    7
+    8
+    9
+    10
+    11
+    12
+    13
+    14
+    15
+    16
+    17
+    18
+    19
+    20
+    21
+    22
+    23
+    24
+    25
+    26
+    27
+    28
+    29
+    30
     ");
 
     Ok(())

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -663,7 +663,7 @@ impl SquashCommitsOperation {
     pub(crate) fn execute_inner(&self, ctx: &mut Context) -> anyhow::Result<CommitSquashResult> {
         but_api::commit::squash::commit_squash(
             ctx,
-            self.source,
+            vec![self.source],
             self.destination,
             MessageCombinationStrategy::KeepBoth,
             DryRun::No,

--- a/crates/but/src/command/legacy/rub/squash.rs
+++ b/crates/but/src/command/legacy/rub/squash.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use anyhow::{Context as _, bail};
 use bstr::BString;
 use but_core::{DryRun, ref_metadata::StackId, sync::RepoExclusive};
@@ -203,17 +201,6 @@ fn squash_commits_internal(
     perm: &mut RepoExclusive,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
-    // Validate all commits are on the same stack
-    let target_stack = stack_id_by_commit_id(ctx, target_oid)?;
-    for source_oid in &source_oids {
-        let source_stack = stack_id_by_commit_id(ctx, *source_oid)?;
-        if source_stack != target_stack {
-            bail!(
-                "Commits must be on the same stack to squash them together. Try squashing commits within a single branch or stack."
-            );
-        }
-    }
-
     // Collect commit messages if we need them for AI generation
     let (source_messages, destination_message) = if ai.is_some() {
         let repo = ctx.repo.get()?;
@@ -263,35 +250,20 @@ fn squash_commits_internal(
     // Keep the complete multi-rewrite sequence atomic: if any step fails,
     // restore the pre-squash snapshot so we don't leave partial rewrites.
     let snapshot = ctx.create_snapshot(SnapshotDetails::new(OperationKind::SquashCommit), perm)?;
-    let squash_result: anyhow::Result<ObjectId> = (|| {
-        // Perform the squash by folding sources into the current target one by one.
-        // We process from bottom to top so each next source remains adjacent to the
-        // rewritten target commit.
-        let mut new_commit_oid = target_oid;
-        let mut rewritten_commits = BTreeMap::<ObjectId, ObjectId>::new();
-        for source_oid in source_oids.iter().rev() {
-            let mut remapped_source_oid = *source_oid;
-            while let Some(next_oid) = rewritten_commits.get(&remapped_source_oid) {
-                remapped_source_oid = *next_oid;
-            }
+    let source_oids_count = source_oids.len();
+    let only_source_commit = source_oids.first().copied();
+    let source_oids_to_squash = source_oids;
 
-            let squash_result = but_api::commit::squash::commit_squash_only_with_perm(
-                ctx,
-                remapped_source_oid,
-                new_commit_oid,
-                MessageCombinationStrategy::KeepBoth,
-                DryRun::No,
-                perm,
-            )?;
-            rewritten_commits.extend(
-                squash_result
-                    .workspace
-                    .replaced_commits
-                    .iter()
-                    .map(|(k, v)| (*k, *v)),
-            );
-            new_commit_oid = squash_result.new_commit;
-        }
+    let squash_result: anyhow::Result<ObjectId> = (|| {
+        let squash_result = but_api::commit::squash::commit_squash_only_with_perm(
+            ctx,
+            source_oids_to_squash,
+            target_oid,
+            MessageCombinationStrategy::KeepBoth,
+            DryRun::No,
+            perm,
+        )?;
+        let new_commit_oid = squash_result.new_commit;
 
         // Determine the final message and apply if needed.
         let final_commit_oid = if let Some(user_summary) = ai {
@@ -350,12 +322,16 @@ fn squash_commits_internal(
     if let Some(out) = out.for_human() {
         let repo = ctx.repo.get()?;
         let final_short = shorten_object_id(&repo, final_commit_oid);
-        if source_oids.len() == 1 {
+        if source_oids_count == 1 {
             // Single commit squash (for backwards compatibility with `but rub`)
             writeln!(
                 out,
                 "Squashed {} → {}",
-                t.cli_id.paint(shorten_object_id(&repo, source_oids[0])),
+                t.cli_id.paint(shorten_object_id(
+                    &repo,
+                    only_source_commit
+                        .context("BUG: Source commits count is one, but first item is none")?
+                )),
                 t.cli_id.paint(&final_short)
             )?
         } else {
@@ -363,7 +339,7 @@ fn squash_commits_internal(
             writeln!(
                 out,
                 "Squashed {} commits → {}",
-                source_oids.len(),
+                source_oids_count,
                 t.cli_id.paint(&final_short)
             )?
         }
@@ -371,7 +347,7 @@ fn squash_commits_internal(
         out.write_value(serde_json::json!({
             "ok": true,
             "new_commit_id": final_commit_oid.to_string(),
-            "squashed_count": source_oids.len(),
+            "squashed_count": source_oids_count,
         }))?;
     }
     Ok(())

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -52,6 +52,11 @@ mod undo;
 
 #[cfg(feature = "legacy")]
 mod util {
+    use std::{
+        collections::BTreeMap,
+        path::{Path, PathBuf},
+    };
+
     use anyhow::Context as _;
 
     use crate::utils::{CommandExt as _, Sandbox};
@@ -122,6 +127,86 @@ mod util {
         cmd.stderr(std::process::Stdio::piped());
         but_testsupport::isolate_env_std_cmd(&mut cmd);
         cmd
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum SnapshotFileContents {
+        Text(String),
+        Binary(Vec<u8>),
+    }
+
+    pub type WorkingDirectorySnapshot = BTreeMap<PathBuf, SnapshotFileContents>;
+
+    /// Capture all regular files from the working directory recursively, excluding `.git`.
+    pub fn working_directory_snapshot(env: &Sandbox) -> anyhow::Result<WorkingDirectorySnapshot> {
+        let root = env.projects_root();
+        let mut snapshot = WorkingDirectorySnapshot::new();
+        collect_files_recursively(root, root, &mut snapshot)?;
+        Ok(snapshot)
+    }
+
+    fn collect_files_recursively(
+        root: &Path,
+        dir: &Path,
+        out: &mut WorkingDirectorySnapshot,
+    ) -> anyhow::Result<()> {
+        for entry in std::fs::read_dir(dir)
+            .with_context(|| format!("failed to read directory '{}'", dir.display()))?
+        {
+            let entry = entry.with_context(|| {
+                format!("failed to read directory entry in '{}'", dir.display())
+            })?;
+            let path = entry.path();
+            let file_name = entry.file_name();
+
+            if file_name.to_string_lossy() == ".git" {
+                continue;
+            }
+
+            let file_type = entry
+                .file_type()
+                .with_context(|| format!("failed to determine type for '{}'", path.display()))?;
+            if file_type.is_dir() {
+                collect_files_recursively(root, &path, out)?;
+                continue;
+            }
+            if !file_type.is_file() {
+                continue;
+            }
+
+            let relative_path = path
+                .strip_prefix(root)
+                .with_context(|| {
+                    format!(
+                        "expected '{}' to be under root '{}'",
+                        path.display(),
+                        root.display()
+                    )
+                })?
+                .to_path_buf();
+            let contents = std::fs::read(&path)
+                .with_context(|| format!("failed to read file '{}'", path.display()))?;
+            out.insert(relative_path, snapshot_file_contents(contents));
+        }
+        Ok(())
+    }
+
+    fn snapshot_file_contents(contents: Vec<u8>) -> SnapshotFileContents {
+        if is_printable_text(&contents) {
+            // Safe because `is_printable_text` verifies valid UTF-8 first.
+            SnapshotFileContents::Text(String::from_utf8(contents).expect("validated utf-8"))
+        } else {
+            SnapshotFileContents::Binary(contents)
+        }
+    }
+
+    fn is_printable_text(contents: &[u8]) -> bool {
+        let Ok(text) = std::str::from_utf8(contents) else {
+            return false;
+        };
+
+        text.chars()
+            .all(|ch| !ch.is_control() || matches!(ch, '\n' | '\r' | '\t'))
     }
 
     /// Find a branch by name in `status` output.

--- a/crates/but/tests/but/command/squash.rs
+++ b/crates/but/tests/but/command/squash.rs
@@ -1,3 +1,4 @@
+use anyhow::Context as _;
 use bstr::ByteSlice;
 use snapbox::str;
 
@@ -33,10 +34,13 @@ fn squash_requires_at_least_two_commits() -> anyhow::Result<()> {
 
     // Only one commit exists (from scenario)
     // Try to squash a single commit - should fail
+    let working_directory_before = util::working_directory_snapshot(&env)?;
     env.but("squash c0").assert().failure().stderr_eq(str![[r#"
 Failed to squash commits. No matching branch or commit found for 'c0'
 
 "#]]);
+    let working_directory_after = util::working_directory_snapshot(&env)?;
+    assert_eq!(working_directory_before, working_directory_after);
 
     Ok(())
 }
@@ -48,10 +52,13 @@ fn squash_branch_with_single_commit_fails() -> anyhow::Result<()> {
 
     // Branch A has only 1 commit from the scenario
     // Try to squash branch with single commit - should fail
+    let working_directory_before = util::working_directory_snapshot(&env)?;
     env.but("squash A").assert().failure().stderr_eq(str![[r#"
 Failed to squash commits. Branch 'A' has only one commit, nothing to squash
 
 "#]]);
+    let working_directory_after = util::working_directory_snapshot(&env)?;
+    assert_eq!(working_directory_before, working_directory_after);
 
     Ok(())
 }
@@ -64,6 +71,7 @@ fn squash_nonexistent_commit_fails() -> anyhow::Result<()> {
     setup_branch_with_commits(&env, "A", 1);
 
     // Try to squash with nonexistent commit ID
+    let working_directory_before = util::working_directory_snapshot(&env)?;
     env.but("squash nonexistent c0")
         .assert()
         .failure()
@@ -71,6 +79,8 @@ fn squash_nonexistent_commit_fails() -> anyhow::Result<()> {
 Failed to squash commits. No matching commit found for 'nonexistent'
 
 "#]]);
+    let working_directory_after = util::working_directory_snapshot(&env)?;
+    assert_eq!(working_directory_before, working_directory_after);
 
     Ok(())
 }
@@ -85,7 +95,10 @@ fn squash_branch_by_name_succeeds() -> anyhow::Result<()> {
 
     // Squash all commits in branch A by using branch name
     // This should succeed as we have 3 commits total
+    let working_directory_before = util::working_directory_snapshot(&env)?;
     env.but("squash A").assert().success();
+    let working_directory_after = util::working_directory_snapshot(&env)?;
+    assert_eq!(working_directory_before, working_directory_after);
 
     Ok(())
 }
@@ -99,7 +112,10 @@ fn squash_with_drop_message_flag_succeeds() -> anyhow::Result<()> {
     setup_branch_with_commits(&env, "A", 1);
 
     // Squash branch with --drop-message flag
+    let working_directory_before = util::working_directory_snapshot(&env)?;
     env.but("squash A --drop-message").assert().success();
+    let working_directory_after = util::working_directory_snapshot(&env)?;
+    assert_eq!(working_directory_before, working_directory_after);
 
     Ok(())
 }
@@ -113,9 +129,12 @@ fn squash_with_custom_message_succeeds() -> anyhow::Result<()> {
     setup_branch_with_commits(&env, "A", 1);
 
     // Squash with custom message
+    let working_directory_before = util::working_directory_snapshot(&env)?;
     env.but("squash A -m 'Custom squash message'")
         .assert()
         .success();
+    let working_directory_after = util::working_directory_snapshot(&env)?;
+    assert_eq!(working_directory_before, working_directory_after);
 
     Ok(())
 }
@@ -128,9 +147,12 @@ fn squash_mutually_exclusive_flags_fails() -> anyhow::Result<()> {
     setup_branch_with_commits(&env, "A", 1);
 
     // Try to use both --drop-message and --message flags - should fail
+    let working_directory_before = util::working_directory_snapshot(&env)?;
     env.but("squash A -m 'Custom message' --drop-message")
         .assert()
         .failure();
+    let working_directory_after = util::working_directory_snapshot(&env)?;
+    assert_eq!(working_directory_before, working_directory_after);
 
     Ok(())
 }
@@ -143,6 +165,7 @@ fn squash_with_invalid_range_format_fails() -> anyhow::Result<()> {
     setup_branch_with_commits(&env, "A", 2);
 
     // Try to use invalid range format with triple dots
+    let working_directory_before = util::working_directory_snapshot(&env)?;
     env.but("squash c0..c1..c2")
         .assert()
         .failure()
@@ -150,6 +173,8 @@ fn squash_with_invalid_range_format_fails() -> anyhow::Result<()> {
 Failed to squash commits. Range format should be 'start..end', got 'c0..c1..c2'
 
 "#]]);
+    let working_directory_after = util::working_directory_snapshot(&env)?;
+    assert_eq!(working_directory_before, working_directory_after);
 
     Ok(())
 }
@@ -162,7 +187,10 @@ fn squash_with_empty_range_part_fails() -> anyhow::Result<()> {
     setup_branch_with_commits(&env, "A", 2);
 
     // Try range with empty start
+    let working_directory_before = util::working_directory_snapshot(&env)?;
     env.but("squash ..c1").assert().failure();
+    let working_directory_after = util::working_directory_snapshot(&env)?;
+    assert_eq!(working_directory_before, working_directory_after);
 
     Ok(())
 }
@@ -174,6 +202,7 @@ fn squash_comma_list_with_nonexistent_commit_fails() -> anyhow::Result<()> {
 
     // Try comma-separated list with only nonexistent commits
     // This tests the comma parsing path without needing real commit IDs
+    let working_directory_before = util::working_directory_snapshot(&env)?;
     env.but("squash nonexistent1,nonexistent2")
         .assert()
         .failure()
@@ -181,6 +210,8 @@ fn squash_comma_list_with_nonexistent_commit_fails() -> anyhow::Result<()> {
 Failed to squash commits. Commit 'nonexistent1' not found
 
 "#]]);
+    let working_directory_after = util::working_directory_snapshot(&env)?;
+    assert_eq!(working_directory_before, working_directory_after);
 
     Ok(())
 }
@@ -192,6 +223,7 @@ fn squash_range_with_nonexistent_endpoint_fails() -> anyhow::Result<()> {
 
     // Try range with nonexistent endpoints
     // This tests the range parsing path without needing real commit IDs
+    let working_directory_before = util::working_directory_snapshot(&env)?;
     env.but("squash nonexistent1..nonexistent2")
         .assert()
         .failure()
@@ -199,6 +231,8 @@ fn squash_range_with_nonexistent_endpoint_fails() -> anyhow::Result<()> {
 Failed to squash commits. Start of range 'nonexistent1' must match exactly one commit
 
 "#]]);
+    let working_directory_after = util::working_directory_snapshot(&env)?;
+    assert_eq!(working_directory_before, working_directory_after);
 
     Ok(())
 }
@@ -211,6 +245,7 @@ fn squash_ai_conflicts_with_message() -> anyhow::Result<()> {
     setup_branch_with_commits(&env, "A", 1);
 
     // Try to use both --ai and --message flags - should fail
+    let working_directory_before = util::working_directory_snapshot(&env)?;
     env.but("squash A --ai -m 'Custom message'")
         .assert()
         .failure()
@@ -222,6 +257,8 @@ Usage: but squash --ai[=<AI>] <COMMITS>...
 For more information, try '--help'.
 
 "#]]);
+    let working_directory_after = util::working_directory_snapshot(&env)?;
+    assert_eq!(working_directory_before, working_directory_after);
 
     Ok(())
 }
@@ -234,6 +271,7 @@ fn squash_ai_conflicts_with_drop_message() -> anyhow::Result<()> {
     setup_branch_with_commits(&env, "A", 1);
 
     // Try to use both --ai and --drop-message flags - should fail
+    let working_directory_before = util::working_directory_snapshot(&env)?;
     env.but("squash A --ai --drop-message")
         .assert()
         .failure()
@@ -245,6 +283,8 @@ Usage: but squash --ai[=<AI>] <COMMITS>...
 For more information, try '--help'.
 
 "#]]);
+    let working_directory_after = util::working_directory_snapshot(&env)?;
+    assert_eq!(working_directory_before, working_directory_after);
 
     Ok(())
 }
@@ -257,6 +297,7 @@ fn concurrent_squashes_on_independent_branches_succeed() -> anyhow::Result<()> {
     env.but("branch new branchB").assert().success();
     setup_branch_with_commits(&env, "A", 1);
     setup_branch_with_commits(&env, "branchB", 2);
+    let working_directory_before = util::working_directory_snapshot(&env)?;
 
     let child_a = util::but_std_cmd(&env, "squash A").spawn()?;
     let child_b = util::but_std_cmd(&env, "squash branchB").spawn()?;
@@ -274,9 +315,455 @@ fn concurrent_squashes_on_independent_branches_succeed() -> anyhow::Result<()> {
         "squash on branchB failed: {}",
         out_b.stderr.as_bstr()
     );
+    let working_directory_after = util::working_directory_snapshot(&env)?;
+    assert_eq!(working_directory_before, working_directory_after);
 
     assert_eq!(branch_commit_count(&env, "A")?, 1);
     assert_eq!(branch_commit_count(&env, "branchB")?, 1);
+
+    Ok(())
+}
+
+#[test]
+fn squash_multiple_commits_from_list_succeeds() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    setup_branch_with_commits(&env, "A", 3);
+
+    let status_before = util::status_json(&env)?;
+    let branch_a_before = util::find_branch(&status_before, "A")?;
+    let commits_before = branch_a_before["commits"]
+        .as_array()
+        .context("Missing commits for branch A")?;
+
+    let source_top = commits_before[0]["cliId"]
+        .as_str()
+        .context("Missing top source commit cliId")?;
+    let source_second = commits_before[1]["cliId"]
+        .as_str()
+        .context("Missing second source commit cliId")?;
+    let target = commits_before[2]["cliId"]
+        .as_str()
+        .context("Missing target commit cliId")?;
+
+    let working_directory_before = util::working_directory_snapshot(&env)?;
+    env.but(format!("squash {source_top},{source_second},{target}"))
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Squashed 2 commits → [..]
+
+"#]]);
+    let working_directory_after = util::working_directory_snapshot(&env)?;
+    assert_eq!(working_directory_before, working_directory_after);
+
+    let status_after = util::status_json(&env)?;
+    let branch_a_after = util::find_branch(&status_after, "A")?;
+    let commits_after = branch_a_after["commits"]
+        .as_array()
+        .context("Missing commits for branch A after squash")?;
+
+    assert_eq!(
+        commits_after.len(),
+        2,
+        "A should have 2 commits after squashing 2 sources into 1 target"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn squash_list_with_bottom_target_keeps_target_message_first() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+    setup_branch_with_commits(&env, "A", 3);
+
+    insta::assert_snapshot!(env.git_log()?, @r"
+    * c7b6336 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 8a1f552 (A) commit 3
+    * 39dd878 commit 2
+    * 8128859 commit 1
+    * 9477ae7 add A
+    * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
+    ");
+
+    let status_before = util::status_json(&env)?;
+    let branch_a_before = util::find_branch(&status_before, "A")?;
+    let commits_before = branch_a_before["commits"]
+        .as_array()
+        .context("Missing commits for branch A")?;
+
+    let source_top = commits_before[0]["cliId"]
+        .as_str()
+        .context("Missing top source commit cliId")?;
+    let source_second = commits_before[1]["cliId"]
+        .as_str()
+        .context("Missing second source commit cliId")?;
+    let target = commits_before[2]["cliId"]
+        .as_str()
+        .context("Missing target commit cliId")?;
+
+    let working_directory_before = util::working_directory_snapshot(&env)?;
+    env.but(format!("squash {source_top},{source_second},{target}"))
+        .assert()
+        .success();
+    let working_directory_after = util::working_directory_snapshot(&env)?;
+    assert_eq!(working_directory_before, working_directory_after);
+
+    let log_after = env.git_log()?;
+    assert!(
+        log_after.contains("(A) commit 1"),
+        "expected squashed branch tip message to be target-first (commit 1), got:\n{log_after}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn squash_list_with_middle_target_keeps_target_message_first() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+    setup_branch_with_commits(&env, "A", 3);
+
+    insta::assert_snapshot!(env.git_log()?, @r"
+    * c7b6336 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 8a1f552 (A) commit 3
+    * 39dd878 commit 2
+    * 8128859 commit 1
+    * 9477ae7 add A
+    * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
+    ");
+
+    let status_before = util::status_json(&env)?;
+    let branch_a_before = util::find_branch(&status_before, "A")?;
+    let commits_before = branch_a_before["commits"]
+        .as_array()
+        .context("Missing commits for branch A")?;
+
+    let source_top = commits_before[0]["cliId"]
+        .as_str()
+        .context("Missing top source commit cliId")?;
+    let target = commits_before[1]["cliId"]
+        .as_str()
+        .context("Missing second source commit cliId")?;
+    let source_third = commits_before[2]["cliId"]
+        .as_str()
+        .context("Missing target commit cliId")?;
+
+    let working_directory_before = util::working_directory_snapshot(&env)?;
+    env.but(format!("squash {source_top},{source_third},{target}"))
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Squashed 2 commits → [..]
+
+"#]]);
+    let working_directory_after = util::working_directory_snapshot(&env)?;
+    assert_eq!(working_directory_before, working_directory_after);
+
+    let log_after = env.git_log()?;
+    assert!(
+        log_after.contains("(A) commit 2"),
+        "expected squashed branch tip message to be target-first (commit 2), got:\n{log_after}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn squash_multiple_commits_keeps_squashed_commit_content() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+    setup_branch_with_commits(&env, "A", 3);
+
+    insta::assert_snapshot!(env.git_log()?, @r"
+    * c7b6336 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 8a1f552 (A) commit 3
+    * 39dd878 commit 2
+    * 8128859 commit 1
+    * 9477ae7 add A
+    * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
+    ");
+
+    let status_before = util::status_json(&env)?;
+    let branch_a_before = util::find_branch(&status_before, "A")?;
+    let commits_before = branch_a_before["commits"]
+        .as_array()
+        .context("Missing commits for branch A")?;
+
+    let target_message_before = commits_before[2]["message"]
+        .as_str()
+        .context("Missing target commit message")?
+        .to_string();
+    let source_top_message = commits_before[0]["message"]
+        .as_str()
+        .context("Missing top source commit message")?
+        .to_string();
+    let source_second_message = commits_before[1]["message"]
+        .as_str()
+        .context("Missing second source commit message")?
+        .to_string();
+    let source_top = commits_before[0]["cliId"]
+        .as_str()
+        .context("Missing top source commit cliId")?;
+    let source_second = commits_before[1]["cliId"]
+        .as_str()
+        .context("Missing second source commit cliId")?;
+    let target = commits_before[2]["cliId"]
+        .as_str()
+        .context("Missing target commit cliId")?;
+
+    let working_directory_before = util::working_directory_snapshot(&env)?;
+    env.but(format!("squash {source_top},{source_second},{target}"))
+        .assert()
+        .success();
+    let working_directory_after = util::working_directory_snapshot(&env)?;
+    assert_eq!(working_directory_before, working_directory_after);
+
+    let status_after = util::status_json(&env)?;
+    let branch_a_after = util::find_branch(&status_after, "A")?;
+    let commits_after = branch_a_after["commits"]
+        .as_array()
+        .context("Missing commits for branch A after squash")?;
+    assert_eq!(commits_after.len(), 2);
+
+    let squashed_message = commits_after[0]["message"]
+        .as_str()
+        .context("Missing squashed commit message")?;
+    assert_eq!(
+        squashed_message,
+        format!("{target_message_before}\n\n{source_top_message}\n\n{source_second_message}")
+    );
+
+    let repo = env.open_repo()?;
+    let first_blob = repo.rev_parse_single(b"A:A-file1.txt")?.object()?;
+    let second_blob = repo.rev_parse_single(b"A:A-file2.txt")?.object()?;
+    let third_blob = repo.rev_parse_single(b"A:A-file3.txt")?.object()?;
+
+    insta::assert_snapshot!(first_blob.data.as_bstr(), @"content for commit 1\n");
+    insta::assert_snapshot!(second_blob.data.as_bstr(), @"content for commit 2\n");
+    insta::assert_snapshot!(third_blob.data.as_bstr(), @"content for commit 3\n");
+
+    let log_after = env.git_log()?;
+    assert!(
+        log_after.contains("(A) commit 1"),
+        "expected squashed A tip message to start with target commit message, got:\n{log_after}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn squash_multiple_commits_from_different_branches_on_same_stack_succeeds() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "two-stacks-one-single-and-ready-to-mingle-one-double",
+    )?;
+    env.setup_metadata(&["A", "B"])?;
+
+    env.file("c-extra.txt", "another change on C\n");
+    env.but("commit C -m 'extra on C'").assert().success();
+
+    let status_before = util::status_json(&env)?;
+    let branch_b_before = util::find_branch(&status_before, "B")?;
+    let branch_c_before = util::find_branch(&status_before, "C")?;
+
+    let b_commits_before = branch_b_before["commits"]
+        .as_array()
+        .context("Missing commits for branch B")?;
+    let c_commits_before = branch_c_before["commits"]
+        .as_array()
+        .context("Missing commits for branch C")?;
+
+    let source_b = b_commits_before[0]["cliId"]
+        .as_str()
+        .context("Missing source commit from B")?;
+    let source_c = c_commits_before[0]["cliId"]
+        .as_str()
+        .context("Missing source commit from C")?;
+    let target_c = c_commits_before[1]["cliId"]
+        .as_str()
+        .context("Missing target commit from C")?;
+
+    let working_directory_before = util::working_directory_snapshot(&env)?;
+    env.but(format!("squash {source_b} {source_c} {target_c}"))
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Squashed 2 commits → [..]
+
+"#]]);
+    let working_directory_after = util::working_directory_snapshot(&env)?;
+    assert_eq!(working_directory_before, working_directory_after);
+
+    let status_after = util::status_json(&env)?;
+    let branch_b_after = util::find_branch(&status_after, "B")?;
+    let branch_c_after = util::find_branch(&status_after, "C")?;
+
+    let b_commits_after = branch_b_after["commits"]
+        .as_array()
+        .context("Missing commits for branch B after squash")?;
+    let c_commits_after = branch_c_after["commits"]
+        .as_array()
+        .context("Missing commits for branch C after squash")?;
+
+    assert_eq!(
+        b_commits_after.len() + c_commits_after.len(),
+        1,
+        "B and C should have a single squashed commit left in total"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn squash_branch_c_in_three_stacks_keeps_content_and_updates_graph() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("three-stacks")?;
+    env.setup_metadata(&["A", "B", "C"])?;
+
+    let normalized_log = env.git_log()?.replace("  \n", "\n");
+    insta::assert_snapshot!(normalized_log, @r"
+    *-.   205e798 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\ \
+    | | * a748762 (B) B: another 10 lines at the bottom
+    | | * 62e05ba B: 10 lines at the bottom
+    | * | add59d2 (A) A: 10 lines on top
+    | |/
+    * | 930563a (C) C: add another 10 lines to new file
+    * | 68a2fc3 C: add 10 lines to new file
+    * | 984fd1c C: new file with 10 lines
+    |/
+    * 8f0d338 (tag: base, origin/main, origin/HEAD, main) base
+    ");
+
+    let working_directory_before = util::working_directory_snapshot(&env)?;
+    env.but("squash C").assert().success();
+    let working_directory_after = util::working_directory_snapshot(&env)?;
+    assert_eq!(working_directory_before, working_directory_after);
+
+    let status_after = util::status_json(&env)?;
+    let branch_c_after = util::find_branch(&status_after, "C")?;
+    let commits_after = branch_c_after["commits"]
+        .as_array()
+        .context("Missing commits for branch C after squash")?;
+    assert_eq!(commits_after.len(), 1);
+
+    let repo = env.open_repo()?;
+    let new_file_blob = repo.rev_parse_single(b"C:new-file")?.object()?;
+    insta::assert_snapshot!(new_file_blob.data.as_bstr(), @"
+    1
+    2
+    3
+    4
+    5
+    6
+    7
+    8
+    9
+    10
+    11
+    12
+    13
+    14
+    15
+    16
+    17
+    18
+    19
+    20
+    21
+    22
+    23
+    24
+    25
+    26
+    27
+    28
+    29
+    30
+    ");
+
+    let normalized_log = env.git_log()?.replace("  \n", "\n");
+    assert!(
+        normalized_log.contains("(C) C: new file with 10 lines"),
+        "expected squashed C tip message to begin with target commit message, got:\n{normalized_log}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn squash_all_c_commits_into_second_commit_of_b_keeps_new_file_content() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("three-stacks")?;
+    env.setup_metadata(&["A", "B", "C"])?;
+
+    let status_before = util::status_json(&env)?;
+    let branch_b_before = util::find_branch(&status_before, "B")?;
+    let branch_c_before = util::find_branch(&status_before, "C")?;
+
+    let b_commits_before = branch_b_before["commits"]
+        .as_array()
+        .context("Missing commits for branch B")?;
+    let c_commits_before = branch_c_before["commits"]
+        .as_array()
+        .context("Missing commits for branch C")?;
+
+    let b_second_commit = b_commits_before[1]["cliId"]
+        .as_str()
+        .context("Missing second commit cliId in B")?;
+    let c_commit_ids = c_commits_before
+        .iter()
+        .map(|commit| {
+            commit["cliId"]
+                .as_str()
+                .context("Missing cliId for commit in C")
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    let working_directory_before = util::working_directory_snapshot(&env)?;
+    env.but(format!(
+        "squash {} {b_second_commit}",
+        c_commit_ids.join(" ")
+    ))
+    .assert()
+    .success();
+    let working_directory_after = util::working_directory_snapshot(&env)?;
+    assert_eq!(working_directory_before, working_directory_after);
+
+    let repo = env.open_repo()?;
+    let new_file_blob = repo.rev_parse_single(b"B:new-file")?.object()?;
+    insta::assert_snapshot!(new_file_blob.data.as_bstr(), @r"
+    1
+    2
+    3
+    4
+    5
+    6
+    7
+    8
+    9
+    10
+    11
+    12
+    13
+    14
+    15
+    16
+    17
+    18
+    19
+    20
+    21
+    22
+    23
+    24
+    25
+    26
+    27
+    28
+    29
+    30
+    ");
 
     Ok(())
 }

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -160,7 +160,7 @@ export declare function commitMoveChangesBetween(projectId: string, sourceCommit
 export declare function commitReword(projectId: string, commitId: string, message: string, dryRun: boolean): Promise<CommitRewordResult>
 
 /**
- * Squash `subject_commit_id` into `target_commit_id` and record an oplog
+ * Squash `subject_commit_ids` into `target_commit_id` and record an oplog
  * snapshot on success.
  *
  * This acquires exclusive worktree access from `ctx` before rewriting the
@@ -169,7 +169,7 @@ export declare function commitReword(projectId: string, commitId: string, messag
  * When `dry_run` is enabled, the returned workspace previews the squashed
  * result and no oplog entry is persisted. For details, see [`commit_squash_with_perm()`].
  */
-export declare function commitSquash(projectId: string, subjectCommitId: string, targetCommitId: string, howToCombineMessages: MessageCombinationStrategy, dryRun: boolean): Promise<CommitSquashResult>
+export declare function commitSquash(projectId: string, subjectCommitIds: Array<string>, targetCommitId: string, howToCombineMessages: MessageCombinationStrategy, dryRun: boolean): Promise<CommitSquashResult>
 
 /**
  * Uncommit one or more commits, removing them from branch history while


### PR DESCRIPTION
Allow multiple commits from anywhere in the workspace to be squashed
into anywhere.

- Update the tests to match the new signature
- Update the tests to be more strict about the fact that the workspace should stay as is, after squash operations
- Update squash commits usage

closes GB-968

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #13527
- <kbd>&nbsp;1&nbsp;</kbd> #13525 👈 
<!-- GitButler Footer Boundary Bottom -->