### PR TITLE
ci(lite): use Xcode 26.x on macOS 26 to fix build error

### DIFF
--- a/.github/workflows/lite.yml
+++ b/.github/workflows/lite.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: macos-15 # [macOs, ARM64]
+          - platform: macos-26 # [macOs, ARM64]
           - platform: ubuntu-22.04 # [linux, x64]
           - platform: windows-latest # [windows, x64]
     env:
@@ -37,9 +37,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get -y install pkg-config libxss-dev libdbus-1-dev
-      - name: Select Xcode 26.3
-        if: runner.os == 'macOS'
-        run: sudo xcode-select -s /Applications/Xcode_26.3.app
       - uses: ./.github/actions/init-env-node
       - name: Set version
         working-directory: apps/lite

--- a/.github/workflows/lite.yml
+++ b/.github/workflows/lite.yml
@@ -37,6 +37,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get -y install pkg-config libxss-dev libdbus-1-dev
+      - name: Select Xcode 26.3
+        if: runner.os == 'macOS'
+        run: sudo xcode-select -s /Applications/Xcode_26.3.app
       - uses: ./.github/actions/init-env-node
       - name: Set version
         working-directory: apps/lite


### PR DESCRIPTION
## 🧢 Changes
The new icons require Xcode 26.x to be packaged. Or, rather, the tool that handles the icons has that requirement.

> Note: I tried with Xcode 26.3 on macOS 15 [as per this issue](https://github.com/actions/runner-images/issues/12991), but it then failed with a bunch of strange build issues instead. So for now we'll just build on macOS 26.