### PR TITLE
Detect and reject individual no-effect changes after cherry-pick

### DIFF
--- a/crates/but-core/src/tree/mod.rs
+++ b/crates/but-core/src/tree/mod.rs
@@ -153,6 +153,50 @@ pub fn create_tree(
                 }
                 tree_with_changes = merge_result.tree.write()?.detach();
             }
+            // After the cherry-pick, some changes may have had no effect on the target tree
+            // (e.g. deleting a file that only exists in another stack's tree, not in this
+            // branch). Check each change individually by comparing its path entry between
+            // the target tree and the result tree — if they match, the change was a no-op.
+            // We compare both object_id and mode to catch mode-only changes (e.g. executable bit).
+            // For renames, we also check that the previous_path was actually removed.
+            if needs_cherry_pick {
+                let target = target_tree.attach(repo).object()?.peel_to_tree()?;
+                let result = tree_with_changes.attach(repo).object()?.peel_to_tree()?;
+                fn entries_match(
+                    target: &gix::Tree<'_>,
+                    result: &gix::Tree<'_>,
+                    path: &[u8],
+                ) -> anyhow::Result<bool> {
+                    let target_entry = target.lookup_entry(path.split_str("/"))?;
+                    let result_entry = result.lookup_entry(path.split_str("/"))?;
+                    Ok(target_entry.map(|e| (e.mode(), e.object_id()))
+                        == result_entry.map(|e| (e.mode(), e.object_id())))
+                }
+                for possible_change in changes.iter_mut() {
+                    let spec = match possible_change {
+                        Ok(spec) => spec,
+                        Err(_) => continue,
+                    };
+                    let path_unchanged = entries_match(&target, &result, &spec.path)?;
+                    let previous_path_unchanged = match &spec.previous_path {
+                        Some(p) => entries_match(&target, &result, p)?,
+                        None => true,
+                    };
+                    if path_unchanged && previous_path_unchanged {
+                        into_err_spec(possible_change, RejectionReason::NoEffectiveChanges);
+                    }
+                }
+            }
+            // If every change was individually rejected, there is nothing to commit —
+            // unless some were cherry-pick conflicts, in which case we still create a
+            // commit so the user can see and resolve the conflicts.
+            if changes.iter().all(|c| c.is_err())
+                && !changes
+                    .iter()
+                    .any(|c| matches!(c, Err((RejectionReason::CherryPickMergeConflict, _))))
+            {
+                break 'retry (None, None);
+            }
             break 'retry (
                 Some(tree_with_changes),
                 Some(tree_with_changes_without_cherry_pick),

--- a/crates/but-workspace/tests/fixtures/scenario/two-stacks-with-extra-file.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/two-stacks-with-extra-file.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A workspace commit with two stacks.
+# Stack A modifies `file` (prepends lines).
+# Stack B creates `new-file`.
+git init
+
+seq 50 60 >file && git add . && git commit -m "base" && git tag base
+setup_target_to_match_main
+
+git branch B
+
+git checkout -b A
+{ seq 10; seq 50 60; } >file && git add . && git commit -m "A: 10 lines on top of file"
+
+git checkout B
+seq 10 >new-file && git add . && git commit -m "B: new file with 10 lines"
+
+create_workspace_commit_once A B

--- a/crates/but-workspace/tests/workspace/commit_engine/new_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/new_commit.rs
@@ -1236,6 +1236,52 @@ fn validate_no_change_on_noop() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// When committing a deletion of a file that only exists in another stack's tree
+/// alongside a valid change, the deletion should be rejected as `NoEffectiveChanges`
+/// while the valid change still produces a commit.
+#[test]
+fn deletion_of_file_from_other_stack_is_rejected_per_change() -> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario("two-stacks-with-extra-file");
+
+    // Delete `new-file` which only exists in stack B's tree, not in A.
+    let new_file_path = repo.workdir_path("new-file").expect("non-bare");
+    std::fs::remove_file(&new_file_path)?;
+
+    // Also modify `file` which does exist in stack A's tree.
+    write_sequence(&repo, "file", [(1, 5), (50, 60)])?;
+
+    let parent_commit = repo.rev_parse_single("A")?;
+    let outcome = commit_engine::create_commit(
+        &repo,
+        Destination::NewCommit {
+            parent_commit_id: Some(parent_commit.into()),
+            message: "modify file and delete new-file on stack A".into(),
+            stack_segment: None,
+        },
+        vec![diff_spec(None, "file", []), diff_spec(None, "new-file", [])],
+        CONTEXT_LINES,
+    )?;
+
+    assert!(
+        outcome.new_commit.is_some(),
+        "a commit is created because the file modification is valid"
+    );
+    insta::assert_debug_snapshot!(outcome.rejected_specs, @r#"
+    [
+        (
+            NoEffectiveChanges,
+            DiffSpec {
+                previous_path: None,
+                path: "new-file",
+                hunk_headers: [],
+            },
+        ),
+    ]
+    "#);
+
+    Ok(())
+}
+
 const UI_CONTEXT_LINES: u32 = 3;
 
 mod utils {


### PR DESCRIPTION
## Problem

When committing a mix of changes to a branch, some changes could be silently dropped — the commit succeeded, but the caller received no rejection feedback for the omitted changes.

**Example:** deleting a file that only exists in another stack's workspace tree. The deletion has no effect on this branch's tree, but was not reported as rejected.

## Root cause

The post-cherry-pick check only compared entire trees:

```
if tree_with_changes == target_tree { reject all }
```

When at least one change was effective the trees differed, so individual no-ops slipped through undetected.

## Fix

After the cherry-pick, check each change individually via an `entries_match` helper that compares both mode and object_id at a given path between the target and result trees:

```
for each change:
  if entries_match(target, result, change.path)
     && entries_match(target, result, change.previous_path):
    reject as NoEffectiveChanges
```

Comparing mode (not just object_id) catches mode-only changes like executable bit toggles. Checking `previous_path` catches renames where only the source removal was effective.

## Test

A new `two-stacks-with-extra-file` fixture verifies that committing a file deletion from another stack alongside a valid modification:
- rejects the deletion as `NoEffectiveChanges`
- still produces a commit for the modification