### PR TITLE
caleb/persist-temporary-change-ids

### DIFF
--- a/crates/but-core/src/commit/mod.rs
+++ b/crates/but-core/src/commit/mod.rs
@@ -97,6 +97,14 @@ impl Headers {
         }
     }
 
+    /// Create a new instance from a specified change_id
+    pub fn from_change_id(change_id: ChangeId) -> Self {
+        Headers {
+            change_id: Some(change_id),
+            conflicted: None,
+        }
+    }
+
     /// Extract header information from the given `commit`, or return `None` if not present.
     pub fn try_from_commit(commit: &gix::objs::Commit) -> Option<Self> {
         Self::try_from_commit_headers(|| commit.extra_headers())

--- a/crates/but-rebase/src/graph_rebase/cherry_pick.rs
+++ b/crates/but-rebase/src/graph_rebase/cherry_pick.rs
@@ -337,6 +337,7 @@ fn commit_from_unconflicted_tree<'repo>(
     let repo = to_rebase.id.repo;
 
     let headers = to_rebase.headers();
+    let change_id = to_rebase.change_id();
     let mut new_commit = to_rebase.inner;
     new_commit.tree = resolved_tree_id.detach();
 
@@ -348,11 +349,12 @@ fn commit_from_unconflicted_tree<'repo>(
     {
         new_commit.extra_headers.remove(pos);
     } else if headers.is_none() {
-        let headers = Headers::from_config(&repo.config_snapshot());
+        let headers = Headers::from_change_id(change_id);
         new_commit
             .extra_headers
             .extend(Vec::<(BString, BString)>::from(&headers));
     }
+
     new_commit.parents = parents.into();
 
     Ok(crate::commit::create(
@@ -411,7 +413,7 @@ fn commit_from_conflicted_tree<'repo>(
 
     let mut headers = to_rebase
         .headers()
-        .unwrap_or_else(|| Headers::from_config(&repo.config_snapshot()));
+        .unwrap_or_else(|| Headers::from_change_id(to_rebase.change_id()));
     headers.conflicted = None;
     to_rebase.tree = tree.write().context("failed to write tree")?.detach();
     to_rebase.parents = parents.into();

--- a/crates/but-rebase/src/graph_rebase/commit.rs
+++ b/crates/but-rebase/src/graph_rebase/commit.rs
@@ -1,8 +1,8 @@
 //! Provides some slightly higher level tools to help with manipulating commits, in preparation for use in the editor.
 
 use anyhow::{Context, Result, bail};
-use but_core::RefMetadata;
 use but_core::commit::SignCommit;
+use but_core::{RefMetadata, commit::Headers};
 use gix::prelude::ObjectIdExt;
 
 use crate::{
@@ -104,7 +104,7 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
         Ok(new_id)
     }
 
-    /// Creates a commit with only the signature and author set correctly.
+    /// Creates a commit with only the signature, author, and headers set correctly.
     ///
     /// The ID of the commit is all zeros & the commit hasn't been written into any ODB
     pub fn empty_commit(&self) -> Result<but_core::CommitOwned> {
@@ -128,7 +128,7 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
             author,
             encoding: None,
             message: b"".into(),
-            extra_headers: vec![],
+            extra_headers: (&Headers::from_config(&self.repo.config_snapshot())).into(),
         };
 
         Ok(but_core::CommitOwned {

--- a/crates/but-rebase/tests/rebase/graph_rebase/change_id.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/change_id.rs
@@ -1,0 +1,80 @@
+//! Change id tests
+
+use anyhow::Result;
+use but_graph::Graph;
+use but_rebase::graph_rebase::{Editor, LookupStep, Step, ToSelector};
+use gix::prelude::ObjectIdExt;
+
+use crate::utils::{fixture_writable, standard_options};
+
+#[test]
+fn temporary_change_id_persisted() -> Result<()> {
+    let (repo, _tmpdir, mut meta) = fixture_writable("four-commits")?;
+
+    let target = repo.rev_parse_single("HEAD~")?;
+    let target_parent = repo.rev_parse_single("HEAD~~")?;
+    let target_commit = but_core::Commit::from_id(target)?;
+    insta::assert_snapshot!(target_commit.change_id(), @"uonoxlzsyllzwskypkxkwtqyzusvwpzp");
+    insta::assert_debug_snapshot!(target_commit.extra_headers, @"[]");
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+
+    // An operation to cause the parent we care about to be rebased
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+    let target_selector = target.to_selector(&editor)?;
+    editor.replace(target_parent, Step::None)?;
+
+    let outcome = editor.rebase()?;
+
+    let new_target = outcome.lookup_pick(target_selector)?;
+    let new_target_commit = but_core::Commit::from_id(new_target.attach(outcome.repo()))?;
+    insta::assert_debug_snapshot!(new_target_commit.extra_headers, @r#"
+    [
+        (
+            "gitbutler-headers-version",
+            "2",
+        ),
+        (
+            "change-id",
+            "uonoxlzsyllzwskypkxkwtqyzusvwpzp",
+        ),
+    ]
+    "#);
+
+    assert_eq!(
+        new_target_commit.change_id(),
+        target_commit.change_id(),
+        "The change ID should remain and end up persisted in the output commit's headers"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn empty_commit_uses_default_change_id() -> Result<()> {
+    let (repo, _tmpdir, mut meta) = fixture_writable("four-commits")?;
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let ec = editor.empty_commit()?;
+
+    insta::assert_snapshot!(ec.change_id(), @"1");
+    insta::assert_debug_snapshot!(ec.extra_headers, @r#"
+    [
+        (
+            "gitbutler-headers-version",
+            "2",
+        ),
+        (
+            "change-id",
+            "1",
+        ),
+    ]
+    "#);
+
+    Ok(())
+}

--- a/crates/but-rebase/tests/rebase/graph_rebase/cherry_pick.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/cherry_pick.rs
@@ -35,7 +35,7 @@ fn basic_cherry_pick_clean() -> Result<()> {
 
     insta::assert_debug_snapshot!(result, @"
     Commit(
-        Sha1(023c575a8c22020139844490ba2e8f333fcec85c),
+        Sha1(5a8f27d64a93b97e42b375c14540acebba2b1d09),
     )
     ");
 
@@ -73,7 +73,7 @@ fn basic_cherry_pick_cp_conflicts() -> Result<()> {
 
     insta::assert_debug_snapshot!(result, @"
     ConflictedCommit(
-        Sha1(9661555c611ff64e8c597f7f5a0575f211eb2e12),
+        Sha1(c36dcfcf8bab780dcacc0bc43e8a31af2a1e7703),
     )
     ");
 
@@ -149,7 +149,7 @@ fn single_parent_to_multiple_parents_clean() -> Result<()> {
 
     insta::assert_debug_snapshot!(result, @"
     Commit(
-        Sha1(39763a0f3cb7ca0f3eac78368173aa6367aeffcf),
+        Sha1(26eb34db737ae1cee6887cd1ab9a48c72c3d9c04),
     )
     ");
 
@@ -190,7 +190,7 @@ fn single_parent_to_multiple_parents_cp_conflicts() -> Result<()> {
 
     insta::assert_debug_snapshot!(result, @"
     ConflictedCommit(
-        Sha1(c8779c405b92941176effe9eb7a72c0dd410c3fd),
+        Sha1(333dd65cbcc689b08744e30717faa343f88b0554),
     )
     ");
 
@@ -280,7 +280,7 @@ fn multiple_parents_to_single_parent_clean() -> Result<()> {
 
     insta::assert_debug_snapshot!(result, @"
     Commit(
-        Sha1(1327f60f892048e2dd2c96c639e6b6aa750bdbe3),
+        Sha1(52a5e75c1e032898649d840c92a4e0a0ef03a60b),
     )
     ");
 
@@ -319,7 +319,7 @@ fn multiple_parents_to_single_parent_cp_conflicts() -> Result<()> {
 
     insta::assert_debug_snapshot!(result, @"
     ConflictedCommit(
-        Sha1(2d4dcd916020924f2412642b842a791dfea74571),
+        Sha1(3621c40c48ee697ce42ace960055702479ca5267),
     )
     ");
 
@@ -410,7 +410,7 @@ fn multiple_parents_to_multiple_parents_clean() -> Result<()> {
 
     insta::assert_debug_snapshot!(result, @"
     Commit(
-        Sha1(819265d9df0efd0ecba56b9f930f16eea335d329),
+        Sha1(e1211f8c8ed78875cd0c231a3d9e51cff51186f9),
     )
     ");
 
@@ -451,7 +451,7 @@ fn multiple_parents_to_multiple_parents_cp_conflicts() -> Result<()> {
 
     insta::assert_debug_snapshot!(result, @"
     ConflictedCommit(
-        Sha1(bf66deb17cc4e84faa063a3253566004aabaf7fe),
+        Sha1(718d834a2a57256c4a54706573a5d9863d54a653),
     )
     ");
 
@@ -629,7 +629,7 @@ fn single_parent_to_no_parents_clean() -> Result<()> {
 
     insta::assert_debug_snapshot!(result, @"
     Commit(
-        Sha1(756d7a456e069d4553d52d339158135390d3780e),
+        Sha1(768bf9f3dd8f1e6c5d24af762e87bba00a87cd5c),
     )
     ");
 
@@ -666,7 +666,7 @@ fn no_parents_to_single_parent_clean() -> Result<()> {
 
     insta::assert_debug_snapshot!(result, @"
     Commit(
-        Sha1(f3555f184de4e805e12a6ee83e406f3a39eb2091),
+        Sha1(288077e946039664793caf577166f21a82f70830),
     )
     ");
 
@@ -704,7 +704,7 @@ fn no_parents_to_single_parent_cp_conflicts() -> Result<()> {
 
     insta::assert_debug_snapshot!(result, @"
     ConflictedCommit(
-        Sha1(2ee47b5cbe2705d5d81f4b4067ef4753d87b3b02),
+        Sha1(46139f9346b201bf8cbff2112adecd3c99a2a956),
     )
     ");
 
@@ -754,7 +754,7 @@ fn cherry_pick_back_to_original_parents_unconflicts() -> Result<()> {
 
     insta::assert_debug_snapshot!(result, @"
     ConflictedCommit(
-        Sha1(bf66deb17cc4e84faa063a3253566004aabaf7fe),
+        Sha1(718d834a2a57256c4a54706573a5d9863d54a653),
     )
     ");
 
@@ -775,7 +775,7 @@ fn cherry_pick_back_to_original_parents_unconflicts() -> Result<()> {
 
     insta::assert_debug_snapshot!(result, @"
     Commit(
-        Sha1(2a307db18bf263e3a802ac71282c5d8016ea75a1),
+        Sha1(56ee45903fbd7570c857b02d4c5487e718564e72),
     )
     ");
 
@@ -827,7 +827,7 @@ fn cherry_pick_recursive_merge() -> Result<()> {
 
     insta::assert_debug_snapshot!(result, @"
     Commit(
-        Sha1(cd1d00c1d637d5567f7a0739d1aa9ca3e65b990e),
+        Sha1(b127ce2b2cf3e3c5bf2527a6082b565df4f8ab65),
     )
     ");
 

--- a/crates/but-rebase/tests/rebase/graph_rebase/conflictable_restriction.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/conflictable_restriction.rs
@@ -36,7 +36,7 @@ fn by_default_conflicts_are_allowed() -> Result<()> {
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:main[🌳]
-        ├── ·103b227 (⌂|1) ►c
+        ├── ·04d1892 (⌂|1) ►c
         └── ·5e0ba46 (⌂|1) ►a, ►b
             └── ►:1[1]:base
                 └── ·6155f21 (⌂|1)
@@ -51,7 +51,7 @@ fn by_default_conflicts_are_allowed() -> Result<()> {
     author author <author@example.com> 946684800 +0000
     committer Committer (Memory Override) <committer@example.com> 946771200 +0000
     gitbutler-headers-version 2
-    change-id 1
+    change-id ulsktwtuywxwowluzmmxlqrqnyxktwuz
 
     [conflict] c
 
@@ -149,7 +149,7 @@ fn if_a_commit_has_been_configured_not_to_conflict_and_doesnt_end_up_conflicted_
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:main[🌳]
-        └── ·00c31ec (⌂|1) ►c
+        └── ·8b4d335 (⌂|1) ►c
             └── ►:1[1]:b
                 ├── ·7762cf9 (⌂|1)
                 └── ·3b3bd41 (⌂|1)
@@ -163,7 +163,7 @@ fn if_a_commit_has_been_configured_not_to_conflict_and_doesnt_end_up_conflicted_
 
     // The rebase is successful because `c` remained unconflicted
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * 00c31ec (HEAD -> main, c) c
+    * 8b4d335 (HEAD -> main, c) c
     * 7762cf9 (b) I'm a new commit! Hello there
     * 3b3bd41 b
     * 5e0ba46 (a) a

--- a/crates/but-rebase/tests/rebase/graph_rebase/disconnect.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/disconnect.rs
@@ -48,18 +48,18 @@ fn disconnect_and_remove_middle_commit_in_linear_history() -> Result<()> {
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:main[🌳]
-        ├── ·4de0144 (⌂|1)
+        ├── ·b4fd8ee (⌂|1)
         ├── ·d591dfe (⌂|1)
         └── ·35b8235 (⌂|1)
     ");
     let outcome = outcome.materialize()?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-	* 4de0144 (HEAD -> main) c
-	* d591dfe a
-	* 35b8235 base
-	");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * b4fd8ee (HEAD -> main) c
+    * d591dfe a
+    * 35b8235 base
+    ");
     insta::assert_snapshot!(git_status(&repo)?, @"");
 
     Ok(())
@@ -109,14 +109,14 @@ fn disconnect_and_remove_two_middle_commits_in_linear_history() -> Result<()> {
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:main[🌳]
-        ├── ·f55e07c (⌂|1)
+        ├── ·19f8134 (⌂|1)
         └── ·35b8235 (⌂|1)
     ");
     let outcome = outcome.materialize()?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * f55e07c (HEAD -> main) c
+    * 19f8134 (HEAD -> main) c
     * 35b8235 base
     ");
     insta::assert_snapshot!(git_status(&repo)?, @"");
@@ -166,9 +166,9 @@ fn disconnect_and_remove_commit_in_merge_history_rewires_children() -> Result<()
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:with-inner-merge[🌳]
-        └── ·dde6cc8 (⌂|1)
+        └── ·4023659 (⌂|1)
             └── ►:1[1]:anon:
-                └── ·5f962e2 (⌂|1)
+                └── ·01c4df0 (⌂|1)
                     ├── ►:2[3]:anon:
                     │   └── ·8f0d338 (⌂|1) ►A, ►main, ►tags/base
                     └── ►:3[2]:B
@@ -183,8 +183,8 @@ fn disconnect_and_remove_commit_in_merge_history_rewires_children() -> Result<()
     assert_eq!(a_now, base, "A should now point to base after disconnect");
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * dde6cc8 (HEAD -> with-inner-merge) on top of inner merge
-    *   5f962e2 Merge branch 'B' into with-inner-merge
+    * 4023659 (HEAD -> with-inner-merge) on top of inner merge
+    *   01c4df0 Merge branch 'B' into with-inner-merge
     |\  
     | * 984fd1c (B) C: new file with 10 lines
     |/  
@@ -241,9 +241,9 @@ fn disconnect_and_remove_merge_with_two_parents_and_two_children() -> Result<()>
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:with-two-children[🌳]
-        └── ·f914957 (⌂|1)
+        └── ·87269f1 (⌂|1)
             ├── ►:1[1]:C1
-            │   └── ·d8cc9ec (⌂|1)
+            │   └── ·3e50be4 (⌂|1)
             │       ├── ►:3[2]:anon:
             │       │   └── ·bc0e772 (⌂|1) ►M, ►P1
             │       │       └── ►:5[3]:main
@@ -252,7 +252,7 @@ fn disconnect_and_remove_merge_with_two_parents_and_two_children() -> Result<()>
             │           └── ·392a8f8 (⌂|1)
             │               └── →:5: (main)
             └── ►:2[1]:C2
-                └── ·72b8072 (⌂|1)
+                └── ·c291781 (⌂|1)
                     ├── →:3:
                     └── →:4: (P2)
     ");
@@ -290,11 +290,11 @@ fn disconnect_and_remove_merge_with_two_parents_and_two_children() -> Result<()>
     );
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   f914957 (HEAD -> with-two-children) tip
+    *   87269f1 (HEAD -> with-two-children) tip
     |\  
-    | *   72b8072 (C2) C2: second child
+    | *   c291781 (C2) C2: second child
     | |\  
-    * | \   d8cc9ec (C1) C1: first child
+    * | \   3e50be4 (C1) C1: first child
     |\ \ \  
     | |/ /  
     |/| /   
@@ -366,17 +366,17 @@ fn disconnect_and_remove_merge_with_two_parents_and_two_children_from_one_side()
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:with-two-children[🌳]
-        └── ·3305e26 (⌂|1)
+        └── ·9de031b (⌂|1)
             ├── ►:1[1]:C1
-            │   └── ·f928700 (⌂|1)
+            │   └── ·54d0b0d (⌂|1)
             │       └── ►:3[2]:P1
             │           └── ·bc0e772 (⌂|1)
             │               └── ►:5[4]:main
             │                   └── ·7674a5e (⌂|1) ►tags/base
             └── ►:2[1]:C2
-                └── ·0e87cd3 (⌂|1)
+                └── ·41cb528 (⌂|1)
                     └── ►:4[2]:M
-                        └── ·3089592 (⌂|1)
+                        └── ·9f6b11a (⌂|1)
                             └── ►:6[3]:P2
                                 └── ·392a8f8 (⌂|1)
                                     └── →:5: (main)
@@ -416,12 +416,12 @@ fn disconnect_and_remove_merge_with_two_parents_and_two_children_from_one_side()
     );
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   3305e26 (HEAD -> with-two-children) tip
+    *   9de031b (HEAD -> with-two-children) tip
     |\  
-    | * 0e87cd3 (C2) C2: second child
-    | * 3089592 (M) M: merge two parents
+    | * 41cb528 (C2) C2: second child
+    | * 9f6b11a (M) M: merge two parents
     | * 392a8f8 (P2) P2: second merge parent
-    * | f928700 (C1) C1: first child
+    * | 54d0b0d (C1) C1: first child
     * | bc0e772 (P1) P1: first merge parent
     |/  
     * 7674a5e (tag: base, main) base
@@ -483,17 +483,17 @@ fn disconnect_remove_merge_with_two_parents_and_two_children_children_only() -> 
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:with-two-children[🌳]
-        └── ·2eac185 (⌂|1)
+        └── ·b87b6c9 (⌂|1)
             ├── ►:1[1]:C1
-            │   └── ·76e6d3c (⌂|1)
+            │   └── ·76ecfed (⌂|1)
             │       └── ►:3[2]:M
-            │           └── ·3089592 (⌂|1)
+            │           └── ·9f6b11a (⌂|1)
             │               └── ►:4[3]:P2
             │                   └── ·392a8f8 (⌂|1)
             │                       └── ►:5[4]:main
             │                           └── ·7674a5e (⌂|1) ►tags/base
             └── ►:2[1]:C2
-                └── ·0e87cd3 (⌂|1)
+                └── ·41cb528 (⌂|1)
                     └── →:3: (M)
     ");
     let outcome = outcome.materialize()?;
@@ -556,12 +556,12 @@ fn disconnect_remove_merge_with_two_parents_and_two_children_children_only() -> 
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     * bc0e772 (P1) P1: first merge parent
-    | *   2eac185 (HEAD -> with-two-children) tip
+    | *   b87b6c9 (HEAD -> with-two-children) tip
     | |\  
-    | | * 0e87cd3 (C2) C2: second child
-    | * | 76e6d3c (C1) C1: first child
+    | | * 41cb528 (C2) C2: second child
+    | * | 76ecfed (C1) C1: first child
     | |/  
-    | * 3089592 (M) M: merge two parents
+    | * 9f6b11a (M) M: merge two parents
     | * 392a8f8 (P2) P2: second merge parent
     |/  
     * 7674a5e (tag: base, main) base

--- a/crates/but-rebase/tests/rebase/graph_rebase/insert.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/insert.rs
@@ -47,10 +47,10 @@ fn insert_below_merge_commit() -> Result<()> {
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:with-inner-merge[🌳]
-        ├── ·ceb4158 (⌂|1)
-        └── ·ea55b6e (⌂|1)
+        ├── ·f699c45 (⌂|1)
+        └── ·16b7c68 (⌂|1)
             └── ►:1[1]:anon:
-                └── ·ec48031 (⌂|1)
+                └── ·8ca0053 (⌂|1)
                     ├── ►:2[2]:A
                     │   └── ·add59d2 (⌂|1)
                     │       └── ►:4[3]:main
@@ -63,9 +63,9 @@ fn insert_below_merge_commit() -> Result<()> {
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * ceb4158 (HEAD -> with-inner-merge) on top of inner merge
-    * ea55b6e Merge branch 'B' into with-inner-merge
-    *   ec48031 Commit below the merge commit
+    * f699c45 (HEAD -> with-inner-merge) on top of inner merge
+    * 16b7c68 Merge branch 'B' into with-inner-merge
+    *   8ca0053 Commit below the merge commit
     |\  
     | * 984fd1c (B) C: new file with 10 lines
     * | add59d2 (A) A: 10 lines on top
@@ -75,9 +75,9 @@ fn insert_below_merge_commit() -> Result<()> {
     insta::assert_snapshot!(git_status(&repo)?, @"");
     insta::assert_debug_snapshot!(outcome.history.commit_mappings(), @"
     {
-        Sha1(231acb683a6ecfb1ff546952057c4b3d3764b28c): Sha1(ec48031bb803e3711d7ce5646e80c72d8447aedc),
-        Sha1(2fc288c36c8bb710c78203f78ea9883724ce142b): Sha1(ea55b6e69f7043c1afb46b8daeef988dc212be3c),
-        Sha1(e8ee978dac10e6a85006543ef08be07c5824b4f7): Sha1(ceb4158ddbc6bc4c580c553e7d2aa6c9248d9d9e),
+        Sha1(231acb683a6ecfb1ff546952057c4b3d3764b28c): Sha1(8ca0053aa15fe12ab6b467a82bedf86401628c17),
+        Sha1(2fc288c36c8bb710c78203f78ea9883724ce142b): Sha1(16b7c68c1dae39aa8b5e4c56e3bc4b1d508cfb25),
+        Sha1(e8ee978dac10e6a85006543ef08be07c5824b4f7): Sha1(f699c45a85f07b90f2d9531269d79b2ffbf3795e),
     }
     ");
 
@@ -129,10 +129,10 @@ fn insert_below_merge_commit_excluded_mappings() -> Result<()> {
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:with-inner-merge[🌳]
-        ├── ·ceb4158 (⌂|1)
-        └── ·ea55b6e (⌂|1)
+        ├── ·f699c45 (⌂|1)
+        └── ·16b7c68 (⌂|1)
             └── ►:1[1]:anon:
-                └── ·ec48031 (⌂|1)
+                └── ·8ca0053 (⌂|1)
                     ├── ►:2[2]:A
                     │   └── ·add59d2 (⌂|1)
                     │       └── ►:4[3]:main
@@ -145,9 +145,9 @@ fn insert_below_merge_commit_excluded_mappings() -> Result<()> {
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * ceb4158 (HEAD -> with-inner-merge) on top of inner merge
-    * ea55b6e Merge branch 'B' into with-inner-merge
-    *   ec48031 Commit below the merge commit
+    * f699c45 (HEAD -> with-inner-merge) on top of inner merge
+    * 16b7c68 Merge branch 'B' into with-inner-merge
+    *   8ca0053 Commit below the merge commit
     |\  
     | * 984fd1c (B) C: new file with 10 lines
     * | add59d2 (A) A: 10 lines on top
@@ -157,8 +157,8 @@ fn insert_below_merge_commit_excluded_mappings() -> Result<()> {
     insta::assert_snapshot!(git_status(&repo)?, @"");
     insta::assert_debug_snapshot!(outcome.history.commit_mappings(), @"
     {
-        Sha1(2fc288c36c8bb710c78203f78ea9883724ce142b): Sha1(ea55b6e69f7043c1afb46b8daeef988dc212be3c),
-        Sha1(e8ee978dac10e6a85006543ef08be07c5824b4f7): Sha1(ceb4158ddbc6bc4c580c553e7d2aa6c9248d9d9e),
+        Sha1(2fc288c36c8bb710c78203f78ea9883724ce142b): Sha1(16b7c68c1dae39aa8b5e4c56e3bc4b1d508cfb25),
+        Sha1(e8ee978dac10e6a85006543ef08be07c5824b4f7): Sha1(f699c45a85f07b90f2d9531269d79b2ffbf3795e),
     }
     ");
 
@@ -206,39 +206,39 @@ fn insert_above_commit_with_two_children() -> Result<()> {
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:with-inner-merge[🌳]
-        └── ·9d2b9d9 (⌂|1)
+        └── ·42f9ff4 (⌂|1)
             └── ►:1[1]:anon:
-                └── ·8502201 (⌂|1)
+                └── ·5219d30 (⌂|1)
                     ├── ►:2[2]:A
-                    │   └── ·0379d6c (⌂|1)
+                    │   └── ·72d9d9b (⌂|1)
                     │       └── ►:4[3]:main
-                    │           ├── ·055ead5 (⌂|1) ►tags/base
+                    │           ├── ·3dc4e45 (⌂|1) ►tags/base
                     │           └── ·8f0d338 (⌂|1)
                     └── ►:3[2]:B
-                        └── ·97c7cc6 (⌂|1)
+                        └── ·df0cf44 (⌂|1)
                             └── →:4: (main)
     ");
     let outcome = outcome.materialize()?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * 9d2b9d9 (HEAD -> with-inner-merge) on top of inner merge
-    *   8502201 Merge branch 'B' into with-inner-merge
+    * 42f9ff4 (HEAD -> with-inner-merge) on top of inner merge
+    *   5219d30 Merge branch 'B' into with-inner-merge
     |\  
-    | * 97c7cc6 (B) C: new file with 10 lines
-    * | 0379d6c (A) A: 10 lines on top
+    | * df0cf44 (B) C: new file with 10 lines
+    * | 72d9d9b (A) A: 10 lines on top
     |/  
-    * 055ead5 (tag: base, main) Commit above base commit
+    * 3dc4e45 (tag: base, main) Commit above base commit
     * 8f0d338 base
     ");
     insta::assert_snapshot!(git_status(&repo)?, @"");
     insta::assert_debug_snapshot!(outcome.history.commit_mappings(), @"
     {
-        Sha1(2fc288c36c8bb710c78203f78ea9883724ce142b): Sha1(8502201c3e5e7ccd1acce001dd2c72c1af8f4a02),
-        Sha1(984fd1c6d3975901147b1f02aae6ef0a16e5904e): Sha1(97c7cc62f0ddefff490fa673a101045dfd143749),
-        Sha1(add59d26b2ffd7468fcb44c2db48111dd8f481e5): Sha1(0379d6c1d89617ff6c438e6e2ebdc9d5db4d831e),
-        Sha1(e8aafee980f055ee43ef702a2d159fec9b781db1): Sha1(055ead578607b2021aeb80df7ac67e294d5272a9),
-        Sha1(e8ee978dac10e6a85006543ef08be07c5824b4f7): Sha1(9d2b9d900e9ec5abbb44480114205fcad42ac1da),
+        Sha1(2fc288c36c8bb710c78203f78ea9883724ce142b): Sha1(5219d30048fd87943c2c87401527b75f26a1f8be),
+        Sha1(984fd1c6d3975901147b1f02aae6ef0a16e5904e): Sha1(df0cf447d953bcb8e79bac528f65f53bd498b9d2),
+        Sha1(add59d26b2ffd7468fcb44c2db48111dd8f481e5): Sha1(72d9d9b11a71e30cc0ae1d14d03038568f0d964c),
+        Sha1(e8aafee980f055ee43ef702a2d159fec9b781db1): Sha1(3dc4e4586430dfca273b5bdefc0e7fc5cd99de82),
+        Sha1(e8ee978dac10e6a85006543ef08be07c5824b4f7): Sha1(42f9ff4611aecf1274b35a44b09ab2054b12d52d),
     }
     ");
 

--- a/crates/but-rebase/tests/rebase/graph_rebase/insert_segment.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/insert_segment.rs
@@ -49,9 +49,9 @@ fn insert_single_node_segment_above() -> Result<()> {
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:main[🌳]
-        └── ·5ae394a (⌂|1)
+        └── ·b78a484 (⌂|1)
             ├── ►:1[1]:A
-            │   └── ·77b07be (⌂|1)
+            │   └── ·706b5e8 (⌂|1)
             │       ├── ►:3[3]:anon:
             │       │   └── ·8f0d338 (⌂|1) ►tags/base
             │       └── ►:4[2]:B
@@ -68,12 +68,12 @@ fn insert_single_node_segment_above() -> Result<()> {
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   5ae394a (HEAD -> main) Merge branches 'A', 'B' and 'C'
+    *   b78a484 (HEAD -> main) Merge branches 'A', 'B' and 'C'
     |\  
     | * 930563a (C) C: add another 10 lines to new file
     | * 68a2fc3 C: add 10 lines to new file
     | * 984fd1c C: new file with 10 lines
-    * |   77b07be (A) A: 10 lines on top
+    * |   706b5e8 (A) A: 10 lines on top
     |\ \  
     | |/  
     |/|   
@@ -130,16 +130,16 @@ fn insert_single_node_segment_below() -> Result<()> {
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:main[🌳]
-        └── ·e22f751 (⌂|1)
+        └── ·32e9d3a (⌂|1)
             ├── ►:1[2]:A
-            │   └── ·507ce96 (⌂|1)
+            │   └── ·032ef08 (⌂|1)
             │       ├── ►:4[4]:anon:
             │       │   └── ·8f0d338 (⌂|1) ►tags/base
             │       └── ►:5[3]:anon:
             │           └── ·62e05ba (⌂|1)
             │               └── →:4:
             ├── ►:2[1]:B
-            │   └── ·743ea2e (⌂|1)
+            │   └── ·2d43620 (⌂|1)
             │       └── →:1: (A)
             └── ►:3[1]:C
                 ├── ·930563a (⌂|1)
@@ -151,14 +151,14 @@ fn insert_single_node_segment_below() -> Result<()> {
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *-.   e22f751 (HEAD -> main) Merge branches 'A', 'B' and 'C'
+    *-.   32e9d3a (HEAD -> main) Merge branches 'A', 'B' and 'C'
     |\ \  
     | | * 930563a (C) C: add another 10 lines to new file
     | | * 68a2fc3 C: add 10 lines to new file
     | | * 984fd1c C: new file with 10 lines
-    | * | 743ea2e (B) B: another 10 lines at the bottom
+    | * | 2d43620 (B) B: another 10 lines at the bottom
     |/ /  
-    * |   507ce96 (A) A: 10 lines on top
+    * |   032ef08 (A) A: 10 lines on top
     |\ \  
     | |/  
     |/|   
@@ -218,11 +218,11 @@ fn insert_multi_node_segment_above() -> Result<()> {
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:main[🌳]
-        └── ·b7346f3 (⌂|1)
+        └── ·85677e6 (⌂|1)
             ├── ►:1[1]:anon:
-            │   └── ·4670c6d (⌂|1) ►A, ►B
+            │   └── ·9da738d (⌂|1) ►A, ►B
             │       └── ►:3[2]:anon:
-            │           └── ·1470cfe (⌂|1)
+            │           └── ·8e18b4e (⌂|1)
             │               ├── ►:4[4]:anon:
             │               │   └── ·8f0d338 (⌂|1) ►tags/base
             │               └── ►:5[3]:anon:
@@ -238,13 +238,13 @@ fn insert_multi_node_segment_above() -> Result<()> {
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   b7346f3 (HEAD -> main) Merge branches 'A', 'B' and 'C'
+    *   85677e6 (HEAD -> main) Merge branches 'A', 'B' and 'C'
     |\  
     | * 930563a (C) C: add another 10 lines to new file
     | * 68a2fc3 C: add 10 lines to new file
     | * 984fd1c C: new file with 10 lines
-    * | 4670c6d (B, A) B: another 10 lines at the bottom
-    * |   1470cfe B: 10 lines at the bottom
+    * | 9da738d (B, A) B: another 10 lines at the bottom
+    * |   8e18b4e B: 10 lines at the bottom
     |\ \  
     | |/  
     |/|   
@@ -304,9 +304,9 @@ fn insert_multi_node_segment_below() -> Result<()> {
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:main[🌳]
-        └── ·78624ea (⌂|1)
+        └── ·4db28a9 (⌂|1)
             ├── ►:1[1]:A
-            │   └── ·e4c78ba (⌂|1)
+            │   └── ·71dfc8f (⌂|1)
             │       └── ►:2[2]:B
             │           ├── ·a748762 (⌂|1)
             │           └── ·62e05ba (⌂|1)
@@ -323,12 +323,12 @@ fn insert_multi_node_segment_below() -> Result<()> {
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *-.   78624ea (HEAD -> main) Merge branches 'A', 'B' and 'C'
+    *-.   4db28a9 (HEAD -> main) Merge branches 'A', 'B' and 'C'
     |\ \  
     | | * 930563a (C) C: add another 10 lines to new file
     | | * 68a2fc3 C: add 10 lines to new file
     | | * 984fd1c C: new file with 10 lines
-    * | | e4c78ba (A) A: 10 lines on top
+    * | | 71dfc8f (A) A: 10 lines on top
     |/ /  
     * | a748762 (B) B: another 10 lines at the bottom
     * | 62e05ba B: 10 lines at the bottom
@@ -392,9 +392,9 @@ fn insert_single_node_segment_above_with_explicit_children() -> Result<()> {
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:main[🌳]
-        └── ·a14ecd6 (⌂|1)
+        └── ·caf3957 (⌂|1)
             ├── ►:1[2]:A
-            │   └── ·77b07be (⌂|1)
+            │   └── ·706b5e8 (⌂|1)
             │       ├── ►:4[4]:anon:
             │       │   └── ·8f0d338 (⌂|1) ►tags/base
             │       └── ►:2[3]:B
@@ -403,7 +403,7 @@ fn insert_single_node_segment_above_with_explicit_children() -> Result<()> {
             │               └── →:4:
             ├── →:2: (B)
             └── ►:3[1]:C
-                └── ·53c45c8 (⌂|1)
+                └── ·23b76e7 (⌂|1)
                     ├── ►:5[2]:anon:
                     │   ├── ·68a2fc3 (⌂|1)
                     │   └── ·984fd1c (⌂|1)
@@ -414,13 +414,13 @@ fn insert_single_node_segment_above_with_explicit_children() -> Result<()> {
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *-.   a14ecd6 (HEAD -> main) Merge branches 'A', 'B' and 'C'
+    *-.   caf3957 (HEAD -> main) Merge branches 'A', 'B' and 'C'
     |\ \  
-    | | *   53c45c8 (C) C: add another 10 lines to new file
+    | | *   23b76e7 (C) C: add another 10 lines to new file
     | | |\  
     | |_|/  
     |/| |   
-    * | | 77b07be (A) A: 10 lines on top
+    * | | 706b5e8 (A) A: 10 lines on top
     |\| | 
     | * | a748762 (B) B: another 10 lines at the bottom
     | * | 62e05ba B: 10 lines at the bottom
@@ -487,13 +487,13 @@ fn insert_single_node_segment_below_with_explicit_parents() -> Result<()> {
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:main[🌳]
-        └── ·9cf36b2 (⌂|1)
+        └── ·c1cb047 (⌂|1)
             ├── ►:1[1]:A
-            │   └── ·37fb54d (⌂|1)
+            │   └── ·275b149 (⌂|1)
             │       ├── ►:4[4]:anon:
             │       │   └── ·8f0d338 (⌂|1) ►tags/base
             │       └── ►:2[2]:B
-            │           └── ·d202f84 (⌂|1)
+            │           └── ·9c9c689 (⌂|1)
             │               ├── ►:5[3]:anon:
             │               │   └── ·62e05ba (⌂|1)
             │               │       └── →:4:
@@ -509,11 +509,11 @@ fn insert_single_node_segment_below_with_explicit_parents() -> Result<()> {
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *-.   9cf36b2 (HEAD -> main) Merge branches 'A', 'B' and 'C'
+    *-.   c1cb047 (HEAD -> main) Merge branches 'A', 'B' and 'C'
     |\ \  
-    * | | 37fb54d (A) A: 10 lines on top
+    * | | 275b149 (A) A: 10 lines on top
     |\| | 
-    | * | d202f84 (B) B: another 10 lines at the bottom
+    | * | 9c9c689 (B) B: another 10 lines at the bottom
     | |\| 
     | | * 930563a (C) C: add another 10 lines to new file
     | | * 68a2fc3 C: add 10 lines to new file

--- a/crates/but-rebase/tests/rebase/graph_rebase/mod.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/mod.rs
@@ -5,6 +5,7 @@ use but_meta::{
 };
 use but_testsupport::StackState;
 
+mod change_id;
 mod cherry_pick;
 mod conflictable_restriction;
 mod disconnect;

--- a/crates/but-rebase/tests/rebase/graph_rebase/replace.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/replace.rs
@@ -49,9 +49,9 @@ fn reword_a_commit() -> Result<()> {
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:with-inner-merge[🌳]
-        └── ·b475cbc (⌂|1)
+        └── ·78aaae2 (⌂|1)
             └── ►:1[1]:anon:
-                └── ·3d1e2c5 (⌂|1)
+                └── ·53af95a (⌂|1)
                     ├── ►:2[2]:A
                     │   └── ·6de6b92 (⌂|1)
                     │       └── ►:4[3]:main
@@ -66,8 +66,8 @@ fn reword_a_commit() -> Result<()> {
     assert_eq!(head_tree, repo.head_tree()?.id);
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * b475cbc (HEAD -> with-inner-merge) on top of inner merge
-    *   3d1e2c5 Merge branch 'B' into with-inner-merge
+    * 78aaae2 (HEAD -> with-inner-merge) on top of inner merge
+    *   53af95a Merge branch 'B' into with-inner-merge
     |\  
     | * 984fd1c (B) C: new file with 10 lines
     * | 6de6b92 (A) A: a second coming
@@ -77,8 +77,8 @@ fn reword_a_commit() -> Result<()> {
     insta::assert_snapshot!(git_status(&repo)?, @"");
     insta::assert_debug_snapshot!(outcome.history.commit_mappings(), @"
     {
-        Sha1(2fc288c36c8bb710c78203f78ea9883724ce142b): Sha1(3d1e2c5e12ac74bec07707581688e576ec7643a0),
-        Sha1(e8ee978dac10e6a85006543ef08be07c5824b4f7): Sha1(b475cbc480a447b44d56b703665d2b57ef19a5d0),
+        Sha1(2fc288c36c8bb710c78203f78ea9883724ce142b): Sha1(53af95adeaf78258ee71c74fe4daa6628d750ff1),
+        Sha1(e8ee978dac10e6a85006543ef08be07c5824b4f7): Sha1(78aaae2b4d822ed0cc7e0e83767b5dec2c88791b),
     }
     ");
 
@@ -144,9 +144,9 @@ fn amend_a_commit() -> Result<()> {
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:with-inner-merge[🌳]
-        └── ·4772ab7 (⌂|1)
+        └── ·e7221b5 (⌂|1)
             └── ►:1[1]:anon:
-                └── ·e7d8400 (⌂|1)
+                └── ·8101192 (⌂|1)
                     ├── ►:2[2]:A
                     │   └── ·f1905a8 (⌂|1)
                     │       └── ►:4[3]:main
@@ -159,8 +159,8 @@ fn amend_a_commit() -> Result<()> {
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * 4772ab7 (HEAD -> with-inner-merge) on top of inner merge
-    *   e7d8400 Merge branch 'B' into with-inner-merge
+    * e7221b5 (HEAD -> with-inner-merge) on top of inner merge
+    *   8101192 Merge branch 'B' into with-inner-merge
     |\  
     | * 984fd1c (B) C: new file with 10 lines
     * | f1905a8 (A) A: a second coming
@@ -170,8 +170,8 @@ fn amend_a_commit() -> Result<()> {
     insta::assert_snapshot!(git_status(&repo)?, @"");
     insta::assert_debug_snapshot!(outcome.history.commit_mappings(), @"
     {
-        Sha1(2fc288c36c8bb710c78203f78ea9883724ce142b): Sha1(e7d8400bb33d6e4a947da3485c38193ca3964b81),
-        Sha1(e8ee978dac10e6a85006543ef08be07c5824b4f7): Sha1(4772ab72b13718f64fb387e7e7f2bc124e2c6e13),
+        Sha1(2fc288c36c8bb710c78203f78ea9883724ce142b): Sha1(810119232dd43ad1edc6b3d1a9cc2cd507d92a4e),
+        Sha1(e8ee978dac10e6a85006543ef08be07c5824b4f7): Sha1(e7221b5ace99ba38e222e19e5da9c6966955e37b),
     }
     ");
 

--- a/crates/but-rebase/tests/rebase/graph_rebase/signing_preferences.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/signing_preferences.rs
@@ -77,7 +77,7 @@ fn commits_are_signed_by_default() -> Result<()> {
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:main[🌳]
-        ├── ·de980c3 (⌂|1) ►c
+        ├── ·06106c2 (⌂|1) ►c
         └── ·3bfeb52 (⌂|1) ►a, ►b
             └── ►:1[1]:base
                 └── ·b6e2f57 (⌂|1)
@@ -86,7 +86,7 @@ fn commits_are_signed_by_default() -> Result<()> {
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * de980c3 (HEAD -> main, c) c
+    * 06106c2 (HEAD -> main, c) c
     * 3bfeb52 (b, a) a
     * b6e2f57 (base) base
     ");
@@ -97,7 +97,7 @@ fn commits_are_signed_by_default() -> Result<()> {
     author author <author@example.com> 946684800 +0000
     committer Committer (Memory Override) <committer@example.com> 946771200 +0000
     gitbutler-headers-version 2
-    change-id 1
+    change-id npznqkxwqsymyowwmpltqqvnvuqqrsoy
     gpgsig -----BEGIN SSH SIGNATURE-----
      U1NIU0lHAAAAAQAAARcAAAAHc3NoLXJzYQAAAAMBAAEAAAEBALgYZ0wtPvJyZ40qWRIe8A
      bAYhKYgt0bWX3Z16PyZjWEF+FFx9bRSThY0Bc45TNzon133/aaTWMBnO9RDPw50wZH2ULI
@@ -105,12 +105,12 @@ fn commits_are_signed_by_default() -> Result<()> {
      jf8ezbO+kZg8+J1HMS83gOxhxj15Gwf1cCJAInXr/phYX8BmAZWSHZHu8foy6IG1g1dutr
      2QyAGFddwDKObsrbejsOhwbF7u7PTEGWWO63ZlKS5/QfXg4hCoyWsrTW7lVqI6Xgxk4zOa
      U+EnrNSr2BBXGSSgAqe1vo8TVWggNh/ACdnZa4Y6EAAAADZ2l0AAAAAAAAAAZzaGE1MTIA
-     AAEUAAAADHJzYS1zaGEyLTUxMgAAAQCzgTRGROlhLbgBHE+/7Kp1Iy5zhO3KCQUqL1mxoN
-     MIP2YYq26jA7Xqxd5ZXBmQ/GjuPUb9SRiYt3gGQ24XuE3IPfMk4KEgR+ko/NyDWAx1M/kk
-     J4Kc6h7JoxNFDQFDY1Lj8BXNJ/DemHEHd6ncjBjdZlSlDpeB+x4Lv1fSnRF3RKhzXTA+sZ
-     aHOH9hZhWAftrV1IyG4JOfNeMaaHXt8HEuEPNUvCEajqqFCaQK9jBf3hd7biPUd/fQ2XUm
-     UfWrxBKP4ZKbO+/JQLmtJfIsxev6no7pF2nxnbmX+ivzE8n/TZJR3xuzBtXNsc1zBdkApM
-     LXBDTIkoN64ekxY0tJjYsE
+     AAEUAAAADHJzYS1zaGEyLTUxMgAAAQBPEv21QjFZJ+/CxMSCs1zb3yxEjqvPo181qaioTw
+     BFjDsJgnNLj5H9Uw/uCoTrXkmvOFpdbCJMb0iuf4aiDxqP7Q8wonC66tmdgbkyNQxJyl8T
+     CexJ8bhSrTFGu5vX9E2xdcYt5dCpUrD49w3a4hCAcoLAXrNFuGu9LDRRFfh8Bmp6zjXgYC
+     XZ0tI4iFDutMulDhmQZicFYPomb0TgHOzpDwr9+zX7pJOhX2xbeM3wbgj0hIfCDb2W81Rn
+     A5coj4FSlkXqpYC8mg/jwO54d4cfn2/y2oXesKAY5yxrZPIPlb7vmiLwiEcEh9YQhTT0c0
+     3KOol2J6bRKScwko1nMzSz
      -----END SSH SIGNATURE-----
 
     c
@@ -152,7 +152,7 @@ fn when_cherry_picking_dont_resign_if_not_set() -> Result<()> {
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:main[🌳]
-        ├── ·06fee46 (⌂|1) ►c
+        ├── ·a773b84 (⌂|1) ►c
         └── ·3bfeb52 (⌂|1) ►a, ►b
             └── ►:1[1]:base
                 └── ·b6e2f57 (⌂|1)
@@ -161,7 +161,7 @@ fn when_cherry_picking_dont_resign_if_not_set() -> Result<()> {
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * 06fee46 (HEAD -> main, c) c
+    * a773b84 (HEAD -> main, c) c
     * 3bfeb52 (b, a) a
     * b6e2f57 (base) base
     ");
@@ -172,7 +172,7 @@ fn when_cherry_picking_dont_resign_if_not_set() -> Result<()> {
     author author <author@example.com> 946684800 +0000
     committer Committer (Memory Override) <committer@example.com> 946771200 +0000
     gitbutler-headers-version 2
-    change-id 1
+    change-id npznqkxwqsymyowwmpltqqvnvuqqrsoy
 
     c
     ");
@@ -220,7 +220,7 @@ fn force_picked_commit_with_sign_yes_is_signed_when_otherwise_unchanged() -> Res
 
     let after = visualize_commit_graph_all(&repo)?;
     insta::assert_snapshot!(after, @"
-    * 9500d40 (HEAD -> main, top) top
+    * a120c22 (HEAD -> main, top) top
     * 135e6ba (mid) mid
     * 7a5aacf (base) base
     ");
@@ -291,8 +291,8 @@ fn force_picked_ancestor_does_not_sign_descendants_picked_with_sign_commit_no() 
 
     let after = visualize_commit_graph_all(&repo)?;
     insta::assert_snapshot!(after, @"
-    * 4b4fbf0 (HEAD -> main, top) top
-    * b8cd8b5 (mid) mid
+    * ddf9e11 (HEAD -> main, top) top
+    * 70ea083 (mid) mid
     * 7a5aacf (base) base
     ");
 
@@ -378,8 +378,8 @@ fn force_picked_ancestor_triggers_cascading_signatures_on_descendants_picked_wit
 
     let after = visualize_commit_graph_all(&repo)?;
     insta::assert_snapshot!(after, @"
-    * c29936f (HEAD -> main, top) top
-    * b8cd8b5 (mid) mid
+    * 0ceb853 (HEAD -> main, top) top
+    * 70ea083 (mid) mid
     * 7a5aacf (base) base
     ");
 
@@ -460,7 +460,7 @@ fn commit_picked_with_sign_if_enabled_is_not_signed_when_signing_config_is_disab
 
     let after = visualize_commit_graph_all(&repo)?;
     insta::assert_snapshot!(after, @"
-    * f923739 (HEAD -> main, top) top
+    * de73d4b (HEAD -> main, top) top
     * 7a5aacf (mid, base) base
     ");
 

--- a/crates/but-rebase/tests/rebase/graph_rebase/workspace_commit_behaviour.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/workspace_commit_behaviour.rs
@@ -105,8 +105,8 @@ fn workspace_commit_is_not_signed_after_cherry_pick() -> Result<()> {
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:gitbutler/workspace[🌳]
-        ├── ·31c75e2 (⌂|1)
-        ├── ·de980c3 (⌂|1) ►c, ►main
+        ├── ·badca2f (⌂|1)
+        ├── ·06106c2 (⌂|1) ►c, ►main
         └── ·3bfeb52 (⌂|1) ►a, ►b
             └── ►:1[1]:base
                 └── ·b6e2f57 (⌂|1)
@@ -115,19 +115,19 @@ fn workspace_commit_is_not_signed_after_cherry_pick() -> Result<()> {
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * 31c75e2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    * de980c3 (main, c) c
+    * badca2f (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 06106c2 (main, c) c
     * 3bfeb52 (b, a) a
     * b6e2f57 (base) base
     ");
 
     insta::assert_snapshot!(cat_commit(&repo, "gitbutler/workspace")?, @"
     tree ea0372ea78d32151cb4c2b6a05a084817947c8f3
-    parent de980c3adf6a0fd63e4b0662297c16d0c9e7177c
+    parent 06106c2b20d31a1454a733b85f8737077cee9b5c
     author author <author@example.com> 946684800 +0000
     committer Committer (Memory Override) <committer@example.com> 946771200 +0000
     gitbutler-headers-version 2
-    change-id 1
+    change-id wznplrwlpuqosonpqkwvqtwymskounvy
 
     GitButler Workspace Commit
     ");
@@ -139,7 +139,7 @@ fn workspace_commit_is_not_signed_after_cherry_pick() -> Result<()> {
     author author <author@example.com> 946684800 +0000
     committer Committer (Memory Override) <committer@example.com> 946771200 +0000
     gitbutler-headers-version 2
-    change-id 1
+    change-id npznqkxwqsymyowwmpltqqvnvuqqrsoy
     gpgsig -----BEGIN SSH SIGNATURE-----
      U1NIU0lHAAAAAQAAARcAAAAHc3NoLXJzYQAAAAMBAAEAAAEBALgYZ0wtPvJyZ40qWRIe8A
      bAYhKYgt0bWX3Z16PyZjWEF+FFx9bRSThY0Bc45TNzon133/aaTWMBnO9RDPw50wZH2ULI
@@ -147,12 +147,12 @@ fn workspace_commit_is_not_signed_after_cherry_pick() -> Result<()> {
      jf8ezbO+kZg8+J1HMS83gOxhxj15Gwf1cCJAInXr/phYX8BmAZWSHZHu8foy6IG1g1dutr
      2QyAGFddwDKObsrbejsOhwbF7u7PTEGWWO63ZlKS5/QfXg4hCoyWsrTW7lVqI6Xgxk4zOa
      U+EnrNSr2BBXGSSgAqe1vo8TVWggNh/ACdnZa4Y6EAAAADZ2l0AAAAAAAAAAZzaGE1MTIA
-     AAEUAAAADHJzYS1zaGEyLTUxMgAAAQCzgTRGROlhLbgBHE+/7Kp1Iy5zhO3KCQUqL1mxoN
-     MIP2YYq26jA7Xqxd5ZXBmQ/GjuPUb9SRiYt3gGQ24XuE3IPfMk4KEgR+ko/NyDWAx1M/kk
-     J4Kc6h7JoxNFDQFDY1Lj8BXNJ/DemHEHd6ncjBjdZlSlDpeB+x4Lv1fSnRF3RKhzXTA+sZ
-     aHOH9hZhWAftrV1IyG4JOfNeMaaHXt8HEuEPNUvCEajqqFCaQK9jBf3hd7biPUd/fQ2XUm
-     UfWrxBKP4ZKbO+/JQLmtJfIsxev6no7pF2nxnbmX+ivzE8n/TZJR3xuzBtXNsc1zBdkApM
-     LXBDTIkoN64ekxY0tJjYsE
+     AAEUAAAADHJzYS1zaGEyLTUxMgAAAQBPEv21QjFZJ+/CxMSCs1zb3yxEjqvPo181qaioTw
+     BFjDsJgnNLj5H9Uw/uCoTrXkmvOFpdbCJMb0iuf4aiDxqP7Q8wonC66tmdgbkyNQxJyl8T
+     CexJ8bhSrTFGu5vX9E2xdcYt5dCpUrD49w3a4hCAcoLAXrNFuGu9LDRRFfh8Bmp6zjXgYC
+     XZ0tI4iFDutMulDhmQZicFYPomb0TgHOzpDwr9+zX7pJOhX2xbeM3wbgj0hIfCDb2W81Rn
+     A5coj4FSlkXqpYC8mg/jwO54d4cfn2/y2oXesKAY5yxrZPIPlb7vmiLwiEcEh9YQhTT0c0
+     3KOol2J6bRKScwko1nMzSz
      -----END SSH SIGNATURE-----
 
     c

--- a/crates/but-workspace/tests/workspace/branch/move_branch.rs
+++ b/crates/but-workspace/tests/workspace/branch/move_branch.rs
@@ -55,10 +55,10 @@ fn move_top_branch_to_top_of_another_stack() -> anyhow::Result<()> {
     ws.refresh_from_head(&repo, &meta)?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   26fdd46 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   bdcbf64 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * c813d8d (B) B
-    * | 3db8c14 (C) C
+    * | f2cc60d (C) C
     * | 09d8e52 (A) A
     |/  
     * 85efbe4 (origin/main, main) M
@@ -71,7 +71,7 @@ fn move_top_branch_to_top_of_another_stack() -> anyhow::Result<()> {
     │       └── ·c813d8d (🏘️)
     └── ≡📙:3:C on 85efbe4 {1}
         ├── 📙:3:C
-        │   └── ·3db8c14 (🏘️)
+        │   └── ·f2cc60d (🏘️)
         └── 📙:4:A
             └── ·09d8e52 (🏘️)
     ");
@@ -126,10 +126,10 @@ fn move_bottom_branch_to_top_of_another_stack() -> anyhow::Result<()> {
     ws.refresh_from_head(&repo, &meta)?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   ac869ab (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   1229630 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
-    | * 9f14615 (C) C
-    * | 698ccd3 (B) B
+    | * 8e00332 (C) C
+    * | f9061ed (B) B
     * | 09d8e52 (A) A
     |/  
     * 85efbe4 (origin/main, main) M
@@ -139,10 +139,10 @@ fn move_bottom_branch_to_top_of_another_stack() -> anyhow::Result<()> {
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:5:C on 85efbe4 {2}
     │   └── 📙:5:C
-    │       └── ·9f14615 (🏘️)
+    │       └── ·8e00332 (🏘️)
     └── ≡📙:3:B on 85efbe4 {1}
         ├── 📙:3:B
-        │   └── ·698ccd3 (🏘️)
+        │   └── ·f9061ed (🏘️)
         └── 📙:4:A
             └── ·09d8e52 (🏘️)
     ");
@@ -198,8 +198,8 @@ fn move_single_branch_to_top_of_another_stack() -> anyhow::Result<()> {
     ws.refresh_from_head(&repo, &meta)?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * 263392f (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    * 8dbfefa (A) A
+    * 4c58dd4 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 148f8f3 (A) A
     * 09bc93e (C) C
     * c813d8d (B) B
     * 85efbe4 (origin/main, main) M
@@ -209,7 +209,7 @@ fn move_single_branch_to_top_of_another_stack() -> anyhow::Result<()> {
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     └── ≡📙:3:A on 85efbe4 {2}
         ├── 📙:3:A
-        │   └── ·8dbfefa (🏘️)
+        │   └── ·148f8f3 (🏘️)
         ├── 📙:4:C
         │   └── ·09bc93e (🏘️)
         └── 📙:5:B
@@ -267,10 +267,10 @@ fn reorder_branch_in_stack() -> anyhow::Result<()> {
     ws.refresh_from_head(&repo, &meta)?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   82661e2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   268bc90 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
-    | * 2c58ac6 (B) B
-    | * 9f14615 (C) C
+    | * de0581e (B) B
+    | * 8e00332 (C) C
     * | 09d8e52 (A) A
     |/  
     * 85efbe4 (origin/main, main) M
@@ -280,9 +280,9 @@ fn reorder_branch_in_stack() -> anyhow::Result<()> {
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:4:B on 85efbe4 {2}
     │   ├── 📙:4:B
-    │   │   └── ·2c58ac6 (🏘️)
+    │   │   └── ·de0581e (🏘️)
     │   └── 📙:5:C
-    │       └── ·9f14615 (🏘️)
+    │       └── ·8e00332 (🏘️)
     └── ≡📙:3:A on 85efbe4 {1}
         └── 📙:3:A
             └── ·09d8e52 (🏘️)
@@ -339,9 +339,9 @@ fn insert_branch_in_the_middle_of_a_stack() -> anyhow::Result<()> {
     ws.refresh_from_head(&repo, &meta)?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * 35a28f3 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    * 531d8aa (C) C
-    * 3df48f1 (A) A
+    * 0c5cde5 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 3e7ff55 (C) C
+    * 4dfe841 (A) A
     * c813d8d (B) B
     * 85efbe4 (origin/main, main) M
     ");
@@ -350,9 +350,9 @@ fn insert_branch_in_the_middle_of_a_stack() -> anyhow::Result<()> {
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     └── ≡📙:3:C on 85efbe4 {2}
         ├── 📙:3:C
-        │   └── ·531d8aa (🏘️)
+        │   └── ·3e7ff55 (🏘️)
         ├── 📙:4:A
-        │   └── ·3df48f1 (🏘️)
+        │   └── ·4dfe841 (🏘️)
         └── 📙:5:B
             └── ·c813d8d (🏘️)
     ");
@@ -400,7 +400,7 @@ fn move_empty_branch() -> anyhow::Result<()> {
     ws.refresh_from_head(&repo, &meta)?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * ee3cff8 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 2c820f0 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 09d8e52 (B, A) A
     * 85efbe4 (origin/main, main) M
     ");
@@ -455,7 +455,7 @@ fn move_branch_on_top_of_empty_branch() -> anyhow::Result<()> {
     ws.refresh_from_head(&repo, &meta)?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * ee3cff8 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 2c820f0 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 09d8e52 (A) A
     * 85efbe4 (origin/main, main, B) M
     ");
@@ -651,17 +651,17 @@ fn move_branch_when_base_segment_has_no_ref_name() -> anyhow::Result<()> {
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 148c87a (origin/main) M2
-    | * 3f2f4c5 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    | * 698ccd3 (B) B
+    | * 0db3c2f (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    | * f9061ed (B) B
     | * 09d8e52 (A) A
     |/  
     * 85efbe4 (main) M
     ");
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 85efbe4
     └── ≡📙:3:B on 85efbe4 {1}
         ├── 📙:3:B
-        │   └── ·698ccd3 (🏘️)
+        │   └── ·f9061ed (🏘️)
         └── 📙:4:A
             └── ·09d8e52 (🏘️)
     ");

--- a/crates/but-workspace/tests/workspace/branch/tear_off_branch.rs
+++ b/crates/but-workspace/tests/workspace/branch/tear_off_branch.rs
@@ -54,12 +54,12 @@ fn tear_off_top_most_branch() -> anyhow::Result<()> {
     ws.refresh_from_head(&repo, &meta)?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *-.   18e6497 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *-.   efd284c (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\ \  
     | | * 09d8e52 (A) A
     | * | c813d8d (B) B
     | |/  
-    * / 9f14615 (C) C
+    * / 8e00332 (C) C
     |/  
     * 85efbe4 (origin/main, main) M
     ");
@@ -68,7 +68,7 @@ fn tear_off_top_most_branch() -> anyhow::Result<()> {
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:5:C on 85efbe4 {3}
     │   └── 📙:5:C
-    │       └── ·9f14615 (🏘️)
+    │       └── ·8e00332 (🏘️)
     ├── ≡📙:4:B on 85efbe4 {2}
     │   └── 📙:4:B
     │       └── ·c813d8d (🏘️)
@@ -128,9 +128,9 @@ fn tear_off_bottom_most_branch() -> anyhow::Result<()> {
     ws.refresh_from_head(&repo, &meta)?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *-.   f365cbc (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *-.   af022f8 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\ \  
-    | | * 9f14615 (C) C
+    | | * 8e00332 (C) C
     | * | 09d8e52 (A) A
     | |/  
     * / c813d8d (B) B
@@ -145,7 +145,7 @@ fn tear_off_bottom_most_branch() -> anyhow::Result<()> {
     │       └── ·c813d8d (🏘️)
     ├── ≡📙:4:C on 85efbe4 {2}
     │   └── 📙:4:C
-    │       └── ·9f14615 (🏘️)
+    │       └── ·8e00332 (🏘️)
     └── ≡📙:3:A on 85efbe4 {1}
         └── 📙:3:A
             └── ·09d8e52 (🏘️)
@@ -202,7 +202,7 @@ fn tear_off_only_branch_in_stack() -> anyhow::Result<()> {
     ws.refresh_from_head(&repo, &meta)?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   290169a (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   bb92c8b (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * 09bc93e (C) C
     | * c813d8d (B) B
@@ -265,10 +265,10 @@ fn tear_off_from_single_stack_in_ws_top() -> anyhow::Result<()> {
     ws.refresh_from_head(&repo, &meta)?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   40098a7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   e2d89a5 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * 09d8e52 (A) A
-    * | 5dab59a (B) B
+    * | 1273ba9 (B) B
     |/  
     * 85efbe4 (origin/main, main) M
     ");
@@ -277,7 +277,7 @@ fn tear_off_from_single_stack_in_ws_top() -> anyhow::Result<()> {
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:4:B on 85efbe4 {2}
     │   └── 📙:4:B
-    │       └── ·5dab59a (🏘️)
+    │       └── ·1273ba9 (🏘️)
     └── ≡📙:3:A on 85efbe4 {1}
         └── 📙:3:A
             └── ·09d8e52 (🏘️)
@@ -325,9 +325,9 @@ fn tear_off_from_single_stack_in_ws_bottom() -> anyhow::Result<()> {
     ws.refresh_from_head(&repo, &meta)?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   ce8d25d (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   828af37 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
-    | * 5dab59a (B) B
+    | * 1273ba9 (B) B
     * | 09d8e52 (A) A
     |/  
     * 85efbe4 (origin/main, main) M
@@ -340,7 +340,7 @@ fn tear_off_from_single_stack_in_ws_bottom() -> anyhow::Result<()> {
     │       └── ·09d8e52 (🏘️)
     └── ≡📙:3:B on 85efbe4 {2}
         └── 📙:3:B
-            └── ·5dab59a (🏘️)
+            └── ·1273ba9 (🏘️)
     ");
 
     Ok(())
@@ -385,7 +385,7 @@ fn tear_off_empty_branch() -> anyhow::Result<()> {
     ws.refresh_from_head(&repo, &meta)?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   de62bba (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   d744692 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * 09d8e52 (A) A
     |/  
@@ -443,7 +443,7 @@ fn tear_off_non_empty_branch() -> anyhow::Result<()> {
     ws.refresh_from_head(&repo, &meta)?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   4b2d718 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   b1314f4 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     * | 09d8e52 (A) A
     |/  

--- a/crates/but-workspace/tests/workspace/commit/discard_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/discard_commit.rs
@@ -53,7 +53,7 @@ fn discard_middle_commit_in_non_managed_workspace() -> Result<()> {
     );
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * fc5e5e6 (HEAD -> three) commit three
+    * 0c38dd9 (HEAD -> three) commit three
     | * 16fd221 (origin/two) commit two
     |/  
     * 8b426d0 (two, one) commit one
@@ -117,7 +117,7 @@ fn discard_tip_commit_in_workspace_stack() -> Result<()> {
     assert_eq!(tip_of_c, b, "The C ref should now point to B");
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   5e34c6d (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   95c53c4 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * c813d8d (C, B) B
     * | 09d8e52 (A) A
@@ -173,7 +173,7 @@ fn discard_bottom_commit_in_workspace_stack() -> Result<()> {
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:4:C on 85efbe4 {2}
     │   ├── 📙:4:C
-    │   │   └── ·9f14615 (🏘️)
+    │   │   └── ·8e00332 (🏘️)
     │   └── 📙:5:B
     └── ≡📙:3:A on 85efbe4 {1}
         └── 📙:3:A
@@ -196,9 +196,9 @@ fn discard_bottom_commit_in_workspace_stack() -> Result<()> {
     assert_ne!(b, tip_of_c, "Discarded commit must not remain as C tip");
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   ec062b0 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   bae0ee9 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
-    | * 9f14615 (C) C
+    | * 8e00332 (C) C
     * | 09d8e52 (A) A
     |/  
     * 85efbe4 (origin/main, main, B) M

--- a/crates/but-workspace/tests/workspace/commit/insert_blank_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/insert_blank_commit.rs
@@ -32,8 +32,8 @@ fn insert_below_commit() -> Result<()> {
     .materialize()?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * 70ba329 (HEAD -> three) commit three
-    * 0f4f9d0 (two) commit two
+    * 1b97135 (HEAD -> three) commit three
+    * 5f398b2 (two) commit two
     * b3b14c2 
     | * 16fd221 (origin/two) commit two
     |/  
@@ -69,7 +69,7 @@ fn insert_above_commit() -> Result<()> {
     .materialize()?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * 8e87ff3 (HEAD -> three) commit three
+    * 2b11859 (HEAD -> three) commit three
     * 024b774 (two) 
     * 16fd221 (origin/two) commit two
     * 8b426d0 (one) commit one
@@ -104,7 +104,7 @@ fn insert_below_reference() -> Result<()> {
     .materialize()?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * 8e87ff3 (HEAD -> three) commit three
+    * 2b11859 (HEAD -> three) commit three
     * 024b774 (two) 
     * 16fd221 (origin/two) commit two
     * 8b426d0 (one) commit one
@@ -139,7 +139,7 @@ fn insert_above_reference() -> Result<()> {
     .materialize()?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * 8e87ff3 (HEAD -> three) commit three
+    * 2b11859 (HEAD -> three) commit three
     * 024b774 
     * 16fd221 (origin/two, two) commit two
     * 8b426d0 (one) commit one

--- a/crates/but-workspace/tests/workspace/commit/move_changes.rs
+++ b/crates/but-workspace/tests/workspace/commit/move_changes.rs
@@ -94,13 +94,13 @@ fn move_file_from_head_to_parent() -> Result<()> {
     insta::assert_debug_snapshot!(materialized.history.commit_mappings(), @"
     {
         Sha1(16fd22163adbb1118551777970db5fb4b59f6b9d): Sha1(88ba151b2f14a87051cdbeb3bdf850a6175eb8fe),
-        Sha1(c9f444cbd4d94f5b90aaa3e6e2e388c876cdbdae): Sha1(95562c28cbe1efce7d36dafe97fc35b1f804fba7),
+        Sha1(c9f444cbd4d94f5b90aaa3e6e2e388c876cdbdae): Sha1(5f79d8bc78f0fc157cf33456412cfa443c0ae4fc),
     }
     ");
 
     // Graph structure should be maintained (commit hashes will change)
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * 95562c2 (HEAD -> three) commit three
+    * 5f79d8b (HEAD -> three) commit three
     * 88ba151 (two) commit two
     | * 16fd221 (origin/two) commit two
     |/  
@@ -160,13 +160,13 @@ fn move_file_from_parent_to_head() -> Result<()> {
     insta::assert_debug_snapshot!(materialized.history.commit_mappings(), @"
     {
         Sha1(16fd22163adbb1118551777970db5fb4b59f6b9d): Sha1(0f198e0be723143e843ec2e2f9538f4ba815cd62),
-        Sha1(c9f444cbd4d94f5b90aaa3e6e2e388c876cdbdae): Sha1(c7eb64bce6de865a5cc4c97ab296f424ec41210d),
+        Sha1(c9f444cbd4d94f5b90aaa3e6e2e388c876cdbdae): Sha1(cffb8daaedf92594a000665b3990714ad04115c7),
     }
     ");
 
     // Graph structure should be maintained
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * c7eb64b (HEAD -> three) commit three
+    * cffb8da (HEAD -> three) commit three
     * 0f198e0 (two) commit two
     | * 16fd221 (origin/two) commit two
     |/  
@@ -223,16 +223,16 @@ fn move_file_between_non_adjacent_commits() -> Result<()> {
     let materialized = outcome.rebase.materialize()?;
     insta::assert_debug_snapshot!(materialized.history.commit_mappings(), @"
     {
-        Sha1(16fd22163adbb1118551777970db5fb4b59f6b9d): Sha1(364d4a2e248a71c66f26bb2b4651ea773fe214a5),
+        Sha1(16fd22163adbb1118551777970db5fb4b59f6b9d): Sha1(d9e603c74228d57e22e16431db09647bc281b65a),
         Sha1(8b426d09509e2a1e924d939055e1e3eb4b6e7fb4): Sha1(9bc8248dd9ea42b08f66103cd43352fcd2f45f3d),
-        Sha1(c9f444cbd4d94f5b90aaa3e6e2e388c876cdbdae): Sha1(4d3039f44cc829fd5f1622cecc5eafe93b252fe2),
+        Sha1(c9f444cbd4d94f5b90aaa3e6e2e388c876cdbdae): Sha1(cda98e06158943a26336b4584f016938ae72864b),
     }
     ");
 
     // Graph structure should be maintained
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * 4d3039f (HEAD -> three) commit three
-    * 364d4a2 (two) commit two
+    * cda98e0 (HEAD -> three) commit three
+    * d9e603c (two) commit two
     * 9bc8248 (one) commit one
     * 16fd221 (origin/two) commit two
     * 8b426d0 commit one

--- a/crates/but-workspace/tests/workspace/commit/move_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/move_commit.rs
@@ -74,10 +74,10 @@ fn move_top_commit_to_top_of_another_stack() -> anyhow::Result<()> {
     );
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   26fdd46 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   bdcbf64 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * c813d8d (C, B) B
-    * | 3db8c14 (A) C
+    * | f2cc60d (A) C
     * | 09d8e52 A
     |/  
     * 85efbe4 (origin/main, main) M
@@ -91,7 +91,7 @@ fn move_top_commit_to_top_of_another_stack() -> anyhow::Result<()> {
     │       └── ·c813d8d (🏘️)
     └── ≡📙:3:A on 85efbe4 {1}
         └── 📙:3:A
-            ├── ·3db8c14 (🏘️)
+            ├── ·f2cc60d (🏘️)
             └── ·09d8e52 (🏘️)
     ");
 
@@ -169,10 +169,10 @@ fn move_bottom_commit_to_top_of_another_stack() -> anyhow::Result<()> {
     );
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   ac869ab (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   1229630 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
-    | * 9f14615 (C) C
-    * | 698ccd3 (A) B
+    | * 8e00332 (C) C
+    * | f9061ed (A) B
     * | 09d8e52 A
     |/  
     * 85efbe4 (origin/main, main, B) M
@@ -182,11 +182,11 @@ fn move_bottom_commit_to_top_of_another_stack() -> anyhow::Result<()> {
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:4:C on 85efbe4 {2}
     │   ├── 📙:4:C
-    │   │   └── ·9f14615 (🏘️)
+    │   │   └── ·8e00332 (🏘️)
     │   └── 📙:5:B
     └── ≡📙:3:A on 85efbe4 {1}
         └── 📙:3:A
-            ├── ·698ccd3 (🏘️)
+            ├── ·f9061ed (🏘️)
             └── ·09d8e52 (🏘️)
     ");
 
@@ -262,11 +262,11 @@ fn move_top_commit_to_bottom_of_another_stack() -> anyhow::Result<()> {
     );
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   45976fd (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   b197178 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * c813d8d (C, B) B
-    * | 9bb60db (A) A
-    * | 9f14615 C
+    * | 2506923 (A) A
+    * | 8e00332 C
     |/  
     * 85efbe4 (origin/main, main) M
     ");
@@ -279,8 +279,8 @@ fn move_top_commit_to_bottom_of_another_stack() -> anyhow::Result<()> {
     │       └── ·c813d8d (🏘️)
     └── ≡📙:3:A on 85efbe4 {1}
         └── 📙:3:A
-            ├── ·9bb60db (🏘️)
-            └── ·9f14615 (🏘️)
+            ├── ·2506923 (🏘️)
+            └── ·8e00332 (🏘️)
     ");
 
     Ok(())
@@ -357,10 +357,10 @@ fn move_bottom_commit_to_bottom_of_another_stack() -> anyhow::Result<()> {
     );
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   dbabd50 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   0cd9d1e (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
-    | * 9f14615 (C) C
-    * | 3df48f1 (A) A
+    | * 8e00332 (C) C
+    * | 4dfe841 (A) A
     * | c813d8d B
     |/  
     * 85efbe4 (origin/main, main, B) M
@@ -370,11 +370,11 @@ fn move_bottom_commit_to_bottom_of_another_stack() -> anyhow::Result<()> {
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:4:C on 85efbe4 {2}
     │   ├── 📙:4:C
-    │   │   └── ·9f14615 (🏘️)
+    │   │   └── ·8e00332 (🏘️)
     │   └── 📙:5:B
     └── ≡📙:3:A on 85efbe4 {1}
         └── 📙:3:A
-            ├── ·3df48f1 (🏘️)
+            ├── ·4dfe841 (🏘️)
             └── ·c813d8d (🏘️)
     ");
 
@@ -443,9 +443,9 @@ fn move_single_commit_to_the_top_of_another_branch() -> anyhow::Result<()> {
     );
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   9b0c3a5 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   ce2d156 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
-    | * 8dbfefa (C) A
+    | * 148f8f3 (C) A
     | * 09bc93e C
     | * c813d8d (B) B
     |/  
@@ -456,7 +456,7 @@ fn move_single_commit_to_the_top_of_another_branch() -> anyhow::Result<()> {
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:3:C on 85efbe4 {2}
     │   ├── 📙:3:C
-    │   │   ├── ·8dbfefa (🏘️)
+    │   │   ├── ·148f8f3 (🏘️)
     │   │   └── ·09bc93e (🏘️)
     │   └── 📙:4:B
     │       └── ·c813d8d (🏘️)
@@ -538,10 +538,10 @@ fn move_single_commit_to_the_bottom_of_another_branch() -> anyhow::Result<()> {
     );
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   202b05f (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   dda25f3 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
-    | * f603807 (C) C
-    | * 698ccd3 (B) B
+    | * ad476a8 (C) C
+    | * f9061ed (B) B
     | * 09d8e52 A
     |/  
     * 85efbe4 (origin/main, main, A) M
@@ -551,9 +551,9 @@ fn move_single_commit_to_the_bottom_of_another_branch() -> anyhow::Result<()> {
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:3:C on 85efbe4 {2}
     │   ├── 📙:3:C
-    │   │   └── ·f603807 (🏘️)
+    │   │   └── ·ad476a8 (🏘️)
     │   └── 📙:4:B
-    │       ├── ·698ccd3 (🏘️)
+    │       ├── ·f9061ed (🏘️)
     │       └── ·09d8e52 (🏘️)
     └── ≡📙:5:A on 85efbe4 {1}
         └── 📙:5:A
@@ -767,8 +767,8 @@ fn reorder_commit_in_non_managed_workspace() -> anyhow::Result<()> {
     // which is now a child of three.
     // The origin two branch has not been yet updated and still points to the original 'two' commit.
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * b8c85c3 (HEAD -> three, two) commit two
-    * fc5e5e6 commit three
+    * 09ad3ca (HEAD -> three, two) commit two
+    * 0c38dd9 commit three
     | * 16fd221 (origin/two) commit two
     |/  
     * 8b426d0 (one) commit one
@@ -778,8 +778,8 @@ fn reorder_commit_in_non_managed_workspace() -> anyhow::Result<()> {
     ⌂:0:three[🌳] <> ✓!
     └── ≡:0:three[🌳] {1}
         ├── :0:three[🌳]
-        │   ├── ·b8c85c3 ►two
-        │   └── ·fc5e5e6
+        │   ├── ·09ad3ca ►two
+        │   └── ·0c38dd9
         └── :2:one
             └── ·8b426d0
     ");

--- a/crates/but-workspace/tests/workspace/commit/reword.rs
+++ b/crates/but-workspace/tests/workspace/commit/reword.rs
@@ -53,7 +53,7 @@ fn reword_middle_commit() -> Result<()> {
         .materialize()?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * 9feebdd (HEAD -> three) commit three
+    * d8b7d8a (HEAD -> three) commit three
     * ada51de (two) New name
     | * 16fd221 (origin/two) commit two
     |/  
@@ -86,8 +86,8 @@ fn reword_base_commit() -> Result<()> {
     // We end up with two divergent histories here. This is to be expected if we
     // rewrite the very bottom commit in a repository.
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * fe9fe7a (HEAD -> three) commit three
-    * 096a124 (two) commit two
+    * 9a3264d (HEAD -> three) commit three
+    * 86c4bef (two) commit two
     * 1121ebc (one) New name
     * 16fd221 (origin/two) commit two
     * 8b426d0 commit one

--- a/crates/but-workspace/tests/workspace/commit/squash_commits.rs
+++ b/crates/but-workspace/tests/workspace/commit/squash_commits.rs
@@ -425,7 +425,7 @@ fn squash_across_stacks_subject_into_target() -> Result<()> {
     assert_eq!(squashed_commit.tree_id()?.detach(), subject_tree);
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   d6e2c4d (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   c12bb2a (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * 82d6f41 (B) B
     |/  
@@ -493,7 +493,7 @@ fn squash_across_stacks_target_into_subject() -> Result<()> {
     assert_eq!(squashed_commit.tree_id()?.detach(), subject_tree);
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   e33c9cc (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   9df30a4 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     * | 17e27b0 (A) A
     |/  

--- a/crates/but-workspace/tests/workspace/commit/uncommit_changes.rs
+++ b/crates/but-workspace/tests/workspace/commit/uncommit_changes.rs
@@ -92,7 +92,7 @@ fn uncommit_file_from_parent() -> Result<()> {
 
     // Graph structure should be maintained
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * 2c4471e (HEAD -> three) commit three
+    * 300f366 (HEAD -> three) commit three
     * 0f198e0 (two) commit two
     | * 16fd221 (origin/two) commit two
     |/  
@@ -147,8 +147,8 @@ fn uncommit_file_from_root_commit() -> Result<()> {
 
     // Graph structure should be maintained
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * 72f5d24 (HEAD -> three) commit three
-    * 0a49f31 (two) commit two
+    * 95fb0e5 (HEAD -> three) commit three
+    * 910d5b1 (two) commit two
     * 7fcda42 (one) commit one
     * 16fd221 (origin/two) commit two
     * 8b426d0 commit one

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -64,11 +64,11 @@ fn diamond_partially_historically_integrated_rebase() -> Result<()> {
     rebase.materialize()?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * 03f9366 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    * 22aa077 (E) E
-    *   8719a89 (C) C
+    * 996b85e (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 2eb4a8c (E) E
+    *   aecdc68 (C) C
     |\  
-    | * 59b39ea (D) D
+    | * 020d090 (D) D
     |/  
     * 7de2393 (origin/master, master) o4
     *   7d62953 (o3) o3
@@ -138,7 +138,7 @@ fn diamond_partially_historically_integrated_merge() -> Result<()> {
     rebase.materialize()?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * 96c95ba (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 292b0b3 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     *   ed5f276 (E) Merge refs/remotes/origin/master into merge
     |\  
     | * 7de2393 (origin/master, master) o4
@@ -226,11 +226,11 @@ fn diamond_partially_content_integrated_rebase() -> Result<()> {
     rebase.materialize()?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * 5ba22ce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    * 04b1a3e (E) E
-    *   1144e41 (C) C
+    * 8b48706 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * cb866ec (E) E
+    *   c7b32b8 (C) C
     |\  
-    | * dd00172 (D) D
+    | * e05e7c1 (D) D
     |/  
     * 162b064 (origin/master, master) o4
     * dd87d69 (o3) B
@@ -295,7 +295,7 @@ fn diamond_partially_content_integrated_merge() -> Result<()> {
     rebase.materialize()?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * 6c75185 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * ebd6fa2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     *   0a395ba (E) Merge refs/remotes/origin/master into merge
     |\  
     | * 162b064 (origin/master, master) o4

--- a/crates/but/tests/but/command/merge.rs
+++ b/crates/but/tests/but/command/merge.rs
@@ -34,7 +34,7 @@ fn merge_first_branch_into_gb_local_and_verify_rebase() -> anyhow::Result<()> {
 
     // Verify git log shows both branches before merge
     insta::assert_snapshot!(env.git_log()?, @r"
-    *   945f3cf (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   71ae247 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * edca1cd (second-branch) second commit on branch B
     * | 549e10c (first-branch) first commit on branch A
@@ -123,7 +123,7 @@ To undo this operation:
     * e8d7818 (second-branch) second commit on branch B
     *   61888c9 (gb-local/main, gb-local/HEAD, main) Merge branch 'first-branch'
     |\  
-    | | * 945f3cf (gb-local/gitbutler/workspace) GitButler Workspace Commit
+    | | * 71ae247 (gb-local/gitbutler/workspace) GitButler Workspace Commit
     | |/| 
     |/| | 
     | | * edca1cd (gb-local/second-branch) second commit on branch B

--- a/crates/but/tests/but/command/move.rs
+++ b/crates/but/tests/but/command/move.rs
@@ -375,7 +375,7 @@ Moved 4 commits → before [..]
 ┊●   [..] A: 10 lines on top
 ┊●   [..] C: add another 10 lines to new file
 ┊●   [..] C: add 10 lines to new file
-┊●   fc29de6 C: new file with 10 lines
+┊●   461deb3 C: new file with 10 lines
 ┊●   62e05ba B: 10 lines at the bottom
 ├╯
 ┊
@@ -518,7 +518,7 @@ Moved 4 commits → after a748762
 ┊●   [..] A: 10 lines on top
 ┊●   [..] C: add another 10 lines to new file
 ┊●   [..] C: add 10 lines to new file
-┊●   b665de5 C: new file with 10 lines
+┊●   5d69b97 C: new file with 10 lines
 ┊●   a748762 B: another 10 lines at the bottom
 ┊●   62e05ba B: 10 lines at the bottom
 ├╯
@@ -825,7 +825,7 @@ Moved branch A on top of C.
 ╭┄zz [unassigned changes] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   afff88e add A
+┊●   89a57fc add A
 ┊│
 ┊├┄h0 [C]
 ┊●   3842fc0 add C
@@ -906,7 +906,7 @@ Moved branch A on top of C.
 ╭┄zz [unassigned changes] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   afff88e add A
+┊●   89a57fc add A
 ┊│
 ┊├┄h0 [C]
 ┊●   3842fc0 add C
@@ -996,7 +996,7 @@ Unstacked branch C.
 ├╯
 ┊
 ┊╭┄i0 [C]
-┊●   31e83cd add C
+┊●   661a9b6 add C
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M

--- a/crates/but/tests/but/command/reword.rs
+++ b/crates/but/tests/but/command/reword.rs
@@ -24,7 +24,7 @@ Updated commit message for [..] (now [..])
 "#]]);
 
     insta::assert_snapshot!(env.git_log()?, @"
-    * 0bd57a4 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 8c69cf9 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 2f7c570 (A) Updated commit message
     * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
     ");
@@ -54,7 +54,7 @@ Updated commit message for [..] (now [..])
 
     // Verify the commit message was updated with multiline content
     insta::assert_snapshot!(env.git_log()?, @"
-    * 5996541 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * e6bde18 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * cdf2c74 (A) First line
     * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
     ");

--- a/crates/but/tests/but/command/squash.rs
+++ b/crates/but/tests/but/command/squash.rs
@@ -379,8 +379,8 @@ fn squash_list_with_bottom_target_keeps_target_message_first() -> anyhow::Result
     env.setup_metadata(&["A"])?;
     setup_branch_with_commits(&env, "A", 3);
 
-    insta::assert_snapshot!(env.git_log()?, @r"
-    * c7b6336 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    insta::assert_snapshot!(env.git_log()?, @"
+    * ec2758d (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 8a1f552 (A) commit 3
     * 39dd878 commit 2
     * 8128859 commit 1
@@ -426,8 +426,8 @@ fn squash_list_with_middle_target_keeps_target_message_first() -> anyhow::Result
     env.setup_metadata(&["A"])?;
     setup_branch_with_commits(&env, "A", 3);
 
-    insta::assert_snapshot!(env.git_log()?, @r"
-    * c7b6336 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    insta::assert_snapshot!(env.git_log()?, @"
+    * ec2758d (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 8a1f552 (A) commit 3
     * 39dd878 commit 2
     * 8128859 commit 1
@@ -477,8 +477,8 @@ fn squash_multiple_commits_keeps_squashed_commit_content() -> anyhow::Result<()>
     env.setup_metadata(&["A"])?;
     setup_branch_with_commits(&env, "A", 3);
 
-    insta::assert_snapshot!(env.git_log()?, @r"
-    * c7b6336 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    insta::assert_snapshot!(env.git_log()?, @"
+    * ec2758d (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 8a1f552 (A) commit 3
     * 39dd878 commit 2
     * 8128859 commit 1

--- a/crates/gitbutler-edit-mode/tests/edit_mode.rs
+++ b/crates/gitbutler-edit-mode/tests/edit_mode.rs
@@ -165,8 +165,8 @@ fn multiple_commits_created_during_edit_mode() -> Result<()> {
     save_and_return_to_workspace(&mut ctx)?;
 
     let repo = &*ctx.repo.get()?;
-    insta::assert_snapshot!(visualize_commit_graph(repo, "refs/heads/gitbutler/workspace")?, @r"
-    * 59ab552 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    insta::assert_snapshot!(visualize_commit_graph(repo, "refs/heads/gitbutler/workspace")?, @"
+    * 33e3bfc (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * f6d3539 (branchy) second commit added
     * d39dd61 first commit added
     * 26804c3 foobar
@@ -220,8 +220,8 @@ fn apply_commit_on_itself() -> Result<()> {
 
     let repo = &*ctx.repo.get()?;
     // It works.
-    insta::assert_snapshot!(visualize_commit_graph(repo, "refs/heads/gitbutler/workspace")?, @r"
-    * 85cd48c (HEAD -> gitbutler/workspace, gitbutler/edit) GitButler Workspace Commit
+    insta::assert_snapshot!(visualize_commit_graph(repo, "refs/heads/gitbutler/workspace")?, @"
+    * 16b549b (HEAD -> gitbutler/workspace, gitbutler/edit) GitButler Workspace Commit
     * 6eb9642 (branchy) GitButler Workspace Commit
     * 26804c3 foobar
     * 7950f06 (origin/main, origin/HEAD, main, gitbutler/target) init


### PR DESCRIPTION
* Closes GB-1296

`empty_commit` now makes use of a randomly generated change_id (or one from config). If the user really disliked themselves they could have git timestamps frozen which could result in generating N empty commits with the same sha and deterministic change_id which would not be desirable.

`cherry_pick` now constructs headers using a new `Headers::from_change_id` that takes the given change ID directly. We get the value by calling `change_id()` on the previous `but_core::Commit` object.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #13692 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #13691 
<!-- GitButler Footer Boundary Bottom -->

