### PR TITLE
tui: fix not creating snapshot when rewording commit

### DIFF
--- a/crates/but/src/command/legacy/status/tui/operations.rs
+++ b/crates/but/src/command/legacy/status/tui/operations.rs
@@ -220,14 +220,9 @@ pub(super) fn reword_commit_with_editor_with_message_legacy(
         return Ok(None);
     }
 
-    but_api::commit::reword::commit_reword_only(
-        ctx,
-        commit_id,
-        BString::from(new_message),
-        DryRun::No,
-    )
-    .with_context(|| format!("failed to reword {}", commit_id.to_hex_with_len(7)))
-    .map(Some)
+    but_api::commit::reword::commit_reword(ctx, commit_id, BString::from(new_message), DryRun::No)
+        .with_context(|| format!("failed to reword {}", commit_id.to_hex_with_len(7)))
+        .map(Some)
 }
 
 pub(super) fn current_commit_message(
@@ -256,14 +251,9 @@ pub(super) fn reword_commit_legacy(
         return Ok(None);
     }
 
-    but_api::commit::reword::commit_reword_only(
-        ctx,
-        commit_id,
-        BString::from(new_message),
-        DryRun::No,
-    )
-    .with_context(|| format!("failed to reword {}", commit_id.to_hex_with_len(7)))
-    .map(Some)
+    but_api::commit::reword::commit_reword(ctx, commit_id, BString::from(new_message), DryRun::No)
+        .with_context(|| format!("failed to reword {}", commit_id.to_hex_with_len(7)))
+        .map(Some)
 }
 
 pub(super) fn move_commit_to_branch(

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/undo_opens_confirm_for_latest_snapshot_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/undo_opens_confirm_for_latest_snapshot_001.svg
@@ -325,12 +325,12 @@
   <text x="514" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
   <text x="522" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
   <text x="530" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="546" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">C</text>
-  <text x="554" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">O</text>
-  <text x="562" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
-  <text x="570" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
-  <text x="578" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">I</text>
-  <text x="586" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">T</text>
+  <text x="546" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">R</text>
+  <text x="554" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">E</text>
+  <text x="562" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">W</text>
+  <text x="570" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">O</text>
+  <text x="578" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">R</text>
+  <text x="586" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">D</text>
   <text x="594" y="186" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">?</text>
   <text x="650" y="186" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
   <text x="170" y="204" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/undo_opens_confirm_for_latest_snapshot_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/undo_opens_confirm_for_latest_snapshot_002.svg
@@ -133,27 +133,52 @@
   <text x="186" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
   <text x="194" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
   <text x="202" y="24" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="218" y="24" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
+  <text x="226" y="24" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="234" y="24" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="250" y="24" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="258" y="24" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="266" y="24" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="274" y="24" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="282" y="24" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="290" y="24" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="298" y="24" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="306" y="24" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
   <text x="10" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="42" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">v</text>
-  <text x="50" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
-  <text x="66" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
-  <text x="82" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
-  <text x="90" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
-  <text x="98" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
-  <text x="106" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
-  <text x="114" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">.</text>
-  <text x="122" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
-  <text x="130" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">x</text>
-  <text x="138" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
   <text x="10" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
+  <text x="26" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
+  <text x="34" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="42" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="58" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="66" y="60" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="74" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
   <text x="10" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="18" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
-  <text x="26" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
-  <text x="34" y="78" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
-  <text x="42" y="78" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="58" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
-  <text x="66" y="78" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
-  <text x="74" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="18" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">●</text>
+  <text x="50" y="78" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="58" y="78" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="74" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="82" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="90" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="98" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="114" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
+  <text x="122" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="130" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="146" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="154" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="162" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="170" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="178" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="186" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="202" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="210" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="218" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="226" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="234" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="242" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="250" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="258" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
   <text x="10" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
   <text x="18" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">●</text>
   <text x="50" y="96" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>


### PR DESCRIPTION
Not sure why we used the `*_only` versions but that was certainly a bug.