### PR TITLE
Increase Playwright e2e test timeout to 120s

### DIFF
--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
 	reporter: process.env.CI ? [["github"], ["buildkite-test-collector/playwright/reporter"]] : "dot",
 	/* Per-test timeout. The default 30s is too tight for tests that perform
 	   multiple commits in CI, where backend operations are slower. */
-	timeout: 60_000,
+	timeout: 120_000,
 	/* Assertion timeout. The default 5s is too tight for CI where backend
 	   operations (commits, rebases, upstream integration) are slower. */
 	expect: { timeout: 15_000 },


### PR DESCRIPTION
Extend per-test timeout from 60s to 120s for Playwright e2e tests
because some tests (notably unifiedDiffView.spec.ts) exceed one minute
in CI. This reduces flaky failures caused by slower backend operations
during commits, rebases, and upstream integration in continuous
environments.

<img width="1280" height="584" alt="image" src="https://github.com/user-attachments/assets/5c286272-230e-402f-9074-c621f51891ba" />
