### PR TITLE
update `gix` for SHA-256 support

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,6 +1,7 @@
 estib <stron@me.com> Jose Vega <stron@me.com>
 estib <stron@me.com> Esteban Vega <35891811+estib-vega@users.noreply.github.com>
-Codex <codex@openai.com> chatgpt-codex-connector[bot] <199175422+chatgpt-codex-connector[bot]@users.noreply.github.com> 
-Codex <codex@openai.com> GPT 5.4 <codex@openai.com>
+Byron <sebastian.thiel@icloud.com> chatgpt-codex-connector[bot] <199175422+chatgpt-codex-connector[bot]@users.noreply.github.com> 
+Byron <sebastian.thiel@icloud.com> GPT 5.4 <codex@openai.com>
 Byron <sebastian.thiel@icloud.com> Sebastian Thiel <sebastian.thiel@icloud.com> <63622+Byron@users.noreply.github.com>
+Byron <sebastian.thiel@icloud.com> Codex GPT-5 <codex@openai.com>
 Copilot <198982749+Copilot@users.noreply.github.com> copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -244,7 +244,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -698,6 +698,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -871,7 +880,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "sha2",
+ "sha2 0.10.9",
  "shell-words",
  "snapbox",
  "strum",
@@ -1436,7 +1445,7 @@ dependencies = [
  "itertools",
  "md5",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "snapbox",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
@@ -1605,7 +1614,7 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
  "tower",
  "tower-http",
@@ -1693,7 +1702,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
 ]
 
@@ -2009,7 +2018,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -2160,7 +2169,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2394,6 +2403,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2510,6 +2528,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -2770,7 +2797,7 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
- "sha2",
+ "sha2 0.10.9",
  "zeroize",
 ]
 
@@ -2888,9 +2915,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -2911,7 +2948,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3158,7 +3195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4340,12 +4377,10 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.83.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "gix-actor",
- "gix-archive",
  "gix-attributes",
- "gix-blame",
  "gix-command",
  "gix-commitgraph",
  "gix-config",
@@ -4401,7 +4436,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.41.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "gix-date",
@@ -4410,21 +4445,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-archive"
-version = "0.32.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
-dependencies = [
- "bstr",
- "gix-date",
- "gix-error",
- "gix-object",
- "gix-worktree-stream",
-]
-
-[[package]]
 name = "gix-attributes"
 version = "0.33.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -4441,34 +4464,15 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.3.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "gix-error",
-]
-
-[[package]]
-name = "gix-blame"
-version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
-dependencies = [
- "gix-commitgraph",
- "gix-date",
- "gix-diff",
- "gix-error",
- "gix-hash",
- "gix-object",
- "gix-revwalk",
- "gix-trace 0.1.19",
- "gix-traverse",
- "gix-worktree",
- "smallvec",
- "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-chunk"
 version = "0.7.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "gix-error",
 ]
@@ -4476,7 +4480,7 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.9.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "gix-path 0.12.0",
@@ -4488,7 +4492,7 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.37.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -4502,7 +4506,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.56.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -4519,7 +4523,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.18.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
@@ -4531,7 +4535,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.38.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4549,7 +4553,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.15.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "gix-error",
@@ -4562,7 +4566,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.63.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -4585,7 +4589,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.25.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "gix-discover",
@@ -4604,7 +4608,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.51.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "dunce",
@@ -4618,7 +4622,7 @@ dependencies = [
 [[package]]
 name = "gix-error"
 version = "0.2.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
 ]
@@ -4626,7 +4630,7 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.48.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -4646,7 +4650,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -4665,8 +4669,8 @@ dependencies = [
 
 [[package]]
 name = "gix-fs"
-version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+version = "0.21.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4679,7 +4683,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.26.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
@@ -4691,29 +4695,30 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.25.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "faster-hex",
  "gix-features",
  "serde",
  "sha1-checked",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-hashtable"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "gix-hash",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "parking_lot",
 ]
 
 [[package]]
 name = "gix-ignore"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -4726,16 +4731,16 @@ dependencies = [
 [[package]]
 name = "gix-imara-diff"
 version = "0.2.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
 name = "gix-index"
 version = "0.51.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
@@ -4750,7 +4755,7 @@ dependencies = [
  "gix-traverse",
  "gix-utils",
  "gix-validate 0.11.1",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "itoa",
  "libc",
  "memmap2",
@@ -4763,7 +4768,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "23.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -4773,7 +4778,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.33.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4785,7 +4790,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4810,7 +4815,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bitflags 2.11.1",
  "gix-commitgraph",
@@ -4823,7 +4828,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.60.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4842,7 +4847,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.80.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "arc-swap",
  "gix-features",
@@ -4863,7 +4868,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.70.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "clru",
  "gix-chunk",
@@ -4885,7 +4890,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.21.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4908,7 +4913,7 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "gix-trace 0.1.19",
@@ -4919,7 +4924,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.18.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
@@ -4933,7 +4938,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -4945,7 +4950,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.61.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -4971,7 +4976,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.7.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "gix-error",
@@ -4981,7 +4986,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.63.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -5001,7 +5006,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.41.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "gix-error",
@@ -5016,7 +5021,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.45.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
@@ -5035,7 +5040,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -5050,7 +5055,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.14.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bitflags 2.11.1",
  "gix-path 0.12.0",
@@ -5062,7 +5067,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -5075,7 +5080,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "filetime",
@@ -5097,7 +5102,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "gix-config",
@@ -5111,7 +5116,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "23.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "dashmap",
  "gix-fs",
@@ -5125,7 +5130,7 @@ dependencies = [
 [[package]]
 name = "gix-testtools"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "crc",
@@ -5153,7 +5158,7 @@ checksum = "f69a13643b8437d4ca6845e08143e847a36ca82903eed13303475d0ae8b162e0"
 [[package]]
 name = "gix-trace"
 version = "0.1.19"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "tracing",
 ]
@@ -5161,7 +5166,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.57.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -5180,7 +5185,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.57.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bitflags 2.11.1",
  "gix-commitgraph",
@@ -5196,7 +5201,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.36.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "gix-path 0.12.0",
@@ -5208,7 +5213,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "fastrand",
@@ -5228,7 +5233,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.11.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
 ]
@@ -5236,7 +5241,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.52.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -5254,7 +5259,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "bstr",
  "gix-features",
@@ -5271,7 +5276,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-stream"
 version = "0.32.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=adb8328952478c443ead5f5a8c6851928b377b37#adb8328952478c443ead5f5a8c6851928b377b37"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=db925ecaef8aeb810d7f596ab459372edbc39a6e#db925ecaef8aeb810d7f596ab459372edbc39a6e"
 dependencies = [
  "gix-attributes",
  "gix-error",
@@ -5493,6 +5498,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -5565,7 +5575,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5639,6 +5649,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -6085,7 +6104,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6150,9 +6169,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.21"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e3d65f018c6ae946ab16e80944b97096ed73c35b221d1c478a6c81d8f57940"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -6160,14 +6179,14 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.21"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17c2b211d863c7fde02cbea8a3c1a439b98e109286554f2860bdded7ff83818"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7066,7 +7085,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7610,7 +7629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7797,7 +7816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -8379,7 +8398,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9019,7 +9038,7 @@ version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
  "walkdir",
 ]
 
@@ -9093,7 +9112,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9151,7 +9170,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9320,7 +9339,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "zbus 4.4.0",
 ]
 
@@ -9640,8 +9659,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -9650,7 +9669,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "sha1",
 ]
 
@@ -9661,8 +9680,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -10287,7 +10317,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "syn 2.0.117",
  "tauri-utils",
  "thiserror 2.0.18",
@@ -10699,7 +10729,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10729,7 +10759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10796,7 +10826,7 @@ dependencies = [
  "pest_derive",
  "phf 0.11.3",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "signal-hook 0.3.18",
  "siphasher 1.0.2",
  "terminfo",
@@ -11438,9 +11468,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -12085,7 +12115,7 @@ dependencies = [
  "getrandom 0.3.4",
  "mac_address",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "uuid",
 ]
@@ -12171,7 +12201,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12827,7 +12857,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
- "sha2",
+ "sha2 0.10.9",
  "soup3",
  "tao-macros",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,10 +212,10 @@ backoff = "0.4.0"
 bstr = "1.12.1"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
 # When adjusting this, update `gix-testtools` as well!
-gix = { version = "0.83.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "adb8328952478c443ead5f5a8c6851928b377b37", default-features = false, features = [
-    "sha1",
+gix = { version = "0.83.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "db925ecaef8aeb810d7f596ab459372edbc39a6e", default-features = false, features = [
+    "sha1", "sha256"
 ] }
-gix-testtools = { version = "0.19.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "adb8328952478c443ead5f5a8c6851928b377b37" }
+gix-testtools = { version = "0.19.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "db925ecaef8aeb810d7f596ab459372edbc39a6e" }
 
 
 insta = { version = "1.47.2", features = ["json"] }


### PR DESCRIPTION
And of course, some bugfixes that should affect GitButler positively due to greater Git compatibility.

This means the smaller 50% of the required Git3 compatibility are now done 😁.

This also turns Codex author signatures I recently used into me, to help with blame and log notes.