### PR TITLE
tui: hide "reword with editor" from hotbar

### DIFF
--- a/crates/but/src/command/legacy/status/tui/key_bind/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/key_bind/mod.rs
@@ -568,6 +568,7 @@ impl KeyBindsBuilder<'_> {
             Message::Reword(RewordMessage::WithEditor),
         )
         .long_description("Reword commit with the configured editor")
+        .hide_from_hotbar()
     }
 
     fn files(&mut self) -> KeyBindsInModesBuilder<'_> {


### PR DESCRIPTION
Just a small hotbar clean up. Don't think we need to show "reword with editor".
I imagine most people will reword using "space".