### PR TITLE
`repo` is preferred in our codebase

### DIFF
--- a/crates/but-api/src/commit/uncommit.rs
+++ b/crates/but-api/src/commit/uncommit.rs
@@ -163,7 +163,7 @@ pub fn commit_uncommit_only_with_perm(
         (
             &mut graph.into_workspace()?,
             rebase.history.commit_mappings(),
-            rebase.repository(),
+            rebase.repo(),
         )
     } else {
         let materialized = rebase.materialize_without_checkout()?;
@@ -293,7 +293,7 @@ pub fn commit_uncommit_changes_only_with_perm(
         (
             &mut graph.into_workspace()?,
             outcome.rebase.history.commit_mappings(),
-            outcome.rebase.repository(),
+            outcome.rebase.repo(),
         )
     } else {
         let materialized = outcome.rebase.materialize_without_checkout()?;

--- a/crates/but-api/src/workspace_state.rs
+++ b/crates/but-api/src/workspace_state.rs
@@ -59,7 +59,7 @@ impl WorkspaceState {
     ) -> anyhow::Result<WorkspaceState> {
         Self::from_workspace(
             &rebase.overlayed_graph()?.into_workspace()?,
-            rebase.repository(),
+            rebase.repo(),
             replaced_commits,
         )
     }

--- a/crates/but-rebase/src/graph_rebase/mod.rs
+++ b/crates/but-rebase/src/graph_rebase/mod.rs
@@ -269,7 +269,7 @@ impl<'ws, 'meta, M: RefMetadata> SuccessfulRebase<'ws, 'meta, M> {
     ///
     /// This repository may contain objects that have not been persisted yet,
     /// which makes it suitable for dry-run inspection of [`Self::overlayed_graph`].
-    pub fn repository(&self) -> &gix::Repository {
+    pub fn repo(&self) -> &gix::Repository {
         &self.repo
     }
 


### PR DESCRIPTION
ICBA to typ repo unabrv.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #13692 
- <kbd>&nbsp;1&nbsp;</kbd> #13691 👈 
<!-- GitButler Footer Boundary Bottom -->

