### PR TITLE
add tests for undoing all rub operations

### DIFF
--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -231,6 +231,8 @@ pub(crate) struct CommittedFileToUnassignedOperation<'a> {
 
 /// Represents the operation to perform for a given source and target combination.
 /// This enum serves as the single source of truth for valid rub operations.
+// NOTE: Remember to update crates/but/tests/but/command/undo/undo_rub.rs with an undo test when
+// adding new operations
 #[derive(Debug, strum::EnumDiscriminants)]
 pub(crate) enum RubOperation<'a> {
     UnassignUncommitted(UnassignUncommittedOperation<'a>),

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -113,6 +113,56 @@ mod util {
         serde_json::from_slice(&output.stdout).context("status output should be valid JSON")
     }
 
+    /// Return `but status -f` JSON output as a parsed value.
+    pub fn status_json_with_files(env: &Sandbox) -> anyhow::Result<serde_json::Value> {
+        let output = env.but("--json status -f").allow_json().output()?;
+        serde_json::from_slice(&output.stdout).context("status output should be valid JSON")
+    }
+
+    /// Return the CLI ids for all commits on `branch_name` in `status` output.
+    pub fn branch_commit_ids(status: &serde_json::Value, branch_name: &str) -> Vec<String> {
+        status["stacks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .flat_map(|stack| stack["branches"].as_array().unwrap().iter())
+            .find(|branch| branch["name"].as_str().unwrap() == branch_name)
+            .unwrap()["commits"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|commit| commit["cliId"].as_str().unwrap().to_string())
+            .collect()
+    }
+
+    /// Return the CLI id of the commit on `branch_name` containing `file_path` in `status` output.
+    pub fn branch_commit_id_for_file(
+        status: &serde_json::Value,
+        branch_name: &str,
+        file_path: &str,
+    ) -> Option<String> {
+        status["stacks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .flat_map(|stack| stack["branches"].as_array().unwrap().iter())
+            .find(|branch| branch["name"].as_str().unwrap() == branch_name)
+            .and_then(|branch| {
+                branch["commits"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .find_map(|commit| {
+                        let has_file = commit["changes"]
+                            .as_array()
+                            .unwrap()
+                            .iter()
+                            .any(|change| change["filePath"].as_str().unwrap() == file_path);
+                        has_file.then(|| commit["cliId"].as_str().unwrap().to_string())
+                    })
+            })
+    }
+
     /// Build an isolated `std::process::Command` for `but` with the same environment as the Sandbox.
     pub fn but_std_cmd(env: &Sandbox, args: &str) -> std::process::Command {
         let mut cmd = std::process::Command::new(snapbox::cmd::cargo_bin!("but"));

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -2,7 +2,9 @@ use snapbox::str;
 
 use crate::{
     command::util::{
+        branch_commit_id_for_file, branch_commit_ids,
         commit_file_with_worktree_changes_as_two_hunks, commit_two_files_as_two_hunks_each,
+        status_json_with_files as status_json,
     },
     utils::{CommandExt, Sandbox},
 };
@@ -35,27 +37,6 @@ fn assigned_uncommitted_file_env() -> anyhow::Result<Sandbox> {
     env.file("a.txt", "arbitrary text\n");
     env.but("rub zz:a.txt A").assert().success();
     Ok(env)
-}
-
-fn status_json(env: &Sandbox) -> anyhow::Result<serde_json::Value> {
-    let output = env.but("--json status -f").allow_json().output()?;
-    assert!(output.status.success());
-    Ok(serde_json::from_slice(&output.stdout)?)
-}
-
-fn branch_commit_ids(status: &serde_json::Value, branch_name: &str) -> Vec<String> {
-    status["stacks"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .flat_map(|stack| stack["branches"].as_array().unwrap().iter())
-        .find(|branch| branch["name"].as_str().unwrap() == branch_name)
-        .unwrap()["commits"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .map(|commit| commit["cliId"].as_str().unwrap().to_string())
-        .collect()
 }
 
 fn stack_assigned_contains_file(
@@ -111,37 +92,6 @@ fn branch_commits_contain_file(
         .flat_map(|branch| branch["commits"].as_array().unwrap().iter())
         .flat_map(|commit| commit["changes"].as_array().unwrap().iter())
         .any(|change| change["filePath"].as_str().unwrap() == file_path)
-}
-
-fn branch_commit_id_for_file(
-    status: &serde_json::Value,
-    branch_name: &str,
-    file_path: &str,
-) -> Option<String> {
-    status["stacks"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .flat_map(|stack| stack["branches"].as_array().unwrap().iter())
-        .find(|branch| branch["name"].as_str().unwrap() == branch_name)
-        .and_then(|branch| {
-            branch["commits"]
-                .as_array()
-                .unwrap()
-                .iter()
-                .find_map(|commit| {
-                    let has_file = commit["changes"]
-                        .as_array()
-                        .unwrap()
-                        .iter()
-                        .any(|change| change["filePath"].as_str().unwrap() == file_path);
-                    if has_file {
-                        Some(commit["cliId"].as_str().unwrap().to_string())
-                    } else {
-                        None
-                    }
-                })
-        })
 }
 
 fn committed_file_id_for_file(

--- a/crates/but/tests/but/command/undo.rs
+++ b/crates/but/tests/but/command/undo.rs
@@ -1,5 +1,7 @@
 use crate::utils::Sandbox;
 
+mod undo_rub;
+
 /// Run an undo test tests a roundtrip `mutate` -> `but undo`, and asserts that the status output is
 /// the same before and after the roundtrip.
 fn run_mutate_undo_roundtrip_test<F>(env: &Sandbox, mutate: F) -> anyhow::Result<()>
@@ -87,26 +89,6 @@ fn can_undo_commit() -> anyhow::Result<()> {
             .assert()
             .success()
             .stdout_eq("✓ Created commit [..] on branch A\n")
-            .stderr_eq("");
-
-        Ok(())
-    })?;
-
-    Ok(())
-}
-
-#[test]
-fn can_undo_rubbing_commits() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits")?;
-    env.setup_metadata(&["A"])?;
-
-    run_mutate_undo_roundtrip_test(&env, |env| {
-        env.but("rub")
-            .arg("9a")
-            .arg("fe")
-            .assert()
-            .success()
-            .stdout_eq("Squashed 9ac4652 → f66c907\n")
             .stderr_eq("");
 
         Ok(())

--- a/crates/but/tests/but/command/undo/undo_rub.rs
+++ b/crates/but/tests/but/command/undo/undo_rub.rs
@@ -1,58 +1,13 @@
 use crate::{
     command::{
         undo::run_mutate_undo_roundtrip_test,
-        util::{commit_two_files_as_two_hunks_each, status_json},
+        util::{
+            branch_commit_id_for_file, branch_commit_ids, commit_two_files_as_two_hunks_each,
+            status_json, status_json_with_files,
+        },
     },
-    utils::{CommandExt as _, Sandbox},
+    utils::Sandbox,
 };
-
-fn status_json_with_files(env: &Sandbox) -> anyhow::Result<serde_json::Value> {
-    let output = env.but("--json status -f").allow_json().output()?;
-    assert!(output.status.success());
-    Ok(serde_json::from_slice(&output.stdout)?)
-}
-
-fn branch_commit_ids(status: &serde_json::Value, branch_name: &str) -> Vec<String> {
-    status["stacks"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .flat_map(|stack| stack["branches"].as_array().unwrap().iter())
-        .find(|branch| branch["name"].as_str().unwrap() == branch_name)
-        .unwrap()["commits"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .map(|commit| commit["cliId"].as_str().unwrap().to_string())
-        .collect()
-}
-
-fn branch_commit_id_for_file(
-    status: &serde_json::Value,
-    branch_name: &str,
-    file_path: &str,
-) -> Option<String> {
-    status["stacks"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .flat_map(|stack| stack["branches"].as_array().unwrap().iter())
-        .find(|branch| branch["name"].as_str().unwrap() == branch_name)
-        .and_then(|branch| {
-            branch["commits"]
-                .as_array()
-                .unwrap()
-                .iter()
-                .find_map(|commit| {
-                    let has_file = commit["changes"]
-                        .as_array()
-                        .unwrap()
-                        .iter()
-                        .any(|change| change["filePath"].as_str().unwrap() == file_path);
-                    has_file.then(|| commit["cliId"].as_str().unwrap().to_string())
-                })
-        })
-}
 
 // RubOperation::SquashCommits
 #[test]

--- a/crates/but/tests/but/command/undo/undo_rub.rs
+++ b/crates/but/tests/but/command/undo/undo_rub.rs
@@ -1,0 +1,555 @@
+use crate::{
+    command::{
+        undo::run_mutate_undo_roundtrip_test,
+        util::{commit_two_files_as_two_hunks_each, status_json},
+    },
+    utils::{CommandExt as _, Sandbox},
+};
+
+fn status_json_with_files(env: &Sandbox) -> anyhow::Result<serde_json::Value> {
+    let output = env.but("--json status -f").allow_json().output()?;
+    assert!(output.status.success());
+    Ok(serde_json::from_slice(&output.stdout)?)
+}
+
+fn branch_commit_ids(status: &serde_json::Value, branch_name: &str) -> Vec<String> {
+    status["stacks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .flat_map(|stack| stack["branches"].as_array().unwrap().iter())
+        .find(|branch| branch["name"].as_str().unwrap() == branch_name)
+        .unwrap()["commits"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|commit| commit["cliId"].as_str().unwrap().to_string())
+        .collect()
+}
+
+fn branch_commit_id_for_file(
+    status: &serde_json::Value,
+    branch_name: &str,
+    file_path: &str,
+) -> Option<String> {
+    status["stacks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .flat_map(|stack| stack["branches"].as_array().unwrap().iter())
+        .find(|branch| branch["name"].as_str().unwrap() == branch_name)
+        .and_then(|branch| {
+            branch["commits"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find_map(|commit| {
+                    let has_file = commit["changes"]
+                        .as_array()
+                        .unwrap()
+                        .iter()
+                        .any(|change| change["filePath"].as_str().unwrap() == file_path);
+                    has_file.then(|| commit["cliId"].as_str().unwrap().to_string())
+                })
+        })
+}
+
+// RubOperation::SquashCommits
+#[test]
+fn undo_squash_commits() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits")?;
+    env.setup_metadata(&["A"])?;
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but("rub")
+            .arg("9a")
+            .arg("fe")
+            .assert()
+            .success()
+            .stdout_eq("Squashed 9ac4652 → f66c907\n")
+            .stderr_eq("");
+
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+// RubOperation::UnassignUncommitted
+#[test]
+#[ignore = "undo currently does not restore hunk assignment metadata for rub operations that only move changes between unassigned, branch, and stack buckets"]
+fn undo_unassign_uncommitted() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    env.setup_metadata(&["A", "B"])?;
+    env.file("unassign-uncommitted.txt", "content\n");
+    env.but("rub unassign-uncommitted.txt A").assert().success();
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but("rub A@{stack}:unassign-uncommitted.txt zz")
+            .assert()
+            .success()
+            .stdout_eq("Unstaged the only hunk in unassign-uncommitted.txt in a stack\n")
+            .stderr_eq("");
+
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+// RubOperation::UncommittedToCommit
+#[test]
+fn undo_uncommitted_to_commit() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    env.setup_metadata(&["A", "B"])?;
+    env.file("uncommitted-to-commit.txt", "content\n");
+    let target_commit = branch_commit_ids(&status_json(&env)?, "A")[0].clone();
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but(format!("rub uncommitted-to-commit.txt {target_commit}"))
+            .assert()
+            .success()
+            .stdout_eq("Amended [..] → [..]\n")
+            .stderr_eq("");
+
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+// RubOperation::UncommittedToBranch
+#[test]
+#[ignore = "undo currently does not restore hunk assignment metadata for rub operations that only move changes between unassigned, branch, and stack buckets"]
+fn undo_uncommitted_to_branch() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    env.setup_metadata(&["A", "B"])?;
+    env.file("uncommitted-to-branch.txt", "content\n");
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but("rub uncommitted-to-branch.txt A")
+            .assert()
+            .success()
+            .stdout_eq(
+                "Staged the only hunk in uncommitted-to-branch.txt in the unassigned area → [A].\n",
+            )
+            .stderr_eq("");
+
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+// RubOperation::UncommittedToStack
+#[test]
+#[ignore = "undo currently does not restore hunk assignment metadata for rub operations that only move changes between unassigned, branch, and stack buckets"]
+fn undo_uncommitted_to_stack() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    env.setup_metadata(&["A", "B"])?;
+    env.file("uncommitted-to-stack.txt", "content\n");
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but("rub uncommitted-to-stack.txt A@{stack}")
+            .assert()
+            .success()
+            .stdout_eq("Staged the only hunk in uncommitted-to-stack.txt in the unassigned area → stack [..].\n")
+            .stderr_eq("");
+
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+// RubOperation::StackToUnassigned
+#[test]
+#[ignore = "undo currently does not restore hunk assignment metadata for rub operations that only move changes between unassigned, branch, and stack buckets"]
+fn undo_stack_to_unassigned() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    env.setup_metadata(&["A", "B"])?;
+    env.file("stack-to-unassigned.txt", "content\n");
+    env.but("rub stack-to-unassigned.txt A").assert().success();
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but("rub A@{stack} zz")
+            .assert()
+            .success()
+            .stdout_eq("Unstaged all [A] changes.\n")
+            .stderr_eq("");
+
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+// RubOperation::StackToStack
+#[test]
+#[ignore = "undo currently does not restore hunk assignment metadata for rub operations that only move changes between unassigned, branch, and stack buckets"]
+fn undo_stack_to_stack() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    env.setup_metadata(&["A", "B"])?;
+    env.file("stack-to-stack.txt", "content\n");
+    env.but("rub stack-to-stack.txt A").assert().success();
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but("rub A@{stack} B@{stack}")
+            .assert()
+            .success()
+            .stdout_eq("Staged all [A] changes to [B].\n")
+            .stderr_eq("");
+
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+// RubOperation::StackToBranch
+#[test]
+#[ignore = "undo currently does not restore hunk assignment metadata for rub operations that only move changes between unassigned, branch, and stack buckets"]
+fn undo_stack_to_branch() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    env.setup_metadata(&["A", "B"])?;
+    env.file("stack-to-branch.txt", "content\n");
+    env.but("rub stack-to-branch.txt A").assert().success();
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but("rub A@{stack} B")
+            .assert()
+            .success()
+            .stdout_eq("Staged all [A] changes to [B].\n")
+            .stderr_eq("");
+
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+// RubOperation::StackToCommit
+#[test]
+fn undo_stack_to_commit() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    env.setup_metadata(&["A", "B"])?;
+    env.file("stack-to-commit.txt", "content\n");
+    env.but("rub stack-to-commit.txt A").assert().success();
+    let target_commit = branch_commit_ids(&status_json(&env)?, "A")[0].clone();
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but(format!("rub A@{{stack}} {target_commit}"))
+            .assert()
+            .success()
+            .stdout_eq("Amended files assigned to [A] → [..]\n")
+            .stderr_eq("");
+
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+// RubOperation::UnassignedToCommit
+#[test]
+fn undo_unassigned_to_commit() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    env.setup_metadata(&["A", "B"])?;
+    env.file("unassigned-to-commit.txt", "content\n");
+    let target_commit = branch_commit_ids(&status_json(&env)?, "A")[0].clone();
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but(format!("rub zz {target_commit}"))
+            .assert()
+            .success()
+            .stdout_eq("Amended unassigned files → [..]\n")
+            .stderr_eq("");
+
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+// RubOperation::UnassignedToBranch
+#[test]
+#[ignore = "undo currently does not restore hunk assignment metadata for rub operations that only move changes between unassigned, branch, and stack buckets"]
+fn undo_unassigned_to_branch() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    env.setup_metadata(&["A", "B"])?;
+    env.file("unassigned-to-branch.txt", "content\n");
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but("rub zz A")
+            .assert()
+            .success()
+            .stdout_eq("Staged all unstaged changes to [A].\n")
+            .stderr_eq("");
+
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+// RubOperation::UnassignedToStack
+#[test]
+#[ignore = "undo currently does not restore hunk assignment metadata for rub operations that only move changes between unassigned, branch, and stack buckets"]
+fn undo_unassigned_to_stack() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    env.setup_metadata(&["A", "B"])?;
+    env.file("unassigned-to-stack.txt", "content\n");
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but("rub zz A@{stack}")
+            .assert()
+            .success()
+            .stdout_eq("Staged all unstaged changes to [A].\n")
+            .stderr_eq("");
+
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+// RubOperation::CommitToUnassigned
+#[test]
+fn undo_commit_to_unassigned() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    env.setup_metadata(&["A", "B"])?;
+    commit_two_files_as_two_hunks_each(
+        &env,
+        "A",
+        "commit-to-zz-a.txt",
+        "commit-to-zz-b.txt",
+        "first",
+    );
+    let source_commit = branch_commit_ids(&status_json(&env)?, "A")[0].clone();
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but(format!("rub {source_commit} zz"))
+            .assert()
+            .success()
+            .stdout_eq("Uncommitted [..]\n")
+            .stderr_eq("");
+
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+// RubOperation::CommitToStack
+#[test]
+fn undo_commit_to_stack() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    env.setup_metadata(&["A", "B"])?;
+    commit_two_files_as_two_hunks_each(
+        &env,
+        "A",
+        "commit-to-stack-a.txt",
+        "commit-to-stack-b.txt",
+        "first",
+    );
+    let source_commit = branch_commit_ids(&status_json(&env)?, "A")[0].clone();
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but(format!("rub {source_commit} B@{{stack}}"))
+            .assert()
+            .success()
+            .stdout_eq("Uncommitted [..] to [B]\n")
+            .stderr_eq("");
+
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+// RubOperation::MoveCommitToBranch
+#[test]
+fn undo_move_commit_to_branch() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    env.setup_metadata(&["A", "B"])?;
+    commit_two_files_as_two_hunks_each(
+        &env,
+        "A",
+        "commit-to-branch-a.txt",
+        "commit-to-branch-b.txt",
+        "first",
+    );
+    let source_commit = branch_commit_ids(&status_json(&env)?, "A")[0].clone();
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but(format!("rub {source_commit} B"))
+            .assert()
+            .success()
+            .stdout_eq("Moved [..] → [B]\n")
+            .stderr_eq("");
+
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+// RubOperation::BranchToUnassigned
+#[test]
+#[ignore = "undo currently does not restore hunk assignment metadata for rub operations that only move changes between unassigned, branch, and stack buckets"]
+fn undo_branch_to_unassigned() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    env.setup_metadata(&["A", "B"])?;
+    env.file("branch-to-unassigned.txt", "content\n");
+    env.but("rub branch-to-unassigned.txt A").assert().success();
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but("rub A zz")
+            .assert()
+            .success()
+            .stdout_eq("Unstaged all [A] changes.\n")
+            .stderr_eq("");
+
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+// RubOperation::BranchToStack
+#[test]
+#[ignore = "undo currently does not restore hunk assignment metadata for rub operations that only move changes between unassigned, branch, and stack buckets"]
+fn undo_branch_to_stack() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    env.setup_metadata(&["A", "B"])?;
+    env.file("branch-to-stack.txt", "content\n");
+    env.but("rub branch-to-stack.txt A").assert().success();
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but("rub A B@{stack}")
+            .assert()
+            .success()
+            .stdout_eq("Staged all [A] changes to [B].\n")
+            .stderr_eq("");
+
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+// RubOperation::BranchToCommit
+#[test]
+fn undo_branch_to_commit() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    env.setup_metadata(&["A", "B"])?;
+    env.file("branch-to-commit.txt", "content\n");
+    env.but("rub branch-to-commit.txt A").assert().success();
+    let target_commit = branch_commit_ids(&status_json(&env)?, "A")[0].clone();
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but(format!("rub A {target_commit}"))
+            .assert()
+            .success()
+            .stdout_eq("Amended assigned files [A] → [..]\n")
+            .stderr_eq("");
+
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+// RubOperation::BranchToBranch
+#[test]
+#[ignore = "undo currently does not restore hunk assignment metadata for rub operations that only move changes between unassigned, branch, and stack buckets"]
+fn undo_branch_to_branch() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    env.setup_metadata(&["A", "B"])?;
+    env.file("branch-to-branch.txt", "content\n");
+    env.but("rub branch-to-branch.txt A").assert().success();
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but("rub A B")
+            .assert()
+            .success()
+            .stdout_eq("Staged all [A] changes to [B].\n")
+            .stderr_eq("");
+
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+// RubOperation::CommittedFileToBranch
+#[test]
+fn undo_committed_file_to_branch() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    env.setup_metadata(&["A", "B"])?;
+    commit_two_files_as_two_hunks_each(
+        &env,
+        "A",
+        "file-to-branch-a.txt",
+        "file-to-branch-b.txt",
+        "first",
+    );
+    let source_commit = branch_commit_ids(&status_json(&env)?, "A")[0].clone();
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but(format!("rub {source_commit}:file-to-branch-a.txt B"))
+            .assert()
+            .success()
+            .stdout_eq("Uncommitted changes\n")
+            .stderr_eq("");
+
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+// RubOperation::CommittedFileToCommit
+#[test]
+fn undo_committed_file_to_commit() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+    commit_two_files_as_two_hunks_each(&env, "A", "source-a.txt", "source-b.txt", "source");
+    commit_two_files_as_two_hunks_each(&env, "A", "target-a.txt", "target-b.txt", "target");
+    let status = status_json_with_files(&env)?;
+    let source_commit = branch_commit_id_for_file(&status, "A", "source-a.txt").unwrap();
+    let target_commit = branch_commit_id_for_file(&status, "A", "target-a.txt").unwrap();
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but(format!("rub {source_commit}:source-a.txt {target_commit}"))
+            .assert()
+            .success()
+            .stdout_eq("Moved files between commits!\n")
+            .stderr_eq("");
+
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+// RubOperation::CommittedFileToUnassigned
+#[test]
+fn undo_committed_file_to_unassigned() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    env.setup_metadata(&["A", "B"])?;
+    commit_two_files_as_two_hunks_each(&env, "A", "file-to-zz-a.txt", "file-to-zz-b.txt", "first");
+    let source_commit = branch_commit_ids(&status_json(&env)?, "A")[0].clone();
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but(format!("rub {source_commit}:file-to-zz-a.txt zz"))
+            .assert()
+            .success()
+            .stdout_eq("Uncommitted changes\n")
+            .stderr_eq("");
+
+        Ok(())
+    })?;
+
+    Ok(())
+}


### PR DESCRIPTION
This just adds test coverage but they don't all pass. All the ones that deal
with uncommitted changes fail. That feels like a deeper issue so I'll make a
separate Linear ticket for it and fix it later.