### PR TITLE
Fix blackbox e2e artifact upload: correct logs path and flatten output

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -80,18 +80,18 @@ jobs:
         if: ${{ github.ref != 'refs/heads/master' }}
         run: xvfb-run pnpm test:e2e:blackbox
 
+      - name: Flatten test results
+        if: failure()
+        run: |
+          mkdir -p ./e2e-output
+          find ./e2e/blackbox/videos -type f -exec cp {} ./e2e-output/ \; 2>/dev/null || true
+          find ~/.local/share/com.gitbutler.app*/logs -type f -exec cp {} ./e2e-output/ \; 2>/dev/null || true
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
-          name: e2e-videos
+          name: e2e-blackbox-output
           overwrite: true
-          path: ./e2e/blackbox/videos
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: failure()
-        with:
-          name: e2e-logs
-          overwrite: true
-          path: ~/.config/com.gitbutler.app*/logs
+          path: ./e2e-output/
 
   playwright:
     name: e2e-playwright


### PR DESCRIPTION
## Summary

- Fix the logs path from `~/.config/com.gitbutler.app*/logs` to `~/.local/share/com.gitbutler.app*/logs` (XDG data dir)
- Combine the separate `e2e-videos` and `e2e-logs` artifacts into a single `e2e-blackbox-output` artifact
- Flatten the directory structure so all files (videos + logs) are at the top level, matching the playwright artifact format

## Test plan

- [x] Triggered a test run and verified the artifact contains both videos and logs in a flat structure