### PR TITLE
Add outputs config for but-sdk build

### DIFF
--- a/packages/but-sdk/turbo.json
+++ b/packages/but-sdk/turbo.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "https://turborepo.org/schema.json",
+	"extends": ["//"],
+	"tasks": {
+		"build": {
+			"outputs": ["src/generated/**"]
+		}
+	}
+}


### PR DESCRIPTION
Add an outputs entry to packages/but-sdk/turbo.json so the build task
reports produced files. Running `cargo sdk:build` emitted a warning that
no output files were found for @gitbutler/but-sdk#build, indicating the
task's outputs key was missing. This change declares "src/generated/**"
as the build output to ensure Turborepo caches and recognizes the
produced files.