### PR TITLE
Don't pass the token on login URL creation

### DIFF
--- a/apps/desktop/src/lib/user/userService.svelte.ts
+++ b/apps/desktop/src/lib/user/userService.svelte.ts
@@ -110,9 +110,7 @@ export class UserService {
 	private async getLoginUrl(): Promise<string> {
 		await this.forgetUserCredentials();
 		try {
-			const token = await this.backendApi.endpoints.getLoginToken.fetch(undefined);
-			const url = new URL(token.url);
-			url.host = this.httpClient.apiUrl.host;
+			const url = new URL("/login", this.httpClient.apiUrl);
 			const buildType = await this.backend.invoke<string>("build_type").catch(() => undefined);
 			if (buildType !== undefined && buildType !== "development")
 				url.searchParams.set("bt", buildType);


### PR DESCRIPTION
Don’t pass a token for the creation of the URL

---

For now, this token does nothing. We want to migrate to another type of token we can verify on the client side as well, in order to harden the security around that. For now, just remove this as it’s not used.