### PR TITLE
Use merge-base override to prevent consumed changes reappearing as uncommitted

### DIFF
--- a/crates/but-api/src/commit/create.rs
+++ b/crates/but-api/src/commit/create.rs
@@ -77,8 +77,7 @@ pub(crate) fn commit_create_only_impl(
     let new_commit = commit_selector
         .map(|commit_selector| rebase.lookup_pick(commit_selector))
         .transpose()?;
-    let workspace =
-        WorkspaceState::from_successful_rebase_without_checkout(rebase, &repo, dry_run)?;
+    let workspace = WorkspaceState::from_successful_rebase(rebase, &repo, dry_run)?;
 
     Ok(CommitCreateResult {
         new_commit,

--- a/crates/but-api/src/workspace_state.rs
+++ b/crates/but-api/src/workspace_state.rs
@@ -64,44 +64,6 @@ impl WorkspaceState {
         )
     }
 
-    /// Build a [`WorkspaceState`] from a successful rebase, materializing without checkout.
-    ///
-    /// Use this when the worktree already contains the right content and only the
-    /// index needs to be synced to the new workspace tree. This is the case for
-    /// commit creation, where committed changes came from the worktree and the
-    /// operation cannot cause descendant conflicts, so the workspace tree can't
-    /// diverge from what's on disk.
-    ///
-    /// Do **not** use this for operations that can cause conflicts in descendant
-    /// commits (e.g. amend), as those require a full checkout to update the worktree.
-    ///
-    /// A full checkout would snapshot-and-cherry-pick remaining worktree changes,
-    /// which fails when partially-committed hunks overlap with uncommitted ones.
-    pub(crate) fn from_successful_rebase_without_checkout<M: RefMetadata>(
-        rebase: SuccessfulRebase<'_, '_, M>,
-        repo: &gix::Repository,
-        dry_run: DryRun,
-    ) -> anyhow::Result<WorkspaceState> {
-        if dry_run.into() {
-            return Self::from_rebase_preview(&rebase, rebase.history.commit_mappings());
-        }
-
-        let materialized = rebase.materialize_without_checkout()?;
-        let tree_index = repo.index_from_tree(&repo.head_tree_id()?)?;
-        let mut disk_index = repo.index()?.into_owned_or_cloned();
-        but_workspace::commit_engine::index::sync_index_to_tree(
-            repo.workdir().expect("non-bare"),
-            &tree_index,
-            &mut disk_index,
-        )?;
-        disk_index.write(Default::default())?;
-        Self::from_workspace(
-            materialized.workspace,
-            repo,
-            materialized.history.commit_mappings(),
-        )
-    }
-
     /// Build a [`WorkspaceState`] from a successful rebase, materializing it when needed.
     ///
     /// Use this as the default entry point when an operation ends with a

--- a/crates/but-core/src/snapshot/resolve_tree.rs
+++ b/crates/but-core/src/snapshot/resolve_tree.rs
@@ -33,6 +33,13 @@ pub struct Options {
     ///
     /// If `None`, perform the merge just like Git, which will include conflict markers!
     pub worktree_cherry_pick: Option<gix::merge::tree::Options>,
+    /// If set, use this tree as the merge base instead of the `HEAD` entry from the snapshot.
+    ///
+    /// This is used when an operation consumed some worktree changes (e.g. amend/commit).
+    /// By setting the merge base to `HEAD^{tree}` + consumed changes, the consumed hunks
+    /// are already present in the base and won't appear as diffs in the snapshot side of
+    /// the merge — eliminating duplication without any hunk-level subtraction.
+    pub merge_base_override: Option<gix::ObjectId>,
 }
 
 pub(super) mod function {
@@ -60,6 +67,7 @@ pub(super) mod function {
         target_worktree_tree_id: gix::ObjectId,
         Options {
             worktree_cherry_pick: worktree_cherry_pick_options,
+            merge_base_override,
         }: Options,
     ) -> anyhow::Result<Outcome<'_>> {
         let repo = snapshot_tree.repo;
@@ -71,7 +79,7 @@ pub(super) mod function {
 
         let worktree_cherry_pick = match (&head_tree, worktree) {
             (Some(worktree_base), Some(worktree)) => {
-                let base = worktree_base.object_id();
+                let base = merge_base_override.unwrap_or_else(|| worktree_base.object_id());
                 let ours = target_worktree_tree_id;
                 let theirs = worktree.object_id();
 

--- a/crates/but-core/src/worktree/checkout/function.rs
+++ b/crates/but-core/src/worktree/checkout/function.rs
@@ -53,6 +53,7 @@ pub fn safe_checkout(
     Options {
         uncommitted_changes: conflicting_worktree_changes_opts,
         skip_head_update,
+        merge_base_override,
     }: Options,
 ) -> anyhow::Result<Outcome> {
     let source_tree = current_head_id.attach(repo).object()?.peel_to_tree()?;
@@ -77,6 +78,7 @@ pub fn safe_checkout(
         destination_tree.id,
         &mut opts,
         conflicting_worktree_changes_opts,
+        merge_base_override,
     )?
     .map(|(snapshot_id, new_destination_id)| {
         if let Some(id) = new_destination_id {

--- a/crates/but-core/src/worktree/checkout/mod.rs
+++ b/crates/but-core/src/worktree/checkout/mod.rs
@@ -13,7 +13,7 @@ pub enum UncommitedWorktreeChanges {
 }
 
 /// Options for use in [super::safe_checkout()].
-#[derive(Default, Debug, Copy, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct Options {
     /// How to deal with uncommitted changes.
     pub uncommitted_changes: UncommitedWorktreeChanges,
@@ -21,6 +21,13 @@ pub struct Options {
     ///
     /// This is typically to be avoided, but may be used if you want to change the HEAD location yourself.
     pub skip_head_update: bool,
+    /// If set, use this tree instead of `HEAD^{tree}` as the merge base when
+    /// resolving the worktree snapshot against the new HEAD.
+    ///
+    /// Set this to `HEAD^{tree}` + consumed changes (additive-only) after a
+    /// commit/amend so the consumed hunks cancel in the 3-way merge and don't
+    /// reappear as uncommitted changes.
+    pub merge_base_override: Option<gix::ObjectId>,
 }
 
 /// The successful outcome of [super::safe_checkout()] operation.

--- a/crates/but-core/src/worktree/checkout/utils.rs
+++ b/crates/but-core/src/worktree/checkout/utils.rs
@@ -68,6 +68,7 @@ pub fn merge_worktree_changes_into_destination_or_keep_snapshot(
     destination_tree_id: gix::ObjectId,
     checkout_opts: &mut git2::build::CheckoutBuilder,
     uncommitted_changes: UncommitedWorktreeChanges,
+    merge_base_override: Option<gix::ObjectId>,
 ) -> anyhow::Result<Option<(gix::ObjectId, Option<gix::ObjectId>)>> {
     if files_to_checkout.is_empty() {
         return Ok(None);
@@ -186,6 +187,7 @@ pub fn merge_worktree_changes_into_destination_or_keep_snapshot(
             repo_in_memory
                 .config_snapshot_mut()
                 .set_value(&gix::config::tree::Merge::RENORMALIZE, "true")?;
+
             let out = crate::snapshot::create_tree(
                 source_tree_id.attach(&repo_in_memory),
                 snapshot::create_tree::State {
@@ -201,6 +203,7 @@ pub fn merge_worktree_changes_into_destination_or_keep_snapshot(
                     destination_tree_id,
                     snapshot::resolve_tree::Options {
                         worktree_cherry_pick: None,
+                        merge_base_override,
                     },
                 )?;
                 let new_destination_id =

--- a/crates/but-core/tests/core/worktree/checkout.rs
+++ b/crates/but-core/tests/core/worktree/checkout.rs
@@ -1027,9 +1027,9 @@ fn partial_commit_with_adjacent_lines_conflicts_on_checkout() -> anyhow::Result<
     )?;
 
     // The remaining worktree change (added-b) conflicts with the committed change
-    // (added-a) because both add at the same position. This is the underlying
-    // reason commit_create uses materialize_without_checkout instead of a full
-    // checkout — it avoids this conflict entirely by not touching the worktree.
+    // (added-a) because both add at the same position. Without a merge-base
+    // override that includes the consumed changes, the 3-way merge treats this
+    // as a conflict.
     let err = safe_checkout(head_commit.id, new_commit.id, &repo, Default::default()).unwrap_err();
     assert!(
         err.to_string()
@@ -1078,6 +1078,7 @@ fn overwrite_options() -> checkout::Options {
     checkout::Options {
         uncommitted_changes: UncommitedWorktreeChanges::KeepConflictingInSnapshotAndOverwrite,
         skip_head_update: false,
+        ..Default::default()
     }
 }
 

--- a/crates/but-rebase/src/graph_rebase/commit.rs
+++ b/crates/but-rebase/src/graph_rebase/commit.rs
@@ -19,6 +19,21 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
         &self.repo
     }
 
+    /// Set a merge-base override for checkout so that consumed worktree
+    /// changes don't reappear as uncommitted after materialization.
+    pub fn set_merge_base_override(&mut self, tree_id: gix::ObjectId) {
+        for checkout in &mut self.checkouts {
+            match checkout {
+                super::Checkout::Head {
+                    merge_base_override,
+                    ..
+                } => {
+                    *merge_base_override = Some(tree_id);
+                }
+            }
+        }
+    }
+
     /// Finds a commit from inside the editor's in memory repository.
     pub fn find_commit(&self, id: gix::ObjectId) -> Result<but_core::CommitOwned> {
         but_core::Commit::from_id(id.attach(&self.repo)).map(|c| c.detach())

--- a/crates/but-rebase/src/graph_rebase/creation.rs
+++ b/crates/but-rebase/src/graph_rebase/creation.rs
@@ -289,7 +289,13 @@ impl<'ws, 'meta, M: RefMetadata> Editor<'ws, 'meta, M> {
             initial_references: references,
             // TODO(CTO): We need to eventually list all worktrees that we own
             // here so we can `safe_checkout` them too.
-            checkouts: head_selectors.into_iter().map(Checkout::Head).collect(),
+            checkouts: head_selectors
+                .into_iter()
+                .map(|selector| Checkout::Head {
+                    selector,
+                    merge_base_override: None,
+                })
+                .collect(),
             repo: repo.clone().with_object_memory(),
             history: RevisionHistory::new(),
             workspace,

--- a/crates/but-rebase/src/graph_rebase/materialize.rs
+++ b/crates/but-rebase/src/graph_rebase/materialize.rs
@@ -22,7 +22,10 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
 
         for checkout in self.checkouts {
             match checkout {
-                Checkout::Head(selector) => {
+                Checkout::Head {
+                    selector,
+                    merge_base_override,
+                } => {
                     let selector = self.history.normalize_selector(selector)?;
                     let step = self.graph[selector.id].clone();
 
@@ -48,6 +51,7 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
                         Options {
                             uncommitted_changes: UncommitedWorktreeChanges::KeepAndAbortOnConflict,
                             skip_head_update: true,
+                            merge_base_override,
                         },
                     )?;
                 }

--- a/crates/but-rebase/src/graph_rebase/mod.rs
+++ b/crates/but-rebase/src/graph_rebase/mod.rs
@@ -215,7 +215,14 @@ impl ToSelector for Selector {
 #[derive(Debug, Clone)]
 pub(crate) enum Checkout {
     /// The HEAD of the `repo` the editor was created for.
-    Head(Selector),
+    Head {
+        selector: Selector,
+        /// A pre-computed merge base tree (`HEAD^{tree}` + consumed changes,
+        /// additive-only) to pass through to `safe_checkout`. When set, the
+        /// 3-way snapshot merge uses this as the base so consumed hunks cancel
+        /// and don't reappear as uncommitted changes.
+        merge_base_override: Option<gix::ObjectId>,
+    },
 }
 
 /// Used to manipulate a set of picks.
@@ -291,7 +298,7 @@ impl<'ws, 'meta, M: RefMetadata> SuccessfulRebase<'ws, 'meta, M> {
             .checkouts
             .iter()
             .filter_map(|checkout| match checkout {
-                Checkout::Head(selector) => {
+                Checkout::Head { selector, .. } => {
                     let selector = self.history.normalize_selector(*selector).ok()?;
                     let step = &self.graph[selector.id];
 

--- a/crates/but-workspace/src/branch/apply.rs
+++ b/crates/but-workspace/src/branch/apply.rs
@@ -240,6 +240,7 @@ pub fn apply<'ws>(
             but_core::worktree::checkout::Options {
                 uncommitted_changes,
                 skip_head_update: false,
+                ..Default::default()
             },
         )?;
         let ws = ws
@@ -659,6 +660,7 @@ pub fn apply<'ws>(
         but_core::worktree::checkout::Options {
             uncommitted_changes,
             skip_head_update: true,
+            ..Default::default()
         },
     )?;
     persist_metadata_and_gitconfig(

--- a/crates/but-workspace/src/commit/commit_amend.rs
+++ b/crates/but-workspace/src/commit/commit_amend.rs
@@ -6,6 +6,8 @@ use but_rebase::graph_rebase::{Editor, Selector, Step, SuccessfulRebase, ToCommi
 
 use crate::commit_engine::{Destination, create_commit};
 
+use super::compute_merge_base_override;
+
 /// The result of amending a commit in the graph rebase editor.
 #[derive(Debug)]
 pub struct CommitAmendOutcome<'ws, 'meta, M: RefMetadata> {
@@ -50,6 +52,9 @@ pub fn commit_amend<'ws, 'meta, M: RefMetadata>(
         bail!("Cannot amend a conflicted commit")
     }
 
+    // Clone before `create_commit` consumes the vec — needed afterwards
+    // to determine which changes were consumed (not rejected).
+    let all_changes = changes.clone();
     let create_out = create_commit(
         editor.repo(),
         Destination::AmendCommit {
@@ -67,6 +72,22 @@ pub fn commit_amend<'ws, 'meta, M: RefMetadata>(
             rejected_specs: create_out.rejected_specs,
         });
     };
+
+    // Tell the editor which changes were consumed so the checkout's snapshot
+    // merge doesn't reintroduce them as uncommitted changes.
+    let rejected_paths: std::collections::BTreeSet<_> = create_out
+        .rejected_specs
+        .iter()
+        .map(|(_, spec)| &spec.path)
+        .collect();
+    let consumed: Vec<_> = all_changes
+        .into_iter()
+        .filter(|spec| !rejected_paths.contains(&spec.path))
+        .collect();
+    if !consumed.is_empty() {
+        let merge_base = compute_merge_base_override(editor.repo(), consumed, context_lines)?;
+        editor.set_merge_base_override(merge_base);
+    }
 
     editor.replace(target_selector, Step::new_pick(new_commit_id))?;
 

--- a/crates/but-workspace/src/commit/commit_create.rs
+++ b/crates/but-workspace/src/commit/commit_create.rs
@@ -8,6 +8,8 @@ use but_rebase::graph_rebase::{
 
 use crate::commit_engine::{Destination, create_commit};
 
+use super::compute_merge_base_override;
+
 /// The result of creating and inserting a new commit in the graph rebase editor.
 #[derive(Debug)]
 pub struct CommitCreateOutcome<'ws, 'meta, M: RefMetadata> {
@@ -55,6 +57,9 @@ pub fn commit_create<'ws, 'meta, M: RefMetadata>(
     let parent_commit_id =
         parent_commit_id_for_new_commit(&editor, editor.lookup_step(relative_to_selector)?, side)?;
 
+    // Clone before `create_commit` consumes the vec — needed afterwards
+    // to determine which changes were consumed (not rejected).
+    let all_changes = changes.clone();
     let create_out = create_commit(
         editor.repo(),
         Destination::NewCommit {
@@ -73,6 +78,22 @@ pub fn commit_create<'ws, 'meta, M: RefMetadata>(
             rejected_specs: create_out.rejected_specs,
         });
     };
+
+    // Tell the editor which changes were consumed so the checkout's snapshot
+    // merge doesn't reintroduce them as uncommitted changes.
+    let rejected_paths: std::collections::BTreeSet<_> = create_out
+        .rejected_specs
+        .iter()
+        .map(|(_, spec)| &spec.path)
+        .collect();
+    let consumed: Vec<_> = all_changes
+        .into_iter()
+        .filter(|spec| !rejected_paths.contains(&spec.path))
+        .collect();
+    if !consumed.is_empty() {
+        let merge_base = compute_merge_base_override(editor.repo(), consumed, context_lines)?;
+        editor.set_merge_base_override(merge_base);
+    }
 
     let commit_selector = editor.insert(
         relative_to_selector,

--- a/crates/but-workspace/src/commit/mod.rs
+++ b/crates/but-workspace/src/commit/mod.rs
@@ -1,8 +1,49 @@
 use anyhow::Context as _;
 use bstr::{BString, ByteSlice};
+use but_core::DiffSpec;
 use but_core::ref_metadata::MaybeDebug;
 
 use crate::WorkspaceCommit;
+
+/// Build a merge-base override tree from `HEAD^{tree}` + `consumed` changes
+/// (additive-only). During checkout, the 3-way snapshot merge uses this as its
+/// base so consumed hunks cancel out and don't reappear as uncommitted changes.
+///
+/// Two kinds of changes are excluded to keep the tree additive-only:
+///
+/// * `previous_path` is stripped so rename-source deletions don't leak in.
+/// * Full-file deletions (empty `hunk_headers`, file absent from worktree) are
+///   skipped — including them would remove the path from the base, causing the
+///   snapshot merge to misinterpret the worktree copy as a new addition.
+fn compute_merge_base_override(
+    repo: &gix::Repository,
+    consumed: Vec<DiffSpec>,
+    context_lines: u32,
+) -> anyhow::Result<gix::ObjectId> {
+    let head_tree = repo.head_tree_id_or_empty()?;
+    let workdir = repo.workdir().context("non-bare repository")?;
+    let mut specs: Vec<_> = consumed
+        .into_iter()
+        .filter(|spec| {
+            if spec.hunk_headers.is_empty() {
+                return workdir
+                    .join(gix::path::from_bstr(spec.path.as_bstr()))
+                    .exists();
+            }
+            true
+        })
+        .map(|mut spec| {
+            spec.previous_path = None;
+            Ok(spec)
+        })
+        .collect();
+    if specs.is_empty() {
+        return Ok(head_tree.detach());
+    }
+    let (committed_tree, _base) =
+        but_core::tree::apply_worktree_changes(head_tree.into(), repo, &mut specs, context_lines)?;
+    Ok(committed_tree.detach())
+}
 
 pub mod reword;
 pub use reword::reword;

--- a/crates/but-workspace/tests/fixtures/scenario/amend-with-partial-commit.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/amend-with-partial-commit.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Scenario: A stack with two commits where the second was a partial commit,
+# leaving uncommitted changes. Used to test amending those uncommitted changes
+# back into the first commit.
+#
+# Stack layout:
+#   base (main) -> save 1 (creates test.txt) -> partial 1 (adds line 1.1)
+#   Uncommitted: adds line 1.2 between line 1.1 and line 2
+#
+# After amending line 1.2 into "save 1", the second commit should conflict
+# and there should be no remaining uncommitted changes.
+
+set -eu -o pipefail
+
+echo "/remote/" > .gitignore
+mkdir remote
+pushd remote
+git init --bare
+popd
+
+git init
+
+git remote add origin ./remote
+
+# Base commit on main
+echo "base" > base.txt
+git add .
+git commit -m "base"
+git branch -M main
+git push -u origin main
+
+# Create the stack branch
+git checkout -b stack-1
+
+# First commit: create test.txt with 3 lines
+printf "line 1\nline 2\nline 3\n" > test.txt
+git add test.txt
+git commit -m "save 1"
+
+# Second commit: partial commit adding only line 1.1
+printf "line 1\nline 1.1\nline 2\nline 3\n" > test.txt
+git add test.txt
+git commit -m "partial 1"
+
+# Now add the uncommitted change (line 1.2) that was left out of partial 1
+printf "line 1\nline 1.1\nline 1.2\nline 2\nline 3\n" > test.txt

--- a/crates/but-workspace/tests/workspace/commit/commit_amend.rs
+++ b/crates/but-workspace/tests/workspace/commit/commit_amend.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use but_core::DiffSpec;
 use but_rebase::graph_rebase::{Editor, LookupStep as _};
+use but_testsupport::git_status;
 use but_workspace::commit::commit_amend;
 
 use crate::ref_info::with_workspace_commit::utils::named_writable_scenario_with_description_and_graph as writable_scenario;
@@ -11,6 +12,27 @@ fn worktree_changes_as_specs(repo: &gix::Repository) -> Result<Vec<DiffSpec>> {
         .into_iter()
         .map(DiffSpec::from)
         .collect())
+}
+
+/// Build DiffSpecs with populated hunk_headers, matching how the production
+/// UI/CLI sends them. This is important because the production path always
+/// includes hunk headers even when all hunks of a file are selected.
+fn worktree_changes_as_specs_with_hunks(
+    repo: &gix::Repository,
+    context_lines: u32,
+) -> Result<Vec<DiffSpec>> {
+    let changes = but_core::diff::worktree_changes(repo)?;
+    let mut specs = Vec::new();
+    for change in &changes.changes {
+        let mut spec = DiffSpec::from(change);
+        if let Some(but_core::UnifiedPatch::Patch { hunks, .. }) =
+            change.unified_patch(repo, context_lines)?
+        {
+            spec.hunk_headers = hunks.iter().map(but_core::HunkHeader::from).collect();
+        }
+        specs.push(spec);
+    }
+    Ok(specs)
 }
 
 #[test]
@@ -37,6 +59,63 @@ fn amend_commit_smoke_test() -> Result<()> {
     let spec = format!("{rewritten_id}:amended.txt");
     let object_with_path = repo.rev_parse_single(spec.as_str())?;
     assert_eq!(object_with_path.object()?.kind, gix::objs::Kind::Blob);
+
+    Ok(())
+}
+
+/// Amending uncommitted changes into an earlier commit when a later commit
+/// also touches the same file should leave no uncommitted changes afterwards.
+///
+/// Scenario:
+///   - "save 1" creates test.txt with 3 lines
+///   - "partial 1" adds line 1.1 (partial commit)
+///   - Uncommitted: adds line 1.2
+///   - Amend line 1.2 into "save 1"
+///
+/// After amend, "partial 1" will conflict (rebased onto new "save 1"),
+/// but there should be no remaining uncommitted changes.
+#[test]
+fn amend_into_earlier_commit_leaves_no_uncommitted_changes() -> Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        writable_scenario("amend-with-partial-commit", |_| {})?;
+
+    // Find the "save 1" commit (first commit on the stack, parent of "partial 1")
+    let partial_1_id = repo.rev_parse_single("stack-1")?.detach();
+    let partial_1_commit = repo.find_commit(partial_1_id)?;
+    let save_1_id = partial_1_commit
+        .parent_ids()
+        .next()
+        .expect("has parent")
+        .detach();
+
+    // Verify initial state: there should be uncommitted changes (line 1.2)
+    let status_before = git_status(&repo)?;
+    assert!(
+        status_before.contains("test.txt"),
+        "should have uncommitted changes to test.txt before amend, got: {status_before}"
+    );
+
+    let context_lines = 0;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+    let outcome = commit_amend(
+        editor,
+        save_1_id,
+        worktree_changes_as_specs_with_hunks(&repo, context_lines)?,
+        context_lines,
+    )?;
+
+    assert!(outcome.rejected_specs.is_empty());
+    let _selector = outcome.commit_selector.expect("amend selector exists");
+    let _materialized = outcome.rebase.materialize()?;
+
+    // No uncommitted changes should remain: the change was amended into
+    // "save 1", so it must not persist as an uncommitted worktree change.
+    let status_after = git_status(&repo)?;
+    assert_eq!(
+        status_after, "",
+        "expected no uncommitted changes after amending, but got:\n{status_after}"
+    );
 
     Ok(())
 }

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -169,6 +169,7 @@ fn go_back_to_integration(ctx: &Context, default_target: &Target) -> Result<Base
             but_core::worktree::checkout::Options {
                 uncommitted_changes: UncommitedWorktreeChanges::KeepAndAbortOnConflict,
                 skip_head_update: false,
+                ..Default::default()
             },
         )?;
     } else {

--- a/crates/gitbutler-branch-actions/src/integration.rs
+++ b/crates/gitbutler-branch-actions/src/integration.rs
@@ -183,6 +183,7 @@ pub fn update_workspace_commit_with_vb_state(
             but_core::worktree::checkout::Options {
                 uncommitted_changes: UncommitedWorktreeChanges::KeepAndAbortOnConflict,
                 skip_head_update: true,
+                ..Default::default()
             },
         );
         Some(res)


### PR DESCRIPTION
## Problem

When committing or amending worktree changes, committed hunks could reappear as uncommitted modifications — duplicating lines on disk. This happened when:
- Amending changes into an earlier commit in a stack
- Creating a partial commit (selecting specific hunks)

## Cause

`safe_checkout` preserves uncommitted worktree state across rebases using a 3-way merge:

```
base   = old HEAD tree
ours   = new HEAD tree (after rebase)
theirs = snapshot of worktree before the operation
```

Consumed changes appear in both **ours** (baked in by the rebase) and **theirs** (captured in the snapshot), so the merge treats them as independent additions and duplicates them.

## Fix

Build a **committed tree** (old HEAD + consumed DiffSpecs) and use it as the merge base:

```
base   = old HEAD tree + consumed changes
ours   = new HEAD tree (after rebase)
theirs = snapshot of worktree before the operation
```

Consumed changes now appear in both **base** and **theirs**, producing no diff on the theirs side — so they're not cherry-picked onto the destination. Only genuinely remaining uncommitted changes survive.

The committed tree is built additive-only (stripping `previous_path` for renames) to match the snapshot's additive-only semantics. Without this, a rename's source-side deletion would appear only in the base, causing the merge to treat the source file in the snapshot as a new addition and restore it on disk.

This works at the tree level for any granularity (full files, full hunks, sub-hunk selections) without hunk-level arithmetic.

Both `commit_create` and `commit_amend` now share this mechanism, replacing the previous `materialize_without_checkout` workaround for commit creation.