### PR TITLE
Fix `but remote` serving Tauri-targeted frontend in browser (#13500)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ dist-ssr
 
 .turbo
 build
+embedded-frontend
 .svelte-kit
 package
 !.env.example

--- a/apps/desktop/svelte.config.js
+++ b/apps/desktop/svelte.config.js
@@ -2,6 +2,8 @@ import svelteInjectComment from "@gitbutler/svelte-comment-injector";
 import staticAdapter from "@sveltejs/adapter-static";
 import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 
+const outDir = process.env.SVELTEKIT_OUT_DIR || "build";
+
 const config = {
 	preprocess: [vitePreprocess({ script: true }), svelteInjectComment()],
 	kit: {
@@ -9,8 +11,8 @@ const config = {
 			$components: "./src/components",
 		},
 		adapter: staticAdapter({
-			pages: "build",
-			assets: "build",
+			pages: outDir,
+			assets: outDir,
 			fallback: "index.html",
 			precompress: false,
 			strict: false,

--- a/crates/but-server/build.rs
+++ b/crates/but-server/build.rs
@@ -5,25 +5,25 @@ fn main() {
     // dist directory to exist at compile time. Fail with clear instructions
     // rather than writing placeholder files into the source tree.
     if std::env::var("CARGO_FEATURE_EMBEDDED_FRONTEND").is_ok() {
-        let dist = Path::new("../../apps/desktop/build");
+        let dist = Path::new("../../apps/desktop/embedded-frontend");
         if !dist.exists() {
             // Create an empty directory so rust-embed can compile. The embedded
             // server will serve no frontend assets until `pnpm build` is run:
             //
-            //   VITE_BUILD_TARGET=web VITE_BUTLER_API_BASE_URL=/api \
-            //   pnpm --filter @gitbutler/desktop build
+            //   SVELTEKIT_OUT_DIR=embedded-frontend VITE_BUILD_TARGET=web \
+            //   VITE_BUTLER_API_BASE_URL=/api pnpm --filter @gitbutler/desktop build
             //
             // This allows `cargo check --workspace` to succeed without a prior
             // frontend build (e.g. in CI steps that only lint Rust code).
             let _ = std::fs::create_dir_all(dist);
             println!(
-                "cargo:warning=Frontend assets not found at apps/desktop/build/. \
+                "cargo:warning=Frontend assets not found at apps/desktop/embedded-frontend/. \
                       The embedded server will have no UI until you run `pnpm build`."
             );
             println!("cargo:rustc-env=EMBEDDED_FRONTEND_HASH=0");
             // Always watch the dist directory so Cargo reruns this script once
             // `pnpm build` creates it and populates it with assets.
-            println!("cargo:rerun-if-changed=../../apps/desktop/build");
+            println!("cargo:rerun-if-changed=../../apps/desktop/embedded-frontend");
             return;
         }
 

--- a/crates/but-server/src/frontend.rs
+++ b/crates/but-server/src/frontend.rs
@@ -3,7 +3,7 @@
 //! Build the frontend first (from the repo root):
 //!
 //! ```sh
-//! VITE_BUILD_TARGET=web VITE_BUTLER_API_BASE_URL=/api \
+//! SVELTEKIT_OUT_DIR=embedded-frontend VITE_BUILD_TARGET=web VITE_BUTLER_API_BASE_URL=/api \
 //!   pnpm --filter @gitbutler/desktop build
 //! ```
 //!
@@ -65,7 +65,7 @@ fn extract_inline_script_hashes(html: &str) -> Vec<String> {
 const _: &str = env!("EMBEDDED_FRONTEND_HASH");
 
 #[derive(RustEmbed)]
-#[folder = "../../apps/desktop/build/"]
+#[folder = "../../apps/desktop/embedded-frontend/"]
 struct Assets;
 
 /// Axum fallback handler — serves embedded static files with SPA fallback.

--- a/crates/gitbutler-tauri/tauri-before-build-command.sh
+++ b/crates/gitbutler-tauri/tauri-before-build-command.sh
@@ -18,6 +18,13 @@ if [ "${OS:-}" == "windows" ] || [ "${OS:-}" == "linux" ]; then
   BUT_FEATURES=""
   if [ "${CHANNEL:-}" != "release" ]; then
     BUT_FEATURES="--features irc,remote"
+    # Build the embedded frontend with VITE_BUILD_TARGET=web so it uses the
+    # HTTP backend instead of Tauri IPC (see #13500).  Output to a separate
+    # directory so the Tauri-targeted build in apps/desktop/build/ is not
+    # disturbed.
+    SVELTEKIT_OUT_DIR=embedded-frontend \
+      VITE_BUILD_TARGET=web VITE_BUTLER_API_BASE_URL=/api VITE_EMBEDDED_BUILD=1 \
+      pnpm --filter @gitbutler/desktop build
   fi
   # shellcheck disable=SC2086
   cargo build --release -p but $BUT_FEATURES


### PR DESCRIPTION
The embedded frontend bundled into the `but` CLI was built without
`VITE_BUILD_TARGET=web`, so it used Tauri IPC instead of HTTP — crashing
with "Cannot read properties of undefined" when opened in a browser.

Build the embedded frontend to a separate `apps/desktop/embedded-frontend/`
directory with the correct env vars (`VITE_BUILD_TARGET=web`,
`VITE_BUTLER_API_BASE_URL=/api`) during non-release builds. This keeps it
isolated from the Tauri-targeted build in `apps/desktop/build/` used by
the desktop app, so neither clobbers the other.