### PR TITLE
tui: more consistent "back" behavior

### DIFF
--- a/crates/but/src/command/legacy/status/tui/backstack.rs
+++ b/crates/but/src/command/legacy/status/tui/backstack.rs
@@ -1,0 +1,108 @@
+use std::{collections::VecDeque, ops::Deref};
+
+#[derive(Debug, Default)]
+pub(super) struct Backstack {
+    stack: VecDeque<BackstackEntry>,
+}
+
+impl Backstack {
+    pub(super) fn push_leave_normal_mode(&mut self) {
+        self.push_front(BackstackEntry::LeaveNormalMode);
+    }
+
+    pub(super) fn remove_leave_normal_mode(&mut self) {
+        self.remove(BackstackEntry::LeaveNormalMode);
+    }
+
+    pub(super) fn push_show_file_list(&mut self) {
+        self.push_front(BackstackEntry::ShowFileList);
+    }
+
+    pub(super) fn remove_show_file_list(&mut self) {
+        self.remove(BackstackEntry::ShowFileList);
+    }
+
+    pub(super) fn push_mark(&mut self) {
+        self.remove_mark();
+        self.push_front(BackstackEntry::Mark);
+    }
+
+    pub(super) fn remove_mark(&mut self) {
+        self.remove(BackstackEntry::Mark);
+    }
+
+    fn push_front(&mut self, entry: BackstackEntry) {
+        self.stack.push_front(entry);
+    }
+
+    fn remove(&mut self, entry: BackstackEntry) {
+        self.stack.retain(|e| *e != entry);
+    }
+
+    pub(super) fn pop(&mut self) -> Option<BackstackEntry> {
+        self.stack.pop_front()
+    }
+
+    pub(super) fn clear(&mut self) {
+        self.stack.clear();
+    }
+}
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub(super) enum BackstackEntry {
+    LeaveNormalMode,
+    ShowFileList,
+    Mark,
+}
+
+/// Wrapper type that makes it hard to forget updating the backstack when updating the inner value.
+#[derive(Debug, Default, Clone, Copy)]
+pub(super) struct RememberToUpdateBackstack<T>(T);
+
+impl<T> RememberToUpdateBackstack<T> {
+    /// Get mutable access to the inner value together with the backstack.
+    ///
+    /// rustc will give "unused variable" warnings if we forget to use the backstack passed into
+    /// the closure. This makes it less likely we'll forget to update the backstack.
+    #[inline]
+    pub(super) fn update<F, K>(&mut self, backstack: &mut Backstack, f: F) -> K
+    where
+        F: FnOnce(&mut Backstack, &mut T) -> K,
+    {
+        f(backstack, &mut self.0)
+    }
+
+    /// Get mutable access to the inner value while pushing [`Backstack::LeaveNormalMode`].
+    #[inline]
+    pub(super) fn update_and_push_leave_normal_mode<F, K>(
+        &mut self,
+        backstack: &mut Backstack,
+        f: F,
+    ) -> K
+    where
+        F: FnOnce(&mut T) -> K,
+    {
+        backstack.remove_leave_normal_mode();
+        backstack.push_leave_normal_mode();
+        f(&mut self.0)
+    }
+
+    /// Get a mutable reference to the inner value, without being reminded to update the backstack.
+    ///
+    /// This method should only be used if you're mutating a part of the state and not replacing it
+    /// outright.
+    #[inline]
+    pub(super) fn get_mut_without_updating_backstack_and_i_promise_not_to_change_state(
+        &mut self,
+    ) -> &mut T {
+        &mut self.0
+    }
+}
+
+impl<T> Deref for RememberToUpdateBackstack<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/crates/but/src/command/legacy/status/tui/details/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/details/mod.rs
@@ -188,7 +188,6 @@ impl Details {
             | Message::CopySelection
             | Message::Quit
             | Message::EnterDetailsMode
-            | Message::LeaveDetailsMode
             | Message::Discard
             | Message::DropToBeDiscarded
             | Message::Debug(_)
@@ -204,7 +203,9 @@ impl Details {
             | Message::SetHasFocus(_)
             | Message::RegisterOutOfBandMessage(_)
             | Message::WithOneFrameDelay(_)
-            | Message::EnterNormalMode => false,
+            | Message::Back
+            | Message::UnfocusDetails
+            | Message::EnterNormalModeAfterConfirmingOperation => false,
 
             Message::MoveCursorUp
             | Message::MoveCursorDown
@@ -313,7 +314,7 @@ impl Details {
                     DetailsVisibility::Hidden => {
                         self.cursor = DetailsCursor::default();
                         self.scroll_top = 0;
-                        messages.push(Message::LeaveDetailsMode);
+                        messages.push(Message::UnfocusDetails);
                     }
                     DetailsVisibility::VisibleVertical => {
                         self.mark_dirty();

--- a/crates/but/src/command/legacy/status/tui/key_bind/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/key_bind/mod.rs
@@ -410,7 +410,7 @@ impl KeyBindsBuilder<'_> {
         self.key_bind(
             "normal mode",
             press().control().code(KeyCode::Char('[')),
-            Message::EnterNormalMode,
+            Message::Back,
         )
         .hide_from_hotbar()
         .show_only_in_normal_mode_help_section()
@@ -640,7 +640,7 @@ impl KeyBindsBuilder<'_> {
     }
 
     fn back(&mut self) -> KeyBindsInModesBuilder<'_> {
-        self.key_bind("back", press().code(KeyCode::Esc), Message::EnterNormalMode)
+        self.key_bind("back", press().code(KeyCode::Esc), Message::Back)
             .hide_from_hotbar()
             .show_only_in_normal_mode_help_section()
     }
@@ -772,7 +772,7 @@ impl KeyBindsBuilder<'_> {
         self.key_bind(
             "focus status",
             press().code(KeyCode::Char('h')),
-            Message::EnterNormalMode,
+            Message::UnfocusDetails,
         )
     }
 
@@ -839,6 +839,7 @@ fn register_normal_mode_key_binds(builder: &mut KeyBindsBuilder<'_>, without_mar
     }
 
     builder.reload().register();
+    builder.back().hide_from_hotbar().register();
     builder.help().register();
     builder.quit().register();
 }

--- a/crates/but/src/command/legacy/status/tui/marking.rs
+++ b/crates/but/src/command/legacy/status/tui/marking.rs
@@ -24,6 +24,10 @@ impl Marks {
         self.marks.remove(markable);
     }
 
+    pub(super) fn clear(&mut self) {
+        self.marks.clear();
+    }
+
     pub(super) fn is_empty(&self) -> bool {
         self.marks.is_empty()
     }

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -32,6 +32,7 @@ use crate::{
         status::{
             StatusFlags, StatusOutputLine, TuiLaunchOptions,
             tui::{
+                backstack::{Backstack, BackstackEntry, RememberToUpdateBackstack},
                 branch_picker::{BranchPicker, BranchPickerMessage},
                 confirm::{Confirm, ConfirmMessage},
                 cursor::{Cursor, is_selectable_in_mode},
@@ -66,6 +67,7 @@ use super::{FilesStatusFlag, output::StatusOutputLineData};
 
 use render::{details_viewport, ensure_cursor_visible, render_app, status_viewport_height};
 
+mod backstack;
 mod branch_picker;
 mod confirm;
 mod cursor;
@@ -358,7 +360,7 @@ struct App {
     should_render: bool,
     cursor: Cursor,
     scroll_top: usize,
-    mode: Mode,
+    mode: RememberToUpdateBackstack<Mode>,
     toasts: Toasts,
     renders: u64,
     updates: u64,
@@ -376,6 +378,7 @@ struct App {
     theme: &'static Theme,
     help: Option<Help>,
     has_focus: bool,
+    backstack: Backstack,
 }
 
 #[derive(Debug)]
@@ -423,7 +426,7 @@ impl App {
             scroll_top: 0,
             should_quit: false,
             should_render: true,
-            mode: Mode::default(),
+            mode: Default::default(),
             help: None,
             toasts: Default::default(),
             renders: 0,
@@ -434,6 +437,7 @@ impl App {
             incoming_out_of_band_messages: Default::default(),
             to_be_discarded: Default::default(),
             branch_picker: Default::default(),
+            backstack: Default::default(),
             fps: FpsCounter::new(),
             confirm: None,
             details,
@@ -451,7 +455,7 @@ impl App {
             &self.app_key_binds.branch_picker_key_binds
         } else if self.help.is_some() {
             &self.app_key_binds.help_key_binds
-        } else if let Mode::Normal(NormalMode { marks }) = &self.mode
+        } else if let Mode::Normal(NormalMode { marks }) = &*self.mode
             && !marks.is_empty()
         {
             &self.app_key_binds.normal_with_marks_key_binds
@@ -548,7 +552,7 @@ impl App {
                 if let Some(new_cursor) =
                     Cursor::select_branch(&branch_name.shorten().to_str_lossy(), &self.status_lines)
                 {
-                    self.cursor = if matches!(self.mode, Mode::Rub(_)) {
+                    self.cursor = if matches!(&*self.mode, Mode::Rub(_)) {
                         new_cursor
                             .move_down_within_section(
                                 &self.status_lines,
@@ -606,14 +610,17 @@ impl App {
                     self.handle_rub_use_source_message();
                 }
             },
-            Message::EnterNormalMode => {
-                self.handle_enter_normal_mode(messages);
+            Message::Back => {
+                self.handle_back(messages);
+            }
+            Message::UnfocusDetails => {
+                self.handle_unfocus_details(messages);
+            }
+            Message::EnterNormalModeAfterConfirmingOperation => {
+                self.handle_enter_normal_mode_after_confirming_operation();
             }
             Message::EnterDetailsMode => {
                 self.handle_enter_details_mode(messages);
-            }
-            Message::LeaveDetailsMode => {
-                self.handle_leave_details_mode(messages);
             }
             Message::Files(files_message) => match files_message {
                 FilesMessage::ToggleGlobalFilesList => {
@@ -772,25 +779,66 @@ impl App {
         Ok(())
     }
 
-    fn handle_enter_normal_mode(&mut self, messages: &mut Vec<Message>) {
-        if matches!(self.mode, Mode::Normal(..)) {
-            match self.flags.show_files {
-                FilesStatusFlag::None => {}
-                FilesStatusFlag::All => {
-                    messages.push(Message::Files(FilesMessage::ToggleGlobalFilesList));
+    fn handle_unfocus_details(&mut self, messages: &mut Vec<Message>) {
+        self.mode.update(&mut self.backstack, |backstack, mode| {
+            *mode = Mode::Normal(Default::default());
+            backstack.remove_leave_normal_mode();
+        });
+
+        messages.push(Message::Details(DetailsMessage::Deselect));
+    }
+
+    fn handle_enter_normal_mode_after_confirming_operation(&mut self) {
+        self.mode.update(&mut self.backstack, |backstack, mode| {
+            *mode = Mode::Normal(NormalMode::default());
+            backstack.clear();
+        });
+        self.maybe_move_cursor_into_file_list();
+    }
+
+    fn handle_back(&mut self, messages: &mut Vec<Message>) {
+        if let Some(entry) = self.backstack.pop() {
+            match entry {
+                BackstackEntry::LeaveNormalMode => {
+                    *self
+                        .mode
+                        .get_mut_without_updating_backstack_and_i_promise_not_to_change_state() =
+                        Mode::Normal(NormalMode {
+                            marks: self.marks().cloned().unwrap_or_default(),
+                        });
+                    self.maybe_move_cursor_into_file_list();
                 }
-                FilesStatusFlag::Commit(_) => {
-                    messages.push(Message::Files(FilesMessage::ToggleFilesForCommit));
+                BackstackEntry::ShowFileList => {
+                    self.flags.show_files = FilesStatusFlag::None;
+                    messages.push(Message::Reload(None));
                 }
+                BackstackEntry::Mark => match self
+                    .mode
+                    .get_mut_without_updating_backstack_and_i_promise_not_to_change_state()
+                {
+                    Mode::Normal(normal_mode) => {
+                        normal_mode.marks.clear();
+                    }
+                    Mode::Rub(..) => {
+                        *self
+                            .mode
+                            .get_mut_without_updating_backstack_and_i_promise_not_to_change_state(
+                            ) = Mode::Normal(NormalMode::default());
+                        self.backstack.remove_mark();
+                        self.backstack.remove_leave_normal_mode();
+                        self.maybe_move_cursor_into_file_list();
+                    }
+                    Mode::InlineReword(..)
+                    | Mode::Command(..)
+                    | Mode::Commit(..)
+                    | Mode::Move(..)
+                    | Mode::Details => {}
+                },
             }
         }
+    }
 
-        if matches!(self.mode, Mode::Details) {
-            messages.push(Message::Details(DetailsMessage::Deselect));
-        }
-
-        self.mode = Mode::Normal(NormalMode::default());
-
+    fn maybe_move_cursor_into_file_list(&mut self) {
         match self.flags.show_files {
             FilesStatusFlag::Commit(object_id) => {
                 // When viewing files in a commit cursor movement is constrained to only those
@@ -818,7 +866,11 @@ impl App {
     }
 
     fn handle_enter_details_mode(&mut self, messages: &mut Vec<Message>) {
-        self.mode = Mode::Details;
+        self.mode
+            .update_and_push_leave_normal_mode(&mut self.backstack, |mode| {
+                *mode = Mode::Details;
+            });
+
         if self.details.is_visible() {
             messages.push(Message::Details(DetailsMessage::SelectFirstSection));
         } else {
@@ -832,14 +884,8 @@ impl App {
         }
     }
 
-    fn handle_leave_details_mode(&mut self, messages: &mut Vec<Message>) {
-        if matches!(self.mode, Mode::Details) {
-            messages.push(Message::EnterNormalMode);
-        }
-    }
-
     fn handle_rub_start(&mut self) {
-        let Mode::Normal(normal_mode) = &self.mode else {
+        let Mode::Normal(normal_mode) = &*self.mode else {
             return;
         };
         let Some(selected_line) = self.cursor.selected_line(&self.status_lines) else {
@@ -936,12 +982,15 @@ impl App {
 
         let available_targets = self.available_targets_for_rub_mode(&source);
 
-        self.mode = Mode::Rub(RubMode {
-            source,
-            available_targets,
-            how_to_combine_messages: MessageCombinationStrategy::KeepBoth,
-            _unlock_details: unlock_details,
-        });
+        self.mode
+            .update_and_push_leave_normal_mode(&mut self.backstack, |mode| {
+                *mode = Mode::Rub(RubMode {
+                    source,
+                    available_targets,
+                    how_to_combine_messages: MessageCombinationStrategy::KeepBoth,
+                    _unlock_details: unlock_details,
+                });
+            });
 
         if self
             .cursor
@@ -1012,21 +1061,29 @@ impl App {
 
         let available_targets = self.available_targets_for_rub_mode(&source);
 
-        self.mode = Mode::Rub(RubMode {
-            source,
-            available_targets,
-            how_to_combine_messages: MessageCombinationStrategy::KeepBoth,
-            _unlock_details: None,
-        });
+        self.mode
+            .update_and_push_leave_normal_mode(&mut self.backstack, |mode| {
+                *mode = Mode::Rub(RubMode {
+                    source,
+                    available_targets,
+                    how_to_combine_messages: MessageCombinationStrategy::KeepBoth,
+                    _unlock_details: None,
+                });
+            });
 
         Ok(())
     }
 
-    /// Handles toggling file visibility and requests a status reload.
     fn handle_files_toggle_global_files_list(&mut self, messages: &mut Vec<Message>) {
         self.flags.show_files = match self.flags.show_files {
-            FilesStatusFlag::None => FilesStatusFlag::All,
-            FilesStatusFlag::All | FilesStatusFlag::Commit(_) => FilesStatusFlag::None,
+            FilesStatusFlag::None => {
+                self.backstack.push_show_file_list();
+                FilesStatusFlag::All
+            }
+            FilesStatusFlag::All | FilesStatusFlag::Commit(_) => {
+                self.backstack.remove_show_file_list();
+                FilesStatusFlag::None
+            }
         };
         messages.push(Message::Reload(None));
     }
@@ -1044,10 +1101,12 @@ impl App {
                 let select_after_reload = match self.flags.show_files {
                     FilesStatusFlag::None => {
                         self.flags.show_files = FilesStatusFlag::Commit(*commit_id);
+                        self.backstack.push_show_file_list();
                         Some(SelectAfterReload::FirstFileInCommit(*commit_id))
                     }
                     FilesStatusFlag::All | FilesStatusFlag::Commit(_) => {
                         self.flags.show_files = FilesStatusFlag::None;
+                        self.backstack.remove_show_file_list();
                         Some(SelectAfterReload::Commit(*commit_id))
                     }
                 };
@@ -1055,6 +1114,7 @@ impl App {
             }
         } else {
             self.flags.show_files = FilesStatusFlag::None;
+            self.backstack.remove_show_file_list();
             messages.push(Message::Reload(None));
         };
 
@@ -1065,7 +1125,9 @@ impl App {
         let Mode::Rub(RubMode {
             how_to_combine_messages,
             ..
-        }) = &mut self.mode
+        }) = self
+            .mode
+            .get_mut_without_updating_backstack_and_i_promise_not_to_change_state()
         else {
             return;
         };
@@ -1081,7 +1143,9 @@ impl App {
         let Mode::Rub(RubMode {
             how_to_combine_messages,
             ..
-        }) = &mut self.mode
+        }) = self
+            .mode
+            .get_mut_without_updating_backstack_and_i_promise_not_to_change_state()
         else {
             return;
         };
@@ -1099,7 +1163,7 @@ impl App {
         ctx: &mut Context,
         messages: &mut Vec<Message>,
     ) -> anyhow::Result<()> {
-        let reload_message = match &self.mode {
+        let reload_message = match &*self.mode {
             Mode::Rub(RubMode {
                 source,
                 how_to_combine_messages,
@@ -1170,7 +1234,7 @@ impl App {
         self.flags.show_files = FilesStatusFlag::None;
 
         messages.extend([
-            Message::EnterNormalMode,
+            Message::EnterNormalModeAfterConfirmingOperation,
             reload_message.unwrap_or(Message::Reload(None)),
         ]);
 
@@ -1236,7 +1300,7 @@ impl App {
 
         // ensure we always enter normal mode when something does wrong
         // so we don't get stuck in whatever mode we were in previously
-        messages.push(Message::EnterNormalMode);
+        messages.push(Message::EnterNormalModeAfterConfirmingOperation);
     }
 
     fn select_top_branch_for_stack_after_reload(
@@ -1542,7 +1606,10 @@ impl App {
             | StatusOutputLineData::NoAssignmentsUnstaged => return Ok(()),
         };
 
-        self.mode = Mode::Commit(commit_mode);
+        self.mode
+            .update_and_push_leave_normal_mode(&mut self.backstack, |mode| {
+                *mode = Mode::Commit(commit_mode);
+            });
 
         Ok(())
     }
@@ -1556,7 +1623,7 @@ impl App {
             source,
             scope_to_stack,
             message_composer,
-        }) = &self.mode
+        }) = &*self.mode
         else {
             return Ok(());
         };
@@ -1570,7 +1637,7 @@ impl App {
             .cli_id()
             .is_some_and(|target| **source == **target)
         {
-            messages.push(Message::EnterNormalMode);
+            messages.push(Message::EnterNormalModeAfterConfirmingOperation);
             return Ok(());
         }
 
@@ -1650,7 +1717,7 @@ impl App {
 
         messages.extend(
             [
-                Message::EnterNormalMode,
+                Message::EnterNormalModeAfterConfirmingOperation,
                 Message::Reload(
                     commit_create_result
                         .new_commit
@@ -1684,7 +1751,10 @@ impl App {
     }
 
     fn handle_commit_toggle_message_composer(&mut self, composer: CommitMessageComposer) {
-        if let Mode::Commit(mode) = &mut self.mode {
+        if let Mode::Commit(mode) = self
+            .mode
+            .get_mut_without_updating_backstack_and_i_promise_not_to_change_state()
+        {
             match composer {
                 CommitMessageComposer::Editor => {
                     // you can't toggle the editor composer, that is always the default
@@ -1741,7 +1811,10 @@ impl App {
             | StatusOutputLineData::NoAssignmentsUnstaged => return,
         };
 
-        self.mode = Mode::Move(move_mode);
+        self.mode
+            .update_and_push_leave_normal_mode(&mut self.backstack, |mode| {
+                *mode = Mode::Move(move_mode);
+            });
     }
 
     fn handle_move_confirm(
@@ -1749,7 +1822,7 @@ impl App {
         ctx: &mut Context,
         messages: &mut Vec<Message>,
     ) -> anyhow::Result<()> {
-        let Mode::Move(MoveMode { source }) = &self.mode else {
+        let Mode::Move(MoveMode { source }) = &*self.mode else {
             return Ok(());
         };
 
@@ -1763,7 +1836,7 @@ impl App {
             .cli_id()
             .is_some_and(|target| **source == **target)
         {
-            messages.push(Message::EnterNormalMode);
+            messages.push(Message::EnterNormalModeAfterConfirmingOperation);
             return Ok(());
         }
 
@@ -1852,7 +1925,7 @@ impl App {
         };
 
         messages.extend([
-            Message::EnterNormalMode,
+            Message::EnterNormalModeAfterConfirmingOperation,
             Message::Reload(selection_after_reload),
         ]);
 
@@ -2008,14 +2081,20 @@ impl App {
             | CliId::Stack { .. } => return Ok(()),
         };
 
-        self.mode = Mode::InlineReword(inline_reword_mode);
+        self.mode
+            .update_and_push_leave_normal_mode(&mut self.backstack, |mode| {
+                *mode = Mode::InlineReword(inline_reword_mode);
+            });
 
         Ok(())
     }
 
     /// Handles key input while inline reword mode is active.
     fn handle_reword_inline_input(&mut self, ev: Event) {
-        if let Mode::InlineReword(inline_reword_mode) = &mut self.mode {
+        if let Mode::InlineReword(inline_reword_mode) = self
+            .mode
+            .get_mut_without_updating_backstack_and_i_promise_not_to_change_state()
+        {
             let ev = match inline_reword_mode {
                 InlineRewordMode::Branch { .. } => {
                     if let Event::Key(key_ev) = ev
@@ -2045,10 +2124,10 @@ impl App {
         ctx: &mut Context,
         messages: &mut Vec<Message>,
     ) -> anyhow::Result<()> {
-        let inline_reword_mode = if let Mode::InlineReword(inline_reword_mode) = &self.mode {
+        let inline_reword_mode = if let Mode::InlineReword(inline_reword_mode) = &*self.mode {
             inline_reword_mode
         } else {
-            messages.push(Message::EnterNormalMode);
+            messages.push(Message::EnterNormalModeAfterConfirmingOperation);
             return Ok(());
         };
 
@@ -2064,12 +2143,12 @@ impl App {
                 let Some(reword_result) =
                     operations::reword_commit_legacy(ctx, *commit_id, first_line)?
                 else {
-                    messages.push(Message::EnterNormalMode);
+                    messages.push(Message::EnterNormalModeAfterConfirmingOperation);
                     return Ok(());
                 };
 
                 messages.extend([
-                    Message::EnterNormalMode,
+                    Message::EnterNormalModeAfterConfirmingOperation,
                     Message::Reload(Some(SelectAfterReload::Commit(reword_result.new_commit))),
                 ]);
             }
@@ -2082,7 +2161,7 @@ impl App {
                 )?;
 
                 messages.extend([
-                    Message::EnterNormalMode,
+                    Message::EnterNormalModeAfterConfirmingOperation,
                     Message::Reload(Some(SelectAfterReload::Branch(new_name))),
                 ]);
             }
@@ -2101,7 +2180,7 @@ impl App {
         T: TerminalGuard,
         anyhow::Error: From<<T::Backend as Backend>::Error>,
     {
-        let Mode::InlineReword(inline_reword_mode) = &self.mode else {
+        let Mode::InlineReword(inline_reword_mode) = &*self.mode else {
             return Ok(());
         };
 
@@ -2137,7 +2216,7 @@ impl App {
         drop(_suspend_guard);
 
         messages.extend([
-            Message::EnterNormalMode,
+            Message::EnterNormalModeAfterConfirmingOperation,
             Message::Reload(Some(what_to_select)),
         ]);
 
@@ -2149,14 +2228,20 @@ impl App {
         textarea.set_cursor_line_style(self.theme.default);
         textarea.move_cursor(CursorMove::End);
 
-        self.mode = Mode::Command(CommandMode {
-            textarea: Box::new(textarea),
-            kind,
-        });
+        self.mode
+            .update_and_push_leave_normal_mode(&mut self.backstack, |mode| {
+                *mode = Mode::Command(CommandMode {
+                    textarea: Box::new(textarea),
+                    kind,
+                });
+            });
     }
 
     fn handle_command_input(&mut self, ev: Event) {
-        if let Mode::Command(CommandMode { textarea, .. }) = &mut self.mode {
+        if let Mode::Command(CommandMode { textarea, .. }) = self
+            .mode
+            .get_mut_without_updating_backstack_and_i_promise_not_to_change_state()
+        {
             textarea.input(ev);
         }
     }
@@ -2171,8 +2256,8 @@ impl App {
         T: TerminalGuard,
         anyhow::Error: From<<T::Backend as Backend>::Error>,
     {
-        let Mode::Command(CommandMode { textarea, kind }) = &self.mode else {
-            messages.push(Message::EnterNormalMode);
+        let Mode::Command(CommandMode { textarea, kind }) = &*self.mode else {
+            messages.push(Message::EnterNormalModeAfterConfirmingOperation);
             return Ok(());
         };
 
@@ -2193,7 +2278,7 @@ impl App {
             CommandModeKind::Shell => {
                 let mut args = shell_words::split(input)?.into_iter().map(OsString::from);
                 let Some(binary) = args.next() else {
-                    messages.push(Message::EnterNormalMode);
+                    messages.push(Message::EnterNormalModeAfterConfirmingOperation);
                     return Ok(());
                 };
                 let mut cmd = Command::new(binary);
@@ -2207,7 +2292,10 @@ impl App {
         self.prompt_to_continue(out)?;
 
         if status.success() {
-            messages.extend([Message::EnterNormalMode, Message::Reload(None)]);
+            messages.extend([
+                Message::EnterNormalModeAfterConfirmingOperation,
+                Message::Reload(None),
+            ]);
         } else {
             self.push_transient_error(anyhow::Error::msg(format!(
                 "command exited with status {}",
@@ -2294,7 +2382,7 @@ impl App {
                 Some(&ref_info.ref_name)
             })
             .filter(|name| {
-                if matches!(self.mode, Mode::Rub(_)) {
+                if matches!(&*self.mode, Mode::Rub(_)) {
                     true
                 } else {
                     // not all branches are selectable all the time, for example if we're committing
@@ -2368,13 +2456,15 @@ impl App {
 
         match &**selection {
             CliId::Commit { .. } => {
-                if handle_mark_commit(selection, &mut self.mode)
-                    && let Some(new_cursor) = self.cursor.move_down_within_section(
-                        &self.status_lines,
-                        &self.mode,
-                        self.flags.show_files,
-                    )
-                {
+                if handle_mark_commit(
+                    selection,
+                    self.mode
+                        .get_mut_without_updating_backstack_and_i_promise_not_to_change_state(),
+                ) && let Some(new_cursor) = self.cursor.move_down_within_section(
+                    &self.status_lines,
+                    &self.mode,
+                    self.flags.show_files,
+                ) {
                     self.cursor = new_cursor;
                 }
             }
@@ -2384,7 +2474,9 @@ impl App {
                 stack_id,
             } => {
                 // you cannot select branches in rub mode so we don't need to care about that
-                if let Mode::Normal(normal_mode) = &mut self.mode
+                if let Mode::Normal(normal_mode) = self
+                    .mode
+                    .get_mut_without_updating_backstack_and_i_promise_not_to_change_state()
                     && let Some(stack_id) = *stack_id
                 {
                     handle_mark_branch(&mut normal_mode.marks, ctx, stack_id, name)?;
@@ -2395,6 +2487,14 @@ impl App {
             | CliId::CommittedFile { .. }
             | CliId::Unassigned { .. }
             | CliId::Stack { .. } => {}
+        }
+
+        if let Some(marks) = self.marks() {
+            if marks.is_empty() {
+                self.backstack.remove_mark();
+            } else {
+                self.backstack.push_mark();
+            }
         }
 
         Ok(())
@@ -2616,7 +2716,7 @@ enum Message {
     // Lifecycle
     JustRender,
     Quit,
-    EnterNormalMode,
+    EnterNormalModeAfterConfirmingOperation,
     Reload(Option<SelectAfterReload>),
     ShowError(Arc<anyhow::Error>),
     ShowToast {
@@ -2629,6 +2729,8 @@ enum Message {
     GrowDetails,
     ShrinkDetails,
     SetHasFocus(bool),
+    Back,
+    UnfocusDetails,
 
     // Cursor movement
     MoveCursorUp,
@@ -2651,7 +2753,6 @@ enum Message {
     BranchPicker(BranchPickerMessage),
     Help(HelpMessage),
     EnterDetailsMode,
-    LeaveDetailsMode,
     NewBranch,
     ToggleHelp,
     Mark,

--- a/crates/but/src/command/legacy/status/tui/render.rs
+++ b/crates/but/src/command/legacy/status/tui/render.rs
@@ -58,7 +58,7 @@ pub(super) fn render_app(app: &App, frame: &mut Frame) {
         .border_type(BorderType::Thick)
         .borders(Borders::BOTTOM);
 
-    let (status_block, details_block) = if matches!(app.mode, Mode::Details) {
+    let (status_block, details_block) = if matches!(&*app.mode, Mode::Details) {
         (dimmed_block, focused_block)
     } else {
         (focused_block, dimmed_block)
@@ -197,7 +197,7 @@ pub(super) fn render_status_list_item(
     if line_is_to_be_discarded {
         line.extend([Span::raw("<< discard >>").black().on_red(), Span::raw(" ")]);
     } else if is_selected {
-        match &app.mode {
+        match &*app.mode {
             Mode::Normal(..) | Mode::InlineReword(..) | Mode::Command(..) | Mode::Details => {}
             Mode::Rub(RubMode {
                 source,
@@ -232,7 +232,7 @@ pub(super) fn render_status_list_item(
             }
         }
     } else {
-        match &app.mode {
+        match &*app.mode {
             Mode::Normal(..) | Mode::InlineReword(..) | Mode::Command(..) | Mode::Details => {}
             Mode::Rub(RubMode {
                 source,
@@ -328,7 +328,7 @@ pub(super) fn render_status_list_item(
             .collect();
     }
 
-    match &app.mode {
+    match &*app.mode {
         Mode::InlineReword(inline_reword_mode) => {
             if is_selected {
                 match inline_reword_mode {
@@ -377,7 +377,7 @@ pub(super) fn render_status_list_item(
     }
 
     if is_selected {
-        match &app.mode {
+        match &*app.mode {
             Mode::Commit(commit_mode) => {
                 if matches!(data, StatusOutputLineData::Commit { .. })
                     || matches!(data, StatusOutputLineData::Branch { .. })
@@ -501,9 +501,9 @@ fn render_rub_inline_labels_for_selected_line(
         }
     };
     line.extend([
-        Span::raw("<< ").mode_colors(&app.mode, app.theme),
-        Span::raw(display).mode_colors(&app.mode, app.theme),
-        Span::raw(" >>").mode_colors(&app.mode, app.theme),
+        Span::raw("<< ").mode_colors(&*app.mode, app.theme),
+        Span::raw(display).mode_colors(&*app.mode, app.theme),
+        Span::raw(" >>").mode_colors(&*app.mode, app.theme),
         Span::raw(" "),
     ]);
 }
@@ -522,42 +522,42 @@ fn render_commit_labels_for_selected_line(
         line.extend([source_span(app.theme), Span::raw(" ")]);
         line.extend(
             [
-                Span::raw("<< ").mode_colors(&app.mode, app.theme),
-                Span::raw(NOOP).mode_colors(&app.mode, app.theme),
+                Span::raw("<< ").mode_colors(&*app.mode, app.theme),
+                Span::raw(NOOP).mode_colors(&*app.mode, app.theme),
             ]
             .into_iter()
             .chain(match mode.message_composer {
                 CommitMessageComposer::Editor => None,
                 CommitMessageComposer::Empty => {
-                    Some(Span::raw(" (empty message)").mode_colors(&app.mode, app.theme))
+                    Some(Span::raw(" (empty message)").mode_colors(&*app.mode, app.theme))
                 }
                 CommitMessageComposer::Inline => {
-                    Some(Span::raw(" (reword inline)").mode_colors(&app.mode, app.theme))
+                    Some(Span::raw(" (reword inline)").mode_colors(&*app.mode, app.theme))
                 }
             })
             .chain([
-                Span::raw(" >>").mode_colors(&app.mode, app.theme),
+                Span::raw(" >>").mode_colors(&*app.mode, app.theme),
                 Span::raw(" "),
             ]),
         );
     } else if let Some(display) = commit_operation_display(data, mode) {
         line.extend(
             [
-                Span::raw("<< ").mode_colors(&app.mode, app.theme),
-                Span::raw(display).mode_colors(&app.mode, app.theme),
+                Span::raw("<< ").mode_colors(&*app.mode, app.theme),
+                Span::raw(display).mode_colors(&*app.mode, app.theme),
             ]
             .into_iter()
             .chain(match mode.message_composer {
                 CommitMessageComposer::Editor => None,
                 CommitMessageComposer::Empty => {
-                    Some(Span::raw(" (empty message)").mode_colors(&app.mode, app.theme))
+                    Some(Span::raw(" (empty message)").mode_colors(&*app.mode, app.theme))
                 }
                 CommitMessageComposer::Inline => {
-                    Some(Span::raw(" (reword inline)").mode_colors(&app.mode, app.theme))
+                    Some(Span::raw(" (reword inline)").mode_colors(&*app.mode, app.theme))
                 }
             })
             .chain([
-                Span::raw(" >>").mode_colors(&app.mode, app.theme),
+                Span::raw(" >>").mode_colors(&*app.mode, app.theme),
                 Span::raw(" "),
             ]),
         );
@@ -573,16 +573,16 @@ fn render_move_labels_for_selected_line(
     if data.cli_id().is_some_and(|target| *mode.source == **target) {
         line.extend([source_span(app.theme), Span::raw(" ")]);
         line.extend([
-            Span::raw("<< ").mode_colors(&app.mode, app.theme),
-            Span::raw(NOOP).mode_colors(&app.mode, app.theme),
-            Span::raw(" >>").mode_colors(&app.mode, app.theme),
+            Span::raw("<< ").mode_colors(&*app.mode, app.theme),
+            Span::raw(NOOP).mode_colors(&*app.mode, app.theme),
+            Span::raw(" >>").mode_colors(&*app.mode, app.theme),
             Span::raw(" "),
         ]);
     } else if let Some(display) = move_operation_display(data, mode) {
         line.extend([
-            Span::raw("<< ").mode_colors(&app.mode, app.theme),
-            Span::raw(display).mode_colors(&app.mode, app.theme),
-            Span::raw(" >>").mode_colors(&app.mode, app.theme),
+            Span::raw("<< ").mode_colors(&*app.mode, app.theme),
+            Span::raw(display).mode_colors(&*app.mode, app.theme),
+            Span::raw(" >>").mode_colors(&*app.mode, app.theme),
             Span::raw(" "),
         ]);
     }
@@ -591,9 +591,9 @@ fn render_move_labels_for_selected_line(
 fn render_hotbar(app: &App, area: Rect, frame: &mut Frame) {
     let mode_span = Span::raw(format!(
         "  {}  ",
-        ModeDiscriminant::from(&app.mode).hotbar_string()
+        ModeDiscriminant::from(&*app.mode).hotbar_string()
     ))
-    .mode_colors(&app.mode, app.theme);
+    .mode_colors(&*app.mode, app.theme);
 
     let layout = Layout::horizontal([
         Constraint::Length(mode_span.width() as _),
@@ -606,7 +606,7 @@ fn render_hotbar(app: &App, area: Rect, frame: &mut Frame) {
 
     frame.render_widget(" ", layout[1]);
 
-    match &app.mode {
+    match &*app.mode {
         Mode::Normal(..)
         | Mode::Details
         | Mode::Rub(..)
@@ -616,7 +616,7 @@ fn render_hotbar(app: &App, area: Rect, frame: &mut Frame) {
             let mut line = Line::default();
             let mut key_binds_iter = app
                 .active_key_binds()
-                .iter_key_binds_available_in_mode(ModeDiscriminant::from(&app.mode))
+                .iter_key_binds_available_in_mode(ModeDiscriminant::from(&*app.mode))
                 .filter(|key_bind| !key_bind.hide_from_hotbar())
                 .peekable();
             while let Some(key_bind) = key_binds_iter.next() {
@@ -661,7 +661,7 @@ fn render_toasts(app: &App, area: Rect, frame: &mut Frame) {
 }
 
 fn render_inline_reword(app: &App, area: Rect, frame: &mut Frame) {
-    let inline_reword_mode = if let Mode::InlineReword(inline_reword_mode) = &app.mode {
+    let inline_reword_mode = if let Mode::InlineReword(inline_reword_mode) = &*app.mode {
         inline_reword_mode
     } else {
         return;
@@ -742,6 +742,14 @@ fn render_debug(app: &App, area: Rect, frame: &mut Frame) {
         app.renders
     ))));
 
+    let backstack = format!("{:#?}", app.backstack);
+    let backstack = once(ListItem::new("Backstack").black().on_blue()).chain(
+        backstack
+            .lines()
+            .take(100)
+            .map(|line| ListItem::new(line.to_owned())),
+    );
+
     let details_selection = format!("{:#?}", app.details.selection());
     let details_selection = once(ListItem::new("Details selection").black().on_blue()).chain(
         details_selection
@@ -760,6 +768,8 @@ fn render_debug(app: &App, area: Rect, frame: &mut Frame) {
 
     let list = List::new(
         renders
+            .chain(once(ListItem::new("")))
+            .chain(backstack)
             .chain(once(ListItem::new("")))
             .chain(details_selection)
             .chain(once(ListItem::new("")))

--- a/crates/but/src/command/legacy/status/tui/tests/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/mod.rs
@@ -795,7 +795,7 @@ fn commit_file_toggle_on_commit_without_files_is_noop() {
 }
 
 #[test]
-fn commit_file_list_rub_can_escape_scope_and_esc_reenters_file_list() {
+fn commit_file_list_rub_esc_leaves_rub_and_closes_file_list() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
     env.setup_metadata(&["A", "B"]).unwrap();
 
@@ -814,9 +814,9 @@ fn commit_file_list_rub_can_escape_scope_and_esc_reenters_file_list() {
         .assert_current_line_eq(str!["┊│     94:tm A A"]);
 
     tui.input_then_render(KeyCode::Esc)
-        .assert_current_line_eq(str!["┊│     94:tm A A"])
+        .assert_current_line_eq(str!["┊●   [..] add A"])
         .assert_rendered_term_svg_eq(file![
-            "snapshots/commit_file_list_rub_can_escape_scope_and_esc_reenters_file_list_final.svg"
+            "snapshots/commit_file_list_rub_esc_leaves_rub_and_closes_file_list_final.svg"
         ]);
 }
 
@@ -844,7 +844,7 @@ fn confirm_rub_keeps_commit_file_list_open() {
 }
 
 #[test]
-fn esc_in_normal_mode_keeps_global_file_list_open() {
+fn esc_in_normal_mode_closes_global_file_list() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
     env.setup_metadata(&["A", "B"]).unwrap();
 
@@ -860,14 +860,14 @@ fn esc_in_normal_mode_keeps_global_file_list_open() {
         .assert_current_line_eq(str!["┊│     [..] A A"]);
 
     tui.input_then_render(KeyCode::Esc)
-        .assert_current_line_eq(str!["┊│     94:tm A A"])
+        .assert_current_line_eq(str!["┊●   [..] add A"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/esc_in_normal_mode_closes_global_file_list_final.svg"
         ]);
 }
 
 #[test]
-fn esc_in_normal_mode_keeps_commit_file_list_open() {
+fn esc_in_normal_mode_closes_commit_file_list() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
     env.setup_metadata(&["A", "B"]).unwrap();
 
@@ -880,7 +880,7 @@ fn esc_in_normal_mode_keeps_commit_file_list_open() {
         .assert_current_line_eq(str!["┊│     [..] A A"]);
 
     tui.input_then_render(KeyCode::Esc)
-        .assert_current_line_eq(str!["┊│     94:tm A A"])
+        .assert_current_line_eq(str!["┊●   [..] add A"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/esc_in_normal_mode_closes_commit_file_list_final.svg"
         ]);

--- a/crates/but/src/command/legacy/status/tui/tests/move_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/move_tests.rs
@@ -162,7 +162,10 @@ fn move_branch_to_merge_base_tears_off_branch() {
     tui = tui.recreate();
     tui.render_with_messages(
         None,
-        Vec::from([Message::EnterNormalMode, Message::Reload(None)]),
+        Vec::from([
+            Message::EnterNormalModeAfterConfirmingOperation,
+            Message::Reload(None),
+        ]),
     )
     .assert_rendered_term_svg_eq(file![
         "snapshots/move_branch_to_merge_base_tears_off_branch_final.svg"

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_file_list_rub_esc_leaves_rub_and_closes_file_list_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_file_list_rub_esc_leaves_rub_and_closes_file_list_final.svg
@@ -1,105 +1,105 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
   <rect x="0" y="0" width="820" height="380" fill="#000000" />
-  <rect x="10" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="18" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="26" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="34" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="42" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="50" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="58" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="66" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="74" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="82" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="90" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="98" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="106" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="114" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="122" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="130" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="138" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="146" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="154" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="162" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="170" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="178" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="186" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="194" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="202" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="210" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="218" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="226" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="234" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="242" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="250" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="258" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="266" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="274" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="282" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="290" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="298" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="306" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="314" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="322" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="330" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="338" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="346" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="354" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="362" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="370" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="378" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="386" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="394" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="402" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="410" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="418" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="426" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="434" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="442" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="450" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="458" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="466" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="474" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="482" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="490" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="498" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="506" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="514" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="522" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="530" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="538" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="546" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="554" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="562" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="570" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="578" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="586" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="594" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="602" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="610" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="618" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="626" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="634" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="642" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="650" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="658" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="666" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="674" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="682" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="690" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="698" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="706" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="714" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="722" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="730" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="738" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="746" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="754" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="762" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="770" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="778" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="786" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="794" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="802" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="10" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="18" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="26" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="34" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="42" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="50" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="58" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="66" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="74" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="82" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="90" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="98" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="106" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="114" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="122" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="130" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="138" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="146" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="154" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="162" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="170" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="178" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="186" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="194" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="202" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="210" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="218" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="226" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="234" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="242" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="250" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="258" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="266" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="274" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="282" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="290" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="298" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="306" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="314" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="322" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="330" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="338" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="346" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="354" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="362" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="370" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="378" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="386" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="394" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="402" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="410" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="418" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="426" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="434" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="442" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="450" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="458" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="466" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="474" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="482" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="490" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="498" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="506" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="514" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="522" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="530" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="538" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="546" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="554" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="562" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="570" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="578" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="586" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="594" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="602" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="610" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="618" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="626" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="634" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="642" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="650" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="658" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="666" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="674" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="682" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="690" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="698" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="706" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="714" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="722" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="730" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="738" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="746" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="754" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="762" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="770" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="778" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="786" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="794" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="802" y="64" width="8" height="18" fill="#45475A" />
   <rect x="10" y="352" width="8" height="18" fill="#555555" />
   <rect x="18" y="352" width="8" height="18" fill="#555555" />
   <rect x="26" y="352" width="8" height="18" fill="#555555" />
@@ -112,27 +112,27 @@
   <rect x="82" y="352" width="8" height="18" fill="#555555" />
   <text x="10" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
   <text x="18" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
-  <text x="26" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
-  <text x="34" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
-  <text x="50" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
-  <text x="58" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
-  <text x="66" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
-  <text x="74" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="82" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
-  <text x="90" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
-  <text x="98" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
-  <text x="106" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
-  <text x="114" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
-  <text x="122" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
-  <text x="130" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="146" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
-  <text x="154" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
-  <text x="162" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="170" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
-  <text x="178" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
-  <text x="186" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
-  <text x="194" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
-  <text x="202" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="26" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="34" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="50" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="58" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="66" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="74" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="82" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="90" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="98" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="106" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="114" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="122" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="130" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="146" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="154" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="162" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="178" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="186" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="194" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="202" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
   <text x="218" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
   <text x="226" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
   <text x="234" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
@@ -148,95 +148,86 @@
   <text x="10" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
   <text x="18" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
   <text x="26" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
-  <text x="34" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
-  <text x="42" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="58" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
-  <text x="66" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
-  <text x="74" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
-  <text x="10" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="18" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">●</text>
-  <text x="50" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">9</text>
-  <text x="58" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">4</text>
-  <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
-  <text x="74" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
-  <text x="82" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="90" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
-  <text x="98" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
-  <text x="114" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="122" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="130" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="146" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
-  <text x="10" y="96" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="18" y="96" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
-  <text x="66" y="96" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="74" y="96" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="82" y="96" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">:</text>
-  <text x="90" y="96" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
-  <text x="98" y="96" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
-  <text x="114" y="96" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
-  <text x="130" y="96" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
-  <text x="10" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">├</text>
-  <text x="18" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
+  <text x="34" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="42" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="58" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="66" y="60" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="74" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="10" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">●</text>
+  <text x="50" y="78" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="58" y="78" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="74" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="82" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="90" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="98" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="114" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="122" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="130" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="146" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="10" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">├</text>
+  <text x="18" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
+  <text x="10" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
   <text x="10" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
+  <text x="26" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
+  <text x="34" y="132" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="42" y="132" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="58" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="66" y="132" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">B</text>
+  <text x="74" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
   <text x="10" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="18" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
-  <text x="26" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
-  <text x="34" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
-  <text x="42" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="58" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
-  <text x="66" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">B</text>
-  <text x="74" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
-  <text x="10" y="168" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="18" y="168" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">●</text>
-  <text x="50" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="58" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
-  <text x="66" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
-  <text x="74" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
-  <text x="82" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
-  <text x="90" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="98" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
-  <text x="114" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="122" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="130" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="146" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">B</text>
-  <text x="10" y="186" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">├</text>
-  <text x="18" y="186" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
-  <text x="10" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="10" y="222" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┴</text>
-  <text x="26" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="34" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="42" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
-  <text x="50" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
-  <text x="58" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
-  <text x="66" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
-  <text x="74" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
-  <text x="90" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
-  <text x="98" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
-  <text x="106" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
-  <text x="114" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
-  <text x="122" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
-  <text x="130" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
-  <text x="138" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
-  <text x="146" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
-  <text x="154" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
-  <text x="162" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="170" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
-  <text x="178" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
-  <text x="186" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
-  <text x="202" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
-  <text x="210" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="218" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="226" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="234" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
-  <text x="242" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="250" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
-  <text x="258" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
-  <text x="266" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="274" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
-  <text x="290" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="298" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="306" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="322" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
+  <text x="18" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">●</text>
+  <text x="50" y="150" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="58" y="150" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="66" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="74" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="82" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="90" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="98" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="114" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="122" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="130" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="146" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">B</text>
+  <text x="10" y="168" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">├</text>
+  <text x="18" y="168" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
+  <text x="10" y="186" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="10" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┴</text>
+  <text x="26" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="34" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="42" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="50" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="58" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
+  <text x="66" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="74" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="90" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="98" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="106" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="114" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="122" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="130" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="138" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="146" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="154" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="162" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="178" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="186" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="202" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="210" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="218" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="226" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="234" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="242" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="250" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="258" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="266" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="274" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="290" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="298" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="306" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="322" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
   <text x="10" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
   <text x="18" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
   <text x="26" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/esc_in_normal_mode_closes_commit_file_list_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/esc_in_normal_mode_closes_commit_file_list_final.svg
@@ -1,105 +1,105 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
   <rect x="0" y="0" width="820" height="380" fill="#000000" />
-  <rect x="10" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="18" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="26" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="34" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="42" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="50" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="58" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="66" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="74" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="82" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="90" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="98" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="106" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="114" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="122" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="130" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="138" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="146" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="154" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="162" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="170" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="178" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="186" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="194" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="202" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="210" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="218" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="226" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="234" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="242" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="250" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="258" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="266" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="274" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="282" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="290" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="298" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="306" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="314" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="322" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="330" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="338" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="346" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="354" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="362" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="370" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="378" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="386" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="394" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="402" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="410" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="418" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="426" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="434" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="442" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="450" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="458" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="466" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="474" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="482" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="490" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="498" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="506" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="514" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="522" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="530" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="538" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="546" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="554" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="562" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="570" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="578" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="586" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="594" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="602" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="610" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="618" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="626" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="634" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="642" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="650" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="658" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="666" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="674" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="682" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="690" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="698" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="706" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="714" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="722" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="730" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="738" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="746" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="754" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="762" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="770" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="778" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="786" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="794" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="802" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="10" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="18" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="26" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="34" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="42" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="50" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="58" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="66" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="74" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="82" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="90" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="98" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="106" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="114" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="122" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="130" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="138" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="146" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="154" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="162" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="170" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="178" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="186" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="194" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="202" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="210" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="218" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="226" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="234" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="242" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="250" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="258" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="266" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="274" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="282" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="290" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="298" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="306" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="314" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="322" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="330" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="338" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="346" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="354" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="362" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="370" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="378" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="386" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="394" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="402" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="410" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="418" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="426" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="434" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="442" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="450" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="458" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="466" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="474" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="482" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="490" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="498" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="506" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="514" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="522" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="530" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="538" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="546" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="554" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="562" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="570" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="578" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="586" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="594" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="602" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="610" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="618" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="626" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="634" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="642" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="650" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="658" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="666" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="674" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="682" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="690" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="698" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="706" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="714" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="722" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="730" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="738" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="746" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="754" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="762" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="770" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="778" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="786" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="794" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="802" y="64" width="8" height="18" fill="#45475A" />
   <rect x="10" y="352" width="8" height="18" fill="#555555" />
   <rect x="18" y="352" width="8" height="18" fill="#555555" />
   <rect x="26" y="352" width="8" height="18" fill="#555555" />
@@ -112,27 +112,27 @@
   <rect x="82" y="352" width="8" height="18" fill="#555555" />
   <text x="10" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
   <text x="18" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
-  <text x="26" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
-  <text x="34" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
-  <text x="50" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
-  <text x="58" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
-  <text x="66" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
-  <text x="74" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="82" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
-  <text x="90" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
-  <text x="98" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
-  <text x="106" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
-  <text x="114" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
-  <text x="122" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
-  <text x="130" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="146" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
-  <text x="154" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
-  <text x="162" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="170" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
-  <text x="178" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
-  <text x="186" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
-  <text x="194" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
-  <text x="202" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="26" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="34" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="50" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="58" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="66" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="74" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="82" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="90" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="98" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="106" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="114" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="122" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="130" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="146" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="154" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="162" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="178" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="186" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="194" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="202" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
   <text x="218" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
   <text x="226" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
   <text x="234" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
@@ -148,95 +148,86 @@
   <text x="10" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
   <text x="18" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
   <text x="26" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
-  <text x="34" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
-  <text x="42" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="58" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
-  <text x="66" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
-  <text x="74" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
-  <text x="10" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="18" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">●</text>
-  <text x="50" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">9</text>
-  <text x="58" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">4</text>
-  <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
-  <text x="74" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
-  <text x="82" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="90" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
-  <text x="98" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
-  <text x="114" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="122" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="130" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="146" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
-  <text x="10" y="96" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="18" y="96" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
-  <text x="66" y="96" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="74" y="96" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="82" y="96" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">:</text>
-  <text x="90" y="96" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
-  <text x="98" y="96" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
-  <text x="114" y="96" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
-  <text x="130" y="96" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
-  <text x="10" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">├</text>
-  <text x="18" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
+  <text x="34" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="42" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="58" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="66" y="60" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="74" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="10" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">●</text>
+  <text x="50" y="78" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="58" y="78" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="74" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="82" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="90" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="98" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="114" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="122" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="130" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="146" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="10" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">├</text>
+  <text x="18" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
+  <text x="10" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
   <text x="10" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
+  <text x="26" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
+  <text x="34" y="132" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="42" y="132" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="58" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="66" y="132" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">B</text>
+  <text x="74" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
   <text x="10" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="18" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
-  <text x="26" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
-  <text x="34" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
-  <text x="42" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="58" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
-  <text x="66" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">B</text>
-  <text x="74" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
-  <text x="10" y="168" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="18" y="168" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">●</text>
-  <text x="50" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="58" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
-  <text x="66" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
-  <text x="74" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
-  <text x="82" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
-  <text x="90" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="98" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
-  <text x="114" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="122" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="130" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="146" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">B</text>
-  <text x="10" y="186" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">├</text>
-  <text x="18" y="186" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
-  <text x="10" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="10" y="222" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┴</text>
-  <text x="26" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="34" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="42" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
-  <text x="50" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
-  <text x="58" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
-  <text x="66" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
-  <text x="74" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
-  <text x="90" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
-  <text x="98" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
-  <text x="106" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
-  <text x="114" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
-  <text x="122" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
-  <text x="130" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
-  <text x="138" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
-  <text x="146" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
-  <text x="154" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
-  <text x="162" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="170" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
-  <text x="178" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
-  <text x="186" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
-  <text x="202" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
-  <text x="210" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="218" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="226" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="234" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
-  <text x="242" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="250" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
-  <text x="258" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
-  <text x="266" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="274" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
-  <text x="290" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="298" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="306" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="322" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
+  <text x="18" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">●</text>
+  <text x="50" y="150" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="58" y="150" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="66" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="74" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="82" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="90" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="98" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="114" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="122" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="130" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="146" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">B</text>
+  <text x="10" y="168" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">├</text>
+  <text x="18" y="168" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
+  <text x="10" y="186" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="10" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┴</text>
+  <text x="26" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="34" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="42" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="50" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="58" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
+  <text x="66" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="74" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="90" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="98" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="106" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="114" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="122" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="130" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="138" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="146" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="154" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="162" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="178" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="186" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="202" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="210" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="218" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="226" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="234" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="242" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="250" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="258" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="266" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="274" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="290" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="298" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="306" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="322" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
   <text x="10" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
   <text x="18" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
   <text x="26" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/esc_in_normal_mode_closes_global_file_list_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/esc_in_normal_mode_closes_global_file_list_final.svg
@@ -1,105 +1,105 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
   <rect x="0" y="0" width="820" height="380" fill="#000000" />
-  <rect x="10" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="18" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="26" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="34" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="42" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="50" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="58" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="66" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="74" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="82" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="90" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="98" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="106" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="114" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="122" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="130" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="138" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="146" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="154" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="162" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="170" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="178" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="186" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="194" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="202" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="210" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="218" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="226" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="234" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="242" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="250" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="258" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="266" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="274" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="282" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="290" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="298" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="306" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="314" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="322" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="330" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="338" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="346" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="354" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="362" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="370" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="378" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="386" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="394" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="402" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="410" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="418" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="426" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="434" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="442" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="450" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="458" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="466" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="474" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="482" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="490" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="498" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="506" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="514" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="522" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="530" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="538" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="546" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="554" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="562" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="570" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="578" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="586" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="594" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="602" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="610" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="618" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="626" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="634" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="642" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="650" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="658" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="666" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="674" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="682" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="690" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="698" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="706" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="714" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="722" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="730" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="738" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="746" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="754" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="762" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="770" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="778" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="786" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="794" y="82" width="8" height="18" fill="#45475A" />
-  <rect x="802" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="10" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="18" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="26" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="34" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="42" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="50" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="58" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="66" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="74" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="82" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="90" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="98" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="106" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="114" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="122" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="130" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="138" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="146" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="154" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="162" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="170" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="178" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="186" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="194" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="202" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="210" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="218" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="226" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="234" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="242" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="250" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="258" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="266" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="274" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="282" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="290" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="298" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="306" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="314" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="322" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="330" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="338" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="346" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="354" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="362" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="370" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="378" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="386" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="394" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="402" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="410" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="418" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="426" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="434" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="442" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="450" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="458" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="466" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="474" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="482" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="490" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="498" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="506" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="514" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="522" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="530" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="538" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="546" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="554" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="562" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="570" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="578" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="586" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="594" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="602" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="610" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="618" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="626" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="634" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="642" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="650" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="658" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="666" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="674" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="682" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="690" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="698" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="706" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="714" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="722" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="730" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="738" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="746" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="754" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="762" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="770" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="778" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="786" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="794" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="802" y="64" width="8" height="18" fill="#45475A" />
   <rect x="10" y="352" width="8" height="18" fill="#555555" />
   <rect x="18" y="352" width="8" height="18" fill="#555555" />
   <rect x="26" y="352" width="8" height="18" fill="#555555" />
@@ -153,8 +153,8 @@
   <text x="58" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
   <text x="66" y="60" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
   <text x="74" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
-  <text x="10" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="18" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">●</text>
+  <text x="10" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">●</text>
   <text x="50" y="78" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
   <text x="58" y="78" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
   <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
@@ -162,90 +162,72 @@
   <text x="82" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
   <text x="90" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
   <text x="98" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="114" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="122" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="130" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="146" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
-  <text x="10" y="96" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="18" y="96" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
-  <text x="66" y="96" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="74" y="96" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="82" y="96" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">:</text>
-  <text x="90" y="96" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
-  <text x="98" y="96" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
-  <text x="114" y="96" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
-  <text x="130" y="96" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
-  <text x="10" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">├</text>
-  <text x="18" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
+  <text x="114" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="122" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="130" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="146" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="10" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">├</text>
+  <text x="18" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
+  <text x="10" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
   <text x="10" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
+  <text x="26" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
+  <text x="34" y="132" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="42" y="132" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="58" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="66" y="132" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">B</text>
+  <text x="74" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
   <text x="10" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="18" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
-  <text x="26" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
-  <text x="34" y="150" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
-  <text x="42" y="150" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="58" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
-  <text x="66" y="150" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">B</text>
-  <text x="74" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
-  <text x="10" y="168" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="18" y="168" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">●</text>
-  <text x="50" y="168" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="58" y="168" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="66" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="74" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="82" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="90" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="98" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="114" y="168" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="122" y="168" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="130" y="168" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="146" y="168" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">B</text>
+  <text x="18" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">●</text>
+  <text x="50" y="150" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="58" y="150" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="66" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="74" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="82" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="90" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="98" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="114" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="122" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="130" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="146" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">B</text>
+  <text x="10" y="168" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">├</text>
+  <text x="18" y="168" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
   <text x="10" y="186" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="18" y="186" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
-  <text x="66" y="186" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="74" y="186" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="82" y="186" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">:</text>
-  <text x="90" y="186" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
-  <text x="98" y="186" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
-  <text x="114" y="186" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
-  <text x="130" y="186" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">B</text>
-  <text x="10" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">├</text>
-  <text x="18" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
-  <text x="10" y="222" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="10" y="240" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┴</text>
-  <text x="26" y="240" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="34" y="240" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="42" y="240" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
-  <text x="50" y="240" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
-  <text x="58" y="240" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
-  <text x="66" y="240" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
-  <text x="74" y="240" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
-  <text x="90" y="240" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
-  <text x="98" y="240" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
-  <text x="106" y="240" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
-  <text x="114" y="240" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
-  <text x="122" y="240" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
-  <text x="130" y="240" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
-  <text x="138" y="240" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
-  <text x="146" y="240" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
-  <text x="154" y="240" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
-  <text x="162" y="240" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="170" y="240" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
-  <text x="178" y="240" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
-  <text x="186" y="240" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
-  <text x="202" y="240" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
-  <text x="210" y="240" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="218" y="240" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="226" y="240" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="234" y="240" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
-  <text x="242" y="240" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="250" y="240" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
-  <text x="258" y="240" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
-  <text x="266" y="240" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="274" y="240" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
-  <text x="290" y="240" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="298" y="240" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="306" y="240" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="322" y="240" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
+  <text x="10" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┴</text>
+  <text x="26" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="34" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="42" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="50" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="58" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
+  <text x="66" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="74" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="90" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="98" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="106" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="114" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="122" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="130" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="138" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="146" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="154" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="162" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="178" y="204" style="fill:#AA00AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="186" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="202" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="210" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="218" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="226" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="234" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="242" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="250" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="258" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="266" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="274" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="290" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="298" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="306" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="322" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
   <text x="10" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
   <text x="18" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
   <text x="26" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>


### PR DESCRIPTION
Previously managing what happened when you pressed escape was pretty messy.
There was a hardcoded list of order in which it should back out of things.
However now that we've introduced marking I wanted to take time to refactor
this.

This PR introduces a "backstack" in the TUI where we push an entry when you
enter some state such as a non-normal mode, open the file list, or mark
something.

When you then press escape we pop the stack and undo the entry. Thus if you
show the file list and enter rubbing pressing escape will first leave rub mode
and then close the file list.