### PR TITLE
cli: remove implicit but rub from cli

### DIFF
--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -13,7 +13,8 @@ use std::path::PathBuf;
     name = "but",
     about = "A GitButler CLI tool",
     version = option_env!("VERSION").unwrap_or("dev"),
-    disable_help_subcommand = true
+    disable_help_subcommand = true,
+    override_usage = "but [OPTIONS] [COMMAND]\n       but [OPTIONS] [PATH]"
 )]
 pub struct Args {
     /// Enable tracing for debug and performance information printed to stderr.
@@ -50,13 +51,9 @@ pub struct Args {
     /// {"result": ..., "status_error": ...} if the status query fails (in which case "status" is absent).
     #[clap(long = "status-after", global = true)]
     pub status_after: bool,
-    /// Source entity for rub operation (when no subcommand is specified).
-    /// If no target is specified, this is treated as a path to open on the GUI.
-    #[clap(value_name = "SOURCE")]
-    pub source_or_path: Option<String>,
-    /// Target entity for rub operation (when no subcommand is specified).
-    #[clap(value_name = "TARGET", requires = "source_or_path")]
-    pub target: Option<String>,
+    /// If no command is specified, this is treated as a path to open with the GUI.
+    #[clap(value_name = "PATH")]
+    pub path: Option<PathBuf>,
     /// Subcommand to run.
     #[clap(subcommand)]
     pub cmd: Option<Subcommands>,

--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -49,8 +49,8 @@ pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
         t.error.paint("The GitButler CLI change control system")
     )?;
     writeln!(out)?;
-    writeln!(out, "Usage: but [OPTIONS] <COMMAND>")?;
-    writeln!(out, "       but [OPTIONS] [RUB-SOURCE] [RUB-TARGET]")?;
+    writeln!(out, "Usage: but [OPTIONS] [COMMAND]")?;
+    writeln!(out, "       but [OPTIONS] [PATH]")?;
     writeln!(out)?;
     writeln!(
         out,

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -31,7 +31,7 @@ use clap::Parser;
 pub mod args;
 use args::{
     Args, OutputFormat, Subcommands, actions, alias as alias_args, branch, claude, cursor, forge,
-    metrics, update as update_args, worktree,
+    update as update_args, worktree,
 };
 use but_settings::AppSettings;
 use gix::date::time::CustomFormat;
@@ -41,9 +41,7 @@ use theme::Paint;
 use crate::command::legacy::ShowDiffInEditor;
 use crate::{
     setup::{BackgroundSync, InitCtxOptions},
-    utils::{
-        OneshotMetricsContext, OutputChannel, ResultErrorExt, ResultJsonExt, ResultMetricsExt,
-    },
+    utils::{OutputChannel, ResultErrorExt, ResultJsonExt, ResultMetricsExt},
 };
 
 mod id;
@@ -113,6 +111,11 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     }
 
     let mut args: Args = Args::parse_from(args);
+    if args.path.is_some() && args.cmd.is_some() {
+        anyhow::bail!(
+            "PATH cannot be used together with a subcommand. To run a subcommand in a different directory, use `-C <path>` before the subcommand, for example: `but -C <path> status`"
+        );
+    }
     let app_settings = AppSettings::load_from_default_path_creating_without_customization()?;
     let output_format = if args.json {
         OutputFormat::Json
@@ -143,57 +146,22 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     let namespace = option_env!("IDENTIFIER").unwrap_or("com.gitbutler.app");
     but_secret::secret::set_application_namespace(namespace);
 
-    // If no subcommand is provided, but we have source and target, default to rub
     let mut out = OutputChannel::new_with_optional_pager(output_format, use_pager);
 
     match args.cmd.take() {
-        None if args.source_or_path.is_some() && args.target.is_some() => {
-            // Default to rub when two arguments are provided without a subcommand
-            let source = args
-                .source_or_path
-                .as_ref()
-                .expect("source is checked to be Some in match guard");
-            let target = args
-                .target
-                .as_ref()
-                .expect("target is checked to be Some in match guard");
-            #[cfg(feature = "legacy")]
-            {
-                use but_workspace::commit::squash_commits::MessageCombinationStrategy;
-
-                let status_after = args.status_after;
-                let mut ctx = setup::init_ctx(&args, InitCtxOptions::default(), &mut out)?;
-                out.begin_status_after(status_after);
-                let result = command::legacy::rub::handle(
-                    &mut ctx,
-                    &mut out,
-                    source,
-                    target,
-                    MessageCombinationStrategy::KeepBoth,
-                )
-                .context("Rubbed the wrong way.")
-                .emit_metrics(OneshotMetricsContext::new_if_enabled(
-                    &app_settings,
-                    metrics::CommandName::Rub,
-                ));
-                maybe_run_status_after(status_after, &result, &mut ctx, &mut out).await;
-                result.show_root_cause_error_then_exit_without_destructors(out)
-            }
-            #[cfg(not(feature = "legacy"))]
-            todo!("Non-legacy rub isn't implemented yet")
-        }
-        None if args.source_or_path.is_some() && args.target.is_none() => {
-            // If only one argument is provided without a subcommand, check if this is a valid path.
+        None if args.path.is_some() => {
+            // If one argument is provided without a subcommand, check if this is a valid path.
             let maybe_path = args
-                .source_or_path
+                .path
                 .as_ref()
                 .expect("path is checked to be Some in match guard");
-            let path = std::path::Path::new(args.current_dir.as_path()).join(maybe_path);
+            let path = args.current_dir.join(maybe_path);
 
             // Check if the path exists before trying to open the GUI
             if !path.exists() {
                 anyhow::bail!(
-                    "\"but {maybe_path}\" is not a command. Type \"but --help\" to see all available commands."
+                    "\"but {}\" is not a command. Type \"but --help\" to see all available commands.",
+                    maybe_path.display()
                 );
             }
 
@@ -201,7 +169,7 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
             Ok(())
         }
         None => {
-            // No subcommand and no source/target means run the default alias
+            // No subcommand and no path means run the default alias
             // The default alias expands to "status" which provides a helpful entry point
             let default_args = vec![OsString::from("but"), OsString::from("default")];
             let expanded = alias::expand_aliases(default_args)?;

--- a/crates/but/tests/but/command/help.rs
+++ b/crates/but/tests/but/command/help.rs
@@ -116,3 +116,19 @@ Error: "but nonexistent-directory-entry" is not a command. Type "but --help" to 
 
     Ok(())
 }
+
+#[test]
+fn path_and_subcommand_are_rejected() -> anyhow::Result<()> {
+    let env = Sandbox::empty()?;
+
+    env.but("some-path completions bash")
+        .assert()
+        .failure()
+        .stdout_eq(str![[]])
+        .stderr_eq(str![[r#"
+Error: PATH cannot be used together with a subcommand. To run a subcommand in a different directory, use `-C <path>` before the subcommand, for example: `but -C <path> status`
+
+"#]]);
+
+    Ok(())
+}

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -8,19 +8,20 @@ use crate::{
 };
 
 #[test]
-fn shorthand_without_subcommand() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+fn shorthand_without_subcommand_is_rejected() -> anyhow::Result<()> {
+    let env = Sandbox::empty()?;
 
-    // Must set metadata to match the scenario
-    env.setup_metadata(&["A", "B"])?;
-
-    // Test that calling `but <id1> <id2>` defaults to rub
-    // This should fail with a CliId not found error rather than a command not found error
     env.but("nonexistent1 nonexistent2")
         .assert()
         .failure()
+        .stdout_eq(str![[]])
         .stderr_eq(str![[r#"
-Rubbed the wrong way. Source 'nonexistent1' not found. If you just performed a Git operation (squash, rebase, etc.), try running 'but status' to refresh the current state.
+error: unexpected argument 'nonexistent2' found
+
+Usage: but [OPTIONS] [COMMAND]
+       but [OPTIONS] [PATH]
+
+For more information, try '--help'.
 
 "#]]);
 
@@ -32,7 +33,7 @@ fn assigned_uncommitted_file_env() -> anyhow::Result<Sandbox> {
 
     env.setup_metadata(&["A", "B"])?;
     env.file("a.txt", "arbitrary text\n");
-    env.but("zz:a.txt A").assert().success();
+    env.but("rub zz:a.txt A").assert().success();
     Ok(env)
 }
 
@@ -192,7 +193,7 @@ j0 a.txt│
 #[test]
 fn uncommitted_file_to_unassigned() -> anyhow::Result<()> {
     let env = assigned_uncommitted_file_env()?;
-    env.but("A@{stack}:a.txt zz")
+    env.but("rub A@{stack}:a.txt zz")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -324,7 +325,7 @@ fn committed_file_to_unassigned() -> anyhow::Result<()> {
 
 "#]]);
 
-    env.but("fc:b.txt zz")
+    env.but("rub fc:b.txt zz")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -420,7 +421,7 @@ fn shorthand_uncommitted_hunk_to_unassigned() -> anyhow::Result<()> {
     commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
 
     // Assign the change to A.
-    env.but("a.txt A").assert().success();
+    env.but("rub a.txt A").assert().success();
 
     // Verify that the first hunk is j0, and move it to unassigned.
     env.but("diff A@{stack}:a.txt")
@@ -446,7 +447,7 @@ k0 a.txt│
        9│+lasta
 
 "#]]);
-    env.but("j0 zz")
+    env.but("rub j0 zz")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"

--- a/crates/but/tests/but/command/snapshots/help/no-arg-no-legacy.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/help/no-arg-no-legacy.stdout.term.svg
@@ -23,9 +23,9 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: but [OPTIONS] &lt;COMMAND&gt;</tspan>
+    <tspan x="10px" y="64px"><tspan>Usage: but [OPTIONS] [COMMAND]</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>       but [OPTIONS] [RUB-SOURCE] [RUB-TARGET]</tspan>
+    <tspan x="10px" y="82px"><tspan>       but [OPTIONS] [PATH]</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/crates/but/tests/but/command/snapshots/help/no-arg.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/help/no-arg.stdout.term.svg
@@ -23,9 +23,9 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: but [OPTIONS] &lt;COMMAND&gt;</tspan>
+    <tspan x="10px" y="64px"><tspan>Usage: but [OPTIONS] [COMMAND]</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>       but [OPTIONS] [RUB-SOURCE] [RUB-TARGET]</tspan>
+    <tspan x="10px" y="82px"><tspan>       but [OPTIONS] [PATH]</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>


### PR DESCRIPTION
Before `but a b` would implicitly mean `but rub a b`. This removes that as it leads to confusing UX.