### PR TITLE
Fix "Branches are all up to date" error toast on integrate upstream

### DIFF
--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -568,7 +568,9 @@ pub(crate) fn integrate_upstream(
         let statuses = upstream_integration_statuses(&context)?;
 
         let StackStatuses::UpdatesRequired { statuses, .. } = statuses else {
-            bail!("Branches are all up to date")
+            return Ok(IntegrationOutcome {
+                deleted_branches: vec![],
+            });
         };
 
         if resolutions.len() != context.stacks_in_workspace.len() {


### PR DESCRIPTION
Users clicking "integrate upstream" when branches were already current got an error toast instead of a silent no-op.

The `integrate_upstream` function in `upstream_integration.rs` matches on `StackStatuses::UpdatesRequired` and the else arm (the `UpToDate` case) called `bail!("Branches are all up to date")`, which surfaced as an error toast in the frontend.

Being up-to-date is a valid state, not an error. Replaced the `bail!()` with `Ok(IntegrationOutcome { deleted_branches: vec![] })` so the frontend handles it silently.

