### PR TITLE
Fix integrate-upstream failing when stacks have divergent upstream bases

### DIFF
--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -283,6 +283,62 @@ fn stacks(
     )
 }
 
+/// Verify that all workspace stacks can be octopus-merged without conflicts.
+///
+/// When stacks have divergent upstream bases they can carry different versions
+/// of the same file, causing the sequential octopus merge to fail. Instead of
+/// silently evicting the offending stack, we return a descriptive error so the
+/// user can unapply it manually and retry.
+fn check_workspace_stacks_mergeable(
+    context: &UpstreamIntegrationContext,
+    repo: &gix::Repository,
+) -> Result<()> {
+    // Use an in-memory ODB so the intermediate merge trees don't pollute the
+    // real object store — this is a read-only pre-flight check.
+    let repo = repo.clone().with_object_memory();
+
+    let target_tree = repo.find_commit(context.old_target_id)?.tree_id()?.detach();
+
+    let (merge_options, conflict_kind) = repo.merge_options_fail_fast()?;
+
+    let mut workspace_tree = target_tree;
+    for stack in &context.stacks_in_workspace {
+        let stack_tree = repo.find_commit(stack.tip)?.tree_id()?.detach();
+
+        let mut merge = repo.merge_trees(
+            target_tree,
+            workspace_tree,
+            stack_tree,
+            repo.default_merge_labels(),
+            merge_options.clone(),
+        )?;
+
+        if merge.has_unresolved_conflicts(conflict_kind) {
+            let conflicting_files: Vec<String> = merge
+                .conflicts
+                .iter()
+                .filter(|c| c.is_unresolved(TreatAsUnresolved::git()))
+                .map(|c| c.ours.location().to_str_lossy().into_owned())
+                .collect();
+
+            let stack_name = stack
+                .name()
+                .map(|n| n.to_str_lossy().into_owned())
+                .unwrap_or_else(|| "<unnamed>".to_string());
+
+            bail!(
+                "Stack '{stack_name}' conflicts with other applied stacks on: {}. \
+                 Please unapply it and try again.",
+                conflicting_files.join(", ")
+            );
+        }
+
+        workspace_tree = merge.tree.write()?.detach();
+    }
+
+    Ok(())
+}
+
 #[expect(deprecated, reason = "calls but_workspace::legacy::stack_details_v3")]
 fn stack_details(
     ctx: &Context,
@@ -497,6 +553,12 @@ pub(crate) fn integrate_upstream(
     let repo = ctx.repo.get()?;
     let context =
         UpstreamIntegrationContext::open(ctx, target_commit_oid, permission, &repo, review_map)?;
+
+    // Check that all workspace stacks can be merged together. If any pair
+    // of stacks carries conflicting trees (e.g. from divergent upstream
+    // bases), ask the user to unapply the offending stack first.
+    check_workspace_stacks_mergeable(&context, &repo)?;
+
     let mut virtual_branches_state = VirtualBranchesHandle::new(ctx.project_data_dir());
 
     let mut deleted_branches = vec![];

--- a/crates/gitbutler-branch-actions/tests/branch-actions/driverless.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/driverless.rs
@@ -174,6 +174,23 @@ fn seed_fixture(repo: &gix::Repository, script_name: &str, repo_name: &str) -> R
                 in_workspace: true,
             },
         ],
+        ("workspace-commit.sh", "diverged-stacks") => vec![
+            StackSpec {
+                id: 1,
+                branches_base_to_top: &["stack_a"],
+                in_workspace: true,
+            },
+            StackSpec {
+                id: 2,
+                branches_base_to_top: &["stack_b"],
+                in_workspace: true,
+            },
+            StackSpec {
+                id: 3,
+                branches_base_to_top: &["stack_c"],
+                in_workspace: true,
+            },
+        ],
         unsupported => anyhow::bail!("unsupported driverless fixture {unsupported:?}"),
     };
 

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/apply_virtual_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/apply_virtual_branch.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use but_forge::ForgeReview;
+use but_oxidize::{ObjectIdExt as _, OidExt as _};
 use gitbutler_branch::BranchCreateRequest;
 use gitbutler_branch_actions::upstream_integration::{
     BranchStatus, Resolution, ResolutionApproach, StackStatuses, UpstreamTreeStatus,
@@ -740,4 +741,234 @@ fn integrate_upstream_with_fully_integrated_branch_in_stack() {
         "only branch3 should remain visible"
     );
     assert_eq!(stacks[0].1.branch_details[0].name, "branch3");
+}
+
+/// Regression test for the scenario where stacks carry different amounts of
+/// upstream history, causing `merge_workspace` to fail during `integrate_upstream`.
+///
+/// Reproduces the real-world bug: three stacks are in the workspace, none of
+/// them touch `foo.txt`, yet each stack tree carries a different version of
+/// `foo.txt` because each was previously rebased onto a different intermediate
+/// upstream commit. The stacks don't share a common base, so sequential
+/// octopus-merging their trees against `target.tree()` produces a genuine
+/// textual conflict on a file no stack ever edited.
+///
+/// The graph rebase commit path (used for all commit operations) never calls
+/// `remerged_workspace_tree_v2`, so the inter-stack conflict goes undetected
+/// during normal development. It only surfaces during `integrate_upstream`.
+///
+/// The fix adds a pre-flight check (`check_workspace_stacks_mergeable`) that
+/// detects the conflict early and returns a descriptive error naming the
+/// offending stack and file, so the user can unapply it and retry. No state
+/// is mutated on failure.
+#[test]
+fn integrate_upstream_with_inter_stack_tree_conflict() {
+    let Test { repo, ctx, .. } = &mut Test::default();
+
+    // Initial state: foo.txt exists alongside per-stack files.
+    // No stack will ever edit foo.txt directly — the conflict comes purely
+    // from upstream history divergence.
+    fs::write(repo.path().join("foo.txt"), "original\n").unwrap();
+    fs::write(repo.path().join("file_a.txt"), "a\n").unwrap();
+    fs::write(repo.path().join("file_b.txt"), "b\n").unwrap();
+    fs::write(repo.path().join("file_c.txt"), "c\n").unwrap();
+    let initial = repo.commit_all("initial");
+    repo.push();
+
+    // Upstream commits that progressively change foo.txt:
+    // C1: rename (foo.txt = "renamed")
+    fs::write(repo.path().join("foo.txt"), "renamed\n").unwrap();
+    let c1 = repo.commit_all("upstream: rename foo");
+    // C2: rewrite (foo.txt = multi-line, incompatible with C1 from target's perspective)
+    fs::write(
+        repo.path().join("foo.txt"),
+        "renamed\nextra line\nmore content\n",
+    )
+    .unwrap();
+    let c2 = repo.commit_all("upstream: rewrite foo");
+    // C3: another upstream commit so the target can advance past C2.
+    fs::write(repo.path().join("unrelated.txt"), "new\n").unwrap();
+    repo.commit_all("upstream: unrelated file");
+    repo.push();
+
+    // Reset local back to initial so there's an upstream delta.
+    repo.reset_hard(Some(initial));
+
+    // Set the base branch (target = initial).
+    let mut guard = ctx.exclusive_worktree_access();
+    gitbutler_branch_actions::set_base_branch(
+        ctx,
+        &"refs/remotes/origin/master".parse().unwrap(),
+        guard.write_permission(),
+    )
+    .unwrap();
+    drop(guard);
+
+    // Create three stacks, each editing only its own file (never foo.txt).
+    let stack_ids: Vec<_> = ["stack-a", "stack-b", "stack-c"]
+        .iter()
+        .zip(["file_a.txt", "file_b.txt", "file_c.txt"])
+        .map(|(name, file)| {
+            let mut guard = ctx.exclusive_worktree_access();
+            let entry = gitbutler_branch_actions::create_virtual_branch(
+                ctx,
+                &BranchCreateRequest {
+                    name: Some(name.to_string()),
+                    ..Default::default()
+                },
+                guard.write_permission(),
+            )
+            .unwrap();
+            drop(guard);
+            fs::write(repo.path().join(file), format!("modified by {name}\n")).unwrap();
+            super::create_commit(ctx, entry.id, &format!("{name}: modify {file}")).unwrap();
+            entry.id
+        })
+        .collect();
+
+    // Simulate a previous partial integrate: rebase each stack onto a different
+    // intermediate upstream commit, without advancing the target. This gives
+    // each stack tree a different version of foo.txt purely through upstream
+    // history, even though no stack ever edited foo.txt.
+    //
+    // stack-a → rebased onto initial (foo.txt = "original")
+    // stack-b → rebased onto C1      (foo.txt = "renamed")
+    // stack-c → rebased onto C2      (foo.txt = "renamed\nextra line\nmore content")
+    {
+        let gix_repo = ctx.repo.get().unwrap();
+        let git_repo = git2::Repository::open(repo.path()).unwrap();
+        let sig = git2::Signature::now("test", "test@email.com").unwrap();
+
+        let mut vb_state = gitbutler_stack::VirtualBranchesHandle::new(ctx.project_data_dir());
+
+        let rebase_targets = [initial, c1, c2];
+        let mut new_heads = Vec::new();
+
+        for (stack_id, rebase_onto) in stack_ids.iter().zip(rebase_targets) {
+            let mut stack = vb_state.get_stack(*stack_id).unwrap();
+            let old_head = stack.heads.last().unwrap().head_oid(&gix_repo).unwrap();
+
+            let onto_commit = git_repo.find_commit(rebase_onto).unwrap();
+            let old_commit = git_repo.find_commit(old_head.to_git2()).unwrap();
+            let mut index = git_repo
+                .merge_commits(&onto_commit, &old_commit, None)
+                .unwrap();
+            assert!(
+                !index.has_conflicts(),
+                "cherry-pick onto intermediate upstream should be clean"
+            );
+            let tree_oid = index.write_tree_to(&git_repo).unwrap();
+            let tree = git_repo.find_tree(tree_oid).unwrap();
+            let new_head = git_repo
+                .commit(
+                    None,
+                    &sig,
+                    &sig,
+                    &format!("rebased onto {}", &rebase_onto.to_string()[..8]),
+                    &tree,
+                    &[&onto_commit],
+                )
+                .unwrap();
+
+            stack
+                .set_stack_head(&mut vb_state, &gix_repo, new_head.to_gix())
+                .unwrap();
+            new_heads.push(new_head);
+        }
+
+        // Rebuild the workspace merge commit so stacks_v3 can discover all
+        // three stacks from the graph. The tree used here is arbitrary —
+        // merge_workspace recomputes it from stack trees.
+        let target_commit = git_repo.find_commit(initial).unwrap();
+        let parent_commits: Vec<_> = std::iter::once(&initial)
+            .chain(new_heads.iter())
+            .map(|oid| git_repo.find_commit(*oid).unwrap())
+            .collect();
+        let parent_refs: Vec<_> = parent_commits.iter().collect();
+        let ws_tree = target_commit.tree().unwrap();
+        let ws_oid = git_repo
+            .commit(
+                None,
+                &sig,
+                &sig,
+                "GitButler Workspace Commit",
+                &ws_tree,
+                &parent_refs,
+            )
+            .unwrap();
+        git_repo
+            .reference(
+                "refs/heads/gitbutler/workspace",
+                ws_oid,
+                true,
+                "test: rebuild workspace",
+            )
+            .unwrap();
+    }
+
+    // Integrate upstream. Before the fix, merge_workspace would bail with a
+    // generic "merge conflict when computing workspace tree". Now we get a
+    // descriptive error telling the user which stack and file are problematic.
+    let resolutions: Vec<_> = stack_ids
+        .iter()
+        .map(|id| Resolution {
+            stack_id: *id,
+            approach: ResolutionApproach::Rebase,
+            delete_integrated_branches: false,
+        })
+        .collect();
+    let err =
+        gitbutler_branch_actions::integrate_upstream(ctx, &resolutions, None, &Default::default())
+            .expect_err(
+                "should fail when stacks have conflicting trees from divergent upstream bases",
+            );
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("conflicts with other applied stacks"),
+        "expected descriptive conflict error, got: {msg}"
+    );
+    assert!(
+        msg.contains("foo.txt"),
+        "error should name the conflicting file, got: {msg}"
+    );
+    assert!(
+        msg.contains("unapply"),
+        "error should suggest unapplying, got: {msg}"
+    );
+
+    // The failed integrate_upstream must leave the repository in a clean state:
+    // all three stacks still applied, worktree unchanged, workspace functional.
+    let vb_state = gitbutler_stack::VirtualBranchesHandle::new(ctx.project_data_dir());
+    let applied_stacks = vb_state.list_stacks_in_workspace().unwrap();
+    assert_eq!(
+        applied_stacks.len(),
+        3,
+        "all three stacks should still be applied after a failed integrate"
+    );
+    let mut applied_names: Vec<String> = applied_stacks.iter().map(|s| s.name()).collect();
+    applied_names.sort();
+    assert_eq!(
+        applied_names,
+        vec!["stack-a", "stack-b", "stack-c"],
+        "all stacks should retain their names"
+    );
+
+    // Worktree files should be exactly as they were before the call.
+    assert_eq!(
+        fs::read_to_string(repo.path().join("foo.txt")).unwrap(),
+        "original\n",
+        "foo.txt should be untouched"
+    );
+    for (file, stack_name) in [
+        ("file_a.txt", "stack-a"),
+        ("file_b.txt", "stack-b"),
+        ("file_c.txt", "stack-c"),
+    ] {
+        assert_eq!(
+            fs::read_to_string(repo.path().join(file)).unwrap(),
+            format!("modified by {stack_name}\n"),
+            "{file} should be untouched"
+        );
+    }
 }

--- a/crates/gitbutler-branch-actions/tests/branch-actions/workspace_commit.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/workspace_commit.rs
@@ -108,3 +108,43 @@ fn merge_workspace_succeeds_with_adjacent_hunks_from_both_sides() -> Result<()> 
 
     Ok(())
 }
+
+/// Regression test for a merge-base mismatch between `merge_workspace` and
+/// `remerged_workspace_tree_v2`.
+///
+/// Three stacks based on different upstream commits inherit different versions
+/// of `shared.txt` that none of them intentionally modified. The fix uses the
+/// target's tree as merge base (matching `remerged_workspace_tree_v2`), which
+/// produces a clean merge. The old behavior used `merge_base_octopus` which
+/// fell behind the target, causing false conflicts.
+///
+/// This directly tests `WorkspaceState::create_from_heads_and_target` and
+/// `merge_workspace` — the exact code path that was fixed.
+#[test]
+fn merge_workspace_with_diverged_stacks() -> Result<()> {
+    let (ctx, _temp_dir) = command_ctx("diverged-stacks")?;
+
+    let repo = ctx.repo.get()?;
+    let target_oid = repo.rev_parse_single("current-target")?.detach();
+    let head_oids: Vec<gix::ObjectId> = ["stack_a", "stack_b", "stack_c"]
+        .iter()
+        .map(|name| repo.rev_parse_single(*name).map(|id| id.detach()))
+        .collect::<Result<_, _>>()?;
+
+    // Build WorkspaceState from the stack heads and target — this is exactly
+    // what `integrate_upstream` does before calling `merge_workspace`.
+    let workspace =
+        gitbutler_workspace::branch_trees::WorkspaceState::create_from_heads_and_target(
+            &repo, &head_oids, target_oid,
+        )?;
+
+    // With the fix (target tree as base), this merges cleanly because each
+    // stack's inherited shared.txt differs in a different section.
+    // With the old code (octopus base = init), this would fail because all
+    // stacks replace "base content" with different multi-line content.
+    let gix_repo = ctx.clone_repo_for_merging()?;
+    gitbutler_workspace::branch_trees::merge_workspace(&gix_repo, &workspace)
+        .expect("workspace should merge cleanly with target tree as base");
+
+    Ok(())
+}

--- a/crates/gitbutler-branch-actions/tests/fixtures/workspace-commit.sh
+++ b/crates/gitbutler-branch-actions/tests/fixtures/workspace-commit.sh
@@ -97,3 +97,92 @@ git clone remote adjacent-stacks
   git checkout -b gitbutler/workspace main
   git commit --allow-empty -m "GitButler Workspace Commit"
 )
+
+# Reproduces a merge-base mismatch between merge_workspace and remerged_workspace_tree_v2.
+#
+# Three stacks based on different upstream commits, so their trees inherit
+# different versions of shared.txt. Neither stack modifies shared.txt itself.
+#
+# Remote history: init -> v1 -> v2 -> v3 (target)
+# v1 and v2 each modify a DIFFERENT section of shared.txt relative to v3.
+# v3 has the "canonical" content (target version).
+#
+# merge_base_octopus(stack_a, stack_b, stack_c, v3) = init ("base content").
+# With init as base, stacks replace "base content" with different multi-line
+# content → conflict.
+# With target (v3) as base, stack_a changes section A only, stack_b changes
+# section B only → non-overlapping → clean merge.
+#
+# The test advances origin/main to v4 to trigger integrate_upstream.
+(cd remote
+  git config user.name "Author"
+  git config user.email "author@example.com"
+
+  # v1: section A differs from v3, sections B and C match v3.
+  printf '%s\n' \
+    "--- section A ---" "ALPHA ONE" "ALPHA TWO" "ALPHA THREE" \
+    "--- section B ---" "line b1" "line b2" "line b3" \
+    "--- section C ---" "line c1" "line c2" "line c3" > shared.txt
+  git add . && git commit -m "upstream: shared.txt v1"
+
+  # v2: section A matches v3, section B differs from v3, section C matches v3.
+  printf '%s\n' \
+    "--- section A ---" "line a1" "line a2" "line a3" \
+    "--- section B ---" "BRAVO ONE" "BRAVO TWO" "BRAVO THREE" \
+    "--- section C ---" "line c1" "line c2" "line c3" > shared.txt
+  git add . && git commit -m "upstream: shared.txt v2"
+
+  # v3 (target): canonical content — all sections in their "final" form.
+  printf '%s\n' \
+    "--- section A ---" "line a1" "line a2" "line a3" \
+    "--- section B ---" "line b1" "line b2" "line b3" \
+    "--- section C ---" "line c1" "line c2" "line c3" > shared.txt
+  git add . && git commit -m "upstream: shared.txt v3"
+)
+
+git clone remote diverged-stacks
+(cd diverged-stacks
+  git config user.name "Author"
+  git config user.email "author@example.com"
+
+  # v3 is the current target; v4 will be the new upstream the test advances to.
+  git tag current-target origin/main
+
+  # Create v4 on remote (the commit the test will advance origin/main to).
+  (cd ../remote
+    echo "unrelated new file" > new_upstream.txt
+    git add . && git commit -m "upstream: add new_upstream.txt"
+  )
+  git fetch origin
+
+  git tag upstream-target origin/main
+
+  # stack_a: child of v1, only adds file_a.txt (inherits shared.txt = "v1")
+  git checkout -b stack_a current-target~2
+  echo "stack a work" > file_a.txt
+  commit_with_tick "stack_a: add file_a"
+
+  # stack_b: child of v2, only adds file_b.txt (inherits shared.txt = "v2 ...")
+  git checkout -b stack_b current-target~1
+  echo "stack b work" > file_b.txt
+  commit_with_tick "stack_b: add file_b"
+
+  # stack_c: child of v3, only adds file_c.txt (inherits shared.txt = "v3 ...")
+  git checkout -b stack_c current-target
+  echo "stack c work" > file_c.txt
+  commit_with_tick "stack_c: add file_c"
+
+  # Target metadata points to v3 (= current-target).
+  # origin/main still points to v4; the test will set it to upstream-target.
+  git update-ref refs/remotes/origin/main current-target
+
+  # Build a workspace commit with all three stacks as parents so that
+  # stacks_v3 can discover them from the commit graph.
+  stack_a_oid=$(git rev-parse stack_a)
+  stack_b_oid=$(git rev-parse stack_b)
+  stack_c_oid=$(git rev-parse stack_c)
+  tree=$(git rev-parse stack_c^{tree})
+  ws_commit=$(echo "GitButler Workspace Commit" | git commit-tree "$tree" -p "$stack_a_oid" -p "$stack_b_oid" -p "$stack_c_oid")
+  git checkout -b gitbutler/workspace
+  git reset --hard "$ws_commit"
+)

--- a/crates/gitbutler-workspace/src/branch_trees.rs
+++ b/crates/gitbutler-workspace/src/branch_trees.rs
@@ -7,10 +7,7 @@ use but_ctx::{
 use but_oxidize::{ObjectIdExt, OidExt};
 use gitbutler_cherry_pick::GixRepositoryExt as _;
 
-use crate::{
-    legacy_target_base_oid, legacy_workspace_stack_heads, workspace_base_from_heads,
-    workspace_base_from_heads_and_target,
-};
+use crate::{legacy_target_base_oid, legacy_workspace_stack_heads};
 
 /// A snapshot of the workspace at a point in time.
 #[derive(Debug)]
@@ -43,8 +40,9 @@ impl WorkspaceState {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        let base = workspace_base_from_heads_and_target(repo, head_oids, target_base_oid)?;
-        let base_tree_id = repo.find_commit(base)?.tree_id()?.detach();
+        // Use the target's tree directly as the merge base, matching
+        // `remerged_workspace_tree_v2`.
+        let base_tree_id = repo.find_commit(target_base_oid)?.tree_id()?.detach();
 
         Ok(WorkspaceState {
             heads,
@@ -54,28 +52,12 @@ impl WorkspaceState {
 
     pub fn create_from_heads(
         ctx: &Context,
-        perm: &RepoShared,
+        _perm: &RepoShared,
         heads: &[gix::ObjectId],
     ) -> Result<Self> {
         let repo = &*ctx.repo.get()?;
-
-        let base = workspace_base_from_heads(ctx, perm, heads)?;
-
-        let heads = heads
-            .iter()
-            .map(|head| -> Result<gix::ObjectId> {
-                let commit = repo.find_commit(*head)?;
-                let tree = repo.find_real_tree(&commit, Default::default())?;
-                Ok(tree.detach())
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        let base_tree_id = repo.find_commit(base)?.tree_id()?.detach();
-
-        Ok(WorkspaceState {
-            heads,
-            base: base_tree_id,
-        })
+        let target_base_oid = legacy_target_base_oid(ctx)?;
+        Self::create_from_heads_and_target(repo, heads, target_base_oid)
     }
 }
 


### PR DESCRIPTION
## Problem

When stacks get rebased onto different intermediate upstream commits (e.g. after a partial integrate), their trees carry different versions of upstream-modified files — even files no stack ever edited. The next `integrate_upstream` call fails with a generic "merge conflict when computing workspace tree", giving the user no guidance on what to do.

The e2e test reproduces the real-world scenario: three stacks each edit only their own file, but each is rebased onto a different upstream point. Each tree inherits a different version of `foo.txt` from upstream history alone:

| Stack   | Based on | `foo.txt` content        |
|---------|----------|--------------------------|
| stack-a | initial  | `"original"`             |
| stack-b | C1       | `"renamed"`              |
| stack-c | C2       | `"renamed\nextra\nmore"` |

`merge_workspace` octopus-merges these against `target.tree()`:
1. stack-a → clean (foo.txt unchanged from target)
2. stack-b → clean (only one side changes foo.txt)
3. stack-c → **CONFLICT** (both "ours" and "theirs" changed foo.txt)

## Root cause

Two independent bugs:

**1. Merge-base mismatch** — `WorkspaceState` used `merge_base_octopus` as the base tree, which falls behind the target when stacks have different ancestors. Meanwhile `remerged_workspace_tree_v2` uses `target.tree()`. The disagreement caused `merge_workspace` to see false conflicts that the other path never produced.

**2. No pre-flight conflict check** — `integrate_upstream` had no way to detect inter-stack tree conflicts before starting the integration. When `merge_workspace` hit a conflict deep in the flow, it bailed with a generic error after refs and metadata had already been partially updated.

## Fix

1. Use `target.tree()` directly in `WorkspaceState`, matching `remerged_workspace_tree_v2`.
2. Add `check_workspace_stacks_mergeable()` — a pre-flight check at the start of `integrate_upstream` that octopus-merges all workspace stack trees. If any stack conflicts, it returns a descriptive error naming the stack and conflicting files, e.g.: *"Stack 'stack-c' conflicts with other applied stacks on: foo.txt. Please unapply it and try again."*

This approach avoids silently evicting stacks or mutating state — the user gets a clear error and can decide what to unapply.

## Test plan

- [x] E2e regression test: 3 stacks with divergent upstream bases, none editing `foo.txt` — returns descriptive error naming the conflicting stack and file
- [x] E2e state preservation: after the failed call, all 3 stacks are still applied, worktree files are unchanged
- [x] Unit test: `merge_workspace` with diverged stacks merges cleanly using target tree as base
- [x] All 64 `gitbutler-branch-actions` tests pass