### PR TITLE
Extract expectVisible Playwright utility and increase test timeouts

### DIFF
--- a/e2e/blackbox/tests/add-project.spec.ts
+++ b/e2e/blackbox/tests/add-project.spec.ts
@@ -14,11 +14,6 @@ describe("Project", () => {
 		await findAndClick('button[data-testid="add-local-project"]');
 		// TODO: Remove next click when v3 is default!
 		await findAndClick('button[data-testid="set-base-branch"]');
-
-		const workspaceButton = await $(
-			'button[data-testid="navigation-workspace-button"]',
-		).getElement();
-
-		await expect(workspaceButton).toExist();
+		await findElement('button[data-testid="navigation-workspace-button"]');
 	});
 });

--- a/e2e/blackbox/utils.ts
+++ b/e2e/blackbox/utils.ts
@@ -12,13 +12,13 @@ export async function spawnAndLog(command: string, args: string[]) {
 
 export async function findAndClick(selector: string) {
 	const element = $(selector);
-	await element.waitForClickable({ timeout: 15000 });
+	await element.waitForClickable({ timeout: 30000 });
 	await element.click();
 }
 
 export async function findElement(selector: string) {
 	const element = $(selector);
-	await element.waitForExist({ timeout: 15000 });
+	await element.waitForExist({ timeout: 30000 });
 	return await element.getElement();
 }
 

--- a/e2e/playwright/src/util.ts
+++ b/e2e/playwright/src/util.ts
@@ -1,5 +1,5 @@
 import { TestId } from "@gitbutler/ui/utils/testIds";
-import { type Locator, type Page } from "@playwright/test";
+import { expect, type Locator, type Page } from "@playwright/test";
 
 type TestIdValues = `${TestId}`;
 
@@ -119,6 +119,15 @@ export async function textEditorFillByTestId(page: Page, testId: TestIdValues, v
 	return element;
 }
 
+/**
+ * Wait for a locator to become visible with a generous timeout.
+ * Use this when an async backend operation (commit, rebase, push, etc.)
+ * must complete before the element appears.
+ */
+export async function expectVisible(locator: Locator, timeout = 10_000) {
+	await expect(locator).toBeVisible({ timeout });
+}
+
 export async function sleep(ms: number): Promise<void> {
 	return await new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -127,7 +136,7 @@ export async function sleep(ms: number): Promise<void> {
  * Wait until an element's bounding box stops changing between animation frames.
  * Useful for popups positioned by Floating UI that take a few frames to settle.
  */
-export async function waitForElementToStabilize(page: Page, locator: Locator, timeout = 5000) {
+export async function waitForElementToStabilize(page: Page, locator: Locator, timeout = 10000) {
 	const start = Date.now();
 	let lastBox = await locator.boundingBox();
 	while (Date.now() - start < timeout) {

--- a/e2e/playwright/tests/commitHooks.spec.ts
+++ b/e2e/playwright/tests/commitHooks.spec.ts
@@ -1,6 +1,12 @@
 import { getBaseURL, getButlerPort, type GitButler, startGitButler } from "../src/setup.ts";
 import { test } from "../src/test.ts";
-import { clickByTestId, fillByTestId, getByTestId, waitForTestId } from "../src/util.ts";
+import {
+	clickByTestId,
+	expectVisible,
+	fillByTestId,
+	getByTestId,
+	waitForTestId,
+} from "../src/util.ts";
 import { expect, type Page } from "@playwright/test";
 
 let gitbutler: GitButler;
@@ -78,7 +84,7 @@ test("should show commit-msg hook rejection error", async ({ page, context }, te
 
 	// Should show an error toast about the hook rejection
 	const toastMessage = getByTestId(page, "toast-info-message");
-	await expect(toastMessage).toBeVisible({ timeout: 5000 });
+	await expectVisible(toastMessage);
 	await expect(toastMessage).toContainText("REJECT");
 });
 
@@ -125,7 +131,7 @@ test("should show modified commit message from commit-msg hook", async ({
 	// The commit should be created successfully
 	// Wait for the commit to appear in the commit list
 	const commitRow = getByTestId(page, "commit-row").first();
-	await expect(commitRow).toBeVisible({ timeout: 5000 });
+	await expectVisible(commitRow);
 
 	// The commit title should include the [MODIFIED] prefix added by the hook
 	await expect(commitRow).toContainText("[MODIFIED]");
@@ -166,7 +172,7 @@ test("should allow commits when commit-msg hook passes", async ({ page, context 
 
 	// The commit should be created successfully
 	const commitRow = getByTestId(page, "commit-row").first();
-	await expect(commitRow).toBeVisible({ timeout: 5000 });
+	await expectVisible(commitRow);
 	await expect(commitRow).toContainText("A normal commit message");
 });
 
@@ -213,7 +219,7 @@ test("should reject commit when pre-commit hook fails", async ({ page, context }
 
 	// Should show an error toast about the pre-commit hook rejection
 	const toastMessage = getByTestId(page, "toast-info-message");
-	await expect(toastMessage).toBeVisible({ timeout: 5000 });
+	await expectVisible(toastMessage);
 	await expect(toastMessage).toContainText("FORBIDDEN");
 });
 
@@ -256,7 +262,7 @@ test("should allow commit when pre-commit hook passes", async ({ page, context }
 
 	// The commit should be created successfully (pre-commit hook passed)
 	const commitRow = getByTestId(page, "commit-row").first();
-	await expect(commitRow).toBeVisible({ timeout: 10000 });
+	await expectVisible(commitRow);
 	await expect(commitRow).toContainText("Adding allowed file");
 });
 
@@ -295,7 +301,7 @@ test("should show post-commit hook success", async ({ page, context }, testInfo)
 
 	// The commit should be created successfully
 	const commitRow = getByTestId(page, "commit-row").first();
-	await expect(commitRow).toBeVisible({ timeout: 10000 });
+	await expectVisible(commitRow);
 	await expect(commitRow).toContainText("Testing post-commit hook");
 
 	// Wait for post-commit hook to execute (it runs in background)
@@ -344,7 +350,7 @@ test("should show post-commit hook failure but commit still created", async ({
 
 	// The commit should be created (pre-commit passed)
 	const commitRow = getByTestId(page, "commit-row").first();
-	await expect(commitRow).toBeVisible({ timeout: 10000 });
+	await expectVisible(commitRow);
 	await expect(commitRow).toContainText("Trigger post-commit failure");
 
 	// Wait for post-commit hook to run and fail (it runs in background)

--- a/e2e/playwright/tests/dropResult.spec.ts
+++ b/e2e/playwright/tests/dropResult.spec.ts
@@ -1,6 +1,12 @@
 import { getBaseURL, type GitButler, startGitButler } from "../src/setup.ts";
 import { test } from "../src/test.ts";
-import { clickByTestId, dragAndDropByLocator, getByTestId, waitForTestId } from "../src/util.ts";
+import {
+	clickByTestId,
+	dragAndDropByLocator,
+	expectVisible,
+	getByTestId,
+	waitForTestId,
+} from "../src/util.ts";
 import { expect } from "@playwright/test";
 import { writeFileSync } from "fs";
 
@@ -75,7 +81,7 @@ test("should show commit-failed modal when amending causes a conflict", async ({
 		.getByTestId("uncommitted-changes-file-list")
 		.getByTestId("file-list-item")
 		.filter({ hasText: "a_file" });
-	await expect(fileLocator).toBeVisible({ timeout: 5000 });
+	await expectVisible(fileLocator);
 
 	// Drag the uncommitted file onto the FIRST commit (bottom one).
 	// "Change juliet to JULIET-FIRST" is the first commit.
@@ -89,7 +95,7 @@ test("should show commit-failed modal when amending causes a conflict", async ({
 	// The commit-failed modal should appear because rebasing the second commit
 	// on top of the amended first commit causes a cherry-pick merge conflict.
 	const modal = getByTestId(page, "global-modal-commit-failed");
-	await expect(modal).toBeVisible({ timeout: 10000 });
+	await expectVisible(modal);
 
 	// The modal should indicate that some changes were not committed
 	await expect(modal).toContainText(/changes were not committed|Failed to create commit/);
@@ -134,7 +140,7 @@ test("should squash commits via drag-and-drop without errors", async ({
 	// because local history changed. The upstream action row confirms
 	// the squash was successful.
 	const upstreamSection = getByTestId(page, "upstream-commits-commit-action");
-	await expect(upstreamSection).toBeVisible({ timeout: 15_000 });
+	await expectVisible(upstreamSection, 15_000);
 
 	// The first commit should still be present (it was not part of the squash)
 	const remainingFirst = getByTestId(page, "commit-row").filter({

--- a/e2e/playwright/tests/multiCommitSelection.spec.ts
+++ b/e2e/playwright/tests/multiCommitSelection.spec.ts
@@ -1,6 +1,11 @@
 import { getBaseURL, type GitButler, startGitButler } from "../src/setup.ts";
 import { test } from "../src/test.ts";
-import { getByTestId, waitForElementToStabilize, waitForTestId } from "../src/util.ts";
+import {
+	expectVisible,
+	getByTestId,
+	waitForElementToStabilize,
+	waitForTestId,
+} from "../src/util.ts";
 import { expect, type Page } from "@playwright/test";
 
 let gitbutler: GitButler;
@@ -228,7 +233,7 @@ test("should squash 3 selected commits via context menu", async ({ page, context
 	// because local history changed. The "Upstream has new commits" indicator confirms
 	// the squash was successful.
 	const upstreamSection = page.locator("text=Upstream has new commits");
-	await expect(upstreamSection).toBeVisible({ timeout: 15_000 });
+	await expectVisible(upstreamSection, 15_000);
 
 	// The first commit should still be present (it was not part of the squash)
 	const remainingFirst = getByTestId(page, "commit-row").filter({
@@ -268,7 +273,7 @@ test("should uncommit 3 selected commits via context menu", async ({ page, conte
 
 	// After uncommitting, the uncommitted changes should contain the files
 	const uncommittedHeader = getByTestId(page, "uncommitted-changes-header");
-	await expect(uncommittedHeader).toBeVisible({ timeout: 15_000 });
+	await expectVisible(uncommittedHeader, 15_000);
 
 	// The first commit should still exist (it was not selected)
 	const remainingFirst = getByTestId(page, "commit-row").filter({


### PR DESCRIPTION
Add a shared expectVisible(locator, timeout?) helper to the Playwright
test utilities, replacing hardcoded toBeVisible({ timeout }) calls
across commitHooks, dropResult, and multiCommitSelection tests. Also
bump the default wait-for-visible timeout from 5s to 10s and the
waitForElementToStabilize timeout to 10s.