### PR TITLE
Add CLI E2E tests for live GitHub and GitLab forge workflows

### DIFF
--- a/.github/workflows/e2e-cli-continuous.yml
+++ b/.github/workflows/e2e-cli-continuous.yml
@@ -1,0 +1,79 @@
+name: CLI E2E (Continuous)
+
+on:
+  schedule:
+    # Twice daily: 6am and 6pm UTC.
+    - cron: "0 6,18 * * *"
+  workflow_dispatch:
+
+jobs:
+  cli-e2e:
+    name: cli-e2e-forge
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    container:
+      image: ghcr.io/gitbutlerapp/ci-base-image@sha256:c0ab58bb5f1cd99beb36861f460895be77515f4dd252df736c27c117a8e04a92
+    timeout-minutes: 30
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: e2e-cli-rust-binaries
+          save-if: false
+
+      - name: Setup node environment
+        uses: ./.github/actions/init-env-node
+
+      - name: Build CLI
+        run: cargo build -p but
+
+      - name: Run CLI E2E tests
+        env:
+          GITHUB_TEST_TOKEN: ${{ secrets.CLI_E2E_GITHUB_TOKEN }}
+          GITLAB_TEST_TOKEN: ${{ secrets.CLI_E2E_GITLAB_TOKEN }}
+          GITHUB_TEST_REPO: ${{ vars.CLI_E2E_GITHUB_REPO }}
+          GITLAB_TEST_REPO: ${{ vars.CLI_E2E_GITLAB_REPO }}
+          BUT_BIN: ${{ github.workspace }}/target/debug/but
+        run: pnpm --filter @gitbutler/e2e-cli test:e2e:cli
+
+      - name: Upload results to Buildkite Test Engine
+        if: always() && !cancelled()
+        continue-on-error: true
+        env:
+          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_SUITE_TOKEN_CLI_E2E }}
+          RUN_BRANCH: ${{ github.head_ref || github.ref_name }}
+          RUN_COMMIT_SHA: ${{ github.sha }}
+          RUN_KEY: ${{ github.run_id }}-${{ github.run_attempt }}
+          RUN_NUMBER: ${{ github.run_number }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          curl --fail-with-body -X POST \
+            -H "Authorization: Token $BUILDKITE_ANALYTICS_TOKEN" \
+            -F "data=@e2e/cli/test-results/results.xml" \
+            -F "format=junit" \
+            -F "run_env[CI]=github_actions" \
+            -F "run_env[key]=$RUN_KEY" \
+            -F "run_env[number]=$RUN_NUMBER" \
+            -F "run_env[branch]=$RUN_BRANCH" \
+            -F "run_env[commit_sha]=$RUN_COMMIT_SHA" \
+            -F "run_env[url]=$RUN_URL" \
+            -F "tags[framework]=vitest" \
+            -F "tags[language]=typescript" \
+            -F "tags[type]=e2e-cli" \
+            -F "tags[suite]=continuous-runs" \
+            https://analytics-api.buildkite.com/v1/uploads
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure()
+        with:
+          name: cli-e2e-output
+          path: ./e2e/cli/test-results/
+          retention-days: 14

--- a/crates/but-secret/src/secret.rs
+++ b/crates/but-secret/src/secret.rs
@@ -114,7 +114,12 @@ pub fn set_application_namespace(identifier: impl Into<String>) {
     // hence the specific condition.
     // HACK: we do this here because it's always called by client binaries, and we want it to work
     //       equally there and automatically.
-    if cfg!(debug_assertions) && cfg!(target_os = "macos") {
+    //
+    // In E2E test environments (E2E_TEST_APP_DATA_DIR set), always use git-credentials
+    // regardless of platform — CI containers typically lack a system keychain.
+    if (cfg!(debug_assertions) && cfg!(target_os = "macos"))
+        || std::env::var_os("E2E_TEST_APP_DATA_DIR").is_some()
+    {
         git_credentials::setup().ok();
     }
 }

--- a/crates/but/src/args/config.rs
+++ b/crates/but/src/args/config.rs
@@ -404,6 +404,13 @@ pub enum MetricsStatus {
     Disable,
 }
 
+/// Forge providers for non-interactive authentication.
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub enum ForgeProvider {
+    Github,
+    Gitlab,
+}
+
 impl MetricsStatus {
     pub fn enabled(self) -> bool {
         matches!(self, MetricsStatus::Enable)
@@ -435,7 +442,24 @@ pub enum ForgeSubcommand {
     /// GitLab
     ///  - Personal Access Token (PAT)
     ///  - Self-Hosted
-    Auth,
+    ///
+    /// ## Non-interactive usage (CI)
+    ///
+    /// ```text
+    /// but config forge auth --provider github --token ghp_...
+    /// but config forge auth --provider gitlab --token glpat-...
+    /// ```
+    Auth {
+        /// Personal Access Token to store. When provided, authentication is non-interactive.
+        #[clap(long, env = "BUT_FORGE_TOKEN", hide_env_values = true)]
+        token: Option<String>,
+        /// Forge provider to authenticate with (required when --token is used).
+        #[clap(long, value_enum, requires = "token")]
+        provider: Option<ForgeProvider>,
+        /// Host for GitHub Enterprise or self-hosted GitLab instances.
+        #[clap(long)]
+        host: Option<String>,
+    },
 
     /// List authenticated forge accounts known to GitButler.
     ///

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -523,7 +523,12 @@ pub(crate) async fn forge_config(
     cmd: Option<ForgeSubcommand>,
 ) -> Result<()> {
     match cmd {
-        Some(ForgeSubcommand::Auth) => forge_auth(out).await,
+        Some(ForgeSubcommand::Auth {
+            token: Some(token),
+            provider: Some(provider),
+            host,
+        }) => forge_auth_non_interactive(out, provider, token, host).await,
+        Some(ForgeSubcommand::Auth { .. }) => forge_auth(out).await,
         Some(ForgeSubcommand::ListUsers) => forge_show_overview(out).await,
         Some(ForgeSubcommand::Forget { username }) => forge_forget(username, out).await,
         None => forge_show_overview(out).await,
@@ -659,6 +664,46 @@ fn extract_account_details(
         });
     }
     accounts
+}
+
+/// Authenticate with a forge provider non-interactively using a token.
+/// Intended for CI/automation environments.
+async fn forge_auth_non_interactive(
+    out: &mut OutputChannel,
+    provider: crate::args::config::ForgeProvider,
+    token: String,
+    host: Option<String>,
+) -> Result<()> {
+    use crate::args::config::ForgeProvider;
+
+    let token = but_secret::Sensitive(token);
+    match (provider, host) {
+        (ForgeProvider::Github, None) => {
+            let resp = but_api::github::store_github_pat(token).await?;
+            if let Some(out) = out.for_human() {
+                writeln!(out, "GitHub authentication successful! Welcome, {}.", resp.login)?;
+            }
+        }
+        (ForgeProvider::Github, Some(host)) => {
+            let resp = but_api::github::store_github_enterprise_pat(token, host).await?;
+            if let Some(out) = out.for_human() {
+                writeln!(out, "GitHub Enterprise authentication successful! Welcome, {}.", resp.login)?;
+            }
+        }
+        (ForgeProvider::Gitlab, None) => {
+            let resp = but_api::gitlab::store_gitlab_pat(token).await?;
+            if let Some(out) = out.for_human() {
+                writeln!(out, "GitLab authentication successful! Welcome, {}.", resp.username)?;
+            }
+        }
+        (ForgeProvider::Gitlab, Some(host)) => {
+            let resp = but_api::gitlab::store_gitlab_selfhosted_pat(token, host).await?;
+            if let Some(out) = out.for_human() {
+                writeln!(out, "GitLab (self-hosted) authentication successful! Welcome, {}.", resp.username)?;
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Authenticate with a forge provider (GitHub, GitLab, etc)

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -167,7 +167,7 @@ impl Subcommands {
             | Subcommands::Teardown => Unknown,
             Subcommands::Config(config::Platform { cmd }) => match cmd {
                 Some(config::Subcommands::Forge {
-                    cmd: Some(config::ForgeSubcommand::Auth),
+                    cmd: Some(config::ForgeSubcommand::Auth { .. }),
                 }) => ForgeAuth,
                 Some(config::Subcommands::Forge {
                     cmd: Some(config::ForgeSubcommand::Forget { .. }),

--- a/e2e/cli/package.json
+++ b/e2e/cli/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "@gitbutler/e2e-cli",
+	"type": "module",
+	"private": true,
+	"scripts": {
+		"test:e2e:cli": "vitest run --reporter=default --reporter=junit --outputFile.junit=test-results/results.xml"
+	},
+	"devDependencies": {
+		"vitest": "catalog:"
+	},
+	"dependencies": {
+		"@octokit/rest": "^22.0.0",
+		"tmp-promise": "^3.0.3"
+	}
+}

--- a/e2e/cli/src/but.ts
+++ b/e2e/cli/src/but.ts
@@ -1,0 +1,77 @@
+import { BUT } from "./env.ts";
+import { execFile } from "node:child_process";
+
+export interface ButResult {
+	stdout: string;
+	stderr: string;
+	exitCode: number;
+}
+
+/**
+ * Run `but` with the given arguments in the given working directory.
+ * Returns the full result including stdout, stderr, and exit code.
+ */
+export function but(
+	args: string[],
+	cwd: string,
+	env?: Record<string, string>,
+): Promise<ButResult> {
+	return new Promise((resolve, reject) => {
+		const child = execFile(
+			BUT,
+			args,
+			{
+				cwd,
+				env: {
+					...process.env,
+					// Ensure non-interactive mode for all commands.
+					TERM: "dumb",
+					CI: "true",
+					...env,
+				},
+				maxBuffer: 10 * 1024 * 1024,
+				timeout: 60_000,
+			},
+			(error, stdout, stderr) => {
+				const exitCode = error?.code
+					? typeof error.code === "number"
+						? error.code
+						: 1
+					: 0;
+				resolve({ stdout, stderr, exitCode });
+			},
+		);
+
+		child.on("error", reject);
+	});
+}
+
+/**
+ * Run `but` and assert it succeeds (exit code 0). Returns stdout.
+ * Throws with stderr on failure.
+ */
+export async function butOk(
+	args: string[],
+	cwd: string,
+	env?: Record<string, string>,
+): Promise<string> {
+	const result = await but(args, cwd, env);
+	if (result.exitCode !== 0) {
+		throw new Error(
+			`but ${args.join(" ")} failed (exit ${result.exitCode}):\n${result.stderr}\n${result.stdout}`,
+		);
+	}
+	return result.stdout;
+}
+
+/**
+ * Run `but` with --json and parse the result.
+ */
+export async function butJson<T = unknown>(
+	args: string[],
+	cwd: string,
+	env?: Record<string, string>,
+): Promise<T> {
+	const stdout = await butOk(["--json", ...args], cwd, env);
+	return JSON.parse(stdout) as T;
+}

--- a/e2e/cli/src/env.ts
+++ b/e2e/cli/src/env.ts
@@ -1,0 +1,11 @@
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dirname, "../../..");
+
+export const BUT = process.env.BUT_BIN || path.join(ROOT, "target", "debug", "but");
+
+export const GITHUB_TEST_TOKEN = process.env.GITHUB_TEST_TOKEN || "";
+export const GITLAB_TEST_TOKEN = process.env.GITLAB_TEST_TOKEN || "";
+
+export const GITHUB_TEST_REPO = process.env.GITHUB_TEST_REPO || "";
+export const GITLAB_TEST_REPO = process.env.GITLAB_TEST_REPO || "";

--- a/e2e/cli/src/forge-api.ts
+++ b/e2e/cli/src/forge-api.ts
@@ -1,0 +1,137 @@
+import { GITHUB_TEST_TOKEN, GITLAB_TEST_TOKEN } from "./env.ts";
+
+/**
+ * Minimal GitHub API helpers for verifying PR state.
+ * Uses the REST API directly to avoid extra dependencies.
+ */
+export const github = {
+	async listPullRequests(
+		ownerRepo: string,
+		opts?: { head?: string; state?: string },
+	): Promise<GitHubPR[]> {
+		const params = new URLSearchParams();
+		if (opts?.head) params.set("head", opts.head);
+		if (opts?.state) params.set("state", opts.state ?? "open");
+		params.set("per_page", "100");
+
+		const res = await fetch(
+			`https://api.github.com/repos/${ownerRepo}/pulls?${params}`,
+			{
+				headers: {
+					Authorization: `Bearer ${GITHUB_TEST_TOKEN}`,
+					Accept: "application/vnd.github+json",
+				},
+			},
+		);
+		if (!res.ok) throw new Error(`GitHub API error: ${res.status} ${await res.text()}`);
+		return (await res.json()) as GitHubPR[];
+	},
+
+	async closePullRequest(ownerRepo: string, prNumber: number): Promise<void> {
+		const res = await fetch(
+			`https://api.github.com/repos/${ownerRepo}/pulls/${prNumber}`,
+			{
+				method: "PATCH",
+				headers: {
+					Authorization: `Bearer ${GITHUB_TEST_TOKEN}`,
+					Accept: "application/vnd.github+json",
+				},
+				body: JSON.stringify({ state: "closed" }),
+			},
+		);
+		if (!res.ok) throw new Error(`GitHub API error closing PR: ${res.status}`);
+	},
+
+	async deleteRef(ownerRepo: string, ref: string): Promise<void> {
+		const res = await fetch(
+			`https://api.github.com/repos/${ownerRepo}/git/refs/heads/${ref}`,
+			{
+				method: "DELETE",
+				headers: {
+					Authorization: `Bearer ${GITHUB_TEST_TOKEN}`,
+					Accept: "application/vnd.github+json",
+				},
+			},
+		);
+		// 422 = ref doesn't exist, that's fine.
+		if (!res.ok && res.status !== 422) {
+			throw new Error(`GitHub API error deleting ref: ${res.status}`);
+		}
+	},
+};
+
+/**
+ * Minimal GitLab API helpers for verifying MR state.
+ */
+export const gitlab = {
+	async listMergeRequests(
+		projectPath: string,
+		opts?: { sourceBranch?: string; state?: string },
+	): Promise<GitLabMR[]> {
+		const encoded = encodeURIComponent(projectPath);
+		const params = new URLSearchParams();
+		if (opts?.sourceBranch) params.set("source_branch", opts.sourceBranch);
+		if (opts?.state) params.set("state", opts.state ?? "opened");
+		params.set("per_page", "100");
+
+		const res = await fetch(
+			`https://gitlab.com/api/v4/projects/${encoded}/merge_requests?${params}`,
+			{
+				headers: { "PRIVATE-TOKEN": GITLAB_TEST_TOKEN },
+			},
+		);
+		if (!res.ok) throw new Error(`GitLab API error: ${res.status} ${await res.text()}`);
+		return (await res.json()) as GitLabMR[];
+	},
+
+	async closeMergeRequest(projectPath: string, mrIid: number): Promise<void> {
+		const encoded = encodeURIComponent(projectPath);
+		const res = await fetch(
+			`https://gitlab.com/api/v4/projects/${encoded}/merge_requests/${mrIid}`,
+			{
+				method: "PUT",
+				headers: {
+					"PRIVATE-TOKEN": GITLAB_TEST_TOKEN,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ state_event: "close" }),
+			},
+		);
+		if (!res.ok) throw new Error(`GitLab API error closing MR: ${res.status}`);
+	},
+
+	async deleteBranch(projectPath: string, branch: string): Promise<void> {
+		const encoded = encodeURIComponent(projectPath);
+		const res = await fetch(
+			`https://gitlab.com/api/v4/projects/${encoded}/repository/branches/${encodeURIComponent(branch)}`,
+			{
+				method: "DELETE",
+				headers: { "PRIVATE-TOKEN": GITLAB_TEST_TOKEN },
+			},
+		);
+		if (!res.ok && res.status !== 404) {
+			throw new Error(`GitLab API error deleting branch: ${res.status}`);
+		}
+	},
+};
+
+export interface GitHubPR {
+	number: number;
+	title: string;
+	state: string;
+	draft: boolean;
+	head: { ref: string };
+	base: { ref: string };
+	body: string | null;
+	auto_merge: { enabled: boolean } | null;
+}
+
+export interface GitLabMR {
+	iid: number;
+	title: string;
+	state: string;
+	draft: boolean;
+	source_branch: string;
+	target_branch: string;
+	description: string | null;
+}

--- a/e2e/cli/src/repo.ts
+++ b/e2e/cli/src/repo.ts
@@ -1,0 +1,166 @@
+import { butOk } from "./but.ts";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+export interface TestRepo {
+	/** Absolute path to the local clone. */
+	dir: string;
+	/** The unique prefix used for branch names in this test run. */
+	prefix: string;
+	/** Run a git command in the repo. */
+	git(...args: string[]): Promise<string>;
+	/** Run `but` in the repo. */
+	but(...args: string[]): Promise<string>;
+	/** Create a file and stage it. */
+	createFile(relativePath: string, content: string): Promise<void>;
+	/** Clean up: close any open PRs/MRs for our prefix, delete remote branches, remove temp dir. */
+	cleanup(): Promise<void>;
+}
+
+interface TestRepoOptions {
+	/** Full clone URL, e.g. https://github.com/owner/repo.git */
+	cloneUrl: string;
+	/** Git credentials to embed in the URL or configure via env. */
+	token: string;
+	/** Forge type for cleanup — "github" or "gitlab". */
+	forge: "github" | "gitlab";
+	/** owner/repo for API calls. */
+	ownerRepo: string;
+}
+
+function git(args: string[], cwd: string, env?: Record<string, string>): Promise<string> {
+	return new Promise((resolve, reject) => {
+		execFile(
+			"git",
+			args,
+			{
+				cwd,
+				env: { ...process.env, ...env },
+				maxBuffer: 10 * 1024 * 1024,
+				timeout: 60_000,
+			},
+			(error, stdout, stderr) => {
+				if (error) {
+					reject(
+						new Error(`git ${args.join(" ")} failed:\n${stderr}\n${stdout}`),
+					);
+				} else {
+					resolve(stdout.trim());
+				}
+			},
+		);
+	});
+}
+
+/**
+ * Clone a sandbox repo into a temp directory and initialize `but` in it.
+ *
+ * Each test run gets a unique branch-name prefix to avoid collisions.
+ */
+export async function createTestRepo(opts: TestRepoOptions): Promise<TestRepo> {
+	const prefix = `e2e-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+	const tmpDir = await mkdtemp(path.join(os.tmpdir(), "but-e2e-"));
+
+	// Create an isolated app data dir for this test run.
+	// Setting E2E_TEST_APP_DATA_DIR makes `but` store forge settings here
+	// and also switches the secret backend to git-credentials (no system keychain needed).
+	const appDataDir = path.join(tmpDir, ".but-app-data");
+	await mkdir(appDataDir, { recursive: true });
+
+	const butEnv: Record<string, string> = {
+		E2E_TEST_APP_DATA_DIR: appDataDir,
+	};
+
+	// Configure git credential-store so secrets persist to a plain file.
+	// This is what `but-secret` uses when git-credentials mode is active.
+	const credentialStorePath = path.join(appDataDir, "git-credentials");
+	await git(
+		["config", "--global", "credential.helper", `store --file=${credentialStorePath}`],
+		os.tmpdir(),
+	);
+
+	// Construct authenticated clone URL.
+	const authedUrl = authenticatedUrl(opts.cloneUrl, opts.token, opts.forge);
+
+	// Clone into the temp directory.
+	await git(["clone", authedUrl, tmpDir], os.tmpdir());
+
+	// Configure git identity for commits.
+	await git(["config", "user.email", "e2e-bot@gitbutler.com"], tmpDir);
+	await git(["config", "user.name", "GitButler E2E Bot"], tmpDir);
+
+	// Initialize GitButler in the cloned repo.
+	await butOk(["setup"], tmpDir, butEnv);
+
+	// Authenticate `but` with the forge using the non-interactive --token flag.
+	await butOk(
+		["config", "forge", "auth", "--provider", opts.forge, "--token", opts.token],
+		tmpDir,
+		butEnv,
+	);
+
+	const repo: TestRepo = {
+		dir: tmpDir,
+		prefix,
+
+		async git(...args: string[]) {
+			return git(args, tmpDir);
+		},
+
+		async but(...args: string[]) {
+			return butOk(args, tmpDir, butEnv);
+		},
+
+		async createFile(relativePath: string, content: string) {
+			const fullPath = path.join(tmpDir, relativePath);
+			await writeFile(fullPath, content, "utf-8");
+		},
+
+		async cleanup() {
+			// Delete remote branches matching our prefix.
+			try {
+				const refs = await git(
+					["for-each-ref", "--format=%(refname:short)", "refs/remotes/origin/"],
+					tmpDir,
+				);
+				const branchesToDelete = refs
+					.split("\n")
+					.map((b) => b.replace("origin/", ""))
+					.filter((b) => b.startsWith(prefix));
+
+				for (const branch of branchesToDelete) {
+					try {
+						await git(["push", "origin", "--delete", branch], tmpDir);
+					} catch {
+						// Branch may already be deleted — ignore.
+					}
+				}
+			} catch {
+				// Ignore cleanup failures.
+			}
+
+			// Remove temp directory.
+			await rm(tmpDir, { recursive: true, force: true });
+		},
+	};
+
+	return repo;
+}
+
+function authenticatedUrl(
+	cloneUrl: string,
+	token: string,
+	forge: "github" | "gitlab",
+): string {
+	const url = new URL(cloneUrl);
+	if (forge === "github") {
+		url.username = "x-access-token";
+		url.password = token;
+	} else {
+		url.username = "oauth2";
+		url.password = token;
+	}
+	return url.toString();
+}

--- a/e2e/cli/tests/github-pr.spec.ts
+++ b/e2e/cli/tests/github-pr.spec.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createTestRepo, type TestRepo } from "../src/repo.ts";
+import { github } from "../src/forge-api.ts";
+import { GITHUB_TEST_TOKEN, GITHUB_TEST_REPO } from "../src/env.ts";
+
+const CLONE_URL = `https://github.com/${GITHUB_TEST_REPO}.git`;
+
+describe("GitHub PR lifecycle", () => {
+	let repo: TestRepo;
+	const createdBranches: string[] = [];
+
+	beforeAll(() => {
+		if (!GITHUB_TEST_TOKEN || !GITHUB_TEST_REPO) {
+			throw new Error(
+				"GITHUB_TEST_TOKEN and GITHUB_TEST_REPO must be set to run GitHub e2e tests",
+			);
+		}
+	});
+
+	afterAll(async () => {
+		// Close any PRs we opened and delete remote branches.
+		const [owner] = GITHUB_TEST_REPO.split("/");
+		for (const branch of createdBranches) {
+			const prs = await github.listPullRequests(GITHUB_TEST_REPO, {
+				head: `${owner}:${branch}`,
+				state: "open",
+			});
+			for (const pr of prs) {
+				await github.closePullRequest(GITHUB_TEST_REPO, pr.number).catch(() => {});
+			}
+			await github.deleteRef(GITHUB_TEST_REPO, branch).catch(() => {});
+		}
+
+		await repo?.cleanup();
+	});
+
+	it("should create a single PR", async () => {
+		repo = await createTestRepo({
+			cloneUrl: CLONE_URL,
+			token: GITHUB_TEST_TOKEN,
+			forge: "github",
+			ownerRepo: GITHUB_TEST_REPO,
+		});
+
+		const branchName = `${repo.prefix}-single`;
+		createdBranches.push(branchName);
+
+		// Create a branch and add a commit.
+		await repo.but("branch", "new", branchName);
+		await repo.createFile("test-file.txt", `Created by e2e test ${repo.prefix}\n`);
+		await repo.but("commit", branchName, "-m", "test: add test file");
+
+		// Push the branch.
+		await repo.but("push", branchName);
+
+		// Create a PR using the CLI.
+		await repo.but(
+			"pr",
+			"new",
+			branchName,
+			"-t",
+			"--no-hooks",
+		);
+
+		// Verify the PR exists via the GitHub API.
+		const [owner] = GITHUB_TEST_REPO.split("/");
+		const prs = await github.listPullRequests(GITHUB_TEST_REPO, {
+			head: `${owner}:${branchName}`,
+		});
+		expect(prs.length).toBe(1);
+		expect(prs[0].state).toBe("open");
+	});
+
+	it("should create a draft PR", async () => {
+		const branchName = `${repo.prefix}-draft`;
+		createdBranches.push(branchName);
+
+		await repo.but("branch", "new", branchName);
+		await repo.createFile("draft-file.txt", `Draft PR test ${repo.prefix}\n`);
+		await repo.but("commit", branchName, "-m", "test: draft pr file");
+		await repo.but("push", branchName);
+
+		await repo.but("pr", "new", branchName, "-t", "-d", "--no-hooks");
+
+		const [owner] = GITHUB_TEST_REPO.split("/");
+		const prs = await github.listPullRequests(GITHUB_TEST_REPO, {
+			head: `${owner}:${branchName}`,
+		});
+		expect(prs.length).toBe(1);
+		expect(prs[0].draft).toBe(true);
+	});
+
+	it("should toggle draft state", async () => {
+		// Reuse the draft PR from the previous test.
+		const branchName = `${repo.prefix}-draft`;
+		const [owner] = GITHUB_TEST_REPO.split("/");
+
+		// Set it to ready.
+		await repo.but("pr", "set-ready", branchName);
+
+		let prs = await github.listPullRequests(GITHUB_TEST_REPO, {
+			head: `${owner}:${branchName}`,
+		});
+		expect(prs[0].draft).toBe(false);
+
+		// Set it back to draft.
+		await repo.but("pr", "set-draft", branchName);
+
+		prs = await github.listPullRequests(GITHUB_TEST_REPO, {
+			head: `${owner}:${branchName}`,
+		});
+		expect(prs[0].draft).toBe(true);
+	});
+
+	it("should create stacked PRs with correct targets", async () => {
+		const base = `${repo.prefix}-stack-base`;
+		const top = `${repo.prefix}-stack-top`;
+		createdBranches.push(base, top);
+
+		// Create first branch in the stack.
+		await repo.but("branch", "new", base);
+		await repo.createFile("stack-base.txt", `Stack base ${repo.prefix}\n`);
+		await repo.but("commit", base, "-m", "test: stack base commit");
+		await repo.but("push", base);
+		await repo.but("pr", "new", base, "-t", "--no-hooks");
+
+		// Create second branch on top of the first.
+		await repo.but("branch", "new", top);
+		await repo.createFile("stack-top.txt", `Stack top ${repo.prefix}\n`);
+		await repo.but("commit", top, "-m", "test: stack top commit");
+		await repo.but("push", top);
+		await repo.but("pr", "new", top, "-t", "--no-hooks");
+
+		// Verify the top PR targets the base branch, not the default branch.
+		const [owner] = GITHUB_TEST_REPO.split("/");
+		const topPrs = await github.listPullRequests(GITHUB_TEST_REPO, {
+			head: `${owner}:${top}`,
+		});
+		expect(topPrs.length).toBe(1);
+		expect(topPrs[0].base.ref).toBe(base);
+
+		const basePrs = await github.listPullRequests(GITHUB_TEST_REPO, {
+			head: `${owner}:${base}`,
+		});
+		expect(basePrs.length).toBe(1);
+		// The base PR should target the repo's default branch (usually main or master).
+	});
+
+	it("should update a PR after amending and force-pushing", async () => {
+		const branchName = `${repo.prefix}-amend`;
+		createdBranches.push(branchName);
+
+		await repo.but("branch", "new", branchName);
+		await repo.createFile("amend-file.txt", `Original content ${repo.prefix}\n`);
+		await repo.but("commit", branchName, "-m", "test: original commit");
+		await repo.but("push", branchName);
+		await repo.but("pr", "new", branchName, "-t", "--no-hooks");
+
+		// Amend the commit with new content.
+		await repo.createFile("amend-file.txt", `Amended content ${repo.prefix}\n`);
+		await repo.but("commit", branchName, "-m", "test: amended commit");
+		await repo.but("push", branchName, "--with-force");
+
+		// PR should still be open.
+		const [owner] = GITHUB_TEST_REPO.split("/");
+		const prs = await github.listPullRequests(GITHUB_TEST_REPO, {
+			head: `${owner}:${branchName}`,
+		});
+		expect(prs.length).toBe(1);
+		expect(prs[0].state).toBe("open");
+	});
+});

--- a/e2e/cli/tests/gitlab-mr.spec.ts
+++ b/e2e/cli/tests/gitlab-mr.spec.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createTestRepo, type TestRepo } from "../src/repo.ts";
+import { gitlab } from "../src/forge-api.ts";
+import { GITLAB_TEST_TOKEN, GITLAB_TEST_REPO } from "../src/env.ts";
+
+const CLONE_URL = `https://gitlab.com/${GITLAB_TEST_REPO}.git`;
+
+describe("GitLab MR lifecycle", () => {
+	let repo: TestRepo;
+	const createdBranches: string[] = [];
+
+	beforeAll(() => {
+		if (!GITLAB_TEST_TOKEN || !GITLAB_TEST_REPO) {
+			throw new Error(
+				"GITLAB_TEST_TOKEN and GITLAB_TEST_REPO must be set to run GitLab e2e tests",
+			);
+		}
+	});
+
+	afterAll(async () => {
+		for (const branch of createdBranches) {
+			const mrs = await gitlab
+				.listMergeRequests(GITLAB_TEST_REPO, {
+					sourceBranch: branch,
+					state: "opened",
+				})
+				.catch(() => []);
+			for (const mr of mrs) {
+				await gitlab.closeMergeRequest(GITLAB_TEST_REPO, mr.iid).catch(() => {});
+			}
+			await gitlab.deleteBranch(GITLAB_TEST_REPO, branch).catch(() => {});
+		}
+
+		await repo?.cleanup();
+	});
+
+	it("should create a single MR", async () => {
+		repo = await createTestRepo({
+			cloneUrl: CLONE_URL,
+			token: GITLAB_TEST_TOKEN,
+			forge: "gitlab",
+			ownerRepo: GITLAB_TEST_REPO,
+		});
+
+		const branchName = `${repo.prefix}-single`;
+		createdBranches.push(branchName);
+
+		await repo.but("branch", "new", branchName);
+		await repo.createFile("test-file.txt", `Created by e2e test ${repo.prefix}\n`);
+		await repo.but("commit", branchName, "-m", "test: add test file");
+		await repo.but("push", branchName);
+
+		// `but mr` is an alias for `but pr` — use it to verify the alias works.
+		await repo.but("mr", "new", branchName, "-t", "--no-hooks");
+
+		const mrs = await gitlab.listMergeRequests(GITLAB_TEST_REPO, {
+			sourceBranch: branchName,
+		});
+		expect(mrs.length).toBe(1);
+		expect(mrs[0].state).toBe("opened");
+	});
+
+	it("should create a draft MR", async () => {
+		const branchName = `${repo.prefix}-draft`;
+		createdBranches.push(branchName);
+
+		await repo.but("branch", "new", branchName);
+		await repo.createFile("draft-file.txt", `Draft MR test ${repo.prefix}\n`);
+		await repo.but("commit", branchName, "-m", "test: draft mr file");
+		await repo.but("push", branchName);
+
+		await repo.but("mr", "new", branchName, "-t", "-d", "--no-hooks");
+
+		const mrs = await gitlab.listMergeRequests(GITLAB_TEST_REPO, {
+			sourceBranch: branchName,
+		});
+		expect(mrs.length).toBe(1);
+		// GitLab draft MRs have "Draft:" prefix in title or draft field.
+		expect(mrs[0].draft).toBe(true);
+	});
+
+	it("should toggle draft state", async () => {
+		const branchName = `${repo.prefix}-draft`;
+
+		await repo.but("mr", "set-ready", branchName);
+
+		let mrs = await gitlab.listMergeRequests(GITLAB_TEST_REPO, {
+			sourceBranch: branchName,
+		});
+		expect(mrs[0].draft).toBe(false);
+
+		await repo.but("mr", "set-draft", branchName);
+
+		mrs = await gitlab.listMergeRequests(GITLAB_TEST_REPO, {
+			sourceBranch: branchName,
+		});
+		expect(mrs[0].draft).toBe(true);
+	});
+
+	it("should create stacked MRs with correct targets", async () => {
+		const base = `${repo.prefix}-stack-base`;
+		const top = `${repo.prefix}-stack-top`;
+		createdBranches.push(base, top);
+
+		await repo.but("branch", "new", base);
+		await repo.createFile("stack-base.txt", `Stack base ${repo.prefix}\n`);
+		await repo.but("commit", base, "-m", "test: stack base commit");
+		await repo.but("push", base);
+		await repo.but("mr", "new", base, "-t", "--no-hooks");
+
+		await repo.but("branch", "new", top);
+		await repo.createFile("stack-top.txt", `Stack top ${repo.prefix}\n`);
+		await repo.but("commit", top, "-m", "test: stack top commit");
+		await repo.but("push", top);
+		await repo.but("mr", "new", top, "-t", "--no-hooks");
+
+		const topMrs = await gitlab.listMergeRequests(GITLAB_TEST_REPO, {
+			sourceBranch: top,
+		});
+		expect(topMrs.length).toBe(1);
+		expect(topMrs[0].target_branch).toBe(base);
+
+		const baseMrs = await gitlab.listMergeRequests(GITLAB_TEST_REPO, {
+			sourceBranch: base,
+		});
+		expect(baseMrs.length).toBe(1);
+	});
+
+	it("should update an MR after force-pushing", async () => {
+		const branchName = `${repo.prefix}-amend`;
+		createdBranches.push(branchName);
+
+		await repo.but("branch", "new", branchName);
+		await repo.createFile("amend-file.txt", `Original content ${repo.prefix}\n`);
+		await repo.but("commit", branchName, "-m", "test: original commit");
+		await repo.but("push", branchName);
+		await repo.but("mr", "new", branchName, "-t", "--no-hooks");
+
+		await repo.createFile("amend-file.txt", `Amended content ${repo.prefix}\n`);
+		await repo.but("commit", branchName, "-m", "test: amended commit");
+		await repo.but("push", branchName, "--with-force");
+
+		const mrs = await gitlab.listMergeRequests(GITLAB_TEST_REPO, {
+			sourceBranch: branchName,
+		});
+		expect(mrs.length).toBe(1);
+		expect(mrs[0].state).toBe("opened");
+	});
+});

--- a/e2e/cli/tsconfig.json
+++ b/e2e/cli/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"moduleResolution": "nodenext",
+		"module": "nodenext",
+		"target": "es2022",
+		"lib": ["es2022"],
+		"types": ["node"],
+		"skipLibCheck": true,
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noFallthroughCasesInSwitch": true
+	},
+	"include": ["./**/*.ts"]
+}

--- a/e2e/cli/vitest.config.ts
+++ b/e2e/cli/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		testTimeout: 120_000,
+		hookTimeout: 60_000,
+		// Run test files sequentially to avoid rate-limit and repo contention issues.
+		fileParallelism: false,
+		// Tests within a file run sequentially (they share repo state).
+		sequence: { concurrent: false },
+	},
+});

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - packages/*
   - crates/*
   - e2e
+  - e2e/cli
 
 catalog:
   "@vitest/browser": 3.2.4

--- a/turbo.json
+++ b/turbo.json
@@ -45,6 +45,17 @@
 			"passThroughEnv": ["BUILDKITE_ANALYTICS_TOKEN"],
 			"dependsOn": ["package"]
 		},
+		"test:e2e:cli": {
+			"passThroughEnv": [
+				"BUILDKITE_ANALYTICS_TOKEN",
+				"GITHUB_TEST_TOKEN",
+				"GITLAB_TEST_TOKEN",
+				"GITHUB_TEST_REPO",
+				"GITLAB_TEST_REPO",
+				"BUT_BIN"
+			],
+			"cache": false
+		},
 		"test:ct": {
 			"env": ["PLAYWRIGHT_BROWSERS_PATH"],
 			"dependsOn": ["package", "playwright:install:ct"]


### PR DESCRIPTION
First CLI-level end-to-end test suite that exercises `but` against real
forge APIs on a twice-daily schedule via GitHub Actions.

Test coverage (e2e/cli/):
  - Create single PR / MR
  - Create draft PR / MR
  - Toggle draft ↔ ready state
  - Create stacked PRs / MRs with correct base branch targets
  - Force-push after amend keeps PR / MR open

Infrastructure:
  - `but config forge auth --provider <github|gitlab> --token <PAT>`
    Non-interactive auth for CI — stores token via but-api without
    prompts. Also available via BUT_FORGE_TOKEN env var.
  - `but-secret`: activate git-credentials backend when
    E2E_TEST_APP_DATA_DIR is set (CI containers lack a system keychain).
  - Test helper creates isolated app-data dir + git credential-store
    per run, clones a sandbox repo, and cleans up branches/PRs after.

CI (.github/workflows/e2e-cli-continuous.yml):
  schedule: 0 6,18 * * *  (twice daily)
  build CLI → run vitest → upload JUnit XML to Buildkite Test Engine