### PR TITLE
ci(lite): bundle `but` with the Lite app

### DIFF
--- a/.github/workflows/lite.yml
+++ b/.github/workflows/lite.yml
@@ -42,6 +42,7 @@ jobs:
         working-directory: apps/lite
         run: pnpm version "0.0.${{ github.run_number }}" --no-git-tag-version
       - name: Build
+        shell: bash
         env:
           CHANNEL: nightly
           VERSION: "0.0.${{ github.run_number }}"
@@ -52,10 +53,27 @@ jobs:
           APPLE_TEAM_ID: ${{ runner.os == 'macOS' && secrets.APPLE_PROVIDER_SHORT_NAME || '' }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          CARGO_PROFILE_RELEASE_LTO: fat
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
+          CARGO_PROFILE_RELEASE_OPT_LEVEL: s
         run: |
+          cargo build --release -p but --features "packaged-but-distribution"
+
+          but_path=`find ./target/release -name but | head -n 1`
+          if [ -z "$but_path" ]; then
+            but_path=`find ./target/release -name but.exe | head -n 1`
+          fi
+
+          if [ -z "$but_path" ]; then
+            echo "Failed to find but binary in ./target/release"
+            exit 1
+          fi
+
+          mkdir ./apps/lite/resources/bin
+          cp "$but_path" ./apps/lite/resources/bin/
+
           pnpm --filter @gitbutler/but-sdk build
           pnpm --filter @gitbutler/lite bundle --publish always
-
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         name: Upload artifacts
         with:

--- a/apps/lite/.gitignore
+++ b/apps/lite/.gitignore
@@ -1,1 +1,2 @@
 release/
+resources/bin/

--- a/apps/lite/package.json
+++ b/apps/lite/package.json
@@ -35,6 +35,16 @@
 			"path": "lite/${os}/${arch}",
 			"channel": "${env.CHANNEL}"
 		},
+		"extraFiles": [
+			{
+				"from": "resources/bin",
+				"to": ".",
+				"filter": [
+					"but",
+					"but.exe"
+				]
+			}
+		],
 		"directories": {
 			"output": "release"
 		},

--- a/apps/lite/package.json
+++ b/apps/lite/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@gitbutler/lite",
 	"description": "A Git-compatible version control client - now with fewer calories.",
-	"productName": "gitbutler-lite",
+	"productName": "GitButler Lite",
 	"author": "GitButler Inc. <gitbutler@gitbutler.com> (https://gitbutler.com)",
 	"license": "FSL-1.1-MIT",
 	"homepage": "https://gitbutler.com",


### PR DESCRIPTION
It gets bundled in as an extra file using `extraFiles`, which ends up `Contents` on macOS and the program root for Linux and Windows distributions.

For Linux packages (e.g `deb`), the binary will be exposed without any further tweaking. This is good in the sense that it will "just work", but also has the side effect that the packages are mutually incompatible with the Tauri app's packages as they also bundle `but`.

On macOS and Windows, the executable needs to be added to PATH somehow. For macOS we may resort to the ol' "install with symlink" trick. For Windows I'm not certain at the moment.