### PR TITLE
Fix flaky "no author setup" e2e test (75% reliability)

### DIFF
--- a/apps/desktop/src/components/projectSettings/EnsureAuthorInfo.svelte
+++ b/apps/desktop/src/components/projectSettings/EnsureAuthorInfo.svelte
@@ -14,10 +14,14 @@
 	// Ensure author information is present
 	const authorInfo = $derived(gitService.getAuthorInfo(projectId));
 
+	let hasShownModal = $state(false);
+
 	$effect(() => {
+		if (hasShownModal) return;
 		if (authorInfo.response) {
 			const { name, email } = authorInfo.response;
 			if (name === null || email === null) {
+				hasShownModal = true;
 				uiState.global.modal.set({
 					type: "author-missing",
 					projectId,


### PR DESCRIPTION
The EnsureAuthorInfo effect unconditionally re-opened the author-missing
modal whenever the authorInfo query re-emitted a response with null
name/email. After setAuthorInfo invalidates the cache, the re-fetch
triggers the effect before the fresh response arrives, reopening the
modal and intercepting the commit-to-new-branch-button click.

Track whether the modal has already been shown and skip the effect on
subsequent runs.