### PR TITLE
Improve Playwright e2e test infrastructure

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -173,9 +173,5 @@ jobs:
         if: failure()
         with:
           name: playwright-report
-          path: |
-            ./e2e/playwright-report/
-            ./e2e/test-results/**/trace.zip
-            ./e2e/test-results/**/video.webm
-            ./e2e/test-results/**/error-context.md
+          path: ./e2e/playwright/test-results-flat/
           retention-days: 30

--- a/e2e/playwright/.gitignore
+++ b/e2e/playwright/.gitignore
@@ -1,5 +1,6 @@
 
 /test-results/
+/test-results-flat/
 /playwright-report/
 /blob-report/
 /playwright/.cache/

--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -30,6 +30,9 @@ export default defineConfig({
 	/* Per-test timeout. The default 30s is too tight for tests that perform
 	   multiple commits in CI, where backend operations are slower. */
 	timeout: 60_000,
+	/* Assertion timeout. The default 5s is too tight for CI where backend
+	   operations (commits, rebases, upstream integration) are slower. */
+	expect: { timeout: 15_000 },
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 	use: {
 		/* Base URL to use in actions like `await page.goto('/')`. */

--- a/e2e/playwright/src/test.ts
+++ b/e2e/playwright/src/test.ts
@@ -1,11 +1,29 @@
 import { test as base } from "@playwright/test";
+import fs from "node:fs";
+import path from "node:path";
+
+const FLAT_RESULTS_DIR = path.resolve(import.meta.dirname, "../test-results-flat");
 
 /**
- * Extended test fixture that automatically captures browser console output
- * and attaches it as a plain-text file when a test fails.
+ * Sanitize a string for use as a filename.
  */
-export const test = base.extend<{ _autoConsoleCapture: void }>({
-	_autoConsoleCapture: [
+function sanitizeFilename(name: string): string {
+	return name
+		.replace(/[^a-zA-Z0-9_-]/g, "-")
+		.replace(/-+/g, "-")
+		.replace(/^-|-$/g, "");
+}
+
+/**
+ * Extended test fixture that, on failure, writes console logs and video
+ * to a flat directory with filenames derived from the test title.
+ *
+ * Output: e2e/playwright/test-results-flat/
+ *   <suite>--<test-name>.log
+ *   <suite>--<test-name>.webm
+ */
+export const test = base.extend<{ _autoArtifacts: void }>({
+	_autoArtifacts: [
 		async ({ page }, use, testInfo) => {
 			const logs: string[] = [];
 
@@ -20,11 +38,22 @@ export const test = base.extend<{ _autoConsoleCapture: void }>({
 
 			await use();
 
-			if (logs.length > 0 && testInfo.status !== "passed") {
-				await testInfo.attach("console-log", {
-					body: logs.join("\n"),
-					contentType: "text/plain",
-				});
+			if (testInfo.status !== testInfo.expectedStatus) {
+				const titlePath = testInfo.titlePath.slice(1);
+				const baseName = sanitizeFilename(titlePath.join("--"));
+				const retry = testInfo.retry > 0 ? `-retry${testInfo.retry}` : "";
+				const prefix = `${baseName}${retry}`;
+
+				fs.mkdirSync(FLAT_RESULTS_DIR, { recursive: true });
+
+				if (logs.length > 0) {
+					fs.writeFileSync(path.join(FLAT_RESULTS_DIR, `${prefix}.log`), logs.join("\n"));
+				}
+
+				const video = page.video();
+				if (video) {
+					await video.saveAs(path.join(FLAT_RESULTS_DIR, `${prefix}.webm`));
+				}
 			}
 		},
 		{ auto: true },

--- a/e2e/playwright/src/util.ts
+++ b/e2e/playwright/src/util.ts
@@ -1,5 +1,5 @@
 import { TestId } from "@gitbutler/ui/utils/testIds";
-import { expect, type Locator, type Page } from "@playwright/test";
+import { type Locator, type Page } from "@playwright/test";
 
 type TestIdValues = `${TestId}`;
 
@@ -117,19 +117,6 @@ export async function textEditorFillByTestId(page: Page, testId: TestIdValues, v
 	await element.click();
 	await element.pressSequentially(value);
 	return element;
-}
-
-/**
- * Wait for a locator to become visible with a generous timeout.
- * Use this when an async backend operation (commit, rebase, push, etc.)
- * must complete before the element appears.
- */
-export async function expectVisible(locator: Locator, timeout = 10_000) {
-	await expect(locator).toBeVisible({ timeout });
-}
-
-export async function sleep(ms: number): Promise<void> {
-	return await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /**

--- a/e2e/playwright/tests/commitHooks.spec.ts
+++ b/e2e/playwright/tests/commitHooks.spec.ts
@@ -1,12 +1,6 @@
 import { getBaseURL, getButlerPort, type GitButler, startGitButler } from "../src/setup.ts";
 import { test } from "../src/test.ts";
-import {
-	clickByTestId,
-	expectVisible,
-	fillByTestId,
-	getByTestId,
-	waitForTestId,
-} from "../src/util.ts";
+import { clickByTestId, fillByTestId, getByTestId, waitForTestId } from "../src/util.ts";
 import { expect, type Page } from "@playwright/test";
 
 let gitbutler: GitButler;
@@ -84,7 +78,7 @@ test("should show commit-msg hook rejection error", async ({ page, context }, te
 
 	// Should show an error toast about the hook rejection
 	const toastMessage = getByTestId(page, "toast-info-message");
-	await expectVisible(toastMessage);
+	await expect(toastMessage).toBeVisible();
 	await expect(toastMessage).toContainText("REJECT");
 });
 
@@ -131,7 +125,7 @@ test("should show modified commit message from commit-msg hook", async ({
 	// The commit should be created successfully
 	// Wait for the commit to appear in the commit list
 	const commitRow = getByTestId(page, "commit-row").first();
-	await expectVisible(commitRow);
+	await expect(commitRow).toBeVisible();
 
 	// The commit title should include the [MODIFIED] prefix added by the hook
 	await expect(commitRow).toContainText("[MODIFIED]");
@@ -172,7 +166,7 @@ test("should allow commits when commit-msg hook passes", async ({ page, context 
 
 	// The commit should be created successfully
 	const commitRow = getByTestId(page, "commit-row").first();
-	await expectVisible(commitRow);
+	await expect(commitRow).toBeVisible();
 	await expect(commitRow).toContainText("A normal commit message");
 });
 
@@ -219,7 +213,7 @@ test("should reject commit when pre-commit hook fails", async ({ page, context }
 
 	// Should show an error toast about the pre-commit hook rejection
 	const toastMessage = getByTestId(page, "toast-info-message");
-	await expectVisible(toastMessage);
+	await expect(toastMessage).toBeVisible();
 	await expect(toastMessage).toContainText("FORBIDDEN");
 });
 
@@ -262,7 +256,7 @@ test("should allow commit when pre-commit hook passes", async ({ page, context }
 
 	// The commit should be created successfully (pre-commit hook passed)
 	const commitRow = getByTestId(page, "commit-row").first();
-	await expectVisible(commitRow);
+	await expect(commitRow).toBeVisible();
 	await expect(commitRow).toContainText("Adding allowed file");
 });
 
@@ -301,7 +295,7 @@ test("should show post-commit hook success", async ({ page, context }, testInfo)
 
 	// The commit should be created successfully
 	const commitRow = getByTestId(page, "commit-row").first();
-	await expectVisible(commitRow);
+	await expect(commitRow).toBeVisible();
 	await expect(commitRow).toContainText("Testing post-commit hook");
 
 	// Wait for post-commit hook to execute (it runs in background)
@@ -350,7 +344,7 @@ test("should show post-commit hook failure but commit still created", async ({
 
 	// The commit should be created (pre-commit passed)
 	const commitRow = getByTestId(page, "commit-row").first();
-	await expectVisible(commitRow);
+	await expect(commitRow).toBeVisible();
 	await expect(commitRow).toContainText("Trigger post-commit failure");
 
 	// Wait for post-commit hook to run and fail (it runs in background)

--- a/e2e/playwright/tests/dropResult.spec.ts
+++ b/e2e/playwright/tests/dropResult.spec.ts
@@ -1,12 +1,6 @@
 import { getBaseURL, type GitButler, startGitButler } from "../src/setup.ts";
 import { test } from "../src/test.ts";
-import {
-	clickByTestId,
-	dragAndDropByLocator,
-	expectVisible,
-	getByTestId,
-	waitForTestId,
-} from "../src/util.ts";
+import { clickByTestId, dragAndDropByLocator, getByTestId, waitForTestId } from "../src/util.ts";
 import { expect } from "@playwright/test";
 import { writeFileSync } from "fs";
 
@@ -81,7 +75,7 @@ test("should show commit-failed modal when amending causes a conflict", async ({
 		.getByTestId("uncommitted-changes-file-list")
 		.getByTestId("file-list-item")
 		.filter({ hasText: "a_file" });
-	await expectVisible(fileLocator);
+	await expect(fileLocator).toBeVisible();
 
 	// Drag the uncommitted file onto the FIRST commit (bottom one).
 	// "Change juliet to JULIET-FIRST" is the first commit.
@@ -95,7 +89,7 @@ test("should show commit-failed modal when amending causes a conflict", async ({
 	// The commit-failed modal should appear because rebasing the second commit
 	// on top of the amended first commit causes a cherry-pick merge conflict.
 	const modal = getByTestId(page, "global-modal-commit-failed");
-	await expectVisible(modal);
+	await expect(modal).toBeVisible();
 
 	// The modal should indicate that some changes were not committed
 	await expect(modal).toContainText(/changes were not committed|Failed to create commit/);
@@ -140,7 +134,7 @@ test("should squash commits via drag-and-drop without errors", async ({
 	// because local history changed. The upstream action row confirms
 	// the squash was successful.
 	const upstreamSection = getByTestId(page, "upstream-commits-commit-action");
-	await expectVisible(upstreamSection, 15_000);
+	await expect(upstreamSection).toBeVisible();
 
 	// The first commit should still be present (it was not part of the squash)
 	const remainingFirst = getByTestId(page, "commit-row").filter({

--- a/e2e/playwright/tests/moveBranch.spec.ts
+++ b/e2e/playwright/tests/moveBranch.spec.ts
@@ -1,6 +1,6 @@
 import { getBaseURL, type GitButler, startGitButler } from "../src/setup.ts";
 import { test } from "../src/test.ts";
-import { dragAndDropByLocator, sleep, waitForTestId } from "../src/util.ts";
+import { dragAndDropByLocator, waitForTestId } from "../src/util.ts";
 import { expect } from "@playwright/test";
 
 let gitbutler: GitButler;
@@ -114,8 +114,6 @@ test("move branch to the middle of other stack", async ({ page, context }, testI
 	});
 	stacks = page.getByTestId("stack");
 	await expect(stacks).toHaveCount(2);
-
-	await sleep(500); // It seems that we need to wait a bit for the DOM to stabilize
 
 	branchHeaders = page.getByTestId("branch-header");
 	await expect(branchHeaders).toHaveCount(3);

--- a/e2e/playwright/tests/multiCommitSelection.spec.ts
+++ b/e2e/playwright/tests/multiCommitSelection.spec.ts
@@ -1,11 +1,6 @@
 import { getBaseURL, type GitButler, startGitButler } from "../src/setup.ts";
 import { test } from "../src/test.ts";
-import {
-	expectVisible,
-	getByTestId,
-	waitForElementToStabilize,
-	waitForTestId,
-} from "../src/util.ts";
+import { getByTestId, waitForElementToStabilize, waitForTestId } from "../src/util.ts";
 import { expect, type Page } from "@playwright/test";
 
 let gitbutler: GitButler;
@@ -233,7 +228,7 @@ test("should squash 3 selected commits via context menu", async ({ page, context
 	// because local history changed. The "Upstream has new commits" indicator confirms
 	// the squash was successful.
 	const upstreamSection = page.locator("text=Upstream has new commits");
-	await expectVisible(upstreamSection, 15_000);
+	await expect(upstreamSection).toBeVisible();
 
 	// The first commit should still be present (it was not part of the squash)
 	const remainingFirst = getByTestId(page, "commit-row").filter({
@@ -273,7 +268,7 @@ test("should uncommit 3 selected commits via context menu", async ({ page, conte
 
 	// After uncommitting, the uncommitted changes should contain the files
 	const uncommittedHeader = getByTestId(page, "uncommitted-changes-header");
-	await expectVisible(uncommittedHeader, 15_000);
+	await expect(uncommittedHeader).toBeVisible();
 
 	// The first commit should still exist (it was not selected)
 	const remainingFirst = getByTestId(page, "commit-row").filter({

--- a/e2e/playwright/tests/projectOffboarding.spec.ts
+++ b/e2e/playwright/tests/projectOffboarding.spec.ts
@@ -1,6 +1,6 @@
 import { getBaseURL, type GitButler, startGitButler } from "../src/setup.ts";
 import { test } from "../src/test.ts";
-import { clickByTestId, sleep, waitForTestId, waitForTestIdToNotExist } from "../src/util.ts";
+import { clickByTestId, waitForTestId, waitForTestIdToNotExist } from "../src/util.ts";
 
 let gitbutler: GitButler;
 
@@ -81,6 +81,4 @@ test("should be able to delete a project when multiple exist", async ({
 
 	// Should still be in the workspace
 	await waitForTestId(page, "workspace-view");
-
-	await sleep(10000); // Wait for the project list to update
 });

--- a/e2e/playwright/tests/startTheApp.spec.ts
+++ b/e2e/playwright/tests/startTheApp.spec.ts
@@ -7,7 +7,6 @@ import {
 	fillByTestId,
 	getByTestId,
 	mockPickDirectory,
-	sleep,
 	textEditorFillByTestId,
 	waitForTestId,
 } from "../src/util.ts";
@@ -122,7 +121,7 @@ test("no author setup - should start the application and be able to commit", asy
 	await waitForTestId(page, "global-modal-author-missing");
 	// WebKit needs extra time for the modal inputs to become interactive.
 	// Without this, fill() silently fails and the values don't persist.
-	await sleep(200);
+	await page.waitForTimeout(200);
 	await fillByTestId(page, "global-modal-author-missing-name-input", "Test User");
 	await fillByTestId(page, "global-modal-author-missing-email-input", "test@example.com");
 	await clickByTestId(page, "global-modal-author-missing-action-button", true);


### PR DESCRIPTION
## Summary

- **Remove redundant helpers**: Delete `expectVisible` and `sleep` from `util.ts` — `expectVisible` duplicated the config-level `expect.timeout`, and `sleep` calls were either unnecessary (Playwright assertions already auto-retry) or replaced with `page.waitForTimeout()`
- **Bump assertion timeout to 15s**: Raise `expect.timeout` from 10s to 15s in `playwright.config.ts` so no test needs inline timeout overrides
- **Flatten CI artifacts & capture console logs**: Rewrite the test fixture to write console logs (`.log`) and videos (`.webm`) as flat files named after the test, instead of nested per-test folders with `trace.zip`

## Test plan

- [ ] CI e2e tests pass
- [ ] On failure, the `playwright-report` artifact contains flat `.log` and `.webm` files named after the failing tests