### PR TITLE
Use git config email to match current user avatar

### DIFF
--- a/apps/desktop/src/components/branchesPage/BranchListCard.svelte
+++ b/apps/desktop/src/components/branchesPage/BranchListCard.svelte
@@ -3,7 +3,7 @@
 	import { BRANCH_SERVICE } from "$lib/branches/branchService.svelte";
 	import { GIT_CONFIG_SERVICE } from "$lib/config/gitConfigService";
 	import { getPrStatus } from "$lib/forge/interface/prUtils";
-	import { USER_SERVICE } from "$lib/user/userService";
+	import { useUserAvatarUrl } from "$lib/user/userAvatar.svelte";
 	import { inject } from "@gitbutler/core/context";
 
 	import { AvatarGroup, ReviewBadge, SeriesLabelsRow, TestId, TimeAgo } from "@gitbutler/ui";
@@ -22,15 +22,13 @@
 	}
 
 	const { reviewUnit, projectId, branchListing, prs, selected, onclick }: Props = $props();
+	const userAvatarUrl = useUserAvatarUrl();
 
 	const unknownName = "unknown";
 	const unknownEmail = "example@example.com";
 
-	const userService = inject(USER_SERVICE);
 	const gitConfigService = inject(GIT_CONFIG_SERVICE);
 	const branchService = inject(BRANCH_SERVICE);
-
-	const user = userService.user;
 
 	// TODO: Use information from all PRs in a stack?
 	const pr = $derived(prs.at(0));
@@ -73,13 +71,14 @@
 	async function setAvatars(ownedByUser: boolean, branchListingDetails?: BranchListingDetails) {
 		if (ownedByUser) {
 			const name = (await gitConfigService.get("user.name")) || unknownName;
-			const email = (await gitConfigService.get("user.email")) || unknownEmail;
-			const srcUrl =
-				email.toLowerCase() === $user?.email?.toLowerCase() && $user?.picture
-					? $user?.picture
-					: await gravatarUrlFromEmail(email);
+			const email = (await gitConfigService.get<string>("user.email")) || unknownEmail;
 
-			avatars = [{ username: name, srcUrl: srcUrl }];
+			avatars = [
+				{
+					username: name,
+					srcUrl: userAvatarUrl(email) ?? (await gravatarUrlFromEmail(email)),
+				},
+			];
 		} else if (branchListingDetails) {
 			avatars = branchListingDetails.authors
 				? await Promise.all(
@@ -87,9 +86,8 @@
 							return {
 								username: author.name || unknownName,
 								srcUrl:
-									(author.email?.toLowerCase() === $user?.email?.toLowerCase()
-										? $user?.picture
-										: author.gravatarUrl) ??
+									userAvatarUrl(author.email) ??
+									author.gravatarUrl ??
 									(await gravatarUrlFromEmail(author.email || unknownEmail)),
 							};
 						}),

--- a/apps/desktop/src/components/commit/CommitDetails.svelte
+++ b/apps/desktop/src/components/commit/CommitDetails.svelte
@@ -4,7 +4,7 @@
 	import { splitMessage } from "$lib/commits/commitMessage";
 	import { rewrapCommitMessage } from "$lib/config/uiFeatureFlags";
 	import { SETTINGS } from "$lib/settings/userSettings";
-	import { USER_SERVICE } from "$lib/user/userService";
+	import { useUserAvatarUrl } from "$lib/user/userAvatar.svelte";
 	import { rejoinParagraphs, truncate } from "$lib/utils/string";
 	import { inject } from "@gitbutler/core/context";
 
@@ -20,12 +20,10 @@
 
 	const { commit, rewrap, includeTitle }: Props = $props();
 
-	const userService = inject(USER_SERVICE);
 	const userSettings = inject(SETTINGS);
 	const clipboardService = inject(CLIPBOARD_SERVICE);
+	const userAvatarUrl = useUserAvatarUrl();
 	const zoom = $derived($userSettings.zoom);
-
-	const user = $derived(userService.user);
 
 	let messageWidth = $state(0);
 	const messageWidthRem = $derived(pxToRem(messageWidth, zoom));
@@ -43,16 +41,6 @@
 	const isAbbrev = $derived(abbreviated !== description);
 
 	let expanded = $state(false);
-
-	function getGravatarUrl(email: string, existingravatarUrl: string): string {
-		if ($user?.email === undefined) {
-			return existingravatarUrl;
-		}
-		if (email === $user.email) {
-			return $user.picture ?? existingravatarUrl;
-		}
-		return existingravatarUrl;
-	}
 </script>
 
 <div class="commit">
@@ -61,7 +49,7 @@
 		<Avatar
 			size="medium"
 			username={commit.author.name}
-			srcUrl={getGravatarUrl(commit.author.email, commit.author.gravatarUrl)}
+			srcUrl={userAvatarUrl(commit.author.email) ?? commit.author.gravatarUrl}
 		/>
 		<span class="divider">•</span>
 		<TimeAgo date={commitCreatedAtDate(commit)} />

--- a/apps/desktop/src/components/workspace/EditCommitPanel.svelte
+++ b/apps/desktop/src/components/workspace/EditCommitPanel.svelte
@@ -15,7 +15,7 @@
 	import { createCommitSelection } from "$lib/selection/key";
 	import { SETTINGS } from "$lib/settings/userSettings";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
-	import { USER } from "$lib/user/user";
+	import { useUserAvatarUrl } from "$lib/user/userAvatar.svelte";
 	import { inject } from "@gitbutler/core/context";
 
 	import { AsyncButton, Avatar, Badge, Button, InfoButton, Modal, TestId } from "@gitbutler/ui";
@@ -35,12 +35,13 @@
 	const projectService = inject(PROJECTS_SERVICE);
 	const projectQuery = $derived(projectService.getProject(projectId));
 
-	const user = inject(USER);
 	const stackService = inject(STACK_SERVICE);
 	const modeService = inject(MODE_SERVICE);
 	const userSettings = inject(SETTINGS);
 	const urlService = inject(URL_SERVICE);
 	const fileService = inject(FILE_SERVICE);
+
+	const userAvatarUrl = useUserAvatarUrl();
 
 	const initialFiles = $derived(modeService.initialEditModeState({ projectId }));
 	const uncommittedFiles = $derived(modeService.changesSinceInitialEditState({ projectId }));
@@ -232,9 +233,7 @@
 						<ReduxResult {projectId} result={commitQuery.result}>
 							{#snippet children(commit)}
 								{@const authorImgUrl = commit
-									? commit.author.email?.toLowerCase() === $user?.email?.toLowerCase()
-										? $user?.picture
-										: commit.author.gravatarUrl
+									? (userAvatarUrl(commit.author.email) ?? commit.author.gravatarUrl)
 									: undefined}
 								{@const title = splitMessage(commit.message).title}
 								<h3 class="text-13 text-semibold text-body commit-card__title">

--- a/apps/desktop/src/lib/user/userAvatar.svelte.ts
+++ b/apps/desktop/src/lib/user/userAvatar.svelte.ts
@@ -1,0 +1,33 @@
+import { GIT_CONFIG_SERVICE } from "$lib/config/gitConfigService";
+import { USER_SERVICE } from "$lib/user/userService";
+import { inject } from "@gitbutler/core/context";
+import { get } from "svelte/store";
+
+/**
+ * Returns the current user's profile picture if the given email belongs to them,
+ * `undefined` otherwise. Matches against both the GitButler account email and the
+ * local git config email, since these often differ.
+ */
+export function useUserAvatarUrl(): (email: string | null | undefined) => string | undefined {
+	const userService = inject(USER_SERVICE);
+	const gitConfigService = inject(GIT_CONFIG_SERVICE);
+
+	let gitConfigEmail = $state<string | undefined>();
+
+	$effect(() => {
+		gitConfigService.get<string>("user.email").then((email) => {
+			gitConfigEmail = email;
+		});
+	});
+
+	return (email: string | null | undefined): string | undefined => {
+		if (!email) return undefined;
+		const user = get(userService.user);
+		if (!user?.picture) return undefined;
+		const lower = email.toLowerCase();
+		if (lower === user.email?.toLowerCase() || lower === gitConfigEmail?.toLowerCase()) {
+			return user.picture;
+		}
+		return undefined;
+	};
+}


### PR DESCRIPTION
Fix avatar matching so the app considers the local Git config user.email
in addition to the logged-in GitButler account. Some commits used a
different commit email than the GitButler profile email, causing the
profile picture to not appear. The change loads user.email from git
config and compares it when deciding whether to use the $user.picture or
a gravatar image across BranchListCard, CommitDetails, and
EditCommitPanel. Helper isCurrentUser functions and minor refactors
centralize this logic and prevent missing avatars when commit email
equals the repo git config email.
Use unified current-user helper for avatar logic

Replace direct USER and GIT_CONFIG_SERVICE usage with useIsCurrentUser
helper across several components to make the distinction between account
email and local git config email clearer and consistent. This
centralizes the logic for determining the current user and obtaining
their picture, removes duplicated git config lookups, and simplifies
avatar/gravatar selection so account vs git email handling is less
confusing and easier to maintain.
Use unified user avatar helper for author images

Replace multiple uses of the old useIsCurrentUser/currentUserPicture
helpers with a new useUserAvatarUrl helper. This centralizes logic for
resolving the current user's avatar (matching against both GitButler
account email and local git config email) and falls back to existing
gravatar URLs when appropriate. The change updates BranchListCard,
CommitDetails, and EditCommitPanel to call userAvatarUrl(email) and adds
a new userAvatar utility module to encapsulate the behavior.