### PR TITLE
ci(lite): add missing packaging metadata

### DIFF
--- a/apps/lite/package.json
+++ b/apps/lite/package.json
@@ -1,6 +1,9 @@
 {
 	"name": "@gitbutler/lite",
+	"description": "A Git-compatible version control client - now with fewer calories.",
 	"productName": "gitbutler-lite",
+	"author": "GitButler Inc. <gitbutler@gitbutler.com> (https://gitbutler.com)",
+	"license": "FSL-1.1-MIT",
 	"homepage": "https://gitbutler.com",
 	"private": true,
 	"version": "0.0.1",
@@ -41,21 +44,31 @@
 			"package.json"
 		],
 		"mac": {
-			"target": [
-				"dmg",
-				"zip"
-			],
+			"category": "public.app-category.developer-tools",
+			"darkModeSupport": true,
 			"hardenedRuntime": true,
 			"gatekeeperAssess": false,
 			"entitlements": "resources/entitlements.mac.plist",
-			"entitlementsInherit": "resources/entitlements.mac.inherit.plist"
+			"entitlementsInherit": "resources/entitlements.mac.inherit.plist",
+			"target": [
+				"dmg",
+				"zip"
+			]
 		},
 		"linux": {
+			"category": "Development",
 			"target": [
 				"deb",
 				"appimage"
 			],
-			"maintainer": "GitButler <gitbutler@gitbutler.com>"
+			"desktop": {
+				"entry": {
+					"Name": "GitButler Lite",
+					"Type": "Application",
+					"GenericName": "Version Control System"
+				}
+			},
+			"executableName": "gitbutler-lite"
 		},
 		"win": {
 			"target": [


### PR DESCRIPTION
Makes the distributions a little nicer with more fleshed out metadata.

Now we're just missing icons.