### PR TITLE
commit move: Compose moves in one rebase

### DIFF
--- a/crates/but-api/src/commit/move_commit.rs
+++ b/crates/but-api/src/commit/move_commit.rs
@@ -80,33 +80,23 @@ pub fn commit_move_only_with_perm(
         .next()
         .expect("non-empty commit list always has a first subject");
 
-    let mut rebase =
-        but_workspace::commit::move_commit(editor, first_subject, relative_to.clone(), side)?;
+    let mut editor = but_workspace::commit::move_commit_no_rebase(
+        editor,
+        first_subject,
+        relative_to.clone(),
+        side,
+    )?;
 
-    for original_subject_id in subjects {
-        let remapped_ids = rebase.history.commit_mappings();
-        let subject_id = remapped_ids
-            .get(&original_subject_id)
-            .copied()
-            .unwrap_or(original_subject_id);
-
-        let remapped_relative_to = match &relative_to {
-            RelativeTo::Commit(target_commit_id) => RelativeTo::Commit(
-                remapped_ids
-                    .get(target_commit_id)
-                    .copied()
-                    .unwrap_or(*target_commit_id),
-            ),
-            RelativeTo::Reference(reference_name) => RelativeTo::Reference(reference_name.clone()),
-        };
-
-        rebase = but_workspace::commit::move_commit(
-            rebase.into_editor(),
+    for subject_id in subjects {
+        editor = but_workspace::commit::move_commit_no_rebase(
+            editor,
             subject_id,
-            remapped_relative_to,
+            relative_to.clone(),
             side,
         )?;
     }
+
+    let rebase = editor.rebase()?;
 
     Ok(CommitMoveResult {
         workspace: WorkspaceState::from_successful_rebase(rebase, &repo, dry_run)?,

--- a/crates/but/tests/but/command/move.rs
+++ b/crates/but/tests/but/command/move.rs
@@ -371,10 +371,10 @@ Moved 4 commits → before [..]
 ├╯
 ┊
 ┊╭┄h0 [B]
-┊●   c399e25 B: another 10 lines at the bottom
-┊●   72227c2 A: 10 lines on top
-┊●   c26fa8e C: add another 10 lines to new file
-┊●   640a48b C: add 10 lines to new file
+┊●   [..] B: another 10 lines at the bottom
+┊●   [..] A: 10 lines on top
+┊●   [..] C: add another 10 lines to new file
+┊●   [..] C: add 10 lines to new file
 ┊●   fc29de6 C: new file with 10 lines
 ┊●   62e05ba B: 10 lines at the bottom
 ├╯
@@ -515,9 +515,9 @@ Moved 4 commits → after a748762
 ├╯
 ┊
 ┊╭┄h0 [B]
-┊●   a42a7dc A: 10 lines on top
-┊●   48bd306 C: add another 10 lines to new file
-┊●   99b8c8b C: add 10 lines to new file
+┊●   [..] A: 10 lines on top
+┊●   [..] C: add another 10 lines to new file
+┊●   [..] C: add 10 lines to new file
 ┊●   b665de5 C: new file with 10 lines
 ┊●   a748762 B: another 10 lines at the bottom
 ┊●   62e05ba B: 10 lines at the bottom


### PR DESCRIPTION
Make it so that all move operations are made inside one rebase

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #13527 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #13525
<!-- GitButler Footer Boundary Bottom -->