### PR TITLE
Add native Kimi Moonshot AI support

### DIFF
--- a/apps/desktop/src/components/settings/AiSettings.svelte
+++ b/apps/desktop/src/components/settings/AiSettings.svelte
@@ -109,6 +109,10 @@
 			label: "GPT 5.4 Nano (recommended)",
 			value: OpenAIModelName.GPT54Nano,
 		},
+		{
+			label: "Kimi K2.6",
+			value: OpenAIModelName.KimiK26,
+		},
 	];
 
 	const anthropicModelOptions = [

--- a/apps/desktop/src/lib/ai/openAIClient.ts
+++ b/apps/desktop/src/lib/ai/openAIClient.ts
@@ -4,6 +4,7 @@ import {
 	SHORT_DEFAULT_PR_TEMPLATE,
 } from "$lib/ai/prompts";
 import OpenAI from "openai";
+import type { ChatCompletionCreateParamsStreaming } from "openai/resources/chat/completions";
 import type {
 	OpenAIModelName,
 	OpenRouterModelName,
@@ -13,6 +14,17 @@ import type {
 } from "$lib/ai/types";
 
 const DEFAULT_MAX_TOKENS = 1024;
+type MoonshotChatCompletionCreateParamsStreaming = ChatCompletionCreateParamsStreaming & {
+	thinking?: { type: "disabled" };
+};
+
+type MoonshotChatCompletionResponse = {
+	choices?: Array<{
+		message?: {
+			content?: string | null;
+		};
+	}>;
+};
 
 export class OpenAIClient implements AIClient {
 	defaultCommitTemplate = SHORT_DEFAULT_COMMIT_TEMPLATE;
@@ -22,6 +34,7 @@ export class OpenAIClient implements AIClient {
 	private client: OpenAI;
 	private openAIKey: string;
 	private modelName: OpenAIModelName | OpenRouterModelName;
+	private baseURL: string | undefined;
 
 	constructor(
 		openAIKey: string,
@@ -30,20 +43,25 @@ export class OpenAIClient implements AIClient {
 	) {
 		this.openAIKey = openAIKey;
 		this.modelName = modelName;
+		this.baseURL = baseURL;
 		this.client = new OpenAI({ apiKey: openAIKey, dangerouslyAllowBrowser: true, baseURL });
 	}
 
 	async evaluate(prompt: Prompt, options?: AIEvalOptions): Promise<string> {
-		// The 'max_tokens' parameter has been renamed to 'max_completion_tokens' in the OpenAI API.
-		// This change aligns with the updated API specification where 'max_completion_tokens'
-		// specifically controls the maximum number of tokens for the completion portion of the response.
-		// https://platform.openai.com/docs/api-reference/completions/create
-		const response = await this.client.chat.completions.create({
-			max_completion_tokens: options?.maxTokens ?? DEFAULT_MAX_TOKENS,
+		const usesMoonshot = this.usesMoonshot();
+		if (usesMoonshot) {
+			return await this.evaluateMoonshot(prompt, options);
+		}
+
+		const tokenLimit = options?.maxTokens ?? DEFAULT_MAX_TOKENS;
+		const request: MoonshotChatCompletionCreateParamsStreaming = {
+			max_completion_tokens: tokenLimit,
 			messages: prompt,
 			model: this.modelName,
 			stream: true,
-		});
+		};
+
+		const response = await this.client.chat.completions.create(request);
 
 		const buffer: string[] = [];
 		for await (const chunk of response) {
@@ -52,5 +70,41 @@ export class OpenAIClient implements AIClient {
 			buffer.push(token);
 		}
 		return buffer.join("");
+	}
+
+	private usesMoonshot() {
+		return this.baseURL?.includes("moonshot.ai") || this.modelName.startsWith("kimi-");
+	}
+
+	private async evaluateMoonshot(prompt: Prompt, options?: AIEvalOptions): Promise<string> {
+		const apiBase = (this.baseURL || "https://api.moonshot.ai/v1").replace(/\/+$/, "");
+		const response = await fetch(`${apiBase}/chat/completions`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${this.openAIKey}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				max_tokens: options?.maxTokens ?? DEFAULT_MAX_TOKENS,
+				messages: prompt,
+				model: this.modelName,
+				stream: false,
+				// Kimi defaults to thinking mode. For short commit and branch summaries,
+				// disable it so the response arrives as normal content.
+				thinking: { type: "disabled" },
+			}),
+		});
+
+		if (!response.ok) {
+			const errorText = await response.text();
+			throw new Error(
+				`Moonshot API request failed with HTTP ${response.status}: ${errorText.slice(0, 500)}`,
+			);
+		}
+
+		const data = (await response.json()) as MoonshotChatCompletionResponse;
+		const message = data.choices?.[0]?.message?.content ?? "";
+		options?.onToken?.(message);
+		return message;
 	}
 }

--- a/apps/desktop/src/lib/ai/types.ts
+++ b/apps/desktop/src/lib/ai/types.ts
@@ -17,6 +17,7 @@ export enum OpenAIModelName {
 	GPT54 = "gpt-5.4",
 	GPT54Mini = "gpt-5.4-mini",
 	GPT54Nano = "gpt-5.4-nano",
+	KimiK26 = "kimi-k2.6",
 }
 
 // https://docs.anthropic.com/en/docs/about-claude/models/overview

--- a/crates/but-llm/src/openai.rs
+++ b/crates/but-llm/src/openai.rs
@@ -1,10 +1,15 @@
 use anyhow::{Context as _, Result};
-use async_openai::{Client, config::OpenAIConfig};
+use async_openai::{
+    Client,
+    config::OpenAIConfig,
+    types::chat::{ChatCompletionRequestMessage, ChatCompletionRequestSystemMessage},
+};
 use but_secret::{Sensitive, secret};
 use but_tools::tool::Toolset;
 use reqwest::header::{HeaderMap, HeaderValue};
-use schemars::JsonSchema;
+use schemars::{JsonSchema, schema_for};
 use serde::de::DeserializeOwned;
+use serde_json::json;
 
 use crate::{
     AI_OPENAI_CUSTOM_ENDPOINT_KEY, AI_OPENAI_KEY_OPTION_KEY, AI_OPENAI_MODEL_NAME_KEY,
@@ -19,6 +24,30 @@ use crate::{
 };
 
 pub const GB_OPENAI_API_BASE: &str = "https://app.gitbutler.com/api/proxy/openai";
+const KIMI_API_BASE: &str = "https://api.moonshot.ai/v1";
+const DEFAULT_KIMI_MAX_COMPLETION_TOKENS: u32 = 1024;
+
+/// OpenAI-compatible API variants that need different request shapes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OpenAiApiFlavor {
+    /// The official OpenAI API or compatible APIs that accept OpenAI's structured output shape.
+    Standard,
+    /// Kimi/Moonshot's OpenAI-compatible API, which uses JSON mode and a thinking extension.
+    Kimi,
+}
+
+impl OpenAiApiFlavor {
+    /// Detects the API variant from the configured model and endpoint.
+    fn from_model_and_endpoint(model: &str, custom_endpoint: Option<&str>) -> Self {
+        if custom_endpoint.is_some_and(|endpoint| endpoint.contains("moonshot.ai"))
+            || model.starts_with("kimi-")
+        {
+            OpenAiApiFlavor::Kimi
+        } else {
+            OpenAiApiFlavor::Standard
+        }
+    }
+}
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, strum::Display)]
 pub enum CredentialsKind {
@@ -88,6 +117,77 @@ impl OpenAiProvider {
         } else {
             config
         }
+    }
+
+    /// Returns the OpenAI-compatible API variant for the selected model.
+    fn api_flavor(&self, model: &str) -> OpenAiApiFlavor {
+        OpenAiApiFlavor::from_model_and_endpoint(model, self.custom_endpoint.as_deref())
+    }
+
+    /// Returns the direct API base used for a Kimi request.
+    fn kimi_api_base(&self) -> String {
+        self.custom_endpoint
+            .as_deref()
+            .filter(|endpoint| !endpoint.trim().is_empty())
+            .unwrap_or(KIMI_API_BASE)
+            .trim_end_matches('/')
+            .to_string()
+    }
+
+    /// Returns credentials suitable for a direct OpenAI-compatible request.
+    fn direct_openai_key(&self) -> Result<&Sensitive<String>> {
+        match &self.credentials {
+            (CredentialsKind::EnvVarOpenAiKey | CredentialsKind::OwnOpenAiKey, key) => Ok(key),
+            (CredentialsKind::GitButlerProxied, _) => {
+                anyhow::bail!("Kimi models require a direct OpenAI-compatible API key")
+            }
+        }
+    }
+
+    /// Generates a plain text response through Kimi's OpenAI-compatible HTTP endpoint.
+    fn response_kimi_blocking(
+        &self,
+        system_message: &str,
+        chat_messages: Vec<ChatMessage>,
+        model: &str,
+    ) -> Result<Option<String>> {
+        let api_base = self.kimi_api_base();
+        let api_key = self.direct_openai_key()?.0.clone();
+        let messages = openai_messages(system_message, chat_messages);
+        let model = model.to_string();
+
+        std::thread::spawn(move || {
+            tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(response_kimi(api_base, api_key, messages, model))
+        })
+        .join()
+        .unwrap()
+    }
+
+    /// Generates structured output through Kimi's OpenAI-compatible HTTP endpoint.
+    fn structured_output_kimi_blocking<
+        T: serde::Serialize + DeserializeOwned + JsonSchema + std::marker::Send + 'static,
+    >(
+        &self,
+        system_message: &str,
+        chat_messages: Vec<ChatMessage>,
+        model: &str,
+    ) -> Result<Option<T>> {
+        let api_base = self.kimi_api_base();
+        let api_key = self.direct_openai_key()?.0.clone();
+        let messages = openai_messages(system_message, chat_messages);
+        let model = model.to_string();
+
+        std::thread::spawn(move || {
+            tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(structured_output_kimi::<T>(
+                    api_base, api_key, messages, model,
+                ))
+        })
+        .join()
+        .unwrap()
     }
 
     pub fn credentials_kind(&self) -> CredentialsKind {
@@ -213,6 +313,14 @@ impl LLMClient for OpenAiProvider {
         model: &str,
         on_token: impl Fn(&str) + Send + Sync + 'static,
     ) -> Result<Option<String>> {
+        if self.api_flavor(model) == OpenAiApiFlavor::Kimi {
+            let response = self.response_kimi_blocking(system_message, chat_messages, model)?;
+            if let Some(response) = &response {
+                on_token(response);
+            }
+            return Ok(response);
+        }
+
         stream_response_blocking(self, system_message, chat_messages, model, on_token)
     }
 
@@ -224,6 +332,10 @@ impl LLMClient for OpenAiProvider {
         chat_messages: Vec<ChatMessage>,
         model: &str,
     ) -> Result<Option<T>> {
+        if self.api_flavor(model) == OpenAiApiFlavor::Kimi {
+            return self.structured_output_kimi_blocking::<T>(system_message, chat_messages, model);
+        }
+
         structured_output_blocking::<T>(self, system_message, chat_messages, model)
     }
 
@@ -233,6 +345,245 @@ impl LLMClient for OpenAiProvider {
         chat_messages: Vec<ChatMessage>,
         model: &str,
     ) -> Result<Option<String>> {
+        if self.api_flavor(model) == OpenAiApiFlavor::Kimi {
+            return self.response_kimi_blocking(system_message, chat_messages, model);
+        }
+
         response_blocking(self, system_message, chat_messages, model)
+    }
+}
+
+/// Minimal response shape needed from Kimi chat completions.
+#[derive(Debug, serde::Deserialize)]
+struct KimiChatCompletionResponse {
+    /// Completion choices returned by the API.
+    choices: Vec<KimiChatCompletionChoice>,
+}
+
+/// A single Kimi chat completion choice.
+#[derive(Debug, serde::Deserialize)]
+struct KimiChatCompletionChoice {
+    /// The assistant message for this choice.
+    message: KimiChatCompletionMessage,
+}
+
+/// Message content returned by a Kimi chat completion.
+#[derive(Debug, serde::Deserialize)]
+struct KimiChatCompletionMessage {
+    /// Serialized JSON content when JSON mode is enabled.
+    content: Option<String>,
+}
+
+/// Builds the base request body for Kimi chat completions.
+fn build_kimi_chat_completion_request(
+    messages: Vec<ChatCompletionRequestMessage>,
+    model: String,
+) -> Result<serde_json::Value> {
+    Ok(json!({
+        "model": model,
+        "messages": serde_json::to_value(messages)?,
+        "stream": false,
+        "max_tokens": DEFAULT_KIMI_MAX_COMPLETION_TOKENS,
+        "thinking": {
+            "type": "disabled",
+        },
+    }))
+}
+
+/// Builds a Kimi request body for structured JSON output.
+fn build_kimi_structured_output_request<T: JsonSchema>(
+    mut messages: Vec<ChatCompletionRequestMessage>,
+    model: String,
+) -> Result<serde_json::Value> {
+    let schema = schema_for!(T);
+    let schema_value = serde_json::to_value(&schema)?;
+    let schema_prompt = format!(
+        "Return only a JSON object matching this JSON Schema:\n```json\n{}\n```",
+        serde_json::to_string_pretty(&schema_value)?
+    );
+    messages.insert(
+        1,
+        ChatCompletionRequestSystemMessage::from(schema_prompt).into(),
+    );
+
+    let mut request = build_kimi_chat_completion_request(messages, model)?;
+    request["response_format"] = json!({ "type": "json_object" });
+    Ok(request)
+}
+
+/// Builds OpenAI-compatible chat messages from a system prompt and conversation.
+fn openai_messages(
+    system_message: &str,
+    chat_messages: Vec<ChatMessage>,
+) -> Vec<ChatCompletionRequestMessage> {
+    let mut messages: Vec<ChatCompletionRequestMessage> =
+        vec![ChatCompletionRequestSystemMessage::from(system_message).into()];
+
+    messages.extend(
+        chat_messages
+            .into_iter()
+            .map(ChatCompletionRequestMessage::from)
+            .collect::<Vec<_>>(),
+    );
+    messages
+}
+
+/// Sends a Kimi chat completion request and returns the first assistant message content.
+async fn response_kimi(
+    api_base: String,
+    api_key: String,
+    messages: Vec<ChatCompletionRequestMessage>,
+    model: String,
+) -> Result<Option<String>> {
+    let request = build_kimi_chat_completion_request(messages, model)?;
+    send_kimi_chat_completion(api_base, api_key, request).await
+}
+
+/// Sends a Kimi request and parses the structured response.
+async fn structured_output_kimi<
+    T: serde::Serialize + DeserializeOwned + JsonSchema + std::marker::Send + 'static,
+>(
+    api_base: String,
+    api_key: String,
+    messages: Vec<ChatCompletionRequestMessage>,
+    model: String,
+) -> Result<Option<T>> {
+    let request = build_kimi_structured_output_request::<T>(messages, model)?;
+    let content = send_kimi_chat_completion(api_base, api_key, request).await?;
+    if let Some(content) = content {
+        return Ok(Some(serde_json::from_str::<T>(&content).with_context(
+            || "Failed to parse structured content from Kimi API response",
+        )?));
+    }
+
+    Ok(None)
+}
+
+/// Sends a Kimi request body and extracts the first assistant message content.
+async fn send_kimi_chat_completion(
+    api_base: String,
+    api_key: String,
+    request: serde_json::Value,
+) -> Result<Option<String>> {
+    let response = http_client_builder()
+        .build()?
+        .post(format!("{api_base}/chat/completions"))
+        .bearer_auth(api_key)
+        .json(&request)
+        .send()
+        .await
+        .context("Failed to send Kimi API request")?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let error_text = response
+            .text()
+            .await
+            .unwrap_or_else(|err| format!("failed to read error body: {err}"));
+        let error_preview = error_text.chars().take(500).collect::<String>();
+        anyhow::bail!("Kimi API request failed with HTTP {status}: {error_preview}");
+    }
+
+    let response = response
+        .json::<KimiChatCompletionResponse>()
+        .await
+        .context("Failed to parse Kimi API response")?;
+    for choice in response.choices {
+        if let Some(content) = choice.message.content {
+            return Ok(Some(content));
+        }
+    }
+
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, serde::Serialize, serde::Deserialize, JsonSchema)]
+    #[serde(rename_all = "camelCase")]
+    struct TestStructuredOutput {
+        commit_message: String,
+    }
+
+    /// Creates an OpenAI provider with direct credentials for API flavor tests.
+    fn provider(model: Option<&str>, custom_endpoint: Option<&str>) -> OpenAiProvider {
+        OpenAiProvider {
+            custom_endpoint: custom_endpoint.map(str::to_string),
+            model: model.map(str::to_string),
+            credentials: (
+                CredentialsKind::OwnOpenAiKey,
+                Sensitive("test-key".to_string()),
+            ),
+        }
+    }
+
+    #[test]
+    fn detects_kimi_by_endpoint() {
+        let provider = provider(None, Some("https://api.moonshot.ai/v1"));
+
+        assert_eq!(provider.api_flavor("gpt-4o"), OpenAiApiFlavor::Kimi);
+    }
+
+    #[test]
+    fn detects_kimi_by_model() {
+        let provider = provider(None, None);
+
+        assert_eq!(provider.api_flavor("kimi-k2.6"), OpenAiApiFlavor::Kimi);
+    }
+
+    #[test]
+    fn uses_standard_flavor_for_openai_endpoint() {
+        let provider = provider(None, Some("https://api.openai.com/v1"));
+
+        assert_eq!(provider.api_flavor("gpt-5.4"), OpenAiApiFlavor::Standard);
+    }
+
+    #[test]
+    fn builds_kimi_request_without_thinking() {
+        let messages = vec![
+            ChatCompletionRequestSystemMessage::from("system").into(),
+            ChatMessage::User("Generate a commit message.".to_string()).into(),
+        ];
+
+        let request = build_kimi_chat_completion_request(messages, "kimi-k2.6".to_string())
+            .expect("request builds");
+
+        assert_eq!(request["model"], "kimi-k2.6");
+        assert_eq!(request["thinking"], json!({ "type": "disabled" }));
+        assert_eq!(request["stream"], false);
+        assert_eq!(request["max_tokens"], DEFAULT_KIMI_MAX_COMPLETION_TOKENS);
+        assert!(request.get("max_completion_tokens").is_none());
+        assert!(request.get("response_format").is_none());
+    }
+
+    #[test]
+    fn builds_kimi_request_for_json_mode_with_schema_prompt() {
+        let messages = vec![
+            ChatCompletionRequestSystemMessage::from("system").into(),
+            ChatMessage::User("Generate a commit message.".to_string()).into(),
+        ];
+
+        let request = build_kimi_structured_output_request::<TestStructuredOutput>(
+            messages,
+            "kimi-k2.6".to_string(),
+        )
+        .expect("request builds");
+
+        assert_eq!(request["model"], "kimi-k2.6");
+        assert_eq!(request["response_format"], json!({ "type": "json_object" }));
+        assert_eq!(request["thinking"], json!({ "type": "disabled" }));
+        assert_eq!(request["stream"], false);
+        assert_eq!(request["max_tokens"], DEFAULT_KIMI_MAX_COMPLETION_TOKENS);
+        assert!(request.get("max_completion_tokens").is_none());
+
+        let messages = request["messages"]
+            .as_array()
+            .expect("messages are an array");
+        let schema_message = messages[1]["content"]
+            .as_str()
+            .expect("schema message has content");
+        assert!(schema_message.contains("commitMessage"));
     }
 }

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -1446,7 +1446,7 @@ fn build_csp(remote_origin: Option<&str>, port: u16, script_hashes: &[String]) -
              https://app.staging.gitbutler.com \
              https://o4504644069687296.ingest.sentry.io \
              https://github.com https://api.github.com \
-             https://api.openai.com https://api.anthropic.com \
+             https://api.openai.com https://api.anthropic.com https://api.moonshot.ai \
              https://*.gitlab.com https://gitlab.com \
              wss://irc.gitbutler.com:8097 data:"
         ),

--- a/crates/gitbutler-tauri/tauri.conf.json
+++ b/crates/gitbutler-tauri/tauri.conf.json
@@ -61,7 +61,7 @@
 			"csp": {
 				"default-src": "'self'",
 				"img-src": "'self' asset: https://asset.localhost data: tauri://localhost https://avatars.githubusercontent.com https://*.gitbutler.com  https://gitbutler-public.s3.amazonaws.com https://*.gravatar.com https://io.wp.com https://i0.wp.com https://i1.wp.com https://i2.wp.com https://i3.wp.com https://github.com https://*.googleusercontent.com https://*.giphy.com/ blob:",
-				"connect-src": "'self' ipc: http://ipc.localhost https://eu.posthog.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://app.gitbutler.com https://o4504644069687296.ingest.sentry.io ws://localhost:7703 https://github.com https://api.github.com https://api.openai.com https://api.anthropic.com https://openrouter.ai https://app.staging.gitbutler.com https://*.gitlab.com https://gitlab.com wss://irc.gitbutler.com:8097 data:",
+				"connect-src": "'self' ipc: http://ipc.localhost https://eu.posthog.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://app.gitbutler.com https://o4504644069687296.ingest.sentry.io ws://localhost:7703 https://github.com https://api.github.com https://api.openai.com https://api.anthropic.com https://api.moonshot.ai https://openrouter.ai https://app.staging.gitbutler.com https://*.gitlab.com https://gitlab.com wss://irc.gitbutler.com:8097 data:",
 				"script-src": "'self' 'wasm-unsafe-eval' https://eu.posthog.com https://eu.i.posthog.com https://eu-assets.i.posthog.com",
 				"style-src": "'self' 'unsafe-inline'"
 			}


### PR DESCRIPTION
## 🧢 Changes

- Adds `Kimi K2.6` as a selectable AI model in desktop AI settings.
- Adds Moonshot/Kimi-specific request handling for both the desktop OpenAI client and the Rust `but-llm` OpenAI provider.
- Detects Kimi either from `kimi-*` model names or a `moonshot.ai` custom endpoint.
- Sends Kimi requests with `thinking: { type: "disabled" }`, uses `max_tokens`, and avoids OpenAI-only structured output parameters.
- Supports Kimi structured output through JSON mode by injecting the expected JSON schema into the prompt.
- Requires direct OpenAI-compatible credentials for Kimi instead of GitButler-proxied OpenAI credentials.
- Allows `https://api.moonshot.ai` in desktop/server CSP connect sources.
- Adds Rust tests for Kimi flavor detection and request body generation.

## ☕️ Reasoning

Kimi's Moonshot API is OpenAI-compatible, but it does not accept every request shape GitButler currently sends to OpenAI. In particular, Kimi needs `max_tokens` instead of `max_completion_tokens`, should have thinking disabled for short GitButler AI tasks, and uses JSON mode rather than OpenAI's structured output schema format.

This keeps the existing OpenAI behavior unchanged while routing Kimi models through a small Moonshot-specific path, so users can select `kimi-k2.6` and use their Moonshot API key for commit messages, branch summaries, and other AI-generated text.

## 🧪 Testing

- Added unit coverage for Kimi API flavor detection.
- Added unit coverage for Kimi plain chat and structured JSON request bodies.
- Not run locally while updating this PR description.