### PR TITLE
Support choosing how to combine commit messages when squashing

### DIFF
--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -174,7 +174,7 @@ const registerIpcHandlers = (): void => {
 	ipcMain.handle(
 		liteIpcChannels.commitSquash,
 		(_e, { projectId, sourceCommitId, destinationCommitId, dryRun }: CommitSquashParams) =>
-			commitSquash(projectId, sourceCommitId, destinationCommitId, dryRun),
+			commitSquash(projectId, sourceCommitId, destinationCommitId, "KeepBoth", dryRun),
 	);
 	ipcMain.handle(
 		liteIpcChannels.commitReword,

--- a/crates/but-api/src/commit/squash.rs
+++ b/crates/but-api/src/commit/squash.rs
@@ -3,6 +3,7 @@ use but_api_macros::but_api;
 use but_core::{DryRun, sync::RepoExclusive};
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
 use but_rebase::graph_rebase::{Editor, LookupStep as _};
+use but_workspace::commit::squash_commits::MessageCombinationStrategy;
 use tracing::instrument;
 
 use super::types::CommitSquashResult;
@@ -21,6 +22,7 @@ pub fn commit_squash_only(
     ctx: &mut but_ctx::Context,
     subject_commit_id: gix::ObjectId,
     target_commit_id: gix::ObjectId,
+    how_to_combine_messages: MessageCombinationStrategy,
     dry_run: DryRun,
 ) -> anyhow::Result<CommitSquashResult> {
     let mut guard = ctx.exclusive_worktree_access();
@@ -28,6 +30,7 @@ pub fn commit_squash_only(
         ctx,
         subject_commit_id,
         target_commit_id,
+        how_to_combine_messages,
         dry_run,
         guard.write_permission(),
     )
@@ -45,6 +48,7 @@ pub fn commit_squash_only_with_perm(
     ctx: &mut but_ctx::Context,
     subject_commit_id: gix::ObjectId,
     target_commit_id: gix::ObjectId,
+    how_to_combine_messages: MessageCombinationStrategy,
     dry_run: DryRun,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitSquashResult> {
@@ -52,8 +56,12 @@ pub fn commit_squash_only_with_perm(
     let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
 
-    let outcome =
-        but_workspace::commit::squash_commits(editor, subject_commit_id, target_commit_id)?;
+    let outcome = but_workspace::commit::squash_commits(
+        editor,
+        subject_commit_id,
+        target_commit_id,
+        how_to_combine_messages,
+    )?;
 
     let new_commit = outcome.rebase.lookup_pick(outcome.commit_selector)?;
     let workspace = WorkspaceState::from_successful_rebase(outcome.rebase, &repo, dry_run)?;
@@ -78,6 +86,7 @@ pub fn commit_squash(
     ctx: &mut but_ctx::Context,
     subject_commit_id: gix::ObjectId,
     target_commit_id: gix::ObjectId,
+    how_to_combine_messages: MessageCombinationStrategy,
     dry_run: DryRun,
 ) -> anyhow::Result<CommitSquashResult> {
     let mut guard = ctx.exclusive_worktree_access();
@@ -85,6 +94,7 @@ pub fn commit_squash(
         ctx,
         subject_commit_id,
         target_commit_id,
+        how_to_combine_messages,
         dry_run,
         guard.write_permission(),
     )
@@ -102,6 +112,7 @@ pub fn commit_squash_with_perm(
     ctx: &mut but_ctx::Context,
     subject_commit_id: gix::ObjectId,
     target_commit_id: gix::ObjectId,
+    how_to_combine_messages: MessageCombinationStrategy,
     dry_run: DryRun,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitSquashResult> {
@@ -112,7 +123,14 @@ pub fn commit_squash_with_perm(
         dry_run,
     );
 
-    let res = commit_squash_only_with_perm(ctx, subject_commit_id, target_commit_id, dry_run, perm);
+    let res = commit_squash_only_with_perm(
+        ctx,
+        subject_commit_id,
+        target_commit_id,
+        how_to_combine_messages,
+        dry_run,
+        perm,
+    );
     if let Some(snapshot) = maybe_oplog_entry
         && res.is_ok()
     {

--- a/crates/but-workspace/src/commit/squash_commits.rs
+++ b/crates/but-workspace/src/commit/squash_commits.rs
@@ -105,7 +105,8 @@ but_schemars::register_sdk_type!(MessageCombinationStrategy);
 /// After any reordering, one of the two original commit positions (either the subject or
 /// the target) is replaced by a single squashed commit that has:
 /// - The tree of the commit that was top-most after reordering (subject or target)
-/// - The combined message `subject\n\ntarget`
+/// - A message determined by `how_to_combine_messages`: either the subject message, the
+///   target message, or both messages as `target\n\nsubject`
 ///
 /// The other original commit (subject or target, depending on the chosen ordering) is
 /// removed from history.
@@ -160,12 +161,12 @@ pub fn squash_commits<'ws, 'meta, M: RefMetadata>(
                 }
                 (false, false) => {
                     // both commits have messages, keep both
-                    combined_message.extend_from_slice(subject.message.as_ref());
+                    combined_message.extend_from_slice(target.message.as_ref());
                     if !combined_message.ends_with(b"\n") {
                         combined_message.push(b'\n');
                     }
                     combined_message.push(b'\n');
-                    combined_message.extend_from_slice(target.message.as_ref());
+                    combined_message.extend_from_slice(subject.message.as_ref());
                 }
             }
         }

--- a/crates/but-workspace/src/commit/squash_commits.rs
+++ b/crates/but-workspace/src/commit/squash_commits.rs
@@ -78,6 +78,25 @@ pub struct SquashCommitsOutcome<'ws, 'meta, M: RefMetadata> {
     pub commit_selector: Selector,
 }
 
+/// How to combine messages of commits being squashed.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+pub enum MessageCombinationStrategy {
+    /// Keep both messages.
+    KeepBoth,
+    /// Only keep the message of the subject.
+    ///
+    /// Target message will be discarded.
+    KeepSubject,
+    /// Only keep the message of the target.
+    ///
+    /// Subject message will be discarded.
+    KeepTarget,
+}
+
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(MessageCombinationStrategy);
+
 /// Squash `subject_commit` into `target_commit`.
 ///
 /// Depending on the ancestry relationship between the two commits, this operation may
@@ -94,6 +113,7 @@ pub fn squash_commits<'ws, 'meta, M: RefMetadata>(
     editor: Editor<'ws, 'meta, M>,
     subject_commit: impl ToCommitSelector,
     target_commit: impl ToCommitSelector,
+    how_to_combine_messages: MessageCombinationStrategy,
 ) -> Result<SquashCommitsOutcome<'ws, 'meta, M>> {
     let repo = editor.repo().clone();
     let successful_rebase = editor.rebase()?;
@@ -118,23 +138,36 @@ pub fn squash_commits<'ws, 'meta, M: RefMetadata>(
     let direction = determine_reorder_direction(&workspace, &repo, &subject, &target)?;
 
     let mut combined_message = Vec::new();
-    match (subject.message.is_empty(), target.message.is_empty()) {
-        (true, true) => {
-            // both messages are empty, leave combined message as empty
+    match how_to_combine_messages {
+        MessageCombinationStrategy::KeepSubject => {
+            combined_message.extend_from_slice(subject.message.as_ref());
         }
-        (true, false) => {
+        MessageCombinationStrategy::KeepTarget => {
             combined_message.extend_from_slice(target.message.as_ref());
         }
-        (false, true) => {
-            combined_message.extend_from_slice(subject.message.as_ref());
-        }
-        (false, false) => {
-            combined_message.extend_from_slice(subject.message.as_ref());
-            if !combined_message.ends_with(b"\n") {
-                combined_message.push(b'\n');
+        MessageCombinationStrategy::KeepBoth => {
+            match (subject.message.is_empty(), target.message.is_empty()) {
+                (true, true) => {
+                    // both messages are empty, leave combined message as empty
+                }
+                (true, false) => {
+                    // subject has no message, target does
+                    combined_message.extend_from_slice(target.message.as_ref());
+                }
+                (false, true) => {
+                    // subject has message, target doesn't
+                    combined_message.extend_from_slice(subject.message.as_ref());
+                }
+                (false, false) => {
+                    // both commits have messages, keep both
+                    combined_message.extend_from_slice(subject.message.as_ref());
+                    if !combined_message.ends_with(b"\n") {
+                        combined_message.push(b'\n');
+                    }
+                    combined_message.push(b'\n');
+                    combined_message.extend_from_slice(target.message.as_ref());
+                }
             }
-            combined_message.push(b'\n');
-            combined_message.extend_from_slice(target.message.as_ref());
         }
     }
 

--- a/crates/but-workspace/tests/workspace/commit/squash_commits.rs
+++ b/crates/but-workspace/tests/workspace/commit/squash_commits.rs
@@ -26,7 +26,12 @@ fn squash_top_commit_into_parent() -> Result<()> {
 
     let mut ws = graph.into_workspace()?;
     let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
-    let outcome = squash_commits(editor, subject_id, target_id)?;
+    let outcome = squash_commits(
+        editor,
+        subject_id,
+        target_id,
+        squash_commits::MessageCombinationStrategy::KeepBoth,
+    )?;
 
     let materialized = outcome.rebase.materialize()?;
     let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
@@ -65,6 +70,80 @@ fn squash_top_commit_into_parent() -> Result<()> {
 }
 
 #[test]
+fn squash_top_commit_into_parent_keeping_target_message() -> Result<()> {
+    let (_tmp, graph, repo, mut _meta, _description) =
+        writable_scenario("reword-three-commits", |_| {})?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * c9f444c (HEAD -> three) commit three
+    * 16fd221 (origin/two, two) commit two
+    * 8b426d0 (one) commit one
+    ");
+
+    let subject_id = repo.rev_parse_single("three")?.detach();
+    let target_id = repo.rev_parse_single("two")?.detach();
+    let subject_tree = repo.find_commit(subject_id)?.tree_id()?.detach();
+
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
+    let outcome = squash_commits(
+        editor,
+        subject_id,
+        target_id,
+        squash_commits::MessageCombinationStrategy::KeepTarget,
+    )?;
+
+    let materialized = outcome.rebase.materialize()?;
+    let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
+
+    let squashed_commit = repo.find_commit(squashed_id)?;
+    assert_eq!(
+        squashed_commit.message_raw()?,
+        "commit two\n",
+        "combined message should keep only the target message"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn squash_top_commit_into_parent_keeping_subject_message() -> Result<()> {
+    let (_tmp, graph, repo, mut _meta, _description) =
+        writable_scenario("reword-three-commits", |_| {})?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * c9f444c (HEAD -> three) commit three
+    * 16fd221 (origin/two, two) commit two
+    * 8b426d0 (one) commit one
+    ");
+
+    let subject_id = repo.rev_parse_single("three")?.detach();
+    let target_id = repo.rev_parse_single("two")?.detach();
+    let subject_tree = repo.find_commit(subject_id)?.tree_id()?.detach();
+
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
+    let outcome = squash_commits(
+        editor,
+        subject_id,
+        target_id,
+        squash_commits::MessageCombinationStrategy::KeepSubject,
+    )?;
+
+    let materialized = outcome.rebase.materialize()?;
+    let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
+
+    let squashed_commit = repo.find_commit(squashed_id)?;
+    assert_eq!(
+        squashed_commit.message_raw()?,
+        "commit three\n",
+        "combined message should keep only the subject message"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn squash_reorders_when_subject_is_not_on_top() -> Result<()> {
     let (_tmp, graph, repo, mut _meta, _description) =
         writable_scenario("reword-three-commits", |_| {})?;
@@ -82,7 +161,12 @@ fn squash_reorders_when_subject_is_not_on_top() -> Result<()> {
 
     let mut ws = graph.into_workspace()?;
     let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
-    let outcome = squash_commits(editor, subject_id, target_id)?;
+    let outcome = squash_commits(
+        editor,
+        subject_id,
+        target_id,
+        squash_commits::MessageCombinationStrategy::KeepBoth,
+    )?;
 
     let materialized = outcome.rebase.materialize()?;
     let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
@@ -125,7 +209,13 @@ fn squash_same_commit_is_rejected() -> Result<()> {
     let mut ws = graph.into_workspace()?;
     let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
 
-    let err = squash_commits(editor, commit_id, commit_id).expect_err("must fail");
+    let err = squash_commits(
+        editor,
+        commit_id,
+        commit_id,
+        squash_commits::MessageCombinationStrategy::KeepBoth,
+    )
+    .expect_err("must fail");
     assert!(
         err.to_string()
             .contains("Cannot squash a commit into itself"),
@@ -157,7 +247,12 @@ fn squash_down_keeps_topmost_tree_for_shared_file_lineage() -> Result<()> {
 
     let mut ws = graph.into_workspace()?;
     let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
-    let outcome = squash_commits(editor, subject_id, target_id)?;
+    let outcome = squash_commits(
+        editor,
+        subject_id,
+        target_id,
+        squash_commits::MessageCombinationStrategy::KeepBoth,
+    )?;
 
     let materialized = outcome.rebase.materialize()?;
     let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
@@ -190,7 +285,12 @@ fn squash_up_reorders_subject_below_target_for_shared_file_lineage() -> Result<(
 
     let mut ws = graph.into_workspace()?;
     let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
-    let outcome = squash_commits(editor, subject_id, target_id)?;
+    let outcome = squash_commits(
+        editor,
+        subject_id,
+        target_id,
+        squash_commits::MessageCombinationStrategy::KeepBoth,
+    )?;
 
     let materialized = outcome.rebase.materialize()?;
     let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
@@ -229,7 +329,12 @@ fn squash_down_out_of_order_reorders_subject_below_target_for_shared_file_lineag
 
     let mut ws = graph.into_workspace()?;
     let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
-    let outcome = squash_commits(editor, subject_id, target_id)?;
+    let outcome = squash_commits(
+        editor,
+        subject_id,
+        target_id,
+        squash_commits::MessageCombinationStrategy::KeepBoth,
+    )?;
 
     let materialized = outcome.rebase.materialize()?;
     let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
@@ -284,7 +389,12 @@ fn squash_across_stacks_subject_into_target() -> Result<()> {
     let subject_tree = repo.find_commit(subject_id)?.tree_id()?.detach();
 
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
-    let outcome = squash_commits(editor, subject_id, target_id)?;
+    let outcome = squash_commits(
+        editor,
+        subject_id,
+        target_id,
+        squash_commits::MessageCombinationStrategy::KeepBoth,
+    )?;
 
     let materialized = outcome.rebase.materialize()?;
     let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
@@ -346,7 +456,12 @@ fn squash_across_stacks_target_into_subject() -> Result<()> {
     let subject_tree = repo.find_commit(subject_id)?.tree_id()?.detach();
 
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
-    let outcome = squash_commits(editor, subject_id, target_id)?;
+    let outcome = squash_commits(
+        editor,
+        subject_id,
+        target_id,
+        squash_commits::MessageCombinationStrategy::KeepBoth,
+    )?;
 
     let materialized = outcome.rebase.materialize()?;
     let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;

--- a/crates/but-workspace/tests/workspace/commit/squash_commits.rs
+++ b/crates/but-workspace/tests/workspace/commit/squash_commits.rs
@@ -39,8 +39,8 @@ fn squash_top_commit_into_parent() -> Result<()> {
     let squashed_commit = repo.find_commit(squashed_id)?;
     assert_eq!(
         squashed_commit.message_raw()?,
-        "commit three\n\ncommit two\n",
-        "combined message should be subject followed by target with one blank line"
+        "commit two\n\ncommit three\n",
+        "combined message should be target followed by subject with one blank line"
     );
     assert_eq!(
         squashed_commit.tree_id()?.detach(),
@@ -60,7 +60,7 @@ fn squash_top_commit_into_parent() -> Result<()> {
     );
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * 6426178 (HEAD -> three, two) commit three
+    * 655b033 (HEAD -> three, two) commit two
     | * 16fd221 (origin/two) commit two
     |/  
     * 8b426d0 (one) commit one
@@ -82,7 +82,6 @@ fn squash_top_commit_into_parent_keeping_target_message() -> Result<()> {
 
     let subject_id = repo.rev_parse_single("three")?.detach();
     let target_id = repo.rev_parse_single("two")?.detach();
-    let subject_tree = repo.find_commit(subject_id)?.tree_id()?.detach();
 
     let mut ws = graph.into_workspace()?;
     let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
@@ -119,7 +118,6 @@ fn squash_top_commit_into_parent_keeping_subject_message() -> Result<()> {
 
     let subject_id = repo.rev_parse_single("three")?.detach();
     let target_id = repo.rev_parse_single("two")?.detach();
-    let subject_tree = repo.find_commit(subject_id)?.tree_id()?.detach();
 
     let mut ws = graph.into_workspace()?;
     let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
@@ -174,8 +172,8 @@ fn squash_reorders_when_subject_is_not_on_top() -> Result<()> {
     let squashed_commit = repo.find_commit(squashed_id)?;
     assert_eq!(
         squashed_commit.message_raw()?,
-        "commit two\n\ncommit three\n",
-        "combined message should respect subject-then-target order"
+        "commit three\n\ncommit two\n",
+        "combined message should respect target-then-subject order"
     );
     assert_eq!(
         squashed_commit.tree_id()?.detach(),
@@ -184,7 +182,7 @@ fn squash_reorders_when_subject_is_not_on_top() -> Result<()> {
     );
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * 655b033 (HEAD -> three, two) commit two
+    * 6426178 (HEAD -> three, two) commit three
     | * 16fd221 (origin/two) commit two
     |/  
     * 8b426d0 (one) commit one
@@ -262,7 +260,7 @@ fn squash_down_keeps_topmost_tree_for_shared_file_lineage() -> Result<()> {
     assert_eq!(object.data.as_bstr(), "v3\n");
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * 4fbac4b (HEAD -> three, two) commit three
+    * 69e6e54 (HEAD -> three, two) commit two
     * 8df0fa3 (one) commit one
     ");
 
@@ -302,11 +300,11 @@ fn squash_up_reorders_subject_below_target_for_shared_file_lineage() -> Result<(
     let squashed_commit = repo.find_commit(squashed_id)?;
     assert_eq!(
         squashed_commit.message_raw()?,
-        "commit two\n\ncommit three\n"
+        "commit three\n\ncommit two\n"
     );
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * 69e6e54 (HEAD -> three, two) commit two
+    * 4fbac4b (HEAD -> three, two) commit three
     * 8df0fa3 (one) commit one
     ");
 
@@ -346,12 +344,12 @@ fn squash_down_out_of_order_reorders_subject_below_target_for_shared_file_lineag
     let squashed_commit = repo.find_commit(squashed_id)?;
     assert_eq!(
         squashed_commit.message_raw()?,
-        "commit three\n\ncommit one\n"
+        "commit one\n\ncommit three\n"
     );
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * 1450203 (HEAD -> three, two) [conflict] commit two
-    * f297a08 (one) commit three
+    * 85f51d5 (HEAD -> three, two) [conflict] commit two
+    * f3ac68e (one) commit one
     ");
 
     Ok(())
@@ -400,13 +398,13 @@ fn squash_across_stacks_subject_into_target() -> Result<()> {
     let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
 
     let squashed_commit = repo.find_commit(squashed_id)?;
-    assert_eq!(squashed_commit.message_raw()?, "A\n\nB\n");
+    assert_eq!(squashed_commit.message_raw()?, "B\n\nA\n");
     assert_eq!(squashed_commit.tree_id()?.detach(), subject_tree);
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   f0f9abb (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   d6e2c4d (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
-    | * 17e27b0 (B) A
+    | * 82d6f41 (B) B
     |/  
     * 85efbe4 (origin/main, main, A) M
     ");
@@ -414,7 +412,7 @@ fn squash_across_stacks_subject_into_target() -> Result<()> {
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:3:B on 85efbe4 {2}
     │   └── 📙:3:B
-    │       └── ·17e27b0 (🏘️)
+    │       └── ·82d6f41 (🏘️)
     └── ≡📙:4:A on 85efbe4 {1}
         └── 📙:4:A
     ");
@@ -467,13 +465,13 @@ fn squash_across_stacks_target_into_subject() -> Result<()> {
     let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
 
     let squashed_commit = repo.find_commit(squashed_id)?;
-    assert_eq!(squashed_commit.message_raw()?, "B\n\nA\n");
+    assert_eq!(squashed_commit.message_raw()?, "A\n\nB\n");
     assert_eq!(squashed_commit.tree_id()?.detach(), subject_tree);
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   3d10054 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   e33c9cc (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
-    * | 82d6f41 (A) B
+    * | 17e27b0 (A) A
     |/  
     * 85efbe4 (origin/main, main, B) M
     ");
@@ -483,7 +481,7 @@ fn squash_across_stacks_target_into_subject() -> Result<()> {
     │   └── 📙:4:B
     └── ≡📙:3:A on 85efbe4 {1}
         └── 📙:3:A
-            └── ·82d6f41 (🏘️)
+            └── ·17e27b0 (🏘️)
     ");
 
     Ok(())

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -15,6 +15,7 @@ mod assign;
 pub(crate) mod squash;
 mod undo;
 pub(crate) use assign::branch_name_to_stack_id;
+use but_workspace::commit::squash_commits::MessageCombinationStrategy;
 use gitbutler_oplog::{
     OplogExt,
     entry::{OperationKind, SnapshotDetails},
@@ -660,7 +661,13 @@ impl SquashCommitsOperation {
 
     /// Executes `SquashCommits` by squashing source into target.
     pub(crate) fn execute_inner(&self, ctx: &mut Context) -> anyhow::Result<CommitSquashResult> {
-        but_api::commit::squash::commit_squash(ctx, self.source, self.destination, DryRun::No)
+        but_api::commit::squash::commit_squash(
+            ctx,
+            self.source,
+            self.destination,
+            MessageCombinationStrategy::KeepBoth,
+            DryRun::No,
+        )
     }
 }
 

--- a/crates/but/src/command/legacy/rub/squash.rs
+++ b/crates/but/src/command/legacy/rub/squash.rs
@@ -4,6 +4,7 @@ use anyhow::{Context as _, bail};
 use bstr::BString;
 use but_core::{DryRun, ref_metadata::StackId, sync::RepoExclusive};
 use but_ctx::Context;
+use but_workspace::commit::squash_commits::MessageCombinationStrategy;
 use gitbutler_oplog::{
     OplogExt,
     entry::{OperationKind, SnapshotDetails},
@@ -278,6 +279,7 @@ fn squash_commits_internal(
                 ctx,
                 remapped_source_oid,
                 new_commit_oid,
+                MessageCombinationStrategy::KeepBoth,
                 DryRun::No,
                 perm,
             )?;

--- a/crates/but/tests/but/command/undo.rs
+++ b/crates/but/tests/but/command/undo.rs
@@ -91,7 +91,7 @@ fn can_undo_rubbing_commits() -> anyhow::Result<()> {
             .arg("fe")
             .assert()
             .success()
-            .stdout_eq("Squashed 9ac4652 → 9c8e613\n")
+            .stdout_eq("Squashed 9ac4652 → f66c907\n")
             .stderr_eq("");
 
         Ok(())

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -169,7 +169,7 @@ export declare function commitReword(projectId: string, commitId: string, messag
  * When `dry_run` is enabled, the returned workspace previews the squashed
  * result and no oplog entry is persisted. For details, see [`commit_squash_with_perm()`].
  */
-export declare function commitSquash(projectId: string, subjectCommitId: string, targetCommitId: string, dryRun: boolean): Promise<CommitSquashResult>
+export declare function commitSquash(projectId: string, subjectCommitId: string, targetCommitId: string, howToCombineMessages: MessageCombinationStrategy, dryRun: boolean): Promise<CommitSquashResult>
 
 /**
  * Uncommit one or more commits, removing them from branch history while
@@ -1445,6 +1445,9 @@ export type LineStats = {
   /** The number of files that contributed to these statistics as they were added, removed or modified. */
   filesChanged: number;
 };
+
+/** How to combine messages of commits being squashed. */
+export type MessageCombinationStrategy = "KeepBoth" | "KeepSubject" | "KeepTarget";
 
 /**
  * Basic information to know about a reference we store with the metadata system.


### PR DESCRIPTION
`jj squash` has a `--use-destination-message` flag which discards the message of the subject and only keeps the destination commit's message (what we call the target). I think that option is very useful, especially when squashing "wip commits" into the actual target you wanna push up for review.

This PR lays the groundwork for adding that by adding a new `how_to_combine_messages` argument to `but_workspace::commit::squash_commits`.

It doesn't actually hook it up the CLI and the TUI yet. I'll do that in a follow up PR.

Additionally this PR swaps the order of the squashed commit messages so the target message comes first. Previously we'd put the subject message first but I think thats rarely what you want. Usually I squash my wip commits into my real commits, not the other way around.