### PR TITLE
lite: add various Electron hardening fixes

### DIFF
--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -508,4 +508,10 @@ app.on("web-contents-created", (_, contents) => {
 		console.error(`Blocked opening new window for ${url}`);
 		return { action: "deny" };
 	});
+
+	contents.on("will-attach-webview", (event, webPreferences, _) => {
+		// oxlint-disable-next-line no-console
+		console.error(`Blocked attaching webview ${JSON.stringify(webPreferences)}`);
+		event.preventDefault();
+	});
 });

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -456,3 +456,11 @@ app.on("window-all-closed", () => {
 	WatcherManager.getInstance().destroy();
 	if (process.platform !== "darwin") app.quit();
 });
+
+app.on("web-contents-created", (_, contents) => {
+	contents.on("will-navigate", (event, navigationUrl) => {
+		// oxlint-disable-next-line no-console
+		console.error(`Blocked navigation to ${navigationUrl}`);
+		event.preventDefault();
+	});
+});

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -79,6 +79,30 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 const currentFilePath = fileURLToPath(import.meta.url);
 const currentDirPath = path.dirname(currentFilePath);
 
+// Permissions in this array are allowed by default for trusted origins, without prompting the user for input.
+const trustedOriginDefaultPermissions: Array<
+	| "clipboard-read"
+	| "clipboard-sanitized-write"
+	| "display-capture"
+	| "fullscreen"
+	| "geolocation"
+	| "idle-detection"
+	| "media"
+	| "mediaKeySystem"
+	| "midi"
+	| "midiSysex"
+	| "notifications"
+	| "pointerLock"
+	| "keyboardLock"
+	| "openExternal"
+	| "speaker-selection"
+	| "storage-access"
+	| "top-level-storage-access"
+	| "window-management"
+	| "unknown"
+	| "fileSystem"
+> = ["clipboard-sanitized-write"] as const;
+
 const liteProtocolScheme = "lite";
 const liteProtocolHost = "app";
 const contentRootURL = pathToFileURL(path.join(currentDirPath, "../ui"));
@@ -478,6 +502,16 @@ void app.whenReady().then(async () => {
 			});
 		});
 	}
+
+	session.defaultSession.setPermissionRequestHandler((webContents, permission, callback) => {
+		const url = newUrlOrNull(webContents.getURL());
+		if (isTrustedLocalOrigin(url) && trustedOriginDefaultPermissions.includes(permission))
+			return callback(true);
+
+		// oxlint-disable-next-line no-console
+		console.error(`Blocked permission request for ${permission} from ${url?.href ?? "<unknown>"}`);
+		return callback(false);
+	});
 
 	registerIpcHandlers();
 	await createMainWindow();

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -463,4 +463,10 @@ app.on("web-contents-created", (_, contents) => {
 		console.error(`Blocked navigation to ${navigationUrl}`);
 		event.preventDefault();
 	});
+
+	contents.setWindowOpenHandler(({ url }) => {
+		// oxlint-disable-next-line no-console
+		console.error(`Blocked opening new window for ${url}`);
+		return { action: "deny" };
+	});
 });

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -177,72 +177,110 @@ const buildNativeMenuTemplate = (
 		};
 	});
 
+// Returns true if the `url` is from an origin we trust to perform privileged actions such as executing IPC commands.
+const isTrustedLocalOrigin = (url: URL | null) =>
+	url !== null &&
+	(app.isPackaged
+		? url.protocol === `${liteProtocolScheme}:` && url.host === liteProtocolHost
+		: url.protocol === "http:" && url.host === "127.0.0.1:5173");
+
+const newUrlOrNull = (url: string): URL | null => {
+	try {
+		return new URL(url);
+	} catch {
+		return null;
+	}
+};
+
 const registerIpcHandlers = (): void => {
-	ipcMain.handle(
+	const senderValidatingHandle: typeof ipcMain.handle = (channel, listener) => {
+		const senderValidatingListener: typeof listener = (event, ...args) => {
+			// Validate that the frame is from a trusted origin. This is crucial to prevent unauthorized
+			// access to the IPC bridge if we ever render non-local content.
+			//
+			// See https://www.electronjs.org/docs/latest/tutorial/security#17-validate-the-sender-of-all-ipc-messages
+			const isSenderFrameTrusted =
+				event.senderFrame !== null && isTrustedLocalOrigin(newUrlOrNull(event.senderFrame.url));
+			if (isSenderFrameTrusted)
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-argument @typescript-eslint/no-unsafe-return
+				return listener(event, ...args);
+
+			// oxlint-disable-next-line no-console
+			console.error(`Rejecting untrusted sender frame ${event.senderFrame?.url ?? "<unknown>"}`);
+			return null;
+		};
+
+		ipcMain.handle(channel, senderValidatingListener);
+	};
+
+	senderValidatingHandle(
 		liteIpcChannels.absorptionPlan,
 		(_e, { projectId, target }: AbsorptionPlanParams) => absorptionPlan(projectId, target),
 	);
-	ipcMain.handle(liteIpcChannels.absorb, (_e, { projectId, absorptionPlan }: AbsorbParams) =>
-		absorb(projectId, absorptionPlan),
+	senderValidatingHandle(
+		liteIpcChannels.absorb,
+		(_e, { projectId, absorptionPlan }: AbsorbParams) => absorb(projectId, absorptionPlan),
 	);
-	ipcMain.handle(liteIpcChannels.apply, (_e, { projectId, existingBranch }: ApplyParams) =>
+	senderValidatingHandle(liteIpcChannels.apply, (_e, { projectId, existingBranch }: ApplyParams) =>
 		apply(projectId, existingBranch),
 	);
-	ipcMain.handle(liteIpcChannels.assignHunk, (_e, { projectId, assignments }: AssignHunkParams) =>
-		assignHunk(projectId, assignments),
+	senderValidatingHandle(
+		liteIpcChannels.assignHunk,
+		(_e, { projectId, assignments }: AssignHunkParams) => assignHunk(projectId, assignments),
 	);
-	ipcMain.handle(
+	senderValidatingHandle(
 		liteIpcChannels.branchDetails,
 		(_e, { projectId, branchName, remote }: BranchDetailsParams) =>
 			branchDetails(projectId, branchName, remote),
 	);
-	ipcMain.handle(liteIpcChannels.branchDiff, (_e, { projectId, branch }: BranchDiffParams) =>
-		branchDiff(projectId, branch),
+	senderValidatingHandle(
+		liteIpcChannels.branchDiff,
+		(_e, { projectId, branch }: BranchDiffParams) => branchDiff(projectId, branch),
 	);
-	ipcMain.handle(liteIpcChannels.changesInWorktree, (_e, projectId: string) =>
+	senderValidatingHandle(liteIpcChannels.changesInWorktree, (_e, projectId: string) =>
 		changesInWorktree(projectId),
 	);
-	ipcMain.handle(
+	senderValidatingHandle(
 		liteIpcChannels.commitAmend,
 		(_e, { projectId, commitId, changes, dryRun }: CommitAmendParams) =>
 			commitAmend(projectId, commitId, changes, dryRun),
 	);
-	ipcMain.handle(
+	senderValidatingHandle(
 		liteIpcChannels.commitCreate,
 		(_e, { projectId, relativeTo, side, changes, message, dryRun }: CommitCreateParams) =>
 			commitCreate(projectId, relativeTo, side, changes, message, dryRun),
 	);
-	ipcMain.handle(
+	senderValidatingHandle(
 		liteIpcChannels.commitDiscard,
 		(_e, { projectId, subjectCommitId, dryRun }: CommitDiscardParams) =>
 			commitDiscard(projectId, subjectCommitId, dryRun),
 	);
-	ipcMain.handle(
+	senderValidatingHandle(
 		liteIpcChannels.commitDetailsWithLineStats,
 		(_e, { projectId, commitId }: CommitDetailsWithLineStatsParams) =>
 			commitDetailsWithLineStats(projectId, commitId),
 	);
-	ipcMain.handle(
+	senderValidatingHandle(
 		liteIpcChannels.commitInsertBlank,
 		(_e, { projectId, relativeTo, side, dryRun }: CommitInsertBlankParams) =>
 			commitInsertBlank(projectId, relativeTo, side, dryRun),
 	);
-	ipcMain.handle(
+	senderValidatingHandle(
 		liteIpcChannels.commitMove,
 		(_e, { projectId, subjectCommitIds, relativeTo, side, dryRun }: CommitMoveParams) =>
 			commitMove(projectId, subjectCommitIds, relativeTo, side, dryRun),
 	);
-	ipcMain.handle(
+	senderValidatingHandle(
 		liteIpcChannels.commitSquash,
 		(_e, { projectId, sourceCommitIds, destinationCommitId, dryRun }: CommitSquashParams) =>
 			commitSquash(projectId, sourceCommitIds, destinationCommitId, "KeepBoth", dryRun),
 	);
-	ipcMain.handle(
+	senderValidatingHandle(
 		liteIpcChannels.commitReword,
 		(_e, { projectId, commitId, message, dryRun }: CommitRewordParams) =>
 			commitReword(projectId, commitId, message, dryRun),
 	);
-	ipcMain.handle(
+	senderValidatingHandle(
 		liteIpcChannels.commitMoveChangesBetween,
 		(
 			_e,
@@ -255,47 +293,47 @@ const registerIpcHandlers = (): void => {
 			}: CommitMoveChangesBetweenParams,
 		) => commitMoveChangesBetween(projectId, sourceCommitId, destinationCommitId, changes, dryRun),
 	);
-	ipcMain.handle(
+	senderValidatingHandle(
 		liteIpcChannels.commitUncommit,
 		(_e, { projectId, subjectCommitIds: commitIds, assignTo, dryRun }: CommitUncommitParams) =>
 			commitUncommit(projectId, commitIds, assignTo, dryRun),
 	);
-	ipcMain.handle(
+	senderValidatingHandle(
 		liteIpcChannels.commitUncommitChanges,
 		(_e, { projectId, commitId, changes, assignTo, dryRun }: CommitUncommitChangesParams) =>
 			commitUncommitChanges(projectId, commitId, changes, assignTo, dryRun),
 	);
-	ipcMain.handle(liteIpcChannels.getVersion, () => Promise.resolve(app.getVersion()));
-	ipcMain.handle(liteIpcChannels.headInfo, (_e, projectId: string) => headInfo(projectId));
-	ipcMain.handle(
+	senderValidatingHandle(liteIpcChannels.getVersion, () => Promise.resolve(app.getVersion()));
+	senderValidatingHandle(liteIpcChannels.headInfo, (_e, projectId: string) => headInfo(projectId));
+	senderValidatingHandle(
 		liteIpcChannels.listBranches,
 		(_e, projectId: string, filter: BranchListingFilter | null) => listBranches(projectId, filter),
 	);
-	ipcMain.handle(liteIpcChannels.listProjects, () => listProjectsStateless());
-	ipcMain.handle(
+	senderValidatingHandle(liteIpcChannels.listProjects, () => listProjectsStateless());
+	senderValidatingHandle(
 		liteIpcChannels.moveBranch,
 		(_e, { projectId, subjectBranch, targetBranch, dryRun }: MoveBranchParams) =>
 			moveBranch(projectId, subjectBranch, targetBranch, dryRun),
 	);
-	ipcMain.handle(
+	senderValidatingHandle(
 		liteIpcChannels.updateBranchName,
 		(_e, { projectId, stackId, branchName, newName }: UpdateBranchNameParams) =>
 			updateBranchName(projectId, stackId, branchName, newName),
 	);
-	ipcMain.handle(
+	senderValidatingHandle(
 		liteIpcChannels.tearOffBranch,
 		(_e, { projectId, subjectBranch, dryRun }: TearOffBranchParams) =>
 			tearOffBranch(projectId, subjectBranch, dryRun),
 	);
-	ipcMain.handle(liteIpcChannels.ping, (_event, input: string) =>
+	senderValidatingHandle(liteIpcChannels.ping, (_event, input: string) =>
 		Promise.resolve(`pong: ${input}`),
 	);
-	ipcMain.handle(
+	senderValidatingHandle(
 		liteIpcChannels.pushStackLegacy,
 		(_e, { projectId, stackId, branch }: PushStackLegacyParams) =>
 			pushStackLegacy(projectId, stackId, false, false, branch, true),
 	);
-	ipcMain.handle(
+	senderValidatingHandle(
 		liteIpcChannels.showNativeMenu,
 		async (event, { items, position }: ShowNativeMenuParams) => {
 			const window = BrowserWindow.fromWebContents(event.sender);
@@ -320,24 +358,25 @@ const registerIpcHandlers = (): void => {
 			return selectedItemId;
 		},
 	);
-	ipcMain.handle(
+	senderValidatingHandle(
 		liteIpcChannels.treeChangeDiffs,
 		(_e, { projectId, change }: TreeChangeDiffParams) => treeChangeDiffs(projectId, change),
 	);
-	ipcMain.handle(liteIpcChannels.unapplyStack, (_e, { projectId, stackId }: UnapplyStackParams) =>
-		unapplyStack(projectId, stackId),
+	senderValidatingHandle(
+		liteIpcChannels.unapplyStack,
+		(_e, { projectId, stackId }: UnapplyStackParams) => unapplyStack(projectId, stackId),
 	);
-	ipcMain.handle(
+	senderValidatingHandle(
 		liteIpcChannels.watcherSubscribe,
 		async (event, { projectId }: WatcherSubscribeParams) =>
 			WatcherManager.getInstance().subscribeToProject(projectId, event),
 	);
-	ipcMain.handle(
+	senderValidatingHandle(
 		liteIpcChannels.watcherUnsubscribe,
 		(_e, { subscriptionId }: WatcherUnsubscribeParams) =>
 			WatcherManager.getInstance().removeSubscription(subscriptionId),
 	);
-	ipcMain.handle(liteIpcChannels.watcherStopAll, () =>
+	senderValidatingHandle(liteIpcChannels.watcherStopAll, () =>
 		WatcherManager.getInstance().stopAllWatchersForShutdown(),
 	);
 };

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -67,6 +67,7 @@ import {
 	Menu,
 	net,
 	protocol,
+	session,
 	type MenuItemConstructorOptions,
 } from "electron";
 import { REACT_DEVELOPER_TOOLS, installExtension } from "electron-devtools-installer";
@@ -368,13 +369,78 @@ const createMainWindow = async (): Promise<void> => {
 
 app.enableSandbox(); // forces sandboxing for all renderers, even if they try to launch without
 void app.whenReady().then(async () => {
-	if (!app.isPackaged) await installExtension(REACT_DEVELOPER_TOOLS);
-	if (process.platform === "darwin" && !app.isPackaged) {
-		const dockIcon = getMacDockIcon();
-		if (dockIcon !== undefined && app.dock) app.dock.setIcon(dockIcon);
+	if (app.isPackaged) {
+		registerLiteProtocolHandler();
+
+		// Basic non-Strict CSP based on https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html#basic-non-strict-csp-policy
+		const productionCsp =
+			"default-src 'none';" +
+			"script-src 'self' 'wasm-unsafe-eval';" +
+			// Hash is for inline style in index.html
+			"style-src 'self' 'sha256-XBXaUBQCe+0UGd1QCfoPFCc7UsLKd8xrn9oXNYqjFog=';" +
+			// react-resizable-panels has inline styles in elements. `style-src-attr 'unsafe-inline'` is slightly more narrow
+			// than just `style-src 'unsafe-inline'`, but we should still try to get rid of this.
+			"style-src-attr 'unsafe-inline';" +
+			"font-src 'self';" +
+			"connect-src 'self';" +
+			"object-src 'none';" +
+			"base-uri 'none';" +
+			"frame-ancestors 'none';" +
+			"form-action 'none';" +
+			"img-src 'self' data:;" +
+			"worker-src 'self';";
+
+		session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+			callback({
+				responseHeaders: {
+					...details.responseHeaders,
+					"Content-Security-Policy": [productionCsp],
+				},
+			});
+		});
+	} else {
+		await installExtension(REACT_DEVELOPER_TOOLS);
+
+		if (process.platform === "darwin") {
+			const dockIcon = getMacDockIcon();
+			if (dockIcon !== undefined && app.dock) app.dock.setIcon(dockIcon);
+		}
+
+		// Loose dev CSP to allow for hot reload and development tools. This could be tightened with
+		// nonce-based CSP instead of using unsafe-inline, but it's just not worth the hassle right now.
+		const developmentCsp =
+			"default-src 'none';" +
+			// unsafe-inline necessary for HMR. Potentially fixable with nonce-based Strict CSP.
+			"script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval';" +
+			// unsafe-inline necessary for HMR. Potentially fixable with nonce-based Strict CSP.
+			"style-src 'self' 'unsafe-inline';" +
+			"font-src 'self';" +
+			// ws source for HMR
+			"connect-src 'self' ws://127.0.0.1:5173;" +
+			"object-src 'none';" +
+			"base-uri 'none';" +
+			"frame-ancestors 'none';" +
+			"form-action 'none';" +
+			"img-src 'self' data:;" +
+			"worker-src 'self';";
+
+		session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+			// Skip extensions, or React dev tools don't work
+			if (details.url.startsWith("chrome-extension://")) {
+				callback({ responseHeaders: details.responseHeaders });
+				return;
+			}
+
+			callback({
+				responseHeaders: {
+					...details.responseHeaders,
+					"Content-Security-Policy": [developmentCsp],
+				},
+			});
+		});
 	}
+
 	registerIpcHandlers();
-	registerLiteProtocolHandler();
 	await createMainWindow();
 
 	app.on("activate", () => {

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -366,6 +366,7 @@ const createMainWindow = async (): Promise<void> => {
 	checkForUpdates();
 };
 
+app.enableSandbox(); // forces sandboxing for all renderers, even if they try to launch without
 void app.whenReady().then(async () => {
 	if (!app.isPackaged) await installExtension(REACT_DEVELOPER_TOOLS);
 	if (process.platform === "darwin" && !app.isPackaged) {

--- a/apps/lite/package.json
+++ b/apps/lite/package.json
@@ -27,6 +27,16 @@
 	},
 	"build": {
 		"appId": "com.gitbutler.lite",
+		"electronFuses": {
+			"runAsNode": false,
+			"enableCookieEncryption": true,
+			"enableNodeOptionsEnvironmentVariable": false,
+			"enableNodeCliInspectArguments": false,
+			"enableEmbeddedAsarIntegrityValidation": true,
+			"onlyLoadAppFromAsar": true,
+			"loadBrowserProcessSpecificV8Snapshot": false,
+			"grantFileProtocolExtraPrivileges": false
+		},
 		"publish": {
 			"provider": "s3",
 			"region": "us-east-1",


### PR DESCRIPTION
## 🧢 Changes
Adds a slew of security fixes from the [Electron security checklist](https://www.electronjs.org/docs/latest/tutorial/security#17-validate-the-sender-of-all-ipc-messages).

I've taken the stance of disabling pretty much everything we don't use. When we get to a point where we do want to use any of the disabled features, we'll intentionally enable them as we go.

Every commit in this PR is a standalone fix that could be merged independently of all of the others, but as everything is related to app startup I decided to keep it all in this one PR. See the individual commits for details.