### PR TITLE
faster mutations

### DIFF
--- a/crates/but-graph/src/api.rs
+++ b/crates/but-graph/src/api.rs
@@ -141,17 +141,13 @@ impl Graph {
 
         let mut out = Vec::new();
 
-        // Continue while there are non-stale segments in the queue
-        while queue.iter().any(|(_, sidx)| {
-            !flags
-                .get(sidx)
-                .is_some_and(|f| f.contains(SegmentFlags::STALE))
-        }) {
-            let Some((Reverse(generation), segment_id)) = queue.pop() else {
-                break;
-            };
+        // Process the priority queue until exhausted, skipping stale entries on pop.
+        while let Some((Reverse(generation), segment_id)) = queue.pop() {
+            let segment_flags = flags.get(&segment_id).copied().unwrap_or_default();
+            if segment_flags.contains(SegmentFlags::STALE) {
+                continue;
+            }
 
-            let segment_flags = *flags.get(&segment_id).unwrap_or(&SegmentFlags::empty());
             let mut flags_without_result = segment_flags
                 & (SegmentFlags::SEGMENT1 | SegmentFlags::SEGMENT2 | SegmentFlags::STALE);
 

--- a/crates/but-graph/tests/graph/main.rs
+++ b/crates/but-graph/tests/graph/main.rs
@@ -1,3 +1,4 @@
 mod init;
+mod merge_base;
 mod vis;
 mod workspace;

--- a/crates/but-graph/tests/graph/merge_base.rs
+++ b/crates/but-graph/tests/graph/merge_base.rs
@@ -1,0 +1,99 @@
+use but_graph::{Graph, SegmentIndex, SegmentRelation};
+use but_testsupport::graph_tree;
+
+use crate::init::{read_only_in_memory_scenario, standard_options};
+
+#[test]
+fn find_git_merge_base_handles_duplicate_queue_entries_and_redundant_bases() -> anyhow::Result<()> {
+    let (repo, meta) = read_only_in_memory_scenario("four-diamond")?;
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+
+    let merged = segment_id_by_ref_name(&graph, "refs/heads/merged")?;
+    let a = segment_id_by_ref_name(&graph, "refs/heads/A")?;
+    let c = segment_id_by_ref_name(&graph, "refs/heads/C")?;
+    let main = segment_id_by_ref_name(&graph, "refs/heads/main")?;
+
+    // merged -> (A,C) -> ... -> main causes the walk from merged to queue shared ancestors repeatedly.
+    assert_eq!(graph.find_git_merge_base(merged, main), Some(main));
+
+    // For (merged, A), both A and main are common in ancestry, but A is the nearest one.
+    assert_eq!(graph.find_git_merge_base(merged, a), Some(a));
+    assert_ne!(graph.find_git_merge_base(merged, a), Some(main));
+
+    // Independent branches under the same merge should converge at main.
+    assert_eq!(graph.find_git_merge_base(a, c), Some(main));
+
+    insta::assert_snapshot!(graph_tree(&graph), @"
+
+    └── 👉►:0[0]:merged[🌳]
+        └── ·8a6c109 (⌂|1)
+            ├── ►:1[1]:A
+            │   └── ·62b409a (⌂|1)
+            │       ├── ►:3[2]:anon:
+            │       │   └── ·592abec (⌂|1)
+            │       │       └── ►:7[3]:main
+            │       │           └── ·965998b (⌂|1)
+            │       └── ►:4[2]:B
+            │           └── ·f16dddf (⌂|1)
+            │               └── →:7: (main)
+            └── ►:2[1]:C
+                └── ·7ed512a (⌂|1)
+                    ├── ►:5[2]:anon:
+                    │   └── ·35ee481 (⌂|1)
+                    │       └── →:7: (main)
+                    └── ►:6[2]:D
+                        └── ·ecb1877 (⌂|1)
+                            └── →:7: (main)
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn relation_between_matches_merge_base_in_redundant_ancestor_case() -> anyhow::Result<()> {
+    let (repo, meta) = read_only_in_memory_scenario("four-diamond")?;
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+
+    let merged = segment_id_by_ref_name(&graph, "refs/heads/merged")?;
+    let a = segment_id_by_ref_name(&graph, "refs/heads/A")?;
+    let c = segment_id_by_ref_name(&graph, "refs/heads/C")?;
+
+    assert_eq!(graph.relation_between(a, merged), SegmentRelation::Ancestor);
+    assert_eq!(
+        graph.relation_between(merged, a),
+        SegmentRelation::Descendant
+    );
+    assert_eq!(graph.relation_between(a, c), SegmentRelation::Diverged);
+    insta::assert_snapshot!(graph_tree(&graph), @"
+
+    └── 👉►:0[0]:merged[🌳]
+        └── ·8a6c109 (⌂|1)
+            ├── ►:1[1]:A
+            │   └── ·62b409a (⌂|1)
+            │       ├── ►:3[2]:anon:
+            │       │   └── ·592abec (⌂|1)
+            │       │       └── ►:7[3]:main
+            │       │           └── ·965998b (⌂|1)
+            │       └── ►:4[2]:B
+            │           └── ·f16dddf (⌂|1)
+            │               └── →:7: (main)
+            └── ►:2[1]:C
+                └── ·7ed512a (⌂|1)
+                    ├── ►:5[2]:anon:
+                    │   └── ·35ee481 (⌂|1)
+                    │       └── →:7: (main)
+                    └── ►:6[2]:D
+                        └── ·ecb1877 (⌂|1)
+                            └── →:7: (main)
+    ");
+
+    Ok(())
+}
+
+fn segment_id_by_ref_name(graph: &Graph, name: &str) -> anyhow::Result<SegmentIndex> {
+    let full_name: gix::refs::FullName = name.try_into()?;
+    graph
+        .named_segment_by_ref_name(full_name.as_ref())
+        .map(|s| s.id)
+        .ok_or_else(|| anyhow::anyhow!("missing segment for {name}"))
+}


### PR DESCRIPTION
Speed up mutations by:
1. Skipping on the remote refs correlation work that’s not needed for mutations.
2. Optimize a hot loop when finding the git merge base for segments, so that it runs faster.

### Result
Moving one commit went from **1.49001625s** to **124.636ms**

closes GB-1365