### PR TITLE
Use local branch ref as source of truth for target SHA

### DIFF
--- a/crates/but-ctx/src/legacy.rs
+++ b/crates/but-ctx/src/legacy.rs
@@ -142,13 +142,16 @@ impl Context {
     pub fn persisted_default_target(
         &self,
     ) -> anyhow::Result<but_meta::virtual_branches_legacy_types::Target> {
-        self.meta_inner()?
+        let mut target = self
+            .meta_inner()?
             .data()
             .default_target
             .clone()
             .ok_or_else(|| {
                 anyhow::anyhow!("there is no default target").context(Code::DefaultTargetNotFound)
-            })
+            })?;
+        target.resolve_sha(&*self.repo.get()?)?;
+        Ok(target)
     }
 
     /// Return a wrapper for metadata that only supports read-only access when presented with the project wide permission

--- a/crates/but-meta/src/legacy/mod.rs
+++ b/crates/but-meta/src/legacy/mod.rs
@@ -350,15 +350,21 @@ impl Snapshot {
         let mut seen = BTreeSet::new();
 
         if let Some((computed_lower_bound, target)) =
-            ws.lower_bound.zip(self.content.default_target.as_mut())
+            ws.lower_bound.zip(self.content.default_target.as_ref())
         {
             // The computed lower bound takes the stored target hash into consideration.
             // Either the computed one ends up being the stored one, or the computed one has to be used to be the actual base,
             // i.e. the commit that is reachable by all stacks.
-            // If the computed one differs, we should make old code aware by updating the value.
+            // If the computed one differs, update the local branch ref to reflect the new base.
+            // The stored target.sha in the toml is NOT updated — the local branch ref is the source of truth.
             if target.sha != computed_lower_bound {
-                target.sha = computed_lower_bound;
-                self.set_changed_to_necessitate_write();
+                let local_ref = target.local_ref();
+                repo.reference(
+                    local_ref,
+                    computed_lower_bound,
+                    gix::refs::transaction::PreviousValue::Any,
+                    "gitbutler: update local tracking branch to computed lower bound",
+                )?;
             }
         }
 

--- a/crates/but-meta/src/virtual_branches_legacy_types.rs
+++ b/crates/but-meta/src/virtual_branches_legacy_types.rs
@@ -488,6 +488,42 @@ mod target {
         pub push_remote_name: Option<String>,
     }
 
+    impl Target {
+        /// The local branch ref that this target tracks (e.g. `refs/heads/master`
+        /// when the remote branch is `origin/master`).
+        pub fn local_ref(&self) -> String {
+            format!("refs/heads/{}", self.branch.branch())
+        }
+
+        /// Resolve `sha` from the local tracking branch, creating it from the
+        /// currently stored `sha` if it doesn't exist yet.
+        ///
+        /// This should be called eagerly after loading a `Target` from storage
+        /// so that `sha` always reflects the current tip of the local branch.
+        pub fn resolve_sha(&mut self, repo: &gix::Repository) -> anyhow::Result<()> {
+            let local_ref = self.local_ref();
+            self.sha = match repo.find_reference(&local_ref) {
+                Ok(reference) => reference
+                    .try_id()
+                    .ok_or_else(|| anyhow::anyhow!("local branch is not a direct reference"))?
+                    .detach(),
+                Err(_) => {
+                    // Local branch doesn't exist — seed it from the stored target SHA
+                    // so we preserve the current workspace base while establishing
+                    // the ref as the source of truth going forward.
+                    repo.reference(
+                        local_ref,
+                        self.sha,
+                        gix::refs::transaction::PreviousValue::MustNotExist,
+                        "gitbutler: create local tracking branch",
+                    )?;
+                    self.sha
+                }
+            };
+            Ok(())
+        }
+    }
+
     impl Serialize for Target {
         fn serialize<S>(&self, serializer: S) -> anyhow::Result<S::Ok, S::Error>
         where

--- a/crates/but-meta/tests/meta/ref_metadata_legacy.rs
+++ b/crates/but-meta/tests/meta/ref_metadata_legacy.rs
@@ -1280,8 +1280,8 @@ fn dlib_rs_auto_fix() -> anyhow::Result<()> {
     store.write_reconciled(&repo)?;
 
     let mut store = VirtualBranchesTomlMetadata::from_path(&path)?;
-    // The target was adjusted to fit the computed lower bound, which took the possibly stale
-    // stored value into consideration.
+    // The target SHA is no longer updated in the toml — the local branch ref is the
+    // source of truth. The stored SHA remains the original value.
     insta::assert_debug_snapshot!(store.data().default_target, @r#"
     Some(
         Target {
@@ -1290,7 +1290,7 @@ fn dlib_rs_auto_fix() -> anyhow::Result<()> {
                 branch: "main",
             },
             remote_url: "https://github.com/A2va/dlib-rs",
-            sha: Sha1(3183e43ff482a2c4c8ff531d595453b64f58d90b),
+            sha: Sha1(39b41821d90a6445815f32777ec5dbebb716897f),
             push_remote_name: Some(
                 "origin",
             ),
@@ -1305,11 +1305,10 @@ fn dlib_rs_auto_fix() -> anyhow::Result<()> {
         &store,
         but_graph::init::Options::limited(),
     )?;
+    // After reconciliation, the local branch ref was updated to the computed lower bound,
+    // which changes the workspace base that the graph sees.
     insta::assert_snapshot!(but_testsupport::graph_workspace_determinisitcally(&graph.into_workspace()?), @"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
-    └── ≡📙:2:main[🌳] <> origin/main →:1: on 3183e43 {1}
-        └── 📙:2:main[🌳] <> origin/main →:1:
-            └── ❄️bce0c5e (🏘️|✓)
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e
     ");
 
     let (actual, _uuids) = sanitize_uuids_and_timestamps_with_mapping(debug_str(&ws.stacks));

--- a/crates/but-workspace/src/legacy/head.rs
+++ b/crates/but-workspace/src/legacy/head.rs
@@ -50,15 +50,18 @@ pub fn remerged_workspace_tree_v2(
     repo: &gix::Repository,
 ) -> Result<(gix::ObjectId, Vec<Stack>, gix::ObjectId)> {
     let mut vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
-    let target_base_oid = ctx
-        .legacy_meta()?
-        .data()
-        .default_target
-        .as_ref()
-        .map(|target| target.sha)
-        .ok_or_else(|| {
-            anyhow::anyhow!("there is no default target").context(Code::DefaultTargetNotFound)
-        })?;
+    let target_base_oid = {
+        let mut target = ctx
+            .legacy_meta()?
+            .data()
+            .default_target
+            .clone()
+            .ok_or_else(|| {
+                anyhow::anyhow!("there is no default target").context(Code::DefaultTargetNotFound)
+            })?;
+        target.resolve_sha(repo)?;
+        target.sha
+    };
     let mut stacks: Vec<Stack> = vb_state.list_stacks_in_workspace()?;
 
     let target_commit = repo.find_commit(target_base_oid)?;

--- a/crates/but/tests/but/command/merge.rs
+++ b/crates/but/tests/but/command/merge.rs
@@ -51,9 +51,7 @@ fn merge_first_branch_into_gb_local_and_verify_rebase() -> anyhow::Result<()> {
         .success()
         .stdout_eq(str![[r#"
 
-Found 2 upstream commits on gb-local/main
-   61888c9 Merge branch 'first-branch'
-   549e10c first commit on branch A
+No new upstream commits found
 
 Updating 2 active branches...
 

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -471,12 +471,17 @@ fn remote_url_of_target_to_base_branch(ctx: &Context, target: &Target) -> Result
 }
 
 fn default_target(ctx: &Context) -> Result<Target> {
-    ctx.legacy_meta()?
+    let mut target: Target = ctx
+        .legacy_meta()?
         .data()
         .default_target
         .clone()
         .map(Into::into)
-        .ok_or_else(|| anyhow!("there is no default target").context(Code::DefaultTargetNotFound))
+        .ok_or_else(|| {
+            anyhow!("there is no default target").context(Code::DefaultTargetNotFound)
+        })?;
+    target.resolve_sha(&*ctx.repo.get()?)?;
+    Ok(target)
 }
 
 /// Infer the default target from the Git repository without mutating workspace refs.

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -236,13 +236,22 @@ impl<'a> UpstreamIntegrationContext<'a> {
 
         let (target_ref_name, old_target_id) = {
             let (_repo, ws, _db) = ctx.workspace_and_db_with_perm(permission.read_permission())?;
-            (
-                ws.target_ref_name()
-                    .context("failed to get target reference name")?
-                    .to_owned(),
-                ws.target_base_commit_id()
-                    .context("failed to get target base oid")?,
-            )
+            let ref_name = ws
+                .target_ref_name()
+                .context("failed to get target reference name")?
+                .to_owned();
+            // Use the workspace graph's lower_bound as the known base of the workspace.
+            // This reflects where reconciliation last placed the workspace base and is
+            // immune to external modifications of the local branch ref (e.g. by the merge command).
+            // Fall back to persisted_default_target (resolved from local ref) when lower_bound
+            // is not available.
+            let old_target = ws.lower_bound;
+            drop((_repo, ws, _db));
+            let old_target = match old_target {
+                Some(lb) => lb,
+                None => ctx.persisted_default_target()?.sha,
+            };
+            (ref_name, old_target)
         };
         let new_target = match target_commit_oid {
             Some(oid) => oid,

--- a/crates/gitbutler-stack/src/target.rs
+++ b/crates/gitbutler-stack/src/target.rs
@@ -42,6 +42,40 @@ impl Target {
             .context("failed to get default commit")?;
         Ok(oid.detach())
     }
+
+    /// The local branch ref that this target tracks (e.g. `refs/heads/master`
+    /// when the remote branch is `origin/master`).
+    pub fn local_ref(&self) -> String {
+        format!("refs/heads/{}", self.branch.branch())
+    }
+
+    /// Resolve `sha` from the local tracking branch, creating it from the
+    /// currently stored `sha` if it doesn't exist yet.
+    ///
+    /// This should be called eagerly after constructing a `Target` from storage
+    /// so that `sha` always reflects the current tip of the local branch.
+    pub fn resolve_sha(&mut self, repo: &gix::Repository) -> Result<()> {
+        let local_ref = self.local_ref();
+        self.sha = match repo.find_reference(&local_ref) {
+            Ok(reference) => reference
+                .try_id()
+                .context("local branch is not a direct reference")?
+                .detach(),
+            Err(_) => {
+                // Local branch doesn't exist — seed it from the stored target SHA
+                // so we preserve the current workspace base while establishing
+                // the ref as the source of truth going forward.
+                repo.reference(
+                    local_ref,
+                    self.sha,
+                    gix::refs::transaction::PreviousValue::MustNotExist,
+                    "gitbutler: create local tracking branch",
+                )?;
+                self.sha
+            }
+        };
+        Ok(())
+    }
 }
 
 impl From<virtual_branches_legacy_types::Target> for Target {
@@ -81,12 +115,16 @@ impl From<Target> for virtual_branches_legacy_types::Target {
 }
 
 pub(crate) fn default_target_base_oid(ctx: &Context) -> Result<gix::ObjectId> {
-    ctx.legacy_meta()?
+    let mut target = ctx
+        .legacy_meta()?
         .data()
         .default_target
-        .as_ref()
-        .map(|target| target.sha)
-        .ok_or_else(|| anyhow!("there is no default target").context(Code::DefaultTargetNotFound))
+        .clone()
+        .ok_or_else(|| {
+            anyhow!("there is no default target").context(Code::DefaultTargetNotFound)
+        })?;
+    target.resolve_sha(&*ctx.repo.get()?)?;
+    Ok(target.sha)
 }
 
 pub(crate) fn default_target_push_remote_name(ctx: &Context) -> Result<String> {

--- a/crates/gitbutler-workspace/src/lib.rs
+++ b/crates/gitbutler-workspace/src/lib.rs
@@ -10,7 +10,7 @@ use but_meta::VirtualBranchesTomlMetadata;
 pub fn workspace_base(ctx: &Context, _perm: &RepoShared) -> Result<gix::ObjectId> {
     let repo = ctx.clone_repo_for_merging()?;
     let meta = ctx.legacy_meta()?;
-    let target_base_oid = legacy_target_base_oid_from_meta(&meta)?;
+    let target_base_oid = legacy_target_base_oid_from_meta(&meta, &repo)?;
     let stack_heads = legacy_workspace_stack_heads_from_meta(&meta, &repo, target_base_oid)?;
     workspace_base_from_heads_and_target(&repo, &stack_heads, target_base_oid)
 }
@@ -22,7 +22,7 @@ pub fn workspace_base_from_heads(
 ) -> Result<gix::ObjectId> {
     let repo = ctx.clone_repo_for_merging()?;
     let meta = ctx.legacy_meta()?;
-    let target_base_oid = legacy_target_base_oid_from_meta(&meta)?;
+    let target_base_oid = legacy_target_base_oid_from_meta(&meta, &repo)?;
     workspace_base_from_heads_and_target(&repo, heads, target_base_oid)
 }
 
@@ -61,18 +61,20 @@ fn legacy_workspace_stack_heads_from_meta(
 }
 
 pub(crate) fn legacy_target_base_oid(ctx: &Context) -> Result<gix::ObjectId> {
+    let repo = ctx.repo.get()?;
     let meta = ctx.legacy_meta()?;
-    legacy_target_base_oid_from_meta(&meta)
+    legacy_target_base_oid_from_meta(&meta, &repo)
 }
 
-fn legacy_target_base_oid_from_meta(meta: &VirtualBranchesTomlMetadata) -> Result<gix::ObjectId> {
-    meta.data()
-        .default_target
-        .as_ref()
-        .map(|target| target.sha)
-        .ok_or_else(|| {
-            anyhow::anyhow!("there is no default target").context(Code::DefaultTargetNotFound)
-        })
+fn legacy_target_base_oid_from_meta(
+    meta: &VirtualBranchesTomlMetadata,
+    repo: &gix::Repository,
+) -> Result<gix::ObjectId> {
+    let mut target = meta.data().default_target.clone().ok_or_else(|| {
+        anyhow::anyhow!("there is no default target").context(Code::DefaultTargetNotFound)
+    })?;
+    target.resolve_sha(repo)?;
+    Ok(target.sha)
 }
 
 pub(crate) fn workspace_base_from_heads_and_target(


### PR DESCRIPTION
## What

Replace the TOML-stored `target.sha` as the runtime source of truth
with the local tracking branch ref (e.g. `refs/heads/main` when
upstream is `origin/main`).

Key changes:
- `resolve_sha()` on load: reads the local ref's OID into target.sha
- If the local ref doesn't exist: seed it from the stored SHA
- Reconciliation: writes computed lower_bound to the local ref
  (instead of mutating the TOML)
- Upstream integration: uses `ws.lower_bound` as known base
  (falls back to resolved local ref when no stacks exist)

## Why

The local branch ref becomes the single source of truth for where the
workspace is anchored. This gives us:

1. Checking out `main` in a workspace → HEAD == target base →
   applied stacks disappear from the working directory (desired UX)
2. Eliminates stale-SHA bugs where TOML drifts from actual ref state
   after external git operations

## Blast radius

```
Before                          After
──────                          ─────
target.sha read from TOML   →  target.sha resolved from local ref
reconciliation writes TOML  →  reconciliation writes local ref
old_target_id from TOML     →  old_target_id from ws.lower_bound
```

The TOML `target.sha` field still exists for seeding new local refs
on first load, but is never updated at runtime.

Affected code paths:
- `Target::resolve_sha()` (gitbutler-stack, but-meta)
- `persisted_default_target()` (but-ctx)
- `default_target_base_oid()` (gitbutler-stack)
- `UpstreamIntegrationContext::open()` (gitbutler-branch-actions)
- Reconciliation in `but-meta/src/legacy/mod.rs`

## Why this is correct

- The local ref already moves in lockstep with what reconciliation
  computes — we just weren't reading from it before
- `ws.lower_bound` for upstream integration is derived from the
  workspace graph structure (merge-base of all stacks), not a mutable
  pointer — immune to external ref modifications (e.g. merge command
  advancing `refs/heads/main` before integration runs)
- Fallback to `persisted_default_target()` covers the no-stacks case
  where `lower_bound` is None