### PR TITLE
add a fake -a flag for muscle memory

### DIFF
--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -40,6 +40,7 @@ but <mutation> ... --status-after
 ## Command Patterns
 
 - Commit: `but commit <branch> -m "<msg>" --changes <id>,<id> --status-after`
+- `but commit -a` is accepted as a no-op compatibility flag; GitButler already includes unstaged changes by default.
 - Commit + create branch: `but commit <branch> -c -m "<msg>" --changes <id> --status-after`
 - Amend: `but amend <file-id> <commit-id> --status-after`
 - Reorder commits: `but move <source-commit-id> <target-commit-id> --status-after` (**commit IDs**, not branch names)

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -178,6 +178,7 @@ Commit changes to a branch.
 ```bash
 but commit <branch> --only -m "message"  # Commit ONLY staged changes (recommended)
 but commit <branch> -m "message"         # Commit ALL uncommitted changes to branch
+but commit <branch> -am "message"        # Accepted Git muscle-memory form; -a is a no-op
 but commit <branch> -m "message" --changes <id>,<id>  # Commit specific files or hunks by CLI ID
 but commit <branch> -m "message" --changes <id> --changes <id>  # Alternative: repeat flag
 but commit <branch> --message-file msg.txt  # Read commit message from file

--- a/crates/but/src/args/commit.rs
+++ b/crates/but/src/args/commit.rs
@@ -16,6 +16,9 @@ pub struct Platform {
     /// Only commit staged files, not unstaged files
     #[clap(short = 'o', long = "only")]
     pub only: bool,
+    /// No-op compatibility flag for `git commit -a`.
+    #[clap(short = 'a', long = "all")]
+    pub all: bool,
     /// Bypass pre-commit hooks
     #[clap(short = 'n', long = "no-hooks", alias = "no-verify")]
     pub no_hooks: bool,

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -297,6 +297,7 @@ pub(crate) fn commit(
     branch_hint: Option<&str>,
     file_ids: &[String],
     only: bool,
+    all: bool,
     create_branch: bool,
     no_hooks: bool,
     generate_message: Option<Option<String>>,
@@ -306,6 +307,10 @@ pub(crate) fn commit(
     let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
 
     let t = theme::get();
+
+    if all && let Some(out) = out.for_human() {
+        writeln!(out, "no need for -a here my friend...")?;
+    }
 
     // Get all stacks using but-api
     let stack_entries = workspace::stacks(ctx, None)?;

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -884,6 +884,9 @@ async fn match_subcommand(
                     if commit_args.only {
                         anyhow::bail!("--only cannot be used with 'commit empty'.");
                     }
+                    if commit_args.all {
+                        anyhow::bail!("--all cannot be used with 'commit empty'.");
+                    }
                     if commit_args.no_hooks {
                         anyhow::bail!("--no-hooks cannot be used with 'commit empty'.");
                     }
@@ -996,6 +999,7 @@ async fn match_subcommand(
                         commit_args.branch.as_deref(),
                         &commit_args.changes,
                         commit_args.only,
+                        commit_args.all,
                         commit_args.create,
                         commit_args.no_hooks,
                         commit_args.ai.clone(),

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -94,6 +94,27 @@ fn commit_with_message_flag() -> anyhow::Result<()> {
 }
 
 #[test]
+fn commit_with_git_all_flag_prints_hint() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+    env.file("new-file.txt", "test content");
+
+    env.but("commit -am 'Add new file'")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+no need for -a here my friend...
+✓ Created commit [..] on branch A
+
+"#]]);
+
+    let log = env.git_log()?;
+    assert!(log.contains("Add new file"));
+
+    Ok(())
+}
+
+#[test]
 fn commit_with_branch_hint() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
     insta::assert_snapshot!(env.git_log()?, @r"


### PR DESCRIPTION
I constantly still run `but commit -am 'something'` because I'm used to Git for `-a`. Thought it would be nice to not have it blow up every time.