### PR TITLE
Report Buildkite test results for web vitest, UI component tests, and e2e playwright component tests

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -667,7 +667,8 @@ jobs:
         if: ${{ steps.playwright-cache.outputs.cache-hit != 'true' }}
       - name: run playwright tests
         run: pnpm test:ct
-        if: ${{ github.ref != 'refs/heads/master' }}
+        env:
+          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_SUITE_TOKEN_PLAYWRIGHT_CT }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -157,12 +157,9 @@ jobs:
           echo BUT=$PWD/target/debug/but >> $GITHUB_ENV
       - name: Setup node environment
         uses: ./.github/actions/init-env-node
-        if: ${{ github.ref != 'refs/heads/master' }}
       - id: get_playwright_version
         uses: eviden-actions/get-playwright-version@dbf7574765e85d04661ac1717f3cb8a99474ffd7 # v1
-        if: ${{ github.ref != 'refs/heads/master' }}
       - name: Cache playwright binaries
-        if: ${{ github.ref != 'refs/heads/master' }}
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         id: playwright-cache
         with:
@@ -170,7 +167,6 @@ jobs:
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.get_playwright_version.outputs.playwright-version }}
       - name: Build Rust binaries, SvelteKit, and install Playwright
-        if: ${{ github.ref != 'refs/heads/master' }}
         env:
           PLAYWRIGHT_CACHE_HIT: ${{ steps.playwright-cache.outputs.cache-hit }}
         run: |
@@ -188,12 +184,8 @@ jobs:
           wait "$pnpm_pid" || status=1
           [ -n "$pw_pid" ] && { wait "$pw_pid" || status=1; }
           exit "$status"
-      - name: Build Rust binaries
-        if: ${{ github.ref == 'refs/heads/master' }}
-        run: cargo build -p gitbutler-git -p but-server -p but
       - name: Run Playwright tests
         run: pnpm exec turbo run test:e2e:playwright
-        if: ${{ github.ref != 'refs/heads/master' }}
         env:
           BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_SUITE_TOKEN_PLAYWRIGHT }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,6 +31,7 @@
 		"@types/node": "^22.19.11",
 		"@types/postcss-pxtorem": "^6.1.0",
 		"autoprefixer": "^10.4.27",
+		"buildkite-test-collector": "^1.9.5",
 		"diff-match-patch": "^1.0.5",
 		"path": "^0.12.7",
 		"postcss": "catalog:postcss",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -32,6 +32,8 @@ export default defineConfig({
 		exclude: ["node_modules/**/*", "e2e/**/*", "tests/**/*"],
 		environment: "jsdom",
 		setupFiles: ["./vitest-setup.js"],
+		reporters: process.env.CI ? ["default", "buildkite-test-collector/vitest/reporter"] : "default",
+		includeTaskLocation: true,
 	},
 	build: {
 		sourcemap: true,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -48,6 +48,7 @@
 		"@types/postcss-pxtorem": "^6.1.0",
 		"@vitest/browser": "catalog:",
 		"autoprefixer": "^10.4.27",
+		"buildkite-test-collector": "^1.9.5",
 		"cpy-cli": "^5.0.0",
 		"cssnano": "^7.1.3",
 		"dayjs": "^1.11.20",

--- a/packages/ui/playwright-ct.config.ts
+++ b/packages/ui/playwright-ct.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
 	/* Opt out of parallel tests on CI. */
 	workers: process.env.CI ? 1 : undefined,
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
-	reporter: "list",
+	reporter: process.env.CI ? [["list"], ["buildkite-test-collector/playwright/reporter"]] : "list",
 
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 	use: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -382,7 +382,7 @@ importers:
         version: 5.54.0
       svelte-check:
         specifier: catalog:svelte
-        version: 4.4.5(picomatch@4.0.3)(svelte@5.54.0)(typescript@5.9.3)
+        version: 4.4.5(picomatch@4.0.4)(svelte@5.54.0)(typescript@5.9.3)
       tinykeys:
         specifier: ^2.1.0
         version: 2.1.0
@@ -580,6 +580,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.27
         version: 10.4.27(postcss@8.5.10)
+      buildkite-test-collector:
+        specifier: ^1.9.5
+        version: 1.9.5
       diff-match-patch:
         specifier: ^1.0.5
         version: 1.0.5
@@ -659,6 +662,19 @@ importers:
       wdio-video-reporter:
         specifier: ^6.0.0
         version: 6.2.0(expect-webdriverio@5.6.5)(webdriverio@9.27.0)
+
+  e2e/cli:
+    dependencies:
+      '@octokit/rest':
+        specifier: ^22.0.0
+        version: 22.0.1
+      tmp-promise:
+        specifier: ^3.0.3
+        version: 3.0.3
+    devDependencies:
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(sass-embedded@1.98.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/but-sdk:
     devDependencies:
@@ -956,6 +972,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.27
         version: 10.4.27(postcss@8.5.10)
+      buildkite-test-collector:
+        specifier: ^1.9.5
+        version: 1.9.5
       cpy-cli:
         specifier: ^5.0.0
         version: 5.0.0
@@ -13598,7 +13617,7 @@ snapshots:
       magic-string: 0.30.21
       sirv: 3.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(sass-embedded@1.98.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(sass-embedded@1.98.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.2)
       ws: 8.19.0
     optionalDependencies:
       playwright: 1.58.2
@@ -13704,7 +13723,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(sass-embedded@1.98.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(sass-embedded@1.98.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -18477,18 +18496,6 @@ snapshots:
       svelte: 5.54.0
       zimmerframe: 1.1.2
 
-  svelte-check@4.4.5(picomatch@4.0.3)(svelte@5.54.0)(typescript@5.9.3):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      chokidar: 4.0.3
-      fdir: 6.5.0(picomatch@4.0.3)
-      picocolors: 1.1.1
-      sade: 1.8.1
-      svelte: 5.54.0
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - picomatch
-
   svelte-check@4.4.5(picomatch@4.0.4)(svelte@5.54.0)(typescript@5.9.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -19096,11 +19103,11 @@ snapshots:
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 6.4.2(@types/node@22.19.15)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -19141,11 +19148,11 @@ snapshots:
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 6.4.2(@types/node@22.19.15)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -19186,11 +19193,11 @@ snapshots:
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 6.4.2(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.2)


### PR DESCRIPTION
## Summary

- Add `buildkite-test-collector` to apps/web and configure vitest reporter in CI
- Add Buildkite reporter to packages/ui Playwright component tests
- Pass `BUILDKITE_ANALYTICS_TOKEN` to the component test step in push.yaml
- Remove ref-gating on e2e Playwright steps so they run (and report) on all branches including master

## Test plan

- [ ] Verify apps/web vitest results appear in Buildkite Test Analytics
- [ ] Verify packages/ui Playwright CT results appear in Buildkite Test Analytics
- [ ] Verify e2e Playwright tests still run and report on PRs and master

🤖 Generated with [Claude Code](https://claude.com/claude-code)