### PR TITLE
`but rub` accidentally restores unrelated deleted files

### DIFF
--- a/crates/but-api/src/workspace_state.rs
+++ b/crates/but-api/src/workspace_state.rs
@@ -88,7 +88,7 @@ impl WorkspaceState {
 
         let materialized = rebase.materialize_without_checkout()?;
         let tree_index = repo.index_from_tree(&repo.head_tree_id()?)?;
-        let mut disk_index = repo.open_index()?;
+        let mut disk_index = repo.index()?.into_owned_or_cloned();
         but_workspace::commit_engine::index::sync_index_to_tree(
             repo.workdir().expect("non-bare"),
             &tree_index,

--- a/crates/but-core/src/worktree/checkout/function.rs
+++ b/crates/but-core/src/worktree/checkout/function.rs
@@ -144,7 +144,7 @@ pub fn safe_checkout(
         )?;
 
         if num_deleted_files > 0
-            && let Ok(mut index) = repo.open_index()
+            && let Ok(mut index) = repo.index().map(|index| index.into_owned_or_cloned())
         {
             for (kind, path_to_alter) in &changed_files {
                 if matches!(kind, ChangeKind::Deletion)

--- a/crates/but-core/src/worktree/checkout/utils.rs
+++ b/crates/but-core/src/worktree/checkout/utils.rs
@@ -53,6 +53,10 @@ use crate::{
 ///   - `destination_tree_id` has a tree at that path and preserved worktree content exists underneath
 ///     it, so checkout should materialize the destination subtree.
 ///
+///   If none of those cases adds a pathspec for a pure-deletion checkout, this function adds one
+///   checkout-deletion path as a guardrail so `git2` does not interpret an empty pathspec as a request
+///   to checkout the whole destination tree.
+///
 ///   Normal added or modified checkout paths are still added by the caller.
 /// * `uncommitted_changes` - Policy for preserved worktree changes that do not apply cleanly to
 ///   `destination_tree_id`: either abort before checkout, or keep the conflicting content in the
@@ -107,6 +111,7 @@ pub fn merge_worktree_changes_into_destination_or_keep_snapshot(
             change_lut.track_file(ignored.path.as_ref());
         }
 
+        let mut added_deleted_worktree_pathspec = false;
         for wt_change in &worktree_changes.changes {
             match wt_change.status {
                 TreeStatus::Deletion { .. } => {
@@ -143,6 +148,7 @@ pub fn merge_worktree_changes_into_destination_or_keep_snapshot(
                     // checks out a destination subtree with preserved worktree content underneath.
                     if !checkout_deletion_intersections.is_empty() || destination_needs_checkout {
                         checkout_opts.path(wt_change.path.as_bytes());
+                        added_deleted_worktree_pathspec = true;
                     }
                 }
                 TreeStatus::Addition { .. } | TreeStatus::Modification { .. } => {}
@@ -150,6 +156,16 @@ pub fn merge_worktree_changes_into_destination_or_keep_snapshot(
                     unreachable!("rename tracking was disabled")
                 }
             }
+        }
+        if !added_deleted_worktree_pathspec
+            && files_to_checkout
+                .iter()
+                .all(|(kind, _)| matches!(kind, ChangeKind::Deletion))
+            && let Some((_, path)) = files_to_checkout.first()
+        {
+            // Keep pure-deletion checkouts from reaching `git2` with an empty pathspec, which
+            // would apply the destination tree broadly and restore unrelated worktree deletions.
+            checkout_opts.path(path.as_bytes());
         }
 
         let mut selection_of_changes_checkout_would_affect = BTreeSet::new();

--- a/crates/but-core/src/worktree/checkout/utils.rs
+++ b/crates/but-core/src/worktree/checkout/utils.rs
@@ -18,39 +18,84 @@ use crate::{
     worktree::checkout::{Outcome, UncommitedWorktreeChanges},
 };
 
+/// Preserve any uncommitted worktree changes that would be affected by a checkout from one tree to another.
+///
+/// If the checkout would touch paths with local worktree changes, the *relevant* worktree changes are first
+/// captured in a snapshot tree based on `source_tree_id`. That snapshot is then resolved onto
+/// `destination_tree_id`; depending on `uncommitted_changes`, unresolved conflicts either abort the
+/// checkout or are kept in the snapshot while the checkout proceeds.
+///
+/// Returns `None` if there are no checkout changes, or if no local worktree changes need to be preserved.
+/// Otherwise returns the snapshot tree ID and, if resolving the snapshot changed the checkout target, the
+/// replacement destination tree ID to check out, the one that contains the non-conflicting worktree changes.
+///
+/// # Parameters
+///
+/// * `files_to_checkout` - Repo-relative paths, with their change kinds, that the checkout from
+///   `source_tree_id` to `destination_tree_id` intends to add, modify, or delete.
+/// * `repo` - Repository used to inspect the current worktree, read the current `HEAD` tree, create
+///   snapshot trees, and persist any in-memory objects needed by the adjusted destination tree if one is written.
+///   No changes will be observable if there is no intersecting worktree changes.
+/// * `source_tree_id` - The tree expected to match the repository's current `HEAD`. It is used as the
+///   base for the snapshot of local worktree changes, and is verified against the actual `HEAD` before
+///   preserving changes.
+/// * `destination_tree_id` - The tree the checkout originally intends to write into the worktree. If
+///   preserved worktree changes can be cleanly reapplied, they are resolved onto this tree and may
+///   produce a replacement destination tree in the return value.
+/// * `checkout_opts` - The checkout builder that the caller will later pass to `git2` for the actual
+///   checkout. This function only adds explicit pathspecs for deleted local worktree paths that the
+///   checkout may need to recreate after the caller removes checkout deletions from disk:
+///
+///   - the deleted worktree path intersects a checkout deletion, so the pathspec constrains `git2`
+///     instead of letting an empty pathspec checkout everything;
+///   - `destination_tree_id` still has a file at that path, so checkout should restore it from the
+///     destination tree;
+///   - `destination_tree_id` has a tree at that path and preserved worktree content exists underneath
+///     it, so checkout should materialize the destination subtree.
+///
+///   Normal added or modified checkout paths are still added by the caller.
+/// * `uncommitted_changes` - Policy for preserved worktree changes that do not apply cleanly to
+///   `destination_tree_id`: either abort before checkout, or keep the conflicting content in the
+///   snapshot while allowing the checkout to overwrite the worktree.
 pub fn merge_worktree_changes_into_destination_or_keep_snapshot(
-    changed_files: &[(ChangeKind, BString)],
+    files_to_checkout: &[(ChangeKind, BString)],
     repo: &gix::Repository,
     source_tree_id: gix::ObjectId,
     destination_tree_id: gix::ObjectId,
     checkout_opts: &mut git2::build::CheckoutBuilder,
     uncommitted_changes: UncommitedWorktreeChanges,
 ) -> anyhow::Result<Option<(gix::ObjectId, Option<gix::ObjectId>)>> {
-    if changed_files.is_empty() {
+    if files_to_checkout.is_empty() {
         return Ok(None);
     };
-    let changes = crate::diff::worktree_changes_no_renames(repo)?;
-    if !changes.changes.is_empty() || !changes.ignored_changes.is_empty() {
+    let worktree_changes = crate::diff::worktree_changes_no_renames(repo)?;
+    if !worktree_changes.changes.is_empty() || !worktree_changes.ignored_changes.is_empty() {
         let actual_head_tree_id = repo.head_tree_id_or_empty()?;
         if actual_head_tree_id != source_tree_id {
             bail!(
                 "Specified HEAD {source_tree_id} didn't match actual HEAD^{{tree}} {actual_head_tree_id}"
             )
         }
-        // Figure out which added or modified files are actually touched. Deletions we ignore, and allow
-        // these files to be recreated during checkout even if they were part in a rename
-        // (we don't do rename tracking here)
+        let mut checkout_deletions_lut = super::tree::Lut::default();
+        let mut checkout_writes_tree_entries = false;
+        for (kind, path) in files_to_checkout {
+            if matches!(kind, ChangeKind::Deletion) {
+                checkout_deletions_lut.track_file(path.as_ref());
+            } else {
+                checkout_writes_tree_entries = true;
+            }
+        }
+        let destination_tree = checkout_writes_tree_entries
+            .then(|| destination_tree_id.attach(repo).object()?.peel_to_tree())
+            .transpose()?;
+
         let mut change_lut = super::tree::Lut::default();
-        for change in &changes.changes {
-            match change.status {
-                TreeStatus::Deletion { .. } => {
-                    // additive snapshots only so checkout can write onto deleted files
-                    // (and has to, to restore more)
-                    checkout_opts.path(change.path.as_bytes());
-                }
+        for wt_change in &worktree_changes.changes {
+            match wt_change.status {
+                TreeStatus::Deletion { .. } => {}
                 TreeStatus::Addition { .. } | TreeStatus::Modification { .. } => {
                     // It's not about the actual values, just to have a lookup for overlapping paths.
-                    change_lut.track_file(change.path.as_ref());
+                    change_lut.track_file(wt_change.path.as_ref());
                 }
                 TreeStatus::Rename { .. } => {
                     unreachable!("rename tracking was disabled")
@@ -58,12 +103,57 @@ pub fn merge_worktree_changes_into_destination_or_keep_snapshot(
             }
         }
         // Pick up conflicts as well, let's ignore nothing for the selection.
-        for ignored in &changes.ignored_changes {
+        for ignored in &worktree_changes.ignored_changes {
             change_lut.track_file(ignored.path.as_ref());
         }
 
+        for wt_change in &worktree_changes.changes {
+            match wt_change.status {
+                TreeStatus::Deletion { .. } => {
+                    let mut checkout_deletion_intersections = BTreeSet::new();
+                    checkout_deletions_lut.get_intersecting(
+                        wt_change.path.as_ref(),
+                        &mut checkout_deletion_intersections,
+                    );
+                    let destination_entry_kind = destination_tree
+                        .as_ref()
+                        .map(|tree| {
+                            tree.lookup_entry(
+                                super::tree::to_components(wt_change.path.as_ref())
+                                    .map(ToOwned::to_owned),
+                            )
+                            .map(|entry| entry.map(|entry| entry.mode().kind()))
+                        })
+                        .transpose()?
+                        .flatten();
+                    let mut worktree_content_intersections = BTreeSet::new();
+                    change_lut.get_intersecting(
+                        wt_change.path.as_ref(),
+                        &mut worktree_content_intersections,
+                    );
+                    let destination_needs_checkout = match destination_entry_kind {
+                        Some(gix::object::tree::EntryKind::Tree) => {
+                            !worktree_content_intersections.is_empty()
+                        }
+                        Some(_) => true,
+                        None => false,
+                    };
+                    // Add an explicit pathspec for deleted worktree paths when it either constrains
+                    // a checkout deletion, restores a file that still exists in the destination, or
+                    // checks out a destination subtree with preserved worktree content underneath.
+                    if !checkout_deletion_intersections.is_empty() || destination_needs_checkout {
+                        checkout_opts.path(wt_change.path.as_bytes());
+                    }
+                }
+                TreeStatus::Addition { .. } | TreeStatus::Modification { .. } => {}
+                TreeStatus::Rename { .. } => {
+                    unreachable!("rename tracking was disabled")
+                }
+            }
+        }
+
         let mut selection_of_changes_checkout_would_affect = BTreeSet::new();
-        for file_to_be_modified in changed_files
+        for file_to_be_modified in files_to_checkout
             .iter()
             // Deleted files shouldn't be in the snapshot as they won't ever be in our way.
             // .filter(|(kind, _)| !matches!(kind, ChangeKind::Deletion))
@@ -83,7 +173,7 @@ pub fn merge_worktree_changes_into_destination_or_keep_snapshot(
             let out = crate::snapshot::create_tree(
                 source_tree_id.attach(&repo_in_memory),
                 snapshot::create_tree::State {
-                    changes,
+                    changes: worktree_changes,
                     selection: selection_of_changes_checkout_would_affect,
                     head: false,
                 },

--- a/crates/but-core/tests/core/worktree/checkout.rs
+++ b/crates/but-core/tests/core/worktree/checkout.rs
@@ -83,6 +83,57 @@ fn no_op_trees_never_touch_worktree() -> anyhow::Result<()> {
 }
 
 #[test]
+fn pure_deletion_checkout_does_not_restore_unrelated_worktree_deletions() -> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario_slow("all-file-types-renamed-and-modified");
+    insta::assert_snapshot!(git_status(&repo)?, @r"
+     D executable
+     D file
+     D link
+    ?? executable-renamed
+    ?? file-renamed
+    ?? link-renamed
+    ");
+
+    insta::assert_snapshot!(visualize_index(&*repo.index()?), @"
+    100755:01e79c3 executable
+    100644:3aac70f file
+    120000:c4c364c link
+    ");
+
+    let (head_commit, new_commit) = build_commit(
+        &repo,
+        |tree| {
+            tree.remove("executable")?;
+            Ok(())
+        },
+        "delete executable",
+    )?;
+
+    let out = safe_checkout(head_commit.id, new_commit.id, &repo, Default::default())?;
+    insta::assert_debug_snapshot!(out, @r#"
+    Outcome {
+        snapshot_tree: None,
+        num_deleted_files: 1,
+        num_added_or_updated_files: 0,
+        head_update: "Update refs/heads/main to Some(Object(Sha1(5eedd314adfb480212989a303c7651717062a9b2)))",
+    }
+    "#);
+    insta::assert_snapshot!(visualize_index(&*repo.index()?), @r"
+    100644:3aac70f file
+    120000:c4c364c link
+    ");
+    insta::assert_snapshot!(git_status(&repo)?, @r"
+     D file
+     D link
+    ?? executable-renamed
+    ?? file-renamed
+    ?? link-renamed
+    ");
+
+    Ok(())
+}
+
+#[test]
 fn worktree_and_index_deletions_are_ignored_in_snapshots() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario("deletion-addition-untracked");
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* 226d5ea (HEAD -> main) init");

--- a/crates/but-core/tests/core/worktree/checkout.rs
+++ b/crates/but-core/tests/core/worktree/checkout.rs
@@ -134,6 +134,49 @@ fn pure_deletion_checkout_does_not_restore_unrelated_worktree_deletions() -> any
 }
 
 #[test]
+fn pure_deletion_checkout_keeps_non_intersecting_worktree_deletion() -> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario("unborn-empty");
+
+    let blob_id = repo.write_blob(b"content")?;
+    let mut editor = repo.empty_tree().edit()?;
+    editor.upsert("a.txt", EntryKind::Blob, blob_id)?;
+    editor.upsert("b.txt", EntryKind::Blob, blob_id)?;
+    editor.upsert("c.txt", EntryKind::Blob, blob_id)?;
+    let initial_tree_id = editor.write()?.detach();
+    let initial_commit = repo.new_commit("init", initial_tree_id, None::<gix::ObjectId>)?;
+    safe_checkout(
+        repo.empty_tree().id,
+        initial_commit.id,
+        &repo,
+        Default::default(),
+    )?;
+
+    std::fs::remove_file(repo.workdir_path("b.txt").expect("non-bare repository"))?;
+    insta::assert_snapshot!(git_status(&repo)?, @" D b.txt");
+
+    let (head_commit, new_commit) = build_commit(
+        &repo,
+        |tree| {
+            tree.remove("a.txt")?;
+            Ok(())
+        },
+        "delete a.txt",
+    )?;
+    let out = safe_checkout(head_commit.id, new_commit.id, &repo, Default::default())?;
+    assert!(out.snapshot_tree.is_none());
+    assert_eq!(out.num_deleted_files, 1);
+    assert_eq!(out.num_added_or_updated_files, 0);
+    assert!(out.head_update.is_some());
+
+    assert!(!repo.workdir_path("a.txt").unwrap().exists());
+    assert!(!repo.workdir_path("b.txt").unwrap().exists());
+    assert!(repo.workdir_path("c.txt").unwrap().exists());
+    insta::assert_snapshot!(git_status(&repo)?, @" D b.txt");
+
+    Ok(())
+}
+
+#[test]
 fn worktree_and_index_deletions_are_ignored_in_snapshots() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario("deletion-addition-untracked");
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* 226d5ea (HEAD -> main) init");

--- a/crates/but-workspace/src/legacy/commit_engine/mod.rs
+++ b/crates/but-workspace/src/legacy/commit_engine/mod.rs
@@ -367,7 +367,7 @@ pub fn create_commit_and_update_refs(
         // Assume an index to be present and adjust it to match the new tree.
 
         let tree_index = repo.index_from_tree(&repo.head_tree_id()?)?;
-        let mut disk_index = repo.open_index()?;
+        let mut disk_index = repo.index()?.into_owned_or_cloned();
         crate::commit_engine::index::sync_index_to_tree(
             repo.workdir().expect("non-bare"),
             &tree_index,

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -1327,6 +1327,64 @@ Amended the only hunk in rename-target-single.txt in the unassigned area → [..
 }
 
 #[test]
+fn rub_unassigned_deleted_file_to_commit_keeps_unrelated_deleted_file() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    env.setup_metadata(&["A", "B"])?;
+
+    env.file("a.txt", "a\n");
+    env.file("b.txt", "b\n");
+    env.file("c.txt", "c\n");
+    env.but("commit A -m 'Add a.txt, b.txt, and c.txt'")
+        .assert()
+        .success();
+
+    std::fs::remove_file(env.projects_root().join("a.txt"))?;
+    std::fs::remove_file(env.projects_root().join("b.txt"))?;
+
+    let before = status_json(&env)?;
+    let source_file_id = unassigned_cli_id_for_file(&before, "a.txt")
+        .expect("a.txt deletion should be present in the unassigned area");
+    let target_commit = branch_commit_ids(&before, "A")[0].clone();
+    assert!(
+        unassigned_contains_file(&before, "b.txt"),
+        "b.txt deletion should start in the unassigned area"
+    );
+
+    env.but(format!("rub {source_file_id} {target_commit}"))
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Amended the only hunk in a.txt in the unassigned area → [..]
+
+"#]])
+        .stderr_eq(str![""]);
+
+    let after = status_json(&env)?;
+    assert!(
+        !unassigned_contains_file(&after, "a.txt"),
+        "selected a.txt deletion should be amended into the target commit"
+    );
+    assert!(
+        unassigned_contains_file(&after, "b.txt"),
+        "unrelated b.txt deletion should remain unassigned"
+    );
+    assert!(
+        !env.projects_root().join("a.txt").exists(),
+        "selected a.txt deletion should stay applied to the worktree"
+    );
+    assert!(
+        !env.projects_root().join("b.txt").exists(),
+        "unrelated b.txt deletion should stay applied to the worktree"
+    );
+    assert!(
+        env.projects_root().join("c.txt").exists(),
+        "untouched c.txt should stay in the worktree"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn rub_matrix_unassigned_to_stack_smoke() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
     env.setup_metadata(&["A", "B"])?;


### PR DESCRIPTION
Added an active regression reproduction for issue #13531 in rub.rs.

It creates `a.txt`, `b.txt`, `c.txt`, commits them to `A`, deletes `a.txt` and `b.txt`, rubs only the `a.txt` deletion into the commit, then asserts `b.txt` remains deleted and unassigned. But that is currently failing.

### Tasks

* [x] reproduce
* [x] fix
* [x] refackiew
