### PR TITLE
Fix move-branch failing when base segment has no ref name

### DIFF
--- a/crates/but-workspace/src/branch/move_branch.rs
+++ b/crates/but-workspace/src/branch/move_branch.rs
@@ -375,20 +375,10 @@ fn get_disconnect_parameters<'ws, 'meta, M: RefMetadata>(
 
     let parents_to_disconnect = if let Some(stack_base_segment) = stack_base_segment {
         // Base segment is part of the source stack.
-        let base_segment_ref_name = stack_base_segment
-            .ref_name()
-            .context("Base segment doesn't have a ref name.")?;
-        let reference_selector = editor.select_reference(base_segment_ref_name)?;
-        let selectors = SomeSelectors::new(vec![reference_selector])?;
-        SelectorSet::Some(selectors)
+        select_segment(editor, stack_base_segment)?
     } else if let Some(graph_base_segment) = graph_base_segment {
         // Base segment is outside of workspace (probably target branch).
-        let ref_name = graph_base_segment
-            .ref_name()
-            .context("Graph base segment doesn't have a ref name.")?;
-        let reference_selector = editor.select_reference(ref_name)?;
-        let selectors = SomeSelectors::new(vec![reference_selector])?;
-        SelectorSet::Some(selectors)
+        select_segment(editor, graph_base_segment)?
     } else if subject_segment.base_segment_id.is_some() {
         // Base segment could not be found, but there is an ID defined. Error out.
         bail!(
@@ -436,4 +426,43 @@ fn get_disconnect_parameters<'ws, 'meta, M: RefMetadata>(
     let children_to_disconnect = SelectorSet::Some(selectors);
 
     Ok((delimiter, children_to_disconnect, parents_to_disconnect))
+}
+
+/// Select a segment by its ref name if available, otherwise fall back to its tip commit.
+fn select_segment<M: RefMetadata>(
+    editor: &Editor<'_, '_, M>,
+    segment: &impl SegmentLike,
+) -> anyhow::Result<SelectorSet> {
+    let selector = if let Some(ref_name) = segment.ref_name() {
+        editor.select_reference(ref_name)?
+    } else if let Some(tip) = segment.tip() {
+        editor.select_commit(tip)?
+    } else {
+        bail!("Base segment has neither a ref name nor any commits.");
+    };
+    let selectors = SomeSelectors::new(vec![selector])?;
+    Ok(SelectorSet::Some(selectors))
+}
+
+trait SegmentLike {
+    fn ref_name(&self) -> Option<&gix::refs::FullNameRef>;
+    fn tip(&self) -> Option<gix::ObjectId>;
+}
+
+impl SegmentLike for StackSegment {
+    fn ref_name(&self) -> Option<&gix::refs::FullNameRef> {
+        self.ref_name()
+    }
+    fn tip(&self) -> Option<gix::ObjectId> {
+        self.tip()
+    }
+}
+
+impl SegmentLike for but_graph::Segment {
+    fn ref_name(&self) -> Option<&gix::refs::FullNameRef> {
+        self.ref_name()
+    }
+    fn tip(&self) -> Option<gix::ObjectId> {
+        self.tip()
+    }
 }

--- a/crates/but-workspace/tests/fixtures/scenario/ws-ref-ws-commit-two-stacks-advanced-remote.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/ws-ref-ws-commit-two-stacks-advanced-remote.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A ws-ref points to a workspace commit, with two stacks inside:
+# - Each stack has a single branch with a single commit
+# - origin/main has advanced past the fork point where both branches diverge
+# This means the base segment at the old fork point has no ref name.
+git init
+commit M
+git branch A
+git checkout -b B
+  commit B
+git checkout A
+  commit A
+
+# Set up the remote tracking to point at main *before* advancing it.
+setup_target_to_match_main
+
+# Advance origin/main past the fork point.
+# This makes the original M commit an unnamed segment in the graph.
+tick
+git update-ref refs/remotes/origin/main "$(git commit-tree -p $(git rev-parse refs/remotes/origin/main) -m 'M2' $(git rev-parse main^{tree}))"
+
+create_workspace_commit_once A B

--- a/crates/but-workspace/tests/workspace/branch/move_branch.rs
+++ b/crates/but-workspace/tests/workspace/branch/move_branch.rs
@@ -601,6 +601,74 @@ fn empty_move_keeps_display_order_aligned_with_metadata() -> anyhow::Result<()> 
     Ok(())
 }
 
+#[test]
+fn move_branch_when_base_segment_has_no_ref_name() -> anyhow::Result<()> {
+    // When origin/main advances past the fork point, the old fork commit becomes
+    // an unnamed base segment. Moving a branch should still work by falling back
+    // to selecting by the segment's tip commit.
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-ws-commit-two-stacks-advanced-remote",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "B", StackState::InWorkspace, &[]);
+            },
+        )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   a236c53 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * c813d8d (B) B
+    * | 09d8e52 (A) A
+    |/  
+    | * 148c87a (origin/main) M2
+    |/  
+    * 85efbe4 (main) M
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 85efbe4
+    ├── ≡📙:4:B on 85efbe4 {2}
+    │   └── 📙:4:B
+    │       └── ·c813d8d (🏘️)
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            └── ·09d8e52 (🏘️)
+    ");
+
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+    // Move B on top of A — the base segment at the old fork point has no ref name.
+    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
+        but_workspace::branch::move_branch(
+            editor,
+            "refs/heads/B".try_into()?,
+            "refs/heads/A".try_into()?,
+        )?;
+
+    rebase.materialize()?;
+    set_workspace_metadata(&mut meta, &ws, ws_meta)?;
+    ws.refresh_from_head(&repo, &meta)?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * 148c87a (origin/main) M2
+    | * 3f2f4c5 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    | * 698ccd3 (B) B
+    | * 09d8e52 (A) A
+    |/  
+    * 85efbe4 (main) M
+    ");
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 85efbe4
+    └── ≡📙:3:B on 85efbe4 {1}
+        ├── 📙:3:B
+        │   └── ·698ccd3 (🏘️)
+        └── 📙:4:A
+            └── ·09d8e52 (🏘️)
+    ");
+
+    Ok(())
+}
+
 fn stack_display_order(ws: &but_graph::projection::Workspace) -> Vec<String> {
     ws.stacks
         .iter()

--- a/e2e/playwright/scripts/fetch-in-clone.sh
+++ b/e2e/playwright/scripts/fetch-in-clone.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo "GIT CONFIG $GIT_CONFIG_GLOBAL"
+echo "DATA DIR $E2E_TEST_APP_DATA_DIR"
+echo "DIRECTORY: $1"
+
+# Fetch updates from the remote.
+pushd "$1"
+  git fetch origin
+popd

--- a/e2e/playwright/tests/branches.spec.ts
+++ b/e2e/playwright/tests/branches.spec.ts
@@ -643,3 +643,41 @@ test("should be able to unapply a stack", async ({ page, context }, testInfo) =>
 	branchHeaders = getByTestId(page, "branch-header").filter({ hasText: "branch1" });
 	await expect(branchHeaders).toHaveCount(0);
 });
+
+test("should be able to move a branch when origin/master has advanced past the fork point", async ({
+	page,
+	context,
+}, testInfo) => {
+	const workdir = testInfo.outputPath("workdir");
+	const configdir = testInfo.outputPath("config");
+	gitbutler = await startGitButler(workdir, configdir, context);
+
+	// Set up project with branches (branch1 and branch3 fork from initial master).
+	await gitbutler.runScript("project-with-remote-branches.sh");
+	// Apply branch1 and branch3 as two separate stacks.
+	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
+	await gitbutler.runScript("apply-upstream-branch.sh", ["branch3", "local-clone"]);
+
+	// Advance remote master past the fork point. This creates a commit on
+	// origin/master that is ahead of where branch1 and branch3 diverge.
+	await gitbutler.runScript("project-with-remote-branches__add-commit-to-base.sh");
+	// Fetch so that origin/master advances in the local clone, making the
+	// old fork point an unnamed segment in the graph.
+	await gitbutler.runScript("fetch-in-clone.sh", ["local-clone"]);
+
+	// Move branch3 on top of branch1. This should succeed even though the
+	// base segment at the old fork point has no ref name.
+	await gitbutler.runScript("move-branch.sh", ["branch3", "branch1", "local-clone"]);
+
+	await page.goto("/");
+
+	// Should load the workspace
+	await waitForTestId(page, "workspace-view");
+
+	// There should be one stack with both branches
+	const stacks = getByTestId(page, "stack");
+	await expect(stacks).toHaveCount(1);
+
+	const branchHeaders = getByTestId(page, "branch-header");
+	await expect(branchHeaders).toHaveCount(2);
+});


### PR DESCRIPTION
## Problem

Moving a branch onto another stack fails with:

```
"Graph base segment doesn't have a ref name"
```

This happens when `origin/master` advances past the fork point where branches diverge — the old fork point becomes an unnamed segment in the graph, and the disconnect logic in `get_disconnect_parameters` assumed every base segment would carry a ref.

## Changes

- Extract a `select_segment` helper that tries the ref name first, then falls back to `segment.tip()`.
- Introduce a `SegmentLike` trait to unify `StackSegment` and `but_graph::Segment` behind a common interface.
- Add a crate-level test (`move_branch_when_base_segment_has_no_ref_name`) that directly exercises the fallback path with an unnamed base segment.
- Add an E2E test that reproduces the full scenario: apply two branches, advance `origin/master`, fetch, then move one branch onto the other.