### PR TITLE
Fix flaky "no author setup" e2e test on WebKit

### DIFF
--- a/apps/desktop/src/components/settings/AuthorMissingModalContent.svelte
+++ b/apps/desktop/src/components/settings/AuthorMissingModalContent.svelte
@@ -2,6 +2,7 @@
 	import { GIT_SERVICE } from "$lib/git/gitService";
 	import { inject } from "@gitbutler/core/context";
 	import { TestId, ModalHeader, ModalFooter, Textbox, EmailTextbox, Button } from "@gitbutler/ui";
+	import { untrack } from "svelte";
 	import type { AuthorMissingModalState } from "$lib/state/uiState.svelte";
 
 	type Props = {
@@ -14,8 +15,8 @@
 	const gitService = inject(GIT_SERVICE);
 	const [setAuthorInfo, settingInfo] = gitService.setAuthorInfo;
 
-	let name = $derived(data.authorName);
-	let email = $derived(data.authorEmail);
+	let name = $state(untrack(() => data.authorName));
+	let email = $state(untrack(() => data.authorEmail));
 	let emailTextbox: any;
 
 	async function handleSubmit() {

--- a/e2e/playwright/src/util.ts
+++ b/e2e/playwright/src/util.ts
@@ -1,5 +1,5 @@
 import { TestId } from "@gitbutler/ui/utils/testIds";
-import { type Locator, type Page } from "@playwright/test";
+import { expect, type Locator, type Page } from "@playwright/test";
 
 type TestIdValues = `${TestId}`;
 
@@ -100,7 +100,10 @@ export async function fillByTestId(
 	value: string,
 ): Promise<Locator> {
 	const element = await waitForTestId(page, testId);
-	await element.fill(value);
+	await expect(async () => {
+		await element.fill(value);
+		await expect(element).toHaveValue(value);
+	}).toPass();
 	return element;
 }
 

--- a/e2e/playwright/tests/startTheApp.spec.ts
+++ b/e2e/playwright/tests/startTheApp.spec.ts
@@ -119,12 +119,13 @@ test("no author setup - should start the application and be able to commit", asy
 
 	// Should see the author missing modal
 	await waitForTestId(page, "global-modal-author-missing");
-	// WebKit needs extra time for the modal inputs to become interactive.
-	// Without this, fill() silently fails and the values don't persist.
-	await page.waitForTimeout(200);
+
 	await fillByTestId(page, "global-modal-author-missing-name-input", "Test User");
 	await fillByTestId(page, "global-modal-author-missing-email-input", "test@example.com");
-	await clickByTestId(page, "global-modal-author-missing-action-button", true);
+	await clickByTestId(page, "global-modal-author-missing-action-button");
+
+	// Wait for the author-missing modal to close before interacting with the page
+	await expect(getByTestId(page, "global-modal-author-missing")).toBeHidden();
 
 	// Let's write some files
 	const filePath = gitbutler.pathInWorkdir("local-clone/test-file.txt");


### PR DESCRIPTION
The test intermittently fails because the author-missing modal
intercepts clicks on the commit button. Two root causes were found:

1. The modal's name/email fields used `$derived`, which recomputes
   whenever its reactive dependencies update. If a background state
   change fires between Playwright's fill() and the submit click, the
   derived values reset to empty, leaving the submit button disabled
   and the modal stuck open. Fixed by using `$state(untrack(...))` to
   capture the initial value as stable local state.

2. On WebKit, fill() can silently drop input values when the element
   isn't fully interactive yet. Fixed by making fillByTestId retry the
   fill+assert cycle via expect().toPass(), benefiting all callers.

Additionally, wait for the modal to be hidden before continuing to
prevent the modal overlay from intercepting subsequent clicks.