### PR TITLE
Fix CI publish failure introduced by embedded web frontend change

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -63,6 +63,14 @@ jobs:
         run: pnpm build:desktop -- --mode ${{ env.vitemode }}
         env:
           SENTRY_RELEASE: ${{ env.version }}
+      - name: Build embedded web frontend
+        if: env.channel != 'release'
+        run: pnpm build:desktop
+        env:
+          SVELTEKIT_OUT_DIR: embedded-frontend
+          VITE_BUILD_TARGET: web
+          VITE_BUTLER_API_BASE_URL: /api
+          VITE_EMBEDDED_BUILD: "1"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         name: Upload pnpm-store contents
         with:
@@ -74,6 +82,14 @@ jobs:
         with:
           name: sveltekit-build
           path: ./apps/desktop/build/
+          retention-days: 1
+          if-no-files-found: error
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: env.channel != 'release'
+        name: Upload embedded web frontend
+        with:
+          name: embedded-frontend
+          path: ./apps/desktop/embedded-frontend/
           retention-days: 1
           if-no-files-found: error
 
@@ -188,6 +204,12 @@ jobs:
         with:
           name: sveltekit-build
           path: ./apps/desktop/build/
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        if: env.channel != 'release'
+        name: Download embedded web frontend
+        with:
+          name: embedded-frontend
+          path: ./apps/desktop/embedded-frontend/
       - name: Build binary
         shell: bash
         run: |

--- a/crates/gitbutler-tauri/tauri-before-build-command.sh
+++ b/crates/gitbutler-tauri/tauri-before-build-command.sh
@@ -18,13 +18,14 @@ if [ "${OS:-}" == "windows" ] || [ "${OS:-}" == "linux" ]; then
   BUT_FEATURES=""
   if [ "${CHANNEL:-}" != "release" ]; then
     BUT_FEATURES="--features irc,remote"
-    # Build the embedded frontend with VITE_BUILD_TARGET=web so it uses the
-    # HTTP backend instead of Tauri IPC (see #13500).  Output to a separate
-    # directory so the Tauri-targeted build in apps/desktop/build/ is not
-    # disturbed.
-    SVELTEKIT_OUT_DIR=embedded-frontend \
-      VITE_BUILD_TARGET=web VITE_BUTLER_API_BASE_URL=/api VITE_EMBEDDED_BUILD=1 \
-      pnpm --filter @gitbutler/desktop build
+    # Build a web-targeted frontend for `but remote` into a separate directory
+    # so it doesn't clobber the Tauri-targeted build in apps/desktop/build/.
+    # In CI, the web frontend is pre-built and downloaded as an artifact.
+    if [ "${CI:-}" != "true" ]; then
+      SVELTEKIT_OUT_DIR=embedded-frontend \
+        VITE_BUILD_TARGET=web VITE_BUTLER_API_BASE_URL=/api VITE_EMBEDDED_BUILD=1 \
+        pnpm build:desktop
+    fi
   fi
   # shellcheck disable=SC2086
   cargo build --release -p but $BUT_FEATURES

--- a/turbo.json
+++ b/turbo.json
@@ -7,13 +7,21 @@
 		},
 		"build": {
 			"dependsOn": ["package"],
-			"passThroughEnv": ["SENTRY_AUTH_TOKEN", "GITHUB_TOKEN"],
+			"passThroughEnv": [
+				"SENTRY_AUTH_TOKEN",
+				"GITHUB_TOKEN",
+				"SVELTEKIT_OUT_DIR",
+				"VITE_BUILD_TARGET",
+				"VITE_BUTLER_API_BASE_URL",
+				"VITE_EMBEDDED_BUILD"
+			],
 			"env": ["SENTRY_RELEASE"],
 			"outputs": [
 				".svelte-kit/**",
 				"!.sveltekit/types",
 				"!.sveltekit/*.d.ts",
 				"dist/**",
+				"embedded-frontend/**",
 				".vercel/**"
 			]
 		},


### PR DESCRIPTION
The previous commit built the web frontend inside
`tauri-before-build-command.sh` using `pnpm --filter`, which skips
turborepo's workspace dependency builds and fails to resolve
`@gitbutler/core`. Move the web frontend build into the `build-sveltekit`
CI job instead, where turborepo handles dependency ordering, and pass the
output as a separate artifact to `build-tauri`.