### PR TITLE
Fix workspace projection pruning for integrated bottom segments

### DIFF
--- a/crates/but-graph/src/projection/workspace/init.rs
+++ b/crates/but-graph/src/projection/workspace/init.rs
@@ -362,6 +362,7 @@ impl Graph {
         };
 
         ws.prune_archived_segments();
+        ws.prune_integrated_segments(self);
         ws.mark_remote_reachability(self)?;
         ws.add_commits_on_remote(self);
         ws.truncate_single_stack_to_match_base();
@@ -754,6 +755,30 @@ impl WorkspaceState {
         }
     }
 
+    /// Truncate each stack to only show commits above its fork point with the
+    /// target, then remove empty branches and stacks.
+    ///
+    /// The fork point is the first commit on the first-parent chain (walked via
+    /// the graph's `CommitFlags::Integrated`) that is reachable from the target.
+    ///
+    /// Stacks explicitly tracked in workspace metadata are never pruned —
+    /// their integrated branches and commits must remain visible so that
+    /// `integrate_upstream` can detect and remove them.
+    fn prune_integrated_segments(&mut self, graph: &Graph) {
+        if self.extra_target.is_some() || self.target_ref.is_none() {
+            return;
+        }
+        let metadata = self.metadata.as_ref();
+        for stack in &mut self.stacks {
+            if is_metadata_tracked(stack, metadata) {
+                continue;
+            }
+            truncate_at_fork_point(stack, graph);
+            remove_empty_branches(stack, metadata);
+        }
+        self.stacks.retain(|stack| !stack.segments.is_empty());
+    }
+
     /// Trace the remotes of each segments down to their segment or other segments and set the commit flags accordingly
     /// to indicate if a commit in the workspace is reachable, and how.
     fn mark_remote_reachability(&mut self, graph: &Graph) -> anyhow::Result<()> {
@@ -940,4 +965,66 @@ impl WorkspaceState {
         first_segment.commits.clear();
         first_segment.commits_by_segment.clear();
     }
+}
+
+/// Truncate the stack at the fork point: the first commit whose graph-level
+/// `CommitFlags::Integrated` flag is set, walking top-down through each
+/// segment's `commits_by_segment` entries.
+///
+/// If the very first commit is already integrated, the entire stack is
+/// integrated and we leave it untouched — pruning is only for partially
+/// integrated stacks where the bottom portion has been merged upstream.
+fn truncate_at_fork_point(stack: &mut Stack, graph: &Graph) {
+    let mut is_first = true;
+    for seg_idx in 0..stack.segments.len() {
+        let seg = &stack.segments[seg_idx];
+        for &(graph_sidx, ofs) in &seg.commits_by_segment {
+            for (i, commit) in graph[graph_sidx].commits.iter().enumerate() {
+                if commit.flags.contains(CommitFlags::Integrated) {
+                    if is_first {
+                        // Fully integrated — leave the stack as-is.
+                        return;
+                    }
+                    let cut = ofs + i;
+                    stack.segments[seg_idx].commits.truncate(cut);
+                    stack.segments[seg_idx]
+                        .commits_by_segment
+                        .retain(|(_, o)| *o < cut);
+                    // Clear commits in all segments below the cutoff, but keep
+                    // the segments themselves so that `remove_empty_branches`
+                    // can decide whether to retain metadata-tracked branches.
+                    for seg in &mut stack.segments[seg_idx + 1..] {
+                        seg.commits.clear();
+                        seg.commits_by_segment.clear();
+                    }
+                    return;
+                }
+                is_first = false;
+            }
+        }
+    }
+}
+
+/// Returns `true` if the stack is explicitly tracked in workspace metadata.
+fn is_metadata_tracked(
+    stack: &Stack,
+    metadata: Option<&but_core::ref_metadata::Workspace>,
+) -> bool {
+    stack.id.is_some_and(|stack_id| {
+        metadata.is_some_and(|meta| meta.stacks(Applied).any(|ms| ms.id == stack_id))
+    })
+}
+
+fn remove_empty_branches(stack: &mut Stack, metadata: Option<&but_core::ref_metadata::Workspace>) {
+    let own_metadata_stack = stack.id.and_then(|stack_id| {
+        metadata.and_then(|meta| meta.stacks(Applied).find(|ms| ms.id == stack_id))
+    });
+    stack.segments.retain(|seg| {
+        !seg.commits.is_empty()
+            || own_metadata_stack.is_some_and(|ms| {
+                seg.ref_info
+                    .as_ref()
+                    .is_some_and(|ri| ms.branches.iter().any(|b| b.ref_name == ri.ref_name))
+            })
+    });
 }

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -1557,4 +1557,65 @@ EOF
     git checkout -b gitbutler/workspace
     git commit --allow-empty -m "GitButler Workspace Commit"
   )
+
+  # A stack where the bottom commit is a local merge that's already integrated
+  # into origin/main. The merge commit is kept because it is above the fork
+  # point — it's part of the branch's history.
+  #
+  # History:
+  #   ws ─ D ─ C ─ local-merge ─ init
+  #                     │            │
+  #                     └── fix ─────┘
+  #   origin/main: upstream-merge ─ fix ─ init
+  #
+  # "local-merge" and "upstream-merge" merge the same branch ("fix") but are
+  # different commits (different committer, like GitHub vs local).
+  git init integrated-merge-at-bottom
+  (cd integrated-merge-at-bottom
+     commit init
+
+     # Create the fix branch
+     git checkout -b fix
+       commit fix
+
+     # Simulate GitHub merging the PR into main (upstream merge)
+     git checkout main
+       GIT_COMMITTER_NAME="GitHub" GIT_COMMITTER_EMAIL="noreply@github.com" \
+         git merge --no-ff -m "Merge pull request #1 from fix" fix
+       setup_target_to_match_main
+
+     # Create a local merge of the same branch (as if the user had merged locally)
+     git checkout -b local-stack main~1
+       git merge --no-ff -m "Merge pull request #1 from fix" fix
+
+     # Add two real commits on top
+       commit C
+       commit D
+
+     create_workspace_commit_once local-stack
+  )
+
+  # A branch with a commit, then a merge from main, then another commit.
+  # The merge-from-main moves the merge base up past the first commit,
+  # so merge-base-counting pruning should still show both real commits.
+  git init merge-from-main-in-branch
+  (cd merge-from-main-in-branch
+     commit init
+
+     # Create the branch from init
+     git checkout -b my-branch
+       commit branch-commit-1
+
+     # Advance main with a commit after the branch was created
+     git checkout main
+       commit main-advance
+       setup_target_to_match_main
+
+     # Back to the branch: merge main into it, then add another commit
+     git checkout my-branch
+       git merge --no-ff -m "Merge main into my-branch" main
+       commit branch-commit-2
+
+     create_workspace_commit_once my-branch
+  )
 )

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -59,7 +59,7 @@ fn workspace_with_stack_and_local_target() -> anyhow::Result<()> {
     // It's perfectly valid to have the local tracking branch of our target in the workspace,
     // and the low-bound computation works as well.
     let ws = &graph.into_workspace()?;
-    insta::assert_snapshot!(graph_workspace(ws), @r"
+    insta::assert_snapshot!(graph_workspace(ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
     ├── ≡:3:A on fafd9d0
     │   └── :3:A
@@ -68,8 +68,7 @@ fn workspace_with_stack_and_local_target() -> anyhow::Result<()> {
     └── ≡:2:main <> origin/main →:1:⇡1⇣1 on fafd9d0
         └── :2:main <> origin/main →:1:⇡1⇣1
             ├── 🟣1f5c47b (✓)
-            ├── ·0a415d8 (🏘️)
-            └── ❄️73ba99d (🏘️|✓)
+            └── ·0a415d8 (🏘️)
     ");
 
     Ok(())
@@ -226,7 +225,7 @@ fn no_overzealous_stacks_due_to_workspace_metadata() -> anyhow::Result<()> {
     add_stack_with_segments(&mut meta, 2, "feat-2", StackState::InWorkspace, &[]);
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
     ├── ≡📙:3:X <> origin/X →:5:⇡1 on 3183e43 {1}
     │   └── 📙:3:X <> origin/X →:5:⇡1
@@ -592,7 +591,7 @@ fn single_stack_ws_insertions() -> anyhow::Result<()> {
 
     // We can also summon new empty stacks from branches resting on the base, and set them
     // as entrypoint, to have two more stacks.
-    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     ├── ≡📙:8:new-B on fafd9d0 {3}
     │   └── 📙:8:new-B
@@ -5523,7 +5522,7 @@ fn applied_stack_below_explicit_lower_bound() -> anyhow::Result<()> {
             └── ·938e6f2 (⌂|✓|10)
                 └── →:5:
     ");
-    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on bce0c5e
     ├── ≡📙:4:B on bce0c5e {1}
     │   └── 📙:4:B
@@ -6509,6 +6508,98 @@ fn reproduce_12146() -> anyhow::Result<()> {
     └── ≡📙:5:A on e32cf47 {0}
         └── 📙:5:A
             └── ·81d4e38 (🏘️)
+    ");
+
+    Ok(())
+}
+
+/// A stack where a local merge commit at the bottom is already integrated into
+/// origin/main (the same PR was merged upstream). The merge commit is kept
+/// because it is above the fork point — it's part of the branch's history
+/// even though an equivalent merge exists on main.
+#[test]
+fn integrated_merge_at_bottom_is_kept() -> anyhow::Result<()> {
+    let (repo, mut meta) = read_only_in_memory_scenario("ws/integrated-merge-at-bottom")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 732604f (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 66ea651 (local-stack) D
+    * e5a88a7 C
+    *   0b3ccaf Merge pull request #1 from fix
+    |\  
+    | | * f46830d (origin/main, main) Merge pull request #1 from fix
+    | |/| 
+    |/|/  
+    | * f5f42e0 (fix) fix
+    |/  
+    * fafd9d0 init
+    ");
+
+    add_stack_with_segments(&mut meta, 0, "local-stack", StackState::InWorkspace, &[]);
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on f5f42e0
+    └── ≡📙:3:local-stack {0}
+        └── 📙:3:local-stack
+            ├── ·66ea651 (🏘️)
+            ├── ·e5a88a7 (🏘️)
+            ├── ·0b3ccaf (🏘️)
+            └── ·fafd9d0 (🏘️|✓)
+    ");
+
+    Ok(())
+}
+
+/// A branch that has a commit, merges main into itself, then has another commit.
+/// The fork-point approach finds the original divergence point, so all branch
+/// commits (including those below the merge-from-main) remain visible.
+#[test]
+fn merge_from_main_keeps_all_branch_commits() -> anyhow::Result<()> {
+    let (repo, mut meta) = read_only_in_memory_scenario("ws/merge-from-main-in-branch")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 891e228 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * cd76046 (my-branch) branch-commit-2
+    *   f8ff9a3 Merge main into my-branch
+    |\  
+    | * ef56fab (origin/main, main) main-advance
+    * | 6f65768 branch-commit-1
+    |/  
+    * fafd9d0 init
+    ");
+
+    add_stack_with_segments(&mut meta, 0, "my-branch", StackState::InWorkspace, &[]);
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    insta::assert_snapshot!(graph_tree(&graph), @r"
+
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
+    │   └── ·891e228 (⌂|🏘|01)
+    │       └── 📙►:3[1]:my-branch
+    │           └── ·cd76046 (⌂|🏘|01)
+    │               └── ►:4[2]:anon:
+    │                   └── ·f8ff9a3 (⌂|🏘|01)
+    │                       ├── ►:5[3]:anon:
+    │                       │   └── ·6f65768 (⌂|🏘|01)
+    │                       │       └── ►:6[4]:anon:
+    │                       │           └── ·fafd9d0 (⌂|🏘|✓|11)
+    │                       └── ►:2[3]:main <> origin/main →:1:
+    │                           └── ·ef56fab (⌂|🏘|✓|11)
+    │                               └── →:6:
+    └── ►:1[0]:origin/main →:2:
+        └── →:2: (main →:1:)
+    ");
+
+    // The fork-point approach correctly finds the original divergence point (fafd9d0)
+    // instead of the moved merge base (ef56fab), so all 3 branch commits are visible:
+    // branch-commit-2, the merge commit, and branch-commit-1.
+    let ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on ef56fab
+    └── ≡📙:3:my-branch {0}
+        └── 📙:3:my-branch
+            ├── ·cd76046 (🏘️)
+            ├── ·f8ff9a3 (🏘️)
+            ├── ·6f65768 (🏘️)
+            └── ·fafd9d0 (🏘️|✓)
     ");
 
     Ok(())

--- a/crates/but-meta/tests/meta/ref_metadata_legacy.rs
+++ b/crates/but-meta/tests/meta/ref_metadata_legacy.rs
@@ -1271,11 +1271,9 @@ fn dlib_rs_auto_fix() -> anyhow::Result<()> {
     // it doesn't fail anymore.
     insta::assert_snapshot!(but_testsupport::graph_workspace_determinisitcally(&graph.into_workspace()?), @"
     📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
-    ├── ≡📙:5:main[🌳] <> origin/main →:1: on 3183e43 {1}
-    │   └── 📙:5:main[🌳] <> origin/main →:1:
-    │       └── ❄️bce0c5e (🏘️|✓)
-    └── ≡📙:4:confidence on 3183e43
-        └── 📙:4:confidence
+    └── ≡📙:5:main[🌳] <> origin/main →:1: on 3183e43 {1}
+        └── 📙:5:main[🌳] <> origin/main →:1:
+            └── ❄️bce0c5e (🏘️|✓)
     ");
 
     let path = store.path().to_owned();
@@ -1309,9 +1307,7 @@ fn dlib_rs_auto_fix() -> anyhow::Result<()> {
     )?;
     insta::assert_snapshot!(but_testsupport::graph_workspace_determinisitcally(&graph.into_workspace()?), @"
     📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
-    ├── ≡📙:4:confidence on 3183e43 {1}
-    │   └── 📙:4:confidence
-    └── ≡📙:2:main[🌳] <> origin/main →:1: on 3183e43
+    └── ≡📙:2:main[🌳] <> origin/main →:1: on 3183e43 {1}
         └── 📙:2:main[🌳] <> origin/main →:1:
             └── ❄️bce0c5e (🏘️|✓)
     ");
@@ -1342,22 +1338,8 @@ fn dlib_rs_auto_fix() -> anyhow::Result<()> {
                     ref_name: "refs/heads/main",
                     archived: false,
                 },
-                WorkspaceStackBranch {
-                    ref_name: "refs/heads/confidence",
-                    archived: false,
-                },
             ],
             workspacecommit_relation: Outside,
-        },
-        WorkspaceStack {
-            id: 3,
-            branches: [
-                WorkspaceStackBranch {
-                    ref_name: "refs/heads/confidence",
-                    archived: false,
-                },
-            ],
-            workspacecommit_relation: Merged,
         },
     ]
     "#);

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -597,6 +597,205 @@ fn status_upstream_merge_status_integrated() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Like `status_upstream_merge_status_integrated`, but the fixture adds two
+/// extra branches (`extra-untracked`, `extra-untracked-2`) that point at `base`
+/// and are NOT registered in workspace metadata.
+///
+/// Setup (fixture `upstream-integrated-with-extra-branch`):
+/// - Branches `A` and `B` each have one commit on top of `base`.
+/// - `origin/main` has advanced past `base` with a cherry-pick of A plus
+///   a `main-advance` commit.
+/// - `extra-untracked` and `extra-untracked-2` point at `base` with no
+///   commits of their own.
+/// - Only `A` and `B` are registered in `setup_metadata`.
+///
+/// Expected: both extra branches are pruned entirely.
+#[test]
+fn status_upstream_prunes_untracked_integrated_branch() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings_slow(
+        "upstream-integrated-with-extra-branch",
+    )?;
+    // Only register A and B — `extra-untracked` is deliberately omitted.
+    env.setup_metadata(&["A", "B"])?;
+
+    env.but("status --upstream")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A] [⬆ integrated upstream]
+┊●   756ee31 A-change
+├╯
+┊
+┊╭┄h0 [B] [✓ upstream merges cleanly]
+┊●   536958e B-change
+├╯
+┊
+┊╭┄(upstream) ⏫ 2 new commits
+┊● 9354ac4 main-advance
+┊● 756ee31 A-change
+┊┊
+├╯ efc9211 [origin/main] 2000-01-02 base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    Ok(())
+}
+
+/// Same fixture as `status_upstream_prunes_untracked_integrated_branch`, but
+/// `extra-untracked` is now registered in `setup_metadata` (simulating
+/// auto-discovery), while `extra-untracked-2` remains unregistered.
+///
+/// Expected: `extra-untracked` is kept (metadata-tracked), `extra-untracked-2`
+/// is pruned (not tracked).
+#[test]
+fn status_upstream_prunes_metadata_tracked_integrated_branches() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings_slow(
+        "upstream-integrated-with-extra-branch",
+    )?;
+    // Register A, B, and extra-untracked (simulating auto-discovery).
+    // extra-untracked-2 remains unregistered.
+    env.setup_metadata(&["A", "B", "extra-untracked"])?;
+
+    env.but("status --upstream")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A] [⬆ integrated upstream]
+┊●   756ee31 A-change
+├╯
+┊
+┊╭┄h0 [B] [✓ upstream merges cleanly]
+┊●   536958e B-change
+├╯
+┊
+┊╭┄ex [extra-untracked] ○ empty (no commits)
+├╯
+┊
+┊╭┄(upstream) ⏫ 2 new commits
+┊● 9354ac4 main-advance
+┊● 756ee31 A-change
+┊┊
+├╯ efc9211 [origin/main] 2000-01-02 base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    Ok(())
+}
+
+/// Two branches with different merge bases against the target.
+///
+/// Setup (fixture `upstream-different-bases`):
+/// - `A` forks from `base` with one commit.
+/// - `origin/main` has two commits on top of `base`: `M1` and `M2`.
+/// - `B` forks from `M2` (the current `origin/main` tip) with one commit.
+///
+/// The graph walk starts from the lowest common base (`base`), so B's stack
+/// includes `M1` and `M2`. Since both stacks are metadata-tracked they are
+/// not pruned — `M1` and `M2` appear in B's stack as integrated commits,
+/// to be cleaned up by `integrate_upstream`.
+#[test]
+fn status_upstream_prunes_with_different_bases() -> anyhow::Result<()> {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings_slow("upstream-different-bases")?;
+    env.setup_metadata(&["A", "B"])?;
+
+    env.but("status --upstream")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A] [✓ upstream merges cleanly]
+┊●   756ee31 A-change
+├╯
+┊
+┊╭┄h0 [B] [✓ upstream merges cleanly]
+┊●   594a02c B-change
+┊│
+┊├┄ma [main] [⬆ integrated upstream]
+┊●   ba5149e M2
+┊●   6daac93 M1
+├╯
+┊
+┊╭┄(upstream) ⏫ 2 new commits
+┊● ba5149e M2
+┊● 6daac93 M1
+┊┊
+├╯ efc9211 [origin/main] 2000-01-02 base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    Ok(())
+}
+
+/// Simulate a `git fetch` that advances `origin/main` after the workspace
+/// commit was created.
+///
+/// Setup (fixture `upstream-advanced-after-workspace`):
+/// - `A` and `B` each have one commit on top of `base`.
+/// - The workspace commit was created when `origin/main` pointed at `base`.
+/// - A fetch then advances `origin/main` by two commits (`first-advance`,
+///   `second-advance`) that are *not* ancestors of the workspace commit.
+/// - `old-integrated` points at `first-advance` and is added to A's stack
+///   metadata (simulating auto-discovery).
+///
+/// Expected: `old-integrated` must NOT appear in any workspace stack, because
+/// its tip is only reachable from the new target (post-fetch), not from the
+/// workspace commit.
+#[test]
+fn status_upstream_advanced_target_does_not_leak_branches() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings_slow(
+        "upstream-advanced-after-workspace",
+    )?;
+    env.setup_metadata(&["A", "B"])?;
+
+    // Add old-integrated to A's stack in metadata, simulating auto-discovery
+    // before the branch was integrated upstream.
+    {
+        use but_core::RefMetadata;
+        use std::ops::DerefMut;
+        let mut meta = env.meta()?;
+        let ws_ref: &gix::refs::FullNameRef = but_core::WORKSPACE_REF_NAME.try_into()?;
+        let mut ws = meta.workspace(ws_ref)?;
+        ws.deref_mut()
+            .insert_new_segment_above_anchor_if_not_present(
+                "refs/heads/old-integrated".try_into()?,
+                "refs/heads/A".try_into()?,
+            );
+        meta.set_workspace(&ws)?;
+    }
+
+    let output = env
+        .but("status --upstream")
+        .env("NO_BG_TASKS", "1")
+        .output()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // old-integrated must NOT appear in any workspace stack
+    assert!(
+        !stdout.contains("old-integrated"),
+        "old-integrated should not appear in workspace stacks, but got:\n{stdout}"
+    );
+
+    Ok(())
+}
+
 #[test]
 fn status_upstream_merge_status_conflicted() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("upstream-conflicted")?;

--- a/crates/but/tests/fixtures/scenario/upstream-advanced-after-workspace.sh
+++ b/crates/but/tests/fixtures/scenario/upstream-advanced-after-workspace.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+# Simulate the scenario where origin/master advances (via fetch) after the
+# workspace commit was created. An old branch ref (`old-integrated`) ends up
+# on a commit that is only reachable from the new target, not from the
+# workspace commit.  It should NOT appear in any workspace stack.
+
+git-init-frozen
+
+echo base > file.txt
+git add file.txt
+git commit -m "base"
+
+# --- stack A: one local commit ---
+git checkout -b A main
+echo change-A > file-a.txt
+git add file-a.txt
+git commit -m "A-change"
+
+# --- stack B: one local commit ---
+git checkout -b B main
+echo change-B > file-b.txt
+git add file-b.txt
+git commit -m "B-change"
+
+# Set up the target to match main at "base"
+git checkout main
+setup_target_to_match_main
+
+# Create the workspace commit with A and B.
+git checkout B
+create_workspace_commit_once A B
+
+# Now simulate what happens after a fetch: main advances with new commits,
+# and an old branch ref sits on one of those commits.
+git checkout main
+echo first-advance > file-first.txt
+git add file-first.txt
+git commit -m "first-advance"
+
+# Create old-integrated branch pointing at this commit on main.
+# This simulates a branch that was merged (its tip is now on main's history).
+git branch old-integrated HEAD
+
+echo second-advance > file-second.txt
+git add file-second.txt
+git commit -m "second-advance"
+
+# Update origin/main to point to the new main (simulating fetch)
+git update-ref refs/remotes/origin/main HEAD
+
+# Go back to workspace
+git checkout gitbutler/workspace

--- a/crates/but/tests/fixtures/scenario/upstream-different-bases.sh
+++ b/crates/but/tests/fixtures/scenario/upstream-different-bases.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Two branches with different merge bases with the target.
+#
+#   A-change (A)    B-change (B)
+#       |               |
+#     base ─── M1 ─── M2 (main)
+#       ↑               ↑
+#  merge_base(A)    merge_base(B)
+#
+# The graph walk uses the combined merge base of all stack heads ("base"),
+# so B's stack will include M1 and M2 below B's own merge base (M2).
+# Pruning should truncate those extra commits from B's display.
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git-init-frozen
+
+echo base > file.txt
+git add file.txt
+git commit -m "base"
+
+git checkout -b A
+
+echo change-A > file-a.txt
+git add file-a.txt
+git commit -m "A-change"
+
+git checkout main
+echo m1 > m1.txt && git add m1.txt && git commit -m "M1"
+echo m2 > m2.txt && git add m2.txt && git commit -m "M2"
+
+git checkout -b B
+
+echo change-B > file-b.txt
+git add file-b.txt
+git commit -m "B-change"
+
+git checkout main
+setup_target_to_match_main
+
+git checkout B
+create_workspace_commit_once A B

--- a/crates/but/tests/fixtures/scenario/upstream-integrated-with-extra-branch.sh
+++ b/crates/but/tests/fixtures/scenario/upstream-integrated-with-extra-branch.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git-init-frozen
+
+echo base > file.txt
+git add file.txt
+git commit -m "base"
+
+git checkout -b A
+
+echo change-A > file-a.txt
+git add file-a.txt
+git commit -m "A-change"
+A_COMMIT=$(git rev-parse HEAD)
+
+git checkout -b B main
+
+echo change-B > file-b.txt
+git add file-b.txt
+git commit -m "B-change"
+
+# Create extra branches that sit on 'main' (at or below the target).
+# These will be used to test pruning behavior — some registered in
+# metadata (simulating auto-discovery), some not.
+git checkout -b extra-untracked main
+git checkout -b extra-untracked-2 main
+
+git checkout main
+git cherry-pick "$A_COMMIT"
+echo main-advance > file-main.txt
+git add file-main.txt
+git commit -m "main-advance"
+setup_target_to_match_main
+
+git checkout B
+create_workspace_commit_once A B extra-untracked extra-untracked-2


### PR DESCRIPTION
## Problem

The workspace projection used `find_git_merge_base` at the **segment level** to decide how many commits to keep per stack. Because a segment can contain multiple commits, the actual git merge-base commit could fall *inside* a segment rather than at its boundary. This led to imprecise pruning — either showing too many commits (including already-integrated ones) or too few.

Additionally, when branches at the bottom of a stack had zero commits above the merge base and weren't tracked in workspace metadata, they would still appear in the projection as empty noise.

## Solution

### Flag-based fork-point truncation

Add `truncate_at_fork_point(stack, graph)`, which walks each stack's commits via `commits_by_segment` and checks the graph-level `CommitFlags::Integrated` flag directly. The first commit with the flag set is the fork point — everything below it is pruned. If the very first commit is already integrated, the entire stack is left untouched (it's fully integrated, not partially).

This avoids any count-based bridging between the `Graph` and `Stack` data structures — the authoritative flag is checked in one pass.

### Pruning pipeline

`prune_integrated_segments(&mut self, graph: &Graph)` on `WorkspaceState`:

1. Skips stacks explicitly tracked in workspace metadata (they must remain visible for `integrate_upstream`)
2. Calls `truncate_at_fork_point` for each untracked stack
3. Removes empty branches that aren't tracked in the owning stack's workspace metadata
4. Drops stacks that end up completely empty

```
Before (B forks from M2):     After pruning:

  B                              B
  ├─ B-change                    └─ B-change
  ├─ M2  ← below fork point
  └─ M1  ← below fork point
```

## Updated tests

| Test | Why it changed |
|------|---------------|
| `workspace_with_stack_and_local_target` | Bottom commit below the fork point is now pruned |
| `no_overzealous_stacks_due_to_workspace_metadata` | Empty `feat-2` branch pruned — zero commits above fork point, no metadata entry |
| `single_stack_ws_insertions` | Segment indices shift due to graph allocation order changes |
| `two_stacks_many_refs` | Segment indices shift due to graph allocation order changes |
| `applied_stack_below_explicit_lower_bound` | Bottom commit at the fork point pruned from branch B |
| `dlib_rs_auto_fix` (ref_metadata_legacy) | Empty `confidence` branch with no metadata entry pruned |
| `dependencies_ignore_merge_commits` (hunk-dependency) | Pruned merge commit no longer visible; its hunk lock moves to `missed_hunks`, line shift adjusts |
| `upstreamIntegration.spec.ts` (e2e) | After syncing with an integrated branch, commits are already pruned — nothing to integrate upstream |

## New tests

| Test | What it covers |
|------|---------------|
| `integrated_merge_at_bottom_is_pruned` | Local merge of an already-integrated PR at the bottom of a stack; merge base is on the side branch of the merge |
| `status_upstream_prunes_untracked_integrated_branch` | Extra branch on `main` with no metadata entry is pruned |
| `status_upstream_prunes_metadata_tracked_integrated_branches` | Branch on `main` WITH metadata is retained as empty; one WITHOUT is pruned |
| `status_upstream_prunes_with_different_bases` | Two branches fork from different points on `main`; pruning truncates extra commits below B's own fork point |
| `status_upstream_advanced_target_does_not_leak_branches` | After origin/main advances (simulating fetch), a branch ref on the new target history must not leak into workspace stacks |