### PR TITLE
Passthrough `SSH_AUTH_SOCK` env var to `dev`

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -28,7 +28,8 @@
 		"dev": {
 			"dependsOn": ["package"],
 			"cache": false,
-			"persistent": true
+			"persistent": true,
+			"passThroughEnv": ["SSH_AUTH_SOCK"]
 		},
 		"check": {
 			"dependsOn": ["package"]


### PR DESCRIPTION
Needed for `dev:lite`. Fixes GB-1236.