### PR TITLE
Fix new commit appearing in all branches when added to bottom of stack

### DIFF
--- a/apps/desktop/src/components/branch/BranchCard.svelte
+++ b/apps/desktop/src/components/branch/BranchCard.svelte
@@ -201,7 +201,6 @@
 						type: "commit",
 						stackId: args.stackId,
 						branchName,
-						parentCommitId: args.baseCommit,
 					});
 				}}
 				iconName={args.iconName}

--- a/apps/desktop/src/components/commit/NewCommitView.svelte
+++ b/apps/desktop/src/components/commit/NewCommitView.svelte
@@ -66,6 +66,7 @@
 				finalBranchName = await stackService.fetchNewBranchName(projectId);
 			}
 			const parentId = commitAction?.parentCommitId;
+			const insertBelow = commitAction?.insertBelow;
 
 			if (!finalStackId) {
 				const stack = await createNewStack({
@@ -120,6 +121,7 @@
 				{
 					projectId,
 					parentId,
+					insertBelow,
 					stackId: finalStackId,
 					message: finalMessage,
 					stackBranchName: finalBranchName,

--- a/apps/desktop/src/components/views/BranchCommitList.svelte
+++ b/apps/desktop/src/components/views/BranchCommitList.svelte
@@ -343,6 +343,7 @@
 								{commitId}
 								selected={(commitAction?.parentCommitId === commitId ||
 									(first && commitAction?.parentCommitId === undefined)) &&
+									!commitAction?.insertBelow &&
 									commitAction?.branchName === branchName}
 								{first}
 								last={false}
@@ -526,18 +527,20 @@
 						)}
 						{#if controller.isCommitting && last}
 							<CommitPositionIndicator
-								commitId={branchDetails.baseCommit}
+								commitId={commit.id}
 								{first}
 								{last}
 								selected={exclusiveAction?.type === "commit" &&
-									exclusiveAction.parentCommitId === branchDetails.baseCommit &&
+									exclusiveAction.parentCommitId === commit.id &&
+									exclusiveAction.insertBelow === true &&
 									commitAction?.branchName === branchName}
 								onclick={() => {
 									controller.projectState.exclusiveAction.set({
 										type: "commit",
 										stackId,
 										branchName,
-										parentCommitId: branchDetails.baseCommit,
+										parentCommitId: commit.id,
+										insertBelow: true,
 									});
 								}}
 							/>

--- a/apps/desktop/src/lib/stacks/stackEndpoints.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.ts
@@ -50,6 +50,8 @@ export type CreateCommitRequest = {
 	message: string;
 	/** Undefined means that the backend will infer the parent to be the current head of stackBranchName */
 	parentId: string | undefined;
+	/** When true, insert below `parentId` instead of above it. */
+	insertBelow?: boolean;
 	stackBranchName: string;
 	worktreeChanges: DiffSpec[];
 	dryRun: boolean;
@@ -151,7 +153,7 @@ export function toCommitCreatePlacement(args: CreateCommitRequest): {
 				type: "commit",
 				subject: args.parentId,
 			},
-			side: "above",
+			side: args.insertBelow ? "below" : "above",
 		};
 	}
 

--- a/apps/desktop/src/lib/state/uiState.svelte.ts
+++ b/apps/desktop/src/lib/state/uiState.svelte.ts
@@ -70,6 +70,7 @@ export type ExclusiveAction =
 			stackId: string | undefined;
 			branchName: string | undefined;
 			parentCommitId?: string;
+			insertBelow?: boolean;
 	  }
 	| {
 			type: "edit-commit-message";


### PR DESCRIPTION
When adding a commit to the bottom of a branch, the frontend was
targeting the shared merge-base commit with `InsertSide::Above`. Since
all stacks share this commit, the insert redirected every incoming edge
— including other stacks' Reference edges — causing the new commit to
appear in all branches.

Instead, target the branch's own bottom commit with `InsertSide::Below`.
This only redirects that commit's outgoing edge, so other stacks are
unaffected. For empty branches (no commits yet), omit the parent so the
default `Reference + Below` path is used.