### PR TITLE
remove `first_parent_commit_ids_until_with_graph` as `llvm-project` couldn't load

### DIFF
--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -12,7 +12,7 @@ use but_oxidize::ObjectIdExt;
 use gitbutler_git::GitContextExt as _;
 use gitbutler_project::FetchResult;
 use gitbutler_reference::{Refname, RemoteRefname};
-use gitbutler_repo::first_parent_commit_ids_until_with_graph;
+use gitbutler_repo::first_parent_commit_ids_until;
 use gitbutler_stack::{Stack, Target, canned_branch_name};
 use serde::Serialize;
 use tracing::instrument;
@@ -365,26 +365,23 @@ pub(crate) fn target_to_base_branch(ctx: &Context, target: &Target) -> Result<Ba
         .merge_base_with_graph(target.sha, target_commit_id, &mut graph)?
         .detach();
 
-    let diverged_ahead =
-        first_parent_commit_ids_until_with_graph(repo, target.sha, merge_base, &mut graph)
-            .context("failed to get fork point")?;
-    let diverged_behind =
-        first_parent_commit_ids_until_with_graph(repo, target_commit_id, merge_base, &mut graph)
-            .context("failed to get fork point")?;
+    let diverged_ahead = first_parent_commit_ids_until(repo, target.sha, merge_base)
+        .context("failed to get fork point")?;
+    let diverged_behind = first_parent_commit_ids_until(repo, target_commit_id, merge_base)
+        .context("failed to get fork point")?;
 
     // if there are commits ahead of the base branch consider it diverged
     let diverged = !diverged_ahead.is_empty();
 
     // gather a list of commits between oid and target.sha
-    let upstream_commits =
-        first_parent_commit_ids_until_with_graph(repo, target_commit_id, target.sha, &mut graph)
-            .context("failed to get upstream commits")?
-            .iter()
-            .map(|id| {
-                let commit = repo.find_commit(*id)?;
-                commit_to_remote_commit(&commit)
-            })
-            .collect::<Result<Vec<_>>>()?;
+    let upstream_commits = first_parent_commit_ids_until(repo, target_commit_id, target.sha)
+        .context("failed to get upstream commits")?
+        .iter()
+        .map(|id| {
+            let commit = repo.find_commit(*id)?;
+            commit_to_remote_commit(&commit)
+        })
+        .collect::<Result<Vec<_>>>()?;
 
     // get some recent commits
     let recent_commits = first_parent_commit_ids_with_limit(repo, target.sha, 20)

--- a/crates/gitbutler-repo/src/lib.rs
+++ b/crates/gitbutler-repo/src/lib.rs
@@ -5,7 +5,6 @@ mod traversal;
 
 pub use traversal::{
     commit_ids_excluding_reachable_from_with_graph, first_parent_commit_ids_until,
-    first_parent_commit_ids_until_with_graph,
 };
 
 pub use commands::{FileInfo, RepoCommands};

--- a/crates/gitbutler-repo/src/traversal.rs
+++ b/crates/gitbutler-repo/src/traversal.rs
@@ -26,40 +26,6 @@ pub fn first_parent_commit_ids_until(
         .collect()
 }
 
-/// Like [`first_parent_commit_ids_until()`], but reuses `graph` across repeated ancestry queries.
-///
-/// The implementation is `merge_base` based.
-pub fn first_parent_commit_ids_until_with_graph(
-    repo: &gix::Repository,
-    from: gix::ObjectId,
-    stop_before: gix::ObjectId,
-    graph: &mut Graph<'_, '_, graph::Commit<Flags>>,
-) -> Result<Vec<gix::ObjectId>> {
-    let mut commit_ids = Vec::new();
-    let mut current = Some(from);
-
-    while let Some(commit_id) = current {
-        let reaches_hidden_history = match repo.merge_base_with_graph(commit_id, stop_before, graph)
-        {
-            Ok(merge_base) => merge_base.detach() == commit_id,
-            Err(gix::repository::merge_base_with_graph::Error::NotFound { .. }) => false,
-            Err(err) => return Err(err.into()),
-        };
-        if reaches_hidden_history {
-            break;
-        }
-
-        commit_ids.push(commit_id);
-        current = repo
-            .find_commit(commit_id)?
-            .parent_ids()
-            .next()
-            .map(|parent_id| parent_id.detach());
-    }
-
-    Ok(commit_ids)
-}
-
 /// Return commits reachable from `from` that are not reachable from `stop_before`.
 ///
 /// This matches the semantics of walking `from` with `stop_before` hidden.


### PR DESCRIPTION
It seems like that performance workaround didn't scale after all, despite graph-reuse. So I brought back the normal version, which in conjunction with a fixed `gix` does the trick.

Now `llvm-project` hangs in hunk-dependencies, but that's another matter.
