### PR TITLE
Preserve uncommitted deletions when amending one stack

### DIFF
--- a/crates/but-core/src/worktree/checkout/tree.rs
+++ b/crates/but-core/src/worktree/checkout/tree.rs
@@ -22,6 +22,11 @@ impl Default for Lut {
 
 #[expect(clippy::indexing_slicing)]
 impl Lut {
+    /// Return `true` if no files have been tracked.
+    pub fn nodes_is_empty(&self) -> bool {
+        self.nodes.len() == 1 && self.nodes[0].children.is_empty()
+    }
+
     /// Insert a node for each component in slash-separated `rela_path`.
     pub fn track_file(&mut self, rela_path: &BStr) {
         let mut next_index = self.nodes.len();

--- a/crates/but-core/src/worktree/checkout/utils.rs
+++ b/crates/but-core/src/worktree/checkout/utils.rs
@@ -82,14 +82,15 @@ pub fn merge_worktree_changes_into_destination_or_keep_snapshot(
             )
         }
         let mut checkout_deletions_lut = super::tree::Lut::default();
-        let mut checkout_writes_tree_entries = false;
+        let mut checkout_writes_lut = super::tree::Lut::default();
         for (kind, path) in files_to_checkout {
             if matches!(kind, ChangeKind::Deletion) {
                 checkout_deletions_lut.track_file(path.as_ref());
             } else {
-                checkout_writes_tree_entries = true;
+                checkout_writes_lut.track_file(path.as_ref());
             }
         }
+        let checkout_writes_tree_entries = !checkout_writes_lut.nodes_is_empty();
         let destination_tree = checkout_writes_tree_entries
             .then(|| destination_tree_id.attach(repo).object()?.peel_to_tree())
             .transpose()?;
@@ -121,33 +122,70 @@ pub fn merge_worktree_changes_into_destination_or_keep_snapshot(
                         wt_change.path.as_ref(),
                         &mut checkout_deletion_intersections,
                     );
-                    let destination_entry_kind = destination_tree
-                        .as_ref()
-                        .map(|tree| {
-                            tree.lookup_entry(
-                                super::tree::to_components(wt_change.path.as_ref())
-                                    .map(ToOwned::to_owned),
-                            )
-                            .map(|entry| entry.map(|entry| entry.mode().kind()))
-                        })
-                        .transpose()?
-                        .flatten();
-                    let mut worktree_content_intersections = BTreeSet::new();
-                    change_lut.get_intersecting(
+                    let mut checkout_write_intersections = BTreeSet::new();
+                    checkout_writes_lut.get_intersecting(
                         wt_change.path.as_ref(),
-                        &mut worktree_content_intersections,
+                        &mut checkout_write_intersections,
                     );
-                    let destination_needs_checkout = match destination_entry_kind {
-                        Some(gix::object::tree::EntryKind::Tree) => {
-                            !worktree_content_intersections.is_empty()
-                        }
-                        Some(_) => true,
-                        None => false,
+
+                    // Look up the destination entry kind only when at least one
+                    // intersection set is non-empty — otherwise we already know
+                    // no pathspec will be added.
+                    let destination_entry_kind = if !checkout_deletion_intersections.is_empty()
+                        || !checkout_write_intersections.is_empty()
+                    {
+                        destination_tree
+                            .as_ref()
+                            .map(|tree| {
+                                tree.lookup_entry(
+                                    super::tree::to_components(wt_change.path.as_ref())
+                                        .map(ToOwned::to_owned),
+                                )
+                                .map(|entry| entry.map(|entry| entry.mode().kind()))
+                            })
+                            .transpose()?
+                            .flatten()
+                    } else {
+                        None
                     };
-                    // Add an explicit pathspec for deleted worktree paths when it either constrains
-                    // a checkout deletion, restores a file that still exists in the destination, or
-                    // checks out a destination subtree with preserved worktree content underneath.
-                    if !checkout_deletion_intersections.is_empty() || destination_needs_checkout {
+
+                    // Only consider restoring a worktree-deleted file from the destination
+                    // tree when the checkout would actually write to that path (or a path
+                    // underneath it). Without this guard, *every* uncommitted deletion whose
+                    // file still exists in the destination tree would be unconditionally
+                    // restored, even if the checkout doesn't touch that path at all.
+                    let destination_needs_checkout = if checkout_write_intersections.is_empty() {
+                        false
+                    } else {
+                        match destination_entry_kind {
+                            Some(gix::object::tree::EntryKind::Tree) => {
+                                let mut worktree_content_intersections = BTreeSet::new();
+                                change_lut.get_intersecting(
+                                    wt_change.path.as_ref(),
+                                    &mut worktree_content_intersections,
+                                );
+                                !worktree_content_intersections.is_empty()
+                            }
+                            Some(_) => true,
+                            None => false,
+                        }
+                    };
+
+                    // Add an explicit pathspec for deleted worktree paths when it either
+                    // constrains a checkout deletion or restores a file from the destination.
+                    //
+                    // When the destination entry is a tree (directory), we must NOT add the
+                    // pathspec: `git2` with `disable_pathspec_match` treats it as a literal
+                    // blob path, which can trigger a "null OID" error when it encounters a
+                    // tree instead of a blob. The checkout of files *under* that directory
+                    // is already covered by the non-deletion pathspecs in `safe_checkout`.
+                    let is_destination_tree = matches!(
+                        destination_entry_kind,
+                        Some(gix::object::tree::EntryKind::Tree)
+                    );
+                    if (!checkout_deletion_intersections.is_empty() && !is_destination_tree)
+                        || destination_needs_checkout
+                    {
                         checkout_opts.path(wt_change.path.as_bytes());
                         added_deleted_worktree_pathspec = true;
                     }

--- a/crates/but-core/tests/core/worktree/checkout.rs
+++ b/crates/but-core/tests/core/worktree/checkout.rs
@@ -223,11 +223,13 @@ fn worktree_and_index_deletions_are_ignored_in_snapshots() -> anyhow::Result<()>
     ");
     insta::assert_snapshot!(visualize_index(&*repo.index()?), @r"
     100644:3e75765 added-to-index
-    100644:637f034 to-be-deleted-in-index
     100644:e69de29 to-be-deleted/a
     ");
+    // `to-be-deleted-in-index` was staged for deletion (`git rm`) and is no longer
+    // restored by the checkout — the checkout only touches `to-be-deleted` → `to-be-deleted/a`.
     insta::assert_snapshot!(git_status(&repo)?, @r"
     A  added-to-index
+    D  to-be-deleted-in-index
     ?? untracked
     ");
 
@@ -415,18 +417,22 @@ inserted in new tree
     * 89b113a (HEAD -> main) edited 'file' (add single line)
     * 647cc94 init
     ");
+    // `file-to-be-renamed-in-index` is no longer restored by the checkout — the checkout
+    // only touches `file`, so the index rename (`RM file-to-be-renamed-in-index -> …`) is preserved.
     insta::assert_snapshot!(visualize_index(&*repo.index()?), @r"
     100644:832f532 file
     100755:cb89473 file-in-index
     100644:3d3b36f file-renamed-in-index
     100644:3d3b36f file-to-be-renamed
-    100644:3d3b36f file-to-be-renamed-in-index
     ");
     // Notably, 'file' is not in the index anymore, as that now always matches the worktree.
+    // The rename of `file-to-be-renamed-in-index` and deletion of `file-to-be-renamed` are
+    // preserved — the checkout only touched `file`.
     insta::assert_snapshot!(git_status(&repo)?, @r"
     M  file
     M  file-in-index
-    AM file-renamed-in-index
+    RM file-to-be-renamed-in-index -> file-renamed-in-index
+     D file-to-be-renamed
     ?? file-renamed
     ");
 
@@ -569,17 +575,17 @@ fn snapshot_fails_by_default_if_changed_file_turns_into_directory() -> anyhow::R
     * 434b908 (HEAD -> main) turn changed files into a directories
     * 647cc94 init
     ");
+    // `file-to-be-renamed-in-index` is no longer restored — the checkout only touches
+    // `file` and `file-in-index` (turned into directories), not unrelated deleted paths.
     insta::assert_snapshot!(visualize_index(&*repo.index()?), @r"
     100644:e69de29 file-in-index/a
     100644:3d3b36f file-renamed-in-index
     100644:3d3b36f file-to-be-renamed
-    100644:3d3b36f file-to-be-renamed-in-index
     100644:e69de29 file/a
     ");
-    // Note how the deleted file (which is in the destination tree) was restored, because we are additive,
-    // and can't differentiate between missing files and deleted files.
     insta::assert_snapshot!(git_status(&repo)?, @r"
-    AM file-renamed-in-index
+    RM file-to-be-renamed-in-index -> file-renamed-in-index
+     D file-to-be-renamed
     ?? file-renamed
     ");
 
@@ -854,18 +860,16 @@ fn forced_changes_with_snapshot_and_directory_to_file() -> anyhow::Result<()> {
 
     // TODO: use `gix` to also checkout 'dir-to-be-file', for some reason `git2` doesn't check it out
     //       even though it's given and it's part of the tree.
+    // Worktree-deleted files (`executable`, `file`, `link`, `other-file`) are no longer restored
+    // by the checkout — only `dir-to-be-file` and `file-to-be-dir/b/a` are being checked out.
     insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
     .
     ├── .git:40755
-    ├── executable:100755
-    ├── file:100644
     ├── file-to-be-dir:40755
     │   ├── b:40755
     │   │   └── a:100644
     │   └── file:100644
-    ├── link:120755
     ├── link-renamed:120755
-    ├── other-file:100644
     └── to-be-overwritten:100644
     ");
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
@@ -883,7 +887,11 @@ fn forced_changes_with_snapshot_and_directory_to_file() -> anyhow::Result<()> {
     ");
     insta::assert_snapshot!(git_status(&repo)?, @r"
     D  dir-to-be-file
+     D executable
+     D file
     A  file-to-be-dir/file
+     D link
+     D other-file
      M to-be-overwritten
     ?? link-renamed
     ");
@@ -998,8 +1006,12 @@ fn unrelated_additions_do_not_affect_worktree_changes() -> anyhow::Result<()> {
     100644:e69de29 unrelated
     ");
 
-    // It also restored the deleted files, after all they are part of the tree.
+    // Deleted files stay deleted — the checkout only adds `unrelated`, which
+    // doesn't intersect with the worktree deletions.
     insta::assert_snapshot!(git_status(&repo)?, @r"
+     D executable
+     D file
+     D link
     ?? executable-renamed
     ?? file-renamed
     ?? link-renamed

--- a/crates/but-workspace/tests/fixtures/scenario/amend-two-stacks-with-deletions.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/amend-two-stacks-with-deletions.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Scenario: Two independent branches (A and B) in the workspace.
+# Branch A has a commit that adds a-file.txt.
+# Branch B has a commit that adds b-file.txt.
+# The workspace commit merges both.
+#
+# Uncommitted state:
+#   - a-file.txt is modified
+#   - b-file.txt is deleted
+#
+# Used to test that amending a-file.txt into A's commit does NOT
+# discard the uncommitted deletion of b-file.txt.
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git init
+commit M
+setup_target_to_match_main
+
+git branch B
+git checkout -b A
+  echo "content-a" > a-file.txt
+  git add a-file.txt
+  git commit -m "add a-file"
+git checkout B
+  echo "content-b" > b-file.txt
+  git add b-file.txt
+  git commit -m "add b-file"
+create_workspace_commit_once A B
+
+# Uncommitted changes: modify a-file, delete b-file
+echo "modified-a" > a-file.txt
+rm b-file.txt

--- a/crates/but-workspace/tests/workspace/commit/commit_amend.rs
+++ b/crates/but-workspace/tests/workspace/commit/commit_amend.rs
@@ -4,7 +4,10 @@ use but_rebase::graph_rebase::{Editor, LookupStep as _};
 use but_testsupport::git_status;
 use but_workspace::commit::commit_amend;
 
-use crate::ref_info::with_workspace_commit::utils::named_writable_scenario_with_description_and_graph as writable_scenario;
+use crate::ref_info::with_workspace_commit::utils::{
+    StackState, add_stack_with_segments,
+    named_writable_scenario_with_description_and_graph as writable_scenario,
+};
 
 fn worktree_changes_as_specs(repo: &gix::Repository) -> Result<Vec<DiffSpec>> {
     Ok(but_core::diff::worktree_changes(repo)?
@@ -115,6 +118,85 @@ fn amend_into_earlier_commit_leaves_no_uncommitted_changes() -> Result<()> {
     assert_eq!(
         status_after, "",
         "expected no uncommitted changes after amending, but got:\n{status_after}"
+    );
+
+    Ok(())
+}
+
+/// Amending a modified file into one stack must not discard uncommitted
+/// deletions on a different stack.
+///
+/// Scenario (two independent branches A and B in the workspace):
+///   - Branch A: adds a-file.txt
+///   - Branch B: adds b-file.txt
+///   - Uncommitted: a-file.txt modified, b-file.txt deleted
+///   - Amend only a-file.txt into A's commit
+///
+/// After amend, b-file.txt must still appear as a deleted uncommitted change.
+#[test]
+fn amend_with_two_stacks_preserves_uncommitted_deletions() -> Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        writable_scenario("amend-two-stacks-with-deletions", |meta| {
+            add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            add_stack_with_segments(meta, 2, "B", StackState::InWorkspace, &[]);
+        })?;
+
+    let workdir = repo.workdir().expect("non-bare repo");
+
+    // Verify initial state: a-file.txt modified, b-file.txt deleted
+    let status_before = git_status(&repo)?;
+    assert!(
+        status_before.contains("a-file.txt"),
+        "should have uncommitted changes to a-file.txt before amend, got: {status_before}"
+    );
+    assert!(
+        status_before.contains("b-file.txt"),
+        "should have uncommitted deletion of b-file.txt before amend, got: {status_before}"
+    );
+    assert!(
+        !workdir.join("b-file.txt").exists(),
+        "b-file.txt should be deleted on disk"
+    );
+
+    // Build DiffSpecs for only a-file.txt (the file we want to amend)
+    let all_changes = but_core::diff::worktree_changes(&repo)?;
+    let a_file_specs: Vec<DiffSpec> = all_changes
+        .changes
+        .iter()
+        .filter(|c| c.path == "a-file.txt")
+        .map(DiffSpec::from)
+        .collect();
+    assert_eq!(
+        a_file_specs.len(),
+        1,
+        "should have exactly one spec for a-file.txt"
+    );
+
+    // Find the commit on branch A
+    let a_commit_id = repo.rev_parse_single("A")?.detach();
+
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+    let outcome = commit_amend(editor, a_commit_id, a_file_specs, 0)?;
+
+    assert!(outcome.rejected_specs.is_empty());
+    let _materialized = outcome.rebase.materialize()?;
+
+    // After amend: a-file.txt should no longer be modified (it was amended)
+    // but b-file.txt should STILL be deleted (uncommitted deletion preserved)
+    assert!(
+        !workdir.join("b-file.txt").exists(),
+        "b-file.txt should still be deleted on disk after amend"
+    );
+
+    let status_after = git_status(&repo)?;
+    assert!(
+        !status_after.contains("a-file.txt"),
+        "a-file.txt should no longer appear as modified after amend, got:\n{status_after}"
+    );
+    assert!(
+        status_after.contains("b-file.txt"),
+        "b-file.txt should still appear as a deleted file after amend, got:\n{status_after}"
     );
 
     Ok(())


### PR DESCRIPTION
Reported by @estib-vega: when the workspace has multiple stacks and the worktree contains both modified and deleted files, amending a single file into one stack discards all uncommitted deletions — the deleted files silently reappear on disk and `git status` shows them as clean.

### Symptom

```
# before amend: a-file.txt modified, b-file.txt deleted
but rub --amend <commit> -- a-file.txt
# after amend: b-file.txt is back on disk (bug)
```

### Root cause

In `merge_worktree_changes_into_destination_or_keep_snapshot`, every worktree-deleted file whose path still existed as a blob in the destination tree got an unconditional pathspec for `git2`'s `checkout_tree`. This restored the file even when the checkout only touched completely unrelated paths.

### Fix

- Track checkout write paths in a `Lut` (`checkout_writes_lut`), not just a boolean. Gate `destination_needs_checkout` on the worktree-deleted path actually intersecting a checkout write — if the checkout doesn't write near the deleted file, leave it alone.
- Skip adding pathspecs when the destination entry is a tree (directory), not a blob. `git2` with `disable_pathspec_match` cannot handle directory-typed pathspecs and errors with "null OID cannot exist".
- Add `Lut::nodes_is_empty()` helper.

### Test changes

- **New**: `amend_with_two_stacks_preserves_uncommitted_deletions` reproduces the two-stack scenario with a dedicated fixture.
- **Updated**: 5 existing `but-core` checkout snapshots that were codifying the buggy restore-on-checkout behavior (e.g. the old comment "It also restored the deleted files, after all they are part of the tree" is now corrected).