### PR TITLE
Fix Svelte 5 reactive race when closing project settings modal

### DIFF
--- a/apps/desktop/src/components/views/GlobalModalRouter.svelte
+++ b/apps/desktop/src/components/views/GlobalModalRouter.svelte
@@ -83,6 +83,18 @@
 
 	const modalProps = $derived(mapModalStateToProps(uiState.global.modal.current));
 
+	// Svelte 5 can propagate prop changes into the child block before the outer
+	// {#if} re-evaluates and unmounts it, causing crashes like
+	// "undefined is not an object (evaluating 'data.projectId')". stableModalData
+	// latches the last non-null modalProps so the children always see valid data;
+	// the {#if modalProps && stableModalData} gate handles visibility.
+	let stableModalData = $state<ModalData | null>(null);
+	$effect.pre(() => {
+		if (modalProps !== null) {
+			stableModalData = modalProps;
+		}
+	});
+
 	let modal = $state<Modal>();
 
 	// Show the modal whenever modalProps becomes truthy.
@@ -98,7 +110,7 @@
 		// If the login confirmation modal is closed without explicit user action (e.g., via ESC),
 		// we should reject the incoming user to maintain state consistency.
 		// We check if there's still an incoming user to avoid calling reject after accept/reject buttons.
-		if (modalProps?.state.type === "login-confirmation") {
+		if (stableModalData?.state.type === "login-confirmation") {
 			if (userService.incomingUserLogin) {
 				userService.rejectIncomingUser();
 			}
@@ -121,23 +133,23 @@
 	}
 </script>
 
-{#if modalProps}
+{#if modalProps && stableModalData}
 	<Modal
 		bind:this={modal}
-		{...modalProps.props}
+		{...stableModalData.props}
 		onClose={handleModalClose}
 		onSubmit={(close) => close()}
 	>
-		{#if modalProps.state.type === "commit-failed"}
-			<CommitFailedModalContent data={modalProps.state} oncloseclick={closeModal} />
-		{:else if modalProps.state.type === "author-missing"}
-			<AuthorMissingModalContent data={modalProps.state} close={closeModal} />
-		{:else if modalProps.state.type === "general-settings"}
-			<GeneralSettingsModalContent data={modalProps.state} />
-		{:else if modalProps.state.type === "project-settings"}
-			<ProjectSettingsModalContent data={modalProps.state} />
-		{:else if modalProps.state.type === "login-confirmation"}
-			<LoginConfirmationModalContent data={modalProps.state} close={closeModal} />
+		{#if stableModalData.state.type === "commit-failed"}
+			<CommitFailedModalContent data={stableModalData.state} oncloseclick={closeModal} />
+		{:else if stableModalData.state.type === "author-missing"}
+			<AuthorMissingModalContent data={stableModalData.state} close={closeModal} />
+		{:else if stableModalData.state.type === "general-settings"}
+			<GeneralSettingsModalContent data={stableModalData.state} />
+		{:else if stableModalData.state.type === "project-settings"}
+			<ProjectSettingsModalContent data={stableModalData.state} />
+		{:else if stableModalData.state.type === "login-confirmation"}
+			<LoginConfirmationModalContent data={stableModalData.state} close={closeModal} />
 		{/if}
 	</Modal>
 {/if}


### PR DESCRIPTION
## 🧢 Changes
When closeSettings() sets modalProps to null, Svelte 5 can propagate updated props to child components before the outer {#if} guard destroys the block, causing TypeErrors like "null is not an object (evaluating '$.get(modalProps).state')" and "undefined is not an object (evaluating 'data.projectId')".

Introduce stableModalData — a $state updated only in $effect.pre when modalProps is non-null. Child components receive stableModalData (frozen at the last valid value during teardown) rather than reading modalProps directly, breaking the reactive propagation chain.

Related issues:
- #13252: A bit different but points to @mtsgrd who pushed related fixes a few days after the issue was raised. I think this compliments these and will help avoid similar problems.

## ☕️ Reasoning

Sent a little bug report in the Discord when I found I could no longer remove projects on v0.19.9. The previous approach was very minimal — each commit patched exactly the line that crashed in production telemetry:

5c4f0137ae: telemetry showed null.close() → swap to handleModalClose
20e5a8432c: CI showed teardown race → add closeModal() with null guard
ac13c2ee31: error page showed "project not found" → reorder navigation/delete

If someone later adds a new modal type that closes itself via state mutation, it won't reintroduce this class of bug.

<img width="776" height="274" alt="image" src="https://github.com/user-attachments/assets/dc453f99-126d-45c2-84c6-291c591c3ba0" />

## Media

### Before fix, GitButler Client running 0.19.9

1. Remove project
2. Error toast shows


https://github.com/user-attachments/assets/13a7c953-38e0-4149-9a08-1cc5dd050b31



### After fix:

1. Remove project
2. Project view is updated to a different project, project removed from project list and no error toast
    - Console complains about IPC cache issue, but as you can see the UI bug has been resolved. 

https://github.com/user-attachments/assets/5703e15d-d6f4-47e9-9032-ccd21d2e5867



