### PR TITLE
Fix unapply introducing uncommitted changes with integrated commits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3940,7 +3940,6 @@ dependencies = [
  "git2",
  "git2-hooks",
  "gitbutler-branch",
- "gitbutler-cherry-pick",
  "gitbutler-commit",
  "gitbutler-git",
  "gitbutler-operating-modes",

--- a/crates/gitbutler-branch-actions/Cargo.toml
+++ b/crates/gitbutler-branch-actions/Cargo.toml
@@ -43,7 +43,6 @@ gitbutler-reference.workspace = true
 gitbutler-commit.workspace = true
 gitbutler-url.workspace = true
 gitbutler-operating-modes.workspace = true
-gitbutler-cherry-pick.workspace = true
 gitbutler-stack.workspace = true
 gitbutler-workspace.workspace = true
 gitbutler-project.workspace = true

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_removal.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_removal.rs
@@ -2,10 +2,8 @@ use anyhow::{Context as _, Result};
 use but_core::{DiffSpec, RepositoryExt};
 use but_ctx::access::RepoExclusive;
 use but_oxidize::ObjectIdExt;
-use gitbutler_cherry_pick::GixRepositoryExt as _;
 use gitbutler_repo_actions::RepoActionsExt;
 use gitbutler_stack::StackId;
-use gitbutler_workspace::workspace_base;
 use tracing::instrument;
 
 use super::{BranchManager, checkout_remerged_head};
@@ -67,21 +65,20 @@ impl BranchManager<'_> {
             }
             res?
         } else {
-            // On v3 we want to take the `current_wd_tree` and try to extract
-            // whatever branch we want to unapply. There are a handful of ways
-            // to achieve this, including calculating the inverse diff and
-            // applying that.
+            // We want to transition the worktree from its current state (all
+            // stacks merged + uncommitted edits) to the new state (remaining
+            // stacks only), while preserving any uncommitted worktree changes.
             //
-            // We can however do more or less what `git revert` does, and
-            // perform a three-way merge where the `ours` side is the cwdt, the
-            // `theirs` side is the workspace root, and the `base` is the head
-            // of the branch we want to unapply.
+            // The correct 3-way merge for this is:
+            //   base  = current workspace commit tree (all stacks merged)
+            //   ours  = cwdt (workspace + uncommitted changes)
+            //   theirs = remerged tree (target + remaining stacks only)
             //
-            // In order to handle locked files, I'm going to choose to
-            // resolve conflicts in the favor of `ours` (the cwdt) which will
-            // keep any locked changes in the cwdt.
+            // For files with no uncommitted edits: base==ours, so theirs wins
+            // → cleanly transitions to the new workspace state.
+            // For files with uncommitted edits: base≠ours, and on conflict
+            // FileFavor::Ours preserves the user's uncommitted work.
 
-            // dump current assignments into a WIP commit
             let merge_options = repo
                 .tree_merge_options()?
                 .with_file_favor(Some(gix::merge::tree::FileFavor::Ours))
@@ -89,16 +86,21 @@ impl BranchManager<'_> {
 
             #[expect(deprecated)]
             let cwdt = repo.create_wd_tree(0)?;
-            let workspace_base = repo
-                .find_commit(workspace_base(self.ctx, perm.read_permission())?)?
-                .tree_id()?;
-            let commit = repo.find_commit(stack.head_oid(self.ctx)?)?;
-            let stack_head = repo.find_real_tree(&commit, Default::default())?;
+            let (remerged_tree_id, _, _) =
+                but_workspace::legacy::remerged_workspace_tree_v2(self.ctx, &repo)?;
+
+            // The current workspace commit tree represents the committed state
+            // with all stacks merged (before this unapply). Using it as the
+            // merge base means only uncommitted changes show up as "ours" diffs.
+            let current_workspace_tree = {
+                let mut head = repo.head()?;
+                head.peel_to_commit()?.tree_id()?.detach()
+            };
 
             let mut merge = repo.merge_trees(
-                stack_head,
+                current_workspace_tree,
                 cwdt,
-                workspace_base,
+                remerged_tree_id,
                 repo.default_merge_labels(),
                 merge_options,
             )?;

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/unapply_without_saving_virtual_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/unapply_without_saving_virtual_branch.rs
@@ -49,3 +49,177 @@ fn should_unapply_diff() {
         .collect::<Vec<_>>();
     assert!(!refnames.contains(&"refs/gitbutler/name".to_string()));
 }
+
+/// Regression test: unapplying a stack must not re-introduce files from an old
+/// `workspace_base` ancestor that are absent from both the current workspace and
+/// the unapplied stack's head tree.
+///
+/// Setup:
+///   T1  (old target) — has `ghost.txt`
+///   T2  (new target) — `ghost.txt` deleted by target itself
+///   Stack R (remaining) — branched from T1, *explicitly* deletes `ghost.txt`,
+///                         so R_head tree does NOT contain it. Because R branches
+///                         from T1, merge_base(R_head, T2) = T1 (has `ghost.txt`).
+///   Stack U (unapplied) — branched from T2, never touches `ghost.txt`.
+///
+/// With the old code (base=U_head, theirs=workspace_base=T1):
+///   - `ghost.txt`: base=absent, ours=absent, theirs=present → ADDED by merge ← BUG
+///   - The workspace commit (T2 + R) correctly has no `ghost.txt`, so git status
+///     reports it as untracked—a spurious uncommitted change.
+///
+/// With the fix (base=HEAD=workspace_commit, theirs=remerged=T2+R):
+///   - All three agree `ghost.txt` is absent → correctly absent after unapply.
+#[test]
+fn unapply_with_integrated_commits_no_spurious_uncommitted_changes() {
+    // cv3 = false routes unapply through the 3-way merge else-branch, which is
+    // where the bug lived (base=stack_head, theirs=workspace_base ancestor).
+    let Test { repo, ctx, .. } = &mut Test::new_with_settings(|settings| {
+        settings.feature_flags.cv3 = false;
+    });
+
+    // ── T1: old target has ghost.txt ─────────────────────────────────────────
+    std::fs::write(repo.path().join("ghost.txt"), "I should not come back").unwrap();
+    repo.commit_all("T1: add ghost.txt");
+    repo.push();
+
+    let mut guard = ctx.exclusive_worktree_access();
+    gitbutler_branch_actions::set_base_branch(
+        ctx,
+        &"refs/remotes/origin/master".parse().unwrap(),
+        guard.write_permission(),
+    )
+    .unwrap();
+    drop(guard);
+
+    // ── Stack R: branched from T1, explicitly deletes ghost.txt ──────────────
+    // R's HEAD tree must NOT contain ghost.txt so the workspace commit is clean,
+    // but merge_base(R_head, T2) will still resolve to T1 (which has ghost.txt).
+    std::fs::remove_file(repo.path().join("ghost.txt")).unwrap();
+    std::fs::write(repo.path().join("r-file.txt"), "stack R work").unwrap();
+    let mut guard = ctx.exclusive_worktree_access();
+    let stack_r = gitbutler_branch_actions::create_virtual_branch(
+        ctx,
+        &BranchCreateRequest {
+            name: Some("stack-r".to_string()),
+            ..Default::default()
+        },
+        guard.write_permission(),
+    )
+    .unwrap();
+    drop(guard);
+    create_commit(ctx, stack_r.id, "stack-r: delete ghost.txt, add r-file.txt").unwrap();
+
+    // ── T2: advance remote master, deleting ghost.txt ────────────────────────
+    {
+        let remote_url = repo
+            .local_repo
+            .find_remote("origin")
+            .unwrap()
+            .url()
+            .unwrap()
+            .to_string();
+        let remote_path = repo.path().parent().unwrap().join(&remote_url);
+        let remote_repo = git2::Repository::open_bare(&remote_path).unwrap();
+
+        let parent = remote_repo
+            .find_reference("refs/heads/master")
+            .unwrap()
+            .peel_to_commit()
+            .unwrap();
+
+        // T2 tree: preserve the parent tree and remove only ghost.txt.
+        let parent_tree = parent.tree().unwrap();
+        let mut tb = remote_repo.treebuilder(Some(&parent_tree)).unwrap();
+        tb.remove("ghost.txt").unwrap();
+        let tree_oid = tb.write().unwrap();
+        let tree = remote_repo.find_tree(tree_oid).unwrap();
+        let sig = git2::Signature::now("test", "test@test.com").unwrap();
+        remote_repo
+            .commit(
+                Some("refs/heads/master"),
+                &sig,
+                &sig,
+                "T2: delete ghost.txt",
+                &tree,
+                &[&parent],
+            )
+            .unwrap();
+    }
+    repo.local_repo
+        .find_remote("origin")
+        .unwrap()
+        .fetch(
+            &["refs/heads/master:refs/remotes/origin/master"],
+            None,
+            None,
+        )
+        .unwrap();
+
+    // Advance the stored target SHA to T2 WITHOUT rebasing stack R.
+    // Stack R remains branched from T1, so workspace_base = merge_base(R_head, T2) = T1.
+    let t2_sha = {
+        let oid = repo
+            .local_repo
+            .find_reference("refs/remotes/origin/master")
+            .unwrap()
+            .target()
+            .unwrap();
+        let bytes: [u8; 20] = oid.as_bytes().try_into().unwrap();
+        gix::ObjectId::Sha1(bytes)
+    };
+    {
+        let mut guard = ctx.exclusive_worktree_access();
+        let mut meta = ctx.legacy_meta_mut(guard.write_permission()).unwrap();
+        let mut target = meta.data().default_target.clone().unwrap();
+        target.sha = t2_sha;
+        meta.set_default_target(target).unwrap();
+    }
+
+    // ── Stack U: created after T2, never touches ghost.txt ───────────────────
+    std::fs::write(repo.path().join("u-file.txt"), "stack U work").unwrap();
+    let mut guard = ctx.exclusive_worktree_access();
+    let stack_u = gitbutler_branch_actions::create_virtual_branch(
+        ctx,
+        &BranchCreateRequest {
+            name: Some("stack-u".to_string()),
+            ..Default::default()
+        },
+        guard.write_permission(),
+    )
+    .unwrap();
+    drop(guard);
+    create_commit(ctx, stack_u.id, "stack-u: add u-file.txt").unwrap();
+
+    // ── Unapply stack U ───────────────────────────────────────────────────────
+    // With the old code: workspace_base = T1 tree (has ghost.txt).
+    // Since neither U_head nor cwdt contain ghost.txt, the merge adds it. BUG.
+    // With the fix: base = HEAD (no ghost.txt), theirs = remerged T2+R (no ghost.txt). OK.
+    let stacks = stack_details(ctx);
+    let stack_u_id = stacks
+        .iter()
+        .find(|s| s.1.derived_name == "stack-u")
+        .map(|s| s.0)
+        .unwrap();
+
+    let mut guard = ctx.exclusive_worktree_access();
+    gitbutler_branch_actions::unapply_stack(ctx, guard.write_permission(), stack_u_id, Vec::new())
+        .unwrap();
+    drop(guard);
+
+    // No uncommitted changes should appear — ghost.txt must not be re-introduced.
+    let mut opts = git2::StatusOptions::new();
+    opts.include_untracked(true);
+    let statuses = repo.local_repo.statuses(Some(&mut opts)).unwrap();
+    let status_entries: Vec<_> = statuses
+        .iter()
+        .map(|e| format!("{}: {:?}", e.path().unwrap_or("?"), e.status()))
+        .collect();
+    assert!(
+        statuses.is_empty(),
+        "Expected no uncommitted changes after unapplying stack, but got: {status_entries:?}"
+    );
+    assert!(
+        !repo.path().join("ghost.txt").exists(),
+        "ghost.txt should not have been re-introduced by the unapply merge"
+    );
+}


### PR DESCRIPTION
## Summary

When you unapply a stack, files that have nothing to do with that stack can appear as uncommitted changes in your workspace. For example:

1. You have two stacks: **Stack A** and **Stack B**
2. Stack A was branched from an older version of `master` that contained a file (`ghost.txt`) which has since been deleted upstream
3. You unapply Stack B (which never touched `ghost.txt`)
4. **Bug:** `ghost.txt` suddenly appears as an untracked file in your workspace

This happens because the old unapply code used an ancestor commit (`workspace_base`) as the merge target. That ancestor still contained files that were deleted in the current target, so the 3-way merge re-introduced them.

## Fix

Replace both the merge base and "theirs" in the unapply 3-way merge:

- **base**: workspace commit tree (HEAD) instead of the unapplied stack's head tree
- **theirs**: remerged tree (target + remaining stacks) instead of the old `workspace_base` ancestor

This way, files with no uncommitted edits satisfy `base == ours`, so `theirs` (the correct new state) wins cleanly. Files with uncommitted edits have `base ≠ ours` and are preserved via `FileFavor::Ours`.

## Test plan

- [x] Added regression test that sets up the exact ghost-file scenario and asserts no spurious uncommitted changes after unapply
- [x] Verified test **fails** against the old code (`ghost.txt: Status(WT_NEW)`)
- [x] Verified test **passes** with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)