### PR TITLE
fix(but): make `but undo` restore to latest snapshot

### DIFF
--- a/crates/but/src/command/legacy/oplog.rs
+++ b/crates/but/src/command/legacy/oplog.rs
@@ -246,10 +246,11 @@ pub(crate) fn undo_last_operation(
     ctx: &mut but_ctx::Context,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
-    // Get the last two snapshots - restore to the second one back
-    let snapshots = but_api::legacy::oplog::list_snapshots(ctx, 2, None, None, None)?;
+    // As we snapshot before mutation, undoing the last operation is equivalent to restoring the
+    // latest snapshot.
+    let snapshots = but_api::legacy::oplog::list_snapshots(ctx, 1, None, None, None)?;
 
-    if snapshots.len() < 2 {
+    if snapshots.is_empty() {
         if let Some(out) = out.for_human() {
             let t = theme::get();
             writeln!(
@@ -261,8 +262,7 @@ pub(crate) fn undo_last_operation(
         return Ok(());
     }
 
-    // TODO: Why the second most recent one, and not use the most recent one?
-    let target_snapshot = &snapshots[1];
+    let target_snapshot = &snapshots[0];
 
     let target_operation = target_snapshot
         .details

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -47,6 +47,8 @@ mod squash;
 mod status;
 #[cfg(feature = "legacy")]
 mod teardown;
+#[cfg(feature = "legacy")]
+mod undo;
 
 #[cfg(feature = "legacy")]
 mod util {

--- a/crates/but/tests/but/command/undo.rs
+++ b/crates/but/tests/but/command/undo.rs
@@ -1,0 +1,146 @@
+use crate::utils::Sandbox;
+
+/// Run an undo test tests a roundtrip `mutate` -> `but undo`, and asserts that the status output is
+/// the same before and after the roundtrip.
+fn run_mutate_undo_roundtrip_test<F>(env: &Sandbox, mutate: F) -> anyhow::Result<()>
+where
+    F: FnOnce(&Sandbox) -> anyhow::Result<()>,
+{
+    // Arrange
+    let status_output_before = env.but("status").output()?;
+    mutate(env)?;
+    let status_output_after_mutate = env.but("status").output()?;
+    assert_ne!(
+        status_output_before, status_output_after_mutate,
+        "mutate must visibly change state"
+    );
+
+    // Act
+    env.but("undo").assert().success().stdout_eq(
+        r#"Undoing operation...
+  Reverting to: [..]
+✓ Undo completed successfully! Restored to snapshot:[..]
+"#,
+    );
+
+    // Assert
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(status_output_before.stdout)
+        .stderr_eq(status_output_before.stderr);
+
+    Ok(())
+}
+
+#[test]
+fn can_undo_discard() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+    let path = "new-file.txt";
+    env.file(path, "content");
+
+    let mutate = |env: &Sandbox| -> anyhow::Result<()> {
+        env.but("discard")
+            .arg(path)
+            .assert()
+            .success()
+            .stdout_eq("Successfully discarded changes to 1 item\n")
+            .stderr_eq("");
+
+        Ok(())
+    };
+
+    run_mutate_undo_roundtrip_test(&env, mutate)?;
+
+    Ok(())
+}
+
+#[test]
+fn can_undo_commit() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+    let path = "new-file.txt";
+    env.file(path, "content");
+
+    let mutate = |env: &Sandbox| -> anyhow::Result<()> {
+        env.file("new-file.txt", "content");
+
+        env.but("commit -m 'Add file'")
+            .assert()
+            .success()
+            .stdout_eq("✓ Created commit [..] on branch A\n")
+            .stderr_eq("");
+
+        Ok(())
+    };
+
+    run_mutate_undo_roundtrip_test(&env, mutate)?;
+
+    Ok(())
+}
+
+#[test]
+fn can_undo_rubbing_commits() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits")?;
+    env.setup_metadata(&["A"])?;
+
+    let mutate = |env: &Sandbox| -> anyhow::Result<()> {
+        env.but("rub")
+            .arg("9a")
+            .arg("fe")
+            .assert()
+            .success()
+            .stdout_eq("Squashed 9ac4652 → 9c8e613\n")
+            .stderr_eq("");
+
+        Ok(())
+    };
+
+    run_mutate_undo_roundtrip_test(&env, mutate)?;
+
+    Ok(())
+}
+
+#[test]
+#[ignore = "Test harness runs with cv3 feature flag, and but_core::worktree::safe_checkout_from_head does not restore the worktree file A for some reason"]
+fn can_undo_unapply() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    let mutate = |env: &Sandbox| -> anyhow::Result<()> {
+        env.but("unapply A")
+            .assert()
+            .success()
+            .stdout_eq("Unapplied stack with branches 'A' from workspace\n")
+            .stderr_eq("");
+
+        Ok(())
+    };
+
+    run_mutate_undo_roundtrip_test(&env, mutate)?;
+
+    Ok(())
+}
+
+#[test]
+#[ignore = "Test harness runs with cv3 feature flag, and but_core::worktree::safe_checkout_from_head does not remove the worktree file A for some reason"]
+fn can_undo_clean_apply() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+    env.but("unapply A").assert().success();
+
+    let mutate = |env: &Sandbox| -> anyhow::Result<()> {
+        env.but("apply A")
+            .assert()
+            .success()
+            .stdout_eq("Applied branch 'A' to workspace\n")
+            .stderr_eq("");
+
+        Ok(())
+    };
+
+    run_mutate_undo_roundtrip_test(&env, mutate)?;
+
+    Ok(())
+}

--- a/crates/but/tests/fixtures/scenario/one-stack-two-commits.sh
+++ b/crates/but/tests/fixtures/scenario/one-stack-two-commits.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git-init-frozen
+commit-file Base
+setup_target_to_match_main
+
+git checkout -b A
+commit-file first
+commit-file second
+
+create_workspace_commit_once A


### PR DESCRIPTION
We snapshot _before_ mutation, meaning that undoing the latest mutation is equivalent to restoring to the latest snapshot. `but undo` has seemingly always been restoring to the second-to-latest snapshot, which undoes two mutations rather than one.

The fix is simply to restore to the latest snapshot. This commit also adds in a bunch of tests for `but undo`, some of which are currently disabled as they do not pass with `but_core::worktree::safe_checkout_from_head` that's enabled via the `cv3` feature flag. Removing that flag from the test harness makes them pass. As this is not a problem with `but undo` itself, I'll defer fixing them for later.