### PR TITLE
Fix new commit appearing in all branches when added to bottom of stack

### DIFF
--- a/crates/but-rebase/src/graph_rebase/mutate.rs
+++ b/crates/but-rebase/src/graph_rebase/mutate.rs
@@ -711,7 +711,21 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
                 let new_idx = self.graph.add_node(step);
                 self.graph.add_edge(new_idx, target.id, Edge { order: 0 });
 
+                // When the target has both Reference and non-Reference incoming edges
+                // (e.g. a shared merge-base commit), preserve Reference edges so that
+                // other stacks' refs aren't pulled to the newly inserted commit.
+                // When *all* incoming edges are References (e.g. inserting above a
+                // branch tip), redirect them so the new commit becomes part of that stack.
+                let has_pick_parent = edges
+                    .iter()
+                    .any(|(_, _, src)| !matches!(self.graph[*src], Step::Reference { .. }));
+
                 for (edge_id, edge_weight, edge_source) in edges {
+                    if has_pick_parent
+                        && matches!(self.graph[edge_source], Step::Reference { .. })
+                    {
+                        continue;
+                    }
                     self.graph.remove_edge(edge_id);
                     self.graph.add_edge(edge_source, new_idx, edge_weight);
                 }

--- a/crates/but-rebase/tests/fixtures/scenario/workspace-one-commit-one-empty.sh
+++ b/crates/but-rebase/tests/fixtures/scenario/workspace-one-commit-one-empty.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+source "$(dirname "$0")/shared.sh"
+
+git init
+
+# Create the base commit (merge_base)
+git commit --allow-empty -m "base"
+
+# stack-2 (empty) pointing to base
+git update-ref refs/heads/stack-2 HEAD
+
+# main branch diverges from base with an additional commit
+git commit --allow-empty -m "main diverged"
+
+# Setup remote tracking for main
+mkdir -p .git/refs/remotes/origin
+cp .git/refs/heads/main .git/refs/remotes/origin/main
+
+cat <<EOF >>.git/config
+[remote "origin"]
+	url = ./fake/local/path/which-is-fine-as-we-dont-fetch-or-push
+	fetch = +refs/heads/*:refs/remotes/origin/*
+
+[branch "main"]
+  remote = "origin"
+  merge = refs/heads/main
+EOF
+
+# stack-1 with one commit on top of base (not main)
+git checkout -b stack-1 stack-2
+git commit --allow-empty -m "top"
+
+# Create workspace commit merging both stacks
+# Note: stack-2 (empty) is parent 1, stack-1 (with commit) is parent 2
+id=$(git commit-tree HEAD^{tree} -p stack-2 -p stack-1 -m "GitButler Workspace Commit")
+git checkout -b gitbutler/workspace
+git reset --hard $id

--- a/crates/but-rebase/tests/rebase/graph_rebase/insert.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/insert.rs
@@ -245,6 +245,86 @@ fn insert_above_commit_with_two_children() -> Result<()> {
     Ok(())
 }
 
+/// Inserting above the merge-base commit (shared by multiple stacks)
+/// should only affect the target stack, not other stacks whose refs also
+/// point to the merge base.
+#[test]
+fn insert_above_merge_base_does_not_affect_empty_stack() -> Result<()> {
+    use super::add_stack_with_segments;
+    use but_testsupport::StackState;
+
+    let (mut repo, _tmpdir, mut meta) = fixture_writable("workspace-one-commit-one-empty")?;
+
+    add_stack_with_segments(&mut meta, 1, "stack-1", StackState::InWorkspace, &[]);
+    add_stack_with_segments(&mut meta, 2, "stack-2", StackState::InWorkspace, &[]);
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   010b439 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * b848287 (stack-1) top
+    |/  
+    | * ea75ec7 (origin/main, main) main diverged
+    |/  
+    * 965998b (stack-2) base
+    ");
+
+    let graph = Graph::from_head(
+        &repo,
+        &*meta,
+        crate::utils::standard_options(),
+    )?
+    .validated()?;
+
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    // Find stack-2's ref target before the operation
+    let stack_2_ref_before = repo
+        .find_reference("refs/heads/stack-2")?
+        .target()
+        .try_id()
+        .expect("direct ref")
+        .to_owned();
+
+    // Select the merge base commit (shared by both stacks).
+    // This is what the frontend does: relativeTo: Commit(baseCommit), side: "above"
+    let base_commit_id = repo.rev_parse_single("stack-2")?.detach();
+    let selector = editor
+        .select_commit(base_commit_id)
+        .context("Failed to find base commit in editor graph")?;
+
+    // Create a blank commit to insert above the merge base
+    let commit = editor.empty_commit()?;
+    let new_id =
+        editor.new_commit_untracked(commit, but_rebase::commit::DateMode::CommitterUpdateAuthorUpdate)?;
+
+    // Insert above the merge base — this is the actual code path the frontend takes
+    editor.insert(selector, Step::new_untracked_pick(new_id), InsertSide::Above)?;
+
+    let outcome = editor.rebase()?;
+    outcome.materialize()?;
+
+    // Verify stack-2's ref hasn't changed
+    let stack_2_ref_after = repo.reload()?.find_reference("refs/heads/stack-2")?
+        .target()
+        .try_id()
+        .expect("direct ref")
+        .to_owned();
+
+    assert_eq!(
+        stack_2_ref_before, stack_2_ref_after,
+        "stack-2 ref should not change when inserting above the merge base.\n\
+         Before: {stack_2_ref_before}\n\
+         After:  {stack_2_ref_after}\n\
+         The empty stack's ref was moved to the newly inserted commit!"
+    );
+
+    // Also verify the graph looks correct
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?);
+
+    Ok(())
+}
+
 #[test]
 #[ignore]
 fn inserts_violating_fp_protection_should_cause_rebase_failure() -> Result<()> {


### PR DESCRIPTION
`InsertSide::Above` was redirecting all incoming edges to the newly
inserted node. When the target is a shared commit (e.g. the merge base),
this pulled Reference edges from other stacks, causing their refs to
point to the new commit and making it appear in every branch.

Now, when the target has both Reference and non-Reference (Pick) incoming
edges, only the Pick edges are redirected. Reference edges are preserved
so other stacks' refs stay where they are. When all incoming edges are
References (e.g. inserting above a branch tip), they are still redirected
so the new commit becomes part of that stack.