### PR TITLE
Add remove edge editor operation

### DIFF
--- a/crates/but-rebase/src/graph_rebase/mutate.rs
+++ b/crates/but-rebase/src/graph_rebase/mutate.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashSet;
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Context as _, Result, anyhow, bail};
 use but_core::RefMetadata;
 use petgraph::{Direction, visit::EdgeRef};
 use serde::{Deserialize, Serialize};
@@ -795,6 +795,34 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
         );
 
         Ok(())
+    }
+
+    /// Removes all edges between a child and parent, returning the orders of the removed edges.
+    pub fn remove_edges(
+        &mut self,
+        child: impl ToSelector,
+        parent: impl ToSelector,
+    ) -> Result<Vec<usize>> {
+        let child = self.history.normalize_selector(child.to_selector(self)?)?;
+        let parent = self.history.normalize_selector(parent.to_selector(self)?)?;
+
+        let edges = self
+            .graph
+            .edges_directed(child.id, Direction::Outgoing)
+            .filter_map(|e| (e.target() == parent.id).then_some(e.id()))
+            .collect::<Vec<_>>();
+
+        let mut orders = vec![];
+        for edge in edges {
+            let weight = self
+                .graph
+                .remove_edge(edge)
+                .context("BUG: Failed to remove edge")?;
+
+            orders.push(weight.order);
+        }
+
+        Ok(orders)
     }
 }
 

--- a/crates/but-rebase/tests/rebase/graph_rebase/edge.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/edge.rs
@@ -1,4 +1,4 @@
-//! These tests exercise the add_edge operation.
+//! These tests exercise the add_edge and remove_edge operations.
 
 use anyhow::Result;
 use but_graph::Graph;
@@ -84,6 +84,52 @@ fn adding_a_valid_edge_is_successful() -> Result<()> {
     ◎ refs/heads/main
     ◎ refs/tags/base
     ● 8f0d338 base
+    ╵
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn remove_edge_returns_no_orders_when_no_edges_found() -> Result<()> {
+    let (repo, mut meta) = fixture("four-commits")?;
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let c = repo.rev_parse_single("HEAD")?.detach();
+    let a = repo.rev_parse_single("HEAD~2")?.detach();
+    let c_selector = editor.select_commit(c)?;
+    let a_selector = editor.select_commit(a)?;
+
+    editor.remove_edges(c_selector, a_selector)?;
+
+    Ok(())
+}
+
+#[test]
+fn removing_an_existing_edge_returns_its_order_and_allows_readding_it() -> Result<()> {
+    let (repo, mut meta) = fixture("four-commits")?;
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let b = repo.rev_parse_single("HEAD~")?.detach();
+    let a = repo.rev_parse_single("HEAD~2")?.detach();
+    let b_selector = editor.select_commit(b)?;
+    let a_selector = editor.select_commit(a)?;
+
+    assert_eq!(editor.remove_edges(b_selector, a_selector)?, vec![0]);
+    editor.add_edge(b_selector, a_selector, 0)?;
+
+    insta::assert_snapshot!(editor.steps_ascii(), @"
+    ◎ refs/heads/main
+    ● 120e3a9 c
+    ● a96434e b
+    ● d591dfe a
+    ● 35b8235 base
     ╵
     ");
 

--- a/crates/but-rebase/tests/rebase/graph_rebase/mod.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/mod.rs
@@ -5,10 +5,10 @@ use but_meta::{
 };
 use but_testsupport::StackState;
 
-mod add_edge;
 mod cherry_pick;
 mod conflictable_restriction;
 mod disconnect;
+mod edge;
 mod editor_creation;
 mod insert;
 mod insert_segment;


### PR DESCRIPTION
The operation `disconnect_segment_from` can perform the role of a `remove_edges`, but it doesn’t inform the caller of the order of removed edge, and is probably overkill for certain operations.

In upstream integration, we want to say:

```rs
            for (child, parent) in edges_to_replace {
                let removed = editor.remove_edges(child, parent)?;
                // Add back the lowest ordered parent that was removed.
                // We could add back multiple, but it's likely unintentional
                // that there were two parents in the first place.
                if let Some(removed) = removed.iter().min() {
                    editor.add_edge(child, target_ref_selector, *removed)?;
                }
            }
```

and having a `remove_edges` operation makes the intent very clear to a reader.