### PR TITLE
Update `gix` for a more conformant git-config parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4351,8 +4351,8 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.81.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.83.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "gix-actor",
  "gix-archive",
@@ -4382,7 +4382,7 @@ dependencies = [
  "gix-object",
  "gix-odb",
  "gix-pack",
- "gix-path 0.11.2",
+ "gix-path 0.12.0",
  "gix-pathspec",
  "gix-prompt",
  "gix-protocol",
@@ -4395,12 +4395,12 @@ dependencies = [
  "gix-status",
  "gix-submodule",
  "gix-tempfile",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
+ "gix-trace 0.1.19",
  "gix-transport",
  "gix-traverse",
  "gix-url",
  "gix-utils",
- "gix-validate 0.11.0",
+ "gix-validate 0.11.1",
  "gix-worktree",
  "gix-worktree-state",
  "gix-worktree-stream",
@@ -4412,20 +4412,19 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.40.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.41.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "gix-date",
  "gix-error",
  "serde",
- "winnow 1.0.1",
 ]
 
 [[package]]
 name = "gix-archive"
-version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.32.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "gix-date",
@@ -4436,14 +4435,14 @@ dependencies = [
 
 [[package]]
 name = "gix-attributes"
-version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.33.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "gix-glob",
- "gix-path 0.11.2",
+ "gix-path 0.12.0",
  "gix-quote",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
+ "gix-trace 0.1.19",
  "kstring",
  "serde",
  "smallvec",
@@ -4453,16 +4452,16 @@ dependencies = [
 
 [[package]]
 name = "gix-bitmap"
-version = "0.3.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.3.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "gix-error",
 ]
 
 [[package]]
 name = "gix-blame"
-version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.13.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -4471,7 +4470,7 @@ dependencies = [
  "gix-hash",
  "gix-object",
  "gix-revwalk",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
+ "gix-trace 0.1.19",
  "gix-traverse",
  "gix-worktree",
  "smallvec",
@@ -4480,28 +4479,28 @@ dependencies = [
 
 [[package]]
 name = "gix-chunk"
-version = "0.7.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.7.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "gix-error",
 ]
 
 [[package]]
 name = "gix-command"
-version = "0.8.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.9.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
- "gix-path 0.11.2",
+ "gix-path 0.12.0",
  "gix-quote",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
+ "gix-trace 0.1.19",
  "shell-words",
 ]
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.37.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -4514,48 +4513,46 @@ dependencies = [
 
 [[package]]
 name = "gix-config"
-version = "0.54.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.56.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "gix-config-value",
  "gix-features",
  "gix-glob",
- "gix-path 0.11.2",
+ "gix-path 0.12.0",
  "gix-ref",
  "gix-sec",
- "memchr",
  "smallvec",
  "thiserror 2.0.18",
  "unicode-bom",
- "winnow 1.0.1",
 ]
 
 [[package]]
 name = "gix-config-value"
-version = "0.17.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.18.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
- "gix-path 0.11.2",
+ "gix-path 0.12.0",
  "libc",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-credentials"
-version = "0.37.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.38.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-config-value",
  "gix-date",
- "gix-path 0.11.2",
+ "gix-path 0.12.0",
  "gix-prompt",
  "gix-sec",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
+ "gix-trace 0.1.19",
  "gix-url",
  "serde",
  "thiserror 2.0.18",
@@ -4563,8 +4560,8 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.15.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.15.3"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "gix-error",
@@ -4576,8 +4573,8 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.61.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.63.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -4588,10 +4585,10 @@ dependencies = [
  "gix-imara-diff",
  "gix-index",
  "gix-object",
- "gix-path 0.11.2",
+ "gix-path 0.12.0",
  "gix-pathspec",
  "gix-tempfile",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
+ "gix-trace 0.1.19",
  "gix-traverse",
  "gix-worktree",
  "thiserror 2.0.18",
@@ -4599,8 +4596,8 @@ dependencies = [
 
 [[package]]
 name = "gix-dir"
-version = "0.23.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.25.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "gix-discover",
@@ -4608,9 +4605,9 @@ dependencies = [
  "gix-ignore",
  "gix-index",
  "gix-object",
- "gix-path 0.11.2",
+ "gix-path 0.12.0",
  "gix-pathspec",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
+ "gix-trace 0.1.19",
  "gix-utils",
  "gix-worktree",
  "thiserror 2.0.18",
@@ -4618,13 +4615,13 @@ dependencies = [
 
 [[package]]
 name = "gix-discover"
-version = "0.49.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.51.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "dunce",
  "gix-fs",
- "gix-path 0.11.2",
+ "gix-path 0.12.0",
  "gix-ref",
  "gix-sec",
  "thiserror 2.0.18",
@@ -4632,22 +4629,22 @@ dependencies = [
 
 [[package]]
 name = "gix-error"
-version = "0.2.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.2.3"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
 ]
 
 [[package]]
 name = "gix-features"
-version = "0.46.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.48.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bytes",
  "crc32fast",
  "crossbeam-channel",
- "gix-path 0.11.2",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
+ "gix-path 0.12.0",
+ "gix-trace 0.1.19",
  "gix-utils",
  "libc",
  "once_cell",
@@ -4660,8 +4657,8 @@ dependencies = [
 
 [[package]]
 name = "gix-filter"
-version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.30.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -4670,9 +4667,9 @@ dependencies = [
  "gix-hash",
  "gix-object",
  "gix-packetline",
- "gix-path 0.11.2",
+ "gix-path 0.12.0",
  "gix-quote",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
+ "gix-trace 0.1.19",
  "gix-utils",
  "smallvec",
  "thiserror 2.0.18",
@@ -4680,33 +4677,33 @@ dependencies = [
 
 [[package]]
 name = "gix-fs"
-version = "0.19.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.21.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "fastrand",
  "gix-features",
- "gix-path 0.11.2",
+ "gix-path 0.12.0",
  "gix-utils",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-glob"
-version = "0.24.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.26.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
  "gix-features",
- "gix-path 0.11.2",
+ "gix-path 0.12.0",
  "serde",
 ]
 
 [[package]]
 name = "gix-hash"
-version = "0.23.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.25.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -4717,8 +4714,8 @@ dependencies = [
 
 [[package]]
 name = "gix-hashtable"
-version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.15.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "gix-hash",
  "hashbrown 0.16.1",
@@ -4727,31 +4724,30 @@ dependencies = [
 
 [[package]]
 name = "gix-ignore"
-version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.21.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "gix-glob",
- "gix-path 0.11.2",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
+ "gix-path 0.12.0",
+ "gix-trace 0.1.19",
  "serde",
  "unicode-bom",
 ]
 
 [[package]]
 name = "gix-imara-diff"
-version = "0.2.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.2.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
- "hashbrown 0.16.1",
- "memchr",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
 name = "gix-index"
-version = "0.49.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.51.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4765,7 +4761,7 @@ dependencies = [
  "gix-object",
  "gix-traverse",
  "gix-utils",
- "gix-validate 0.11.0",
+ "gix-validate 0.11.1",
  "hashbrown 0.16.1",
  "itoa",
  "libc",
@@ -4778,8 +4774,8 @@ dependencies = [
 
 [[package]]
 name = "gix-lock"
-version = "21.0.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "23.0.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -4788,8 +4784,8 @@ dependencies = [
 
 [[package]]
 name = "gix-mailmap"
-version = "0.32.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.33.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4800,8 +4796,8 @@ dependencies = [
 
 [[package]]
 name = "gix-merge"
-version = "0.14.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.16.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4812,12 +4808,12 @@ dependencies = [
  "gix-imara-diff",
  "gix-index",
  "gix-object",
- "gix-path 0.11.2",
+ "gix-path 0.12.0",
  "gix-quote",
  "gix-revision",
  "gix-revwalk",
  "gix-tempfile",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
+ "gix-trace 0.1.19",
  "gix-worktree",
  "nonempty",
  "thiserror 2.0.18",
@@ -4825,8 +4821,8 @@ dependencies = [
 
 [[package]]
 name = "gix-negotiate"
-version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.31.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bitflags 2.11.0",
  "gix-commitgraph",
@@ -4838,8 +4834,8 @@ dependencies = [
 
 [[package]]
 name = "gix-object"
-version = "0.58.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.60.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4848,18 +4844,17 @@ dependencies = [
  "gix-hash",
  "gix-hashtable",
  "gix-utils",
- "gix-validate 0.11.0",
+ "gix-validate 0.11.1",
  "itoa",
  "serde",
  "smallvec",
  "thiserror 2.0.18",
- "winnow 1.0.1",
 ]
 
 [[package]]
 name = "gix-odb"
-version = "0.78.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.80.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "arc-swap",
  "gix-features",
@@ -4868,7 +4863,7 @@ dependencies = [
  "gix-hashtable",
  "gix-object",
  "gix-pack",
- "gix-path 0.11.2",
+ "gix-path 0.12.0",
  "gix-quote",
  "memmap2",
  "parking_lot",
@@ -4879,8 +4874,8 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.68.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.70.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "clru",
  "gix-chunk",
@@ -4889,7 +4884,7 @@ dependencies = [
  "gix-hash",
  "gix-hashtable",
  "gix-object",
- "gix-path 0.11.2",
+ "gix-path 0.12.0",
  "gix-tempfile",
  "memmap2",
  "parking_lot",
@@ -4901,12 +4896,12 @@ dependencies = [
 
 [[package]]
 name = "gix-packetline"
-version = "0.21.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.21.3"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
+ "gix-trace 0.1.19",
  "thiserror 2.0.18",
 ]
 
@@ -4917,40 +4912,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cb06c3e4f8eed6e24fd915fa93145e28a511f4ea0e768bae16673e05ed3f366"
 dependencies = [
  "bstr",
- "gix-trace 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-trace 0.1.18",
  "gix-validate 0.10.1",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-path"
-version = "0.11.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.12.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
- "gix-validate 0.11.0",
+ "gix-trace 0.1.19",
+ "gix-validate 0.11.1",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-pathspec"
-version = "0.16.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.18.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
  "gix-attributes",
  "gix-config-value",
  "gix-glob",
- "gix-path 0.11.2",
+ "gix-path 0.12.0",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-prompt"
-version = "0.14.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.15.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -4961,8 +4956,8 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.59.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.61.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -4976,20 +4971,19 @@ dependencies = [
  "gix-refspec",
  "gix-revwalk",
  "gix-shallow",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
+ "gix-trace 0.1.19",
  "gix-transport",
  "gix-utils",
  "maybe-async",
  "nonempty",
  "serde",
  "thiserror 2.0.18",
- "winnow 1.0.1",
 ]
 
 [[package]]
 name = "gix-quote"
-version = "0.7.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.7.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "gix-error",
@@ -4998,8 +4992,8 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.61.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.63.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -5007,35 +5001,34 @@ dependencies = [
  "gix-hash",
  "gix-lock",
  "gix-object",
- "gix-path 0.11.2",
+ "gix-path 0.12.0",
  "gix-tempfile",
  "gix-utils",
- "gix-validate 0.11.0",
+ "gix-validate 0.11.1",
  "memmap2",
  "serde",
  "thiserror 2.0.18",
- "winnow 1.0.1",
 ]
 
 [[package]]
 name = "gix-refspec"
-version = "0.39.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.41.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "gix-error",
  "gix-glob",
  "gix-hash",
  "gix-revision",
- "gix-validate 0.11.0",
+ "gix-validate 0.11.1",
  "smallvec",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-revision"
-version = "0.43.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.45.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -5046,15 +5039,15 @@ dependencies = [
  "gix-hashtable",
  "gix-object",
  "gix-revwalk",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64)",
+ "gix-trace 0.1.19",
  "nonempty",
  "serde",
 ]
 
 [[package]]
 name = "gix-revwalk"
-version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.31.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -5068,11 +5061,11 @@ dependencies = [
 
 [[package]]
 name = "gix-sec"
-version = "0.13.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.14.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bitflags 2.11.0",
- "gix-path 0.11.2",
+ "gix-path 0.12.0",
  "libc",
  "serde",
  "windows-sys 0.61.2",
@@ -5080,8 +5073,8 @@ dependencies = [
 
 [[package]]
 name = "gix-shallow"
-version = "0.10.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.12.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -5093,8 +5086,8 @@ dependencies = [
 
 [[package]]
 name = "gix-status"
-version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.30.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "filetime",
@@ -5106,7 +5099,7 @@ dependencies = [
  "gix-hash",
  "gix-index",
  "gix-object",
- "gix-path 0.11.2",
+ "gix-path 0.12.0",
  "gix-pathspec",
  "gix-worktree",
  "portable-atomic",
@@ -5115,12 +5108,12 @@ dependencies = [
 
 [[package]]
 name = "gix-submodule"
-version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.30.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "gix-config",
- "gix-path 0.11.2",
+ "gix-path 0.12.0",
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
@@ -5129,8 +5122,8 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "21.0.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "23.0.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "dashmap",
  "gix-fs",
@@ -5144,7 +5137,7 @@ dependencies = [
 [[package]]
 name = "gix-testtools"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "crc",
@@ -5161,7 +5154,6 @@ dependencies = [
  "parking_lot",
  "tar",
  "tempfile",
- "winnow 1.0.1",
 ]
 
 [[package]]
@@ -5172,16 +5164,16 @@ checksum = "f69a13643b8437d4ca6845e08143e847a36ca82903eed13303475d0ae8b162e0"
 
 [[package]]
 name = "gix-trace"
-version = "0.1.18"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.1.19"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "gix-transport"
-version = "0.55.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.57.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -5199,8 +5191,8 @@ dependencies = [
 
 [[package]]
 name = "gix-traverse"
-version = "0.55.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.57.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bitflags 2.11.0",
  "gix-commitgraph",
@@ -5215,11 +5207,11 @@ dependencies = [
 
 [[package]]
 name = "gix-url"
-version = "0.35.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.36.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
- "gix-path 0.11.2",
+ "gix-path 0.12.0",
  "percent-encoding",
  "serde",
  "thiserror 2.0.18",
@@ -5227,8 +5219,8 @@ dependencies = [
 
 [[package]]
 name = "gix-utils"
-version = "0.3.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.3.2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "fastrand",
@@ -5247,16 +5239,16 @@ dependencies = [
 
 [[package]]
 name = "gix-validate"
-version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.11.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
 ]
 
 [[package]]
 name = "gix-worktree"
-version = "0.50.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.52.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -5266,15 +5258,15 @@ dependencies = [
  "gix-ignore",
  "gix-index",
  "gix-object",
- "gix-path 0.11.2",
- "gix-validate 0.11.0",
+ "gix-path 0.12.0",
+ "gix-validate 0.11.1",
  "serde",
 ]
 
 [[package]]
 name = "gix-worktree-state"
-version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.30.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "bstr",
  "gix-features",
@@ -5282,7 +5274,7 @@ dependencies = [
  "gix-fs",
  "gix-index",
  "gix-object",
- "gix-path 0.11.2",
+ "gix-path 0.12.0",
  "gix-worktree",
  "io-close",
  "thiserror 2.0.18",
@@ -5290,8 +5282,8 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-stream"
-version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=63b841907ce30b36bb50da5aae3a9e1a06eadf64#63b841907ce30b36bb50da5aae3a9e1a06eadf64"
+version = "0.32.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
 dependencies = [
  "gix-attributes",
  "gix-error",
@@ -5300,7 +5292,7 @@ dependencies = [
  "gix-fs",
  "gix-hash",
  "gix-object",
- "gix-path 0.11.2",
+ "gix-path 0.12.0",
  "gix-traverse",
  "parking_lot",
 ]
@@ -12676,15 +12668,6 @@ name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,10 +214,10 @@ backoff = "0.4.0"
 bstr = "1.12.1"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
 # When adjusting this, update `gix-testtools` as well!
-gix = { version = "0.81.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "63b841907ce30b36bb50da5aae3a9e1a06eadf64", default-features = false, features = [
+gix = { version = "0.83.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "adb8328952478c443ead5f5a8c6851928b377b37", default-features = false, features = [
     "sha1",
 ] }
-gix-testtools = { version = "0.19.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "63b841907ce30b36bb50da5aae3a9e1a06eadf64" }
+gix-testtools = { version = "0.19.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "adb8328952478c443ead5f5a8c6851928b377b37" }
 
 
 insta = { version = "1.45.1", features = ["json"] }


### PR DESCRIPTION
Also, all parsers are now faster, up to 20%.

That's not relevant in practice though, for individual users at least.

Fixes https://github.com/gitbutlerapp/gitbutler/issues/8948 