### PR TITLE
Implement a non-legacy upstream integration

### DIFF
--- a/crates/but-api/src/lib.rs
+++ b/crates/but-api/src/lib.rs
@@ -25,6 +25,9 @@ pub mod gitlab;
 /// Functions that take a branch as input.
 pub mod branch;
 
+/// Functions that operate on the workspace.
+pub mod workspace;
+
 /// Functions that operate commits
 pub mod commit;
 

--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -1,0 +1,174 @@
+//! Functions that operate on the workspace.
+
+use crate::WorkspaceState;
+use but_api_macros::but_api;
+use but_core::{DryRun, RefMetadata, sync::RepoExclusive};
+use but_oplog::legacy::{OperationKind, SnapshotDetails};
+use but_workspace::IntegrateUpstreamOutcome;
+use tracing::instrument;
+
+/// JSON transport types for workspace APIs.
+pub mod json {
+    use serde::{Deserialize, Serialize};
+
+    /// JSON transport type for how a stack bottom should be updated.
+    #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+    #[serde(rename_all = "camelCase")]
+    pub enum BottomUpdateKind {
+        /// Rebase the selected bottom-most commit onto the target branch.
+        Rebase,
+        /// Create a merge commit at the top of the selected stack.
+        Merge,
+    }
+
+    #[cfg(feature = "export-schema")]
+    but_schemars::register_sdk_type!(BottomUpdateKind);
+
+    impl From<BottomUpdateKind> for but_workspace::BottomUpdateKind {
+        fn from(value: BottomUpdateKind) -> Self {
+            match value {
+                BottomUpdateKind::Rebase => Self::Rebase,
+                BottomUpdateKind::Merge => Self::Merge,
+            }
+        }
+    }
+
+    /// JSON transport type describing one stack bottom to update.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+    #[serde(rename_all = "camelCase")]
+    pub struct BottomUpdate {
+        /// How the selected stack bottom should be updated.
+        pub kind: BottomUpdateKind,
+        /// The bottom-most commit or empty bottom reference to update.
+        pub selector: crate::commit::json::RelativeTo,
+    }
+
+    #[cfg(feature = "export-schema")]
+    but_schemars::register_sdk_type!(BottomUpdate);
+
+    impl From<BottomUpdate> for but_workspace::BottomUpdate {
+        fn from(value: BottomUpdate) -> Self {
+            let BottomUpdate { kind, selector } = value;
+            Self {
+                kind: kind.into(),
+                selector: selector.into(),
+            }
+        }
+    }
+}
+
+/// Integrate upstream changes into the current workspace without recording an
+/// oplog entry.
+///
+/// This acquires exclusive worktree access from `ctx`, applies the requested
+/// upstream updates, and returns the resulting workspace state. When `dry_run`
+/// is enabled, the returned workspace previews the integration without
+/// materializing the rebase. See
+/// [`workspace_integrate_upstream_only_with_perm()`] for lower-level details.
+#[but_api(try_from = crate::json::WorkspaceState)]
+#[instrument(err(Debug))]
+pub fn workspace_integrate_upstream_only(
+    ctx: &mut but_ctx::Context,
+    updates: Vec<json::BottomUpdate>,
+    dry_run: DryRun,
+) -> anyhow::Result<WorkspaceState> {
+    let mut guard = ctx.exclusive_worktree_access();
+    workspace_integrate_upstream_only_with_perm(
+        ctx,
+        updates.into_iter().map(Into::into).collect(),
+        dry_run,
+        guard.write_permission(),
+    )
+}
+
+/// Integrate upstream changes into the current workspace and record an oplog
+/// snapshot on success.
+///
+/// This acquires exclusive worktree access from `ctx`, applies the requested
+/// upstream updates, and commits a best-effort `MergeUpstream` oplog snapshot
+/// when the integration succeeds. When `dry_run` is enabled, the returned
+/// workspace previews the integration and no oplog entry is persisted. See
+/// [`workspace_integrate_upstream_with_perm()`] for lower-level details.
+#[but_api(napi, try_from = crate::json::WorkspaceState)]
+#[instrument(err(Debug))]
+pub fn workspace_integrate_upstream(
+    ctx: &mut but_ctx::Context,
+    updates: Vec<json::BottomUpdate>,
+    dry_run: DryRun,
+) -> anyhow::Result<WorkspaceState> {
+    let mut guard = ctx.exclusive_worktree_access();
+    workspace_integrate_upstream_with_perm(
+        ctx,
+        updates.into_iter().map(Into::into).collect(),
+        dry_run,
+        guard.write_permission(),
+    )
+}
+
+/// Integrate upstream changes under caller-held exclusive repository access
+/// and record an oplog snapshot on success.
+///
+/// It prepares a best-effort `MergeUpstream` oplog snapshot, performs the
+/// integration, and commits the snapshot only if the mutation succeeds. When
+/// `dry_run` is enabled, it returns a preview of the resulting workspace state
+/// and skips oplog persistence. For lower-level implementation details, see
+/// [`but_workspace::integrate_upstream()`].
+pub fn workspace_integrate_upstream_with_perm(
+    ctx: &mut but_ctx::Context,
+    updates: Vec<but_workspace::BottomUpdate>,
+    dry_run: DryRun,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<WorkspaceState> {
+    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
+        ctx,
+        SnapshotDetails::new(OperationKind::MergeUpstream),
+        perm.read_permission(),
+        dry_run,
+    );
+
+    let result = workspace_integrate_upstream_only_with_perm(ctx, updates, dry_run, perm);
+    if let Some(snapshot) = maybe_oplog_entry
+        && result.is_ok()
+    {
+        snapshot.commit(ctx, perm).ok();
+    }
+
+    result
+}
+
+/// Integrate upstream changes under caller-held exclusive repository access.
+///
+/// This delegates to [`but_workspace::integrate_upstream()`] and returns the
+/// resulting workspace state. When `dry_run` is enabled, it returns a preview
+/// of the resulting workspace without materializing the rebase.
+pub fn workspace_integrate_upstream_only_with_perm(
+    ctx: &mut but_ctx::Context,
+    updates: Vec<but_workspace::BottomUpdate>,
+    dry_run: DryRun,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<WorkspaceState> {
+    let mut meta = ctx.meta()?;
+    let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
+    let IntegrateUpstreamOutcome { rebase, ws_meta } =
+        but_workspace::integrate_upstream(&mut ws, &mut meta, &repo, updates)?;
+
+    if dry_run.into() {
+        return WorkspaceState::from_rebase_preview(&rebase, rebase.history.commit_mappings());
+    }
+
+    let materialized = rebase.materialize()?;
+
+    if let Some(ref_name) = materialized.workspace.ref_name() {
+        let mut md = materialized.meta.workspace(ref_name)?;
+        *md = ws_meta;
+        materialized.meta.set_workspace(&md)?;
+    }
+
+    WorkspaceState::from_workspace(
+        materialized.workspace,
+        &repo,
+        materialized.history.commit_mappings(),
+    )
+}

--- a/crates/but-rebase/src/graph_rebase/commit.rs
+++ b/crates/but-rebase/src/graph_rebase/commit.rs
@@ -74,13 +74,7 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
             bail!("BUG: collect_ordered_parents provided a non-pick return value");
         };
 
-        Ok((
-            Selector {
-                id: *first_parent,
-                revision: self.history.current_revision(),
-            },
-            self.find_commit(pick.id)?,
-        ))
+        Ok((self.new_selector(*first_parent), self.find_commit(pick.id)?))
     }
 
     /// Writes a commit with correct signing to the in memory repository,

--- a/crates/but-rebase/src/graph_rebase/mod.rs
+++ b/crates/but-rebase/src/graph_rebase/mod.rs
@@ -403,6 +403,15 @@ pub struct RevisionHistory {
     commit_mappings: BTreeMap<gix::ObjectId, gix::ObjectId>,
 }
 
+impl<'ws, 'meta, M: RefMetadata> Editor<'ws, 'meta, M> {
+    pub(crate) fn new_selector(&self, id: StepGraphIndex) -> Selector {
+        Selector {
+            id,
+            revision: self.history.current_revision(),
+        }
+    }
+}
+
 impl RevisionHistory {
     pub(crate) fn new() -> Self {
         Default::default()

--- a/crates/but-rebase/src/graph_rebase/mutate.rs
+++ b/crates/but-rebase/src/graph_rebase/mutate.rs
@@ -248,10 +248,7 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
             if let Step::Pick(Pick { id, .. }) = self.graph[node_idx]
                 && id == target
             {
-                return Some(Selector {
-                    id: node_idx,
-                    revision: self.history.current_revision(),
-                });
+                return Some(self.new_selector(node_idx));
             }
         }
 
@@ -264,10 +261,7 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
             if let Step::Reference { refname } = &self.graph[node_idx]
                 && target == refname.as_ref()
             {
-                return Some(Selector {
-                    id: node_idx,
-                    revision: self.history.current_revision(),
-                });
+                return Some(self.new_selector(node_idx));
             }
         }
 
@@ -282,15 +276,7 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
         Ok(self
             .graph
             .edges_directed(target.id, Direction::Incoming)
-            .map(|edge| {
-                (
-                    Selector {
-                        id: edge.source(),
-                        revision: self.history.current_revision(),
-                    },
-                    edge.weight().order,
-                )
-            })
+            .map(|edge| (self.new_selector(edge.source()), edge.weight().order))
             .collect())
     }
 
@@ -302,16 +288,39 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
         Ok(self
             .graph
             .edges_directed(target.id, Direction::Outgoing)
-            .map(|edge| {
-                (
-                    Selector {
-                        id: edge.target(),
-                        revision: self.history.current_revision(),
-                    },
-                    edge.weight().order,
-                )
-            })
+            .map(|edge| (self.new_selector(edge.target()), edge.weight().order))
             .collect())
+    }
+
+    /// For a given step, find all the references that point to it.
+    ///
+    /// The reference selectors are provided in no particular order.
+    pub fn step_references(&self, target: impl ToSelector) -> Result<Vec<Selector>> {
+        let target = self.history.normalize_selector(target.to_selector(self)?)?;
+
+        let mut references = vec![];
+        let mut seen = HashSet::new();
+        let mut tips = vec![target.id];
+
+        while let Some(tip) = tips.pop() {
+            for edge in self.graph.edges_directed(tip, Direction::Incoming) {
+                let child = edge.source();
+                if !seen.insert(child) {
+                    continue;
+                }
+
+                match &self.graph[child] {
+                    Step::None => tips.push(child),
+                    Step::Reference { .. } => {
+                        references.push(self.new_selector(child));
+                        tips.push(child);
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        Ok(references)
     }
 
     /// Replaces the node that the function was pointing to.
@@ -716,10 +725,7 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
                     self.graph.add_edge(edge_source, new_idx, edge_weight);
                 }
 
-                Ok(Selector {
-                    id: new_idx,
-                    revision: self.history.current_revision(),
-                })
+                Ok(self.new_selector(new_idx))
             }
             InsertSide::Below => {
                 let edges = self
@@ -736,10 +742,7 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
                     self.graph.add_edge(new_idx, edge_target, edge_weight);
                 }
 
-                Ok(Selector {
-                    id: new_idx,
-                    revision: self.history.current_revision(),
-                })
+                Ok(self.new_selector(new_idx))
             }
         }
     }

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -14,7 +14,7 @@ use axum::{
     response::IntoResponse,
     routing::{MethodRouter, any, get, post},
 };
-use but_api::{commit, diff, github, gitlab, json, legacy, platform};
+use but_api::{commit, diff, github, gitlab, json, legacy, platform, workspace};
 use but_claude::{Broadcaster, Claude};
 use but_ctx::{Context, ProjectHandleOrLegacyProjectId};
 #[cfg(feature = "irc")]
@@ -1159,6 +1159,10 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
         .route(
             "/commit_uncommit",
             but_post(commit::uncommit::commit_uncommit_cmd),
+        )
+        .route(
+            "/workspace_integrate_upstream",
+            but_post(workspace::workspace_integrate_upstream_cmd),
         )
         .route("/build_type", but_post(platform::build_type_cmd));
 

--- a/crates/but-workspace/src/changeset.rs
+++ b/crates/but-workspace/src/changeset.rs
@@ -335,7 +335,6 @@ fn is_similarity_candidate(commit: &crate::ref_info::LocalCommit) -> bool {
 }
 
 /// Similarity matches between workspace commits and upstream commits, computed from commit IDs.
-#[expect(dead_code)]
 pub(crate) struct SimilarityByCommitIds {
     /// Upstream commit IDs keyed by the workspace commit ID that matched them.
     pub(crate) matches_by_workspace_commit: HashMap<gix::ObjectId, gix::ObjectId>,
@@ -345,7 +344,6 @@ pub(crate) struct SimilarityByCommitIds {
 ///
 /// The returned matches use the same cheap and optional expensive checks as [`RefInfo::compute_similarity`]
 /// for upstream integration: change IDs are skipped, while commit data and changeset IDs are considered.
-#[expect(dead_code)]
 pub(crate) fn compute_similarity_by_commit_ids(
     repo: &gix::Repository,
     upstream_commit_ids: &[gix::ObjectId],

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -58,6 +58,11 @@ mod branch_details;
 pub use branch_details::{branch_details, local_commits_for_branch};
 use but_graph::{SegmentIndex, projection::TargetCommit};
 
+mod upstream_integration;
+pub use upstream_integration::{
+    BottomUpdate, BottomUpdateKind, IntegrateUpstreamOutcome, integrate_upstream,
+};
+
 /// Information about refs, as seen from within or outsie of a workspace.
 ///
 /// We always try to deduce a set of stacks that are currently applied to a workspace,

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -1,0 +1,482 @@
+//! Integrating upstream changes
+
+use std::collections::{HashMap, HashSet};
+
+use anyhow::{Context, Result, bail};
+
+use but_core::RefMetadata;
+use but_graph::projection::commit::is_managed_workspace_by_message;
+use but_rebase::{
+    commit::DateMode,
+    graph_rebase::{
+        Editor, GraphEditorOptions, LookupStep, Pick, Selector, Step, SuccessfulRebase, ToSelector,
+        mutate::{InsertSide, RelativeTo},
+    },
+};
+
+use crate::changeset::compute_similarity_by_commit_ids;
+
+/// Whether a bottom most commit should be rebased, or a merge commit should be
+/// created at the top of the commit run.
+#[derive(Clone, Copy, PartialEq)]
+pub enum BottomUpdateKind {
+    /// Rebase the selected bottom-most commit onto the target branch.
+    Rebase,
+    /// Create a merge commit at the top of the selected stack.
+    Merge,
+}
+
+/// Describes a particular bottom node and how it should be updated.
+pub struct BottomUpdate {
+    /// Describes how the associated branch should be updated.
+    pub kind: BottomUpdateKind,
+    /// A pointer to one of the bottom most commits in a stack.
+    pub selector: RelativeTo,
+}
+
+/// The outcome of integrating upstream
+pub struct IntegrateUpstreamOutcome<'ws, 'meta, M: RefMetadata> {
+    /// The updated worskpace metadata.
+    pub ws_meta: but_core::ref_metadata::Workspace,
+    /// The rebased outcome.
+    pub rebase: SuccessfulRebase<'ws, 'meta, M>,
+}
+
+#[derive(Clone, Debug)]
+struct AnnotatedNode {
+    to_rebase: bool,
+    historically_integrated: bool,
+    content_integrated: bool,
+}
+
+impl AnnotatedNode {
+    fn new() -> Self {
+        Self {
+            to_rebase: false,
+            historically_integrated: false,
+            content_integrated: false,
+        }
+    }
+}
+
+/// Describes a sub-graph of commits from beneath workspace commit (or from HEAD
+/// with a direct checkout) until the target commit or it's decendants.
+#[derive(Clone, Debug)]
+struct Stack {
+    to_merge: bool,
+    nodes: HashMap<Selector, AnnotatedNode>,
+    heads: HashSet<Selector>,
+    bottoms: HashSet<Selector>,
+}
+
+/// Integrate upstream changes into the workspace by either:
+/// - Rebasing a stack onto `target` and dropping commits that are included
+///   content-wise upstream.
+/// - Merging upstream changes into a stack.
+///
+/// When workspace is checked out, a stacks are considered the subgraphs between
+/// the ws commit and `target.sha`. Otherwise, a stack is considered all the
+/// steps between the head commit and the `target.sha`.
+///
+/// A is a graph of commits. A stack may have multiple head commits (commits
+/// with no children in the workspace), and multiple bottom commits (commits
+/// with no parents in the workspace).
+///
+/// Updates are performed by specifying a particular update operation for a
+/// particular bottom commit.
+///
+/// All bottom commits can be updated by marking them to be rebased. If a stack
+/// has one head and one bottom, it is eligable to have upstream merged into it.
+///
+/// ## Notes on the algorithm:
+///
+/// The algorithm works as follows:
+///
+/// ### Collecting the stacks:
+/// - Stacks are identified as the seperate sub-graphs between `workspace head`
+///   and `target.sha`.
+/// - Each node in a stack that is included in `target.ref` gets marked as
+///   `historically_integrated`.
+/// - Each node in a stack commit node that is determined to be
+///   upstream-integrated gets marked as `content_integrated`.
+/// - Any `Reference` or `None` node whose parents are all `content_integrated`
+///   get marked as `contented_integrated`.
+///
+/// ### Resolving the updates
+/// - We validate updates match a bottom in a stack, and that Merge updates are
+///   only marked on stacks with one head and one bottom.
+/// - For `Rebase` updates, we propogate a `to_rebase` flag to all the children
+///   nodes of that bottom.
+///
+/// ### Performing merges
+/// - We create a merge commit either the top `Pick` or `None` step, or beneath
+///   the top `Reference` step.
+///
+/// ### Performing rebases
+/// - We identify edges between commits that are not `historically_integrated`
+///   and those that are. These edges get replaced with edges to `target.ref`
+/// - We replace all steps marked as `content_integrated` that are not
+///   `historically_integrated` with `None` steps.
+pub fn integrate_upstream<'ws, 'meta, M: RefMetadata>(
+    workspace: &'ws mut but_graph::projection::Workspace,
+    meta: &'meta mut M,
+    repo: &gix::Repository,
+    updates: Vec<BottomUpdate>,
+) -> Result<IntegrateUpstreamOutcome<'ws, 'meta, M>> {
+    let mut ws_meta = workspace
+        .metadata
+        .clone()
+        .context("Cannot update a workspace with no metadata")?;
+    let target_sha = ws_meta
+        .target_commit_id
+        .context("Cannot update a workspace without a target sha")?;
+    let target_ref = workspace
+        .target_ref
+        .clone()
+        .context("Cannot update a workspace with no target ref")?;
+    let target_ref_commit = repo.find_reference(&target_ref.ref_name)?.id();
+
+    let entrypoint = workspace.graph.lookup_entrypoint()?;
+    let head_commit = entrypoint
+        .commit
+        .context("Cannot update workspace without head commit")?;
+    let head_commit = repo.find_commit(head_commit.id)?;
+    let head_is_workspace_commit = is_managed_workspace_by_message(head_commit.message_raw()?);
+
+    let editor_options = GraphEditorOptions {
+        extra_refs: vec![target_ref.ref_name.as_ref()],
+        ..GraphEditorOptions::default()
+    };
+    let mut editor = Editor::create_with_opts(workspace, meta, repo, &editor_options)?;
+
+    let updates_with_selectors = updates
+        .iter()
+        .map(|update| Ok((update.selector.to_selector(&editor)?, update.kind)))
+        .collect::<Result<Vec<_>, anyhow::Error>>()?;
+
+    let target_ref_selector = target_ref.ref_name.to_selector(&editor)?;
+    let target_sha_selector = target_sha.to_selector(&editor)?;
+
+    let from_target_ref = traverse_nodes(&editor, target_ref_selector)?;
+    let mut from_target_sha = traverse_nodes(&editor, target_sha_selector)?;
+    from_target_sha.extend(editor.step_references(target_sha_selector)?);
+
+    let mut stacks = collect_stacks(
+        head_commit,
+        head_is_workspace_commit,
+        &editor,
+        from_target_sha,
+        from_target_ref,
+    )?;
+
+    // Validate described updates and find commits to rebase
+    for stack in &mut stacks {
+        let relevant_updates = updates_with_selectors
+            .iter()
+            .filter(|(s, _)| stack.bottoms.contains(s))
+            .collect::<Vec<_>>();
+
+        if relevant_updates
+            .iter()
+            .any(|(_, kind)| *kind == BottomUpdateKind::Merge)
+        {
+            if relevant_updates.len() > 1 {
+                bail!("Found multiple updates for a stack using the merge strategy");
+            }
+            if stack.heads.len() != 1 || stack.bottoms.len() != 1 {
+                bail!(
+                    "Merge strategy must only be used on stacks with one head and one bottom commit"
+                );
+            }
+
+            stack.to_merge = true
+        } else {
+            // currently the only other kind is rebase.
+            let mut tips = relevant_updates.iter().map(|(s, _)| *s).collect::<Vec<_>>();
+            let mut seen = tips.iter().cloned().collect::<HashSet<_>>();
+
+            while let Some(tip) = tips.pop() {
+                for c in editor
+                    .direct_children(tip)?
+                    .iter()
+                    .filter_map(|(c, _)| stack.nodes.contains_key(c).then_some(*c))
+                {
+                    if seen.insert(c) {
+                        tips.push(c);
+                    }
+                }
+            }
+
+            for seen in seen {
+                if let Some(attrs) = stack.nodes.get_mut(&seen) {
+                    attrs.to_rebase = true;
+                }
+            }
+        }
+    }
+
+    for stack in &stacks {
+        if stack.to_merge {
+            let head = stack
+                .heads
+                .iter()
+                .next()
+                .context("BUG: Head should exist")?;
+            let head_step = editor.lookup_step(*head)?;
+
+            let insert_side = match head_step {
+                Step::Pick(_) | Step::None => InsertSide::Above,
+                Step::Reference { .. } => InsertSide::Below,
+            };
+
+            let mut merge_commit = editor.empty_commit()?;
+            merge_commit.message = format!("Merge {} into merge", target_ref.ref_name).into();
+            let merge_commit =
+                editor.new_commit_untracked(merge_commit, DateMode::CommitterKeepAuthorKeep)?;
+            let merge_commit = editor.insert(
+                *head,
+                Step::Pick(Pick::new_untracked_pick(merge_commit)),
+                insert_side,
+            )?;
+            editor.add_edge(merge_commit, target_ref_selector, 1)?;
+        } else {
+            let mut edges_to_replace = HashSet::new();
+
+            // Currently, if I have a diamond (A<-B, A<-C, B<-D, C<-D), and `C`
+            // was historically integrated, we end up with both `B` and `D` with
+            // a graph (target<-B, target<-D, B<-D).
+            //
+            // The edge `target<-D` is superflous.
+            //
+            // We should be able to drop edges under the following condition:
+            // "If a commit that has an edge we would consider re-parenting; if
+            // it has a parent commit that also has an edge that we're going to
+            // re-parent to pointing to target, we drop this commit's edge
+            // instead"
+            for (node, attrs) in stack.nodes.iter() {
+                if !attrs.to_rebase {
+                    continue;
+                };
+                if attrs.historically_integrated {
+                    continue;
+                };
+                if attrs.content_integrated {
+                    editor.replace(*node, Step::None)?;
+                }
+
+                for (parent, _) in editor.direct_parents(*node)? {
+                    let Some(p_attrs) = stack.nodes.get(&parent) else {
+                        edges_to_replace.insert((*node, parent));
+                        continue;
+                    };
+
+                    if p_attrs.historically_integrated {
+                        edges_to_replace.insert((*node, parent));
+                    }
+                }
+            }
+
+            for (child, parent) in edges_to_replace {
+                let removed = editor.remove_edges(child, parent)?;
+                // Add back the lowest ordered parent that was removed.
+                // We could add back multiple, but it's likely unintentional
+                // that there were two parents in the first place.
+                if let Some(removed) = removed.iter().min() {
+                    editor.add_edge(child, target_ref_selector, *removed)?;
+                }
+            }
+        }
+    }
+
+    ws_meta.target_commit_id = Some(target_ref_commit.detach());
+    Ok(IntegrateUpstreamOutcome {
+        ws_meta,
+        rebase: editor.rebase()?,
+    })
+}
+
+fn collect_stacks<'ws, 'meta, M: RefMetadata>(
+    head_commit: gix::Commit<'_>,
+    head_is_workspace_commit: bool,
+    editor: &Editor<'ws, 'meta, M>,
+    from_target_sha: HashSet<Selector>,
+    from_target_ref: HashSet<Selector>,
+) -> Result<Vec<Stack>> {
+    let mut stacks = if head_is_workspace_commit {
+        editor
+            .direct_parents(head_commit.id)?
+            .into_iter()
+            .map(|(c, _)| Stack {
+                to_merge: false,
+                nodes: HashMap::from([(c, AnnotatedNode::new())]),
+                heads: HashSet::from([c]),
+                bottoms: HashSet::new(),
+            })
+            .collect()
+    } else {
+        let c = editor.select_commit(head_commit.id)?;
+        vec![Stack {
+            to_merge: false,
+            nodes: HashMap::from([(c, AnnotatedNode::new())]),
+            heads: HashSet::from([c]),
+            bottoms: HashSet::new(),
+        }]
+    };
+    for stack in &mut stacks {
+        let mut tips = stack.nodes.keys().copied().collect::<Vec<_>>();
+
+        while let Some(tip) = tips.pop() {
+            for (parent, _order) in editor.direct_parents(tip)? {
+                if from_target_sha.contains(&parent) {
+                    continue;
+                }
+
+                if stack.nodes.insert(parent, AnnotatedNode::new()).is_none() {
+                    tips.push(parent);
+                }
+            }
+        }
+    }
+    let mut output_stacks = vec![];
+    while let Some(mut out) = stacks.pop() {
+        for bix in (0..stacks.len()).rev() {
+            #[expect(clippy::indexing_slicing)]
+            if out.nodes.keys().any(|o| stacks[bix].nodes.contains_key(o)) {
+                let b = stacks.swap_remove(bix);
+
+                out.nodes.extend(b.nodes);
+                out.heads.extend(b.heads);
+            }
+        }
+
+        output_stacks.push(out);
+    }
+
+    let upstream_commits = commit_ids(
+        editor,
+        from_target_ref
+            .iter()
+            .filter_map(|s| (!from_target_sha.contains(s)).then_some(*s)),
+    )?;
+    let mut workspace_selectors = HashSet::new();
+    for stack in &output_stacks {
+        workspace_selectors.extend(stack.nodes.keys());
+    }
+    let integration = compute_similarity_by_commit_ids(
+        editor.repo(),
+        &upstream_commits,
+        &commit_ids(editor, workspace_selectors)?,
+        true,
+    )?;
+
+    for stack in &mut output_stacks {
+        let Stack { nodes, bottoms, .. } = stack;
+
+        for node in nodes.keys() {
+            if editor
+                .direct_parents(*node)?
+                .iter()
+                .all(|(p, _)| !nodes.contains_key(p))
+            {
+                bottoms.insert(*node);
+            }
+        }
+
+        for (node, attrs) in nodes.iter_mut() {
+            if from_target_ref.contains(node) {
+                attrs.historically_integrated = true;
+            }
+
+            let node = editor.lookup_step(*node)?;
+
+            if let Step::Pick(Pick { id, .. }) = node
+                && integration.matches_by_workspace_commit.contains_key(&id)
+            {
+                attrs.content_integrated = true;
+            }
+        }
+
+        // Propogate content_integrated up to Reference or None steps who's
+        // parents are _all_ content_integrated.
+        //
+        // We shouldn't need to do the same for historically_integrated
+        // references because they should already be covered by the topography
+        // on the Editor's graph.
+        let mut tips = bottoms
+            .iter()
+            .filter_map(|b| stack.nodes.get(b)?.content_integrated.then_some(*b))
+            .collect::<Vec<_>>();
+        let mut seen = tips.iter().cloned().collect::<HashSet<_>>();
+
+        while let Some(tip) = tips.pop() {
+            for (child, _) in editor.direct_children(tip)? {
+                if editor
+                    .direct_parents(child)?
+                    .into_iter()
+                    .filter_map(|(p, _)| stack.nodes.get(&p))
+                    .any(|p_attr| !p_attr.content_integrated)
+                {
+                    continue;
+                }
+
+                let c_step = editor.lookup_step(child)?;
+                let Some(c_attrs) = stack.nodes.get_mut(&child) else {
+                    continue;
+                };
+                if matches!(c_step, Step::Pick(_)) && !c_attrs.content_integrated {
+                    continue;
+                }
+                if seen.insert(child) {
+                    tips.push(child);
+
+                    c_attrs.content_integrated = true;
+                }
+            }
+        }
+    }
+
+    Ok(output_stacks)
+}
+
+/// Convert a list of selectors into their current commit ids.
+///
+/// Use the commit ids with great care as they might go out of date or have
+/// expected parentages after mutations in the editor.
+///
+/// Prefer using the selectors if possible.
+fn commit_ids<'ws, 'meta, M: RefMetadata>(
+    editor: &Editor<'ws, 'meta, M>,
+    selectors: impl IntoIterator<Item = Selector>,
+) -> Result<Vec<gix::ObjectId>> {
+    selectors
+        .into_iter()
+        .filter_map(|s| {
+            editor
+                .lookup_step(s)
+                .map(|s| match s {
+                    Step::Pick(Pick { id, .. }) => Some(id),
+                    _ => None,
+                })
+                .transpose()
+        })
+        .collect()
+}
+
+/// Find all the parent nodes from and including the provided tip.
+fn traverse_nodes<'ws, 'meta, M: RefMetadata>(
+    editor: &Editor<'ws, 'meta, M>,
+    tip: Selector,
+) -> Result<HashSet<Selector>> {
+    let mut seen = HashSet::from([tip]);
+    let mut tips = vec![tip];
+
+    while let Some(tip) = tips.pop() {
+        for (parent, _) in editor.direct_parents(tip)? {
+            if seen.insert(parent) {
+                tips.push(parent);
+            }
+        }
+    }
+
+    Ok(seen)
+}

--- a/crates/but-workspace/tests/fixtures/scenario/diamond-partially-content-integrated.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/diamond-partially-content-integrated.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+function commit_file_with_message() {
+  local file="${1:?first argument is the filename}"
+  local content="${2:?second argument is the content}"
+  local message="${3:?third argument is the commit message}"
+  echo "$content" >"$file"
+  git add "$file"
+  git commit -m "$message"
+}
+
+git init --initial-branch=master
+echo "Workspace stack whose merge parent was content-integrated upstream" >.git/description
+
+commit o1
+git branch o1
+
+git checkout -b A
+commit_file_with_message a.txt A A
+
+git checkout -b B
+commit_file_with_message b.txt B B
+
+git checkout -b D A
+commit D
+
+git checkout -b C B
+git merge --no-ff -m C D
+
+git checkout -b E C
+commit E
+
+git checkout master
+commit o2
+git cherry-pick A
+git cherry-pick B
+git branch o3
+commit o4
+
+setup_remote_tracking master master
+cat <<EOF >>.git/config
+[remote "origin"]
+	url = ./fake/local/path/which-is-fine-as-we-dont-fetch-or-push
+	fetch = +refs/heads/*:refs/remotes/origin/*
+
+[branch "master"]
+	remote = "origin"
+	merge = refs/heads/master
+EOF
+
+git checkout E
+create_workspace_commit_once E

--- a/crates/but-workspace/tests/fixtures/scenario/diamond-partially-historically-integrated.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/diamond-partially-historically-integrated.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git init --initial-branch=master
+echo "Workspace stack whose merge parent was historically integrated upstream" >.git/description
+
+commit o1
+git branch o1
+
+git checkout -b A
+commit A
+
+git checkout -b B
+commit B
+
+git checkout -b D A
+commit D
+
+git checkout -b C B
+git merge --no-ff -m C D
+
+git checkout -b E C
+commit E
+
+git checkout master
+commit o2
+git merge --no-ff -m o3 B
+git branch o3
+commit o4
+
+setup_remote_tracking master master
+cat <<EOF >>.git/config
+[remote "origin"]
+	url = ./fake/local/path/which-is-fine-as-we-dont-fetch-or-push
+	fetch = +refs/heads/*:refs/remotes/origin/*
+
+[branch "master"]
+	remote = "origin"
+	merge = refs/heads/master
+EOF
+
+git checkout E
+create_workspace_commit_once E

--- a/crates/but-workspace/tests/workspace/main.rs
+++ b/crates/but-workspace/tests/workspace/main.rs
@@ -10,5 +10,6 @@ mod shallow_clone;
 mod target_history;
 mod tree_manipulation;
 mod ui;
+mod upstream_integration;
 
 mod utils;

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -1,0 +1,317 @@
+use anyhow::Result;
+use but_graph::init::Options;
+use but_meta::virtual_branches_legacy_types::Target;
+use but_rebase::graph_rebase::mutate::RelativeTo;
+use but_testsupport::{graph_workspace, visualize_commit_graph_all};
+use but_workspace::{BottomUpdate, BottomUpdateKind, integrate_upstream};
+
+use crate::ref_info::with_workspace_commit::utils::{
+    StackState, add_stack, named_writable_scenario_with_description,
+};
+
+#[test]
+fn diamond_partially_historically_integrated_rebase() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("diamond-partially-historically-integrated")?;
+    let o1_id = repo.rev_parse_single("o1")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "master"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: o1_id,
+        push_remote_name: None,
+    });
+    add_stack(&mut meta, 1, "E", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        Options {
+            extra_target_commit_id: Some(o1_id),
+            ..Options::limited()
+        },
+    )?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 61ee5f5 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 972cf74 (E) E
+    *   9e74c75 (C) C
+    |\  
+    | * d6a7004 (D) D
+    | | * 7de2393 (origin/master, master) o4
+    | | *   7d62953 (o3) o3
+    | | |\  
+    | |_|/  
+    |/| |   
+    * | | ffb801b (B) B
+    |/ /  
+    * | 448b195 (A) A
+    | * d1b2089 o2
+    |/  
+    * 85aa44b (o1) o1
+    ");
+
+    let mut workspace = graph.into_workspace()?;
+    let but_workspace::IntegrateUpstreamOutcome { rebase, .. } = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A")?.detach()),
+        }],
+    )?;
+
+    rebase.materialize()?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 03f9366 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 22aa077 (E) E
+    *   8719a89 (C) C
+    |\  
+    | * 59b39ea (D) D
+    |/  
+    * 7de2393 (origin/master, master) o4
+    *   7d62953 (o3) o3
+    |\  
+    | * ffb801b (B) B
+    | * 448b195 (A) A
+    * | d1b2089 o2
+    |/  
+    * 85aa44b (o1) o1
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn diamond_partially_historically_integrated_merge() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("diamond-partially-historically-integrated")?;
+    let o1_id = repo.rev_parse_single("o1")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "master"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: o1_id,
+        push_remote_name: None,
+    });
+    add_stack(&mut meta, 1, "E", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        Options {
+            extra_target_commit_id: Some(o1_id),
+            ..Options::limited()
+        },
+    )?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 61ee5f5 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 972cf74 (E) E
+    *   9e74c75 (C) C
+    |\  
+    | * d6a7004 (D) D
+    | | * 7de2393 (origin/master, master) o4
+    | | *   7d62953 (o3) o3
+    | | |\  
+    | |_|/  
+    |/| |   
+    * | | ffb801b (B) B
+    |/ /  
+    * | 448b195 (A) A
+    | * d1b2089 o2
+    |/  
+    * 85aa44b (o1) o1
+    ");
+
+    let mut workspace = graph.into_workspace()?;
+    let but_workspace::IntegrateUpstreamOutcome { rebase, .. } = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Merge,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A")?.detach()),
+        }],
+    )?;
+
+    rebase.materialize()?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 96c95ba (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   ed5f276 (E) Merge refs/remotes/origin/master into merge
+    |\  
+    | * 7de2393 (origin/master, master) o4
+    | *   7d62953 (o3) o3
+    | |\  
+    | * | d1b2089 o2
+    * | | 972cf74 E
+    * | |   9e74c75 (C) C
+    |\ \ \  
+    | |_|/  
+    |/| |   
+    | * | d6a7004 (D) D
+    * | | ffb801b (B) B
+    |/ /  
+    * / 448b195 (A) A
+    |/  
+    * 85aa44b (o1) o1
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn diamond_partially_content_integrated_rebase() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("diamond-partially-content-integrated")?;
+    let o1_id = repo.rev_parse_single("o1")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "master"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: o1_id,
+        push_remote_name: None,
+    });
+    add_stack(&mut meta, 1, "E", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        Options {
+            extra_target_commit_id: Some(o1_id),
+            ..Options::limited()
+        },
+    )?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 3e02fbd (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * a6588cf (E) E
+    *   4827d2f (C) C
+    |\  
+    | * d8d0970 (D) D
+    * | 3d3bfa7 (B) B
+    |/  
+    * f5b02d3 (A) A
+    | * 162b064 (origin/master, master) o4
+    | * dd87d69 (o3) B
+    | * 5c0b375 A
+    | * d1b2089 o2
+    |/  
+    * 85aa44b (o1) o1
+    ");
+
+    let mut workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/master⇣4 on 85aa44b
+    └── ≡📙:4:E on 85aa44b {1}
+        ├── 📙:4:E
+        │   └── ·a6588cf (🏘️)
+        ├── :6:C
+        │   └── ·4827d2f (🏘️)
+        ├── :7:B
+        │   └── ·3d3bfa7 (🏘️)
+        └── :9:A
+            └── ·f5b02d3 (🏘️)
+    ");
+    let but_workspace::IntegrateUpstreamOutcome { rebase, .. } = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A")?.detach()),
+        }],
+    )?;
+
+    rebase.materialize()?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 5ba22ce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 04b1a3e (E) E
+    *   1144e41 (C) C
+    |\  
+    | * dd00172 (D) D
+    |/  
+    * 162b064 (origin/master, master) o4
+    * dd87d69 (o3) B
+    * 5c0b375 A
+    * d1b2089 o2
+    * 85aa44b (o1) o1
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn diamond_partially_content_integrated_merge() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("diamond-partially-content-integrated")?;
+    let o1_id = repo.rev_parse_single("o1")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "master"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: o1_id,
+        push_remote_name: None,
+    });
+    add_stack(&mut meta, 1, "E", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        Options {
+            extra_target_commit_id: Some(o1_id),
+            ..Options::limited()
+        },
+    )?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 3e02fbd (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * a6588cf (E) E
+    *   4827d2f (C) C
+    |\  
+    | * d8d0970 (D) D
+    * | 3d3bfa7 (B) B
+    |/  
+    * f5b02d3 (A) A
+    | * 162b064 (origin/master, master) o4
+    | * dd87d69 (o3) B
+    | * 5c0b375 A
+    | * d1b2089 o2
+    |/  
+    * 85aa44b (o1) o1
+    ");
+
+    let mut workspace = graph.into_workspace()?;
+    let but_workspace::IntegrateUpstreamOutcome { rebase, .. } = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Merge,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A")?.detach()),
+        }],
+    )?;
+
+    rebase.materialize()?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 6c75185 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   0a395ba (E) Merge refs/remotes/origin/master into merge
+    |\  
+    | * 162b064 (origin/master, master) o4
+    | * dd87d69 (o3) B
+    | * 5c0b375 A
+    | * d1b2089 o2
+    * | a6588cf E
+    * |   4827d2f (C) C
+    |\ \  
+    | * | d8d0970 (D) D
+    * | | 3d3bfa7 (B) B
+    |/ /  
+    * / f5b02d3 (A) A
+    |/  
+    * 85aa44b (o1) o1
+    ");
+
+    Ok(())
+}

--- a/crates/gitbutler-tauri/permissions/default.toml
+++ b/crates/gitbutler-tauri/permissions/default.toml
@@ -219,4 +219,5 @@ commands.allow = [
   "update_user_profile",
   "update_workspace_rule",
   "upstream_integration_statuses",
+  "workspace_integrate_upstream",
 ]

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -14,7 +14,7 @@
 use std::sync::Arc;
 
 use anyhow::{Context, bail};
-use but_api::{commit, diff, github, gitlab, legacy, platform};
+use but_api::{commit, diff, github, gitlab, legacy, platform, workspace};
 use but_claude::{Broadcaster, Claude};
 #[cfg(feature = "irc")]
 use but_irc::IrcManager;
@@ -541,6 +541,7 @@ fn main() -> anyhow::Result<()> {
                 commit::squash::tauri_commit_squash::commit_squash,
                 commit::uncommit::tauri_commit_uncommit_changes::commit_uncommit_changes,
                 commit::uncommit::tauri_commit_uncommit::commit_uncommit,
+                workspace::tauri_workspace_integrate_upstream::workspace_integrate_upstream,
                 platform::tauri_build_type::build_type,
             ])
             .menu(move |handle| menu::build(handle, &app_settings_for_menu))

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -317,6 +317,18 @@ export declare function updateReviewFooters(projectId: string, reviews: Array<Fo
  * part of any applied stack.
  */
 export declare function warmCiChecksCache(projectId: string): Promise<void>
+
+/**
+ * Integrate upstream changes into the current workspace and record an oplog
+ * snapshot on success.
+ *
+ * This acquires exclusive worktree access from `ctx`, applies the requested
+ * upstream updates, and commits a best-effort `MergeUpstream` oplog snapshot
+ * when the integration succeeds. When `dry_run` is enabled, the returned
+ * workspace previews the integration and no oplog entry is persisted. See
+ * [`workspace_integrate_upstream_with_perm()`] for lower-level details.
+ */
+export declare function workspaceIntegrateUpstream(projectId: string, updates: Array<BottomUpdate>, dryRun: boolean): Promise<WorkspaceState>
 export declare class WatcherHandle {
   /** Stop the underlying watcher if it is still active. */
   stop(): boolean
@@ -478,6 +490,17 @@ export type BaseBranchResolutionApproach = {
 } | {
   type: "hardReset";
 };
+
+/** JSON transport type describing one stack bottom to update. */
+export type BottomUpdate = {
+  /** How the selected stack bottom should be updated. */
+  kind: BottomUpdateKind;
+  /** The bottom-most commit or empty bottom reference to update. */
+  selector: RelativeTo;
+};
+
+/** JSON transport type for how a stack bottom should be updated. */
+export type BottomUpdateKind = "rebase" | "merge";
 
 /** Metadata about branches, associated with any Git branch. */
 export type Branch = {

--- a/packages/but-sdk/src/generated/index.js
+++ b/packages/but-sdk/src/generated/index.js
@@ -579,7 +579,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { absorb, absorptionPlan, apply, assignHunk, branchDetails, branchDiff, changesInWorktree, changesInWorktreeWithPerm, commitAmend, commitCreate, commitDetailsWithLineStats, commitDiscard, commitInsertBlank, commitMove, commitMoveChangesBetween, commitReword, commitSquash, commitUncommit, commitUncommitChanges, forgeProvider, getReview, headInfo, listAvailableReviewTemplates, listBranches, listCiChecksAndUpdateCache, listProjectsStateless, listReviews, listReviewsForBranch, mergeReview, moveBranch, publishReview, pushStackLegacy, removeBranch, reviewTemplate, setReviewAutoMerge, setReviewDraftiness, setReviewTemplate, tearOffBranch, treeChangeDiffs, unapplyStack, updateBranchName, updateReviewFooters, warmCiChecksCache, WatcherHandle, watcherStart } = nativeBinding
+const { absorb, absorptionPlan, apply, assignHunk, branchDetails, branchDiff, changesInWorktree, changesInWorktreeWithPerm, commitAmend, commitCreate, commitDetailsWithLineStats, commitDiscard, commitInsertBlank, commitMove, commitMoveChangesBetween, commitReword, commitSquash, commitUncommit, commitUncommitChanges, forgeProvider, getReview, headInfo, listAvailableReviewTemplates, listBranches, listCiChecksAndUpdateCache, listProjectsStateless, listReviews, listReviewsForBranch, mergeReview, moveBranch, publishReview, pushStackLegacy, removeBranch, reviewTemplate, setReviewAutoMerge, setReviewDraftiness, setReviewTemplate, tearOffBranch, treeChangeDiffs, unapplyStack, updateBranchName, updateReviewFooters, warmCiChecksCache, workspaceIntegrateUpstream, WatcherHandle, watcherStart } = nativeBinding
 export { absorb }
 export { absorptionPlan }
 export { apply }
@@ -623,5 +623,6 @@ export { unapplyStack }
 export { updateBranchName }
 export { updateReviewFooters }
 export { warmCiChecksCache }
+export { workspaceIntegrateUpstream }
 export { WatcherHandle }
 export { watcherStart }


### PR DESCRIPTION
Integrate upstream changes into the workspace by either:
- Rebasing a stack onto <target> and dropping commits that are included
  content-wise upstream.
- Merging upstream changes into a stack.

When workspace is checked out, a stacks are considered the subgraphs between
the ws commit and <target.sha>. Otherwise, a stack is considered all the
steps between the head commit and the <target.sha>.

A is a graph of commits. A stack may have multiple head commits (commits
with no children in the workspace), and multiple bottom commits (commits
with no parents in the workspace).

Updates are performed by specifying a particular update operation for a
particular bottom commit.

All bottom commits can be updated by marking them to be rebased. If a stack
has one head and one bottom, it is eligable to have upstream merged into it.

## Notes on the algorithm:

The algorithm works as follows:

### Collecting the stacks:
- Stacks are identified as the seperate sub-graphs between <workspace head>
  and <target.sha>.
- Each node in a stack that is included in <target.ref> gets marked as
  `historically_integrated`.
- Each node in a stack commit node that is determined to be
  upstream-integrated gets marked as `content_integrated`.
- Any `Reference` or `None` node whose parents are all `content_integrated`
  get marked as `contented_integrated`.

### Resolving the updates
- We validate updates match a bottom in a stack, and that Merge updates are
  only marked on stacks with one head and one bottom.
- For `Rebase` updates, we propogate a `to_rebase` flag to all the children
  nodes of that bottom.

### Performing merges
- We create a merge commit either the top `Pick` or `None` step, or beneath
  the top `Reference` step.

### Performing rebases
- We identify edges between commits that are not `historically_integrated`
  and those that are. These edges get replaced with edges to <target.ref>
- We replace all steps marked as `content_integrated` that are not
  `historically_integrated` with `None` steps.