### PR TITLE
Parallelize but-api-macros CI tests with a matrix strategy

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -330,6 +330,18 @@ jobs:
     permissions:
       contents: read
       packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - features: ""
+            cache_suffix: default
+          - features: "--features legacy"
+            cache_suffix: legacy
+          - features: "--features tauri"
+            cache_suffix: tauri
+          - features: "--features napi"
+            cache_suffix: napi
     container:
       image: ghcr.io/gitbutlerapp/ci-base-image@sha256:3eaeae1b07072796a53dc1e7585cdc1f462d0b11d10ecd3685c6fa8082d647dd
     env:
@@ -344,10 +356,10 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: cargo-test-but-api-macros
+          shared-key: cargo-test-but-api-macros-${{ matrix.cache_suffix }}
           save-if: ${{ github.ref == 'refs/heads/master' }}
-      - name: Test but-api-macros feature matrix
-        run: make test-but-api-macros
+      - name: Test but-api-macros ${{ matrix.features || '(default)' }}
+        run: cargo test -p but-api-macros-tests ${{ matrix.features }}
 
   rust-test-tauri:
     needs: changes

--- a/Makefile
+++ b/Makefile
@@ -53,11 +53,3 @@ nextest:
 .PHONY: clippy-fix
 clippy-fix:
 	cargo clippy --workspace --all-targets --fix --allow-dirty
-
-# Test: compile-time coverage for `but-api-macros` across relevant feature combinations.
-.PHONY: test-but-api-macros
-test-but-api-macros:
-	cargo test -p but-api-macros-tests
-	cargo test -p but-api-macros-tests --features legacy
-	cargo test -p but-api-macros-tests --features tauri
-	cargo test -p but-api-macros-tests --features napi


### PR DESCRIPTION
The but-api-macros tests were running 4 sequential cargo test invocations
(default, legacy, tauri, napi features), each triggering a recompile.
Use a GitHub Actions matrix to run them in parallel on separate runners.