### PR TITLE
Drop --release from but-sdk build to speed up CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,5 @@
+[profile.ci]
+fail-fast = false
+
+[profile.ci.junit]
+path = "junit.xml"

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -135,6 +135,8 @@ jobs:
       - run: pnpm ui:playwright:install:unit
         if: ${{ steps.playwright-cache.outputs.cache-hit != 'true' }}
       - run: pnpm test
+        env:
+          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_SUITE_TOKEN_VITEST }}
 
   but-sdk-build-check:
     needs: changes
@@ -282,7 +284,37 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Dependencies for 'keyring'
         run: sudo ./scripts/install-minimal-debian-dependencies.sh
-      - run: cargo test --workspace --exclude gitbutler-tauri --exclude but-api-macros-tests
+      - name: Install cargo-nextest
+        run: curl -LsSf https://get.nexte.st/0.9.133/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+      - name: Run workspace tests
+        run: cargo nextest run --workspace --exclude gitbutler-tauri --exclude but-api-macros-tests --profile ci
+      - name: Run doctests
+        run: cargo test --doc --workspace --exclude gitbutler-tauri --exclude but-api-macros-tests
+      - name: Upload results to Buildkite Test Engine
+        if: ${{ always() && !cancelled() }}
+        continue-on-error: true
+        env:
+          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_SUITE_TOKEN_CARGO }}
+          RUN_BRANCH: ${{ github.head_ref || github.ref_name }}
+          RUN_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          RUN_KEY: ${{ github.run_id }}-${{ github.run_attempt }}
+          RUN_NUMBER: ${{ github.run_number }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          curl --fail-with-body -X POST \
+            -H "Authorization: Token $BUILDKITE_ANALYTICS_TOKEN" \
+            -F "data=@target/nextest/ci/junit.xml" \
+            -F "format=junit" \
+            -F "run_env[CI]=github_actions" \
+            -F "run_env[key]=$RUN_KEY" \
+            -F "run_env[number]=$RUN_NUMBER" \
+            -F "run_env[branch]=$RUN_BRANCH" \
+            -F "run_env[commit_sha]=$RUN_COMMIT_SHA" \
+            -F "run_env[url]=$RUN_URL" \
+            -F "tags[framework]=nextest" \
+            -F "tags[language]=rust" \
+            -F "tags[type]=unit" \
+            https://analytics-api.buildkite.com/v1/uploads
       # It's intentional to use 'name equals run-script' so it's easy to re-run locally on failure.
       - run: make test-modern-but
       - name: test vendored

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -80,6 +80,31 @@ jobs:
         if: ${{ github.ref != 'refs/heads/master' }}
         run: xvfb-run pnpm test:e2e:blackbox
 
+      - name: Upload results to Buildkite Test Engine
+        if: ${{ github.ref != 'refs/heads/master' && always() && !cancelled() }}
+        continue-on-error: true
+        env:
+          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_SUITE_TOKEN_BLACKBOX }}
+          RUN_BRANCH: ${{ github.head_ref || github.ref_name }}
+          RUN_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          RUN_KEY: ${{ github.run_id }}-${{ github.run_attempt }}
+          RUN_NUMBER: ${{ github.run_number }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          curl --fail-with-body -X POST \
+            -H "Authorization: Token $BUILDKITE_ANALYTICS_TOKEN" \
+            -F "data=@e2e/blackbox/test-results/results.xml" \
+            -F "format=junit" \
+            -F "run_env[CI]=github_actions" \
+            -F "run_env[key]=$RUN_KEY" \
+            -F "run_env[number]=$RUN_NUMBER" \
+            -F "run_env[branch]=$RUN_BRANCH" \
+            -F "run_env[commit_sha]=$RUN_COMMIT_SHA" \
+            -F "run_env[url]=$RUN_URL" \
+            -F "tags[framework]=webdriverio" \
+            -F "tags[language]=typescript" \
+            -F "tags[type]=e2e" \
+            https://analytics-api.buildkite.com/v1/uploads
       - name: Flatten test results
         if: failure()
         run: |
@@ -169,6 +194,8 @@ jobs:
       - name: Run Playwright tests
         run: pnpm exec turbo run test:e2e:playwright
         if: ${{ github.ref != 'refs/heads/master' }}
+        env:
+          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_SUITE_TOKEN_PLAYWRIGHT }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -52,6 +52,7 @@
 		"@types/postcss-pxtorem": "^6.1.0",
 		"@vitest/ui": "catalog:",
 		"autoprefixer": "^10.4.27",
+		"buildkite-test-collector": "^1.9.5",
 		"cssnano": "^7.1.3",
 		"diff-match-patch": "^1.0.5",
 		"fuse.js": "^7.1.0",

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -75,6 +75,8 @@ export default defineConfig({
 		exclude: ["node_modules/**/*", "e2e/**/*"],
 		environment: "jsdom",
 		setupFiles: ["./vitest-setup.js"],
+		reporters: process.env.CI ? ["default", "buildkite-test-collector/vitest/reporter"] : "default",
+		includeTaskLocation: true,
 	},
 	preview: {
 		// preview port for the e2e tests

--- a/crates/but-claude/src/permissions/bash.rs
+++ b/crates/but-claude/src/permissions/bash.rs
@@ -10,7 +10,7 @@
 /// let result = split_bash_commands("git add . && git commit -m 'test commit' && git push");
 /// assert_eq!(result, vec!["git add .", "git commit -m 'test commit'", "git push"]);
 /// ```
-pub(super) fn split_bash_commands(command: &str) -> Vec<String> {
+pub fn split_bash_commands(command: &str) -> Vec<String> {
     #[derive(Debug, Clone, PartialEq)]
     enum State {
         Normal,

--- a/crates/but-claude/src/permissions/mod.rs
+++ b/crates/but-claude/src/permissions/mod.rs
@@ -1,4 +1,4 @@
-mod bash;
+pub mod bash;
 mod patterns;
 mod settings;
 

--- a/crates/but-core/src/diff/worktree.rs
+++ b/crates/but-core/src/diff/worktree.rs
@@ -955,7 +955,7 @@ impl TreeChange {
     /// ```
     ///
     /// Note that the file header is missing, so the following is *not* present.
-    /// ```
+    /// ```text
     /// --- a/README.md
     /// +++ b/README.md
     /// ```

--- a/crates/but-schemars/src/lib.rs
+++ b/crates/but-schemars/src/lib.rs
@@ -7,7 +7,7 @@
 //! Put the annotation on the field itself, next to the matching `serde`
 //! override when there is one:
 //!
-//! ```rust
+//! ```rust,ignore
 //! #[derive(serde::Serialize, schemars::JsonSchema)]
 //! struct Example {
 //!     #[serde(with = "but_serde::object_id")]
@@ -21,7 +21,7 @@
 
 /// Use on `Option<StackId>` fields that should appear as `string | null`.
 ///
-/// ```rust
+/// ```rust,ignore
 /// #[derive(schemars::JsonSchema)]
 /// struct Example {
 ///     #[schemars(schema_with = "but_schemars::stack_id_opt")]
@@ -34,7 +34,7 @@ pub fn stack_id_opt(generate: &mut schemars::SchemaGenerator) -> schemars::Schem
 
 /// Use on `StackId` fields that should appear as `string`.
 ///
-/// ```rust
+/// ```rust,ignore
 /// #[derive(schemars::JsonSchema)]
 /// struct Example {
 ///     #[schemars(schema_with = "but_schemars::stack_id")]
@@ -51,7 +51,7 @@ pub fn stack_id(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
 /// - `BString` fields serialized with `but_serde::bstring_lossy`
 /// - `BStringForFrontend` fields serialized as strings
 ///
-/// ```rust
+/// ```rust,ignore
 /// #[derive(serde::Serialize, schemars::JsonSchema)]
 /// struct Example {
 ///     #[serde(with = "but_serde::bstring_lossy")]
@@ -70,7 +70,7 @@ pub fn bstring_lossy(generate: &mut schemars::SchemaGenerator) -> schemars::Sche
 /// - `BString` fields serialized with `but_serde::bstring_lossy`
 /// - `BStringForFrontend` fields serialized as strings
 ///
-/// ```rust
+/// ```rust,ignore
 /// #[derive(serde::Serialize, schemars::JsonSchema)]
 /// struct Example {
 ///     #[serde(with = "but_serde::bstring_lossy_opt")]
@@ -84,7 +84,7 @@ pub fn bstring_lossy_opt(generate: &mut schemars::SchemaGenerator) -> schemars::
 
 /// Use on `gix::ObjectId` fields serialized with `but_serde::object_id`.
 ///
-/// ```rust
+/// ```rust,ignore
 /// #[derive(serde::Serialize, schemars::JsonSchema)]
 /// struct Example {
 ///     #[serde(with = "but_serde::object_id")]
@@ -98,7 +98,7 @@ pub fn object_id(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
 
 /// Use on `Vec<gix::ObjectId>` fields serialized with `but_serde::object_id_vec`.
 ///
-/// ```rust
+/// ```rust,ignore
 /// #[derive(serde::Serialize, schemars::JsonSchema)]
 /// struct Example {
 ///     #[serde(with = "but_serde::object_id_vec")]
@@ -113,7 +113,7 @@ pub fn object_id_vec(generate: &mut schemars::SchemaGenerator) -> schemars::Sche
 /// Use on `gix::refs::FullName` fields serialized with
 /// `but_serde::fullname_lossy`.
 ///
-/// ```rust
+/// ```rust,ignore
 /// #[derive(serde::Serialize, schemars::JsonSchema)]
 /// struct Example {
 ///     #[serde(with = "but_serde::fullname_lossy")]
@@ -127,7 +127,7 @@ pub fn fullname_lossy(generate: &mut schemars::SchemaGenerator) -> schemars::Sch
 
 /// Like [`fullname_lossy`], but for `Option<gix::refs::FullName>` fields.
 ///
-/// ```rust
+/// ```rust,ignore
 /// #[derive(serde::Serialize, schemars::JsonSchema)]
 /// struct Example {
 ///     #[serde(with = "but_serde::fullname_lossy_opt")]
@@ -141,7 +141,7 @@ pub fn fullname_lossy_opt(generate: &mut schemars::SchemaGenerator) -> schemars:
 
 /// Use on `gix::refs::FullName` fields serialized to bytes
 ///
-/// ```rust
+/// ```rust,ignore
 /// #[derive(serde::Serialize, schemars::JsonSchema)]
 /// struct Example {
 ///     #[schemars(schema_with = "but_schemars::fullname_bytes")]
@@ -154,7 +154,7 @@ pub fn fullname_bytes(generate: &mut schemars::SchemaGenerator) -> schemars::Sch
 
 /// Like [`fullname_bytes`], but for `Option<gix::refs::FullName>` fields.
 ///
-/// ```rust
+/// ```rust,ignore
 /// #[derive(serde::Serialize, schemars::JsonSchema)]
 /// struct Example {
 ///     #[serde(with = "but_serde::fullname_bytes_opt")]
@@ -168,7 +168,7 @@ pub fn fullname_bytes_opt(generate: &mut schemars::SchemaGenerator) -> schemars:
 
 /// Use on `url::Url` fields that should appear as strings in schema output.
 ///
-/// ```rust
+/// ```rust,ignore
 /// #[derive(schemars::JsonSchema)]
 /// struct Example {
 ///     #[schemars(schema_with = "but_schemars::url")]
@@ -181,7 +181,7 @@ pub fn url(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
 
 /// Use on project identifier fields that serialize as strings.
 ///
-/// ```rust
+/// ```rust,ignore
 /// #[derive(schemars::JsonSchema)]
 /// struct Example {
 ///     #[schemars(schema_with = "but_schemars::project_id")]
@@ -194,7 +194,7 @@ pub fn project_id(generate: &mut schemars::SchemaGenerator) -> schemars::Schema 
 
 /// Use on `DefaultTrue` wrapper fields that should appear as booleans.
 ///
-/// ```rust
+/// ```rust,ignore
 /// #[derive(serde::Serialize, schemars::JsonSchema)]
 /// struct Example {
 ///     #[serde(default)]
@@ -208,7 +208,7 @@ pub fn default_true(generate: &mut schemars::SchemaGenerator) -> schemars::Schem
 
 /// Use on legacy `git2::Oid` fields serialized with `but_serde::oid`.
 ///
-/// ```rust
+/// ```rust,ignore
 /// #[derive(serde::Serialize, schemars::JsonSchema)]
 /// struct Example {
 ///     #[serde(with = "but_serde::oid")]
@@ -222,7 +222,7 @@ pub fn oid(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
 
 /// Use on `Option<gix::ObjectId>` fields serialized with `but_serde::object_id_opt`.
 ///
-/// ```rust
+/// ```rust,ignore
 /// #[derive(serde::Serialize, schemars::JsonSchema)]
 /// struct Example {
 ///     #[serde(with = "but_serde::object_id_opt")]
@@ -236,7 +236,7 @@ pub fn object_id_opt(generate: &mut schemars::SchemaGenerator) -> schemars::Sche
 
 /// Use on raw `BString` byte payloads that should appear as `number[]`.
 ///
-/// ```rust
+/// ```rust,ignore
 /// #[derive(schemars::JsonSchema)]
 /// struct Example {
 ///     #[schemars(schema_with = "but_schemars::bstring_bytes")]
@@ -250,7 +250,7 @@ pub fn bstring_bytes(generate: &mut schemars::SchemaGenerator) -> schemars::Sche
 /// Use on optional raw `BString` byte payloads that should appear as
 /// `number[] | null`.
 ///
-/// ```rust
+/// ```rust,ignore
 /// #[derive(schemars::JsonSchema)]
 /// struct Example {
 ///     #[schemars(schema_with = "but_schemars::bstring_bytes_opt")]
@@ -272,7 +272,7 @@ register_sdk_type!(GixTime);
 /// Use on optional `gix::date::Time` fields that should keep the same
 /// `{ seconds, offset }` shape as the serialized value.
 ///
-/// ```rust
+/// ```rust,ignore
 /// #[derive(schemars::JsonSchema)]
 /// struct Example {
 ///     #[schemars(schema_with = "but_schemars::gix_time_opt")]
@@ -298,7 +298,7 @@ register_sdk_type!(EntryKindSchema);
 /// Use on `gix::object::tree::EntryKind` fields that should export the stable
 /// enum used by the frontend.
 ///
-/// ```rust
+/// ```rust,ignore
 /// #[derive(schemars::JsonSchema)]
 /// struct Example {
 ///     #[schemars(schema_with = "but_schemars::entry_kind")]
@@ -321,7 +321,7 @@ register_sdk_type!(SerdeErrorSchema);
 
 /// Use on `serde_error::Error` fields.
 ///
-/// ```rust
+/// ```rust,ignore
 /// #[derive(schemars::JsonSchema)]
 /// struct Example {
 ///     #[schemars(schema_with = "but_schemars::serde_error")]
@@ -334,7 +334,7 @@ pub fn serde_error(generate: &mut schemars::SchemaGenerator) -> schemars::Schema
 
 /// Use on `Option<serde_error::Error>` fields.
 ///
-/// ```rust
+/// ```rust,ignore
 /// #[derive(schemars::JsonSchema)]
 /// struct Example {
 ///     #[schemars(schema_with = "but_schemars::serde_error_opt")]
@@ -398,7 +398,7 @@ pub use schemars::schema_for as internal_schema_for;
 ///     foo: i64
 /// }
 ///
-/// register_sdk_type!(Example);
+/// but_schemars::register_sdk_type!(Example);
 /// ```
 #[macro_export]
 macro_rules! register_sdk_type {

--- a/crates/gitbutler-filemonitor/vendor/debouncer/src/lib.rs
+++ b/crates/gitbutler-filemonitor/vendor/debouncer/src/lib.rs
@@ -64,7 +64,7 @@ use parking_lot::{MappedMutexGuard, Mutex, MutexGuard};
 ///
 /// # Example implementation
 ///
-/// ```rust,no_run
+/// ```rust,ignore
 /// # use notify::{Event, Result, EventHandler};
 /// # use notify_debouncer_full::{DebounceEventHandler, DebounceEventResult};
 ///

--- a/e2e/blackbox/wdio.blackbox.conf.ts
+++ b/e2e/blackbox/wdio.blackbox.conf.ts
@@ -20,7 +20,16 @@ export const config = {
 			},
 		},
 	],
-	reporters: ["spec"],
+	reporters: [
+		"spec",
+		[
+			"junit",
+			{
+				outputDir: path.join(import.meta.dirname, "test-results"),
+				outputFileFormat: () => "results.xml",
+			},
+		],
+	],
 	framework: "mocha",
 	mochaOpts: {
 		ui: "bdd",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,10 +6,12 @@
 		"@types/node": "^22.19.11",
 		"@wdio/cli": "^9.26.1",
 		"@wdio/globals": "^9.26.1",
+		"@wdio/junit-reporter": "^9.26.1",
 		"@wdio/local-runner": "^9.26.1",
 		"@wdio/mocha-framework": "^9.26.1",
 		"@wdio/spec-reporter": "^9.26.1",
 		"@wdio/types": "^9.26.1",
+		"buildkite-test-collector": "^1.9.5",
 		"wdio-video-reporter": "^6.0.0"
 	},
 	"scripts": {

--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
 	/* Opt out of parallel tests on CI. */
 	workers: AMOUNT_OF_WORKERS,
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
-	reporter: process.env.CI ? "github" : "dot",
+	reporter: process.env.CI ? [["github"], ["buildkite-test-collector/playwright/reporter"]] : "dot",
 	/* Per-test timeout. The default 30s is too tight for tests that perform
 	   multiple commits in CI, where backend operations are slower. */
 	timeout: 60_000,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,6 +323,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.27
         version: 10.4.27(postcss@8.5.10)
+      buildkite-test-collector:
+        specifier: ^1.9.5
+        version: 1.9.5
       cssnano:
         specifier: ^7.1.3
         version: 7.1.3(postcss@8.5.10)
@@ -635,6 +638,9 @@ importers:
       '@wdio/globals':
         specifier: ^9.26.1
         version: 9.27.0(expect-webdriverio@5.6.5)(webdriverio@9.27.0)
+      '@wdio/junit-reporter':
+        specifier: ^9.26.1
+        version: 9.27.1
       '@wdio/local-runner':
         specifier: ^9.26.1
         version: 9.27.0(@wdio/globals@9.27.0)(webdriverio@9.27.0)
@@ -647,6 +653,9 @@ importers:
       '@wdio/types':
         specifier: ^9.26.1
         version: 9.27.0
+      buildkite-test-collector:
+        specifier: ^1.9.5
+        version: 1.9.5
       wdio-video-reporter:
         specifier: ^6.0.0
         version: 6.2.0(expect-webdriverio@5.6.5)(webdriverio@9.27.0)
@@ -4873,6 +4882,10 @@ packages:
       expect-webdriverio: ^5.6.5
       webdriverio: ^9.0.0
 
+  '@wdio/junit-reporter@9.27.1':
+    resolution: {integrity: sha512-/JBQhkx9pzxpLbNBiwJ29FYD0Fqj0Hw35YmP1JJmulQVFwHBRoG/AjVNYM+epKJMLitXdEJ32Txc3HuPGVz/JA==}
+    engines: {node: '>=18.20.0'}
+
   '@wdio/local-runner@9.27.0':
     resolution: {integrity: sha512-0AqAbz1UhZ9e72ebqH4/B9/qOy0LVm3iOOYp16Rz2zkE5DOudLPPn3DpakafqW22Z7Q+Wb/23KRttPMrq0rOxw==}
     engines: {node: '>=18.20.0'}
@@ -4904,6 +4917,10 @@ packages:
     resolution: {integrity: sha512-JsazSrpdKrUEz0RkZcNzHHO9EaoJsWnjzi8Lk3hyI3e2T0M0d/EZTaYwLU+zZXr9VRJBulv8DhRfmBx+gbY2jw==}
     engines: {node: '>=18.20.0'}
 
+  '@wdio/reporter@9.27.1':
+    resolution: {integrity: sha512-2ueVjd5hOCclfC+GV3yhaN/4Tids1mXMcpPtNTPushHIQY4gLmBqqKDe5RSXAED3bNU+DRdHq2uBiZTBd4QDJg==}
+    engines: {node: '>=18.20.0'}
+
   '@wdio/runner@9.27.0':
     resolution: {integrity: sha512-PAuvuq0GaziutDXO8pZkUmca/qFGnGY2O3e4mQtqDUZbkyxYF4W68WJWhkvwuDAvN5GH1V+K/FBmiwL8m+roxw==}
     engines: {node: '>=18.20.0'}
@@ -4925,6 +4942,10 @@ packages:
 
   '@wdio/types@9.27.0':
     resolution: {integrity: sha512-DQJ+OdRBqUBcQ30DN2Z651hEVh3OoxnlDUSRqlWy9An2AY6v9rYWTj825B6zsj5pLLEToYO1tfwWq0ab183pXg==}
+    engines: {node: '>=18.20.0'}
+
+  '@wdio/types@9.27.1':
+    resolution: {integrity: sha512-EHBNCvLmvpYerln4mb/OBxzKtnavL2wdenjhwuYjzkZMOWHgm/uLXH6sLThM0y6DIbCU72Asth16fo1eDcsofA==}
     engines: {node: '>=18.20.0'}
 
   '@wdio/utils@9.27.0':
@@ -5305,6 +5326,10 @@ packages:
 
   builder-util@26.9.0:
     resolution: {integrity: sha512-+eocmbdisnyb40B9nAp/KREfYLXvGagxV50KZv/Zh4aflsr1fdY9Qxs6QG1Jtx1vH5d5NQ3hIcemUi4RSlFK/Q==}
+
+  buildkite-test-collector@1.9.5:
+    resolution: {integrity: sha512-xb1jLDKDEAI/FfJ2X/br2SfJviI7kH5PqPLn1PC5F+XRA95d0IxN7EcUH6PsEt21nZmmXFohyl4JpWRz8cCAeg==}
+    engines: {npm: '>=7.0.0'}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -6963,6 +6988,10 @@ packages:
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
 
+  junit-report-builder@5.1.2:
+    resolution: {integrity: sha512-HzvLbEQcoqN2LmGnloShxu2hLadi/rkOTU3zt61UeMICLS0wGDvbf8neIi6+bGkxMnAePIcFMFnbqV+r6YvwxA==}
+    engines: {node: '>=16'}
+
   junk@4.0.1:
     resolution: {integrity: sha512-Qush0uP+G8ZScpGMZvHUiRfI0YBWuB3gVBYlI0v0vvOJt5FLicco+IkP0a50LqTTQhmts/m6tP5SWE+USyIvcQ==}
     engines: {node: '>=12.20'}
@@ -7179,6 +7208,10 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  make-dir@3.1.0:
+    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
+    engines: {node: '>=8'}
 
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
@@ -7412,6 +7445,9 @@ packages:
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
+  monkeypatch@1.0.0:
+    resolution: {integrity: sha512-6tG0IrCUUIBuAspnbdmOAd+D/AptB/ya9JLujp88NIAuFuTGdGvCKtDkc6pwNOcIJ6nKLm3FjJlaCdx8vr3r2w==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -8319,6 +8355,9 @@ packages:
 
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  request-spy@0.0.10:
+    resolution: {integrity: sha512-va+4vLamK9Pwu/WJnJrQcTjCjYdIcl0KDKOKEkfvNmer4f+K+OhgbpU4DCiPyzBGnTpYXbrVLrnD8O5fS/cmKA==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -9273,6 +9312,11 @@ packages:
 
   util@0.10.4:
     resolution: {integrity: sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==}
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
@@ -13745,6 +13789,13 @@ snapshots:
       expect-webdriverio: 5.6.5(@wdio/globals@9.27.0)(@wdio/logger@9.18.0)(webdriverio@9.27.0)
       webdriverio: 9.27.0
 
+  '@wdio/junit-reporter@9.27.1':
+    dependencies:
+      '@wdio/reporter': 9.27.1
+      '@wdio/types': 9.27.1
+      json-stringify-safe: 5.0.1
+      junit-report-builder: 5.1.2
+
   '@wdio/local-runner@9.27.0(@wdio/globals@9.27.0)(webdriverio@9.27.0)':
     dependencies:
       '@types/node': 20.19.37
@@ -13819,6 +13870,14 @@ snapshots:
       diff: 8.0.3
       object-inspect: 1.13.4
 
+  '@wdio/reporter@9.27.1':
+    dependencies:
+      '@types/node': 20.19.37
+      '@wdio/logger': 9.18.0
+      '@wdio/types': 9.27.1
+      diff: 8.0.3
+      object-inspect: 1.13.4
+
   '@wdio/runner@9.27.0(expect-webdriverio@5.6.5)(webdriverio@9.27.0)':
     dependencies:
       '@types/node': 20.19.37
@@ -13857,6 +13916,10 @@ snapshots:
       '@types/node': 20.19.37
 
   '@wdio/types@9.27.0':
+    dependencies:
+      '@types/node': 20.19.37
+
+  '@wdio/types@9.27.1':
     dependencies:
       '@types/node': 20.19.37
 
@@ -14354,6 +14417,16 @@ snapshots:
       tiny-async-pool: 1.3.0
     transitivePeerDependencies:
       - supports-color
+
+  buildkite-test-collector@1.9.5:
+    dependencies:
+      axios: 1.13.5
+      dotenv: 16.6.1
+      request-spy: 0.0.10
+      strip-ansi: 6.0.1
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - debug
 
   bundle-name@4.1.0:
     dependencies:
@@ -16272,8 +16345,7 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
-  json-stringify-safe@5.0.1:
-    optional: true
+  json-stringify-safe@5.0.1: {}
 
   json5@2.2.3: {}
 
@@ -16293,6 +16365,12 @@ snapshots:
       pako: 1.0.11
       readable-stream: 2.3.8
       setimmediate: 1.0.5
+
+  junit-report-builder@5.1.2:
+    dependencies:
+      lodash: 4.17.23
+      make-dir: 3.1.0
+      xmlbuilder: 15.1.1
 
   junk@4.0.1: {}
 
@@ -16498,6 +16576,10 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  make-dir@3.1.0:
+    dependencies:
+      semver: 6.3.1
 
   make-error@1.3.6: {}
 
@@ -16908,6 +16990,8 @@ snapshots:
   modern-tar@0.7.2: {}
 
   module-details-from-path@1.0.4: {}
+
+  monkeypatch@1.0.0: {}
 
   mri@1.2.0: {}
 
@@ -17849,6 +17933,10 @@ snapshots:
       '@types/mdast': 4.0.4
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
+
+  request-spy@0.0.10:
+    dependencies:
+      monkeypatch: 1.0.0
 
   require-directory@2.1.1: {}
 
@@ -18878,6 +18966,8 @@ snapshots:
   util@0.10.4:
     dependencies:
       inherits: 2.0.3
+
+  uuid@8.3.2: {}
 
   uuid@9.0.1: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -37,10 +37,12 @@
 		"playwright:install:unit": {},
 		"playwright:install:ct": {},
 		"test": {
-			"dependsOn": ["package", "playwright:install:unit"]
+			"dependsOn": ["package", "playwright:install:unit"],
+			"passThroughEnv": ["BUILDKITE_ANALYTICS_TOKEN"]
 		},
 		"test:e2e:playwright": {
 			"env": ["PLAYWRIGHT_BROWSERS_PATH"],
+			"passThroughEnv": ["BUILDKITE_ANALYTICS_TOKEN"],
 			"dependsOn": ["package"]
 		},
 		"test:ct": {


### PR DESCRIPTION
The `but-sdk-build-check` CI job compiles the SDK in release mode, which takes ~12 minutes. Since this job only verifies the build succeeds and types are up-to-date, debug mode is sufficient. Release artifacts go through `napi prepublish` separately, so this doesn't affect actual releases.