### PR TITLE
Refactor UserService to use reactive properties and RTKQ endpoints

### DIFF
--- a/apps/desktop/src/components/onboarding/LoginConfirmationModalContent.svelte
+++ b/apps/desktop/src/components/onboarding/LoginConfirmationModalContent.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { USER_SERVICE } from "$lib/user/userService";
+	import { USER_SERVICE } from "$lib/user/userService.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import { Button, ModalHeader, ModalFooter, SkeletonBone } from "@gitbutler/ui";
 	import { gravatarUrlFromEmail } from "@gitbutler/ui/components/avatar/gravatar";
@@ -13,12 +13,14 @@
 	const { close }: Props = $props();
 
 	const userService = inject(USER_SERVICE);
-	const incomingUser = $derived(userService.incomingUserLogin);
-	const incomingUserEmail = $derived($incomingUser?.email);
+	const incomingUserEmail = $derived(userService.incomingUserLogin?.email);
 	const incomingUserName = $derived(
-		$incomingUser?.login ?? $incomingUser?.name ?? incomingUserEmail ?? "unknown",
+		userService.incomingUserLogin?.login ??
+			userService.incomingUserLogin?.name ??
+			incomingUserEmail ??
+			"unknown",
 	);
-	const incomingUserAvatarUrl = $derived($incomingUser?.picture);
+	const incomingUserAvatarUrl = $derived(userService.incomingUserLogin?.picture);
 
 	async function getUserAvatarURL(): Promise<string | null> {
 		if (incomingUserAvatarUrl) return incomingUserAvatarUrl;
@@ -30,8 +32,8 @@
 	}
 
 	function acceptLogin() {
-		if ($incomingUser) {
-			userService.acceptIncomingUser($incomingUser);
+		if (userService.incomingUserLogin) {
+			userService.acceptIncomingUser(userService.incomingUserLogin);
 		}
 		close();
 	}

--- a/apps/desktop/src/components/projectSettings/CloudForm.svelte
+++ b/apps/desktop/src/components/projectSettings/CloudForm.svelte
@@ -4,14 +4,13 @@
 	import SettingsSection from "$components/shared/SettingsSection.svelte";
 	import { projectAiExperimentalFeaturesEnabled, projectAiGenEnabled } from "$lib/config/config";
 	import { useSettingsModal } from "$lib/settings/settingsModal.svelte";
-	import { USER_SERVICE } from "$lib/user/userService";
+	import { USER_SERVICE } from "$lib/user/userService.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import { Button, CardGroup, Spacer, Toggle } from "@gitbutler/ui";
 
 	const { projectId }: { projectId: string } = $props();
 
 	const userService = inject(USER_SERVICE);
-	const user = userService.user;
 	const { openGeneralSettings } = useSettingsModal();
 
 	const aiGenEnabled = $derived(projectAiGenEnabled(projectId));
@@ -27,7 +26,7 @@
 
 	<Spacer />
 
-	{#if !$user}
+	{#if !userService.user}
 		<AccessTokenSignIn />
 		<Spacer />
 	{/if}

--- a/apps/desktop/src/components/settings/AiCredentialCheck.svelte
+++ b/apps/desktop/src/components/settings/AiCredentialCheck.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
 	import { AI_SERVICE, type DiffInput } from "$lib/ai/service";
 	import { ModelKind } from "$lib/ai/types";
-	import { USER_SERVICE } from "$lib/user/userService";
+	import { USER_SERVICE } from "$lib/user/userService.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import { Button, InfoMessage, Link } from "@gitbutler/ui";
 	import { slide } from "svelte/transition";
 
 	const aiService = inject(AI_SERVICE);
 	const userService = inject(USER_SERVICE);
-	const user = userService.user;
 
 	let testing = $state(false);
 	let isStreaming = $state(false);
@@ -74,7 +73,7 @@
 
 			if (!isConfigValid) {
 				if (modelKind === ModelKind.OpenAI || modelKind === ModelKind.Anthropic) {
-					if (isUsingButlerAPI && !$user) {
+					if (isUsingButlerAPI && !userService.user) {
 						throw new Error("Please sign in to use GitButler's AI API");
 					} else {
 						throw new Error("Please provide a valid API key for your selected AI service");
@@ -208,7 +207,7 @@
 				{#snippet content()}
 					<div class="result-content" transition:slide={{ duration: 250 }}>
 						{#if error}
-							{#if (modelKind === ModelKind.OpenAI || modelKind === ModelKind.Anthropic) && isUsingButlerAPI && !$user}
+							{#if (modelKind === ModelKind.OpenAI || modelKind === ModelKind.Anthropic) && isUsingButlerAPI && !userService.user}
 								<span> Please sign in to use GitButler's AI API. </span>
 							{:else if modelKind === ModelKind.OpenAI || modelKind === ModelKind.Anthropic}
 								<span> Please check your API key or try GitButler's API. </span>

--- a/apps/desktop/src/components/settings/AiSettings.svelte
+++ b/apps/desktop/src/components/settings/AiSettings.svelte
@@ -7,7 +7,7 @@
 	import { OpenAIModelName, AnthropicModelName, ModelKind } from "$lib/ai/types";
 	import { GIT_CONFIG_SERVICE } from "$lib/config/gitConfigService";
 	import { SECRET_SERVICE } from "$lib/secrets/secretsService";
-	import { USER_SERVICE } from "$lib/user/userService";
+	import { USER_SERVICE } from "$lib/user/userService.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import {
 		CardGroup,
@@ -28,7 +28,6 @@
 	const secretsService = inject(SECRET_SERVICE);
 	const aiService = inject(AI_SERVICE);
 	const userService = inject(USER_SERVICE);
-	const user = userService.user;
 	let initialized = false;
 
 	let modelKind: ModelKind | undefined = $state();
@@ -224,7 +223,7 @@
 				</Select>
 
 				{#if openAIKeyOption === KeyOption.ButlerAPI}
-					{#if !$user}
+					{#if !userService.user}
 						<AuthorizationBanner message="Please sign in to use the GitButler API." />
 					{:else}
 						{@render shortNote("GitButler uses OpenAI API for commit messages and branch names.")}
@@ -292,7 +291,7 @@
 				</Select>
 
 				{#if anthropicKeyOption === KeyOption.ButlerAPI}
-					{#if !$user}
+					{#if !userService.user}
 						<AuthorizationBanner message="Please sign in to use the GitButler API." />
 					{:else}
 						{@render shortNote(

--- a/apps/desktop/src/components/settings/ExperimentalSettings.svelte
+++ b/apps/desktop/src/components/settings/ExperimentalSettings.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
 	import { fModeEnabled } from "$lib/config/uiFeatureFlags";
 	import { SETTINGS_SERVICE } from "$lib/settings/appSettings";
-	import { USER } from "$lib/user/user";
+	import { USER_SERVICE } from "$lib/user/userService.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import { CardGroup, Toggle } from "@gitbutler/ui";
 
 	const settingsService = inject(SETTINGS_SERVICE);
 	const settingsStore = settingsService.appSettings;
 
-	const user = inject(USER);
+	const userService = inject(USER_SERVICE);
 </script>
 
 <p class="text-12 text-body experimental-settings__text">
@@ -34,7 +34,7 @@
 		{/snippet}
 	</CardGroup.Item>
 
-	{#if $user?.role === "admin"}
+	{#if userService.user?.role === "admin"}
 		<CardGroup.Item labelFor="single-branch">
 			{#snippet title()}
 				Single-branch mode

--- a/apps/desktop/src/components/settings/GeneralSettings.svelte
+++ b/apps/desktop/src/components/settings/GeneralSettings.svelte
@@ -15,7 +15,7 @@
 		type TerminalSettings,
 	} from "$lib/settings/userSettings";
 	import { UPDATER_SERVICE } from "$lib/updater/updater";
-	import { USER_SERVICE } from "$lib/user/userService";
+	import { USER_SERVICE } from "$lib/user/userService.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import {
 		Button,
@@ -34,7 +34,6 @@
 	const userService = inject(USER_SERVICE);
 	const settingsService = inject(SETTINGS_SERVICE);
 	const projectsService = inject(PROJECTS_SERVICE);
-	const user = userService.user;
 
 	const updaterService = inject(UPDATER_SERVICE);
 	const disableAutoChecks = updaterService.disableAutoChecks;
@@ -52,7 +51,7 @@
 	let isDeleting = $state(false);
 	let loaded = $state(false);
 
-	let userPicture = $state($user?.picture);
+	let userPicture = $state(userService.user?.picture);
 
 	let deleteConfirmationModal: ReturnType<typeof Modal> | undefined = $state();
 
@@ -104,7 +103,7 @@
 	}));
 
 	$effect(() => {
-		if ($user && !loaded) {
+		if (userService.user && !loaded) {
 			loaded = true;
 			userService.getUser().then((cloudUser) => {
 				const userData: User = {
@@ -121,14 +120,14 @@
 				userPicture = userData.picture;
 				userService.setUser(userData);
 			});
-			newName = $user?.name || "";
+			newName = userService.user?.name || "";
 		}
 	});
 
 	let selectedPictureFile: File | undefined = $state();
 
 	async function onSubmit(e: SubmitEvent) {
-		if (!$user) return;
+		if (!userService.user) return;
 		saving = true;
 
 		e.preventDefault();
@@ -173,7 +172,7 @@
 	let showSymlink = $state(false);
 </script>
 
-{#if $user}
+{#if userService.user}
 	<CardGroup>
 		<form onsubmit={onSubmit} class="profile-form">
 			<ProfilePictureUpload
@@ -185,7 +184,7 @@
 			<div id="contact-info" class="contact-info">
 				<div class="contact-info__fields">
 					<Textbox label="Full name" bind:value={newName} required />
-					<Textbox label="Email" bind:value={$user.email} readonly />
+					<Textbox label="Email" value={userService.user?.email} readonly />
 				</div>
 
 				<Button type="submit" style="pop" loading={saving}>Update profile</Button>

--- a/apps/desktop/src/components/settings/GeneralSettingsModalContent.svelte
+++ b/apps/desktop/src/components/settings/GeneralSettingsModalContent.svelte
@@ -13,7 +13,7 @@
 	import { URL_SERVICE } from "$lib/backend/url";
 	import { SETTINGS_SERVICE } from "$lib/settings/appSettings";
 	import { generalSettingsPages } from "$lib/settings/generalSettingsPages";
-	import { USER_SERVICE } from "$lib/user/userService";
+	import { USER_SERVICE } from "$lib/user/userService.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import { Icon } from "@gitbutler/ui";
 	import type { GeneralSettingsModalState, GeneralSettingsPageId } from "$lib/state/uiState.svelte";
@@ -25,7 +25,6 @@
 	const { data }: Props = $props();
 
 	const userService = inject(USER_SERVICE);
-	const user = userService.user;
 	const settingsService = inject(SETTINGS_SERVICE);
 	const settingsStore = settingsService.appSettings;
 	const ircEnabled = $derived($settingsStore?.featureFlags.irc ?? false);
@@ -42,7 +41,7 @@
 	title="Global settings"
 	pages={generalSettingsPages.filter((p) => p.id !== "irc" || ircEnabled)}
 	selectedId={currentSelectedId}
-	isAdmin={$user?.role === "admin"}
+	isAdmin={userService.user?.role === "admin"}
 	onSelectPage={selectPage}
 >
 	{#snippet content({ currentPage })}

--- a/apps/desktop/src/components/settings/IrcSettings.svelte
+++ b/apps/desktop/src/components/settings/IrcSettings.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
 	import { IRC_API_SERVICE } from "$lib/irc/ircApiService";
 	import { SETTINGS_SERVICE } from "$lib/settings/appSettings";
-	import { USER } from "$lib/user/user";
+	import { USER_SERVICE } from "$lib/user/userService.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import { Badge, Button, CardGroup, Textbox, Toggle } from "@gitbutler/ui";
 	import type { IconName } from "@gitbutler/ui";
 	import type { ComponentColorType } from "@gitbutler/ui/utils/colorTypes";
 
 	const settingsService = inject(SETTINGS_SERVICE);
-	const user = inject(USER);
+	const userService = inject(USER_SERVICE);
 	const ircApiService = inject(IRC_API_SERVICE);
 
 	const settings = settingsService.appSettings;
@@ -117,7 +117,7 @@
 				value={irc.connection.nickname ?? ""}
 				size="large"
 				label="Nickname"
-				placeholder={$user?.login ?? "your-nickname"}
+				placeholder={userService.user?.login ?? "your-nickname"}
 				onchange={(value) => settingsService.updateIrc({ connection: { nickname: value || null } })}
 			/>
 		</CardGroup.Item>
@@ -158,7 +158,7 @@
 				value={irc.connection.realname ?? ""}
 				size="large"
 				label="Real Name"
-				placeholder={$user?.name ?? $user?.login ?? "Your Name"}
+				placeholder={userService.user?.name ?? userService.user?.login ?? "Your Name"}
 				onchange={(value) => settingsService.updateIrc({ connection: { realname: value || null } })}
 			/>
 		</CardGroup.Item>

--- a/apps/desktop/src/components/shared/AccessTokenSignIn.svelte
+++ b/apps/desktop/src/components/shared/AccessTokenSignIn.svelte
@@ -1,16 +1,15 @@
 <script lang="ts">
 	import signinSvg from "$lib/assets/token.svg?raw";
-	import { USER_SERVICE } from "$lib/user/userService";
+	import { USER_SERVICE } from "$lib/user/userService.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import { Button, CardGroup, Textbox, Spacer } from "@gitbutler/ui";
 
 	const userService = inject(USER_SERVICE);
-	const user = userService.user;
 
 	let accessToken = $state("");
 </script>
 
-{#if !$user}
+{#if !userService.user}
 	<CardGroup.Item standalone>
 		<div class="token-content">
 			<div class="token-svg">

--- a/apps/desktop/src/components/shared/IllustrationSplitLayout.svelte
+++ b/apps/desktop/src/components/shared/IllustrationSplitLayout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import ProfileButton from "$components/shared/ProfileButton.svelte";
-	import { USER } from "$lib/user/user";
+	import { USER_SERVICE } from "$lib/user/userService.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import { type Snippet } from "svelte";
 
@@ -13,7 +13,7 @@
 
 	const { hideDetails, img, children, testId }: Props = $props();
 
-	const user = inject(USER);
+	const userService = inject(USER_SERVICE);
 </script>
 
 <div class="decorative-split-view" data-testid={testId}>
@@ -27,7 +27,7 @@
 
 	<div class="right-side" data-tauri-drag-region>
 		<div class="right-side-wrapper">
-			{#if user && !hideDetails}
+			{#if userService.user && !hideDetails}
 				<div class="account-button">
 					<ProfileButton />
 				</div>

--- a/apps/desktop/src/components/shared/ProfileButton.svelte
+++ b/apps/desktop/src/components/shared/ProfileButton.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
 	import { useSettingsModal } from "$lib/settings/settingsModal.svelte";
-	import { USER } from "$lib/user/user";
+	import { USER_SERVICE } from "$lib/user/userService.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import { ProfileButton } from "@gitbutler/ui";
 
-	const user = inject(USER);
+	const userService = inject(USER_SERVICE);
 	const { openGeneralSettings } = useSettingsModal();
 </script>
 
-<ProfileButton srcUrl={$user?.picture ?? null} onclick={async () => openGeneralSettings()} />
+<ProfileButton
+	srcUrl={userService.user?.picture ?? null}
+	onclick={async () => openGeneralSettings()}
+/>

--- a/apps/desktop/src/components/shared/ShareIssueModal.svelte
+++ b/apps/desktop/src/components/shared/ShareIssueModal.svelte
@@ -5,7 +5,7 @@
 	import { GIT_SERVICE } from "$lib/git/gitService";
 	import { SHORTCUT_SERVICE } from "$lib/shortcuts/shortcutService";
 	import { DATA_SHARING_SERVICE } from "$lib/support/dataSharing";
-	import { USER } from "$lib/user/user";
+	import { USER_SERVICE } from "$lib/user/userService.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import { HTTP_CLIENT } from "@gitbutler/shared/network/httpClient";
 
@@ -25,7 +25,7 @@
 	const fileService = inject(FILE_SERVICE);
 	const dataSharingService = inject(DATA_SHARING_SERVICE);
 	const gitService = inject(GIT_SERVICE);
-	const user = inject(USER);
+	const userService = inject(USER_SERVICE);
 	const backend = inject(BACKEND);
 
 	export function show() {
@@ -64,7 +64,7 @@
 
 	async function submit() {
 		const message = messageInputValue;
-		const email = $user?.email ?? emailInputValue;
+		const email = userService.user?.email ?? emailInputValue;
 
 		// put together context information to send with the feedback
 		let context = "";
@@ -93,7 +93,7 @@
 					: undefined,
 			]).then(
 				async ([logs, repo, graph]) =>
-					await createFeedback($user?.access_token, {
+					await createFeedback(userService.user?.access_token, {
 						email,
 						message,
 						context,
@@ -159,7 +159,7 @@
 			review it for you and help identify how we can help resolve the issue.
 		</p>
 
-		{#if !$user}
+		{#if !userService.user}
 			<EmailTextbox
 				label="Email"
 				placeholder="Provide an email so that we can get back to you"

--- a/apps/desktop/src/components/views/GlobalModalRouter.svelte
+++ b/apps/desktop/src/components/views/GlobalModalRouter.svelte
@@ -6,14 +6,13 @@
 	import GeneralSettingsModalContent from "$components/settings/GeneralSettingsModalContent.svelte";
 	import ProjectSettingsModalContent from "$components/settings/ProjectSettingsModalContent.svelte";
 	import { type GlobalModalState, UI_STATE } from "$lib/state/uiState.svelte";
-	import { USER_SERVICE } from "$lib/user/userService";
+	import { USER_SERVICE } from "$lib/user/userService.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import { Modal, TestId } from "@gitbutler/ui";
 	import type { ModalProps } from "@gitbutler/ui";
 
 	const uiState = inject(UI_STATE);
 	const userService = inject(USER_SERVICE);
-	const incomingUserLogin = $derived(userService.incomingUserLogin);
 
 	type ModalData = {
 		state: GlobalModalState;
@@ -112,7 +111,7 @@
 		// we should reject the incoming user to maintain state consistency.
 		// We check if there's still an incoming user to avoid calling reject after accept/reject buttons.
 		if (modalProps?.state.type === "login-confirmation") {
-			if ($incomingUserLogin) {
+			if (userService.incomingUserLogin) {
 				userService.rejectIncomingUser();
 			}
 		}

--- a/apps/desktop/src/lib/bootstrap/deps.ts
+++ b/apps/desktop/src/lib/bootstrap/deps.ts
@@ -67,8 +67,7 @@ import {
 	UPSTREAM_INTEGRATION_SERVICE,
 } from "$lib/upstream/upstreamIntegrationService.svelte";
 import { TokenMemoryService } from "$lib/user/tokenMemoryService";
-import { USER } from "$lib/user/user";
-import { USER_SERVICE, UserService } from "$lib/user/userService";
+import { USER_SERVICE, UserService } from "$lib/user/userService.svelte";
 import { WorktreeService, WORKTREE_SERVICE } from "$lib/worktree/worktreeService.svelte";
 import { provideAll } from "@gitbutler/core/context";
 import { FeedService, FEED_SERVICE } from "@gitbutler/shared/feeds/service";
@@ -161,7 +160,14 @@ export function initDependencies(args: {
 	const aiPromptService = new AIPromptService();
 	const aiService = new AIService(gitConfig, secretsService, httpClient, tokenMemoryService);
 	const claudeCodeService = new ClaudeCodeService(backend, clientState.backendApi);
-	const userService = new UserService(backend, httpClient, tokenMemoryService, posthog, uiState);
+	const userService = new UserService(
+		clientState.backendApi,
+		backend,
+		httpClient,
+		tokenMemoryService,
+		posthog,
+		uiState,
+	);
 	const ircApiService = new IrcApiService(clientState.backendApi);
 	const attachmentService = new AttachmentService(clientState);
 
@@ -381,7 +387,6 @@ export function initDependencies(args: {
 		[UPLOADS_SERVICE, uploadsService],
 		[UPSTREAM_INTEGRATION_SERVICE, upstreamIntegrationService],
 		[URL_SERVICE, urlService],
-		[USER, userService.user],
 		[USER_SERVICE, userService],
 		[WORKTREE_SERVICE, worktreeService],
 		[EXTERNAL_LINK_SERVICE, externalLinkService],

--- a/apps/desktop/src/lib/state/backendApi.ts
+++ b/apps/desktop/src/lib/state/backendApi.ts
@@ -8,6 +8,7 @@ import { buildStackEndpoints } from "$lib/stacks/stackEndpoints";
 import { tauriBaseQuery, type TauriBaseQueryFn } from "$lib/state/backendQuery";
 import { butlerModule } from "$lib/state/butlerModule";
 import { ReduxTag } from "$lib/state/tags";
+import { buildUserEndpoints } from "$lib/user/userEndpoints";
 import { buildWorktreeEndpoints } from "$lib/worktree/worktreeEndpoints";
 import { buildCreateApi, coreModule } from "@reduxjs/toolkit/query";
 import type { HookContext } from "$lib/state/context";
@@ -38,6 +39,7 @@ export function createBackendApi(ctx: HookContext) {
 			...buildProjectEndpoints(build),
 			...buildActionEndpoints(build),
 			...buildIrcEndpoints(build),
+			...buildUserEndpoints(build),
 		}),
 	});
 }

--- a/apps/desktop/src/lib/state/tags.ts
+++ b/apps/desktop/src/lib/state/tags.ts
@@ -43,6 +43,8 @@ export enum ReduxTag {
 	IrcChannels = "IrcChannels",
 	IrcMessages = "IrcMessages",
 	IrcUsers = "IrcUsers",
+	User = "User",
+	UserProfile = "UserProfile",
 }
 
 type Tag<T extends string | number> = {

--- a/apps/desktop/src/lib/user/tokenMemoryService.ts
+++ b/apps/desktop/src/lib/user/tokenMemoryService.ts
@@ -1,5 +1,5 @@
 import { writable, type Readable } from "svelte/store";
-import type { UserService as _UserService } from "$lib/user/userService";
+import type { UserService as _UserService } from "$lib/user/userService.svelte";
 
 /**
  * Holds the logged in user's token in memory

--- a/apps/desktop/src/lib/user/user.ts
+++ b/apps/desktop/src/lib/user/user.ts
@@ -1,8 +1,3 @@
-import { InjectionToken } from "@gitbutler/core/context";
-import type { Writable } from "svelte/store";
-
-export const USER = new InjectionToken<Writable<User>>("User");
-
 export type User = {
 	id: number;
 	name: string | undefined;

--- a/apps/desktop/src/lib/user/userAvatar.svelte.ts
+++ b/apps/desktop/src/lib/user/userAvatar.svelte.ts
@@ -1,7 +1,6 @@
 import { GIT_CONFIG_SERVICE } from "$lib/config/gitConfigService";
-import { USER_SERVICE } from "$lib/user/userService";
+import { USER_SERVICE } from "$lib/user/userService.svelte";
 import { inject } from "@gitbutler/core/context";
-import { get } from "svelte/store";
 
 /**
  * Returns the current user's profile picture if the given email belongs to them,
@@ -22,7 +21,7 @@ export function useUserAvatarUrl(): (email: string | null | undefined) => string
 
 	return (email: string | null | undefined): string | undefined => {
 		if (!email) return undefined;
-		const user = get(userService.user);
+		const user = userService.user;
 		if (!user?.picture) return undefined;
 		const lower = email.toLowerCase();
 		if (lower === user.email?.toLowerCase() || lower === gitConfigEmail?.toLowerCase()) {

--- a/apps/desktop/src/lib/user/userEndpoints.ts
+++ b/apps/desktop/src/lib/user/userEndpoints.ts
@@ -1,0 +1,72 @@
+import { ReduxTag, invalidatesType, providesType } from "$lib/state/tags";
+import type { BackendEndpointBuilder } from "$lib/state/backendApi";
+import type { User } from "$lib/user/user";
+import type { ApiUser } from "@gitbutler/shared/users/types";
+
+export type LoginToken = {
+	/** Used for polling the user; should NEVER be sent to the browser. */
+	token: string;
+	browser_token: string;
+	expires: string;
+	url: string;
+};
+
+export function buildUserEndpoints(build: BackendEndpointBuilder) {
+	return {
+		getUser: build.query<User | undefined, void>({
+			extraOptions: { command: "get_user" },
+			query: () => undefined,
+			providesTags: [providesType(ReduxTag.User)],
+		}),
+
+		getUserProfile: build.query<ApiUser, void>({
+			extraOptions: { command: "get_user_profile" },
+			query: () => undefined,
+			providesTags: [providesType(ReduxTag.UserProfile)],
+		}),
+
+		getLoginToken: build.query<LoginToken, void>({
+			extraOptions: { command: "get_login_token" },
+			query: () => undefined,
+		}),
+
+		setUser: build.mutation<void, { user: User }>({
+			extraOptions: { command: "set_user" },
+			query: (args) => args,
+			invalidatesTags: [invalidatesType(ReduxTag.User)],
+		}),
+
+		deleteUser: build.mutation<void, void>({
+			extraOptions: { command: "delete_user" },
+			query: () => undefined,
+			invalidatesTags: [invalidatesType(ReduxTag.User)],
+		}),
+
+		loginWithToken: build.mutation<User, { token: string }>({
+			extraOptions: { command: "login_with_token" },
+			query: (args) => args,
+			invalidatesTags: [invalidatesType(ReduxTag.User)],
+		}),
+
+		updateUserProfile: build.mutation<
+			any,
+			{
+				params: {
+					name?: string;
+					website?: string;
+					twitter?: string;
+					bluesky?: string;
+					timezone?: string;
+					location?: string;
+					email_share?: boolean;
+					avatar_base64?: string;
+					avatar_filename?: string;
+				};
+			}
+		>({
+			extraOptions: { command: "update_user_profile" },
+			query: (args) => args,
+			invalidatesTags: [invalidatesType(ReduxTag.UserProfile)],
+		}),
+	};
+}

--- a/apps/desktop/src/lib/user/userService.svelte.ts
+++ b/apps/desktop/src/lib/user/userService.svelte.ts
@@ -4,74 +4,52 @@ import { type UiState } from "$lib/state/uiState.svelte";
 import { InjectionToken } from "@gitbutler/core/context";
 import { type HttpClient } from "@gitbutler/shared/network/httpClient";
 import { chipToasts } from "@gitbutler/ui";
-import { derived, writable, type Readable } from "svelte/store";
 import type { IBackend } from "$lib/backend";
+import type { BackendApi } from "$lib/state/backendApi";
 import type { PostHogWrapper } from "$lib/telemetry/posthog";
 import type { TokenMemoryService } from "$lib/user/tokenMemoryService";
 import type { User } from "$lib/user/user";
 import type { ApiUser } from "@gitbutler/shared/users/types";
 
-export type LoginToken = {
-	/** Used for polling the user; should NEVER be sent to the browser. */
-	token: string;
-	browser_token: string;
-	expires: string;
-	url: string;
-};
-
 export const USER_SERVICE = new InjectionToken<UserService>("UserService");
 
 export class UserService {
-	readonly loading = writable(false);
+	private _incomingUserLogin = $state<User | undefined>(undefined);
+	private userQuery;
 
-	readonly user = writable<User | undefined>(undefined, () => {
-		this.refresh();
-	});
-	readonly userLogin = derived<Readable<User | undefined>, string | undefined>(
-		this.user,
-		(user, set) => {
-			set(user?.login ?? undefined);
-		},
-	);
-	readonly error = writable();
-	readonly incomingUserLogin = writable<User | undefined>(undefined);
+	get user(): User | undefined {
+		return this.userQuery.response;
+	}
 
-	async refresh() {
-		const user = await this.backend.invoke<User | undefined>("get_user");
-		if (user) {
-			this.tokenMemoryService.setToken(user.access_token);
-			// Telemetry is alreary set when the user is set.
-			// Just in case the user ID changes in the backend outside the usual cycle, we set it again here.
-			await this.setUserTelemetry(user);
-			this.user.set(user);
-			return user;
-		}
-
-		this.posthog.setAnonymousPostHogUser();
-		this.user.set(undefined);
+	get incomingUserLogin(): User | undefined {
+		return this._incomingUserLogin;
 	}
 
 	constructor(
+		private backendApi: BackendApi,
 		private backend: IBackend,
 		private httpClient: HttpClient,
 		private tokenMemoryService: TokenMemoryService,
 		private posthog: PostHogWrapper,
 		private uiState: UiState,
-	) {}
+	) {
+		this.userQuery = this.backendApi.endpoints.getUser.useQuery(undefined);
+
+		$effect(() => {
+			if (this.userQuery.result.isSuccess && !this.userQuery.response) {
+				this.posthog.setAnonymousPostHogUser();
+			}
+		});
+	}
 
 	async setUser(user: User | undefined) {
 		if (user) {
-			await this.backend.invoke("set_user", { user });
+			await this.backendApi.endpoints.setUser.mutate({ user });
 			this.tokenMemoryService.setToken(user.access_token);
 			await this.setUserTelemetry(user);
 		} else {
-			await this.clearUser();
+			await this.backendApi.endpoints.deleteUser.mutate(undefined);
 		}
-		this.user.set(user);
-	}
-
-	private async clearUser() {
-		await this.backend.invoke("delete_user");
 	}
 
 	private async setUserTelemetry(user: User) {
@@ -81,9 +59,10 @@ export class UserService {
 
 	async setUserAccessToken(token: string, bypassConfirmationToast = false) {
 		try {
-			const currentUser = await this.refresh();
+			const currentUser = await this.backendApi.endpoints.getUser.fetch(undefined, {
+				forceRefetch: true,
+			});
 			if (currentUser) {
-				// Error out if we're trying to set a token when we've already logged in.
 				showError(
 					"Error: Attempting to log in before logging out first",
 					"There's already an account logged in, please log out before attempting to log in to another account.",
@@ -91,15 +70,14 @@ export class UserService {
 				return;
 			}
 
-			const user = await this.backend.invoke<User>("login_with_token", { token });
+			const user = await this.backendApi.endpoints.loginWithToken.mutate({ token });
 
 			if (bypassConfirmationToast) {
-				// In the case that the token is e.g. pasted directly, we don't need a confirmation toast.
 				await this.setUser(user);
 				return;
 			}
 
-			this.incomingUserLogin.set(user);
+			this._incomingUserLogin = user;
 			// Display a login confirmation modal
 			this.uiState.global.modal.set({
 				type: "login-confirmation",
@@ -115,16 +93,15 @@ export class UserService {
 			throw new Error("No incoming user to accept");
 		}
 		await this.setUser(incomingUser);
-		this.incomingUserLogin.set(undefined);
+		this._incomingUserLogin = undefined;
 	}
 
 	async rejectIncomingUser() {
-		this.incomingUserLogin.set(undefined);
+		this._incomingUserLogin = undefined;
 	}
 
 	async forgetUserCredentials() {
-		await this.clearUser();
-		this.user.set(undefined);
+		await this.backendApi.endpoints.deleteUser.mutate(undefined);
 		this.tokenMemoryService.setToken(undefined);
 		await this.posthog.resetPostHog();
 		resetSentry();
@@ -133,7 +110,7 @@ export class UserService {
 	private async getLoginUrl(): Promise<string> {
 		await this.forgetUserCredentials();
 		try {
-			const token = await this.backend.invoke<LoginToken>("get_login_token");
+			const token = await this.backendApi.endpoints.getLoginToken.fetch(undefined);
 			const url = new URL(token.url);
 			url.host = this.httpClient.apiUrl.host;
 			const buildType = await this.backend.invoke<string>("build_type").catch(() => undefined);
@@ -167,7 +144,7 @@ export class UserService {
 	}
 
 	async getUser(): Promise<ApiUser> {
-		return await this.backend.invoke<ApiUser>("get_user_profile");
+		return await this.backendApi.endpoints.getUserProfile.fetch(undefined);
 	}
 
 	async updateUser(params: {
@@ -192,7 +169,7 @@ export class UserService {
 			avatarFilename = params.picture.name;
 		}
 
-		return await this.backend.invoke("update_user_profile", {
+		return await this.backendApi.endpoints.updateUserProfile.mutate({
 			params: {
 				name: params.name,
 				website: params.website,

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -27,7 +27,7 @@
 	import { SHORTCUT_SERVICE } from "$lib/shortcuts/shortcutService";
 	import { CLIENT_STATE } from "$lib/state/clientState.svelte";
 	import { POSTHOG_WRAPPER } from "$lib/telemetry/posthog";
-	import { USER_SERVICE } from "$lib/user/userService";
+	import { USER_SERVICE } from "$lib/user/userService.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import { ChipToastContainer } from "@gitbutler/ui";
 	import { FOCUS_MANAGER } from "@gitbutler/ui/focus/focusManager";


### PR DESCRIPTION
## Summary

- Replace Svelte store-based state management in `UserService` with Svelte 5 reactive properties (`$state`/getters) and migrate all backend IPC calls to RTK Query endpoints
- Remove the `USER` injection token; consumers now use `USER_SERVICE` directly and access `userService.user` as a reactive getter
- Add `userEndpoints.ts` with RTKQ endpoints (`getUser`, `setUser`, `deleteUser`, `loginWithToken`, `getLoginToken`, `getUserProfile`, `updateUserProfile`) and `User`/`UserProfile` cache tags
- Sync token memory and telemetry via `$effect` on the user query result

## Test plan

- [x] `svelte-check` passes (12 errors, all pre-existing)
- [x] All 57 Playwright e2e tests pass