### PR TITLE
Ignore updates for unversioned builds

### DIFF
--- a/crates/but-update/src/cache.rs
+++ b/crates/but-update/src/cache.rs
@@ -51,6 +51,7 @@ impl AvailableUpdate {
 /// This function checks the cache for a previously performed update check and returns
 /// update information if:
 /// - A cached update check exists
+/// - The current build has a real compile-time `VERSION`
 /// - The cached status indicates an update is available (`up_to_date == false`)
 /// - The update is not currently suppressed
 /// - The available version differs from the current version (not a no-op)
@@ -64,6 +65,17 @@ impl AvailableUpdate {
 /// * `Ok(None)` - No update is available, no cache exists, cache is invalid, update is suppressed, or update is a no-op
 /// * `Err(_)` - Failed to access the cache
 pub fn available_update(cache: &but_db::AppCacheHandle) -> anyhow::Result<Option<AvailableUpdate>> {
+    available_update_for_version(cache, crate::current_version())
+}
+
+fn available_update_for_version(
+    cache: &but_db::AppCacheHandle,
+    current_version: Option<&str>,
+) -> anyhow::Result<Option<AvailableUpdate>> {
+    let Some(current_version) = current_version else {
+        return Ok(None);
+    };
+
     let cached = match cache.update_check().get() {
         Some(cached) => cached,
         None => return Ok(None),
@@ -87,11 +99,8 @@ pub fn available_update(cache: &but_db::AppCacheHandle) -> anyhow::Result<Option
         }
     }
 
-    // Update is available and not suppressed
-    let current_version = option_env!("VERSION").unwrap_or("0.0.0").to_string();
-
     let update = AvailableUpdate {
-        current_version,
+        current_version: current_version.to_string(),
         available_version: cached.status.latest_version,
         release_notes: cached.status.release_notes,
         url: cached.status.url,
@@ -147,4 +156,63 @@ pub fn suppress_update(cache: &mut but_db::AppCacheHandle, hours: u32) -> anyhow
         .update_check_mut()?
         .suppress(hours)
         .map_err(Into::into)
+}
+
+#[cfg(test)]
+mod tests {
+    use but_db::{
+        AppCacheHandle,
+        cache::{CachedCheckResult, CheckUpdateStatus},
+    };
+    use chrono::DateTime;
+
+    use super::available_update_for_version;
+
+    #[test]
+    fn returns_update_when_versions_differ() -> anyhow::Result<()> {
+        let mut cache = in_memory_cache();
+        cache.update_check_mut()?.save(&cached_update("1.2.3"))?;
+
+        let update = available_update_for_version(&cache, Some("1.2.2"))?
+            .expect("update should be available");
+
+        assert_eq!(update.current_version, "1.2.2");
+        assert_eq!(update.available_version, "1.2.3");
+        assert_eq!(
+            update.release_notes,
+            Some("Bug fixes and improvements".to_string())
+        );
+        assert_eq!(update.url, Some("https://example.com/download".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_no_op_update_when_versions_match() -> anyhow::Result<()> {
+        let mut cache = in_memory_cache();
+        cache.update_check_mut()?.save(&cached_update("1.2.3"))?;
+
+        let update = available_update_for_version(&cache, Some("1.2.3"))?;
+
+        assert!(update.is_none());
+        Ok(())
+    }
+
+    fn cached_update(version: &str) -> CachedCheckResult {
+        CachedCheckResult {
+            checked_at: DateTime::from_timestamp(1000000, 0).unwrap(),
+            status: CheckUpdateStatus {
+                up_to_date: false,
+                latest_version: version.to_string(),
+                release_notes: Some("Bug fixes and improvements".to_string()),
+                url: Some("https://example.com/download".to_string()),
+                signature: Some("signature123".to_string()),
+            },
+            suppressed_at: None,
+            suppress_duration_hours: None,
+        }
+    }
+
+    fn in_memory_cache() -> AppCacheHandle {
+        AppCacheHandle::new_at_path(":memory:")
+    }
 }

--- a/crates/but-update/src/check.rs
+++ b/crates/but-update/src/check.rs
@@ -38,8 +38,8 @@ impl std::fmt::Display for AppName {
 /// Returns information about the latest available version, including download URLs and release notes.
 ///
 /// The `CHANNEL` environment variable (set at compile time) determines which release channel to query.
-/// Defaults to `"nightly"` if not set. The `VERSION` environment variable specifies the current version.
-/// Defaults to `"0.0.0"` if not set.
+/// The `VERSION` environment variable specifies the current version. If either value is missing,
+/// the build is treated as a development build and update checking is skipped.
 ///
 /// Returns `None` if the database lock cannot be obtained, indicating another process is performing
 /// the update check.
@@ -65,8 +65,11 @@ pub fn check_status_with_url(
     cache: &mut but_db::AppCacheHandle,
     url_override: Option<&str>,
 ) -> anyhow::Result<Option<CheckUpdateStatus>> {
-    // In development/test builds without CHANNEL set, skip update checking
+    // In development/test builds without CHANNEL set, skip update checking.
     let Some(channel) = option_env!("CHANNEL") else {
+        return Ok(Some(CheckUpdateStatus::default()));
+    };
+    let Some(version) = crate::current_version() else {
         return Ok(Some(CheckUpdateStatus::default()));
     };
 
@@ -78,7 +81,6 @@ pub fn check_status_with_url(
 
     let os = env::consts::OS;
     let arch = env::consts::ARCH;
-    let version = option_env!("VERSION").unwrap_or("0.0.0");
     let creds = secret::retrieve("gitbutler_access_token", secret::Namespace::BuildKind)?;
 
     let mut headers = HeaderMap::new();
@@ -245,7 +247,7 @@ impl Default for CheckUpdateStatus {
     fn default() -> Self {
         Self {
             up_to_date: true,
-            latest_version: "0.0.0".to_string(),
+            latest_version: "dev".to_string(),
             release_notes: None,
             url: None,
             signature: None,

--- a/crates/but-update/src/lib.rs
+++ b/crates/but-update/src/lib.rs
@@ -75,3 +75,15 @@ pub fn is_probably_still_running(cache: &mut but_db::AppCacheHandle) -> bool {
         .flatten()
         .is_none()
 }
+
+/// Return the compile-time application version used for update checks.
+///
+/// Development and local builds intentionally return `None` so they do not
+/// participate in published release-channel update comparisons.
+pub fn current_version() -> Option<&'static str> {
+    let version = option_env!("VERSION")?;
+    if version.is_empty() || version == "0.0.0" {
+        return None;
+    }
+    Some(version)
+}

--- a/crates/but-update/tests/update/available_update.rs
+++ b/crates/but-update/tests/update/available_update.rs
@@ -5,16 +5,14 @@ use but_db::{
 use chrono::DateTime;
 
 #[test]
-fn no_op_update_when_versions_match() -> anyhow::Result<()> {
+fn ignores_cached_update_without_build_version() -> anyhow::Result<()> {
     let mut cache = in_memory_cache();
 
-    // Seed the cache with up_to_date=false but latest_version="0.0.0"
-    // which matches the VERSION fallback in available_update()
     let cached_result = CachedCheckResult {
         checked_at: DateTime::from_timestamp(1000000, 0).unwrap(),
         status: CheckUpdateStatus {
             up_to_date: false,
-            latest_version: "0.0.0".to_string(),
+            latest_version: "1.2.3".to_string(),
             release_notes: Some("Test release notes".to_string()),
             url: Some("https://example.com/download".to_string()),
             signature: Some("signature123".to_string()),
@@ -25,51 +23,11 @@ fn no_op_update_when_versions_match() -> anyhow::Result<()> {
 
     cache.update_check_mut()?.save(&cached_result)?;
 
-    // available_update should return None because the versions match (no-op)
     let result = but_update::available_update(&cache)?;
     assert!(
         result.is_none(),
-        "Expected None for no-op update where latest_version matches current_version"
+        "Expected None when this binary was compiled without a release VERSION"
     );
-
-    Ok(())
-}
-
-#[test]
-fn returns_update_when_versions_differ() -> anyhow::Result<()> {
-    let mut cache = in_memory_cache();
-
-    // Seed the cache with up_to_date=false and a different version
-    let cached_result = CachedCheckResult {
-        checked_at: DateTime::from_timestamp(1000000, 0).unwrap(),
-        status: CheckUpdateStatus {
-            up_to_date: false,
-            latest_version: "1.2.3".to_string(),
-            release_notes: Some("Bug fixes and improvements".to_string()),
-            url: Some("https://example.com/download".to_string()),
-            signature: Some("signature123".to_string()),
-        },
-        suppressed_at: None,
-        suppress_duration_hours: None,
-    };
-
-    cache.update_check_mut()?.save(&cached_result)?;
-
-    // available_update should return Some because versions differ
-    let result = but_update::available_update(&cache)?;
-    assert!(
-        result.is_some(),
-        "Expected Some(AvailableUpdate) when versions differ"
-    );
-
-    let update = result.unwrap();
-    assert_eq!(update.current_version, "0.0.0");
-    assert_eq!(update.available_version, "1.2.3");
-    assert_eq!(
-        update.release_notes,
-        Some("Bug fixes and improvements".to_string())
-    );
-    assert_eq!(update.url, Some("https://example.com/download".to_string()));
 
     Ok(())
 }

--- a/crates/but/src/command/update.rs
+++ b/crates/but/src/command/update.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 #[cfg(all(unix, not(feature = "packaged-but-distribution")))]
 use but_installer::VersionRequest;
 use but_settings::AppSettings;
-use but_update::{AppName, CheckUpdateStatus, check_status};
+use but_update::{AppName, CheckUpdateStatus, check_status, current_version};
 
 pub fn handle(
     cmd: update::Subcommands,
@@ -50,14 +50,22 @@ fn check_for_updates(out: &mut OutputChannel, app_settings: &AppSettings) -> Res
 fn print_human_output(writer: &mut dyn std::fmt::Write, status: &CheckUpdateStatus) -> Result<()> {
     let t = theme::get();
     if status.up_to_date {
-        writeln!(
-            writer,
-            "{} You're running the latest version ({})",
-            t.sym().success,
-            t.important.paint(&status.latest_version)
-        )?;
+        if let Some(current_version) = current_version() {
+            writeln!(
+                writer,
+                "{} You're running the latest version ({})",
+                t.sym().success,
+                t.important.paint(current_version)
+            )?;
+        } else {
+            writeln!(
+                writer,
+                "{} Update checks are only available for versioned release and nightly builds",
+                t.attention.paint("→")
+            )?;
+        }
     } else {
-        let current_version = option_env!("VERSION").unwrap_or("0.0.0");
+        let current_version = current_version().unwrap_or("dev");
 
         let install_hint = {
             #[cfg(feature = "packaged-but-distribution")]


### PR DESCRIPTION
## 🧢 Changes

- Treats missing, empty, or `0.0.0` compile-time `VERSION` values as unversioned development builds.
- Skips remote update checks when the build does not have a real release/nightly version.
- Ignores cached update results for unversioned builds instead of comparing them against a `0.0.0` fallback.
- Changes the default update status version from `0.0.0` to `dev`.
- Updates `but update check` human output to explain that update checks are only available for versioned release and nightly builds.
- Adds focused coverage for version-aware cached update handling and current-version request behavior.

## ☕️ Reasoning

Local and development builds can be compiled without a real `VERSION`. Previously those builds fell back to `0.0.0`, which made update checks compare a dev binary against published release data and could surface a misleading available update.

This makes unversioned builds opt out of release-channel update comparisons entirely, while keeping normal update behavior for packaged release and nightly builds that do include a real compile-time version.

## 🧪 Testing

- Added/updated Rust tests for cached update handling with and without a real build version.
- Not run locally while updating this PR description.