### PR TITLE
but: support undoing commit rewording

### DIFF
--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -194,7 +194,7 @@ fn edit_commit_message_by_id_and_reword_commit(
     .filter(|new_message| should_update_commit_message(&current_message, new_message));
 
     if let Some(new_message) = new_message {
-        let new_commit_oid = but_api::commit::reword::commit_reword_only_with_perm(
+        let new_commit_oid = but_api::commit::reword::commit_reword_with_perm(
             ctx,
             commit_oid,
             BString::from(new_message),

--- a/crates/but/tests/but/command/reword.rs
+++ b/crates/but/tests/but/command/reword.rs
@@ -23,10 +23,10 @@ Updated commit message for [..] (now [..])
 
 "#]]);
 
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log()?, @"
     * 0bd57a4 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 2f7c570 (A) Updated commit message
-    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
     ");
 
     Ok(())
@@ -53,10 +53,10 @@ Updated commit message for [..] (now [..])
 "#]]);
 
     // Verify the commit message was updated with multiline content
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log()?, @"
     * 5996541 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * cdf2c74 (A) First line
-    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
     ");
 
     let repo = env.open_repo()?;

--- a/crates/but/tests/but/command/undo.rs
+++ b/crates/but/tests/but/command/undo.rs
@@ -138,9 +138,26 @@ fn can_undo_clean_apply() -> anyhow::Result<()> {
             .stderr_eq("");
 
         Ok(())
-    };
+    })?;
 
-    run_mutate_undo_roundtrip_test(&env, mutate)?;
+    Ok(())
+}
+
+#[test]
+fn can_undo_rewording_commit() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits")?;
+    env.setup_metadata(&["A"])?;
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but("reword")
+            .args(["9ac4652", "-m", "reworded"])
+            .assert()
+            .success()
+            .stdout_eq("Updated commit message for [..] (now [..])\n")
+            .stderr_eq("");
+
+        Ok(())
+    })?;
 
     Ok(())
 }

--- a/crates/but/tests/but/command/undo.rs
+++ b/crates/but/tests/but/command/undo.rs
@@ -8,8 +8,27 @@ where
 {
     // Arrange
     let status_output_before = env.but("status").output()?;
+
+    {
+        eprintln!("Status before mutation:");
+        let output = String::from_utf8(status_output_before.stdout.clone()).unwrap();
+        for line in output.lines() {
+            eprintln!("    {line}");
+        }
+    }
+
     mutate(env)?;
     let status_output_after_mutate = env.but("status").output()?;
+
+    {
+        eprintln!();
+        eprintln!("Status after mutation:");
+        let output = String::from_utf8(status_output_after_mutate.stdout.clone()).unwrap();
+        for line in output.lines() {
+            eprintln!("    {line}");
+        }
+    }
+
     assert_ne!(
         status_output_before, status_output_after_mutate,
         "mutate must visibly change state"
@@ -40,7 +59,7 @@ fn can_undo_discard() -> anyhow::Result<()> {
     let path = "new-file.txt";
     env.file(path, "content");
 
-    let mutate = |env: &Sandbox| -> anyhow::Result<()> {
+    run_mutate_undo_roundtrip_test(&env, |env| {
         env.but("discard")
             .arg(path)
             .assert()
@@ -49,9 +68,7 @@ fn can_undo_discard() -> anyhow::Result<()> {
             .stderr_eq("");
 
         Ok(())
-    };
-
-    run_mutate_undo_roundtrip_test(&env, mutate)?;
+    })?;
 
     Ok(())
 }
@@ -63,7 +80,7 @@ fn can_undo_commit() -> anyhow::Result<()> {
     let path = "new-file.txt";
     env.file(path, "content");
 
-    let mutate = |env: &Sandbox| -> anyhow::Result<()> {
+    run_mutate_undo_roundtrip_test(&env, |env| {
         env.file("new-file.txt", "content");
 
         env.but("commit -m 'Add file'")
@@ -73,9 +90,7 @@ fn can_undo_commit() -> anyhow::Result<()> {
             .stderr_eq("");
 
         Ok(())
-    };
-
-    run_mutate_undo_roundtrip_test(&env, mutate)?;
+    })?;
 
     Ok(())
 }
@@ -85,7 +100,7 @@ fn can_undo_rubbing_commits() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits")?;
     env.setup_metadata(&["A"])?;
 
-    let mutate = |env: &Sandbox| -> anyhow::Result<()> {
+    run_mutate_undo_roundtrip_test(&env, |env| {
         env.but("rub")
             .arg("9a")
             .arg("fe")
@@ -95,9 +110,7 @@ fn can_undo_rubbing_commits() -> anyhow::Result<()> {
             .stderr_eq("");
 
         Ok(())
-    };
-
-    run_mutate_undo_roundtrip_test(&env, mutate)?;
+    })?;
 
     Ok(())
 }
@@ -108,7 +121,7 @@ fn can_undo_unapply() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
     env.setup_metadata(&["A"])?;
 
-    let mutate = |env: &Sandbox| -> anyhow::Result<()> {
+    run_mutate_undo_roundtrip_test(&env, |env| {
         env.but("unapply A")
             .assert()
             .success()
@@ -116,9 +129,7 @@ fn can_undo_unapply() -> anyhow::Result<()> {
             .stderr_eq("");
 
         Ok(())
-    };
-
-    run_mutate_undo_roundtrip_test(&env, mutate)?;
+    })?;
 
     Ok(())
 }
@@ -130,7 +141,7 @@ fn can_undo_clean_apply() -> anyhow::Result<()> {
     env.setup_metadata(&["A"])?;
     env.but("unapply A").assert().success();
 
-    let mutate = |env: &Sandbox| -> anyhow::Result<()> {
+    run_mutate_undo_roundtrip_test(&env, |env| {
         env.but("apply A")
             .assert()
             .success()


### PR DESCRIPTION
For some reason we didn't create an oplog entry when rewording commits. This fixes that and adds a test.