### PR TITLE
but_api macro: Auto export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1120,6 +1120,7 @@ dependencies = [
  "anyhow",
  "boolean-enums",
  "bstr",
+ "but-api-macros",
  "but-error",
  "but-oxidize",
  "but-project-handle",
@@ -1222,8 +1223,10 @@ name = "but-error"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "but-api-macros",
  "but-schemars",
  "schemars 1.2.1",
+ "serde",
 ]
 
 [[package]]
@@ -1244,6 +1247,7 @@ name = "but-forge"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "but-api-macros",
  "but-db",
  "but-forge-storage",
  "but-github",
@@ -1293,6 +1297,7 @@ name = "but-github"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "but-api-macros",
  "but-error",
  "but-forge-storage",
  "but-schemars",
@@ -1311,6 +1316,7 @@ name = "but-gitlab"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "but-api-macros",
  "but-error",
  "but-forge-storage",
  "but-schemars",
@@ -1348,6 +1354,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bstr",
+ "but-api-macros",
  "but-core",
  "but-db",
  "but-graph",
@@ -1369,6 +1376,7 @@ name = "but-hunk-dependency"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "but-api-macros",
  "but-core",
  "but-ctx",
  "but-graph",
@@ -1536,6 +1544,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bstr",
+ "but-api-macros",
  "but-core",
  "but-gerrit",
  "but-graph",
@@ -1647,6 +1656,7 @@ name = "but-settings"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "but-api-macros",
  "but-path",
  "but-schemars",
  "but-utils",
@@ -1740,6 +1750,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bstr",
+ "but-api-macros",
  "but-core",
  "but-ctx",
  "but-error",
@@ -3933,6 +3944,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bstr",
+ "but-api-macros",
  "but-core",
  "but-schemars",
  "gitbutler-reference",
@@ -3948,6 +3960,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bstr",
+ "but-api-macros",
  "but-askpass",
  "but-core",
  "but-ctx",
@@ -4016,6 +4029,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bstr",
+ "but-api-macros",
  "but-core",
  "but-ctx",
  "but-graph",
@@ -4101,6 +4115,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bstr",
+ "but-api-macros",
  "but-core",
  "but-ctx",
  "but-schemars",
@@ -4147,6 +4162,7 @@ name = "gitbutler-project"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "but-api-macros",
  "but-core",
  "but-error",
  "but-forge",

--- a/apps/desktop/src/components/forge/PushButton.svelte
+++ b/apps/desktop/src/components/forge/PushButton.svelte
@@ -56,9 +56,9 @@
 	const urlService = inject(URL_SERVICE);
 	const clipboardService = inject(CLIPBOARD_SERVICE);
 
-	// Get current project to check gerrit_mode
+	// Get current project to check gerritMode
 	const projectResponse = $derived(projectsService.getProject(projectId));
-	const isGerritMode = $derived(projectResponse.response?.gerrit_mode ?? false);
+	const isGerritMode = $derived(projectResponse.response?.gerritMode ?? false);
 	const runHooks = $derived(projectRunCommitHooks(projectId));
 
 	// Component is read-only when stackId is undefined

--- a/apps/desktop/src/lib/analytics/commitAnalytics.ts
+++ b/apps/desktop/src/lib/analytics/commitAnalytics.ts
@@ -94,7 +94,7 @@ export class CommitAnalytics {
 				// Number of times F key shortcuts have been "clicked"
 				fKeyActivations: this.fModeManager.activations,
 				// Whether gerrit mode is enabled for this project
-				gerritMode: project.gerrit_mode,
+				gerritMode: project.gerritMode,
 				// Rule metrics
 				...this.getRuleMetrics(rules),
 				// Behavior metrics

--- a/apps/desktop/src/lib/project/project.ts
+++ b/apps/desktop/src/lib/project/project.ts
@@ -19,15 +19,15 @@ export type Project = {
 	omit_certificate_check: boolean | undefined;
 	use_diff_context: boolean | undefined;
 	// Produced just for the frontend to determine if the project is open in any window.
-	is_open: boolean;
+	isOpen: boolean;
 	forge_override: ForgeName | undefined;
 	preferred_forge_user: ForgeUser | null;
 	// Gerrit mode enabled for this project, derived from git configuration
-	gerrit_mode: boolean;
+	gerritMode: boolean;
 	/**
 	 * The path to the forge review template, if set in git configuration.
 	 */
-	forge_review_template_path: string | null;
+	forgeReviewTemplatePath: string | null;
 };
 
 export function vscodePath(path: string) {

--- a/apps/desktop/src/lib/project/projectsService.ts
+++ b/apps/desktop/src/lib/project/projectsService.ts
@@ -86,7 +86,7 @@ export class ProjectsService {
 	isGerritProject(projectId: string) {
 		return this.backendApi.endpoints.project.useQuery(
 			{ projectId, noValidation: true },
-			{ transform: (data) => data.gerrit_mode },
+			{ transform: (data) => data.gerritMode },
 		);
 	}
 

--- a/crates/but-api-macros/src/lib.rs
+++ b/crates/but-api-macros/src/lib.rs
@@ -2,8 +2,457 @@ use std::collections::HashMap;
 
 use convert_case::{Case, Casing};
 use proc_macro::TokenStream;
-use quote::{format_ident, quote};
+use quote::{ToTokens, format_ident, quote};
 use syn::{FnArg, ItemFn, Pat, parse_macro_input};
+
+/// Apply transport boilerplate for DTO structs/enums and register schemas for SDK export.
+///
+/// Defaults:
+/// - `derive(Debug, Serialize)`
+/// - `#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]`
+/// - `#[serde(rename_all = "camelCase")]`
+/// - `#[cfg(feature = "export-schema")] but_schemars::register_sdk_type!(Type)`
+///
+/// Options:
+/// - `deserialize` -> also derive `Deserialize`
+/// - `no_debug` -> do not derive `Debug`
+/// - `no_serialize` -> do not derive `Serialize`
+/// - `rename_all = "..."` -> override serde rename_all casing
+/// - `rename_all_fields = "..."` -> for enums, override serde rename_all_fields casing
+/// - `tag = "...", content = "..."` -> adjacent tagging for enums
+/// - `schemars_rename = "..."` -> override exported schema type name
+#[proc_macro_attribute]
+pub fn but_transport(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let options = match syn::parse::Parser::parse(TransportOptions::parse, attr) {
+        Ok(options) => options,
+        Err(err) => return err.into_compile_error().into(),
+    };
+
+    let parsed_item = parse_macro_input!(item as syn::Item);
+    match expand_but_transport(options, parsed_item) {
+        Ok(expanded) => expanded.into(),
+        Err(err) => err.into_compile_error().into(),
+    }
+}
+
+#[derive(Debug)]
+struct TransportOptions {
+    deserialize: bool,
+    no_debug: bool,
+    no_serialize: bool,
+    rename_all: String,
+    rename_all_fields: Option<String>,
+    tag: Option<String>,
+    content: Option<String>,
+    schemars_rename: Option<String>,
+    register: bool,
+}
+
+impl Default for TransportOptions {
+    fn default() -> Self {
+        Self {
+            deserialize: false,
+            no_debug: false,
+            no_serialize: false,
+            rename_all: "camelCase".into(),
+            rename_all_fields: None,
+            tag: None,
+            content: None,
+            schemars_rename: None,
+            register: true,
+        }
+    }
+}
+
+impl TransportOptions {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut options = Self::default();
+
+        while !input.is_empty() {
+            if input.peek(syn::Ident) && input.peek2(syn::Token![=]) {
+                let key: syn::Ident = input.parse()?;
+                input.parse::<syn::Token![=]>()?;
+                match key.to_string().as_str() {
+                    "rename_all" => {
+                        let value: syn::LitStr = input.parse()?;
+                        options.rename_all = value.value();
+                    }
+                    "rename_all_fields" => {
+                        let value: syn::LitStr = input.parse()?;
+                        options.rename_all_fields = Some(value.value());
+                    }
+                    "tag" => {
+                        let value: syn::LitStr = input.parse()?;
+                        options.tag = Some(value.value());
+                    }
+                    "content" => {
+                        let value: syn::LitStr = input.parse()?;
+                        options.content = Some(value.value());
+                    }
+                    "register" => {
+                        let value: syn::LitBool = input.parse()?;
+                        options.register = value.value;
+                    }
+                    "schemars_rename" => {
+                        let value: syn::LitStr = input.parse()?;
+                        options.schemars_rename = Some(value.value());
+                    }
+                    _ => {
+                        return Err(syn::Error::new_spanned(
+                            key,
+                            "Unknown option. Supported: deserialize, no_debug, no_serialize, rename_all, rename_all_fields, tag, content, schemars_rename, register",
+                        ));
+                    }
+                }
+            } else {
+                let key: syn::Ident = input.parse()?;
+                if key == "deserialize" {
+                    options.deserialize = true;
+                } else if key == "no_debug" {
+                    options.no_debug = true;
+                } else if key == "no_serialize" {
+                    options.no_serialize = true;
+                } else {
+                    return Err(syn::Error::new_spanned(
+                        key,
+                        "Unknown flag. Supported: deserialize, no_debug, no_serialize",
+                    ));
+                }
+            }
+
+            if !input.is_empty() {
+                input.parse::<syn::Token![,]>()?;
+            }
+        }
+
+        if options.content.is_some() && options.tag.is_none() {
+            return Err(syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "`content = ...` requires `tag = ...`",
+            ));
+        }
+
+        Ok(options)
+    }
+}
+
+fn expand_but_transport(
+    options: TransportOptions,
+    mut item: syn::Item,
+) -> Result<proc_macro2::TokenStream, syn::Error> {
+    let (ident, attrs, is_enum) = match &mut item {
+        syn::Item::Struct(item_struct) => {
+            if !item_struct.generics.params.is_empty() {
+                return Err(syn::Error::new_spanned(
+                    &item_struct.generics,
+                    "#[but_transport] does not support generic transport types",
+                ));
+            }
+            auto_apply_special_handlers_on_fields(&mut item_struct.fields);
+            (&item_struct.ident, &mut item_struct.attrs, false)
+        }
+        syn::Item::Enum(item_enum) => {
+            if !item_enum.generics.params.is_empty() {
+                return Err(syn::Error::new_spanned(
+                    &item_enum.generics,
+                    "#[but_transport] does not support generic transport types",
+                ));
+            }
+            for variant in &mut item_enum.variants {
+                auto_apply_special_handlers_on_fields(&mut variant.fields);
+            }
+            (&item_enum.ident, &mut item_enum.attrs, true)
+        }
+        _ => {
+            return Err(syn::Error::new_spanned(
+                item,
+                "#[but_transport] can only be used on structs and enums",
+            ));
+        }
+    };
+
+    let derive_serialize = !options.no_serialize;
+    let derive_deserialize = options.deserialize;
+    let derive_debug = !options.no_debug;
+
+    let derive_idents: Vec<syn::Ident> = [
+        derive_debug.then_some(format_ident!("Debug")),
+        derive_serialize.then_some(format_ident!("Serialize")),
+        derive_deserialize.then_some(format_ident!("Deserialize")),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+
+    if !derive_idents.is_empty() {
+        let derive_attr: syn::Attribute = syn::parse_quote! { #[derive(#(#derive_idents),*)] };
+        attrs.push(derive_attr);
+    }
+
+    attrs.push(syn::parse_quote! {
+        #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+    });
+
+    if let Some(schemars_rename) = options.schemars_rename {
+        let schemars_rename = syn::LitStr::new(&schemars_rename, proc_macro2::Span::call_site());
+        attrs.push(syn::parse_quote! {
+            #[cfg_attr(feature = "export-schema", schemars(rename = #schemars_rename))]
+        });
+    }
+
+    let has_serde_derive = derive_serialize || derive_deserialize;
+    if has_serde_derive {
+        let rename_all = syn::LitStr::new(&options.rename_all, proc_macro2::Span::call_site());
+        let rename_all_fields = options
+            .rename_all_fields
+            .as_ref()
+            .map(|value| syn::LitStr::new(value, proc_macro2::Span::call_site()));
+        if is_enum {
+            if let Some(tag) = options.tag {
+                let tag = syn::LitStr::new(&tag, proc_macro2::Span::call_site());
+                if let Some(content) = options.content {
+                    let content = syn::LitStr::new(&content, proc_macro2::Span::call_site());
+                    if let Some(rename_all_fields) = rename_all_fields {
+                        attrs.push(syn::parse_quote! {
+                            #[serde(rename_all = #rename_all, rename_all_fields = #rename_all_fields, tag = #tag, content = #content)]
+                        });
+                    } else {
+                        attrs.push(syn::parse_quote! {
+                            #[serde(rename_all = #rename_all, tag = #tag, content = #content)]
+                        });
+                    }
+                } else {
+                    if let Some(rename_all_fields) = rename_all_fields {
+                        attrs.push(syn::parse_quote! {
+                            #[serde(rename_all = #rename_all, rename_all_fields = #rename_all_fields, tag = #tag)]
+                        });
+                    } else {
+                        attrs.push(syn::parse_quote! {
+                            #[serde(rename_all = #rename_all, tag = #tag)]
+                        });
+                    }
+                }
+            } else {
+                if let Some(rename_all_fields) = rename_all_fields {
+                    attrs.push(syn::parse_quote! {
+                        #[serde(rename_all = #rename_all, rename_all_fields = #rename_all_fields)]
+                    });
+                } else {
+                    attrs.push(syn::parse_quote! { #[serde(rename_all = #rename_all)] });
+                }
+            }
+        } else {
+            if options.rename_all_fields.is_some() {
+                return Err(syn::Error::new_spanned(
+                    ident,
+                    "`rename_all_fields` is only supported for enums",
+                ));
+            }
+            attrs.push(syn::parse_quote! { #[serde(rename_all = #rename_all)] });
+        }
+    } else {
+        if options.rename_all_fields.is_some() {
+            return Err(syn::Error::new_spanned(
+                ident,
+                "`rename_all_fields` is only supported for enums",
+            ));
+        }
+    }
+
+    let register_item = if options.register {
+        Some(quote! {
+            #[cfg(feature = "export-schema")]
+            but_schemars::register_sdk_type!(#ident);
+        })
+    } else {
+        None
+    };
+
+    let marker_impl = quote! {
+        #[cfg(feature = "export-schema")]
+        impl but_schemars::SdkTransportType for #ident {}
+    };
+
+    Ok(quote! {
+        #item
+        #marker_impl
+        #register_item
+    })
+}
+
+fn auto_apply_special_handlers_on_fields(fields: &mut syn::Fields) {
+    for field in fields {
+        if has_special_handler_attrs(&field.attrs) {
+            continue;
+        }
+
+        let handler = special_handler_for_type(&field.ty);
+        match handler {
+            Some(SpecialHandler::ObjectId) => {
+                field
+                    .attrs
+                    .push(syn::parse_quote! { #[serde(with = "but_serde::object_id")] });
+                field.attrs.push(syn::parse_quote! {
+                    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
+                });
+            }
+            Some(SpecialHandler::HexHash) => {
+                field.attrs.push(syn::parse_quote! {
+                    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
+                });
+            }
+            Some(SpecialHandler::OptionHexHash) => {
+                field.attrs.push(syn::parse_quote! {
+                    #[cfg_attr(feature = "export-schema", schemars(with = "Option<String>"))]
+                });
+            }
+            Some(SpecialHandler::VecHexHash) => {
+                field.attrs.push(syn::parse_quote! {
+                    #[cfg_attr(feature = "export-schema", schemars(with = "Vec<String>"))]
+                });
+            }
+            Some(SpecialHandler::StackId) => {
+                field.attrs.push(syn::parse_quote! {
+                    #[cfg_attr(feature = "export-schema", schemars(schema_with = "but_schemars::stack_id"))]
+                });
+            }
+            Some(SpecialHandler::OptionStackId) => {
+                field.attrs.push(syn::parse_quote! {
+                    #[cfg_attr(feature = "export-schema", schemars(schema_with = "but_schemars::stack_id_opt"))]
+                });
+            }
+            Some(SpecialHandler::BStringForFrontend) => {
+                field.attrs.push(syn::parse_quote! {
+                    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
+                });
+            }
+            Some(SpecialHandler::OptionBStringForFrontend) => {
+                field.attrs.push(syn::parse_quote! {
+                    #[cfg_attr(feature = "export-schema", schemars(with = "Option<String>"))]
+                });
+            }
+            Some(SpecialHandler::VecBStringForFrontend) => {
+                field.attrs.push(syn::parse_quote! {
+                    #[cfg_attr(feature = "export-schema", schemars(with = "Vec<String>"))]
+                });
+            }
+            Some(SpecialHandler::BString) => {
+                field.attrs.push(syn::parse_quote! {
+                    #[serde(serialize_with = "but_serde::bstring_lossy::serialize")]
+                });
+                field.attrs.push(syn::parse_quote! {
+                    #[cfg_attr(feature = "export-schema", schemars(schema_with = "but_schemars::bstring_lossy"))]
+                });
+            }
+            Some(SpecialHandler::OptionBString) => {
+                field
+                    .attrs
+                    .push(syn::parse_quote! { #[serde(with = "but_serde::bstring_lossy_opt")] });
+                field.attrs.push(syn::parse_quote! {
+                    #[cfg_attr(feature = "export-schema", schemars(schema_with = "but_schemars::bstring_lossy_opt"))]
+                });
+            }
+            Some(SpecialHandler::FullName) => {
+                field
+                    .attrs
+                    .push(syn::parse_quote! { #[serde(with = "but_serde::fullname_lossy")] });
+                field.attrs.push(syn::parse_quote! {
+                    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
+                });
+            }
+            None => {}
+        }
+    }
+}
+
+fn has_special_handler_attrs(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        if attr.path().is_ident("schemars") {
+            return true;
+        }
+
+        if attr.path().is_ident("cfg_attr")
+            && attr.meta.to_token_stream().to_string().contains("schemars")
+        {
+            return true;
+        }
+
+        if attr.path().is_ident("serde") {
+            return serde_attr_has_custom_handler(attr);
+        }
+
+        false
+    })
+}
+
+fn serde_attr_has_custom_handler(attr: &syn::Attribute) -> bool {
+    let mut has_custom_handler = false;
+    let _ = attr.parse_nested_meta(|meta| {
+        if meta.path.is_ident("with")
+            || meta.path.is_ident("serialize_with")
+            || meta.path.is_ident("deserialize_with")
+        {
+            has_custom_handler = true;
+        }
+        Ok(())
+    });
+    has_custom_handler
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SpecialHandler {
+    ObjectId,
+    HexHash,
+    OptionHexHash,
+    VecHexHash,
+    StackId,
+    OptionStackId,
+    BString,
+    OptionBString,
+    BStringForFrontend,
+    OptionBStringForFrontend,
+    VecBStringForFrontend,
+    FullName,
+}
+
+fn special_handler_for_type(ty: &syn::Type) -> Option<SpecialHandler> {
+    let syn::Type::Path(type_path) = ty else {
+        return None;
+    };
+
+    if is_object_id_path(&type_path.path) {
+        Some(SpecialHandler::ObjectId)
+    } else if is_hex_hash_path(&type_path.path) {
+        Some(SpecialHandler::HexHash)
+    } else if is_hex_hash_container_path(&type_path.path, "Option") {
+        Some(SpecialHandler::OptionHexHash)
+    } else if is_hex_hash_container_path(&type_path.path, "Vec") {
+        Some(SpecialHandler::VecHexHash)
+    } else if is_stack_id_path(&type_path.path) {
+        Some(SpecialHandler::StackId)
+    } else if is_stack_id_container_path(&type_path.path, "Option") {
+        Some(SpecialHandler::OptionStackId)
+    } else if is_bstring_path(&type_path.path) {
+        Some(SpecialHandler::BString)
+    } else if is_bstring_container_path(&type_path.path, "Option") {
+        Some(SpecialHandler::OptionBString)
+    } else if is_bstring_for_frontend_path(&type_path.path) {
+        Some(SpecialHandler::BStringForFrontend)
+    } else if is_bstring_for_frontend_container_path(&type_path.path, "Option") {
+        Some(SpecialHandler::OptionBStringForFrontend)
+    } else if is_bstring_for_frontend_container_path(&type_path.path, "Vec") {
+        Some(SpecialHandler::VecBStringForFrontend)
+    } else if type_path
+        .path
+        .segments
+        .last()
+        .is_some_and(|last| last.ident == "FullName")
+    {
+        Some(SpecialHandler::FullName)
+    } else {
+        None
+    }
+}
 
 /// A macro to help generate wrappers which are used by some clients to support deserialisation of parameters
 /// for calls, and serialisation of return values, usually with JSON in mind.
@@ -871,6 +1320,63 @@ fn is_hex_hash_container_path(path: &syn::Path, expected_container: &str) -> boo
     };
 
     is_hex_hash_path(&type_path.path)
+}
+
+fn is_bstring_for_frontend_path(path: &syn::Path) -> bool {
+    path.segments
+        .last()
+        .is_some_and(|last| last.ident == "BStringForFrontend")
+        && (path.segments.len() == 1 || path.segments[0].ident == "but_serde")
+}
+
+fn is_stack_id_path(path: &syn::Path) -> bool {
+    path.segments
+        .last()
+        .is_some_and(|last| last.ident == "StackId")
+}
+
+fn is_stack_id_container_path(path: &syn::Path, expected_container: &str) -> bool {
+    let Some(inner_ty) = single_generic_type_arg(path, expected_container) else {
+        return false;
+    };
+    let syn::Type::Path(type_path) = inner_ty else {
+        return false;
+    };
+
+    is_stack_id_path(&type_path.path)
+}
+
+fn is_bstring_path(path: &syn::Path) -> bool {
+    path.segments
+        .last()
+        .is_some_and(|last| last.ident == "BString")
+        && (path.segments.len() == 1
+            || path.segments[0].ident == "bstr"
+            || (path.segments.len() >= 2
+                && path.segments[0].ident == "gix"
+                && path.segments[1].ident == "bstr"))
+}
+
+fn is_bstring_for_frontend_container_path(path: &syn::Path, expected_container: &str) -> bool {
+    let Some(inner_ty) = single_generic_type_arg(path, expected_container) else {
+        return false;
+    };
+    let syn::Type::Path(type_path) = inner_ty else {
+        return false;
+    };
+
+    is_bstring_for_frontend_path(&type_path.path)
+}
+
+fn is_bstring_container_path(path: &syn::Path, expected_container: &str) -> bool {
+    let Some(inner_ty) = single_generic_type_arg(path, expected_container) else {
+        return false;
+    };
+    let syn::Type::Path(type_path) = inner_ty else {
+        return false;
+    };
+
+    is_bstring_path(&type_path.path)
 }
 
 fn is_full_name_ref_path(path: &syn::Path) -> bool {
@@ -1836,5 +2342,131 @@ mod tests {
             !params.requires_legacy,
             "full-name references should not force legacy wrapper generation"
         );
+    }
+
+    #[test]
+    fn but_transport_struct_defaults_and_object_id_handler() {
+        let item: syn::Item = parse_quote! {
+            pub struct Example {
+                pub commit_id: gix::ObjectId,
+                pub title: String,
+            }
+        };
+
+        let expanded = super::expand_but_transport(super::TransportOptions::default(), item)
+            .expect("transport macro expansion should succeed")
+            .to_string();
+
+        assert!(expanded.contains("derive (Debug , Serialize)"));
+        assert!(
+            expanded.contains(
+                "cfg_attr (feature = \"export-schema\" , derive (schemars :: JsonSchema))"
+            )
+        );
+        assert!(expanded.contains("serde (rename_all = \"camelCase\")"));
+        assert!(expanded.contains("serde (with = \"but_serde::object_id\")"));
+        assert!(expanded.contains("register_sdk_type ! (Example)"));
+    }
+
+    #[test]
+    fn but_transport_enum_tagging_and_deserialize_and_full_name_handler() {
+        let options = syn::parse::Parser::parse2(
+            super::TransportOptions::parse,
+            quote!(deserialize, tag = "type", content = "subject"),
+        )
+        .expect("options should parse");
+
+        let item: syn::Item = parse_quote! {
+            pub enum ExampleEnum {
+                Reference(gix::refs::FullName),
+            }
+        };
+
+        let expanded = super::expand_but_transport(options, item)
+            .expect("transport macro expansion should succeed")
+            .to_string();
+
+        assert!(expanded.contains("derive (Debug , Serialize , Deserialize)"));
+        assert!(expanded.contains(
+            "serde (rename_all = \"camelCase\" , tag = \"type\" , content = \"subject\")"
+        ));
+        assert!(expanded.contains("serde (with = \"but_serde::fullname_lossy\")"));
+        assert!(expanded.contains("schemars (with = \"String\")"));
+    }
+
+    #[test]
+    fn but_transport_hex_hash_handlers_map_to_string_shapes() {
+        let item: syn::Item = parse_quote! {
+            pub struct Example {
+                pub commit_id: crate::json::HexHash,
+                pub maybe_commit_id: Option<crate::json::HexHash>,
+                pub commit_ids: Vec<crate::json::HexHash>,
+            }
+        };
+
+        let expanded = super::expand_but_transport(super::TransportOptions::default(), item)
+            .expect("transport macro expansion should succeed")
+            .to_string();
+
+        assert!(expanded.contains("schemars (with = \"String\")"));
+        assert!(expanded.contains("schemars (with = \"Option<String>\")"));
+        assert!(expanded.contains("schemars (with = \"Vec<String>\")"));
+    }
+
+    #[test]
+    fn but_transport_stack_id_handler_maps_to_stack_id_schema() {
+        let item: syn::Item = parse_quote! {
+            pub struct Example {
+                pub stack_id: StackId,
+                pub maybe_stack_id: Option<StackId>,
+            }
+        };
+
+        let expanded = super::expand_but_transport(super::TransportOptions::default(), item)
+            .expect("transport macro expansion should succeed")
+            .to_string();
+
+        assert!(expanded.contains("schemars (schema_with = \"but_schemars::stack_id\")"));
+        assert!(expanded.contains("schemars (schema_with = \"but_schemars::stack_id_opt\")"));
+    }
+
+    #[test]
+    fn but_transport_bstring_for_frontend_handlers_map_to_string_shapes() {
+        let item: syn::Item = parse_quote! {
+            pub struct Example {
+                pub path: but_serde::BStringForFrontend,
+                pub maybe_path: Option<but_serde::BStringForFrontend>,
+                pub paths: Vec<but_serde::BStringForFrontend>,
+            }
+        };
+
+        let expanded = super::expand_but_transport(super::TransportOptions::default(), item)
+            .expect("transport macro expansion should succeed")
+            .to_string();
+
+        assert!(expanded.contains("schemars (with = \"String\")"));
+        assert!(expanded.contains("schemars (with = \"Option<String>\")"));
+        assert!(expanded.contains("schemars (with = \"Vec<String>\")"));
+    }
+
+    #[test]
+    fn but_transport_bstring_handler_maps_to_lossy_string_attrs() {
+        let item: syn::Item = parse_quote! {
+            pub struct Example {
+                pub path: bstr::BString,
+                pub maybe_path: Option<bstr::BString>,
+            }
+        };
+
+        let expanded = super::expand_but_transport(super::TransportOptions::default(), item)
+            .expect("transport macro expansion should succeed")
+            .to_string();
+
+        assert!(
+            expanded.contains("serde (serialize_with = \"but_serde::bstring_lossy::serialize\")")
+        );
+        assert!(expanded.contains("schemars (schema_with = \"but_schemars::bstring_lossy\")"));
+        assert!(expanded.contains("serde (with = \"but_serde::bstring_lossy_opt\")"));
+        assert!(expanded.contains("schemars (schema_with = \"but_schemars::bstring_lossy_opt\")"));
     }
 }

--- a/crates/but-api-macros/tests/tests/ui/fail/default_cmd_requires_legacy.rs
+++ b/crates/but-api-macros/tests/tests/ui/fail/default_cmd_requires_legacy.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)]
+
 // Case: `_cmd` wrappers for context-remapped functions remain legacy-only.
 // It verifies:
 // - calling `<fn>_cmd` without `legacy` fails to compile

--- a/crates/but-api-macros/tests/tests/ui/fail/default_cmd_requires_legacy.stderr
+++ b/crates/but-api-macros/tests/tests/ui/fail/default_cmd_requires_legacy.stderr
@@ -1,21 +1,21 @@
 error[E0425]: cannot find function `with_context_cmd` in this scope
-  --> tests/ui/fail/default_cmd_requires_legacy.rs:17:13
+  --> tests/ui/fail/default_cmd_requires_legacy.rs:19:13
    |
-12 | pub fn with_context(_ctx: but_ctx::Context, value: i32) -> anyhow::Result<i32> {
+14 | pub fn with_context(_ctx: but_ctx::Context, value: i32) -> anyhow::Result<i32> {
    | ------------------------------------------------------------------------------ similarly named function `with_context` defined here
 ...
-17 |     let _ = with_context_cmd(serde_json::json!({
+19 |     let _ = with_context_cmd(serde_json::json!({
    |             ^^^^^^^^^^^^^^^^
    |
 note: found an item that was configured out
-  --> tests/ui/fail/default_cmd_requires_legacy.rs:12:8
+  --> tests/ui/fail/default_cmd_requires_legacy.rs:14:8
    |
-11 | #[but_api]
+13 | #[but_api]
    | ---------- the item is gated behind the `legacy` feature
-12 | pub fn with_context(_ctx: but_ctx::Context, value: i32) -> anyhow::Result<i32> {
+14 | pub fn with_context(_ctx: but_ctx::Context, value: i32) -> anyhow::Result<i32> {
    |        ^^^^^^^^^^^^
 help: a function with a similar name exists
    |
-17 -     let _ = with_context_cmd(serde_json::json!({
-17 +     let _ = with_context(serde_json::json!({
+19 -     let _ = with_context_cmd(serde_json::json!({
+19 +     let _ = with_context(serde_json::json!({
    |

--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -38,6 +38,7 @@ napi = ["dep:napi", "dep:napi-derive", "legacy", "export-schema"]
 path-bytes = []
 ## Generate JSON schemas for TypeScript type generation via schemars.
 export-schema = [
+    "dep:but-schemars",
     "but-error/export-schema",
     "but-workspace/export-schema",
     "but-hunk-assignment/export-schema",
@@ -47,6 +48,7 @@ export-schema = [
     "gitbutler-branch/export-schema",
     "gitbutler-branch-actions/export-schema",
     "gitbutler-edit-mode/export-schema",
+    "but-settings/export-schema",
 ]
 ## Make legacy functionality available.
 legacy = [
@@ -77,6 +79,7 @@ legacy = [
 but-serde.workspace = true
 but-path.workspace = true
 but-api-macros.workspace = true
+but-schemars = { workspace = true, optional = true }
 but-error.workspace = true
 but-core.workspace = true
 but-graph.workspace = true
@@ -140,7 +143,6 @@ open.workspace = true
 url = { version = "2.5", optional = true }
 uuid.workspace = true
 which = "8.0.2"
-but-schemars.workspace = true
 
 [dev-dependencies]
 but-api = { path = ".", features = ["legacy"]}

--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -25,9 +25,7 @@ pub mod json {
     use crate::branch::MoveBranchResult as InternalMoveBranchResult;
 
     /// JSON sibling of [`but_workspace::branch::apply::Outcome`].
-    #[derive(Debug, Serialize)]
-    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-    #[serde(rename_all = "camelCase")]
+    #[but_api_macros::but_transport]
     pub struct ApplyOutcome {
         /// Whether the workspace changed while applying the branch.
         pub workspace_changed: bool,
@@ -36,9 +34,6 @@ pub mod json {
         /// Whether the workspace reference had to be created.
         pub workspace_ref_created: bool,
     }
-    #[cfg(feature = "export-schema")]
-    but_schemars::register_sdk_type!(ApplyOutcome);
-
     impl<'a> From<but_workspace::branch::apply::Outcome<'a>> for ApplyOutcome {
         fn from(value: but_workspace::branch::apply::Outcome<'a>) -> Self {
             let workspace_changed = value.workspace_changed();
@@ -58,17 +53,12 @@ pub mod json {
         }
     }
 
-    #[derive(Debug, Serialize)]
-    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-    #[serde(rename_all = "camelCase")]
+    #[but_api_macros::but_transport]
     /// JSON transport type for moving a branch.
     pub struct MoveBranchResult {
         /// Workspace state after moving or tearing off a branch.
         pub workspace: crate::json::WorkspaceState,
     }
-    #[cfg(feature = "export-schema")]
-    but_schemars::register_sdk_type!(MoveBranchResult);
-
     impl TryFrom<InternalMoveBranchResult> for MoveBranchResult {
         type Error = anyhow::Error;
 

--- a/crates/but-api/src/commit/json.rs
+++ b/crates/but-api/src/commit/json.rs
@@ -14,16 +14,11 @@ use super::types::{
 };
 
 /// JSON transport type for moving changes between commits.
-#[derive(Debug, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
 pub struct MoveChangesResult {
     /// Workspace state after moving changes.
     pub workspace: crate::json::WorkspaceState,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(MoveChangesResult);
 
 impl TryFrom<EngineMoveChangesResult> for MoveChangesResult {
     type Error = anyhow::Error;
@@ -38,9 +33,7 @@ impl TryFrom<EngineMoveChangesResult> for MoveChangesResult {
 }
 
 /// A change that was rejected during commit creation, with the reason for rejection.
-#[derive(Debug, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
 pub struct RejectedChange {
     /// The reason the change was rejected.
     pub reason: but_core::tree::create_tree::RejectionReason,
@@ -54,25 +47,16 @@ pub struct RejectedChange {
     pub path_bytes: bstr::BString,
 }
 
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(RejectedChange);
-
 /// JSON transport type for creating a commit in the rebase graph.
-#[derive(Debug, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
 pub struct CommitCreateResult {
     /// The new commit if one was created.
-    #[cfg_attr(feature = "export-schema", schemars(with = "Option<String>"))]
     pub new_commit: Option<HexHash>,
     /// Changes that were rejected during commit creation.
     pub rejected_changes: Vec<RejectedChange>,
     /// Workspace state after the create or amend.
     pub workspace: crate::json::WorkspaceState,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(CommitCreateResult);
 
 impl TryFrom<EngineCommitCreateResult> for CommitCreateResult {
     type Error = anyhow::Error;
@@ -100,19 +84,13 @@ impl TryFrom<EngineCommitCreateResult> for CommitCreateResult {
 }
 
 /// JSON transport type for rewording a commit.
-#[derive(Debug, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
 pub struct CommitRewordResult {
     /// The new commit ID after rewording.
-    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
     pub new_commit: HexHash,
     /// Workspace state after the reword.
     pub workspace: crate::json::WorkspaceState,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(CommitRewordResult);
 
 impl TryFrom<EngineCommitRewordResult> for CommitRewordResult {
     type Error = anyhow::Error;
@@ -131,19 +109,13 @@ impl TryFrom<EngineCommitRewordResult> for CommitRewordResult {
 }
 
 /// JSON transport type for squashing commits.
-#[derive(Debug, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
 pub struct CommitSquashResult {
     /// The new commit ID after squashing.
-    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
     pub new_commit: HexHash,
     /// Workspace state after the squash.
     pub workspace: crate::json::WorkspaceState,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(CommitSquashResult);
 
 impl TryFrom<EngineCommitSquashResult> for CommitSquashResult {
     type Error = anyhow::Error;
@@ -162,19 +134,13 @@ impl TryFrom<EngineCommitSquashResult> for CommitSquashResult {
 }
 
 /// JSON transport type for inserting a blank commit.
-#[derive(Debug, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
 pub struct CommitInsertBlankResult {
     /// The new blank commit ID.
-    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
     pub new_commit: HexHash,
     /// Workspace state after inserting the blank commit.
     pub workspace: crate::json::WorkspaceState,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(CommitInsertBlankResult);
 
 impl TryFrom<EngineCommitInsertBlankResult> for CommitInsertBlankResult {
     type Error = anyhow::Error;
@@ -193,16 +159,11 @@ impl TryFrom<EngineCommitInsertBlankResult> for CommitInsertBlankResult {
 }
 
 /// JSON transport type for moving a commit.
-#[derive(Debug, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
 pub struct CommitMoveResult {
     /// Workspace state after moving the commit.
     pub workspace: crate::json::WorkspaceState,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(CommitMoveResult);
 
 impl TryFrom<EngineCommitMoveResult> for CommitMoveResult {
     type Error = anyhow::Error;
@@ -216,19 +177,13 @@ impl TryFrom<EngineCommitMoveResult> for CommitMoveResult {
     }
 }
 /// JSON transport type for discarding a commit.
-#[derive(Debug, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
 pub struct CommitDiscardResult {
     /// The commit that was discarded as a result of this operation.
-    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
     pub discarded_commit: HexHash,
     /// Workspace state after discarding the commit.
     pub workspace: crate::json::WorkspaceState,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(CommitDiscardResult);
 
 impl TryFrom<EngineCommitDiscardResult> for CommitDiscardResult {
     type Error = anyhow::Error;
@@ -247,19 +202,13 @@ impl TryFrom<EngineCommitDiscardResult> for CommitDiscardResult {
 }
 
 /// JSON transport type for uncommitting one or more commits.
-#[derive(Debug, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
 pub struct UncommitResult {
     /// The IDs of the commits that were uncommitted.
-    #[cfg_attr(feature = "export-schema", schemars(with = "Vec<String>"))]
     pub uncommitted_ids: Vec<HexHash>,
     /// Workspace state after uncommitting.
     pub workspace: crate::json::WorkspaceState,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(UncommitResult);
 
 impl TryFrom<EngineUncommitResult> for UncommitResult {
     type Error = anyhow::Error;
@@ -279,17 +228,12 @@ impl TryFrom<EngineUncommitResult> for UncommitResult {
 
 /// Specifies a location, usually used to either have something inserted
 /// relative to it, or for the selected object to actually be replaced.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase", tag = "type", content = "subject")]
+#[but_api_macros::but_transport(deserialize, tag = "type", content = "subject")]
+#[derive(Clone)]
 pub enum RelativeTo {
     /// Relative to a commit.
-    #[serde(with = "but_serde::object_id")]
-    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
     Commit(gix::ObjectId),
     /// Relative to a reference.
-    #[serde(with = "but_serde::fullname_lossy")]
-    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
     Reference(gix::refs::FullName),
     /// Relative to a reference, this time with teeth.
     #[cfg_attr(
@@ -298,9 +242,6 @@ pub enum RelativeTo {
     )]
     ReferenceBytes(gix::refs::FullName),
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(RelativeTo);
 
 impl From<RelativeTo> for but_rebase::graph_rebase::mutate::RelativeTo {
     fn from(value: RelativeTo) -> Self {

--- a/crates/but-api/src/diff.rs
+++ b/crates/but-api/src/diff.rs
@@ -18,9 +18,7 @@ pub mod json {
     use serde::Serialize;
 
     /// The JSON sibling of [but_core::diff::CommitDetails].
-    #[derive(Debug, Serialize)]
-    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-    #[serde(rename_all = "camelCase")]
+    #[but_api_macros::but_transport]
     pub struct CommitDetails {
         /// The commit itself.
         // TODO: make this our own json structure - this one is GUI specific and isn't great
@@ -34,9 +32,6 @@ pub mod json {
         /// Conflicting entries in `commit` as stored in the conflict commit metadata.
         pub conflict_entries: Option<but_core::commit::ConflictEntries>,
     }
-    #[cfg(feature = "export-schema")]
-    but_schemars::register_sdk_type!(CommitDetails);
-
     impl From<but_core::diff::CommitDetails> for CommitDetails {
         fn from(value: but_core::diff::CommitDetails) -> Self {
             let but_core::diff::CommitDetails {

--- a/crates/but-api/src/json.rs
+++ b/crates/but-api/src/json.rs
@@ -132,9 +132,7 @@ mod hex_hash {
 pub use hex_hash::{HexHash, HexHashString};
 
 /// Shared JSON transport type for mutation workspace results.
-#[derive(Debug, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
 pub struct WorkspaceState {
     /// Commits that were replaced by the operation. Maps `oldId -> newId`.
     #[cfg_attr(
@@ -145,9 +143,6 @@ pub struct WorkspaceState {
     /// The post-operation workspace view presented to the frontend.
     pub head_info: but_workspace::ui::RefInfo,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(WorkspaceState);
 
 impl TryFrom<crate::WorkspaceState> for WorkspaceState {
     type Error = anyhow::Error;
@@ -416,7 +411,8 @@ fn bstring_schema(generate: &mut schemars::SchemaGenerator) -> schemars::Schema 
 }
 
 /// The full name of a Git reference.
-#[derive(Debug, Clone, schemars::JsonSchema, Serialize)]
+#[but_api_macros::but_transport]
+#[derive(Clone)]
 pub struct FullRefName {
     /// The full name, like `refs/heads/main` or `refs/remotes/origin/foo`.
     /// Note that it might be degenerated if it can't be represented in Unicode.
@@ -426,9 +422,6 @@ pub struct FullRefName {
     #[schemars(schema_with = "bstring_schema")]
     pub full_bytes: bstr::BString,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(FullRefName);
-
 impl From<gix::refs::FullName> for FullRefName {
     fn from(value: gix::refs::FullName) -> Self {
         FullRefName {

--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -7,6 +7,7 @@ use but_forge::{
     ForgeName, ReviewTemplateFunctions, available_review_templates, get_review_template_functions,
 };
 use gitbutler_repo::RepoCommands;
+use serde::Serialize;
 use tracing::instrument;
 
 /// (Deprecated) Get the list of PR template paths for the given project and forge.
@@ -70,17 +71,14 @@ pub fn pr_template(
 }
 
 /// Information about the project's review template.
-#[derive(Debug, Clone, serde::Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[but_api_macros::but_transport]
+#[derive(Clone)]
 pub struct ReviewTemplateInfo {
     /// The relative path to the review template within the repository.
     pub path: String,
     /// The content of the review template.
     pub content: String,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(ReviewTemplateInfo);
 
 /// Get the review template content for the given project and relative path.
 ///

--- a/crates/but-api/src/legacy/modes.rs
+++ b/crates/but-api/src/legacy/modes.rs
@@ -5,20 +5,16 @@ use but_core::{ref_metadata::StackId, ui::TreeChange};
 use but_ctx::Context;
 use gitbutler_edit_mode::ConflictEntryPresence;
 use gitbutler_operating_modes::{EditModeMetadata, OperatingMode};
+use serde::Serialize;
 use tracing::instrument;
 
 use crate::json::Error;
 
-#[derive(Debug, serde::Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
 pub struct HeadAndMode {
     pub head: Option<String>,
     pub operating_mode: OperatingMode,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(HeadAndMode);
-
 #[but_api]
 #[instrument(err(Debug))]
 pub fn operating_mode(ctx: &Context) -> Result<HeadAndMode, Error> {
@@ -36,12 +32,10 @@ pub fn operating_mode(ctx: &Context) -> Result<HeadAndMode, Error> {
     })
 }
 
-#[derive(Debug, serde::Serialize, schemars::JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
 pub struct HeadSha {
     head_sha: String,
 }
-but_schemars::register_sdk_type!(HeadSha);
 
 #[but_api]
 #[instrument(err(Debug))]

--- a/crates/but-api/src/legacy/projects.rs
+++ b/crates/but-api/src/legacy/projects.rs
@@ -4,6 +4,7 @@ use anyhow::{Result, anyhow};
 use but_api_macros::but_api;
 use but_ctx::{Context, ProjectHandleOrLegacyProjectId};
 use but_error::Code;
+use serde::Serialize;
 use tracing::instrument;
 
 #[but_api]
@@ -175,17 +176,13 @@ pub fn is_gerrit(ctx: &but_ctx::Context) -> Result<bool> {
     gitbutler_project::gerrit::is_used_by_default_remote(&*ctx.repo.get()?)
 }
 
-#[derive(serde::Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[but_api_macros::but_transport]
 pub struct ProjectForFrontend {
     #[serde(flatten)]
     pub inner: gitbutler_project::api::Project,
     /// Tell if the project is known to be open in a Window in the frontend.
     pub is_open: bool,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(ProjectForFrontend);
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/but-api/src/legacy/stack.rs
+++ b/crates/but-api/src/legacy/stack.rs
@@ -319,9 +319,7 @@ pub mod json {
     use serde::Serialize;
 
     /// JSON-friendly version of [`gitbutler_git::PushResult`].
-    #[derive(Debug, Serialize)]
-    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-    #[serde(rename_all = "camelCase")]
+    #[but_api_macros::but_transport]
     pub struct PushResult {
         /// The name of the remote to which the branches were pushed.
         pub remote: String,
@@ -331,9 +329,6 @@ pub mod json {
         /// Format: (branch_name, before_sha, after_sha)
         pub branch_sha_updates: Vec<(String, String, String)>,
     }
-    #[cfg(feature = "export-schema")]
-    but_schemars::register_sdk_type!(PushResult);
-
     impl From<gitbutler_git::PushResult> for PushResult {
         fn from(value: gitbutler_git::PushResult) -> Self {
             Self {

--- a/crates/but-api/src/platform.rs
+++ b/crates/but-api/src/platform.rs
@@ -1,14 +1,13 @@
 use anyhow::Result;
 use but_api_macros::but_api;
+use serde::Serialize;
 
 /// Capabilities that vary by how the backend was launched.
 ///
 /// Consumed by the frontend to conditionally show or hide affordances that
 /// only work when the user is on the same machine as the server (e.g. adding
 /// a local project requires a real filesystem path).
-#[derive(Debug, serde::Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(register = false)]
 pub struct ServerCapabilities {
     /// True when the server is reachable from outside localhost (e.g. a
     /// tunnel is active). False in the Tauri desktop app and when

--- a/crates/but-api/src/watcher.rs
+++ b/crates/but-api/src/watcher.rs
@@ -4,12 +4,11 @@
 
 use but_hunk_assignment::WorktreeChanges;
 use gitbutler_operating_modes::OperatingMode;
-use schemars::JsonSchema;
 use serde::Serialize;
 
 /// The type of payloads a watcher event can have
-#[derive(Debug, Clone, Serialize, JsonSchema)]
-#[serde(tag = "type", content = "subject", rename_all = "camelCase")]
+#[but_api_macros::but_transport(tag = "type", content = "subject")]
+#[derive(Clone)]
 pub enum WatcherPayload {
     /// Git remote information was fetched.
     GitFetch(WatcherGitFetchPayload),
@@ -23,20 +22,14 @@ pub enum WatcherPayload {
     WorktreeChanges(WatcherWorktreeChangesPayload),
 }
 
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(WatcherPayload);
-
 /// Git fetch event
-#[derive(Debug, Clone, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Clone)]
 pub struct WatcherGitFetchPayload;
 
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(WatcherGitFetchPayload);
-
 /// Git head (and operating mode) change event
-#[derive(Debug, Clone, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Clone)]
 pub struct WatcherGitHeadPayload {
     /// The SHA of the repository's HEAD.
     pub head: String,
@@ -44,35 +37,23 @@ pub struct WatcherGitHeadPayload {
     pub operating_mode: OperatingMode,
 }
 
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(WatcherGitHeadPayload);
-
 /// Git files activity. Supplies the head sha
-#[derive(Debug, Clone, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Clone)]
 pub struct WatcherGitActivityPayload {
     /// The SHA of the repository's HEAD.
     pub head_sha: String,
 }
 
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(WatcherGitActivityPayload);
-
 /// Remote tracking refs changed (e.g. after a push or external git operation).
-#[derive(Debug, Clone, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Clone)]
 pub struct WatcherGitRemoteActivityPayload;
 
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(WatcherGitRemoteActivityPayload);
-
 /// Worktree files changes.
-#[derive(Debug, Clone, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Clone)]
 pub struct WatcherWorktreeChangesPayload {
     /// The file changes in the repository.
     pub changes: WorktreeChanges,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(WatcherWorktreeChangesPayload);

--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -12,18 +12,14 @@ pub mod json {
     use serde::{Deserialize, Serialize};
 
     /// JSON transport type for how a stack bottom should be updated.
-    #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-    #[serde(rename_all = "camelCase")]
+    #[but_api_macros::but_transport(deserialize)]
+    #[derive(Clone, Copy)]
     pub enum BottomUpdateKind {
         /// Rebase the selected bottom-most commit onto the target branch.
         Rebase,
         /// Create a merge commit at the top of the selected stack.
         Merge,
     }
-
-    #[cfg(feature = "export-schema")]
-    but_schemars::register_sdk_type!(BottomUpdateKind);
 
     impl From<BottomUpdateKind> for but_workspace::BottomUpdateKind {
         fn from(value: BottomUpdateKind) -> Self {
@@ -35,18 +31,14 @@ pub mod json {
     }
 
     /// JSON transport type describing one stack bottom to update.
-    #[derive(Debug, Clone, Serialize, Deserialize)]
-    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-    #[serde(rename_all = "camelCase")]
+    #[but_api_macros::but_transport(deserialize)]
+    #[derive(Clone)]
     pub struct BottomUpdate {
         /// How the selected stack bottom should be updated.
         pub kind: BottomUpdateKind,
         /// The bottom-most commit or empty bottom reference to update.
         pub selector: crate::commit::json::RelativeTo,
     }
-
-    #[cfg(feature = "export-schema")]
-    but_schemars::register_sdk_type!(BottomUpdate);
 
     impl From<BottomUpdate> for but_workspace::BottomUpdate {
         fn from(value: BottomUpdate) -> Self {

--- a/crates/but-core/Cargo.toml
+++ b/crates/but-core/Cargo.toml
@@ -17,6 +17,7 @@ legacy = []
 
 [dependencies]
 but-error.workspace = true
+but-api-macros.workspace = true
 but-project-handle.workspace = true
 but-serde.workspace = true
 

--- a/crates/but-core/src/commit/mod.rs
+++ b/crates/but-core/src/commit/mod.rs
@@ -663,9 +663,8 @@ impl Commit<'_> {
 }
 
 /// Represents what was causing a particular commit to conflict when rebased.
-#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Default, Clone, PartialEq)]
 pub struct ConflictEntries {
     /// The ancestors that were conflicted
     pub ancestor_entries: Vec<PathBuf>,
@@ -674,8 +673,6 @@ pub struct ConflictEntries {
     /// The theirs side entries that were conflicted
     pub their_entries: Vec<PathBuf>,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(ConflictEntries);
 
 impl ConflictEntries {
     /// If there are any conflict entries

--- a/crates/but-core/src/diff/commit_details.rs
+++ b/crates/but-core/src/diff/commit_details.rs
@@ -1,3 +1,5 @@
+use serde::Serialize;
+
 /// A bundle of information about a commit.
 #[derive(Debug, Clone)]
 pub struct CommitDetails {
@@ -12,9 +14,8 @@ pub struct CommitDetails {
 }
 
 /// Line statistics obtained from diffing the blobs of one or more [TreeChange](crate::TreeChange).
-#[derive(Default, Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, serde::Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Default, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct LineStats {
     /// The total amount of lines added in the between blobs of the two trees.
     pub lines_added: u64,
@@ -23,8 +24,6 @@ pub struct LineStats {
     /// The number of files that contributed to these statistics as they were added, removed or modified.
     pub files_changed: u64,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(LineStats);
 
 /// Lifecycle
 impl CommitDetails {

--- a/crates/but-core/src/diff_types.rs
+++ b/crates/but-core/src/diff_types.rs
@@ -4,9 +4,8 @@ use serde::{Deserialize, Serialize};
 use crate::TreeChange;
 
 /// A change that should be used to create a new commit or alter an existing one, along with enough information to know where to find it.
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Default, Clone, PartialEq)]
 pub struct DiffSpec {
     /// The previous location of the entry, the source of a rename if there was one.
     #[serde(rename = "previousPathBytes")]
@@ -30,8 +29,6 @@ pub struct DiffSpec {
     /// Otherwise, the whole file is being deleted.
     pub hunk_headers: Vec<HunkHeader>,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(DiffSpec);
 
 impl From<&TreeChange> for DiffSpec {
     fn from(change: &crate::TreeChange) -> Self {
@@ -54,9 +51,8 @@ impl From<TreeChange> for DiffSpec {
 }
 
 /// The header of a hunk that represents a change to a file.
-#[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Serialize, Deserialize, Hash)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize, no_debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub struct HunkHeader {
     /// The 1-based line number at which the previous version of the file started.
     pub old_start: u32,
@@ -67,8 +63,6 @@ pub struct HunkHeader {
     /// The non-zero number of lines included in the new version of the file.
     pub new_lines: u32,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(HunkHeader);
 
 impl From<&crate::unified_diff::DiffHunk> for HunkHeader {
     fn from(

--- a/crates/but-core/src/lib.rs
+++ b/crates/but-core/src/lib.rs
@@ -257,9 +257,8 @@ pub struct CommitOwned {
 
 /// A patch in unified diff format to show how a resource changed or now looks like (in case it was newly added),
 /// or how it previously looked like in case of a deletion.
-#[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(tag = "type", content = "subject")]
+#[but_api_macros::but_transport(tag = "type", content = "subject", rename_all = "PascalCase")]
+#[derive(Clone)]
 pub enum UnifiedPatch {
     /// The resource was a binary and couldn't be diffed.
     Binary,
@@ -283,8 +282,6 @@ pub enum UnifiedPatch {
         lines_removed: u32,
     },
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(UnifiedPatch);
 
 /// Either git reference or a virtual reference (i.e. a reference not visible in Git).
 #[derive(Debug, Clone, PartialEq)]
@@ -409,8 +406,8 @@ pub struct ChangeState {
 }
 
 /// The status we can't handle, which always originated in the worktree.
-#[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[but_api_macros::but_transport(rename_all = "PascalCase")]
+#[derive(Clone)]
 pub enum IgnoredWorktreeTreeChangeStatus {
     /// A conflicting entry in the index. The worktree state of the entry is unclear.
     Conflict,
@@ -420,25 +417,16 @@ pub enum IgnoredWorktreeTreeChangeStatus {
     /// is the same as what Git is currently tracking.
     TreeIndexWorktreeChangeIneffective,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(IgnoredWorktreeTreeChangeStatus);
 
 /// A way to indicate that a path in the index isn't suitable for committing and needs to be dealt with.
-#[derive(Clone, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[but_api_macros::but_transport(no_debug)]
+#[derive(Clone)]
 pub struct IgnoredWorktreeChange {
     /// The worktree-relative path to the change.
-    #[serde(serialize_with = "but_serde::bstring_lossy::serialize")]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::bstring_lossy")
-    )]
     pub path: BString,
     /// The status that caused this change to be ignored.
     pub status: IgnoredWorktreeTreeChangeStatus,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(IgnoredWorktreeChange);
 
 /// The type returned by [`worktree_changes()`](diff::worktree_changes).
 #[derive(Clone)]

--- a/crates/but-core/src/ref_metadata.rs
+++ b/crates/but-core/src/ref_metadata.rs
@@ -1,4 +1,5 @@
 use gix::refs::FullNameRef;
+use serde::Serialize;
 use uuid::Uuid;
 
 use crate::Id;
@@ -292,17 +293,14 @@ impl Workspace {
 }
 
 /// Metadata about branches, associated with any Git branch.
-#[derive(serde::Serialize, Clone, Eq, PartialEq, Default)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(no_debug)]
+#[derive(Clone, Eq, PartialEq, Default)]
 pub struct Branch {
     /// Standard data we want to know about any ref.
     pub ref_info: RefInfo,
     /// Information about possibly ongoing reviews in various forges.
     pub review: Review,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(Branch);
 
 /// Mutations
 impl Branch {
@@ -356,10 +354,8 @@ impl<T: std::fmt::Debug> std::fmt::Debug for MaybeDebug<'_, T> {
 ///
 /// It allows keeping track of when it changed, but also if we created it initially, a useful
 /// bit of information.
-#[derive(serde::Serialize, Default, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "export-schema", schemars(rename = "MetadataRefInfo"))]
+#[but_api_macros::but_transport(no_debug, schemars_rename = "MetadataRefInfo")]
+#[derive(Default, Clone, Eq, PartialEq)]
 pub struct RefInfo {
     /// The time of creation, *if we created the reference*.
     #[cfg_attr(
@@ -374,9 +370,6 @@ pub struct RefInfo {
     )]
     pub updated_at: Option<gix::date::Time>,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(RefInfo);
 
 /// Mutations
 impl RefInfo {
@@ -527,17 +520,14 @@ impl WorkspaceStack {
 }
 
 /// Metadata about branches, associated with any Git branch.
-#[derive(serde::Serialize, Clone, Eq, PartialEq, Default)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(no_debug)]
+#[derive(Clone, Eq, PartialEq, Default)]
 pub struct Review {
     /// The number for the PR that was associated with this branch.
     pub pull_request: Option<usize>,
     /// A handle to the review created with the GitButler review system.
     pub review_id: Option<String>,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(Review);
 
 impl std::fmt::Debug for Review {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/but-core/src/settings.rs
+++ b/crates/but-core/src/settings.rs
@@ -21,31 +21,24 @@ pub mod git {
     /// UI types
     pub mod ui {
         use but_serde::BStringForFrontend;
+        use serde::{Deserialize, Serialize};
 
         /// See [`GitConfigSettings`](crate::GitConfigSettings) for the docs.
-        #[derive(Debug, PartialEq, Clone, Default, serde::Serialize, serde::Deserialize)]
-        #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-        #[serde(rename_all = "camelCase")]
+        #[but_api_macros::but_transport(deserialize)]
+        #[derive(PartialEq, Clone, Default)]
         #[expect(missing_docs)]
         pub struct GitConfigSettings {
             #[serde(rename = "signCommits")]
             pub gitbutler_sign_commits: Option<bool>,
             pub gitbutler_gerrit_mode: Option<bool>,
-            #[cfg_attr(feature = "export-schema", schemars(with = "Option<String>"))]
             pub gitbutler_forge_review_template_path: Option<BStringForFrontend>,
             pub gitbutler_gitlab_project_id: Option<String>,
             pub gitbutler_gitlab_upstream_project_id: Option<String>,
-            #[cfg_attr(feature = "export-schema", schemars(with = "Option<String>"))]
             pub signing_key: Option<BStringForFrontend>,
-            #[cfg_attr(feature = "export-schema", schemars(with = "Option<String>"))]
             pub signing_format: Option<BStringForFrontend>,
-            #[cfg_attr(feature = "export-schema", schemars(with = "Option<String>"))]
             pub gpg_program: Option<BStringForFrontend>,
-            #[cfg_attr(feature = "export-schema", schemars(with = "Option<String>"))]
             pub gpg_ssh_program: Option<BStringForFrontend>,
         }
-        #[cfg(feature = "export-schema")]
-        but_schemars::register_sdk_type!(GitConfigSettings);
 
         impl From<crate::GitConfigSettings> for GitConfigSettings {
             fn from(

--- a/crates/but-core/src/tree/mod.rs
+++ b/crates/but-core/src/tree/mod.rs
@@ -8,11 +8,11 @@ use crate::{DiffSpec, HunkHeader, HunkRange, RepositoryExt, UnifiedPatch, apply_
 
 /// Utility types for the [`create_tree()`] function
 pub mod create_tree {
+    use serde::Serialize;
 
     /// Provide a description of why a [`crate::DiffSpec`] was rejected for application to the tree of a commit.
-    #[derive(Default, Debug, Copy, Clone, PartialEq, serde::Serialize)]
-    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-    #[serde(rename_all = "camelCase")]
+    #[but_api_macros::but_transport]
+    #[derive(Default, Copy, Clone, PartialEq)]
     pub enum RejectionReason {
         /// All changes were applied, but they didn't end up effectively change the tree to something differing from the target tree.
         /// This means the changes were a no-op.
@@ -47,9 +47,6 @@ pub mod create_tree {
         /// However, at least one hunk was not fully contained.
         MissingDiffSpecAssociation,
     }
-
-    #[cfg(feature = "export-schema")]
-    but_schemars::register_sdk_type!(RejectionReason);
 }
 use create_tree::RejectionReason;
 

--- a/crates/but-core/src/ui.rs
+++ b/crates/but-core/src/ui.rs
@@ -10,9 +10,8 @@ use crate::IgnoredWorktreeChange;
 ///
 /// Not registered as a frontend type library because it is flattened into a
 /// super WorktreeChanges type.
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[but_api_macros::but_transport(register = false)]
+#[derive(Clone)]
 pub struct WorktreeChanges {
     /// Changes that could be committed.
     pub changes: Vec<TreeChange>,
@@ -47,17 +46,14 @@ impl From<crate::WorktreeChanges> for WorktreeChanges {
 }
 
 /// All the changes that were made to the tree, including stats
-#[derive(Default, Debug, Clone, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Default, Clone)]
 pub struct TreeChanges {
     /// The changes that were made to the tree.
     pub changes: Vec<TreeChange>,
     /// The stats of the changes.
     pub stats: TreeStats,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(TreeChanges);
 
 impl TreeChanges {
     pub fn try_to_unidiff(
@@ -86,14 +82,9 @@ fn changes_to_unidiff(
     Ok(out)
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone)]
 pub struct TreeChange {
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::bstring_lossy")
-    )]
     pub path: BStringForFrontend,
     /// Something silently carried back and forth between the frontend and the backend.
     #[cfg_attr(
@@ -103,8 +94,6 @@ pub struct TreeChange {
     pub path_bytes: BString,
     pub status: TreeStatus,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(TreeChange);
 
 impl From<gix::object::tree::diff::Stats> for TreeStats {
     fn from(stats: gix::object::tree::diff::Stats) -> Self {
@@ -116,9 +105,8 @@ impl From<gix::object::tree::diff::Stats> for TreeStats {
     }
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Default, Clone)]
 pub struct TreeStats {
     /// The total amount of lines added.
     pub lines_added: u64,
@@ -127,12 +115,14 @@ pub struct TreeStats {
     /// The number of files added, removed or modified.
     pub files_changed: u64,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(TreeStats);
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(tag = "type", content = "subject")]
+#[but_api_macros::but_transport(
+    deserialize,
+    tag = "type",
+    content = "subject",
+    rename_all = "PascalCase"
+)]
+#[derive(Clone)]
 pub enum TreeStatus {
     Addition {
         state: ChangeState,
@@ -151,10 +141,6 @@ pub enum TreeStatus {
     },
     Rename {
         #[serde(rename = "previousPath")]
-        #[cfg_attr(
-            feature = "export-schema",
-            schemars(schema_with = "but_schemars::bstring_lossy")
-        )]
         previous_path: BStringForFrontend,
         /// Something silently carried back and forth between the frontend and the backend.
         #[serde(rename = "previousPathBytes")]
@@ -169,8 +155,6 @@ pub enum TreeStatus {
         flags: Option<ModeFlags>,
     },
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(TreeStatus);
 
 impl From<TreeStatus> for crate::TreeStatus {
     fn from(value: TreeStatus) -> Self {
@@ -248,15 +232,9 @@ impl From<crate::TreeStatus> for TreeStatus {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone, Copy)]
 pub struct ChangeState {
-    #[serde(with = "but_serde::object_id")]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::object_id")
-    )]
     pub id: gix::ObjectId,
     #[cfg_attr(
         feature = "export-schema",
@@ -264,11 +242,9 @@ pub struct ChangeState {
     )]
     pub kind: EntryKind,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(ChangeState);
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[but_api_macros::but_transport(deserialize, rename_all = "PascalCase")]
+#[derive(Copy, Clone, PartialEq, Eq)]
 #[expect(missing_docs)]
 pub enum ModeFlags {
     ExecutableBitAdded,
@@ -277,8 +253,6 @@ pub enum ModeFlags {
     TypeChangeLinkToFile,
     TypeChange,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(ModeFlags);
 
 impl From<TreeChange> for crate::TreeChange {
     fn from(

--- a/crates/but-core/src/unified_diff.rs
+++ b/crates/but-core/src/unified_diff.rs
@@ -9,9 +9,8 @@ use serde::{Deserialize, Serialize};
 use super::{ChangeState, UnifiedPatch};
 
 /// A hunk as used in a [UnifiedPatch], which also contains all added and removed lines.
-#[derive(Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize, no_debug)]
+#[derive(Clone)]
 pub struct DiffHunk {
     /// The 1-based line number at which the previous version of the file started.
     pub old_start: u32,
@@ -37,15 +36,8 @@ pub struct DiffHunk {
     ///
     /// Also note that this has possibly been decoded lossily, assuming UTF8 if the encoding couldn't be determined,
     /// replacing invalid codepoints with markers.
-    #[serde(serialize_with = "but_serde::bstring_lossy::serialize")]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::bstring_lossy")
-    )]
     pub diff: BString,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(DiffHunk);
 
 impl std::fmt::Debug for DiffHunk {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/but-error/Cargo.toml
+++ b/crates/but-error/Cargo.toml
@@ -6,6 +6,9 @@ authors.workspace = true
 publish = false
 rust-version.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["but-schemars", "schemars"]
+
 [lib]
 doctest = true
 

--- a/crates/but-error/Cargo.toml
+++ b/crates/but-error/Cargo.toml
@@ -14,6 +14,8 @@ export-schema = ["dep:schemars", "dep:but-schemars"]
 
 [dependencies]
 anyhow.workspace = true
+but-api-macros.workspace = true
+serde.workspace = true
 schemars = { workspace = true, optional = true }
 but-schemars = { workspace = true, optional = true }
 

--- a/crates/but-error/src/lib.rs
+++ b/crates/but-error/src/lib.rs
@@ -107,6 +107,7 @@
 //! to `anyhow::Error`.
 //!
 //! By default, `thiserror` instances have no context.
+use serde::Serialize;
 use std::{borrow::Cow, fmt::Debug};
 
 /// A unique code that consumers of the API may rely on to identify errors.
@@ -117,8 +118,8 @@ use std::{borrow::Cow, fmt::Debug};
 /// Remove variants when no longer in use.
 ///
 /// In practice, it should match its [frontend counterpart](https://github.com/gitbutlerapp/gitbutler/blob/fa973fd8f1ae8807621f47601803d98b8a9cf348/app/src/lib/backend/ipc.ts#L5).
-#[derive(Debug, Default, Copy, Clone, PartialOrd, PartialEq)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[but_api_macros::but_transport(rename_all = "PascalCase")]
+#[derive(Default, Copy, Clone, PartialOrd, PartialEq)]
 pub enum Code {
     /// Much like a catch-all error code. It shouldn't be attached explicitly unless
     /// a message is provided as well as part of a [`Context`].
@@ -149,9 +150,6 @@ pub enum Code {
     /// single source of truth for codes the desktop app may surface.
     GitHubTokenExpired,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(Code);
 
 impl std::fmt::Display for Code {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/but-forge/Cargo.toml
+++ b/crates/but-forge/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 rust-version.workspace = true
 description = "Utilities to interact with forges in a somewhat generic way"
 
+[package.metadata.cargo-machete]
+ignored = ["but-schemars", "schemars"]
+
 [features]
 export-schema = [
   "dep:schemars",

--- a/crates/but-forge/Cargo.toml
+++ b/crates/but-forge/Cargo.toml
@@ -20,6 +20,7 @@ doctest = false
 
 [dependencies]
 but-utils.workspace = true
+but-api-macros.workspace = true
 but-github.workspace = true
 but-gitlab.workspace = true
 but-forge-storage.workspace = true

--- a/crates/but-forge/src/ci.rs
+++ b/crates/but-forge/src/ci.rs
@@ -81,13 +81,13 @@ fn ci_checks_for_ref(
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Clone)]
 pub struct CiCheck {
     pub id: i64,
     pub name: String,
     pub output: CiOutput,
+    #[cfg_attr(feature = "export-schema", schemars(with = "Option<String>"))]
     pub started_at: Option<chrono::DateTime<chrono::Utc>>,
     pub status: CiStatus,
     pub head_sha: String,
@@ -98,11 +98,9 @@ pub struct CiCheck {
     #[serde(skip_serializing)]
     pub reference: String,
     #[serde(skip_serializing)]
+    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
     pub last_sync_at: chrono::NaiveDateTime,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(CiCheck);
 
 impl CiCheck {
     /// The struct version for persistence compatibility purposes
@@ -111,24 +109,20 @@ impl CiCheck {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Default)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Clone, Default)]
 pub struct CiOutput {
     pub summary: String,
     pub text: String,
     pub title: String,
 }
 
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(CiOutput);
-
-#[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Clone)]
 pub enum CiStatus {
     Complete {
         conclusion: CiConclusion,
+        #[cfg_attr(feature = "export-schema", schemars(with = "Option<String>"))]
         completed_at: Option<chrono::DateTime<chrono::Utc>>,
     },
     InProgress,
@@ -136,12 +130,8 @@ pub enum CiStatus {
     Unknown,
 }
 
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(CiStatus);
-
-#[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Clone)]
 pub enum CiConclusion {
     ActionRequired,
     Cancelled,
@@ -153,12 +143,8 @@ pub enum CiConclusion {
     Unknown,
 }
 
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(CiConclusion);
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone)]
 pub struct PullRequestMinimal {
     pub id: i64,
     pub number: i64,
@@ -168,9 +154,6 @@ pub struct PullRequestMinimal {
     pub head_ref: String,
     pub head_repo_url: Option<String>,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(PullRequestMinimal);
 
 impl From<but_github::CheckRun> for CiCheck {
     fn from(value: but_github::CheckRun) -> Self {

--- a/crates/but-forge/src/forge.rs
+++ b/crates/but-forge/src/forge.rs
@@ -1,8 +1,7 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "lowercase")]
+#[but_api_macros::but_transport(deserialize, rename_all = "lowercase")]
+#[derive(PartialEq, Clone)]
 /// Supported git forge types
 pub enum ForgeName {
     GitHub,
@@ -10,9 +9,6 @@ pub enum ForgeName {
     Bitbucket,
     Azure,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(ForgeName);
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -29,15 +25,17 @@ impl PartialEq for ForgeRepoInfo {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(tag = "provider", rename_all = "lowercase", content = "details")]
+#[but_api_macros::but_transport(
+    deserialize,
+    rename_all = "lowercase",
+    tag = "provider",
+    content = "details"
+)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum ForgeUser {
     GitHub(but_github::GithubAccountIdentifier),
     GitLab(but_gitlab::GitlabAccountIdentifier),
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(ForgeUser);
 
 impl ForgeUser {
     pub fn github(&self) -> Option<&but_github::GithubAccountIdentifier> {

--- a/crates/but-forge/src/review.rs
+++ b/crates/but-forge/src/review.rs
@@ -180,17 +180,13 @@ fn is_valid_review_template_path_azure(_path: &path::Path) -> bool {
     false
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone)]
 pub struct ForgeReviewLabel {
     pub name: String,
     pub description: Option<String>,
     pub color: Option<String>,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(ForgeReviewLabel);
 
 impl From<but_github::GitHubPrLabel> for ForgeReviewLabel {
     fn from(label: but_github::GitHubPrLabel) -> Self {
@@ -212,9 +208,8 @@ impl From<but_gitlab::GitLabLabel> for ForgeReviewLabel {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone)]
 /// Represents a user from a forge platform (e.g., GitHub, GitLab).
 ///
 /// This structure contains information about a user account on a forge platform,
@@ -233,9 +228,6 @@ pub struct ForgeReviewUser {
     /// Indicates whether this account is a bot account
     pub is_bot: bool,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(ForgeReviewUser);
 
 impl Display for ForgeReviewUser {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -274,9 +266,8 @@ impl From<but_gitlab::GitLabUser> for ForgeReviewUser {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone)]
 /// Represents a review (pull request/merge request) from a forge platform (GitHub, GitLab, etc.).
 ///
 /// Contains metadata and state information about a code review, including its location,
@@ -325,11 +316,9 @@ pub struct ForgeReview {
     /// The platform-specific symbol for this review type (e.g., "#" for GitHub pull requests and "!" for MRs).
     pub unit_symbol: String,
     /// The timestamp when this review was last fetched from the forge.
+    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
     pub last_sync_at: chrono::NaiveDateTime,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(ForgeReview);
 
 impl ForgeReview {
     /// Whether the review is still open (not merged or closed)
@@ -433,9 +422,8 @@ impl From<but_gitlab::MergeRequest> for ForgeReview {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone, Default)]
 pub enum CacheConfig {
     CacheOnly,
     CacheWithFallback {
@@ -444,9 +432,6 @@ pub enum CacheConfig {
     #[default]
     NoCache,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(CacheConfig);
 
 /// List the open reviews (e.g. pull requests) for a given forge repository
 pub fn list_forge_reviews_with_cache(
@@ -635,9 +620,8 @@ fn list_forge_reviews(
     Ok(reviews)
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone, Default)]
 pub enum ForgeReviewFilter {
     Today,
     ThisWeek,
@@ -645,9 +629,6 @@ pub enum ForgeReviewFilter {
     #[default]
     All,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(ForgeReviewFilter);
 
 pub async fn list_forge_reviews_for_branch(
     preferred_forge_user: Option<crate::ForgeUser>,
@@ -988,9 +969,8 @@ pub async fn set_review_draftiness(
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone)]
 pub struct CreateForgeReviewParams {
     pub title: String,
     pub body: String,
@@ -998,9 +978,6 @@ pub struct CreateForgeReviewParams {
     pub target_branch: String,
     pub draft: bool,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(CreateForgeReviewParams);
 
 fn github_head_owner_and_repo<'a>(
     forge_repo_info: &'a crate::forge::ForgeRepoInfo,
@@ -1084,9 +1061,8 @@ pub async fn create_forge_review(
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone)]
 pub struct ForgeReviewUpdate {
     /// The unique identifier number for this review within its repository. This can be a PR or MR number.
     pub number: i64,
@@ -1097,9 +1073,6 @@ pub struct ForgeReviewUpdate {
     /// If set, update the base/target branch of this review to the given value.
     pub target_branch: Option<String>,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(ForgeReviewUpdate);
 
 impl From<ForgeReview> for ForgeReviewUpdate {
     fn from(review: ForgeReview) -> Self {

--- a/crates/but-github/Cargo.toml
+++ b/crates/but-github/Cargo.toml
@@ -10,6 +10,9 @@ readme = "../../README.md"
 publish = false
 rust-version.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["but-schemars", "schemars"]
+
 [features]
 export-schema = [
   "dep:schemars",

--- a/crates/but-github/Cargo.toml
+++ b/crates/but-github/Cargo.toml
@@ -11,7 +11,11 @@ publish = false
 rust-version.workspace = true
 
 [features]
-export-schema = ["dep:schemars", "dep:but-schemars"]
+export-schema = [
+  "dep:schemars",
+  "dep:but-schemars",
+  "but-settings/export-schema",
+]
 
 [lib]
 doctest = false
@@ -21,6 +25,7 @@ but-settings.workspace = true
 but-secret.workspace = true
 but-forge-storage.workspace = true
 but-error.workspace = true
+but-api-macros.workspace = true
 
 serde.workspace = true
 anyhow.workspace = true

--- a/crates/but-github/src/lib.rs
+++ b/crates/but-github/src/lib.rs
@@ -350,13 +350,7 @@ pub mod json {
     ///
     /// This struct is used for API responses where the access token needs to be
     /// sent as a plain string. Field names are converted to camelCase for JSON.
-    #[derive(Debug, Serialize)]
-    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(rename = "GithubAuthStatusResponseSensitive")
-    )]
-    #[serde(rename_all = "camelCase")]
+    #[but_api_macros::but_transport(schemars_rename = "GithubAuthStatusResponseSensitive")]
     pub struct AuthStatusResponseSensitive {
         /// The GitHub access token as a plain string (sensitive data).
         pub access_token: String,
@@ -390,20 +384,11 @@ pub mod json {
         }
     }
 
-    #[cfg(feature = "export-schema")]
-    but_schemars::register_sdk_type!(AuthStatusResponseSensitive);
-
     /// Serializable version of [`AuthenticatedUser`] with exposed access token.
     ///
     /// This struct represents an authenticated GitHub user with their credentials
     /// exposed as plain strings for API responses. Field names are converted to camelCase for JSON.
-    #[derive(Debug, Serialize)]
-    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(rename = "GithubAuthenticatedUserSensitive")
-    )]
-    #[serde(rename_all = "camelCase")]
+    #[but_api_macros::but_transport(schemars_rename = "GithubAuthenticatedUserSensitive")]
     pub struct AuthenticatedUserSensitive {
         /// The GitHub access token as a plain string (sensitive data).
         pub access_token: String,
@@ -436,9 +421,6 @@ pub mod json {
             }
         }
     }
-
-    #[cfg(feature = "export-schema")]
-    but_schemars::register_sdk_type!(AuthenticatedUserSensitive);
 }
 
 #[cfg(test)]

--- a/crates/but-github/src/token.rs
+++ b/crates/but-github/src/token.rs
@@ -53,16 +53,13 @@ pub fn clear_all_github_accounts(storage: &but_forge_storage::Controller) -> Res
     Ok(())
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase", tag = "type", content = "info")]
+#[but_api_macros::but_transport(deserialize, tag = "type", content = "info")]
+#[derive(Clone, PartialEq, Eq)]
 pub enum GithubAccountIdentifier {
     OAuthUsername { username: String },
     PatUsername { username: String },
     Enterprise { username: String, host: String },
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(GithubAccountIdentifier);
 
 impl GithubAccountIdentifier {
     pub fn oauth(username: &str) -> Self {

--- a/crates/but-gitlab/Cargo.toml
+++ b/crates/but-gitlab/Cargo.toml
@@ -10,6 +10,9 @@ readme = "../../README.md"
 publish = false
 rust-version.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["but-schemars", "schemars"]
+
 [features]
 export-schema = ["dep:schemars", "dep:but-schemars"]
 

--- a/crates/but-gitlab/Cargo.toml
+++ b/crates/but-gitlab/Cargo.toml
@@ -20,6 +20,7 @@ doctest = false
 but-secret.workspace = true
 but-forge-storage.workspace = true
 but-error.workspace = true
+but-api-macros.workspace = true
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/but-gitlab/src/lib.rs
+++ b/crates/but-gitlab/src/lib.rs
@@ -248,13 +248,7 @@ pub mod json {
     ///
     /// This struct is used for API responses where the access token needs to be
     /// sent as a plain string. Field names are converted to camelCase for JSON.
-    #[derive(Debug, Serialize)]
-    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(rename = "GitlabAuthStatusResponseSensitive")
-    )]
-    #[serde(rename_all = "camelCase")]
+    #[but_api_macros::but_transport(schemars_rename = "GitlabAuthStatusResponseSensitive")]
     pub struct AuthStatusResponseSensitive {
         /// The GitLab access token as a plain string (sensitive data).
         pub access_token: String,
@@ -288,20 +282,11 @@ pub mod json {
         }
     }
 
-    #[cfg(feature = "export-schema")]
-    but_schemars::register_sdk_type!(AuthStatusResponseSensitive);
-
     /// Serializable version of [`AuthenticatedUser`] with exposed access token.
     ///
     /// This struct represents an authenticated GitLab user with their credentials
     /// exposed as plain strings for API responses. Field names are converted to camelCase for JSON.
-    #[derive(Debug, Serialize)]
-    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(rename = "GitlabAuthenticatedUserSensitive")
-    )]
-    #[serde(rename_all = "camelCase")]
+    #[but_api_macros::but_transport(schemars_rename = "GitlabAuthenticatedUserSensitive")]
     pub struct AuthenticatedUserSensitive {
         /// The GitLab access token as a plain string (sensitive data).
         pub access_token: String,
@@ -334,9 +319,6 @@ pub mod json {
             }
         }
     }
-
-    #[cfg(feature = "export-schema")]
-    but_schemars::register_sdk_type!(AuthenticatedUserSensitive);
 }
 
 #[cfg(test)]

--- a/crates/but-gitlab/src/token.rs
+++ b/crates/but-gitlab/src/token.rs
@@ -53,15 +53,12 @@ pub fn clear_all_gitlab_accounts(storage: &but_forge_storage::Controller) -> Res
     Ok(())
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase", tag = "type", content = "info")]
+#[but_api_macros::but_transport(deserialize, tag = "type", content = "info")]
+#[derive(Clone, PartialEq, Eq)]
 pub enum GitlabAccountIdentifier {
     PatUsername { username: String },
     SelfHosted { username: String, host: String },
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(GitlabAccountIdentifier);
 
 impl GitlabAccountIdentifier {
     pub fn pat(username: &str) -> Self {

--- a/crates/but-hunk-assignment/Cargo.toml
+++ b/crates/but-hunk-assignment/Cargo.toml
@@ -10,7 +10,12 @@ rust-version.workspace = true
 doctest = false
 
 [features]
-export-schema = ["dep:schemars", "dep:but-schemars", "but-core/export-schema", "but-hunk-dependency/export-schema"]
+export-schema = [
+  "dep:schemars",
+  "dep:but-schemars",
+  "but-core/export-schema",
+  "but-hunk-dependency/export-schema",
+]
 
 [dependencies]
 but-core.workspace = true
@@ -18,6 +23,7 @@ but-graph.workspace = true
 but-hunk-dependency.workspace = true
 but-db.workspace = true
 but-serde.workspace = true
+but-api-macros.workspace = true
 
 gix.workspace = true
 

--- a/crates/but-hunk-assignment/Cargo.toml
+++ b/crates/but-hunk-assignment/Cargo.toml
@@ -6,6 +6,9 @@ authors.workspace = true
 publish = false
 rust-version.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["schemars"]
+
 [lib]
 doctest = false
 

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -25,9 +25,8 @@ use serde::{Deserialize, Serialize};
 use tracing::instrument;
 use uuid::Uuid;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone)]
 pub struct HunkAssignment {
     /// A stable identifier for the hunk assignment.
     ///   - When a new hunk is first observed (from the uncommitted changes), it is assigned a new id.
@@ -47,10 +46,6 @@ pub struct HunkAssignment {
     pub path_bytes: BString,
     /// The stack to which the hunk is assigned, derived from `branch_ref_bytes`
     /// through workspace projection.
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::stack_id_opt")
-    )]
     pub stack_id: Option<StackId>,
     /// The assigned branch as a full ref name (e.g. `refs/heads/my-branch`).
     /// This is the source of truth for assignment targeting.
@@ -68,8 +63,6 @@ pub struct HunkAssignment {
     #[serde(skip)]
     pub diff: Option<BString>,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(HunkAssignment);
 
 impl HunkAssignment {
     pub fn from_tree_change(change: &TreeChange, patch: Option<UnifiedPatch>) -> Vec<Self> {
@@ -148,14 +141,13 @@ impl From<HunkAssignment> for but_core::DiffSpec {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(
-    rename_all = "camelCase",
+#[but_api_macros::but_transport(
+    deserialize,
     rename_all_fields = "camelCase",
     tag = "type",
     content = "subject"
 )]
+#[derive(Clone, Default)]
 pub enum AbsorptionTarget {
     Branch {
         branch_name: String,
@@ -166,20 +158,15 @@ pub enum AbsorptionTarget {
     TreeChanges {
         changes: Vec<but_core::ui::TreeChange>,
         // Optionally, the stack to which the changes are assigned
-        #[cfg_attr(feature = "export-schema", schemars(with = "Option<String>"))]
         assigned_stack_id: Option<StackId>,
     },
     #[default]
     All,
 }
 
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(AbsorptionTarget);
-
 /// Reason why a file is being absorbed to a particular commit
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "snake_case")]
+#[but_api_macros::but_transport(deserialize, rename_all = "snake_case")]
+#[derive(Clone, PartialEq, Eq)]
 pub enum AbsorptionReason {
     /// File has hunk range overlap with this commit
     HunkDependency,
@@ -188,9 +175,6 @@ pub enum AbsorptionReason {
     /// Default to leftmost stack's topmost commit
     DefaultStack,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(AbsorptionReason);
 
 impl AbsorptionReason {
     pub fn description(&self) -> &str {
@@ -203,34 +187,23 @@ impl AbsorptionReason {
 }
 
 /// Information about a file being absorbed
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone)]
 pub struct FileAbsorption {
     pub path: String,
     pub assignment: HunkAssignment,
 }
 
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(FileAbsorption);
-
 /// Information about absorptions grouped by commit
-#[derive(Debug, Serialize, Deserialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
 pub struct CommitAbsorption {
     #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
     pub stack_id: but_core::ref_metadata::StackId,
-    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
-    #[serde(with = "but_serde::object_id")]
     pub commit_id: gix::ObjectId,
     pub commit_summary: String,
     pub files: Vec<FileAbsorption>,
     pub reason: AbsorptionReason,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(CommitAbsorption);
 
 /// JSON output structure for a file being absorbed
 #[derive(Debug, Serialize)]
@@ -257,14 +230,13 @@ pub struct JsonAbsorbOutput {
 }
 
 /// The target for a hunk assignment request.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(
-    rename_all = "camelCase",
+#[but_api_macros::but_transport(
+    deserialize,
     rename_all_fields = "camelCase",
     tag = "type",
     content = "subject"
 )]
+#[derive(Clone)]
 pub enum HunkAssignmentTarget {
     /// Assign to the topmost branch of the given stack.
     Stack {
@@ -282,12 +254,9 @@ pub enum HunkAssignmentTarget {
         branch_ref_bytes: BString,
     },
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(HunkAssignmentTarget);
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone)]
 /// A request to update a hunk assignment.
 /// If a file has multiple hunks, the UI client should send a list of assignment
 /// requests with the appropriate hunk headers.
@@ -305,12 +274,9 @@ pub struct HunkAssignmentRequest {
     /// Where to assign this hunk. `None` means "unassigned".
     pub target: Option<HunkAssignmentTarget>,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(HunkAssignmentRequest);
 
-#[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Clone)]
 /// Same as `but_core::ui::WorktreeChanges`, but with the addition of hunk assignments.
 pub struct WorktreeChanges {
     #[serde(flatten)]
@@ -328,8 +294,6 @@ pub struct WorktreeChanges {
     )]
     pub dependencies_error: Option<serde_error::Error>,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(WorktreeChanges);
 
 impl From<but_core::ui::WorktreeChanges> for WorktreeChanges {
     fn from(worktree_changes: but_core::ui::WorktreeChanges) -> Self {

--- a/crates/but-hunk-dependency/Cargo.toml
+++ b/crates/but-hunk-dependency/Cargo.toml
@@ -17,6 +17,7 @@ but-core.workspace = true
 but-serde.workspace = true
 but-ctx = { workspace = true }
 but-graph.workspace = true
+but-api-macros.workspace = true
 
 tracing.workspace = true
 anyhow.workspace = true

--- a/crates/but-hunk-dependency/Cargo.toml
+++ b/crates/but-hunk-dependency/Cargo.toml
@@ -6,6 +6,9 @@ authors.workspace = true
 publish = false
 rust-version.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["schemars"]
+
 [lib]
 doctest = false
 

--- a/crates/but-hunk-dependency/src/ranges/mod.rs
+++ b/crates/but-hunk-dependency/src/ranges/mod.rs
@@ -23,9 +23,8 @@ pub struct WorkspaceRanges {
 }
 
 /// An error that can say what went wrong when computing the hunk ranges for a commit in a stack at a given path.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone)]
 #[expect(missing_docs)]
 pub struct CalculationError {
     pub error_message: String,
@@ -36,15 +35,8 @@ pub struct CalculationError {
         schemars(schema_with = "but_schemars::object_id")
     )]
     pub commit_id: gix::ObjectId,
-    #[serde(serialize_with = "but_serde::bstring_lossy::serialize")]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::bstring_lossy")
-    )]
     pub path: BString,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(CalculationError);
 
 #[derive(Debug, Default)]
 struct StackRanges {

--- a/crates/but-hunk-dependency/src/ui.rs
+++ b/crates/but-hunk-dependency/src/ui.rs
@@ -33,8 +33,8 @@ pub fn hunk_dependencies_for_workspace_changes_by_worktree_dir(
 ///
 /// Note that the [`errors`](Self::errors) field may contain information about specific failures, while other paths
 /// may have succeeded computing.
-#[derive(Debug, Clone, Deserialize, Serialize, Default)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone, Default)]
 pub struct HunkDependencies {
     /// A map from hunk diffs to stack and commit dependencies.
     pub diffs: Vec<(String, DiffHunk, Vec<HunkLock>)>,
@@ -42,8 +42,6 @@ pub struct HunkDependencies {
     // TODO: Does the UI really use whatever partial result that there may be? Should this be a real error?
     pub errors: Vec<crate::CalculationError>,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(HunkDependencies);
 
 impl HunkDependencies {
     /// Calculate all hunk dependencies using a preparepd [`crate::WorkspaceRanges`].
@@ -82,46 +80,29 @@ impl HunkDependencies {
 /// A commit that owns this lock, along with the stack that owns it.
 /// A hunk is locked when it depends on changes in commits that are in your workspace. A hunk can
 /// be locked to more than one branch if it overlaps with more than one committed hunk.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct HunkLock {
     /// The ID if available of the stack that contains
     /// [`commit_id`](Self::commit_id).
     pub target: HunkLockTarget,
     /// The commit the hunk applies to.
-    #[serde(with = "but_serde::object_id")]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::object_id")
-    )]
     pub commit_id: gix::ObjectId,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(HunkLock);
 
 /// The target of a hunk lock. If a stack is identifiable, then it's StackId
 /// will be provided.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase", tag = "type", content = "subject")]
+#[but_api_macros::but_transport(deserialize, tag = "type", content = "subject")]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum HunkLockTarget {
     /// References a stack that has a StackId.
-    Stack(
-        #[cfg_attr(
-            feature = "export-schema",
-            schemars(schema_with = "but_schemars::stack_id")
-        )]
-        StackId,
-    ),
+    Stack(StackId),
     /// The hunk is locked to a stack that we can't reference because it didn't
     /// have a StackId. This is likely because the stack that the change is
     /// locked to doesn't have any associated metadata or doesn't have anything
     /// we can use to associate it with metadata.
     Unidentified,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(HunkLockTarget);
 
 impl From<HunkLockTarget> for Option<StackId> {
     fn from(val: HunkLockTarget) -> Self {

--- a/crates/but-irc/Cargo.toml
+++ b/crates/but-irc/Cargo.toml
@@ -19,7 +19,7 @@ serde_json.workspace = true
 tracing.workspace = true
 base64 = "0.22"
 but-project-handle.workspace = true
-but-settings = { path = "../but-settings" }
+but-settings.workspace = true
 notify-rust.workspace = true
 
 # IRC client library (using native TLS for system certificate support)

--- a/crates/but-rebase/Cargo.toml
+++ b/crates/but-rebase/Cargo.toml
@@ -6,6 +6,9 @@ authors.workspace = true
 publish = false
 rust-version.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["but-schemars", "schemars"]
+
 [features]
 default = []
 export-schema = ["dep:schemars", "dep:but-schemars"]

--- a/crates/but-rebase/Cargo.toml
+++ b/crates/but-rebase/Cargo.toml
@@ -17,6 +17,7 @@ doctest = false
 but-core.workspace = true
 but-gerrit.workspace = true
 but-graph.workspace = true
+but-api-macros.workspace = true
 
 gix = { workspace = true, features = ["revision", "merge"] }
 anyhow.workspace = true

--- a/crates/but-rebase/src/graph_rebase/mutate.rs
+++ b/crates/but-rebase/src/graph_rebase/mutate.rs
@@ -12,9 +12,8 @@ use crate::graph_rebase::{
 };
 
 /// Describes where relative to the selector a step should be inserted
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone, Copy)]
 pub enum InsertSide {
     /// When inserting above, any nodes that point to the selector will now
     /// point to the inserted node instead.
@@ -27,8 +26,6 @@ pub enum InsertSide {
     /// IE: Any parent commits will become a parent of what is getting inserted.
     Below,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(InsertSide);
 
 /// Defines the start and end of a segment by pointing to it's parent-most and child-most nodes.
 #[derive(Debug, Clone)]

--- a/crates/but-schemars/src/lib.rs
+++ b/crates/but-schemars/src/lib.rs
@@ -364,6 +364,13 @@ pub struct SchemarEntry {
     pub schema: fn() -> schemars::Schema,
 }
 
+/// Marker trait for types declared as transport DTOs via `#[but_transport]`.
+///
+/// The `#[but_api]` macro uses this marker in export-schema builds to enforce
+/// that collected complex transport types are declared through the transport
+/// macro path instead of being silently auto-registered.
+pub trait SdkTransportType {}
+
 inventory::collect!(SchemarEntry);
 
 use std::borrow::Cow;

--- a/crates/but-settings/Cargo.toml
+++ b/crates/but-settings/Cargo.toml
@@ -7,11 +7,14 @@ publish = false
 rust-version.workspace = true
 
 [features]
+default = ["export-schema"]
+export-schema = []
 
 [lib]
 doctest = false
 
 [dependencies]
+but-api-macros.workspace = true
 but-path.workspace = true
 but-utils.workspace = true
 

--- a/crates/but-settings/src/app_settings.rs
+++ b/crates/but-settings/src/app_settings.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, schemars::JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct TelemetrySettings {
     /// Whether the anonymous metrics are enabled.
     pub app_metrics_enabled: bool,
@@ -25,18 +25,15 @@ impl TelemetrySettings {
             .flatten()
     }
 }
-but_schemars::register_sdk_type!(TelemetrySettings);
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, schemars::JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct GitHubOAuthAppSettings {
     /// Client ID for the GitHub OAuth application. Set this to use custom (non-GitButler) OAuth application.
     pub oauth_client_id: String,
 }
-but_schemars::register_sdk_type!(GitHubOAuthAppSettings);
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, schemars::JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct FeatureFlags {
     /// Turn on the set a v3 version of checkout
     pub cv3: bool,
@@ -68,28 +65,25 @@ pub struct FeatureFlags {
     /// "modern" uses ignore-aware non-recursive watching.
     pub watch_mode: String,
 }
-but_schemars::register_sdk_type!(FeatureFlags);
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, schemars::JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct ExtraCsp {
     /// Additional hosts that the application can connect to.
     pub hosts: Vec<String>,
     /// Additional hosts for img-src that the application can load images from.
     pub img_src: Vec<String>,
 }
-but_schemars::register_sdk_type!(ExtraCsp);
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, schemars::JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Fetch {
     /// The frequency at which the app will automatically fetch. A negative value (e.g. -1) disables auto fetching.
     pub auto_fetch_interval_minutes: isize,
 }
-but_schemars::register_sdk_type!(Fetch);
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, schemars::JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Claude {
     /// Path to the Claude Code executable. Defaults to "claude" if not set.
     pub executable: String,
@@ -104,18 +98,16 @@ pub struct Claude {
     /// Whether to use the configured model in .claude/settings.json instead of passing --model.
     pub use_configured_model: bool,
 }
-but_schemars::register_sdk_type!(Claude);
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, schemars::JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Reviews {
     /// Whether to auto-fill PR title and description from the first commit when a branch has only one commit.
     pub auto_fill_pr_description_from_commit: bool,
 }
-but_schemars::register_sdk_type!(Reviews);
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, schemars::JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct UiSettings {
     /// Whether to use the native system title bar.
     pub use_native_title_bar: bool,
@@ -133,10 +125,9 @@ pub struct UiSettings {
     )]
     pub check_for_updates_interval_in_seconds: u64,
 }
-but_schemars::register_sdk_type!(UiSettings);
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, schemars::JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct IrcSettings {
     /// IRC server configuration
     pub server: IrcServerSettings,
@@ -149,20 +140,18 @@ pub struct IrcSettings {
     /// IRC connection settings
     pub connection: IrcConnectionSettings,
 }
-but_schemars::register_sdk_type!(IrcSettings);
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, schemars::JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct IrcServerSettings {
     /// IRC server hostname (e.g., "irc.gitbutler.com")
     pub host: String,
     /// IRC server port (default: 6697 for TLS)
     pub port: u16,
 }
-but_schemars::register_sdk_type!(IrcServerSettings);
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, schemars::JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct IrcConnectionSettings {
     /// Whether this connection is enabled (controls connect/disconnect).
     pub enabled: bool,
@@ -182,4 +171,3 @@ pub struct IrcConnectionSettings {
     /// IRC real name
     pub realname: Option<String>,
 }
-but_schemars::register_sdk_type!(IrcConnectionSettings);

--- a/crates/but-ts/README.md
+++ b/crates/but-ts/README.md
@@ -1,6 +1,7 @@
 # but-ts
 
-`but-ts` generates TypeScript type declarations from JSON schemas registered in `but-api`.
+`but-ts` generates TypeScript type declarations from JSON schemas registered through
+the SDK schema inventory that gets linked via `but-api`.
 
 ## High-level
 
@@ -27,10 +28,16 @@ This crate is intended to be the single solution for TypeScript type generation.
 
 ## How it works
 
-1. `but-api` registers schema entries in `but_api::schema`.
-2. `but-ts` collects the registry (`collect_all_schemas`).
-3. It converts schema definitions into TypeScript declarations.
-4. It writes/appends output to the target file (`--output`).
+1. `but-ts` links `but-api` so all API modules and their schema registrations are reachable.
+2. Transport schemas are registered into `inventory` as `but_schemars::SchemarEntry`:
+   - `#[but_api(...)]` marks exported API functions and (for schema export builds) enforces that
+     complex transport types are declared through `#[but_transport]`.
+   - `#[but_transport]` applies transport defaults (serde casing/derive + schemars derive)
+     and auto-registers the type for SDK export.
+   - `but_schemars::register_sdk_type!(Type)` can still be used for non-transport helper types.
+3. `but-ts` collects the inventory (`collect_all_schemas`).
+4. It converts schema definitions into TypeScript declarations.
+5. It writes/appends output to the target file (`--output`).
 
 ## Build entrypoint
 
@@ -48,10 +55,20 @@ pnpm --filter @gitbutler/but-sdk build
 
 ## Add a new generated type
 
-1. Make sure the Rust type derives `schemars::JsonSchema`.
-2. Register it in `crates/but-api/src/schema.rs` with `TypeSchemaEntry`.
+For transport DTOs used by `#[but_api]` endpoints:
+
+1. Declare the DTO with `#[but_api_macros::but_transport]` (or `deserialize` variant when needed).
+2. Keep crate feature wiring consistent with transport macros:
+   - include an `export-schema` feature in the crate that declares DTOs
+   - depend on `but-api-macros` in that crate
 3. Re-run `pnpm --filter @gitbutler/but-sdk build:types`.
 4. Confirm it appears in `packages/but-sdk/src/generated/index.d.ts`.
+
+For non-transport types that still need SDK schema export:
+
+1. Derive `schemars::JsonSchema`.
+2. Register with `but_schemars::register_sdk_type!(Type)`.
+3. Re-run `pnpm --filter @gitbutler/but-sdk build:types`.
 
 ## Validation
 

--- a/crates/but-ts/src/main.rs
+++ b/crates/but-ts/src/main.rs
@@ -112,6 +112,7 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 struct CollectedSchemarEntry {
     /// The name of the schema getting registered
     pub name: Cow<'static, str>,
@@ -157,22 +158,7 @@ fn collect_all_schemas(
     // Order by registration location for a stable checking order
     types.sort_by_cached_key(|s| s.registration_location);
 
-    let mut existing_names = HashMap::<&str, &CollectedSchemarEntry>::new();
-
-    for t in &types {
-        if let Some(duplicate) = existing_names.get(t.name.as_ref()) {
-            bail!(
-                "Error when registering schema {} for type {} registered at {}\n\nDuplicate type {} was registered at {}. Consider renaming one of the types with either `#[serde(rename = ...)]` or `#[schemars(rename = ...)]`.\n",
-                t.name,
-                t.type_name,
-                t.registration_location,
-                duplicate.type_name,
-                duplicate.registration_location
-            );
-        } else {
-            existing_names.insert(t.name.as_ref(), t);
-        }
-    }
+    let existing_names = validate_duplicate_registrations(&types)?;
 
     for t in &types {
         if let Some(obj) = t.schema.as_object()
@@ -211,6 +197,34 @@ fn collect_all_schemas(
         .into_iter()
         .map(|s| (s.name.to_string(), s.schema))
         .collect())
+}
+
+fn validate_duplicate_registrations(
+    types: &[CollectedSchemarEntry],
+) -> anyhow::Result<HashMap<&str, &CollectedSchemarEntry>> {
+    let mut existing_names = HashMap::<&str, &CollectedSchemarEntry>::new();
+
+    for t in types {
+        if let Some(duplicate) = existing_names.get(t.name.as_ref()) {
+            let duplicate_schema = duplicate.schema.clone().to_value();
+            let current_schema = t.schema.clone().to_value();
+            if duplicate_schema != current_schema {
+                bail!(
+                    "Error when registering schema {} for type {} registered at {}\n\nDuplicate type {} was registered at {} with a different signature. Consider renaming one of the types with either `#[serde(rename = ...)]` or `#[schemars(rename = ...)]`.\n",
+                    t.name,
+                    t.type_name,
+                    t.registration_location,
+                    duplicate.type_name,
+                    duplicate.registration_location
+                );
+            }
+            continue;
+        }
+
+        existing_names.insert(t.name.as_ref(), t);
+    }
+
+    Ok(existing_names)
 }
 
 /// Determines whether a root schema and a reference schema are equal by the
@@ -573,6 +587,7 @@ mod tests {
     use super::*;
     use schemars::JsonSchema;
     use serde::Serialize;
+    use std::borrow::Cow;
 
     /// Convert a schemars-annotated type to its TypeScript representation.
     fn ts_for<T: JsonSchema>() -> String {
@@ -605,5 +620,62 @@ mod tests {
           tuple_with_optional_members: Array<[number | null, Array<string> | null]> | null;
         }
         ");
+    }
+
+    #[derive(Serialize, JsonSchema)]
+    struct DuplicateSchemaA {
+        value: String,
+    }
+
+    #[derive(Serialize, JsonSchema)]
+    struct DifferentDuplicateSchema {
+        value: i64,
+    }
+
+    #[test]
+    fn allows_identical_duplicate_schema_registrations() {
+        let schema = schemars::schema_for!(DuplicateSchemaA);
+        let entries = vec![
+            CollectedSchemarEntry {
+                name: Cow::Borrowed("DuplicateSchema"),
+                type_name: "crate::a::DuplicateSchemaA",
+                registration_location: "a.rs:1",
+                schema: schema.clone(),
+            },
+            CollectedSchemarEntry {
+                name: Cow::Borrowed("DuplicateSchema"),
+                type_name: "crate::a::DuplicateSchemaA",
+                registration_location: "b.rs:2",
+                schema,
+            },
+        ];
+
+        let validated = validate_duplicate_registrations(&entries).unwrap();
+        assert_eq!(validated.len(), 1);
+        assert!(validated.contains_key("DuplicateSchema"));
+    }
+
+    #[test]
+    fn rejects_different_duplicate_schema_registrations() {
+        let entries = vec![
+            CollectedSchemarEntry {
+                name: Cow::Borrowed("DuplicateSchema"),
+                type_name: "crate::a::DuplicateSchemaA",
+                registration_location: "a.rs:1",
+                schema: schemars::schema_for!(DuplicateSchemaA),
+            },
+            CollectedSchemarEntry {
+                name: Cow::Borrowed("DuplicateSchema"),
+                type_name: "crate::c::DifferentDuplicateSchema",
+                registration_location: "c.rs:3",
+                schema: schemars::schema_for!(DifferentDuplicateSchema),
+            },
+        ];
+
+        let err = validate_duplicate_registrations(&entries).unwrap_err();
+        assert!(
+            err.to_string().contains("different signature"),
+            "unexpected error: {err:#}"
+        );
     }
 }

--- a/crates/but-workspace/Cargo.toml
+++ b/crates/but-workspace/Cargo.toml
@@ -10,6 +10,8 @@ rust-version.workspace = true
 ignored = [
     # Used only by feature-gated legacy modules.
     "git2",
+    # Used by feature-gated schema export.
+    "schemars",
 ]
 
 [lib]

--- a/crates/but-workspace/Cargo.toml
+++ b/crates/but-workspace/Cargo.toml
@@ -29,6 +29,7 @@ export-schema = ["dep:schemars", "dep:but-schemars", "but-core/export-schema"]
 
 [dependencies]
 but-core.workspace = true
+but-api-macros.workspace = true
 but-graph.workspace = true
 but-rebase.workspace = true
 but-error.workspace = true

--- a/crates/but-workspace/src/commit/squash_commits.rs
+++ b/crates/but-workspace/src/commit/squash_commits.rs
@@ -8,6 +8,7 @@ use but_rebase::{
         Editor, Selector, Step, SuccessfulRebase, ToCommitSelector, mutate::InsertSide,
     },
 };
+use serde::{Deserialize, Serialize};
 
 /// The result of a squash_commits operation.
 #[derive(Debug)]
@@ -113,8 +114,8 @@ fn construct_new_squashed_commit<'ws, 'meta, M: RefMetadata>(
 }
 
 /// How to combine messages of commits being squashed.
-#[derive(Debug, serde::Serialize, serde::Deserialize, Copy, Clone)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[but_api_macros::but_transport(deserialize, rename_all = "PascalCase")]
+#[derive(Copy, Clone)]
 pub enum MessageCombinationStrategy {
     /// Keep both messages.
     KeepBoth,
@@ -127,9 +128,6 @@ pub enum MessageCombinationStrategy {
     /// Subject message will be discarded.
     KeepTarget,
 }
-
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(MessageCombinationStrategy);
 
 /// Squash `subjects` into `target_commit`.
 ///

--- a/crates/but-workspace/src/legacy/mod.rs
+++ b/crates/but-workspace/src/legacy/mod.rs
@@ -81,8 +81,8 @@ pub fn log_target_first_parent(
     Ok(commits)
 }
 /// A filter for the list of stacks.
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[but_api_macros::but_transport(deserialize, rename_all = "PascalCase", register = false)]
+#[derive(Clone, Copy, Default)]
 pub enum StacksFilter {
     /// Show all stacks
     All,

--- a/crates/but-workspace/src/legacy/ui.rs
+++ b/crates/but-workspace/src/legacy/ui.rs
@@ -4,23 +4,12 @@ use but_core::ref_metadata::StackId;
 use serde::Serialize;
 
 /// The information about the branch inside a stack
-#[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Clone)]
 pub struct StackHeadInfo {
     /// The name of the branch.
-    #[serde(with = "but_serde::bstring_lossy")]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::bstring_lossy")
-    )]
     pub name: BString,
     /// The tip of the branch.
-    #[serde(with = "but_serde::object_id")]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::object_id")
-    )]
     pub tip: gix::ObjectId,
     /// The associated forge review with this branch, e.g. GitHub PRs or GitLab MRs
     pub review_id: Option<usize>,
@@ -40,39 +29,24 @@ impl StackHeadInfo {
         Ok(())
     }
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(StackHeadInfo);
-
 /// Represents a lightweight version of a [`gitbutler_stack::Stack`] for listing.
 /// NOTE: this is a UI type mostly because it's still modeled after the legacy stack with StackId, something that doesn't exist anymore.
-#[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Clone)]
 pub struct StackEntry {
     /// The ID of the stack.
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::stack_id_opt")
-    )]
     pub id: Option<StackId>,
     /// The list of the branch information that are part of the stack.
     /// The list is never empty.
     /// The first entry in the list is always the most recent branch on top the stack.
     pub heads: Vec<StackHeadInfo>,
     /// The tip of the top-most branch, i.e., the most recent commit that would become the parent of new commits of the topmost stack branch.
-    #[serde(with = "but_serde::object_id")]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::object_id")
-    )]
     pub tip: gix::ObjectId,
     /// The zero-based index for sorting stacks.
     pub order: Option<usize>,
     /// If `true`, then any head in this stack is checked directly so `HEAD` points to it, and this is only ever `true` for a single stack.
     pub is_checked_out: bool,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(StackEntry);
 
 /// **Temporary type to help transitioning to the optional version of stack-entry** and ultimately, to [`crate::RefInfo`].
 /// WARNING: for use by parts in the code that can rely on having a non-optional `stack_id`. The goal is to have none of these.

--- a/crates/but-workspace/src/ui/author.rs
+++ b/crates/but-workspace/src/ui/author.rs
@@ -2,9 +2,8 @@ use bstr::ByteSlice;
 use serde::Serialize;
 
 /// Represents the author of a commit.
-#[derive(Serialize, Hash, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(no_debug)]
+#[derive(Hash, Clone, PartialEq, Eq)]
 pub struct Author {
     /// The name from the git commit signature
     pub name: String,
@@ -14,8 +13,6 @@ pub struct Author {
     #[cfg_attr(feature = "export-schema", schemars(schema_with = "but_schemars::url"))]
     pub gravatar_url: url::Url,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(Author);
 
 impl std::fmt::Debug for Author {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/but-workspace/src/ui/mod.rs
+++ b/crates/but-workspace/src/ui/mod.rs
@@ -20,9 +20,8 @@ use crate::{
 };
 
 /// Represents the state a commit could be in.
-#[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(tag = "type", content = "subject")]
+#[but_api_macros::but_transport(tag = "type", content = "subject", rename_all = "PascalCase")]
+#[derive(Clone)]
 pub enum CommitState {
     /// The commit is only local
     LocalOnly,
@@ -33,18 +32,11 @@ pub enum CommitState {
     ///
     /// This variant carries the remote commit id.
     /// The `remote_commit_id` may be the same as the `id` or it may be different if the local commit has been rebased or updated in another way.
-    #[serde(with = "but_serde::object_id")]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::object_id")
-    )]
     LocalAndRemote(gix::ObjectId),
     /// The commit is considered integrated.
     /// This should happen when this commit or the contents of this commit is already part of the base.
     Integrated,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(CommitState);
 
 impl CommitState {
     fn display(&self, id: gix::ObjectId) -> &'static str {
@@ -63,16 +55,10 @@ impl CommitState {
 }
 
 /// Commit that is a part of a [`StackBranch`](gitbutler_stack::StackBranch) and, as such, containing state derived in relation to the specific branch.
-#[derive(Clone, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(no_debug)]
+#[derive(Clone)]
 pub struct Commit {
     /// The OID of the commit.
-    #[serde(with = "but_serde::object_id")]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::object_id")
-    )]
     pub id: gix::ObjectId,
     /// The parent OIDs of the commit.
     #[serde(with = "but_serde::object_id_vec")]
@@ -82,11 +68,6 @@ pub struct Commit {
     )]
     pub parent_ids: Vec<gix::ObjectId>,
     /// The message of the commit.
-    #[serde(with = "but_serde::bstring_lossy")]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::bstring_lossy")
-    )]
     pub message: BString,
     /// Whether the commit is in a conflicted state.
     /// The Conflicted state of a commit is a GitButler concept.
@@ -109,8 +90,6 @@ pub struct Commit {
     /// Only populated if Gerrit mode is enabled and the commit has an associated review.
     pub gerrit_review_url: Option<String>,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(Commit);
 
 impl TryFrom<gix::Commit<'_>> for Commit {
     type Error = anyhow::Error;
@@ -189,23 +168,12 @@ impl std::fmt::Debug for Commit {
 
 /// Commit that is only at the remote.
 /// Unlike the `Commit` struct, there is no knowledge of GitButler concepts like conflicted state etc.
-#[derive(Clone, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(no_debug)]
+#[derive(Clone)]
 pub struct UpstreamCommit {
     /// The OID of the commit.
-    #[serde(with = "but_serde::object_id")]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::object_id")
-    )]
     pub id: gix::ObjectId,
     /// The message of the commit.
-    #[serde(with = "but_serde::bstring_lossy")]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::bstring_lossy")
-    )]
     pub message: BString,
     /// Commit creation time in Epoch milliseconds.
     pub created_at: i128,
@@ -214,8 +182,6 @@ pub struct UpstreamCommit {
     /// The GitButler change-id associated with this commit, if available.
     pub change_id: Option<String>,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(UpstreamCommit);
 
 impl std::fmt::Debug for UpstreamCommit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -229,9 +195,8 @@ impl std::fmt::Debug for UpstreamCommit {
 }
 
 /// Represents the pushable status for the current stack.
-#[derive(Debug, Clone, PartialEq, Eq, Copy, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Clone, PartialEq, Eq, Copy)]
 pub enum PushStatus {
     /// Can push, but there are no changes to be pushed
     NothingToPush,
@@ -244,20 +209,12 @@ pub enum PushStatus {
     /// Fully integrated, no changes to push.
     Integrated,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(PushStatus);
 
 /// Information about the current state of a branch.
-#[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Clone)]
 pub struct BranchDetails {
     /// The name of the branch. This is the "given name" IE, just `foo` out of `refs/heads/foo`
-    #[serde(with = "but_serde::bstring_lossy")]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::bstring_lossy")
-    )]
     pub name: BString,
     #[serde(with = "but_serde::fullname_lossy")]
     #[cfg_attr(
@@ -268,18 +225,8 @@ pub struct BranchDetails {
     pub reference: gix::refs::FullName,
     /// The id of the linked worktree that has the reference of `name` checked out.
     /// Note that we don't list the main worktree here.
-    #[serde(with = "but_serde::bstring_lossy_opt")]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::bstring_lossy_opt")
-    )]
     pub linked_worktree_id: Option<BString>,
     /// Upstream reference, e.g. `refs/remotes/origin/base-branch-improvements`
-    #[serde(with = "but_serde::bstring_lossy_opt")]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::bstring_lossy_opt")
-    )]
     pub remote_tracking_branch: Option<BString>,
     /// The pull(merge) request associated with the branch, or None if no such entity has not been created.
     pub pr_number: Option<usize>,
@@ -287,20 +234,10 @@ pub struct BranchDetails {
     pub review_id: Option<String>,
     /// This is the last commit in the branch, aka the tip of the branch.
     /// If this is the only branch in the stack or the top-most branch, this is the tip of the stack.
-    #[serde(with = "but_serde::object_id")]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::object_id")
-    )]
     pub tip: gix::ObjectId,
     /// This is the base commit from the perspective of this branch.
     /// If the branch is part of a stack and is on top of another branch, this is the head of the branch below it.
     /// If this branch is at the bottom of the stack, this is the merge base of the stack.
-    #[serde(with = "but_serde::object_id")]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::object_id")
-    )]
     pub base_commit: gix::ObjectId,
     /// The pushable status for the branch.
     pub push_status: PushStatus,
@@ -322,13 +259,10 @@ pub struct BranchDetails {
     /// Whether it's representing a remote head
     pub is_remote_head: bool,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(BranchDetails);
 
 /// Information about the current state of a stack
-#[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Clone)]
 pub struct StackDetails {
     /// This is the name of the top-most branch, provided by the API for convenience
     pub derived_name: String,
@@ -339,8 +273,6 @@ pub struct StackDetails {
     /// Whether the stack is conflicted.
     pub is_conflicted: bool,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(StackDetails);
 
 /// Represents a branch in a `Stack`. It contains commits derived from the local pseudo branch and it's respective remote
 #[derive(Debug, Clone, Serialize)]

--- a/crates/but-workspace/src/ui/ref_info.rs
+++ b/crates/but-workspace/src/ui/ref_info.rs
@@ -5,6 +5,7 @@ use but_core::{
     ref_metadata::{self, StackId},
 };
 use gix::refs::Category;
+use serde::Serialize;
 
 use crate::{
     ref_info::{LocalCommit, LocalCommitRelation},
@@ -13,9 +14,8 @@ use crate::{
 };
 
 /// A reference in `refs/heads`.
-#[derive(serde::Serialize, Debug, Clone)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Clone)]
 pub struct BranchReference {
     /// The full ref name, like `refs/heads/feat`, for usage with the backend.
     #[cfg_attr(
@@ -26,8 +26,6 @@ pub struct BranchReference {
     /// The short version of `full_name_bytes` for display.
     pub display_name: String,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(BranchReference);
 
 impl From<gix::refs::FullName> for BranchReference {
     fn from(value: gix::refs::FullName) -> Self {
@@ -39,9 +37,8 @@ impl From<gix::refs::FullName> for BranchReference {
 }
 
 /// A reference in `refs/remotes`.
-#[derive(serde::Serialize, Debug, Clone)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Clone)]
 pub struct RemoteTrackingReference {
     /// The full ref name, like `refs/remotes/origin/on-remote`, for usage with the backend.
     #[cfg_attr(
@@ -54,8 +51,6 @@ pub struct RemoteTrackingReference {
     /// The symbolic name of the remote, like `origin`, or `origin/other`.
     pub remote_name: String,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(RemoteTrackingReference);
 
 impl RemoteTrackingReference {
     /// Create a new instance from `ref_name` and `remote_names`, essentially splitting the remote
@@ -90,17 +85,14 @@ impl RemoteTrackingReference {
 }
 
 /// Information about the target reference, the one we want to integrate with.
-#[derive(serde::Serialize, Debug, Clone)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Clone)]
 pub struct Target {
     /// The remote tracking branch of the target to integrate with, like `refs/remotes/origin/main`.
     pub remote_tracking_ref: RemoteTrackingReference,
     /// The amount of commits that aren't reachable by any segment in the workspace, they are in its future.
     pub commits_ahead: usize,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(Target);
 
 impl Target {
     fn for_ui(
@@ -120,12 +112,12 @@ impl Target {
 
 pub(crate) mod inner {
     use crate::ui::ref_info::{BranchReference, Stack, Target};
+    use serde::Serialize;
 
     /// The UI-clone of [`crate::RefInfo`].
     /// TODO: should also include base-branch data, see `get_base_branch_data()`.
-    #[derive(serde::Serialize, Debug, Clone)]
-    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-    #[serde(rename_all = "camelCase")]
+    #[but_api_macros::but_transport]
+    #[derive(Clone)]
     pub struct RefInfo {
         /// The name of the ref that points to a workspace commit,
         /// *or* the name of the first stack segment.
@@ -153,8 +145,6 @@ pub(crate) mod inner {
         /// The workspace represents what `HEAD` is pointing to.
         pub is_entrypoint: bool,
     }
-    #[cfg(feature = "export-schema")]
-    but_schemars::register_sdk_type!(RefInfo);
 
     impl RefInfo {
         /// Make sure only the stack and segment that is the entrypoint remains.
@@ -218,15 +208,10 @@ impl TryFrom<crate::RefInfo> for inner::RefInfo {
 }
 
 /// The UI-clone of `branch::Stack`.
-#[derive(serde::Serialize, Debug, Clone)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Clone)]
 pub struct Stack {
     /// Otherwise, it is `None`.
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::stack_id_opt")
-    )]
     pub id: Option<StackId>,
     /// If there is an integration branch, we know a base commit shared with the integration branch from
     /// which we branched off.
@@ -242,8 +227,6 @@ pub struct Stack {
     /// This array is never empty.
     pub segments: Vec<Segment>,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(Stack);
 
 impl Stack {
     fn for_ui(
@@ -259,9 +242,8 @@ impl Stack {
 }
 
 /// A segment of a commit graph, representing a set of commits exclusively.
-#[derive(serde::Serialize, Debug, Clone)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Clone)]
 pub struct Segment {
     ///
     /// It is `None` if this branch is the top-most stack segment and the `ref_name` wasn't pointing to
@@ -315,8 +297,6 @@ pub struct Segment {
     )]
     pub base: Option<gix::ObjectId>,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(Segment);
 
 impl Segment {
     fn for_ui(

--- a/crates/gitbutler-branch-actions/Cargo.toml
+++ b/crates/gitbutler-branch-actions/Cargo.toml
@@ -12,6 +12,7 @@ doctest = false
 [features]
 export-schema = [
   "but-workspace/export-schema",
+  "but-settings/export-schema",
   "gitbutler-project/export-schema",
   "gitbutler-branch/export-schema",
   "dep:schemars",
@@ -20,6 +21,7 @@ export-schema = [
 
 [dependencies]
 but-error.workspace = true
+but-api-macros.workspace = true
 but-serde = { workspace = true, features = ["legacy"] }
 but-meta = { workspace = true, features = ["legacy"] }
 but-settings.workspace = true

--- a/crates/gitbutler-branch-actions/Cargo.toml
+++ b/crates/gitbutler-branch-actions/Cargo.toml
@@ -6,6 +6,9 @@ authors.workspace = true
 publish = false
 rust-version.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["schemars"]
+
 [lib]
 doctest = false
 

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -23,26 +23,15 @@ use crate::{
     remote::{RemoteCommit, commit_to_remote_commit},
 };
 
-#[derive(Debug, Serialize, PartialEq, Clone)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(PartialEq, Clone)]
 pub struct BaseBranch {
     pub branch_name: String,
     pub remote_name: String,
     pub remote_url: String,
     pub push_remote_name: String,
     pub push_remote_url: String,
-    #[serde(with = "but_serde::object_id")]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::object_id")
-    )]
     pub base_sha: gix::ObjectId,
-    #[serde(with = "but_serde::object_id")]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::object_id")
-    )]
     pub current_sha: gix::ObjectId,
     pub behind: usize,
     pub upstream_commits: Vec<RemoteCommit>,
@@ -64,8 +53,6 @@ pub struct BaseBranch {
     pub diverged_behind: Vec<gix::ObjectId>,
     pub short_name: String,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(BaseBranch);
 
 impl BaseBranch {
     pub fn compute_short_name(branch_name: &str, remote_name: &str) -> String {

--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -542,9 +542,8 @@ fn should_list_git_branch(identity: &BranchIdentity) -> bool {
 }
 
 /// A filter that can be applied to the branch listing
-#[derive(Default, Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Default, Clone, Copy, PartialEq)]
 pub struct BranchListingFilter {
     /// If the value is true, the listing will only include branches that have local references or virtual branches.
     /// If the value is false, the listing will include only branches that have local references or virtual branches.
@@ -553,17 +552,14 @@ pub struct BranchListingFilter {
     /// If the value is false, the listing will only include branches that are not applied in the workspace.
     pub applied: Option<bool>,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(BranchListingFilter);
 
 /// Represents a branch that exists for the repository
 /// This also combines the concept of a remote, local and virtual branch in order to provide a unified interface for the UI
 /// Branch entry is not meant to contain all the data a branch can have (e.g. full commit history, all files and diffs, etc.).
 /// It is intended a summary that can be quickly retrieved and displayed in the UI.
 /// For more detailed information, each branch can be queried individually for its `BranchData`.
-#[derive(Debug, Clone, Serialize, PartialEq)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Clone, PartialEq)]
 pub struct BranchListing {
     /// The `identity` of the branch (e.g. `main`, `feature/branch`), excluding the remote name.
     #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
@@ -590,26 +586,18 @@ pub struct BranchListing {
     #[serde(skip)]
     pub head: gix::ObjectId,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(BranchListing);
 
 /// Represents a "commit author" or "signature", based on the data from the git history
-#[derive(Debug, Clone, Serialize, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename = "BranchAuthor", rename_all = "camelCase")]
+#[but_api_macros::but_transport(schemars_rename = "BranchAuthor")]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Author {
     /// The name of the author as configured in the git config
-    #[cfg_attr(feature = "export-schema", schemars(with = "Option<String>"))]
     pub name: Option<BStringForFrontend>,
     /// The email of the author as configured in the git config
-    #[cfg_attr(feature = "export-schema", schemars(with = "Option<String>"))]
     pub email: Option<BStringForFrontend>,
 
-    #[cfg_attr(feature = "export-schema", schemars(with = "Option<String>"))]
     pub gravatar_url: Option<BStringForFrontend>,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(Author);
 
 impl From<gix::actor::SignatureRef<'_>> for Author {
     fn from(value: gix::actor::SignatureRef<'_>) -> Self {
@@ -628,17 +616,12 @@ impl From<gix::actor::SignatureRef<'_>> for Author {
 }
 
 /// Represents a reference to an associated virtual branch
-#[derive(Debug, Clone, Serialize, PartialEq)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Clone, PartialEq)]
 pub struct StackReference {
     /// A non-normalized name of the branch, set by the user
     pub given_name: String,
     /// Virtual Branch UUID identifier
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::stack_id")
-    )]
     pub id: StackId,
     /// Determines if the virtual branch is applied in the workspace
     pub in_workspace: bool,
@@ -648,8 +631,6 @@ pub struct StackReference {
     /// Pull Request numbers by branch name associated with the stack
     pub pull_requests: HashMap<String, usize>,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(StackReference);
 
 /// Takes a list of `branch_names` (the given name, as returned by `BranchListing`) and returns
 /// a list of enriched branch data.
@@ -835,9 +816,8 @@ pub fn get_branch_listing_details(
 }
 
 /// Represents a fat struct with all the data associated with a branch
-#[derive(Debug, Clone, Serialize, PartialEq)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Clone, PartialEq)]
 pub struct BranchListingDetails {
     /// The name of the branch (e.g. `main`, `feature/branch`), excluding the remote name
     #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
@@ -871,8 +851,6 @@ pub struct BranchListingDetails {
     /// The branch may or may not have a virtual branch associated with it.
     pub stack: Option<StackReference>,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(BranchListingDetails);
 
 #[cfg(test)]
 mod tests {

--- a/crates/gitbutler-branch-actions/src/remote.rs
+++ b/crates/gitbutler-branch-actions/src/remote.rs
@@ -5,9 +5,8 @@ use serde::Serialize;
 
 use but_workspace::ui::Author;
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Clone, PartialEq)]
 pub struct RemoteCommit {
     pub id: String,
     #[cfg_attr(
@@ -26,8 +25,6 @@ pub struct RemoteCommit {
     pub parent_ids: Vec<gix::ObjectId>,
     pub conflicted: bool,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(RemoteCommit);
 
 pub(crate) fn commit_to_remote_commit(commit: &gix::Commit) -> Result<RemoteCommit> {
     let parent_ids = commit.parent_ids().map(|id| id.detach()).collect();

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -16,40 +16,30 @@ use serde::{Deserialize, Serialize};
 
 use crate::BranchManagerExt;
 
-#[derive(Serialize, PartialEq, Debug)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(PartialEq)]
 pub struct NameAndStatus {
     pub name: String,
     pub status: BranchStatus,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(NameAndStatus);
 
-#[derive(Serialize, PartialEq, Debug)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(PartialEq)]
 pub struct StackStatus {
     pub tree_status: UpstreamTreeStatus,
     pub branch_statuses: Vec<NameAndStatus>,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(StackStatus);
 
-#[derive(Serialize, PartialEq, Debug)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(tag = "type", content = "subject", rename_all = "camelCase")]
+#[but_api_macros::but_transport(tag = "type", content = "subject")]
+#[derive(PartialEq)]
 pub enum UpstreamTreeStatus {
     SafelyUpdatable,
     Conflicted,
     Empty,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(UpstreamTreeStatus);
 
-#[derive(Serialize, PartialEq, Debug)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(tag = "type", content = "subject", rename_all = "camelCase")]
+#[but_api_macros::but_transport(tag = "type", content = "subject")]
+#[derive(PartialEq)]
 pub enum BranchStatus {
     SafelyUpdatable,
     Integrated,
@@ -59,12 +49,9 @@ pub enum BranchStatus {
     },
     Empty,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(BranchStatus);
 
-#[derive(Serialize, PartialEq, Debug)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(tag = "type", content = "subject", rename_all = "camelCase")]
+#[but_api_macros::but_transport(tag = "type", content = "subject")]
+#[derive(PartialEq)]
 pub enum StackStatuses {
     UpToDate,
     UpdatesRequired {
@@ -78,56 +65,37 @@ pub enum StackStatuses {
         statuses: Vec<(Option<StackId>, StackStatus)>,
     },
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(StackStatuses);
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(tag = "type", content = "subject", rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize, tag = "type", content = "subject")]
+#[derive(PartialEq)]
 pub enum BaseBranchResolutionApproach {
     Rebase,
     Merge,
     HardReset,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(BaseBranchResolutionApproach);
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(tag = "type", content = "subject", rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize, tag = "type", content = "subject")]
+#[derive(Clone, Copy, PartialEq)]
 pub enum ResolutionApproach {
     Rebase,
     Merge,
     Unapply,
     Delete,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(ResolutionApproach);
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(PartialEq)]
 pub struct BaseBranchResolution {
-    #[serde(with = "but_serde::object_id")]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::object_id")
-    )]
     target_commit_oid: gix::ObjectId,
     approach: BaseBranchResolutionApproach,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(BaseBranchResolution);
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(PartialEq)]
 pub struct IntegrationOutcome {
     /// The list of branches that have been deleted as a result of the upstream integration
     deleted_branches: Vec<String>,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(IntegrationOutcome);
 
 impl StackStatus {
     fn create(
@@ -177,20 +145,13 @@ impl StackStatus {
     }
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(PartialEq)]
 pub struct Resolution {
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::stack_id")
-    )]
     pub stack_id: StackId,
     pub approach: ResolutionApproach,
     pub delete_integrated_branches: bool,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(Resolution);
 
 enum IntegrationResult {
     UpdatedObjects {

--- a/crates/gitbutler-branch/Cargo.toml
+++ b/crates/gitbutler-branch/Cargo.toml
@@ -6,6 +6,9 @@ authors.workspace = true
 publish = false
 rust-version.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["but-schemars", "schemars"]
+
 [features]
 export-schema = ["dep:schemars", "dep:but-schemars"]
 

--- a/crates/gitbutler-branch/Cargo.toml
+++ b/crates/gitbutler-branch/Cargo.toml
@@ -13,6 +13,7 @@ export-schema = ["dep:schemars", "dep:but-schemars"]
 doctest = false
 
 [dependencies]
+but-api-macros.workspace = true
 but-core.workspace = true
 gitbutler-reference.workspace = true
 

--- a/crates/gitbutler-branch/src/branch.rs
+++ b/crates/gitbutler-branch/src/branch.rs
@@ -24,15 +24,13 @@ pub struct BranchCreateRequest {
 ///   or `feat/one` for `refs/remotes/my/special/remote/feat/one`.
 /// * For virtual branches, it's either the above if there is a `source_refname` or an `upstream`, or it's the normalized
 ///   name of the virtual branch.
+#[but_api_macros::but_transport(no_debug, no_serialize)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
 pub struct BranchIdentity(
     /// The identity is always a valid reference name, full or partial.
     #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
     pub gix::refs::PartialName,
 );
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(BranchIdentity);
 
 impl Serialize for BranchIdentity {
     fn serialize<S>(&self, s: S) -> std::result::Result<S::Ok, S::Error>

--- a/crates/gitbutler-edit-mode/Cargo.toml
+++ b/crates/gitbutler-edit-mode/Cargo.toml
@@ -6,6 +6,9 @@ authors.workspace = true
 publish = false
 rust-version.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["but-schemars", "schemars"]
+
 [features]
 export-schema = ["dep:schemars", "dep:but-schemars"]
 

--- a/crates/gitbutler-edit-mode/Cargo.toml
+++ b/crates/gitbutler-edit-mode/Cargo.toml
@@ -17,6 +17,7 @@ but-graph = { workspace = true, features = ["legacy"] }
 but-rebase.workspace = true
 but-core.workspace = true
 but-oxidize.workspace = true
+but-api-macros.workspace = true
 but-ctx.workspace = true
 
 gitbutler-commit.workspace = true

--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -369,16 +369,13 @@ pub(crate) fn save_and_return_to_workspace(ctx: &Context, perm: &mut RepoExclusi
     Ok(())
 }
 
-#[derive(Serialize, Debug, Clone)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Clone)]
 pub struct ConflictEntryPresence {
     pub ours: bool,
     pub theirs: bool,
     pub ancestor: bool,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(ConflictEntryPresence);
 
 pub(crate) fn starting_index_state(
     ctx: &Context,

--- a/crates/gitbutler-operating-modes/Cargo.toml
+++ b/crates/gitbutler-operating-modes/Cargo.toml
@@ -6,6 +6,9 @@ authors.workspace = true
 publish = false
 rust-version.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["but-schemars", "schemars"]
+
 [features]
 export-schema = ["dep:schemars", "dep:but-schemars"]
 

--- a/crates/gitbutler-operating-modes/Cargo.toml
+++ b/crates/gitbutler-operating-modes/Cargo.toml
@@ -16,6 +16,7 @@ doctest = false
 but-serde = { workspace = true, features = ["legacy"] }
 but-workspace = { workspace = true, features = ["legacy"] }
 but-core.workspace = true
+but-api-macros.workspace = true
 but-utils.workspace = true
 but-ctx.workspace = true
 but-schemars = { workspace = true, optional = true }

--- a/crates/gitbutler-operating-modes/src/lib.rs
+++ b/crates/gitbutler-operating-modes/src/lib.rs
@@ -60,41 +60,27 @@ pub fn write_edit_mode_metadata(
 }
 
 /// Holds relevant state required to switch to and from edit mode
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(PartialEq, Clone)]
 pub struct EditModeMetadata {
     /// The sha of the commit getting edited.
-    #[serde(with = "but_serde::object_id")]
-    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
     pub commit_oid: gix::ObjectId,
     /// The ref of the vbranch which owns this commit.
     #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
     pub stack_id: StackId,
 }
 
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(EditModeMetadata);
-
-#[derive(Debug, Default, Serialize, PartialEq, Clone)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport]
+#[derive(Default, PartialEq, Clone)]
 pub struct OutsideWorkspaceMetadata {
     /// The name of the currently checked out branch or None if in detached head state.
-    #[serde(with = "but_serde::bstring_lossy_opt")]
-    #[cfg_attr(feature = "export-schema", schemars(with = "Option<String>"))]
     pub branch_name: Option<BString>,
     /// The paths of any files that would conflict with the workspace as it currently is
-    #[cfg_attr(feature = "export-schema", schemars(with = "Vec<String>"))]
     pub worktree_conflicts: Vec<BStringForFrontend>,
 }
 
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(OutsideWorkspaceMetadata);
-
-#[derive(PartialEq, Debug, Clone, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(tag = "type", content = "subject")]
+#[but_api_macros::but_transport(tag = "type", content = "subject", rename_all = "PascalCase")]
+#[derive(PartialEq, Clone)]
 pub enum OperatingMode {
     /// The typical app state when it's on the gitbutler/workspace branch
     OpenWorkspace,
@@ -103,9 +89,6 @@ pub enum OperatingMode {
     /// When the app is off of gitbutler/workspace and in edit mode
     Edit(EditModeMetadata),
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(OperatingMode);
-
 pub fn operating_mode(ctx: &Context, perm: &RepoShared) -> Result<OperatingMode> {
     let repo = ctx.repo.get()?;
     let Ok(head_ref) = repo.head() else {

--- a/crates/gitbutler-project/Cargo.toml
+++ b/crates/gitbutler-project/Cargo.toml
@@ -17,6 +17,7 @@ but-error.workspace = true
 but-path.workspace = true
 but-serde = { workspace = true, features = ["legacy"] }
 but-core.workspace = true
+but-api-macros.workspace = true
 but-utils = { workspace = true, features = ["legacy"] }
 but-forge.workspace = true
 but-project-handle = { workspace = true, features = ["legacy"] }

--- a/crates/gitbutler-project/Cargo.toml
+++ b/crates/gitbutler-project/Cargo.toml
@@ -6,6 +6,9 @@ authors.workspace = true
 publish = false
 rust-version.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["but-serde", "schemars"]
+
 [features]
 export-schema = ["dep:schemars", "dep:but-schemars", "but-forge/export-schema"]
 

--- a/crates/gitbutler-project/src/api.rs
+++ b/crates/gitbutler-project/src/api.rs
@@ -5,8 +5,8 @@ use serde::Serialize;
 /// while preserving the original project structure for persistence.
 ///
 /// Not registered for ts types because it is only consumed while flattened
-#[derive(Debug, Serialize, Clone)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[but_api_macros::but_transport(register = false)]
+#[derive(Clone)]
 pub struct Project {
     #[serde(flatten)]
     inner: crate::Project,

--- a/crates/gitbutler-project/src/project.rs
+++ b/crates/gitbutler-project/src/project.rs
@@ -9,8 +9,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{ProjectHandle, ProjectHandleOrLegacyProjectId, default_true::DefaultTrue};
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[but_api_macros::but_transport(deserialize)]
+#[derive(Clone)]
 pub struct ApiProject {
     pub name: String,
     pub description: Option<String>,
@@ -30,17 +30,15 @@ pub struct ApiProject {
     #[serde(default)]
     pub reviews: bool,
 }
-#[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(ApiProject);
-
-#[derive(Debug, Deserialize, Serialize, Clone)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[but_api_macros::but_transport(deserialize, register = false)]
+#[derive(Clone)]
 pub enum FetchResult {
     Fetched {
+        #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
         timestamp: time::SystemTime,
     },
     Error {
+        #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
         timestamp: time::SystemTime,
         error: String,
     },
@@ -54,21 +52,17 @@ impl FetchResult {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Copy, Clone)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[but_api_macros::but_transport(deserialize, register = false)]
+#[derive(Copy, Clone)]
 pub struct CodePushState {
-    #[serde(with = "but_serde::object_id")]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::object_id")
-    )]
     pub id: gix::ObjectId,
+    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
     pub timestamp: time::SystemTime,
 }
 
 /// Not registered for the frontend types because it is consumed flattened
-#[derive(Debug, Deserialize, Serialize, Clone)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[but_api_macros::but_transport(deserialize, rename_all = "snake_case", register = false)]
+#[derive(Clone)]
 pub struct Project {
     // TODO: We shouldn't need these IDs and most definitely shouldn't persist them.
     //       A project is a `git_dir`, and from there all other project data can be derived.

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -377,17 +377,17 @@ export type AbsorptionTarget = {
 export type ApiProject = {
   name: string;
   description: string | null;
-  repository_id: string;
+  repositoryId: string;
   /** The "gitbuler data, i.e. oplog" URL */
-  git_url: string;
+  gitUrl: string;
   /** The "project" git URL */
-  code_git_url: string | null;
-  created_at: string;
-  updated_at: string;
+  codeGitUrl: string | null;
+  createdAt: string;
+  updatedAt: string;
   /** Determines if the project Operations log will be synched with the GitButHub */
   sync: boolean;
   /** Determines if the project code will be synched with the GitButHub */
-  sync_code?: boolean;
+  syncCode?: boolean;
   reviews?: boolean;
 };
 
@@ -1541,11 +1541,11 @@ export type ProjectForFrontend = {
   forge_override: string | null;
   preferred_forge_user: ForgeUser | null;
   /** Gerrit mode enabled for this project, derived from git configuration */
-  gerrit_mode?: boolean;
+  gerritMode?: boolean;
   /** Path to the forge review template, if set in git configuration. */
-  forge_review_template_path: string | null;
+  forgeReviewTemplatePath: string | null;
   /** Tell if the project is known to be open in a Window in the frontend. */
-  is_open: boolean;
+  isOpen: boolean;
 };
 
 export type PullRequestMinimal = {


### PR DESCRIPTION
Automagically export the ‘complex types’ referenced in the function
signatures.

- Introduce `but_transport`, substituting most of the necessary
  boilerplate.
- Replace a bunch of boiler-plate code for used for transport