### PR TITLE
Reduce flakiness of e2e blackbox test

### DIFF
--- a/e2e/blackbox/tests/add-project.spec.ts
+++ b/e2e/blackbox/tests/add-project.spec.ts
@@ -1,4 +1,4 @@
-import { spawnAndLog, findAndClick, setElementValue } from "../utils.js";
+import { spawnAndLog, findAndClick, findElement, setElementValue } from "../utils.js";
 
 describe("Project", () => {
 	before(() => {
@@ -8,8 +8,7 @@ describe("Project", () => {
 	it("should add a local project", async () => {
 		await findAndClick('button[data-testid="analytics-continue"]');
 
-		const dirInputSelection = $('input[data-testid="test-directory-path"]');
-		const dirInput = await dirInputSelection.getElement();
+		const dirInput = await findElement('input[data-testid="test-directory-path"]');
 		await setElementValue(dirInput, "/tmp/gb-e2e-repos/one-vbranch-on-integration");
 
 		await findAndClick('button[data-testid="add-local-project"]');

--- a/e2e/blackbox/utils.ts
+++ b/e2e/blackbox/utils.ts
@@ -16,6 +16,12 @@ export async function findAndClick(selector: string) {
 	await element.click();
 }
 
+export async function findElement(selector: string) {
+	const element = $(selector);
+	await element.waitForExist({ timeout: 15000 });
+	return await element.getElement();
+}
+
 export async function setElementValue(targetElement: WebdriverIO.Element, value: string) {
 	await browser.execute(
 		(input, path) => {


### PR DESCRIPTION
Fix intermittent e2e blackbox failure by waiting for the test directory
input to be present before trying to get its element. The test was
occasionally attempting to access the input too early, causing flaky
failures; adding an explicit wait stabilizes the interaction and reduces
timing-related race conditions.