### PR TITLE
remove `--prune` from `git fetch` to avoid side-effects with read-only filesystems (#13645)

### DIFF
--- a/crates/gitbutler-git/src/repository.rs
+++ b/crates/gitbutler-git/src/repository.rs
@@ -395,7 +395,7 @@ where
     F: FnMut(String) -> Fut,
     Fut: std::future::Future<Output = Option<String>>,
 {
-    let mut args = vec!["fetch", "--quiet", "--prune"];
+    let mut args = vec!["fetch", "--quiet"];
 
     let refspec = refspec.to_string();
 

--- a/e2e/playwright/tests/branches.spec.ts
+++ b/e2e/playwright/tests/branches.spec.ts
@@ -540,7 +540,9 @@ test("should update the stale selection of an unexisting branch", async ({
 	// We don't prune anymore, hence 3 branches are still present.
 	await expect(branchListCards).toHaveCount(3);
 	firstBranchCard = branchListCards.filter({ hasText: "branch1" });
-	await expect(firstBranchCard).not.toBeVisible();
+	await expect(firstBranchCard).toBeVisible();
+	await expect(firstBranchCard).not.toHaveClass(/\bselected\b/);
+	await expect(getByTestId(page, "current-origin-list-card")).toHaveClass(/\bselected\b/);
 });
 
 test("should be able to delete a local branch", async ({ page, context }, testInfo) => {

--- a/e2e/playwright/tests/branches.spec.ts
+++ b/e2e/playwright/tests/branches.spec.ts
@@ -537,7 +537,8 @@ test("should update the stale selection of an unexisting branch", async ({
 	await expect(header).toContainText("origin/master");
 	// The previously selected branch1 should not be selected anymore
 	branchListCards = getByTestId(page, "branch-list-card");
-	await expect(branchListCards).toHaveCount(2);
+	// We don't prune anymore, hence 3 branches are still present.
+	await expect(branchListCards).toHaveCount(3);
 	firstBranchCard = branchListCards.filter({ hasText: "branch1" });
 	await expect(firstBranchCard).not.toBeVisible();
 });


### PR DESCRIPTION
When a ref `refs/heads/head` exists on the remote, it creates ambiguity with the equally present `refs/remotes/origin/HEAD` when fetching to a local clone. If the remote `HEAD` points to `refs/heads/main` and we have a packed-refs file on a case-sensitive filesystem that looks like

```
    # pack-refs with: peeled fully-peeled sorted
   c30c646d31032f05ad62e5d2a967298c33df0f6f refs/remotes/origin/head
   c30c646d31032f05ad62e5d2a967298c33df0f6f refs/remotes/origin/main
```

Then `--prune` will *somehow* complain about `origin/head` and completely remove `origin/main` from packed-refs.

So removing `--prune` fixes this, but it will also leave the remote-ref cleanup to the users.

Separating this into specific on-demand maintenance seems like a good idea.

Note that with ref-tables, this will not be an issue, but in general, auto-pruning as an operation that removes refs that the user might expect seems to be something to avoid as well.

Fixes #13645.
