### PR TITLE
git config: Treat empty strings as removal

### DIFF
--- a/crates/but-core/src/settings.rs
+++ b/crates/but-core/src/settings.rs
@@ -5,7 +5,7 @@ pub mod git {
     use anyhow::Result;
     use bstr::{BStr, BString, ByteSlice, ByteVec};
 
-    use crate::git_config::edit_repo_config;
+    use crate::git_config::{edit_repo_config, remove_config_value};
 
     const GIT_SIGN_COMMITS: &str = "commit.gpgsign";
     const GITBUTLER_SIGN_COMMITS: &str = "gitbutler.signCommits";
@@ -200,38 +200,66 @@ pub mod git {
                     )?;
                 };
                 if let Some(forge_template_path) = &self.gitbutler_forge_review_template_path {
-                    config.set_raw_value(
-                        GITBUTLER_FORGE_TEMPLATE_PATH,
-                        forge_template_path.as_bstr(),
-                    )?;
+                    if forge_template_path.is_empty() {
+                        remove_config_value(config, GITBUTLER_FORGE_TEMPLATE_PATH)?;
+                    } else {
+                        config.set_raw_value(
+                            GITBUTLER_FORGE_TEMPLATE_PATH,
+                            forge_template_path.as_bstr(),
+                        )?;
+                    }
                 };
                 if let Some(signing_key) = &self.signing_key {
-                    config.set_raw_value(SIGNING_KEY, signing_key.as_bstr())?;
+                    if signing_key.is_empty() {
+                        remove_config_value(config, SIGNING_KEY)?;
+                    } else {
+                        config.set_raw_value(SIGNING_KEY, signing_key.as_bstr())?;
+                    }
                 };
                 if let Some(signing_format) = &self.signing_format {
-                    config.set_raw_value(SIGNING_FORMAT, signing_format.as_bstr())?;
+                    if signing_format.is_empty() {
+                        remove_config_value(config, SIGNING_FORMAT)?;
+                    } else {
+                        config.set_raw_value(SIGNING_FORMAT, signing_format.as_bstr())?;
+                    }
                 }
                 if let Some(gpg_program) = self.gpg_program.as_ref().and_then(osstring_into_bstring)
                 {
-                    config.set_raw_value(GPG_PROGRAM, gpg_program.as_bstr())?;
+                    if gpg_program.is_empty() {
+                        remove_config_value(config, GPG_PROGRAM)?;
+                    } else {
+                        config.set_raw_value(GPG_PROGRAM, gpg_program.as_bstr())?;
+                    }
                 }
                 if let Some(gpg_ssh_program) = self
                     .gpg_ssh_program
                     .as_ref()
                     .and_then(osstring_into_bstring)
                 {
-                    config.set_raw_value(GPG_SSH_PROGRAM, gpg_ssh_program.as_bstr())?;
+                    if gpg_ssh_program.is_empty() {
+                        remove_config_value(config, GPG_SSH_PROGRAM)?;
+                    } else {
+                        config.set_raw_value(GPG_SSH_PROGRAM, gpg_ssh_program.as_bstr())?;
+                    }
                 }
                 if let Some(gitlab_project_id) = self.gitbutler_gitlab_project_id.as_deref() {
-                    config.set_raw_value(GITBUTLER_GITLAB_PROJECT_ID, gitlab_project_id)?;
+                    if gitlab_project_id.is_empty() {
+                        remove_config_value(config, GITBUTLER_GITLAB_PROJECT_ID)?;
+                    } else {
+                        config.set_raw_value(GITBUTLER_GITLAB_PROJECT_ID, gitlab_project_id)?;
+                    }
                 }
                 if let Some(gitlab_upstream_project_id) =
                     self.gitbutler_gitlab_upstream_project_id.as_deref()
                 {
-                    config.set_raw_value(
-                        GITBUTLER_GITLAB_UPSTREAM_PROJECT_ID,
-                        gitlab_upstream_project_id,
-                    )?;
+                    if gitlab_upstream_project_id.is_empty() {
+                        remove_config_value(config, GITBUTLER_GITLAB_UPSTREAM_PROJECT_ID)?;
+                    } else {
+                        config.set_raw_value(
+                            GITBUTLER_GITLAB_UPSTREAM_PROJECT_ID,
+                            gitlab_upstream_project_id,
+                        )?;
+                    }
                 }
 
                 Ok(())

--- a/crates/but-core/tests/core/settings.rs
+++ b/crates/but-core/tests/core/settings.rs
@@ -72,4 +72,77 @@ mod git {
 
         Ok(())
     }
+
+    #[test]
+    fn empty_strings_remove_existing_values() -> anyhow::Result<()> {
+        let tmp = gix_testtools::tempfile::TempDir::new()?;
+        gix::init(tmp.path())?;
+        let repo = gix::open_opts(tmp.path(), gix::open::Options::isolated())?;
+
+        repo.set_git_settings(&GitConfigSettings {
+            gitbutler_sign_commits: Some(true),
+            gitbutler_gerrit_mode: Some(false),
+            gitbutler_forge_review_template_path: Some("template.md".into()),
+            gitbutler_gitlab_project_id: Some("project-id".into()),
+            gitbutler_gitlab_upstream_project_id: Some("upstream-project-id".into()),
+            signing_key: Some("signing key".into()),
+            signing_format: Some("ssh".into()),
+            gpg_program: Some("gpg".into()),
+            gpg_ssh_program: Some("ssh-keygen".into()),
+        })?;
+
+        repo.set_git_settings(&GitConfigSettings {
+            gitbutler_sign_commits: Some(true),
+            gitbutler_gerrit_mode: Some(false),
+            gitbutler_forge_review_template_path: Some("".into()),
+            gitbutler_gitlab_project_id: Some(String::new()),
+            gitbutler_gitlab_upstream_project_id: Some(String::new()),
+            signing_key: Some("".into()),
+            signing_format: Some("".into()),
+            gpg_program: Some("".into()),
+            gpg_ssh_program: Some("".into()),
+        })?;
+
+        let repo = but_testsupport::open_repo(repo.path())?;
+        let actual = repo.git_settings()?;
+        assert_eq!(actual.gitbutler_forge_review_template_path, None);
+        assert_eq!(actual.gitbutler_gitlab_project_id, None);
+        assert_eq!(actual.gitbutler_gitlab_upstream_project_id, None);
+        assert_eq!(actual.signing_key, None);
+        assert_eq!(actual.signing_format, None);
+        assert_eq!(actual.gpg_program, None);
+        assert_eq!(actual.gpg_ssh_program, None);
+
+        let config = repo.config_snapshot();
+        assert!(
+            config.string("gitbutler.forgeReviewTemplatePath").is_none(),
+            "expected empty template path to remove the config key"
+        );
+        assert!(
+            config.string("gitbutler.gitlabProjectId").is_none(),
+            "expected empty project ID to remove the config key"
+        );
+        assert!(
+            config.string("gitbutler.gitlabUpstreamProjectId").is_none(),
+            "expected empty upstream project ID to remove the config key"
+        );
+        assert!(
+            config.string("user.signingKey").is_none(),
+            "expected empty signing key to remove the config key"
+        );
+        assert!(
+            config.string("gpg.format").is_none(),
+            "expected empty signing format to remove the config key"
+        );
+        assert!(
+            config.trusted_program("gpg.program").is_none(),
+            "expected empty gpg program to remove the config key"
+        );
+        assert!(
+            config.trusted_program("gpg.ssh.program").is_none(),
+            "expected empty gpg ssh program to remove the config key"
+        );
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
When passing empty strings to the git config, remove the entry
altogether.

---

This fixes some observed issues in which we’d store empty strings as config values for e.g. `gpg.program` leading to errors even outside of gitbutler.