### PR TITLE
Fix status segment metadata lookup

### DIFF
--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -258,12 +258,10 @@ async fn build_status_context<'a>(
         let mut guard = ctx.exclusive_worktree_access();
         but_rules::process_rules(ctx, guard.write_permission()).ok(); // TODO: this is doing double work (hunk-dependencies can be reused)
 
-        // TODO: use this for JSON status information (regular status information
-        //       already uses this)
-        let meta = ctx.meta()?;
-        let head_info = but_workspace::head_info(
-            &*ctx.repo.get()?,
-            &meta,
+        let (repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
+        let head_info = but_workspace::graph_to_ref_info(
+            &ws,
+            &repo,
             but_workspace::ref_info::Options {
                 expensive_commit_info: true,
                 ..Default::default()
@@ -290,7 +288,6 @@ async fn build_status_context<'a>(
             }
         }
 
-        let (_repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
         let resolved_target = workspace_target::ResolvedTarget::from_workspace(&ws)?;
         (
             push_statuses_by_segment_id,


### PR DESCRIPTION
it looks like this was causing something 
we were producing 
`warning: head_info does not contain segment that graph has` warnings unexpectedly. 

seems like divergence between a fresh but_workspace::head_info() and the ctx.workspace_from_head() is possible.
So here im deriving head_info with but_workspace::graph_to_ref_info() from the same cached workspace graph that we display

cc as a learning here @jonathantanmy2 @slarse @davidpdrsn 