### PR TITLE
tui: don't show [unassigned changes] in branch picker in move mode

### DIFF
--- a/crates/but/src/command/legacy/status/tui/branch_picker.rs
+++ b/crates/but/src/command/legacy/status/tui/branch_picker.rs
@@ -70,6 +70,7 @@ impl BranchPicker {
     pub(super) fn new<F>(
         branch_names: NonEmpty<FullName>,
         theme: &'static Theme,
+        include_unassigned: bool,
         on_branch_selected: F,
     ) -> Self
     where
@@ -78,8 +79,13 @@ impl BranchPicker {
         let mut textarea = TextArea::default();
         textarea.set_cursor_line_style(theme.default);
 
-        let mut items = NonEmpty::new(Item::Unassigned);
-        items.extend(branch_names.map(Item::Branch));
+        let items = if include_unassigned {
+            let mut items = NonEmpty::new(Item::Unassigned);
+            items.extend(branch_names.map(Item::Branch));
+            items
+        } else {
+            branch_names.map(Item::Branch)
+        };
 
         let mut this = Self {
             items,

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -2248,9 +2248,16 @@ impl App {
             .collect::<Vec<_>>();
 
         if let Some(branch_names) = NonEmpty::from_vec(branch_names) {
+            let include_unassigned = Cursor::select_unassigned(&self.status_lines)
+                .and_then(|cursor| cursor.selected_line(&self.status_lines))
+                .is_some_and(|unassigned| {
+                    is_selectable_in_mode(unassigned, &self.mode, self.flags.show_files)
+                });
+
             self.branch_picker = Some(BranchPicker::new(
                 branch_names,
                 self.theme,
+                include_unassigned,
                 |item, messages| {
                     match item {
                         branch_picker::Item::Branch(branch_name) => {


### PR DESCRIPTION
`[unassigned changes]` can't be selected in move mode so it shouldn't be shown in the branch picker.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #13597 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #13596
- <kbd>&nbsp;1&nbsp;</kbd> #13595
<!-- GitButler Footer Boundary Bottom -->