### PR TITLE
cli+tui: make repeated but undos work

### DIFF
--- a/apps/desktop/src/components/history/SnapshotCard.svelte
+++ b/apps/desktop/src/components/history/SnapshotCard.svelte
@@ -162,6 +162,7 @@
 			case "UpdateWorkspaceBase":
 				return { text: "Update workspace base", icon: "refresh" };
 			case "RestoreFromSnapshot":
+			case "RestoreFromSnapshotViaUndo":
 				return { text: "Revert snapshot" };
 			case "OnDemandSnapshot":
 				return {
@@ -175,7 +176,11 @@
 		}
 	}
 
-	const isRestoreSnapshot = untrack(() => entry.details?.operation === "RestoreFromSnapshot");
+	const isRestoreSnapshot = untrack(
+		() =>
+			entry.details?.operation === "RestoreFromSnapshot" ||
+			entry.details?.operation === "RestoreFromSnapshotViaUndo",
+	);
 	const error = untrack(() => entry.details?.trailers.find((t) => t.key === "error")?.value);
 
 	const operation = mapOperation(untrack(() => entry.details));

--- a/apps/desktop/src/lib/history/history.ts
+++ b/apps/desktop/src/lib/history/history.ts
@@ -45,8 +45,7 @@ class SnapshotPager {
 		if (!this.cursor) throw new Error("Not without a cursor");
 		if (get(this.isAllLoaded)) return; // Nothing to do.
 
-		// TODO: Update API so we don't have to .slice()
-		const more = (await this.fetch(this.cursor)).slice(1);
+		const more = await this.fetch(this.cursor);
 
 		if (more.length === 0) {
 			this.isAllLoaded.set(true);

--- a/apps/desktop/src/lib/history/types.ts
+++ b/apps/desktop/src/lib/history/types.ts
@@ -28,6 +28,7 @@ export type Operation =
 	| "MoveCommit"
 	| "MoveBranch"
 	| "TearOffBranch"
+	| "RestoreFromSnapshotViaUndo"
 	| "RestoreFromSnapshot"
 	| "ReorderCommit"
 	| "InsertBlankCommit"

--- a/apps/desktop/src/routes/[projectId]/history/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/history/+page.svelte
@@ -59,7 +59,10 @@
 		snapshots.forEach((snapshot, index) => idToIndexMap.set(snapshot.id, index));
 
 		const ranges = snapshots.flatMap((snapshot, startIndex) => {
-			if (snapshot.details?.operation === "RestoreFromSnapshot") {
+			if (
+				snapshot.details?.operation === "RestoreFromSnapshot" ||
+				snapshot.details?.operation === "RestoreFromSnapshotViaUndo"
+			) {
 				const restoredId = snapshot.details?.trailers.find((t) => t.key === "restored_from")?.value;
 				if (restoredId !== undefined) {
 					const endIndex = idToIndexMap.get(restoredId);

--- a/crates/but-api/src/legacy/oplog.rs
+++ b/crates/but-api/src/legacy/oplog.rs
@@ -26,13 +26,14 @@ use tracing::instrument;
 
 /// List snapshots in the oplog.
 ///
-/// - `project_id`: The ID of the project to list snapshots for.
 /// - `limit`: Maximum number of snapshots to return.
-/// - `sha`: Optional SHA to filter snapshots starting from a specific commit.
+/// - `sha`: Optional SHA to filter snapshots starting after a specific commit.
 /// - `exclude_kind`: Optional list of operation kinds to exclude from the results.
 /// - `include_kind`: Optional list of operation kinds to include (if set, only these kinds are returned).
 ///
 /// Returns a vector of `Snapshot` entries.
+///
+/// Prefer using [`snapshots_iter`] if possible.
 ///
 /// # Errors
 /// Returns an error if the project cannot be found or if there is an issue accessing the oplog.
@@ -45,9 +46,77 @@ pub fn list_snapshots(
     exclude_kind: Option<Vec<OperationKind>>,
     include_kind: Option<Vec<OperationKind>>,
 ) -> Result<Vec<Snapshot>> {
-    let snapshots =
-        ctx.list_snapshots(limit, sha, exclude_kind.unwrap_or_default(), include_kind)?;
+    let snapshots = ctx
+        .snapshots_iter(sha, exclude_kind.unwrap_or_default(), include_kind)?
+        .take(limit)
+        .collect::<anyhow::Result<Vec<_>>>()?;
     Ok(snapshots)
+}
+
+/// Iterate snapshots in the oplog.
+///
+/// - `sha`: Optional SHA to filter snapshots starting after a specific commit.
+/// - `exclude_kind`: Optional list of operation kinds to exclude from the results.
+/// - `include_kind`: Optional list of operation kinds to include (if set, only these kinds are returned).
+///
+/// Returns an iterator of `Snapshot` entries.
+///
+/// # Errors
+/// Returns an error if the project cannot be found or if there is an issue accessing the oplog.
+#[instrument(err(Debug))]
+pub fn snapshots_iter(
+    ctx: &but_ctx::Context,
+    sha: Option<gix::ObjectId>,
+    exclude_kind: Option<Vec<OperationKind>>,
+    include_kind: Option<Vec<OperationKind>>,
+) -> Result<impl Iterator<Item = Result<Snapshot>>> {
+    ctx.snapshots_iter(sha, exclude_kind.unwrap_or_default(), include_kind)
+}
+
+/// Get the snapshot that an undo operation should restore to.
+///
+/// This handles multiple consecutive undos by walking backwards in the oplog.
+#[but_api]
+#[instrument(err(Debug))]
+pub fn get_undo_target_snapshot(ctx: &but_ctx::Context) -> Result<Option<Snapshot>> {
+    // Undo snapshots are bookkeeping entries, not operations we should restore to directly. Walk
+    // newest-to-oldest and let each undo entry cancel one older real operation.
+    //
+    // This handles both repeated undos:
+    //
+    //     [UNDO]   <- skip one real operation
+    //     [UNDO]   <- skip one real operation
+    //     [REWORD] <- skipped
+    //     [REWORD] <- skipped
+    //     [REWORD] <- target
+    //
+    // And a new operation after an undo:
+    //
+    //     [UNDO]   <- skip one real operation
+    //     [REWORD] <- skipped
+    //     [UNDO]   <- skip one more real operation, not a valid target itself
+    //     [REWORD] <- skipped
+    //     [REWORD] <- target
+    let snapshots = ctx.snapshots_iter(None, Vec::new(), None)?;
+    let mut real_operations_to_skip = 0_usize;
+
+    for snapshot in snapshots {
+        let snapshot = snapshot?;
+
+        if snapshot.details.as_ref().is_some_and(|details| {
+            matches!(details.operation, OperationKind::RestoreFromSnapshotViaUndo)
+        }) {
+            real_operations_to_skip += 1;
+            continue;
+        }
+
+        if real_operations_to_skip == 0 {
+            return Ok(Some(snapshot));
+        }
+        real_operations_to_skip -= 1;
+    }
+
+    Ok(None)
 }
 
 /// Gets a specific snapshot by its commit SHA.
@@ -88,6 +157,8 @@ pub fn create_snapshot(
     Ok(oid)
 }
 
+pub use gitbutler_oplog::RestoreKind;
+
 /// Restores the project to a specific snapshot. This operation also creates a new snapshot in the oplog.
 ///
 /// - `project_id`: The ID of the project to restore.
@@ -103,8 +174,19 @@ pub fn create_snapshot(
 #[but_api]
 #[instrument(err(Debug))]
 pub fn restore_snapshot(ctx: &mut but_ctx::Context, sha: gix::ObjectId) -> Result<()> {
+    restore_snapshot_with_kind(ctx, RestoreKind::ExplicitRestoreFromSnapshot, sha)
+}
+
+/// Restores the project to a specific snapshot using a specific kind of restore. This operation
+/// also creates a new snapshot in the oplog.
+#[instrument(err(Debug))]
+pub fn restore_snapshot_with_kind(
+    ctx: &mut but_ctx::Context,
+    restore_kind: RestoreKind,
+    sha: gix::ObjectId,
+) -> Result<()> {
     let mut guard = ctx.exclusive_worktree_access();
-    ctx.restore_snapshot(sha, guard.write_permission())?;
+    ctx.restore_snapshot(sha, restore_kind, guard.write_permission())?;
     Ok(())
 }
 

--- a/crates/but/src/command/legacy/oplog.rs
+++ b/crates/but/src/command/legacy/oplog.rs
@@ -1,3 +1,4 @@
+use but_api::legacy::oplog::RestoreKind;
 use but_core::RepositoryExt;
 use gitbutler_oplog::entry::{OperationKind, Snapshot};
 use gix::{date::time::CustomFormat, prelude::ObjectIdExt};
@@ -45,7 +46,9 @@ pub(crate) fn show_oplog(
         None
     };
 
-    let snapshots = but_api::legacy::oplog::list_snapshots(ctx, 20, since_sha, None, include_kind)?;
+    let snapshots = but_api::legacy::oplog::snapshots_iter(ctx, since_sha, None, include_kind)?
+        .take(20)
+        .collect::<anyhow::Result<Vec<_>>>()?;
 
     if snapshots.is_empty() {
         if let Some(out) = out.for_json() {
@@ -118,7 +121,7 @@ pub(crate) fn show_oplog(
             let operation_colored = match operation_type {
                 "COMMIT" => t.success.paint(operation_type),
                 "AMEND" | "REWORD" => t.attention.paint(operation_type),
-                "UNDO_COMMIT" | "RESTORE" => t.error.paint(operation_type),
+                "UNDO_COMMIT" | "RESTORE" | "UNDO" => t.error.paint(operation_type),
                 "DISCARD" => t.error.paint(operation_type),
                 "BRANCH" | "CHECKOUT" => t.local_branch.paint(operation_type),
                 "MOVE" | "REORDER" | "MOVE_HUNK" => t.info.paint(operation_type),
@@ -199,7 +202,11 @@ pub(crate) fn restore_to_oplog(
     }
 
     // Restore to the target snapshot using the but-api crate
-    but_api::legacy::oplog::restore_snapshot(ctx, commit_id)?;
+    but_api::legacy::oplog::restore_snapshot_with_kind(
+        ctx,
+        RestoreKind::ExplicitRestoreFromSnapshot,
+        commit_id,
+    )?;
 
     if let Some(out) = out.for_human() {
         let t = theme::get();
@@ -220,23 +227,10 @@ pub(crate) fn undo_last_operation(
     ctx: &mut but_ctx::Context,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
-    // As we snapshot before mutation, undoing the last operation is equivalent to restoring the
-    // latest snapshot.
-    let snapshots = but_api::legacy::oplog::list_snapshots(ctx, 1, None, None, None)?;
-
-    if snapshots.is_empty() {
-        if let Some(out) = out.for_human() {
-            let t = theme::get();
-            writeln!(
-                out,
-                "{}",
-                t.attention.paint("No previous operations to undo.")
-            )?;
-        }
+    let Some(target_snapshot) = but_api::legacy::oplog::get_undo_target_snapshot(ctx)? else {
+        print_no_snapshot_to_restore_to(out)?;
         return Ok(());
-    }
-
-    let target_snapshot = &snapshots[0];
+    };
 
     let target_operation = target_snapshot
         .details
@@ -244,7 +238,7 @@ pub(crate) fn undo_last_operation(
         .map(|d| d.title.as_str())
         .unwrap_or("Unknown operation");
 
-    let target_time = snapshot_time_string(target_snapshot);
+    let target_time = snapshot_time_string(&target_snapshot);
 
     if let Some(out) = out.for_human() {
         let t = theme::get();
@@ -259,7 +253,11 @@ pub(crate) fn undo_last_operation(
 
     // Restore to the previous snapshot using the but_api
     // TODO: Why does this not require force? It will also overwrite user changes (I think).
-    but_api::legacy::oplog::restore_snapshot(ctx, target_snapshot.commit_id)?;
+    but_api::legacy::oplog::restore_snapshot_with_kind(
+        ctx,
+        RestoreKind::RestoreFromSnapshotViaUndo,
+        target_snapshot.commit_id,
+    )?;
 
     if let Some(out) = out.for_human() {
         let t = theme::get();
@@ -274,6 +272,18 @@ pub(crate) fn undo_last_operation(
         )?;
     }
 
+    Ok(())
+}
+
+fn print_no_snapshot_to_restore_to(out: &mut OutputChannel) -> anyhow::Result<()> {
+    if let Some(out) = out.for_human() {
+        let t = theme::get();
+        writeln!(
+            out,
+            "{}",
+            t.attention.paint("No previous operations to undo.")
+        )?;
+    }
     Ok(())
 }
 

--- a/crates/but/src/command/legacy/rub/squash.rs
+++ b/crates/but/src/command/legacy/rub/squash.rs
@@ -310,7 +310,12 @@ fn squash_commits_internal(
     let final_commit_oid = match squash_result {
         Ok(final_commit_oid) => final_commit_oid,
         Err(err) => {
-            ctx.restore_snapshot(snapshot, perm).with_context(|| {
+            ctx.restore_snapshot(
+                snapshot,
+                gitbutler_oplog::RestoreKind::ExplicitRestoreFromSnapshot,
+                perm,
+            )
+            .with_context(|| {
                 format!("Failed to restore snapshot {snapshot} after squash failure")
             })?;
             return Err(err);

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -11,7 +11,7 @@ use std::{
 
 use anyhow::Context as _;
 use bstr::{BString, ByteSlice};
-use but_api::diff::ComputeLineStats;
+use but_api::{diff::ComputeLineStats, legacy::oplog::RestoreKind};
 use but_core::ref_metadata::StackId;
 use but_core::tree::create_tree::RejectionReason;
 use but_ctx::Context;
@@ -2531,13 +2531,9 @@ impl App {
     }
 
     fn handle_undo(&mut self, ctx: &mut Context) -> anyhow::Result<()> {
-        let snapshots = but_api::legacy::oplog::list_snapshots(ctx, 1, None, None, None)?;
-
-        if snapshots.is_empty() {
+        let Some(target_snapshot) = but_api::legacy::oplog::get_undo_target_snapshot(ctx)? else {
             return Ok(());
-        }
-
-        let target_snapshot = snapshots.first().unwrap();
+        };
 
         let text = {
             let time = target_snapshot
@@ -2566,7 +2562,11 @@ impl App {
 
         let commit = target_snapshot.commit_id;
         self.confirm = Some(Confirm::new(text, self.theme, move |ctx, messages| {
-            but_api::legacy::oplog::restore_snapshot(ctx, commit)?;
+            but_api::legacy::oplog::restore_snapshot_with_kind(
+                ctx,
+                RestoreKind::RestoreFromSnapshotViaUndo,
+                commit,
+            )?;
             messages.push(Message::Reload(None));
             Ok(())
         }));

--- a/crates/but/tests/but/command/undo.rs
+++ b/crates/but/tests/but/command/undo.rs
@@ -54,6 +54,24 @@ where
     Ok(())
 }
 
+#[track_caller]
+fn reword(
+    env: &Sandbox,
+    commit_before: &str,
+    commit_after: &str,
+    new_message: &str,
+) -> anyhow::Result<std::process::Output> {
+    env.but("reword")
+        .args([commit_before, "-m", new_message])
+        .assert()
+        .success()
+        .stdout_eq(format!(
+            "Updated commit message for {commit_before} (now {commit_after})\n"
+        ))
+        .stderr_eq("");
+    Ok(env.but("status").output()?)
+}
+
 #[test]
 fn can_undo_discard() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
@@ -170,6 +188,386 @@ fn can_undo_rewording_branch() -> anyhow::Result<()> {
 
         Ok(())
     })?;
+
+    Ok(())
+}
+
+#[test]
+fn can_undo_repeatedly() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits")?;
+    env.setup_metadata(&["A"])?;
+
+    let status_one = reword(&env, "9ac4652", "9f9095e", "one")?;
+    let status_two = reword(&env, "9f9095e", "baa6a31", "two")?;
+    let status_three = reword(&env, "baa6a31", "a1fa8e0", "three")?;
+    reword(&env, "a1fa8e0", "c5d642c", "four")?;
+
+    env.but("oplog")
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout_eq(
+            r#"Operations History
+──────────────────────────────────────────────────
+74dbb64 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+d3394b6 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+850a5fa 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+"#,
+        );
+
+    env.but("undo").assert().success().stdout_eq(
+        r#"Undoing operation...
+  Reverting to: UpdateCommitMessage (2000-01-02 00:00:00)
+✓ Undo completed successfully! Restored to snapshot: 74dbb64
+"#,
+    );
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(status_three.stdout)
+        .stderr_eq(status_three.stderr);
+
+    env.but("oplog")
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout_eq(
+            r#"Operations History
+──────────────────────────────────────────────────
+a68383b 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+74dbb64 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+d3394b6 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+850a5fa 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+"#,
+        );
+
+    env.but("undo").assert().success().stdout_eq(
+        r#"Undoing operation...
+  Reverting to: UpdateCommitMessage (2000-01-02 00:00:00)
+✓ Undo completed successfully! Restored to snapshot: d3394b6
+"#,
+    );
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(status_two.stdout)
+        .stderr_eq(status_two.stderr);
+
+    env.but("oplog")
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout_eq(
+            r#"Operations History
+──────────────────────────────────────────────────
+4852c7f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+a68383b 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+74dbb64 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+d3394b6 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+850a5fa 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+"#,
+        );
+
+    env.but("undo").assert().success().stdout_eq(
+        r#"Undoing operation...
+  Reverting to: UpdateCommitMessage (2000-01-02 00:00:00)
+✓ Undo completed successfully! Restored to snapshot: 850a5fa
+"#,
+    );
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(status_one.stdout)
+        .stderr_eq(status_one.stderr);
+
+    env.but("oplog")
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout_eq(
+            r#"Operations History
+──────────────────────────────────────────────────
+0fabcd0 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+4852c7f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+a68383b 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+74dbb64 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+d3394b6 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+850a5fa 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+"#,
+        );
+
+    Ok(())
+}
+
+#[test]
+fn can_undo_explicit_restore() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits")?;
+    env.setup_metadata(&["A"])?;
+
+    reword(&env, "9ac4652", "9f9095e", "one")?;
+    let status_two = reword(&env, "9f9095e", "baa6a31", "two")?;
+    reword(&env, "baa6a31", "a1fa8e0", "three")?;
+    let status_four = reword(&env, "a1fa8e0", "c5d642c", "four")?;
+
+    env.but("oplog")
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout_eq(
+            r#"Operations History
+──────────────────────────────────────────────────
+74dbb64 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+d3394b6 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+850a5fa 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+"#,
+        );
+
+    env.but("oplog")
+        .args(["restore", "d3394b6"])
+        .assert()
+        .success()
+        .stdout_eq(
+            r#"
+✓ Restore completed successfully!
+
+Workspace has been restored to the selected snapshot.
+"#,
+        );
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(status_two.stdout.clone())
+        .stderr_eq(status_two.stderr.clone());
+
+    env.but("oplog")
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout_eq(
+            r#"Operations History
+──────────────────────────────────────────────────
+fb3fac3 2000-01-02 00:00:00 [RESTORE] Restored from snapshot
+74dbb64 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+d3394b6 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+850a5fa 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+"#,
+        );
+
+    env.but("undo").assert().success().stdout_eq(
+        r#"Undoing operation...
+  Reverting to: Restored from snapshot (2000-01-02 00:00:00)
+✓ Undo completed successfully! Restored to snapshot: fb3fac3
+"#,
+    );
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(status_four.stdout)
+        .stderr_eq(status_four.stderr);
+
+    env.but("oplog")
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout_eq(
+            r#"Operations History
+──────────────────────────────────────────────────
+d363393 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+fb3fac3 2000-01-02 00:00:00 [RESTORE] Restored from snapshot
+74dbb64 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+d3394b6 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+850a5fa 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+"#,
+        );
+
+    Ok(())
+}
+
+#[test]
+fn can_undo_perform_operation_then_undo_again() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits")?;
+    env.setup_metadata(&["A"])?;
+
+    reword(&env, "9ac4652", "9f9095e", "one")?;
+    let status_two = reword(&env, "9f9095e", "baa6a31", "two")?;
+    let status_three = reword(&env, "baa6a31", "a1fa8e0", "three")?;
+    reword(&env, "a1fa8e0", "c5d642c", "four")?;
+
+    env.but("oplog")
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout_eq(
+            r#"Operations History
+──────────────────────────────────────────────────
+74dbb64 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+d3394b6 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+850a5fa 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+"#,
+        );
+
+    env.but("undo").assert().success().stdout_eq(
+        r#"Undoing operation...
+  Reverting to: UpdateCommitMessage (2000-01-02 00:00:00)
+✓ Undo completed successfully! Restored to snapshot: 74dbb64
+"#,
+    );
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(status_three.stdout.clone())
+        .stderr_eq(status_three.stderr.clone());
+
+    reword(&env, "a1fa8e0", "022806e", "three-new")?;
+
+    env.but("oplog")
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout_eq(
+            r#"Operations History
+──────────────────────────────────────────────────
+944fd88 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+a68383b 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+74dbb64 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+d3394b6 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+850a5fa 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+"#,
+        );
+
+    env.but("undo").assert().success().stdout_eq(
+        r#"Undoing operation...
+  Reverting to: UpdateCommitMessage (2000-01-02 00:00:00)
+✓ Undo completed successfully! Restored to snapshot: 944fd88
+"#,
+    );
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(status_three.stdout.clone())
+        .stderr_eq(status_three.stderr);
+
+    env.but("oplog")
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout_eq(
+            r#"Operations History
+──────────────────────────────────────────────────
+b31b8c7 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+944fd88 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+a68383b 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+74dbb64 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+d3394b6 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+850a5fa 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+"#,
+        );
+
+    env.but("undo").assert().success().stdout_eq(
+        r#"Undoing operation...
+  Reverting to: UpdateCommitMessage (2000-01-02 00:00:00)
+✓ Undo completed successfully! Restored to snapshot: d3394b6
+"#,
+    );
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(status_two.stdout.clone())
+        .stderr_eq(status_two.stderr.clone());
+
+    Ok(())
+}
+
+#[test]
+fn undoing_past_end_of_oplog() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits")?;
+    env.setup_metadata(&["A"])?;
+
+    let status_zero = env.but("status").output()?;
+    let status_one = reword(&env, "9ac4652", "9f9095e", "one")?;
+    reword(&env, "9f9095e", "baa6a31", "two")?;
+
+    env.but("oplog")
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout_eq(
+            r#"Operations History
+──────────────────────────────────────────────────
+850a5fa 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+"#,
+        );
+
+    env.but("undo").assert().success().stdout_eq(
+        r#"Undoing operation...
+  Reverting to: UpdateCommitMessage (2000-01-02 00:00:00)
+✓ Undo completed successfully! Restored to snapshot: 850a5fa
+"#,
+    );
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(status_one.stdout.clone())
+        .stderr_eq(status_one.stderr.clone());
+
+    env.but("oplog")
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout_eq(
+            r#"Operations History
+──────────────────────────────────────────────────
+cace4c0 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+850a5fa 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+"#,
+        );
+
+    env.but("undo").assert().success().stdout_eq(
+        r#"Undoing operation...
+  Reverting to: UpdateCommitMessage (2000-01-02 00:00:00)
+✓ Undo completed successfully! Restored to snapshot: 7665ea7
+"#,
+    );
+
+    env.but("oplog")
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout_eq(
+            r#"Operations History
+──────────────────────────────────────────────────
+5cc4a31 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+cace4c0 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+850a5fa 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+"#,
+        );
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(status_zero.stdout.clone())
+        .stderr_eq(status_zero.stderr.clone());
+
+    env.but("undo").assert().success().stdout_eq(
+        r#"No previous operations to undo.
+"#,
+    );
 
     Ok(())
 }

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/oplog.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/oplog.rs
@@ -8,8 +8,8 @@ use std::{io::Write, path::Path};
 use bstr::ByteSlice as _;
 use but_core::{GitConfigSettings, RepositoryExt as _};
 use gitbutler_branch::BranchCreateRequest;
-use gitbutler_oplog::OplogExt;
 use gitbutler_oplog::entry::{OperationKind, SnapshotDetails};
+use gitbutler_oplog::{OplogExt, RestoreKind};
 use gitbutler_stack::VirtualBranchesHandle;
 use itertools::Itertools;
 
@@ -60,7 +60,10 @@ fn workdir_vbranch_restore() -> anyhow::Result<()> {
     )?;
     drop(guard);
 
-    let snapshots = ctx.list_snapshots(10, None, Vec::new(), None)?;
+    let snapshots = ctx
+        .snapshots_iter(None, Vec::new(), None)?
+        .take(10)
+        .collect::<anyhow::Result<Vec<_>>>()?;
     assert_eq!(
         snapshots.len(),
         7,
@@ -70,11 +73,18 @@ fn workdir_vbranch_restore() -> anyhow::Result<()> {
     let previous_files_count = wd_file_count(&worktree_dir)?;
     assert_eq!(previous_files_count, 3, "one file per round");
     let mut guard = ctx.exclusive_worktree_access();
-    ctx.restore_snapshot(snapshots[0].commit_id, guard.write_permission())
-        .expect("restoration succeeds");
+    ctx.restore_snapshot(
+        snapshots[0].commit_id,
+        RestoreKind::RestoreFromSnapshotViaUndo,
+        guard.write_permission(),
+    )
+    .expect("restoration succeeds");
 
     assert_eq!(
-        ctx.list_snapshots(10, None, Vec::new(), None)?.len(),
+        ctx.snapshots_iter(None, Vec::new(), None)?
+            .take(10)
+            .collect::<anyhow::Result<Vec<_>>>()?
+            .len(),
         8,
         "all the previous + 1 restore commit"
     );
@@ -209,7 +219,10 @@ fn basic_oplog() -> anyhow::Result<()> {
         3
     );
 
-    let snapshots = ctx.list_snapshots(10, None, Vec::new(), None)?;
+    let snapshots = ctx
+        .snapshots_iter(None, Vec::new(), None)?
+        .take(10)
+        .collect::<anyhow::Result<Vec<_>>>()?;
 
     let ops = snapshots
         .iter()
@@ -229,7 +242,11 @@ fn basic_oplog() -> anyhow::Result<()> {
 
     {
         let mut guard = ctx.exclusive_worktree_access();
-        ctx.restore_snapshot(snapshots[1].clone().commit_id, guard.write_permission())?;
+        ctx.restore_snapshot(
+            snapshots[1].clone().commit_id,
+            RestoreKind::RestoreFromSnapshotViaUndo,
+            guard.write_permission(),
+        )?;
     }
 
     // restores the conflict files
@@ -240,7 +257,11 @@ fn basic_oplog() -> anyhow::Result<()> {
 
     {
         let mut guard = ctx.exclusive_worktree_access();
-        ctx.restore_snapshot(snapshots[2].clone().commit_id, guard.write_permission())?;
+        ctx.restore_snapshot(
+            snapshots[2].clone().commit_id,
+            RestoreKind::RestoreFromSnapshotViaUndo,
+            guard.write_permission(),
+        )?;
     }
 
     // the restore removed our new branch
@@ -269,7 +290,11 @@ fn basic_oplog() -> anyhow::Result<()> {
     {
         let mut guard = ctx.exclusive_worktree_access();
         // The ctx stores the `git2` repo
-        ctx.restore_snapshot(snapshots[1].commit_id, guard.write_permission())?;
+        ctx.restore_snapshot(
+            snapshots[1].commit_id,
+            RestoreKind::RestoreFromSnapshotViaUndo,
+            guard.write_permission(),
+        )?;
     }
 
     // test missing commits are recreated
@@ -377,7 +402,10 @@ fn restores_gitbutler_workspace() -> anyhow::Result<()> {
     }
 
     // restore the first
-    let snapshots = ctx.list_snapshots(10, None, Vec::new(), None)?;
+    let snapshots = ctx
+        .snapshots_iter(None, Vec::new(), None)?
+        .take(10)
+        .collect::<anyhow::Result<Vec<_>>>()?;
     assert_eq!(
         snapshots.len(),
         3,
@@ -385,8 +413,12 @@ fn restores_gitbutler_workspace() -> anyhow::Result<()> {
     );
 
     let mut guard = ctx.exclusive_worktree_access();
-    ctx.restore_snapshot(snapshots[0].commit_id, guard.write_permission())
-        .expect("can restore the most recent snapshot, to undo commit 2, resetting to commit 1");
+    ctx.restore_snapshot(
+        snapshots[0].commit_id,
+        RestoreKind::RestoreFromSnapshotViaUndo,
+        guard.write_permission(),
+    )
+    .expect("can restore the most recent snapshot, to undo commit 2, resetting to commit 1");
     drop(guard);
 
     assert_eq!(
@@ -401,28 +433,32 @@ fn restores_gitbutler_workspace() -> anyhow::Result<()> {
         1,
         "vbranches aren't affected by this (only the head commit)"
     );
-    let all_snapshots = ctx.list_snapshots(10, None, Vec::new(), None)?;
+    let all_snapshots = ctx
+        .snapshots_iter(None, Vec::new(), None)?
+        .take(10)
+        .collect::<anyhow::Result<Vec<_>>>()?;
     assert_eq!(
         all_snapshots.len(),
         4,
         "the restore is tracked as separate snapshot"
     );
 
-    assert_eq!(
-        ctx.list_snapshots(0, None, Vec::new(), None)?.len(),
-        0,
-        "it respects even non-sensical limits"
-    );
-
-    let snapshots = ctx.list_snapshots(1, None, Vec::new(), None)?;
+    let snapshots = ctx
+        .snapshots_iter(None, Vec::new(), None)?
+        .take(1)
+        .collect::<anyhow::Result<Vec<_>>>()?;
     assert_eq!(snapshots.len(), 1);
     assert_eq!(
-        ctx.list_snapshots(1, None, Vec::new(), None)?,
+        ctx.snapshots_iter(None, Vec::new(), None)?
+            .take(1)
+            .collect::<anyhow::Result<Vec<_>>>()?,
         snapshots,
-        "traversal from oplog head is the same as if it wasn't specified, and the given head is returned first"
+        "traversal from the oplog head is the same as when no cursor is specified"
     );
     assert_eq!(
-        ctx.list_snapshots(10, Some(all_snapshots[2].commit_id), Vec::new(), None)?,
+        ctx.snapshots_iter(Some(all_snapshots[2].commit_id), Vec::new(), None)?
+            .take(10)
+            .collect::<anyhow::Result<Vec<_>>>()?,
         &all_snapshots[3..],
     );
 
@@ -466,7 +502,10 @@ fn restore_snapshot_with_empty_branch_in_workspace() -> anyhow::Result<()> {
     )?;
     drop(guard);
 
-    let snapshots = ctx.list_snapshots(10, None, Vec::new(), None)?;
+    let snapshots = ctx
+        .snapshots_iter(None, Vec::new(), None)?
+        .take(10)
+        .collect::<anyhow::Result<Vec<_>>>()?;
     // CreateBranch (empty), CreateCommit, CreateBranch (has-commits)
     assert_eq!(snapshots.len(), 3);
 
@@ -474,12 +513,19 @@ fn restore_snapshot_with_empty_branch_in_workspace() -> anyhow::Result<()> {
     // This forces the restore code to walk the snapshot tree that contains
     // the empty branch entry (no `commits` subtree).
     let mut guard = ctx.exclusive_worktree_access();
-    ctx.restore_snapshot(snapshots[1].commit_id, guard.write_permission())
-        .expect("restore must succeed even with an empty branch in the workspace");
+    ctx.restore_snapshot(
+        snapshots[1].commit_id,
+        RestoreKind::RestoreFromSnapshotViaUndo,
+        guard.write_permission(),
+    )
+    .expect("restore must succeed even with an empty branch in the workspace");
     drop(guard);
 
     // Verify the restore was recorded.
-    let snapshots_after = ctx.list_snapshots(10, None, Vec::new(), None)?;
+    let snapshots_after = ctx
+        .snapshots_iter(None, Vec::new(), None)?
+        .take(10)
+        .collect::<anyhow::Result<Vec<_>>>()?;
     assert_eq!(
         snapshots_after.len(),
         snapshots.len() + 1,
@@ -511,7 +557,12 @@ fn head_corrupt_is_recreated_automatically() {
     .unwrap();
     drop(guard);
 
-    let snapshots = ctx.list_snapshots(10, None, Vec::new(), None).unwrap();
+    let snapshots = ctx
+        .snapshots_iter(None, Vec::new(), None)
+        .unwrap()
+        .take(10)
+        .collect::<anyhow::Result<Vec<_>>>()
+        .unwrap();
     assert_eq!(
         snapshots.len(),
         1,
@@ -534,7 +585,12 @@ fn head_corrupt_is_recreated_automatically() {
     )
     .expect("the snapshot doesn't fail despite the corrupt head");
 
-    let snapshots = ctx.list_snapshots(10, None, Vec::new(), None).unwrap();
+    let snapshots = ctx
+        .snapshots_iter(None, Vec::new(), None)
+        .unwrap()
+        .take(10)
+        .collect::<anyhow::Result<Vec<_>>>()
+        .unwrap();
     assert_eq!(
         snapshots.len(),
         1,
@@ -566,7 +622,10 @@ fn first_snapshot_diff_works() -> anyhow::Result<()> {
     fs::write(repo.path().join("file.txt"), "content")?;
     let _commit_id = super::create_commit(ctx, stack_entry.id, "first commit")?;
 
-    let snapshots = ctx.list_snapshots(10, None, Vec::new(), None)?;
+    let snapshots = ctx
+        .snapshots_iter(None, Vec::new(), None)?
+        .take(10)
+        .collect::<anyhow::Result<Vec<_>>>()?;
     assert!(!snapshots.is_empty(), "Should have at least one snapshot");
 
     // Test snapshot_diff on all snapshots to make sure none fail (including the first one)

--- a/crates/gitbutler-oplog/src/entry.rs
+++ b/crates/gitbutler-oplog/src/entry.rs
@@ -157,6 +157,11 @@ pub enum OperationKind {
     MoveCommit,
     MoveBranch,
     TearOffBranch,
+    /// Restore via `but undo`
+    RestoreFromSnapshotViaUndo,
+    /// Restore via `but oplog restore`
+    ///
+    /// Or old oplog entries that existed before `RestoreFromSnapshotViaUndo` as introduced.
     RestoreFromSnapshot,
     ReorderCommit,
     InsertBlankCommit,
@@ -191,6 +196,7 @@ impl OperationKind {
             OperationKind::SquashCommit => "SQUASH",
             OperationKind::UpdateCommitMessage => "REWORD",
             OperationKind::MoveCommit => "MOVE",
+            OperationKind::RestoreFromSnapshotViaUndo => "UNDO",
             OperationKind::RestoreFromSnapshot => "RESTORE",
             OperationKind::ReorderCommit => "REORDER",
             OperationKind::InsertBlankCommit => "INSERT_COMMIT",

--- a/crates/gitbutler-oplog/src/lib.rs
+++ b/crates/gitbutler-oplog/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod entry;
 mod oplog;
 pub use oplog::OplogExt;
+pub use oplog::RestoreKind;
 mod reflog;
 mod snapshot;
 pub use snapshot::SnapshotExt;

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -22,7 +22,6 @@ use gix::{
     ObjectId,
     bstr::{BString, ByteSlice, ByteVec},
     object::tree::EntryKind,
-    prelude::ObjectIdExt,
 };
 use tracing::instrument;
 
@@ -67,7 +66,7 @@ pub trait OplogExt {
     /// which yielded the `snapshot_tree_id` for the entire snapshot state.
     /// Use `details` to provide metadata about the snapshot.
     ///
-    /// Committing it makes the snapshot discoverable in [`list_snapshots`](Self::list_snapshots) as well as
+    /// Committing it makes the snapshot discoverable in [`snapshots_iter`](Self::snapshots_iter) as well as
     /// restorable with [`restore_snapshot`](Self::restore_snapshot).
     ///
     /// Returns `Some(snapshot_commit_id)` if it was created or `None` if nothing changed between the previous oplog
@@ -93,23 +92,22 @@ pub trait OplogExt {
         perm: &mut RepoExclusive,
     ) -> Result<gix::ObjectId>;
 
-    /// Lists the snapshots that have been created for the given repository, up to the given limit,
-    /// and with the most recent snapshot first, and at the end of the vec.
+    /// Returns an iterator over snapshots, with the most recent snapshot first.
     ///
-    /// Use `oplog_commit_id` if the traversal root for snapshot discovery should be the specified commit, which
-    /// is usually obtained from a previous iteration. Useful along with `limit` to allow starting where the iteration
-    /// left off. Note that the `oplog_commit_id` is always returned as first item in the result vec.
+    /// Use `oplog_commit_id` if the traversal root for snapshot discovery should be the specified
+    /// commit, which is usually obtained from a previous iteration. The iterator starts after the
+    /// provided `oplog_commit_id`, making it useful as a pagination cursor.
     ///
-    /// An alternative way of retrieving the snapshots would be to manually the oplog head `git log <oplog_head>` available in `.git/gitbutler/operations-log.toml`.
+    /// An alternative way of retrieving the snapshots would be to manually inspect the oplog head
+    /// using `git log <oplog_head>` available in `.git/gitbutler/operations-log.toml`.
     ///
-    /// If there are no snapshots, an empty list is returned.
-    fn list_snapshots(
+    /// If there are no snapshots, an empty iterator is returned.
+    fn snapshots_iter(
         &self,
-        limit: usize,
         oplog_commit_id: Option<gix::ObjectId>,
         exclude_kind: Vec<OperationKind>,
         include_kind: Option<Vec<OperationKind>>,
-    ) -> Result<Vec<Snapshot>>;
+    ) -> Result<impl Iterator<Item = Result<Snapshot>>>;
 
     /// Reverts to a previous state of the working directory, virtual branches and commits.
     /// The provided `snapshot_commit_id` must refer to a valid snapshot commit, as returned by [`create_snapshot`](Self::create_snapshot).
@@ -125,6 +123,7 @@ pub trait OplogExt {
     fn restore_snapshot(
         &self,
         snapshot_commit_id: gix::ObjectId,
+        restore_kind: RestoreKind,
         guard: &mut RepoExclusive,
     ) -> Result<gix::ObjectId>;
 
@@ -195,96 +194,38 @@ impl OplogExt for Context {
     }
 
     #[instrument(skip(self), err(Debug))]
-    fn list_snapshots(
+    fn snapshots_iter(
         &self,
-        limit: usize,
         oplog_commit_id: Option<gix::ObjectId>,
         exclude_kind: Vec<OperationKind>,
         include_kind: Option<Vec<OperationKind>>,
-    ) -> Result<Vec<Snapshot>> {
-        let repo = self.repo.get()?;
-        let traversal_root_id = match oplog_commit_id {
-            Some(id) => id,
+    ) -> Result<impl Iterator<Item = Result<Snapshot>>> {
+        let repo = self.repo.get()?.clone();
+        let next_commit_id = match oplog_commit_id {
+            Some(id) => Some(id),
             None => {
                 let oplog_state = OplogHandle::new(&self.project_data_dir());
-                if let Some(id) = oplog_state.oplog_head()? {
-                    id
-                } else {
-                    return Ok(vec![]);
-                }
+                oplog_state.oplog_head()?
             }
-        }
-        .attach(&repo);
+        };
 
-        let mut snapshots = Vec::new();
-
-        for commit_info in traversal_root_id.ancestors().all()? {
-            if snapshots.len() == limit {
-                break;
-            }
-            let commit_id = commit_info?.id();
-            if oplog_commit_id.is_some() && commit_id == traversal_root_id {
-                continue;
-            }
-            let commit = commit_id.object()?.into_commit();
-            let mut parents = commit.parent_ids();
-            let (first_parent, second_parent) = (parents.next(), parents.next());
-            if second_parent.is_some() {
-                break;
-            }
-
-            let tree = commit.tree()?;
-            if tree
-                .lookup_entry_by_path("virtual_branches.toml")?
-                .is_none()
-            {
-                // We reached a tree that is not a snapshot
-                tracing::warn!("Commit {commit_id} didn't seem to be an oplog commit - skipping");
-                continue;
-            }
-
-            let details = commit
-                .message_raw()?
-                .to_str()
-                .ok()
-                .and_then(|msg| SnapshotDetails::from_str(msg).ok());
-            let commit_time = commit.time()?;
-            if let Some(details) = &details {
-                // Skip if this kind is excluded
-                if exclude_kind.contains(&details.operation) {
-                    continue;
-                }
-                // Skip if include filter is set and this kind is not included
-                if let Some(ref include) = include_kind
-                    && !include.contains(&details.operation)
-                {
-                    continue;
-                }
-            } else if include_kind.is_some() {
-                // If we require specific kinds but have no details, skip
-                continue;
-            }
-
-            snapshots.push(Snapshot {
-                commit_id: commit_id.detach(),
-                details,
-                created_at: commit_time,
-            });
-            if first_parent.is_none() {
-                break;
-            }
-        }
-
-        Ok(snapshots)
+        Ok(SnapshotIter {
+            repo,
+            next_commit_id,
+            skip_initial_commit: oplog_commit_id.is_some(),
+            exclude_kind,
+            include_kind,
+        })
     }
 
     fn restore_snapshot(
         &self,
         snapshot_commit_id: gix::ObjectId,
+        restore_kind: RestoreKind,
         guard: &mut RepoExclusive,
     ) -> Result<gix::ObjectId> {
         // let mut guard = self.exclusive_worktree_access();
-        restore_snapshot(self, snapshot_commit_id, guard)
+        restore_snapshot(self, snapshot_commit_id, restore_kind, guard)
     }
 
     fn snapshot_diff(
@@ -718,9 +659,23 @@ fn commit_snapshot(
     Ok(snapshot_commit_id)
 }
 
+/// The kind of restore to perform.
+#[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize)]
+pub enum RestoreKind {
+    /// An explicit restore that restores to a specific point in the oplog.
+    ///
+    /// Used by `but oplog restore` among others.
+    ExplicitRestoreFromSnapshot,
+    /// An implicit restore that simply restores the previous snapshot.
+    ///
+    /// Used by `but undo` among others.
+    RestoreFromSnapshotViaUndo,
+}
+
 fn restore_snapshot(
     ctx: &Context,
     snapshot_commit_id: gix::ObjectId,
+    restore_kind: RestoreKind,
     exclusive_access: &mut RepoExclusive,
 ) -> Result<gix::ObjectId> {
     // Use a separate repo without caching so we are sure the 'has commit' checks pick up all changes.
@@ -855,9 +810,13 @@ fn restore_snapshot(
     // create new snapshot
     let before_restore_snapshot_tree_id = before_restore_snapshot_result?;
     let restored_date_ms = snapshot_commit.time()?.seconds * 1000;
+    let operation = match restore_kind {
+        RestoreKind::RestoreFromSnapshotViaUndo => OperationKind::RestoreFromSnapshotViaUndo,
+        RestoreKind::ExplicitRestoreFromSnapshot => OperationKind::RestoreFromSnapshot,
+    };
     let details = SnapshotDetails {
         version: Default::default(),
-        operation: OperationKind::RestoreFromSnapshot,
+        operation,
         title: "Restored from snapshot".to_string(),
         body: None,
         trailers: vec![
@@ -1059,6 +1018,86 @@ fn find_oplog_child(
             Some(pid) if pid == target_id => return Ok(Some(current)),
             Some(pid) => current = pid,
             None => return Ok(None),
+        }
+    }
+}
+
+struct SnapshotIter {
+    repo: gix::Repository,
+    next_commit_id: Option<gix::ObjectId>,
+    skip_initial_commit: bool,
+    exclude_kind: Vec<OperationKind>,
+    include_kind: Option<Vec<OperationKind>>,
+}
+
+impl Iterator for SnapshotIter {
+    type Item = Result<Snapshot>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let commit_id = self.next_commit_id.take()?;
+            let commit = match self.repo.find_commit(commit_id) {
+                Ok(commit) => commit,
+                Err(err) => return Some(Err(err.into())),
+            };
+            let mut parents = commit.parent_ids();
+            let (first_parent, second_parent) = (parents.next(), parents.next());
+            if second_parent.is_some() {
+                return None;
+            }
+            self.next_commit_id = first_parent.map(|id| id.detach());
+
+            if self.skip_initial_commit {
+                self.skip_initial_commit = false;
+                continue;
+            }
+
+            let tree = match commit.tree() {
+                Ok(tree) => tree,
+                Err(err) => return Some(Err(err.into())),
+            };
+            let has_legacy_metadata = match tree.lookup_entry_by_path("virtual_branches.toml") {
+                Ok(entry) => entry.is_some(),
+                Err(err) => return Some(Err(err.into())),
+            };
+            if !has_legacy_metadata {
+                // We reached a tree that is not a snapshot
+                tracing::warn!("Commit {commit_id} didn't seem to be an oplog commit - skipping");
+                continue;
+            }
+
+            let details = match commit.message_raw() {
+                Ok(message) => message
+                    .to_str()
+                    .ok()
+                    .and_then(|msg| SnapshotDetails::from_str(msg).ok()),
+                Err(err) => return Some(Err(err.into())),
+            };
+            let commit_time = match commit.time() {
+                Ok(time) => time,
+                Err(err) => return Some(Err(err.into())),
+            };
+            if let Some(details) = &details {
+                // Skip if this kind is excluded
+                if self.exclude_kind.contains(&details.operation) {
+                    continue;
+                }
+                // Skip if include filter is set and this kind is not included
+                if let Some(ref include) = self.include_kind
+                    && !include.contains(&details.operation)
+                {
+                    continue;
+                }
+            } else if self.include_kind.is_some() {
+                // If we require specific kinds but have no details, skip
+                continue;
+            }
+
+            return Some(Ok(Snapshot {
+                commit_id,
+                details,
+                created_at: commit_time,
+            }));
         }
     }
 }


### PR DESCRIPTION
Previously, if you ran `but undo` and then `but undo` again, you'd undo the undo. Thats not intended and instead, what we want to do is undo the operation before the previous undo, basically walking backwards in history. This makes `but undo` do that.

## How it works

I find the undo target by walking from newest to oldest through the oplog and counting how many undos we see. For each undo we see, we skip one non-undo entry. When we're at 0, we know the target is the next entry.

Example when all undos are at the top

```
                                    (n=0)
[UNDO]   <- skip one real operation (n=1)
[UNDO]   <- skip one real operation (n=2)
[REWORD] <- skipped                 (n=1)
[REWORD] <- skipped                 (n=0)
[REWORD] <- target                  take this!
```

And with undos mixed with other operations

```
                                         (n=0)
[UNDO]   <- skip one real operation      (n=1)
[REWORD] <- skipped                      (n=0)
[UNDO]   <- skip one more real operation (n=1)
[REWORD] <- skipped                      (n=0)
[REWORD] <- target                       take this!
```

## Undoing `but oplog restore`

I want `but oplog restore` to be treated differently from `but undo`, i.e., if you run `but oplog restore` and then `but undo`, then we should undo the restore. The restore shouldn't be counted as an undo.

This required changing `OperationKind`, which previously used `RestoreFromSnapshot` for both undos and restores. I've added a new `RestoreFromSnapshotViaUndo` variant that is used for undos so we can tell them apart from explicit restores. That means old undo entries will be categorized as restores, but I don't think there is anything we can do about that.

## `but redo`

We also want to add `but redo` to walk forwards in the oplog. I'm pretty confident we can use the same general strategy to support that as well, but if someone disagrees, I'd like to know 😊 since this introduces data changes. I want to make sure we don't need to make further changes when we do `but redo`. I might wait to merge this until I have a working `but redo` implementation as well.

## Iterating the oplog

Before, we had `ctx.list_snapshots()`, which returned a `Vec<Snapshot>` and required passing a limit on how many oplog entries to retrieve. I've changed that to instead be `ctx.snapshots_iter()`, which returns a lazy iterator. We need this because we don't know specifically how far to walk back to find the undo target, so we cannot provide a limit upfront.

One small behavior change here is that when iterating from a specific oplog commit, that commit isn't included, whereas before it would be. I think this behavior is more appropriate for pagination since clients can just pass the last commit and get exactly the next page to render. There was even a TODO about that in the Svelte app.

## GUI changes

The new `OperationKind` did require some changes in Svelte land, which I'm really not familiar with, so I would like some extra eyes on that.