### PR TITLE
Fix update-base error when branches are fully integrated

### DIFF
--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::{Context as _, Result, bail};
 use bstr::ByteSlice;
@@ -638,9 +638,37 @@ pub(crate) fn integrate_upstream(
                 continue;
             };
 
-            // Update the branch heads
+            let delete_local_refs = resolutions
+                .iter()
+                .find(|r| r.stack_id == *stack_id)
+                .map(|r| r.delete_integrated_branches)
+                .unwrap_or(false);
+
+            // Archive integrated heads before updating branch heads.
+            // `for_archival` captures branches that lost all commits during
+            // integrated-commit filtering. We must archive these before
+            // calling `set_heads_from_rebase_output`, which validates that
+            // rebase references match exactly the non-archived heads.
+            let stack_branches_deleted =
+                stack.archive_integrated_heads(ctx, &repo, for_archival, delete_local_refs)?;
+            deleted_branches.extend(stack_branches_deleted);
+
+            // Update the branch heads, filtering out references for archived
+            // heads so the validation in `set_all_heads` sees a consistent set.
             if let Some(output) = rebase_output {
-                stack.set_heads_from_rebase_output(ctx, output.references.clone())?;
+                let archived_names: HashSet<&str> = stack
+                    .heads
+                    .iter()
+                    .filter(|h| h.archived)
+                    .map(|h| h.name().as_str())
+                    .collect();
+                let active_references: Vec<_> = output
+                    .references
+                    .iter()
+                    .filter(|r| !archived_names.contains(r.reference.to_string().as_str()))
+                    .cloned()
+                    .collect();
+                stack.set_heads_from_rebase_output(ctx, active_references)?;
             }
 
             // Dissociate closed reviews
@@ -654,16 +682,6 @@ pub(crate) fn integrate_upstream(
             }
 
             stack.set_stack_head(&mut virtual_branches_state, &repo, *head)?;
-
-            let delete_local_refs = resolutions
-                .iter()
-                .find(|r| r.stack_id == *stack_id)
-                .map(|r| r.delete_integrated_branches)
-                .unwrap_or(false);
-
-            let stack_branches_deleted =
-                stack.archive_integrated_heads(ctx, &repo, for_archival, delete_local_refs)?;
-            deleted_branches.extend(stack_branches_deleted);
         }
 
         {

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/apply_virtual_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/apply_virtual_branch.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use but_forge::ForgeReview;
 use gitbutler_branch::BranchCreateRequest;
 use gitbutler_branch_actions::upstream_integration::{
-    BranchStatus, StackStatuses, UpstreamTreeStatus,
+    BranchStatus, Resolution, ResolutionApproach, StackStatuses, UpstreamTreeStatus,
 };
 use gitbutler_reference::Refname;
 
@@ -588,4 +588,156 @@ fn upstream_integration_status_with_different_branch_pr() {
         }
         StackStatuses::UpToDate => panic!("Expected UpdatesRequired status"),
     }
+}
+
+/// Regression test: when a stack has a branch whose commits are fully integrated
+/// upstream (part of the new base), `integrate_upstream` should succeed and archive
+/// that branch — not fail with "The new head names do not match the current heads".
+#[test]
+fn integrate_upstream_with_fully_integrated_branch_in_stack() {
+    let Test { repo, ctx, .. } = &mut Test::default();
+
+    // Setup remote: create an initial commit, then add a second commit that
+    // includes the same change branch1 will have, making branch1 "integrated".
+    // Reset local back to the initial commit so there's an upstream delta.
+    {
+        fs::write(repo.path().join("file.txt"), "initial").unwrap();
+        let first = repo.commit_all("initial commit");
+
+        fs::write(repo.path().join("branch1-file.txt"), "branch1 work").unwrap();
+        repo.commit_all("upstream: merge branch1");
+        repo.push();
+        repo.reset_hard(Some(first));
+    }
+
+    // Set the base branch
+    let mut guard = ctx.exclusive_worktree_access();
+    gitbutler_branch_actions::set_base_branch(
+        ctx,
+        &"refs/remotes/origin/master".parse().unwrap(),
+        guard.write_permission(),
+    )
+    .unwrap();
+    drop(guard);
+
+    // Create a stack with two branches: branch1 (bottom) and branch3 (top)
+    let stack_id = {
+        let mut guard = ctx.exclusive_worktree_access();
+        let stack_entry = gitbutler_branch_actions::create_virtual_branch(
+            ctx,
+            &BranchCreateRequest {
+                name: Some("branch1".to_string()),
+                ..Default::default()
+            },
+            guard.write_permission(),
+        )
+        .unwrap();
+        drop(guard);
+
+        // branch1 commit — same content as what's upstream
+        fs::write(repo.path().join("branch1-file.txt"), "branch1 work").unwrap();
+        super::create_commit(ctx, stack_entry.id, "branch1: first commit").unwrap();
+
+        // Add branch3 on top of the stack with different work
+        gitbutler_branch_actions::stack::create_branch(
+            ctx,
+            stack_entry.id,
+            gitbutler_branch_actions::stack::CreateSeriesRequest {
+                name: "branch3".to_string(),
+                target_patch: None,
+                preceding_head: None,
+            },
+        )
+        .unwrap();
+
+        fs::write(repo.path().join("branch3-file.txt"), "branch3 work").unwrap();
+        super::create_commit(ctx, stack_entry.id, "branch3: first commit").unwrap();
+
+        stack_entry.id
+    };
+
+    // Verify the stack has two branches
+    let stacks = stack_details(ctx);
+    assert_eq!(stacks.len(), 1);
+    assert_eq!(stacks[0].1.branch_details.len(), 2);
+
+    // Mark branch1 as integrated via a merged review
+    let branch1_commit = stacks[0].1.branch_details[1].commits[0].id.to_string();
+    let mut review_map = HashMap::new();
+    review_map.insert(
+        "branch1".to_string(),
+        ForgeReview {
+            html_url: "https://github.com/test/repo/pull/1".to_string(),
+            number: 1,
+            title: "Branch1 PR".to_string(),
+            body: None,
+            author: None,
+            labels: vec![],
+            draft: false,
+            source_branch: "branch1".to_string(),
+            target_branch: "master".to_string(),
+            sha: branch1_commit,
+            created_at: Some("2024-01-01T00:00:00Z".to_string()),
+            modified_at: Some("2024-01-02T00:00:00Z".to_string()),
+            merged_at: Some("2024-01-03T00:00:00Z".to_string()),
+            closed_at: None,
+            repository_ssh_url: None,
+            repository_https_url: None,
+            repo_owner: None,
+            reviewers: vec![],
+            unit_symbol: "#".to_string(),
+            last_sync_at: chrono::NaiveDateTime::parse_from_str(
+                "2024-01-04 23:56:04",
+                "%Y-%m-%d %H:%M:%S",
+            )
+            .unwrap(),
+        },
+    );
+
+    // Verify branch1 shows as integrated in statuses
+    let statuses =
+        gitbutler_branch_actions::upstream_integration_statuses(ctx, None, &review_map).unwrap();
+    match &statuses {
+        StackStatuses::UpdatesRequired {
+            statuses,
+            worktree_conflicts: _,
+        } => {
+            let branch1_status = statuses[0]
+                .1
+                .branch_statuses
+                .iter()
+                .find(|s| s.name == "branch1")
+                .expect("branch1 should be in statuses");
+            assert_eq!(
+                branch1_status.status,
+                BranchStatus::Integrated,
+                "branch1 should be marked as integrated"
+            );
+        }
+        StackStatuses::UpToDate => panic!("Expected UpdatesRequired"),
+    }
+
+    // Integrate upstream with a Rebase resolution for this stack.
+    // Before the fix, this would fail with:
+    //   "The new head names do not match the current heads"
+    // because branch1 (fully integrated) is pruned from the rebase output
+    // but was not yet archived when set_heads_from_rebase_output validated.
+    let resolutions = vec![Resolution {
+        stack_id,
+        approach: ResolutionApproach::Rebase,
+        delete_integrated_branches: false,
+    }];
+
+    gitbutler_branch_actions::integrate_upstream(ctx, &resolutions, None, &review_map)
+        .expect("integrate_upstream should succeed when a branch in the stack is fully integrated");
+
+    // After integration, branch1 should be archived and branch3 should remain
+    let stacks = stack_details(ctx);
+    assert_eq!(stacks.len(), 1, "stack should still exist");
+    assert_eq!(
+        stacks[0].1.branch_details.len(),
+        1,
+        "only branch3 should remain visible"
+    );
+    assert_eq!(stacks[0].1.branch_details[0].name, "branch3");
 }


### PR DESCRIPTION
## Summary

Fixes the error `The new head names do not match the current heads` that occurs when updating the workspace base after branches have been fully integrated upstream.

## Problem

`set_all_heads` validates that the rebase output references match exactly the non-archived heads in a stack. When a branch is fully integrated, the rebaser prunes it from its output since there are no remaining commits. However, archival was happening *after* this validation, so the fully-integrated branch was still counted as a non-archived head — causing a mismatch between the head names and the rebase references.

## Fix

- Move branch archival to run **before** `set_heads_from_rebase_output`
- Detect heads that are absent from the rebase output (i.e. branches already fully integrated with no remaining commits) and include them in the archival set

This ensures that by the time validation runs, fully-integrated branches are already marked as archived and excluded from the comparison.