### PR TITLE
Fix "target commit already belongs to another branch" by detecting diverged stack refs

### DIFF
--- a/apps/desktop/src/components/divergence/WorkspaceDivergenceModal.svelte
+++ b/apps/desktop/src/components/divergence/WorkspaceDivergenceModal.svelte
@@ -1,0 +1,256 @@
+<script lang="ts">
+	import { BASE_BRANCH_SERVICE } from "$lib/baseBranch/baseBranchService.svelte";
+	import { inject } from "@gitbutler/core/context";
+	import {
+		AsyncButton,
+		Modal,
+		Select,
+		SelectItem,
+		Icon,
+		InfoMessage,
+		type SelectItemType,
+	} from "@gitbutler/ui";
+	import { SvelteMap } from "svelte/reactivity";
+	import type {
+		DivergenceResolution,
+		DivergenceStatuses,
+		DivergenceApproach,
+		StackRefDivergence,
+	} from "@gitbutler/but-sdk";
+
+	interface Props {
+		projectId: string;
+		onResolved?: () => void;
+		/** Optional custom resolve handler. When set, replaces the default resolveWorkspaceDivergence call. */
+		onResolve?: (resolutions: DivergenceResolution[]) => Promise<void>;
+	}
+
+	const { projectId, onResolved, onResolve }: Props = $props();
+
+	const baseBranchService = inject(BASE_BRANCH_SERVICE);
+	const [resolveWorkspaceDivergence, resolveMutation] =
+		baseBranchService.resolveWorkspaceDivergence;
+
+	let modal = $state<Modal>();
+	let divergences = $state<StackRefDivergence[]>([]);
+	let resolveError = $state<string | undefined>();
+
+	const resolutionChoices = new SvelteMap<string, DivergenceApproach>();
+
+	function defaultApproach(divergence: StackRefDivergence): DivergenceApproach {
+		switch (divergence.status.type) {
+			case "movedToSameTree":
+				return { type: "includeAsIs" };
+			case "movedAboveBase":
+				return divergence.status.conflicted ? { type: "exclude" } : { type: "includeAsIs" };
+			case "movedBelowBase":
+			case "deleted":
+				return { type: "exclude" };
+		}
+	}
+
+	function statusLabel(status: StackRefDivergence["status"]): string {
+		switch (status.type) {
+			case "deleted":
+				return "Deleted";
+			case "movedAboveBase":
+				return status.conflicted ? "Moved (conflicts)" : "Moved";
+			case "movedBelowBase":
+				return "Moved below base";
+			case "movedToSameTree":
+				return "Moved (same content)";
+		}
+	}
+
+	function statusDescription(status: StackRefDivergence["status"]): string {
+		switch (status.type) {
+			case "deleted":
+				return "This branch ref was deleted outside of GitButler.";
+			case "movedAboveBase":
+				return status.conflicted
+					? "This branch was moved and conflicts with the current workspace."
+					: "This branch was moved to a different commit. Including it will change your workspace files.";
+			case "movedBelowBase":
+				return "This branch was moved to a commit below the target base. It has no commits in the workspace.";
+			case "movedToSameTree":
+				return "This branch was moved but the file content is identical. Including it won't change your workspace.";
+		}
+	}
+
+	function optionsForDivergence(divergence: StackRefDivergence): SelectItemType<string>[] {
+		const options: SelectItemType<string>[] = [{ label: "Include as-is", value: "includeAsIs" }];
+		if (divergence.status.type !== "deleted" && divergence.status.type !== "movedBelowBase") {
+			options.push({ label: "Include (rebase)", value: "includeRebase" });
+		}
+		options.push({ label: "Exclude", value: "exclude" });
+		return options;
+	}
+
+	export function show(statuses: DivergenceStatuses) {
+		if (statuses.type !== "divergedRefs") return;
+		showDivergences(statuses.subject.divergences);
+	}
+
+	export function showDivergences(items: StackRefDivergence[]) {
+		resolveError = undefined;
+		resolutionChoices.clear();
+		divergences = items;
+
+		for (const d of divergences) {
+			resolutionChoices.set(d.stackId, defaultApproach(d));
+		}
+
+		modal?.show();
+	}
+
+	async function resolve(close: () => void) {
+		resolveError = undefined;
+
+		const resolutions: DivergenceResolution[] = divergences.map((d) => ({
+			stackId: d.stackId,
+			approach: resolutionChoices.get(d.stackId) ?? defaultApproach(d),
+		}));
+
+		try {
+			if (onResolve) {
+				await onResolve(resolutions);
+			} else {
+				await resolveWorkspaceDivergence({ projectId, resolutions });
+			}
+			close();
+			onResolved?.();
+		} catch (error: unknown) {
+			resolveError = error instanceof Error ? error.message : String(error);
+		}
+	}
+
+	const anyIncluded = $derived(
+		divergences.some((d) => {
+			const choice = resolutionChoices.get(d.stackId);
+			return choice?.type === "includeAsIs" || choice?.type === "includeRebase";
+		}),
+	);
+</script>
+
+<Modal bind:this={modal} width={520}>
+	{#snippet children(_item, _close)}
+		<div class="divergence-modal" data-testid="workspace-divergence-modal">
+			<div class="divergence-modal__header">
+				<Icon name="warning" color="warning" />
+				<h3 class="text-15 text-body text-bold">Branch refs changed externally</h3>
+			</div>
+
+			<p class="divergence-modal__description text-13 text-body">
+				One or more branch refs in your workspace were modified outside of GitButler. Choose how to
+				handle each branch. Including a changed branch may cause a workspace checkout.
+			</p>
+
+			<div class="divergence-modal__list">
+				{#each divergences as divergence (divergence.stackId)}
+					{@const choice = resolutionChoices.get(divergence.stackId) ?? defaultApproach(divergence)}
+					<div class="divergence-item" data-testid="workspace-divergence-modal-divergence-item">
+						<div class="divergence-item__info">
+							<p class="text-13 text-body text-bold">{divergence.refName || "unknown"}</p>
+							<p class="text-12 text-body clr-text-2">{statusLabel(divergence.status)}</p>
+							<p class="text-12 text-body clr-text-3">
+								{statusDescription(divergence.status)}
+							</p>
+						</div>
+						<div class="divergence-item__action">
+							<Select
+								value={choice.type}
+								maxWidth={150}
+								options={optionsForDivergence(divergence)}
+								onselect={(value) => {
+									resolutionChoices.set(divergence.stackId, {
+										type: value,
+									} as DivergenceApproach);
+								}}
+							>
+								{#snippet itemSnippet({ item, highlighted })}
+									<SelectItem selected={highlighted} {highlighted}>
+										{item.label}
+									</SelectItem>
+								{/snippet}
+							</Select>
+						</div>
+					</div>
+				{/each}
+			</div>
+
+			{#if anyIncluded}
+				<InfoMessage>
+					{#snippet content()}
+						Including changed branches will perform a workspace checkout. Your working directory
+						files may change.
+					{/snippet}
+				</InfoMessage>
+			{/if}
+
+			{#if resolveError}
+				<InfoMessage style="danger">
+					{#snippet content()}
+						{resolveError}
+					{/snippet}
+				</InfoMessage>
+			{/if}
+		</div>
+	{/snippet}
+	{#snippet controls(close)}
+		<AsyncButton
+			testId="workspace-divergence-modal-action-button"
+			style="pop"
+			loading={resolveMutation.current.isLoading}
+			action={async () => await resolve(close)}
+		>
+			Apply
+		</AsyncButton>
+	{/snippet}
+</Modal>
+
+<style lang="postcss">
+	.divergence-modal {
+		display: flex;
+		flex-direction: column;
+		padding: 20px;
+		gap: 16px;
+	}
+
+	.divergence-modal__header {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.divergence-modal__description {
+		color: var(--text-2);
+	}
+
+	.divergence-modal__list {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.divergence-item {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 12px;
+		gap: 12px;
+		border: 1px solid var(--border-2);
+		border-radius: var(--radius-m);
+	}
+
+	.divergence-item__info {
+		display: flex;
+		flex: 1;
+		flex-direction: column;
+		min-width: 0;
+		gap: 2px;
+	}
+
+	.divergence-item__action {
+		flex-shrink: 0;
+	}
+</style>

--- a/apps/desktop/src/components/views/AppHeader.svelte
+++ b/apps/desktop/src/components/views/AppHeader.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { goto } from "$app/navigation";
 	import CreateBranchModal from "$components/branch/CreateBranchModal.svelte";
+	import WorkspaceDivergenceModal from "$components/divergence/WorkspaceDivergenceModal.svelte";
 	import SyncButton from "$components/forge/SyncButton.svelte";
 	import IntegrateUpstreamModal from "$components/upstream/IntegrateUpstreamModal.svelte";
 	import { BACKEND } from "$lib/backend";
@@ -61,12 +62,22 @@
 	);
 	const [switchBackToWorkspace, workspaceSwitch] = baseBranchService.switchBackToWorkspace;
 
+	let divergenceModal = $state<ReturnType<typeof WorkspaceDivergenceModal>>();
+
 	async function switchToWorkspace() {
-		if (base) {
-			await switchBackToWorkspace({
-				projectId,
-			});
+		if (!base) return;
+
+		const result = await switchBackToWorkspace({ projectId });
+
+		if (result?.type === "diverged") {
+			divergenceModal?.showDivergences(result.divergences);
 		}
+	}
+
+	async function resolveDivergenceAndSwitch(
+		resolutions: import("@gitbutler/but-sdk").DivergenceResolution[],
+	) {
+		await switchBackToWorkspace({ projectId, resolutions });
 	}
 
 	const upstreamCommits = $derived(base?.behind ?? 0);
@@ -272,6 +283,11 @@
 </div>
 
 <CreateBranchModal bind:this={createBranchModal} {projectId} />
+<WorkspaceDivergenceModal
+	bind:this={divergenceModal}
+	{projectId}
+	onResolve={resolveDivergenceAndSwitch}
+/>
 
 <style>
 	.chrome-header {

--- a/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
+++ b/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
@@ -118,4 +118,8 @@ export default class BaseBranchService {
 	remoteBranches(projectId: string) {
 		return this.backendApi.endpoints.remoteBranches.useQuery({ projectId });
 	}
+
+	get resolveWorkspaceDivergence() {
+		return this.backendApi.endpoints.resolveWorkspaceDivergence.useMutation();
+	}
 }

--- a/apps/desktop/src/lib/branches/branchEndpoints.ts
+++ b/apps/desktop/src/lib/branches/branchEndpoints.ts
@@ -14,9 +14,11 @@ import type {
 	BaseBranchResolutionApproach,
 	BranchListing,
 	BranchListingDetails,
+	DivergenceResolution,
 	IntegrationOutcome,
 	Resolution,
 	StackStatuses,
+	SwitchBackToWorkspaceResult,
 } from "@gitbutler/but-sdk";
 
 export function buildBranchEndpoints(build: BackendEndpointBuilder) {
@@ -57,15 +59,24 @@ export function buildBranchEndpoints(build: BackendEndpointBuilder) {
 				invalidatesList(ReduxTag.StackDetails),
 			],
 		}),
-		switchBackToWorkspace: build.mutation<BaseBranch, { projectId: string }>({
+		switchBackToWorkspace: build.mutation<
+			SwitchBackToWorkspaceResult,
+			{ projectId: string; resolutions?: DivergenceResolution[] }
+		>({
 			extraOptions: { command: "switch_back_to_workspace" },
 			query: (args) => args,
-			invalidatesTags: [
-				invalidatesType(ReduxTag.ForgeProvider),
-				invalidatesType(ReduxTag.BaseBranchData),
-				invalidatesList(ReduxTag.Stacks),
-				invalidatesList(ReduxTag.StackDetails),
-			],
+			invalidatesTags: (result) => {
+				// Only invalidate caches when we actually switched back (not on divergence detection).
+				if (result?.type === "ok") {
+					return [
+						invalidatesType(ReduxTag.ForgeProvider),
+						invalidatesType(ReduxTag.BaseBranchData),
+						invalidatesList(ReduxTag.Stacks),
+						invalidatesList(ReduxTag.StackDetails),
+					];
+				}
+				return [];
+			},
 		}),
 		pushBaseBranch: build.mutation<void, { projectId: string; withForce?: boolean }>({
 			extraOptions: { command: "push_base_branch" },
@@ -140,6 +151,24 @@ export function buildBranchEndpoints(build: BackendEndpointBuilder) {
 			},
 			query: (args) => args,
 			invalidatesTags: [invalidatesList(ReduxTag.UpstreamIntegrationStatus)],
+		}),
+
+		// ── Workspace Divergence ────────────────────────────────────
+		resolveWorkspaceDivergence: build.mutation<
+			void,
+			{ projectId: string; resolutions: DivergenceResolution[] }
+		>({
+			extraOptions: {
+				command: "resolve_workspace_divergence",
+				actionName: "Resolve Workspace Divergence",
+			},
+			query: (args) => args,
+			invalidatesTags: [
+				invalidatesList(ReduxTag.HeadMetadata),
+				invalidatesList(ReduxTag.Stacks),
+				invalidatesList(ReduxTag.StackDetails),
+				invalidatesList(ReduxTag.HeadSha),
+			],
 		}),
 	};
 }

--- a/apps/desktop/src/lib/mode/modeEndpoints.ts
+++ b/apps/desktop/src/lib/mode/modeEndpoints.ts
@@ -68,15 +68,27 @@ export function buildModeEndpoints(build: BackendEndpointBuilder) {
 				if (!hasBackendExtra(lifecycleApi.extra)) {
 					throw new Error("Redux dependency Backend not found!");
 				}
+				const { invoke, listen } = lifecycleApi.extra.backend;
 				await lifecycleApi.cacheDataLoaded;
-				const unsubscribe = lifecycleApi.extra.backend.listen<HeadAndMode>(
-					`project://${arg.projectId}/git/head`,
-					(event) => {
-						lifecycleApi.updateCachedData(() => event.payload);
-					},
+				let finished = false;
+
+				// Re-invoke the command on events to get fresh data including divergence.
+				async function refresh() {
+					if (finished) return;
+					const result = await invoke<HeadAndMode>("operating_mode", arg);
+					lifecycleApi.updateCachedData(() => result);
+				}
+
+				const unsub1 = listen<unknown>(`project://${arg.projectId}/git/head`, refresh);
+				const unsub2 = listen<unknown>(
+					`project://${arg.projectId}/git/workspace-ref-changed`,
+					refresh,
 				);
+
 				await lifecycleApi.cacheEntryRemoved;
-				unsubscribe();
+				finished = true;
+				unsub1();
+				unsub2();
 			},
 		}),
 		headSha: build.query<HeadSha, { projectId: string }>({

--- a/apps/desktop/src/lib/mode/modeService.ts
+++ b/apps/desktop/src/lib/mode/modeService.ts
@@ -41,6 +41,14 @@ export class ModeService {
 		);
 	}
 
+	/** Reactive query for workspace stack ref divergence, derived from the headAndMode query. */
+	divergence(projectId: string) {
+		return this.backendApi.endpoints.headAndMode.useQuery(
+			{ projectId },
+			{ transform: (response) => response.divergence },
+		);
+	}
+
 	/**
 	 * Force-fetch the current mode, bypassing the cache. This updates the
 	 * cache so that reactive subscribers see the new value immediately.

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from "$app/navigation";
+	import WorkspaceDivergenceModal from "$components/divergence/WorkspaceDivergenceModal.svelte";
 	import IrcChatWindow from "$components/irc/IrcChatWindow.svelte";
 	import ProjectSettingsShortcutHandler from "$components/settings/ProjectSettingsShortcutHandler.svelte";
 	import AnalyticsMonitor from "$components/shared/AnalyticsMonitor.svelte";
@@ -94,6 +95,20 @@
 	const worktreeService = inject(WORKTREE_SERVICE);
 
 	const modeQuery = $derived(modeService.mode(projectId));
+
+	// Divergence detection: derived from the headAndMode query (no separate endpoint needed).
+	let divergenceModal = $state<WorkspaceDivergenceModal>();
+	const divergenceQuery = $derived(modeService.divergence(projectId));
+
+	// Show the divergence modal when divergence is first detected.
+	$effect(() => {
+		const statuses = divergenceQuery?.response;
+		if (statuses && statuses.type === "divergedRefs") {
+			untrack(() => {
+				divergenceModal?.show(statuses);
+			});
+		}
+	});
 
 	// =============================================================================
 	// FORGE INTEGRATION (GitHub & GitLab)
@@ -475,6 +490,14 @@
 		<ProblemLoadingRepo {projectId} error={baseError} />
 	{/snippet}
 </ReduxResult>
+
+<WorkspaceDivergenceModal
+	bind:this={divergenceModal}
+	{projectId}
+	onResolved={() => {
+		stackService.invalidateStacksAndDetails();
+	}}
+/>
 
 <IrcChatWindow {projectId} />
 

--- a/crates/but-api/src/legacy/modes.rs
+++ b/crates/but-api/src/legacy/modes.rs
@@ -15,6 +15,9 @@ use crate::json::Error;
 pub struct HeadAndMode {
     pub head: Option<String>,
     pub operating_mode: OperatingMode,
+    /// Divergence detection result, populated only when in workspace mode.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub divergence: Option<gitbutler_branch_actions::stack_divergence::DivergenceStatuses>,
 }
 #[cfg(feature = "export-schema")]
 but_schemars::register_sdk_type!(HeadAndMode);
@@ -30,9 +33,25 @@ pub fn operating_mode(ctx: &Context) -> Result<HeadAndMode, Error> {
         _ => None,
     };
 
+    let mode = gitbutler_operating_modes::operating_mode(ctx, guard.read_permission())?;
+
+    // When in workspace mode, check if any stack refs have diverged externally.
+    let divergence = if mode == OperatingMode::OpenWorkspace {
+        match gitbutler_branch_actions::stack_divergence::detect_diverged_stacks(ctx) {
+            Ok(statuses) => Some(statuses),
+            Err(e) => {
+                tracing::warn!("Failed to detect workspace divergence: {e}");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     Ok(HeadAndMode {
         head: head_ref_short,
-        operating_mode: gitbutler_operating_modes::operating_mode(ctx, guard.read_permission())?,
+        operating_mode: mode,
+        divergence,
     })
 }
 

--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -250,15 +250,20 @@ pub fn integrate_branch_with_steps(
     gitbutler_branch_actions::integrate_branch_with_steps(ctx, stack_id, branch_name, steps)
 }
 
-/// Switch back to the workspace branch state.
+/// Switch back to the workspace branch state with divergence detection.
 ///
-/// This acquires exclusive worktree access from `ctx` before restoring the
-/// workspace branch.
+/// When called without `resolutions`, detects whether any workspace stack refs
+/// have diverged. If divergence is found, returns `Diverged` with details so
+/// the frontend can present resolution options. When called with `resolutions`,
+/// applies the chosen strategies then proceeds with the workspace checkout.
 #[but_api]
 #[instrument(err(Debug))]
-pub fn switch_back_to_workspace(ctx: &mut but_ctx::Context) -> Result<BaseBranch> {
+pub fn switch_back_to_workspace(
+    ctx: &mut but_ctx::Context,
+    resolutions: Option<Vec<gitbutler_branch_actions::stack_divergence::DivergenceResolution>>,
+) -> Result<gitbutler_branch_actions::stack_divergence::SwitchBackToWorkspaceResult> {
     let mut guard = ctx.exclusive_worktree_access();
-    switch_back_to_workspace_with_perm(ctx, guard.write_permission())
+    switch_back_to_workspace_with_perm(ctx, resolutions, guard.write_permission())
 }
 
 #[instrument(skip(perm), err(Debug))]
@@ -267,21 +272,23 @@ pub fn switch_back_to_workspace(ctx: &mut but_ctx::Context) -> Result<BaseBranch
 /// This variant is more composable than [`switch_back_to_workspace`] when the caller already
 /// holds a lock, as it reuses the provided permission token instead of obtaining exclusive access
 /// itself.
+///
+/// Accepts optional divergence resolutions. See [`switch_back_to_workspace`] for details.
 pub fn switch_back_to_workspace_with_perm(
     ctx: &mut but_ctx::Context,
+    resolutions: Option<Vec<gitbutler_branch_actions::stack_divergence::DivergenceResolution>>,
     perm: &mut RepoExclusive,
-) -> Result<BaseBranch> {
-    let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx)
-        .context("Failed to get base branch data")?;
+) -> Result<gitbutler_branch_actions::stack_divergence::SwitchBackToWorkspaceResult> {
+    let result = gitbutler_branch_actions::base::switch_back_to_workspace(ctx, resolutions, perm)?;
 
-    let branch_name = format!("refs/remotes/{}", base_branch.branch_name)
-        .parse()
-        .context("Invalid branch name")?;
+    if matches!(
+        result,
+        gitbutler_branch_actions::stack_divergence::SwitchBackToWorkspaceResult::Ok { .. }
+    ) {
+        crate::legacy::meta::reconcile_in_workspace_state_of_vb_toml(ctx, perm).ok();
+    }
 
-    gitbutler_branch_actions::set_base_branch(ctx, &branch_name, perm)?;
-    crate::legacy::meta::reconcile_in_workspace_state_of_vb_toml(ctx, perm).ok();
-
-    Ok(base_branch)
+    Ok(result)
 }
 
 #[but_api]
@@ -727,6 +734,36 @@ pub async fn resolve_upstream_integration(
         &resolved_reviews,
     )?;
     Ok(new_target_id.to_string())
+}
+
+/// Detect whether any workspace stack refs have diverged from the workspace commit.
+///
+/// Returns structured info about which refs moved and how, so the frontend can present
+/// resolution options to the user.
+#[but_api]
+#[instrument(err(Debug))]
+pub fn check_workspace_divergence(
+    ctx: Context,
+) -> Result<gitbutler_branch_actions::stack_divergence::DivergenceStatuses> {
+    gitbutler_branch_actions::stack_divergence::detect_diverged_stacks(&ctx)
+}
+
+/// Apply user-chosen resolutions for diverged stacks and rebuild the workspace commit.
+///
+/// Each resolution specifies a stack and the approach: IncludeAsIs (accept current position),
+/// IncludeRebase (rebase onto target base), or Exclude (remove from workspace).
+#[but_api]
+#[instrument(err(Debug))]
+pub fn resolve_workspace_divergence(
+    mut ctx: Context,
+    resolutions: Vec<gitbutler_branch_actions::stack_divergence::DivergenceResolution>,
+) -> Result<()> {
+    let mut guard = ctx.exclusive_worktree_access();
+    gitbutler_branch_actions::stack_divergence::resolve_diverged_stacks(
+        &ctx,
+        &resolutions,
+        guard.write_permission(),
+    )
 }
 
 /// Resolve all actively applied reviews for the given project and command context

--- a/crates/but-napi/src/lib.rs
+++ b/crates/but-napi/src/lib.rs
@@ -120,6 +120,10 @@ fn event_from_change(change: gitbutler_watcher::Change) -> WatcherEvent {
                 WatcherGitRemoteActivityPayload
             )),
         },
+        gitbutler_watcher::Change::WorkspaceStackRefChanged { project_id } => WatcherEvent {
+            name: format!("project://{project_id}/git/workspace-ref-changed"),
+            payload: serde_json::json!({}),
+        },
         gitbutler_watcher::Change::WorktreeChanges {
             project_id,
             changes,

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -1622,6 +1622,26 @@ async fn handle_command(
                 Err(e) => Err(e),
             }
         }
+        "check_workspace_divergence" => {
+            let params = deserialize_json(request.params);
+            match params {
+                Ok(params) => {
+                    let result = legacy::virtual_branches::check_workspace_divergence_cmd(params);
+                    result.map(|r| json!(r))
+                }
+                Err(e) => Err(e),
+            }
+        }
+        "resolve_workspace_divergence" => {
+            let params = deserialize_json(request.params);
+            match params {
+                Ok(params) => {
+                    let result = legacy::virtual_branches::resolve_workspace_divergence_cmd(params);
+                    result.map(|r| json!(r))
+                }
+                Err(e) => Err(e),
+            }
+        }
         // GitHub commands (async, not yet migrated)
         "init_github_device_oauth" => {
             let result = github::init_github_device_oauth().await;

--- a/crates/but-server/src/projects.rs
+++ b/crates/but-server/src/projects.rs
@@ -80,6 +80,10 @@ impl ActiveProjects {
                         name: format!("project://{project_id}/git/remote-activity"),
                         payload: serde_json::json!({}),
                     },
+                    Change::WorkspaceStackRefChanged { project_id } => FrontendEvent {
+                        name: format!("project://{project_id}/git/workspace-ref-changed"),
+                        payload: serde_json::json!({}),
+                    },
                     Change::WorktreeChanges {
                         project_id,
                         ref changes,

--- a/crates/but-workspace/tests/workspace/branch/create_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/create_reference.rs
@@ -1226,6 +1226,72 @@ mod with_workspace {
         );
         Ok(())
     }
+
+    /// Creating a new branch in a workspace that has proper metadata stacks plus
+    /// extra "ghost" stacks in the TOML that don't correspond to any actual git refs.
+    #[test]
+    fn create_branch_with_metadata_stacks() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta) = named_writable_scenario("ws-ref-ws-commit-two-stacks")?;
+
+        // Register stacks A and B in the metadata (simulating real production state)
+        add_stack_with_segments(&mut meta, 1, "A", StackState::InWorkspace, &[]);
+        add_stack_with_segments(&mut meta, 2, "B", StackState::InWorkspace, &[]);
+        // Add a "ghost" stack that was previously unapplied/deleted but still in TOML
+        add_stack_with_segments(&mut meta, 3, "deleted-branch", StackState::Inactive, &[]);
+
+        let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
+        let ws = graph.into_workspace()?;
+
+        let c_ref = r("refs/heads/C");
+        let ws = but_workspace::branch::create_reference(
+            c_ref,
+            None,
+            &repo,
+            &ws,
+            &mut meta,
+            stack_id_for_name,
+            None,
+        )?;
+
+        ws.find_segment_and_stack_by_refname(c_ref)
+            .expect("C should be a standalone segment");
+
+        Ok(())
+    }
+
+    /// When workspace metadata has a bloated stack (e.g. ["A", "C", "ghost1", ...])
+    /// and the user creates an independent branch named "C", `update_workspace_metadata`
+    /// finds "C" already in A's stack and marks A's stack as Merged instead of creating
+    /// a new independent stack. C should still appear as its own segment.
+    #[test]
+    fn create_independent_branch_reusing_name_from_bloated_stack() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta) = named_writable_scenario("ws-ref-ws-commit-two-stacks")?;
+
+        // Set up metadata that resembles production: stack A has accumulated
+        // stale branch entries, including one named "C" from a previous dependent branch.
+        add_stack_with_segments(&mut meta, 1, "A", StackState::InWorkspace, &["C", "ghost1"]);
+        add_stack_with_segments(&mut meta, 2, "B", StackState::InWorkspace, &[]);
+
+        let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
+        let ws = graph.into_workspace()?;
+
+        // Try creating an independent branch "C" — same name as the stale entry in A's stack.
+        let c_ref = r("refs/heads/C");
+        let ws = but_workspace::branch::create_reference(
+            c_ref,
+            None,
+            &repo,
+            &ws,
+            &mut meta,
+            stack_id_for_name,
+            None,
+        )?;
+
+        ws.find_segment_and_stack_by_refname(c_ref)
+            .expect("C should be a standalone segment in the workspace");
+
+        Ok(())
+    }
 }
 
 #[test]
@@ -1806,6 +1872,738 @@ fn journey_anon_workspace() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Creating a new independent branch in a workspace that already contains
+/// two stacks with commits should succeed.
+#[test]
+fn create_independent_branch_in_workspace_with_two_stacks() -> anyhow::Result<()> {
+    let (_tmp, repo, mut meta) = named_writable_scenario("ws-ref-ws-commit-two-stacks")?;
+
+    let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
+    let ws = graph.into_workspace()?;
+
+    let c_ref = r("refs/heads/C");
+    let ws = but_workspace::branch::create_reference(
+        c_ref,
+        None,
+        &repo,
+        &ws,
+        &mut meta,
+        stack_id_for_name,
+        None,
+    )?;
+
+    let (stack, segment) = ws
+        .find_segment_and_stack_by_refname(c_ref)
+        .expect("C should be a standalone segment in the workspace");
+    assert!(
+        stack.id.is_some(),
+        "new independent stack should have an ID"
+    );
+    assert_eq!(
+        segment.ref_name().map(|rn| rn.shorten().to_string()),
+        Some("C".to_string()),
+    );
+
+    Ok(())
+}
+
+/// Reproducer: creating a new independent branch when the workspace already
+/// contains an empty stack (one that points at the base commit with no
+/// commits of its own).
+#[test]
+fn create_independent_branch_with_existing_empty_stack() -> anyhow::Result<()> {
+    let (_tmp, repo, mut meta) = named_writable_scenario("ws-with-empty-stack")?;
+
+    let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
+    let ws = graph.into_workspace()?;
+
+    // B is an empty stack already pointing at the base commit.
+    // Creating a new independent branch C should succeed.
+    let c_ref = r("refs/heads/C");
+    let result = but_workspace::branch::create_reference(
+        c_ref,
+        None,
+        &repo,
+        &ws,
+        &mut meta,
+        stack_id_for_name,
+        None,
+    );
+
+    let ws = result?;
+    let (stack, segment) = ws
+        .find_segment_and_stack_by_refname(c_ref)
+        .expect("C should be a standalone segment in the workspace");
+    assert!(
+        stack.id.is_some(),
+        "new independent stack should have an ID"
+    );
+    assert_eq!(
+        segment.ref_name().map(|rn| rn.shorten().to_string()),
+        Some("C".to_string()),
+    );
+
+    Ok(())
+}
+
+/// Creating a new independent branch when origin/main has
+/// advanced past the fork point of existing stacks.
+#[test]
+fn create_independent_branch_with_advanced_remote() -> anyhow::Result<()> {
+    let (_tmp, repo, mut meta) =
+        named_writable_scenario("ws-ref-ws-commit-two-stacks-advanced-remote")?;
+
+    let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
+    let ws = graph.into_workspace()?;
+
+    let c_ref = r("refs/heads/C");
+    let ws = but_workspace::branch::create_reference(
+        c_ref,
+        None,
+        &repo,
+        &ws,
+        &mut meta,
+        stack_id_for_name,
+        None,
+    )?;
+
+    ws.find_segment_and_stack_by_refname(c_ref)
+        .expect("C should be a standalone segment in the workspace");
+
+    Ok(())
+}
+
+/// Reproducer: creating a new independent branch when there are extra
+/// commits on top of the workspace commit (outside commits).
+#[test]
+fn create_independent_branch_with_advanced_workspace() -> anyhow::Result<()> {
+    let (_tmp, repo, mut meta) = named_writable_scenario("ws-ref-ws-commit-one-stack-ws-advanced")?;
+
+    let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
+    let ws = graph.into_workspace()?;
+
+    let c_ref = r("refs/heads/C");
+    let result = but_workspace::branch::create_reference(
+        c_ref,
+        None,
+        &repo,
+        &ws,
+        &mut meta,
+        stack_id_for_name,
+        None,
+    );
+
+    match result {
+        Ok(ws) => {
+            ws.find_segment_and_stack_by_refname(c_ref)
+                .expect("C should be a standalone segment in the workspace");
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("already belongs to another branch") {
+                panic!("BUG REPRODUCED: {msg}");
+            } else {
+                return Err(e);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Creating a second independent branch at the same base commit as an existing one.
+/// Both branches have metadata at the base, so disambiguation fails during traversal.
+/// The `workspace_upgrades` post-processing must recover by creating separate segments.
+#[test]
+fn create_second_independent_branch_at_same_base() -> anyhow::Result<()> {
+    let (_tmp, repo, mut meta) = named_writable_scenario("ws-ref-ws-commit-two-stacks")?;
+
+    let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
+    let ws = graph.into_workspace()?;
+
+    // First, create independent branch D at the base.
+    let d_ref = r("refs/heads/D");
+    let ws = but_workspace::branch::create_reference(
+        d_ref,
+        None,
+        &repo,
+        &ws,
+        &mut meta,
+        stack_id_for_name,
+        None,
+    )?;
+
+    ws.find_segment_and_stack_by_refname(d_ref)
+        .expect("D should be a standalone segment in the workspace");
+
+    // Now create a SECOND independent branch E at the same base commit.
+    let e_ref = r("refs/heads/E");
+    let ws = but_workspace::branch::create_reference(
+        e_ref,
+        None,
+        &repo,
+        &ws,
+        &mut meta,
+        stack_id_for_name,
+        None,
+    )?;
+
+    // E should also appear as its own stack.
+    let (stack, segment) = ws
+        .find_segment_and_stack_by_refname(e_ref)
+        .expect("E should be a standalone segment in the workspace");
+    assert!(
+        stack.id.is_some(),
+        "new independent stack should have an ID"
+    );
+    assert_eq!(
+        segment.ref_name().map(|rn| rn.shorten().to_string()),
+        Some("E".to_string()),
+    );
+
+    Ok(())
+}
+
 fn stack_id_for_name(rn: &gix::refs::FullNameRef) -> StackId {
     StackId::from_number_for_testing(rn.shorten().chars().map(|c| c as u128).sum())
+}
+
+/// Parameterized test infrastructure for `create_reference` across many workspace configurations.
+///
+/// The builder creates a workspace from a fixture, configures metadata with various
+/// levels of "bloat" (ghost entries, stale stacks), and then attempts to create an
+/// independent branch — asserting it succeeds.
+mod parameterized {
+    use but_graph::init::Options;
+    use but_testsupport::graph_workspace;
+
+    use crate::{
+        branch::create_reference::stack_id_for_name,
+        ref_info::with_workspace_commit::utils::{
+            StackState, add_stack_with_segments, named_writable_scenario,
+        },
+        utils::r,
+    };
+
+    /// Which git fixture to use as the base repository structure.
+    #[derive(Debug, Clone, Copy)]
+    enum Fixture {
+        /// Two independent stacks (A, B) each with one commit, forking from M.
+        TwoStacks,
+        /// One stack (B on top of A), both with commits, forking from M.
+        OneStack,
+        /// Two stacks (A with commit, B empty at base), forking from M.
+        EmptyStack,
+        /// Two stacks with origin/main advanced past the fork point.
+        AdvancedRemote,
+    }
+
+    impl Fixture {
+        fn scenario_name(self) -> &'static str {
+            match self {
+                Fixture::TwoStacks => "ws-ref-ws-commit-two-stacks",
+                Fixture::OneStack => "ws-ref-ws-commit-one-stack",
+                Fixture::EmptyStack => "ws-with-empty-stack",
+                Fixture::AdvancedRemote => "ws-ref-ws-commit-two-stacks-advanced-remote",
+            }
+        }
+
+        /// Return the branch names that exist as actual git refs in this fixture
+        /// (excluding main/workspace).
+        fn real_branch_names(self) -> &'static [&'static str] {
+            match self {
+                Fixture::TwoStacks | Fixture::AdvancedRemote | Fixture::EmptyStack => &["A", "B"],
+                Fixture::OneStack => &["A", "B"],
+            }
+        }
+    }
+
+    /// How to configure metadata for each real stack.
+    #[derive(Debug)]
+    struct StackMetaConfig {
+        /// Extra ghost segment names to add to this stack's metadata.
+        ghost_segments: Vec<&'static str>,
+        /// Whether the stack is active or inactive in workspace metadata.
+        in_workspace: bool,
+    }
+
+    impl StackMetaConfig {
+        fn clean() -> Self {
+            StackMetaConfig {
+                ghost_segments: vec![],
+                in_workspace: true,
+            }
+        }
+
+        fn with_ghosts(ghosts: &[&'static str]) -> Self {
+            StackMetaConfig {
+                ghost_segments: ghosts.to_vec(),
+                in_workspace: true,
+            }
+        }
+
+        #[allow(dead_code)]
+        fn inactive() -> Self {
+            StackMetaConfig {
+                ghost_segments: vec![],
+                in_workspace: false,
+            }
+        }
+    }
+
+    /// Configuration for extra stacks that don't correspond to any real git refs.
+    #[derive(Debug)]
+    struct ExtraStack {
+        name: &'static str,
+        segments: Vec<&'static str>,
+        in_workspace: bool,
+    }
+
+    /// Full scenario configuration.
+    #[derive(Debug)]
+    struct Scenario {
+        fixture: Fixture,
+        /// Metadata config for each real branch, indexed by position in `fixture.real_branch_names()`.
+        stack_configs: Vec<StackMetaConfig>,
+        /// Additional stacks in metadata that don't correspond to real git refs.
+        extra_stacks: Vec<ExtraStack>,
+        /// Name of the branch to create.
+        new_branch_name: &'static str,
+    }
+
+    impl Scenario {
+        fn run(&self) -> anyhow::Result<()> {
+            let (_tmp, repo, mut meta) = named_writable_scenario(self.fixture.scenario_name())?;
+            let real_names = self.fixture.real_branch_names();
+
+            // Configure metadata for real stacks.
+            for (i, (name, config)) in real_names.iter().zip(&self.stack_configs).enumerate() {
+                let id = (i + 1) as u128;
+                let state = if config.in_workspace {
+                    StackState::InWorkspace
+                } else {
+                    StackState::Inactive
+                };
+                add_stack_with_segments(&mut meta, id, name, state, &config.ghost_segments);
+            }
+
+            // Add extra stacks.
+            for (i, extra) in self.extra_stacks.iter().enumerate() {
+                let id = (100 + i) as u128;
+                let state = if extra.in_workspace {
+                    StackState::InWorkspace
+                } else {
+                    StackState::Inactive
+                };
+                add_stack_with_segments(&mut meta, id, extra.name, state, &extra.segments);
+            }
+
+            let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
+            let ws = graph.into_workspace()?;
+            let before = graph_workspace(&ws);
+
+            let ref_string = format!("refs/heads/{}", self.new_branch_name);
+            let new_ref = r(&ref_string);
+            let result = but_workspace::branch::create_reference(
+                new_ref,
+                None,
+                &repo,
+                &ws,
+                &mut meta,
+                stack_id_for_name,
+                None,
+            );
+
+            match result {
+                Ok(ws) => {
+                    let (_stack, segment) = ws
+                        .find_segment_and_stack_by_refname(new_ref)
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "Branch '{}' should be findable in the workspace after creation.\n\
+                             Workspace before:\n{before}\n\
+                             Workspace after:\n{}",
+                                self.new_branch_name,
+                                graph_workspace(&ws),
+                            )
+                        });
+                    assert_eq!(
+                        segment.ref_name().map(|rn| rn.shorten().to_string()),
+                        Some(self.new_branch_name.to_string()),
+                        "Segment ref name should match the created branch"
+                    );
+                    Ok(())
+                }
+                Err(e) => {
+                    panic!(
+                        "create_reference failed for scenario {self:?}:\n  error: {e}\n  \
+                         workspace before:\n{before}",
+                    );
+                }
+            }
+        }
+    }
+
+    // --- Parameterized tests ---
+
+    /// Clean metadata, no ghosts — baseline for each fixture.
+    mod clean_metadata {
+        use super::*;
+
+        #[test]
+        fn two_stacks() -> anyhow::Result<()> {
+            Scenario {
+                fixture: Fixture::TwoStacks,
+                stack_configs: vec![StackMetaConfig::clean(), StackMetaConfig::clean()],
+                extra_stacks: vec![],
+                new_branch_name: "C",
+            }
+            .run()
+        }
+
+        #[test]
+        fn one_stack() -> anyhow::Result<()> {
+            Scenario {
+                fixture: Fixture::OneStack,
+                stack_configs: vec![StackMetaConfig::clean(), StackMetaConfig::clean()],
+                extra_stacks: vec![],
+                new_branch_name: "C",
+            }
+            .run()
+        }
+
+        #[test]
+        fn empty_stack() -> anyhow::Result<()> {
+            Scenario {
+                fixture: Fixture::EmptyStack,
+                stack_configs: vec![StackMetaConfig::clean(), StackMetaConfig::clean()],
+                extra_stacks: vec![],
+                new_branch_name: "C",
+            }
+            .run()
+        }
+
+        #[test]
+        fn advanced_remote() -> anyhow::Result<()> {
+            Scenario {
+                fixture: Fixture::AdvancedRemote,
+                stack_configs: vec![StackMetaConfig::clean(), StackMetaConfig::clean()],
+                extra_stacks: vec![],
+                new_branch_name: "C",
+            }
+            .run()
+        }
+    }
+
+    /// Stacks with ghost/stale segment entries that don't correspond to real refs.
+    mod bloated_metadata {
+        use super::*;
+
+        #[test]
+        fn one_ghost_in_first_stack() -> anyhow::Result<()> {
+            Scenario {
+                fixture: Fixture::TwoStacks,
+                stack_configs: vec![
+                    StackMetaConfig::with_ghosts(&["ghost1"]),
+                    StackMetaConfig::clean(),
+                ],
+                extra_stacks: vec![],
+                new_branch_name: "C",
+            }
+            .run()
+        }
+
+        #[test]
+        fn many_ghosts_in_first_stack() -> anyhow::Result<()> {
+            Scenario {
+                fixture: Fixture::TwoStacks,
+                stack_configs: vec![
+                    StackMetaConfig::with_ghosts(&[
+                        "ghost1", "ghost2", "ghost3", "ghost4", "ghost5",
+                    ]),
+                    StackMetaConfig::clean(),
+                ],
+                extra_stacks: vec![],
+                new_branch_name: "C",
+            }
+            .run()
+        }
+
+        #[test]
+        fn ghosts_in_both_stacks() -> anyhow::Result<()> {
+            Scenario {
+                fixture: Fixture::TwoStacks,
+                stack_configs: vec![
+                    StackMetaConfig::with_ghosts(&["ghost1", "ghost2"]),
+                    StackMetaConfig::with_ghosts(&["ghost3", "ghost4"]),
+                ],
+                extra_stacks: vec![],
+                new_branch_name: "C",
+            }
+            .run()
+        }
+
+        #[test]
+        fn new_branch_name_collides_with_ghost() -> anyhow::Result<()> {
+            Scenario {
+                fixture: Fixture::TwoStacks,
+                stack_configs: vec![
+                    StackMetaConfig::with_ghosts(&["C", "ghost1"]),
+                    StackMetaConfig::clean(),
+                ],
+                extra_stacks: vec![],
+                new_branch_name: "C",
+            }
+            .run()
+        }
+
+        #[test]
+        fn new_branch_name_collides_with_ghost_in_second_stack() -> anyhow::Result<()> {
+            Scenario {
+                fixture: Fixture::TwoStacks,
+                stack_configs: vec![
+                    StackMetaConfig::clean(),
+                    StackMetaConfig::with_ghosts(&["C"]),
+                ],
+                extra_stacks: vec![],
+                new_branch_name: "C",
+            }
+            .run()
+        }
+
+        #[test]
+        fn heavily_bloated_one_stack() -> anyhow::Result<()> {
+            Scenario {
+                fixture: Fixture::OneStack,
+                stack_configs: vec![
+                    StackMetaConfig::clean(),
+                    StackMetaConfig::with_ghosts(&[
+                        "g1", "g2", "g3", "g4", "g5", "g6", "g7", "g8", "g9", "g10", "g11", "g12",
+                        "g13", "g14", "g15",
+                    ]),
+                ],
+                extra_stacks: vec![],
+                new_branch_name: "C",
+            }
+            .run()
+        }
+
+        #[test]
+        fn ghost_collides_with_advanced_remote() -> anyhow::Result<()> {
+            Scenario {
+                fixture: Fixture::AdvancedRemote,
+                stack_configs: vec![
+                    StackMetaConfig::with_ghosts(&["C", "ghost1"]),
+                    StackMetaConfig::with_ghosts(&["ghost2"]),
+                ],
+                extra_stacks: vec![],
+                new_branch_name: "C",
+            }
+            .run()
+        }
+    }
+
+    /// Extra stacks in metadata that have no real git refs at all.
+    mod extra_stacks {
+        use super::*;
+
+        #[test]
+        fn one_inactive_extra_stack() -> anyhow::Result<()> {
+            Scenario {
+                fixture: Fixture::TwoStacks,
+                stack_configs: vec![StackMetaConfig::clean(), StackMetaConfig::clean()],
+                extra_stacks: vec![ExtraStack {
+                    name: "deleted-branch",
+                    segments: vec![],
+                    in_workspace: false,
+                }],
+                new_branch_name: "C",
+            }
+            .run()
+        }
+
+        #[test]
+        fn active_extra_stack_with_new_branch_name() -> anyhow::Result<()> {
+            Scenario {
+                fixture: Fixture::TwoStacks,
+                stack_configs: vec![StackMetaConfig::clean(), StackMetaConfig::clean()],
+                extra_stacks: vec![ExtraStack {
+                    name: "C",
+                    segments: vec![],
+                    in_workspace: true,
+                }],
+                new_branch_name: "C",
+            }
+            .run()
+        }
+
+        #[test]
+        fn inactive_extra_stack_with_new_branch_name() -> anyhow::Result<()> {
+            Scenario {
+                fixture: Fixture::TwoStacks,
+                stack_configs: vec![StackMetaConfig::clean(), StackMetaConfig::clean()],
+                extra_stacks: vec![ExtraStack {
+                    name: "C",
+                    segments: vec![],
+                    in_workspace: false,
+                }],
+                new_branch_name: "C",
+            }
+            .run()
+        }
+
+        #[test]
+        fn many_inactive_extra_stacks() -> anyhow::Result<()> {
+            Scenario {
+                fixture: Fixture::TwoStacks,
+                stack_configs: vec![StackMetaConfig::clean(), StackMetaConfig::clean()],
+                extra_stacks: vec![
+                    ExtraStack {
+                        name: "old1",
+                        segments: vec![],
+                        in_workspace: false,
+                    },
+                    ExtraStack {
+                        name: "old2",
+                        segments: vec!["old2a", "old2b"],
+                        in_workspace: false,
+                    },
+                    ExtraStack {
+                        name: "old3",
+                        segments: vec![],
+                        in_workspace: false,
+                    },
+                ],
+                new_branch_name: "C",
+            }
+            .run()
+        }
+
+        #[test]
+        fn extra_stack_with_ghosts_and_collision() -> anyhow::Result<()> {
+            Scenario {
+                fixture: Fixture::TwoStacks,
+                stack_configs: vec![
+                    StackMetaConfig::with_ghosts(&["ghost1"]),
+                    StackMetaConfig::clean(),
+                ],
+                extra_stacks: vec![ExtraStack {
+                    name: "stale-stack",
+                    segments: vec!["C", "another-ghost"],
+                    in_workspace: true,
+                }],
+                new_branch_name: "C",
+            }
+            .run()
+        }
+    }
+
+    /// Combinations: bloated metadata + extra stacks + different fixtures.
+    mod combined {
+        use super::*;
+
+        #[test]
+        fn bloated_plus_inactive_stacks_two_stacks() -> anyhow::Result<()> {
+            Scenario {
+                fixture: Fixture::TwoStacks,
+                stack_configs: vec![
+                    StackMetaConfig::with_ghosts(&["C", "ghost1", "ghost2"]),
+                    StackMetaConfig::with_ghosts(&["ghost3"]),
+                ],
+                extra_stacks: vec![
+                    ExtraStack {
+                        name: "old-stack",
+                        segments: vec!["old-seg"],
+                        in_workspace: false,
+                    },
+                    ExtraStack {
+                        name: "another-old",
+                        segments: vec![],
+                        in_workspace: false,
+                    },
+                ],
+                new_branch_name: "C",
+            }
+            .run()
+        }
+
+        #[test]
+        fn bloated_plus_inactive_empty_stack() -> anyhow::Result<()> {
+            Scenario {
+                fixture: Fixture::EmptyStack,
+                stack_configs: vec![
+                    StackMetaConfig::with_ghosts(&["C"]),
+                    StackMetaConfig::clean(),
+                ],
+                extra_stacks: vec![ExtraStack {
+                    name: "deleted",
+                    segments: vec!["seg1", "seg2"],
+                    in_workspace: false,
+                }],
+                new_branch_name: "C",
+            }
+            .run()
+        }
+
+        #[test]
+        fn bloated_plus_inactive_advanced_remote() -> anyhow::Result<()> {
+            Scenario {
+                fixture: Fixture::AdvancedRemote,
+                stack_configs: vec![
+                    StackMetaConfig::with_ghosts(&["ghost1"]),
+                    StackMetaConfig::with_ghosts(&["C", "ghost2"]),
+                ],
+                extra_stacks: vec![ExtraStack {
+                    name: "archived",
+                    segments: vec![],
+                    in_workspace: false,
+                }],
+                new_branch_name: "C",
+            }
+            .run()
+        }
+
+        #[test]
+        fn collision_in_both_real_and_extra_stack() -> anyhow::Result<()> {
+            Scenario {
+                fixture: Fixture::TwoStacks,
+                stack_configs: vec![
+                    StackMetaConfig::with_ghosts(&["C"]),
+                    StackMetaConfig::clean(),
+                ],
+                extra_stacks: vec![ExtraStack {
+                    name: "extra",
+                    segments: vec!["C"],
+                    in_workspace: true,
+                }],
+                new_branch_name: "C",
+            }
+            .run()
+        }
+
+        #[test]
+        fn one_stack_heavily_bloated_with_extras() -> anyhow::Result<()> {
+            Scenario {
+                fixture: Fixture::OneStack,
+                stack_configs: vec![
+                    StackMetaConfig::with_ghosts(&["C", "g1", "g2", "g3"]),
+                    StackMetaConfig::with_ghosts(&["g4", "g5", "g6", "g7", "g8", "g9", "g10"]),
+                ],
+                extra_stacks: vec![
+                    ExtraStack {
+                        name: "inactive1",
+                        segments: vec!["i1a", "i1b", "i1c"],
+                        in_workspace: false,
+                    },
+                    ExtraStack {
+                        name: "inactive2",
+                        segments: vec![],
+                        in_workspace: false,
+                    },
+                ],
+                new_branch_name: "C",
+            }
+            .run()
+        }
+    }
 }

--- a/crates/but/src/command/legacy/setup.rs
+++ b/crates/but/src/command/legacy/setup.rs
@@ -401,7 +401,36 @@ pub(crate) fn repo(
 
     // switch to gitbutler/workspace if not already there
     if !head_name.starts_with(b"gitbutler/") {
-        but_api::legacy::virtual_branches::switch_back_to_workspace_with_perm(ctx, perm)?;
+        use gitbutler_branch_actions::stack_divergence::{
+            DivergenceApproach, DivergenceResolution, SwitchBackToWorkspaceResult,
+        };
+        let result =
+            but_api::legacy::virtual_branches::switch_back_to_workspace_with_perm(ctx, None, perm)?;
+        if let SwitchBackToWorkspaceResult::Diverged { divergences } = result {
+            if let Some(out) = out.for_human() {
+                writeln!(
+                    out,
+                    "  {}",
+                    t.attention.paint(format!(
+                        "Warning: {} stack ref(s) diverged while outside workspace, excluding them",
+                        divergences.len()
+                    ))
+                )?;
+            }
+            // Auto-exclude all diverged stacks in CLI context.
+            let resolutions: Vec<DivergenceResolution> = divergences
+                .iter()
+                .map(|d| DivergenceResolution {
+                    stack_id: d.stack_id,
+                    approach: DivergenceApproach::Exclude,
+                })
+                .collect();
+            but_api::legacy::virtual_branches::switch_back_to_workspace_with_perm(
+                ctx,
+                Some(resolutions),
+                perm,
+            )?;
+        }
     }
 
     // Install managed hooks to prevent accidental git commits

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -21,6 +21,10 @@ use crate::{
     VirtualBranchesExt,
     integration::update_workspace_commit,
     remote::{RemoteCommit, commit_to_remote_commit},
+    stack_divergence::{
+        DivergenceResolution, DivergenceStatuses, SwitchBackToWorkspaceResult,
+        apply_divergence_resolutions, detect_diverged_stacks,
+    },
 };
 
 #[derive(Debug, Serialize, PartialEq, Clone)]
@@ -154,8 +158,76 @@ pub fn bootstrap_default_target_if_missing(ctx: &Context) -> Result<bool> {
     Ok(true)
 }
 
+#[instrument(skip(ctx, resolutions, perm), err(Debug))]
+fn go_back_to_integration(
+    ctx: &Context,
+    default_target: &Target,
+    resolutions: Option<Vec<DivergenceResolution>>,
+    perm: &mut but_core::sync::RepoExclusive,
+) -> Result<SwitchBackToWorkspaceResult> {
+    // Before checkout or workspace rebuild, detect divergence.
+    // The workspace ref still points to the old workspace commit whose parents
+    // encode the expected stack positions.
+    if resolutions.is_none()
+        && let DivergenceStatuses::DivergedRefs { divergences } = detect_diverged_stacks(ctx)?
+    {
+        return Ok(SwitchBackToWorkspaceResult::Diverged { divergences });
+    }
+
+    // If resolutions were provided, apply them before rebuilding.
+    if let Some(ref resolutions) = resolutions {
+        apply_divergence_resolutions(ctx, resolutions, perm)?;
+    }
+
+    let repo = ctx.repo.get()?;
+    if ctx.settings.feature_flags.cv3 {
+        let workspace_commit_to_checkout =
+            but_workspace::legacy::remerged_workspace_commit_v2(ctx)?;
+        let tree_to_checkout_to_avoid_ref_update =
+            repo.find_commit(workspace_commit_to_checkout)?.tree_id()?;
+        but_core::worktree::safe_checkout(
+            repo.head_id()?.detach(),
+            tree_to_checkout_to_avoid_ref_update.detach(),
+            &repo,
+            but_core::worktree::checkout::Options {
+                uncommitted_changes: UncommitedWorktreeChanges::KeepAndAbortOnConflict,
+                skip_head_update: false,
+                ..Default::default()
+            },
+        )?;
+    } else {
+        let (mut outcome, conflict_kind) =
+            but_workspace::legacy::merge_worktree_with_workspace(ctx, &repo)?;
+
+        if outcome.has_unresolved_conflicts(conflict_kind) {
+            return Err(anyhow!("Conflicts while going back to gitbutler/workspace"))
+                .context(Marker::ProjectConflict);
+        }
+
+        let final_tree_id = outcome.tree.write()?.detach();
+
+        #[expect(deprecated, reason = "checkout/materialization boundary")]
+        let git2_repo = &*ctx.git2_repo.get()?;
+        let final_tree = git2_repo.find_tree(final_tree_id.to_git2())?;
+        git2_repo
+            .checkout_tree(
+                final_tree.as_object(),
+                Some(git2::build::CheckoutBuilder::new().force()),
+            )
+            .context("failed to checkout tree")?;
+    }
+
+    let base = target_to_base_branch(ctx, default_target)?;
+    update_workspace_commit(ctx, false)?;
+    Ok(SwitchBackToWorkspaceResult::Ok {
+        base_branch: Box::new(base),
+    })
+}
+
+/// Legacy go-back-to-integration without divergence detection.
+/// Used by `set_base_branch` which doesn't support the two-phase flow.
 #[instrument(skip(ctx), err(Debug))]
-fn go_back_to_integration(ctx: &Context, default_target: &Target) -> Result<BaseBranch> {
+fn go_back_to_integration_legacy(ctx: &Context, default_target: &Target) -> Result<BaseBranch> {
     let repo = ctx.repo.get()?;
     if ctx.settings.feature_flags.cv3 {
         let workspace_commit_to_checkout =
@@ -199,6 +271,21 @@ fn go_back_to_integration(ctx: &Context, default_target: &Target) -> Result<Base
     Ok(base)
 }
 
+/// Switch back to workspace with divergence detection.
+///
+/// If `resolutions` is `None`, checks for diverged stack refs before proceeding.
+/// When divergence is found, returns `Diverged` so the caller can present options.
+/// When `resolutions` is `Some`, applies the chosen strategies then proceeds
+/// with the workspace checkout and commit rebuild.
+pub fn switch_back_to_workspace(
+    ctx: &Context,
+    resolutions: Option<Vec<DivergenceResolution>>,
+    perm: &mut but_core::sync::RepoExclusive,
+) -> Result<SwitchBackToWorkspaceResult> {
+    let target = default_target(ctx).context("no default target set")?;
+    go_back_to_integration(ctx, &target, resolutions, perm)
+}
+
 pub(crate) fn set_base_branch(
     ctx: &Context,
     target_branch_ref: &RemoteRefname,
@@ -209,7 +296,9 @@ pub(crate) fn set_base_branch(
     if let Ok(target) = default_target(ctx)
         && target.branch.eq(target_branch_ref)
     {
-        return go_back_to_integration(ctx, &target);
+        // When called from set_base_branch (not the divergence-aware path),
+        // skip divergence detection and proceed directly.
+        return go_back_to_integration_legacy(ctx, &target);
     }
 
     // lookup a branch by name

--- a/crates/gitbutler-branch-actions/src/lib.rs
+++ b/crates/gitbutler-branch-actions/src/lib.rs
@@ -23,6 +23,8 @@ pub use base::BaseBranch;
 
 pub mod upstream_integration;
 
+pub mod stack_divergence;
+
 mod integration;
 pub use integration::{
     GITBUTLER_WORKSPACE_COMMIT_TITLE, update_workspace_commit,

--- a/crates/gitbutler-branch-actions/src/stack_divergence.rs
+++ b/crates/gitbutler-branch-actions/src/stack_divergence.rs
@@ -1,0 +1,573 @@
+use anyhow::{Context as _, Result, bail};
+use but_core::RepositoryExt;
+use but_core::ref_metadata::StackId;
+use but_ctx::Context;
+use but_ctx::access::RepoExclusive;
+use but_rebase::RebaseStep;
+use gitbutler_commit::commit_ext::CommitExt;
+use gitbutler_repo::first_parent_commit_ids_until;
+use gitbutler_stack::{Stack, VirtualBranchesHandle};
+use serde::{Deserialize, Serialize};
+
+use crate::BaseBranch;
+use crate::branch_manager::BranchManagerExt;
+
+/// Result of attempting to switch back to the workspace.
+///
+/// When no divergence is detected (or resolutions were provided and applied),
+/// returns `Ok` with the base branch data. When divergence is detected and
+/// no resolutions were provided, returns `Diverged` so the frontend can
+/// present resolution options before retrying.
+#[derive(Serialize, Debug)]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum SwitchBackToWorkspaceResult {
+    /// Successfully switched back to workspace — no divergence or resolutions applied.
+    Ok {
+        #[serde(rename = "baseBranch")]
+        base_branch: Box<BaseBranch>,
+    },
+    /// Divergence detected — frontend should present options and retry with resolutions.
+    Diverged {
+        divergences: Vec<StackRefDivergence>,
+    },
+}
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(SwitchBackToWorkspaceResult);
+
+/// Per-stack divergence info returned to the frontend.
+#[derive(Serialize, PartialEq, Debug)]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct StackRefDivergence {
+    /// The stack that diverged.
+    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
+    pub stack_id: StackId,
+    /// The branch ref name (tip of the stack).
+    pub ref_name: String,
+    /// Where the workspace commit expected this stack's head to be.
+    #[serde(with = "but_serde::object_id")]
+    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
+    pub expected_oid: gix::ObjectId,
+    /// Where the ref actually points now (`None` if the ref was deleted).
+    #[serde(with = "but_serde::object_id_opt")]
+    #[cfg_attr(feature = "export-schema", schemars(with = "Option<String>"))]
+    pub actual_oid: Option<gix::ObjectId>,
+    /// Classification of the divergence.
+    pub status: DivergenceStatus,
+}
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(StackRefDivergence);
+
+/// How a stack ref has diverged from its expected position.
+#[derive(Serialize, PartialEq, Debug)]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum DivergenceStatus {
+    /// Ref was deleted externally.
+    Deleted,
+    /// Ref moved but still above the target base. Including it may change the workspace tree.
+    MovedAboveBase { conflicted: bool },
+    /// Ref moved to or below the target base. The stack has no commits in the workspace.
+    MovedBelowBase,
+    /// Ref moved but the tree at the new position is identical to the old — workspace is unaffected.
+    MovedToSameTree,
+}
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(DivergenceStatus);
+
+/// Top-level result of divergence detection.
+#[derive(Serialize, PartialEq, Debug)]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[serde(tag = "type", content = "subject", rename_all = "camelCase")]
+pub enum DivergenceStatuses {
+    /// All stack refs match the workspace commit — nothing to do.
+    UpToDate,
+    /// One or more stack refs have diverged from the workspace commit.
+    DivergedRefs {
+        divergences: Vec<StackRefDivergence>,
+    },
+}
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(DivergenceStatuses);
+
+/// What the user wants to do with a diverged stack.
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum DivergenceApproach {
+    /// Accept the ref at its current position and rebuild the workspace commit.
+    IncludeAsIs,
+    /// Rebase the stack's commits onto the target base.
+    IncludeRebase,
+    /// Remove the stack from the workspace (mark as unapplied).
+    Exclude,
+}
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(DivergenceApproach);
+
+/// A user's chosen resolution for a single diverged stack.
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct DivergenceResolution {
+    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
+    pub stack_id: StackId,
+    pub approach: DivergenceApproach,
+}
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(DivergenceResolution);
+
+/// Detect whether any workspace stack refs have diverged from the workspace commit.
+///
+/// For each stack, compares where its ref currently points against the workspace commit's
+/// parent that corresponds to that stack. The workspace commit parents are the ground truth
+/// for where each stack's head was when the workspace was last rebuilt.
+pub fn detect_diverged_stacks(ctx: &Context) -> Result<DivergenceStatuses> {
+    let repo = ctx.repo.get()?;
+
+    // Get the workspace commit and its parent OIDs — these are the "expected" positions.
+    let ws_ref = repo
+        .try_find_reference(but_core::WORKSPACE_REF_NAME)?
+        .context("gitbutler/workspace ref not found")?;
+    let ws_commit_id = ws_ref
+        .into_fully_peeled_id()
+        .context("failed to peel workspace ref")?
+        .detach();
+    let ws_commit = repo.find_commit(ws_commit_id)?;
+    let mut unmatched_parents: Vec<gix::ObjectId> =
+        ws_commit.parent_ids().map(|id| id.detach()).collect();
+
+    // Get the target base OID.
+    let target = ctx
+        .persisted_default_target()
+        .context("no default target set")?;
+    let target_base_oid = target.sha;
+
+    // Remove the target from unmatched parents — it's not a stack.
+    unmatched_parents.retain(|id| *id != target_base_oid);
+
+    // Get all stacks in the workspace.
+    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
+    let stacks: Vec<Stack> = vb_state.list_stacks_in_workspace()?;
+
+    let mut divergences = Vec::new();
+
+    for stack in &stacks {
+        // Where does the ref currently point?
+        let actual_oid = resolve_stack_head_from_ref(stack, &repo);
+
+        // Find the expected OID: the workspace commit parent that matches this stack.
+        // If the ref hasn't moved, actual_oid matches one of the parents.
+        let expected_oid = if let Some(actual) = actual_oid {
+            if let Some(pos) = unmatched_parents.iter().position(|id| *id == actual) {
+                // Ref matches a parent — no divergence. Remove from unmatched pool.
+                unmatched_parents.remove(pos);
+                continue;
+            }
+            // Ref doesn't match any remaining parent — it has moved.
+            // The expected OID is the parent we can match via reachability: the parent
+            // from which this stack's ref was previously reachable.
+            find_reachable_parent(&repo, &unmatched_parents, actual)
+        } else {
+            // Ref was deleted. Find the parent that has no other matching stack.
+            None
+        };
+
+        let expected_oid = match expected_oid {
+            Some(oid) => {
+                // Remove from unmatched pool since we've claimed this parent.
+                unmatched_parents.retain(|id| *id != oid);
+                oid
+            }
+            None => {
+                // Can't determine expected OID — take the first unmatched parent if available.
+                if let Some(oid) = unmatched_parents.first().copied() {
+                    unmatched_parents.remove(0);
+                    oid
+                } else {
+                    continue; // No parent to match against.
+                }
+            }
+        };
+
+        let status = classify_divergence(&repo, expected_oid, actual_oid, target_base_oid)?;
+
+        let ref_name = stack
+            .heads
+            .last()
+            .map(|h| h.name.clone())
+            .unwrap_or_default();
+
+        divergences.push(StackRefDivergence {
+            stack_id: stack.id,
+            ref_name,
+            expected_oid,
+            actual_oid,
+            status,
+        });
+    }
+
+    if divergences.is_empty() {
+        return Ok(DivergenceStatuses::UpToDate);
+    }
+
+    // Second pass: check inter-stack conflicts.
+    // Build a workspace tree from all non-diverged stacks, then check whether each
+    // diverged stack's new tree merges cleanly with it. This catches cases where the
+    // moved ref doesn't conflict with the base but DOES conflict with another applied stack.
+    check_inter_stack_conflicts(ctx, &repo, &stacks, &mut divergences, target_base_oid)?;
+
+    Ok(DivergenceStatuses::DivergedRefs { divergences })
+}
+
+/// Try to find which workspace commit parent is the "old" position of a moved ref.
+///
+/// A parent is a match if the actual (moved) OID and the parent share a merge-base
+/// that is not the actual OID itself — meaning they diverged from a common point.
+/// This is a heuristic; it works well when stacks don't share history.
+fn find_reachable_parent(
+    _repo: &gix::Repository,
+    parents: &[gix::ObjectId],
+    _actual: gix::ObjectId,
+) -> Option<gix::ObjectId> {
+    // For now, if there's only one unmatched parent, it must be ours.
+    if parents.len() == 1 {
+        return Some(parents[0]);
+    }
+    // With multiple unmatched parents, we can't reliably determine which one
+    // belonged to this stack without more info. Return None and let the caller
+    // fall back to the first available.
+    None
+}
+
+/// Resolve the stack's top branch ref to where it currently points in the repo.
+/// Returns `None` if the ref has been deleted.
+fn resolve_stack_head_from_ref(stack: &Stack, repo: &gix::Repository) -> Option<gix::ObjectId> {
+    let branch = stack.heads.last()?;
+    repo.try_find_reference(&branch.name)
+        .ok()?
+        .and_then(|mut r| r.peel_to_commit().ok())
+        .map(|c| c.id)
+}
+
+/// Apply user-chosen resolutions for diverged stacks, then rebuild the workspace commit.
+///
+/// This is the second phase of the two-phase divergence handling flow:
+/// 1. `detect_diverged_stacks` identifies what diverged
+/// 2. `resolve_diverged_stacks` applies the user's chosen strategy for each
+///
+/// After resolution, the workspace commit is rebuilt to reflect the new state.
+/// This may trigger a checkout if included stacks have changed trees.
+pub fn resolve_diverged_stacks(
+    ctx: &Context,
+    resolutions: &[DivergenceResolution],
+    permission: &mut RepoExclusive,
+) -> Result<()> {
+    let repo = ctx.repo.get()?;
+    let mut vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
+    let target = ctx
+        .persisted_default_target()
+        .context("no default target set")?;
+    let target_base_oid = target.sha;
+
+    // Phase 1: Process excludes (unapply stacks).
+    for resolution in resolutions {
+        if resolution.approach != DivergenceApproach::Exclude {
+            continue;
+        }
+        ctx.branch_manager().unapply(
+            resolution.stack_id,
+            permission,
+            false, // don't delete vb_state entry
+            Vec::new(),
+            false, // not safe_checkout — we'll rebuild the workspace commit ourselves
+        )?;
+    }
+
+    // Phase 2: Process rebases.
+    for resolution in resolutions {
+        if resolution.approach != DivergenceApproach::IncludeRebase {
+            continue;
+        }
+        let mut stack = vb_state.get_stack(resolution.stack_id)?;
+        let actual_oid = resolve_stack_head_from_ref(&stack, &repo)
+            .context("cannot rebase: stack ref was deleted")?;
+
+        // Collect commits from the stack's current head down to the target base.
+        let commit_ids = first_parent_commit_ids_until(&repo, actual_oid, target_base_oid)?;
+        if commit_ids.is_empty() {
+            continue; // Nothing to rebase — stack is at or below target base.
+        }
+
+        let steps: Vec<RebaseStep> = commit_ids
+            .iter()
+            .map(|commit_id| RebaseStep::Pick {
+                commit_id: *commit_id,
+                new_message: None,
+            })
+            .collect();
+
+        let mut rebase = but_rebase::Rebase::new(&repo, Some(target_base_oid), None)?;
+        rebase.rebase_noops(false);
+        rebase.steps(steps)?;
+        let output = rebase.rebase()?;
+
+        // Check for conflicts in rebased commits.
+        let any_conflicted = output.commit_mapping.iter().any(|(_base, _old, new)| {
+            repo.find_commit(*new)
+                .map(|c| c.is_conflicted())
+                .unwrap_or(false)
+        });
+        if any_conflicted {
+            bail!(
+                "Rebase of stack '{}' produced conflicts — try IncludeAsIs or Exclude instead",
+                stack
+                    .heads
+                    .last()
+                    .map(|h| h.name.as_str())
+                    .unwrap_or("unknown")
+            );
+        }
+
+        // Update the stack's branch refs from the rebase output.
+        stack.set_heads_from_rebase_output(ctx, output.references)?;
+        vb_state.set_stack(stack)?;
+    }
+
+    // Phase 3: For IncludeAsIs, no ref changes are needed — the workspace commit
+    // rebuild will pick up the current ref positions automatically.
+
+    // Phase 4: Rebuild the workspace commit. This merges all in-workspace stacks
+    // and performs a checkout if the tree changed.
+    crate::integration::update_workspace_commit_with_vb_state(&vb_state, ctx, true)?;
+
+    Ok(())
+}
+
+/// Apply divergence resolutions without rebuilding the workspace commit.
+///
+/// This is used by the `switch_back_to_workspace` two-phase flow: resolutions
+/// are applied first (refs moved, stacks unapplied), then `go_back_to_integration`
+/// handles the checkout and workspace commit rebuild.
+pub fn apply_divergence_resolutions(
+    ctx: &Context,
+    resolutions: &[DivergenceResolution],
+    permission: &mut RepoExclusive,
+) -> Result<()> {
+    let repo = ctx.repo.get()?;
+    let mut vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
+    let target = ctx
+        .persisted_default_target()
+        .context("no default target set")?;
+    let target_base_oid = target.sha;
+
+    // Phase 1: Process excludes (unapply stacks).
+    for resolution in resolutions {
+        if resolution.approach != DivergenceApproach::Exclude {
+            continue;
+        }
+        ctx.branch_manager()
+            .unapply(resolution.stack_id, permission, false, Vec::new(), false)?;
+    }
+
+    // Phase 2: Process rebases.
+    for resolution in resolutions {
+        if resolution.approach != DivergenceApproach::IncludeRebase {
+            continue;
+        }
+        let mut stack = vb_state.get_stack(resolution.stack_id)?;
+        let actual_oid = resolve_stack_head_from_ref(&stack, &repo)
+            .context("cannot rebase: stack ref was deleted")?;
+
+        let commit_ids = first_parent_commit_ids_until(&repo, actual_oid, target_base_oid)?;
+        if commit_ids.is_empty() {
+            continue;
+        }
+
+        let steps: Vec<RebaseStep> = commit_ids
+            .iter()
+            .map(|commit_id| RebaseStep::Pick {
+                commit_id: *commit_id,
+                new_message: None,
+            })
+            .collect();
+
+        let mut rebase = but_rebase::Rebase::new(&repo, Some(target_base_oid), None)?;
+        rebase.rebase_noops(false);
+        rebase.steps(steps)?;
+        let output = rebase.rebase()?;
+
+        let any_conflicted = output.commit_mapping.iter().any(|(_base, _old, new)| {
+            repo.find_commit(*new)
+                .map(|c| c.is_conflicted())
+                .unwrap_or(false)
+        });
+        if any_conflicted {
+            bail!(
+                "Rebase of stack '{}' produced conflicts — try IncludeAsIs or Exclude instead",
+                stack
+                    .heads
+                    .last()
+                    .map(|h| h.name.as_str())
+                    .unwrap_or("unknown")
+            );
+        }
+
+        stack.set_heads_from_rebase_output(ctx, output.references)?;
+        vb_state.set_stack(stack)?;
+    }
+
+    // Phase 3: IncludeAsIs — no ref changes needed.
+    // The workspace commit rebuild (done by the caller) will pick up current positions.
+
+    Ok(())
+}
+
+/// Check whether diverged stacks would conflict with other applied stacks.
+///
+/// For each diverged stack marked `MovedAboveBase { conflicted: false }`, builds a
+/// workspace tree from all OTHER stacks (non-diverged use current tree, other diverged
+/// use their new actual tree), then checks if adding this stack would conflict.
+fn check_inter_stack_conflicts(
+    ctx: &Context,
+    repo: &gix::Repository,
+    stacks: &[Stack],
+    divergences: &mut [StackRefDivergence],
+    target_base_oid: gix::ObjectId,
+) -> Result<()> {
+    // Only worth checking for stacks marked MovedAboveBase { conflicted: false }.
+    let any_needs_check = divergences.iter().any(|d| {
+        matches!(
+            d.status,
+            DivergenceStatus::MovedAboveBase { conflicted: false }
+        )
+    });
+    if !any_needs_check {
+        return Ok(());
+    }
+
+    let merge_tree_id = repo.find_commit(target_base_oid)?.tree_id()?.detach();
+    let (merge_options, conflict_kind) = repo.merge_options_fail_fast()?;
+
+    // Build a lookup: stack_id → tree_id for all stacks that would be in the workspace.
+    // Non-diverged stacks use their current head. Diverged stacks use their actual (new) OID.
+    let divergence_map: std::collections::HashMap<StackId, &StackRefDivergence> =
+        divergences.iter().map(|d| (d.stack_id, d)).collect();
+
+    let mut stack_trees: Vec<(StackId, gix::ObjectId)> = Vec::new();
+    for stack in stacks {
+        let tree_id = if let Some(div) = divergence_map.get(&stack.id) {
+            // For diverged stacks that would be included (MovedAboveBase non-conflicted
+            // or MovedToSameTree), use their actual tree.
+            match &div.status {
+                DivergenceStatus::MovedAboveBase { conflicted: false }
+                | DivergenceStatus::MovedToSameTree => {
+                    if let Some(actual) = div.actual_oid {
+                        repo.find_commit(actual)?.tree_id()?.detach()
+                    } else {
+                        continue;
+                    }
+                }
+                // Deleted, MovedBelowBase, or already-conflicted stacks won't be included.
+                _ => continue,
+            }
+        } else {
+            // Non-diverged stack — use current head.
+            repo.find_commit(stack.head_oid(ctx)?)?.tree_id()?.detach()
+        };
+        stack_trees.push((stack.id, tree_id));
+    }
+    // For each candidate divergence, build a workspace tree from all OTHER stacks,
+    // then check if adding this stack's tree would conflict.
+    for divergence in divergences.iter_mut() {
+        if !matches!(
+            divergence.status,
+            DivergenceStatus::MovedAboveBase { conflicted: false }
+        ) {
+            continue;
+        }
+        let check_stack_id = divergence.stack_id;
+
+        // Build workspace tree from all stacks EXCEPT the one being checked.
+        let mut workspace_tree_id = merge_tree_id;
+        for (sid, tree_id) in &stack_trees {
+            if *sid == check_stack_id {
+                continue;
+            }
+            let mut merge = repo.merge_trees(
+                merge_tree_id,
+                workspace_tree_id,
+                *tree_id,
+                repo.default_merge_labels(),
+                merge_options.clone(),
+            )?;
+            if !merge.has_unresolved_conflicts(conflict_kind) {
+                workspace_tree_id = merge.tree.write()?.detach();
+            }
+        }
+
+        // Now check if this diverged stack's tree merges cleanly with the workspace.
+        let Some(check_tree_id) = stack_trees
+            .iter()
+            .find(|(sid, _)| *sid == check_stack_id)
+            .map(|(_, t)| *t)
+        else {
+            continue;
+        };
+        let merge = repo.merge_trees(
+            merge_tree_id,
+            workspace_tree_id,
+            check_tree_id,
+            repo.default_merge_labels(),
+            merge_options.clone(),
+        )?;
+        if merge.has_unresolved_conflicts(conflict_kind) {
+            divergence.status = DivergenceStatus::MovedAboveBase { conflicted: true };
+        }
+    }
+
+    Ok(())
+}
+
+/// Classify how a stack ref has diverged.
+fn classify_divergence(
+    repo: &gix::Repository,
+    expected_oid: gix::ObjectId,
+    actual_oid: Option<gix::ObjectId>,
+    target_base_oid: gix::ObjectId,
+) -> Result<DivergenceStatus> {
+    let Some(actual) = actual_oid else {
+        return Ok(DivergenceStatus::Deleted);
+    };
+
+    // Check if the trees are identical — if so, the workspace is unaffected.
+    let expected_tree = repo.find_commit(expected_oid)?.tree_id()?.detach();
+    let actual_tree = repo.find_commit(actual)?.tree_id()?.detach();
+    if expected_tree == actual_tree {
+        return Ok(DivergenceStatus::MovedToSameTree);
+    }
+
+    // Check if the ref is now at or below the target base.
+    let merge_base = repo
+        .merge_base(actual, target_base_oid)
+        .context("failed to compute merge base")?;
+    if merge_base == actual {
+        // actual is an ancestor of (or equal to) target_base — it's at or below the base.
+        return Ok(DivergenceStatus::MovedBelowBase);
+    }
+
+    // Ref is above the base but has moved. Check if including it would conflict.
+    let (merge_options, conflict_kind) = repo.merge_options_fail_fast()?;
+    let target_tree = repo.find_commit(target_base_oid)?.tree_id()?.detach();
+    let outcome = repo.merge_trees(
+        target_tree,
+        expected_tree,
+        actual_tree,
+        repo.default_merge_labels(),
+        merge_options,
+    )?;
+    let conflicted = outcome.has_unresolved_conflicts(conflict_kind);
+
+    Ok(DivergenceStatus::MovedAboveBase { conflicted })
+}

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/set_base_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/set_base_branch.rs
@@ -244,6 +244,881 @@ mod go_back_to_workspace {
     }
 }
 
+/// Tests that corrupt git state while outside the workspace, simulating what real users
+/// do when they `git switch feature-a`, modify refs, then return to GitButler.
+///
+/// These tests were written to investigate the production error:
+/// "Branch cannot be created: target commit already belongs to another branch"
+/// (89 PostHog events, 48 users). The root cause is a stack branch ref pointing below
+/// the workspace's lower bound (target base), which causes the graph to claim the
+/// target commit for that stack, blocking new independent branches.
+mod adversarial_outside_workspace {
+    use but_core::ref_metadata::StackId;
+    use gitbutler_branch::BranchCreateRequest;
+    use gix::reference::Category;
+    use gix::refs::transaction::PreviousValue;
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    /// Helper: create a branch via the v3 path (workspace_mut_and_db + create_reference).
+    fn create_branch_v3(ctx: &mut Context, name: &str) -> anyhow::Result<()> {
+        let new_ref = Category::LocalBranch
+            .to_full_name(name)
+            .map_err(anyhow::Error::from)?;
+        let mut meta = ctx.meta()?;
+        let (_guard, repo, mut ws, _) = ctx.workspace_mut_and_db()?;
+        let new_ws = but_workspace::branch::create_reference(
+            new_ref.as_ref(),
+            None,
+            &repo,
+            &ws,
+            &mut meta,
+            |_| StackId::generate(),
+            None,
+        )?;
+        *ws = new_ws.into_owned();
+        Ok(())
+    }
+
+    /// Setup: workspace with one stack that has a commit touching `another_file.txt`.
+    /// Returns (early_oid for switching away, stack_entry).
+    fn setup_workspace_with_stack(
+        repo: &mut super::TestRepo,
+        ctx: &mut Context,
+    ) -> (gix::ObjectId, but_workspace::legacy::ui::StackEntryNoOpt) {
+        std::fs::write(repo.path().join("file.txt"), "one").unwrap();
+        let oid_one = repo.commit_all("one");
+        std::fs::write(repo.path().join("file.txt"), "two").unwrap();
+        repo.commit_all("two");
+        repo.push();
+
+        let mut guard = ctx.exclusive_worktree_access();
+        gitbutler_branch_actions::set_base_branch(
+            ctx,
+            &"refs/remotes/origin/master".parse().unwrap(),
+            guard.write_permission(),
+        )
+        .unwrap();
+        drop(guard);
+
+        let mut guard = ctx.exclusive_worktree_access();
+        let stack_entry = gitbutler_branch_actions::create_virtual_branch(
+            ctx,
+            &BranchCreateRequest {
+                name: Some("my-stack".into()),
+                ..Default::default()
+            },
+            guard.write_permission(),
+        )
+        .unwrap();
+        drop(guard);
+
+        std::fs::write(repo.path().join("another_file.txt"), "stack work").unwrap();
+        super::create_commit(ctx, stack_entry.id, "stack commit").unwrap();
+
+        (oid_one, stack_entry)
+    }
+
+    /// Deleting a stack's branch ref while outside the workspace (e.g. `git branch -D my-stack`)
+    /// should not permanently break the workspace — creating branches should still work after
+    /// returning via set_base_branch.
+    #[test]
+    fn delete_stack_branch_ref_while_outside_then_return_and_create() {
+        let Test { repo, ctx, .. } = &mut Test::default();
+
+        let (oid_one, _stack_entry) = setup_workspace_with_stack(repo, ctx);
+
+        repo.checkout_commit(oid_one);
+
+        {
+            let raw_repo = repo.open();
+            if let Ok(reference) = raw_repo.find_reference("refs/heads/my-stack") {
+                reference.delete().unwrap();
+            }
+        }
+
+        let mut guard = ctx.exclusive_worktree_access();
+        let return_result = gitbutler_branch_actions::set_base_branch(
+            ctx,
+            &"refs/remotes/origin/master".parse().unwrap(),
+            guard.write_permission(),
+        );
+        drop(guard);
+
+        if let Err(e) = &return_result {
+            eprintln!("Return after deleting stack branch failed: {e:#}");
+            return;
+        }
+
+        let mut guard = ctx.exclusive_worktree_access();
+        let create_result = gitbutler_branch_actions::create_virtual_branch(
+            ctx,
+            &BranchCreateRequest::default(),
+            guard.write_permission(),
+        );
+        drop(guard);
+
+        if let Err(e) = &create_result {
+            eprintln!("Create branch after stack deletion failed: {e:#}");
+        }
+
+        let v3_result = create_branch_v3(ctx, "v3-after-delete");
+        if let Err(e) = &v3_result {
+            eprintln!("V3 create after stack deletion failed: {e:#}");
+        }
+
+        assert!(
+            create_result.is_ok() || v3_result.is_ok(),
+            "Workspace should be recoverable after stack branch deletion"
+        );
+    }
+
+    /// Forcing a stack ref to point at the target base commit (e.g. `git branch -f my-stack origin/master`)
+    /// is the boundary case: the ref is AT the lower bound, not below it.
+    /// This should work — it's equivalent to an empty stack.
+    #[test]
+    fn force_update_stack_ref_to_target_base_while_outside_then_return_and_create() {
+        let Test { repo, ctx, .. } = &mut Test::default();
+
+        let (oid_one, _stack_entry) = setup_workspace_with_stack(repo, ctx);
+        let target_oid = ctx.persisted_default_target().unwrap().sha;
+
+        repo.checkout_commit(oid_one);
+
+        {
+            let raw_repo = repo.open();
+            raw_repo
+                .reference(
+                    "refs/heads/my-stack",
+                    target_oid,
+                    PreviousValue::Any,
+                    "test: force stack ref to target base",
+                )
+                .unwrap();
+        }
+
+        let mut guard = ctx.exclusive_worktree_access();
+        let return_result = gitbutler_branch_actions::set_base_branch(
+            ctx,
+            &"refs/remotes/origin/master".parse().unwrap(),
+            guard.write_permission(),
+        );
+        drop(guard);
+
+        if let Err(e) = &return_result {
+            eprintln!("Return after force-updating stack ref failed: {e:#}");
+            return;
+        }
+
+        let v3_result = create_branch_v3(ctx, "new-branch");
+        if let Err(e) = &v3_result {
+            eprintln!(
+                "V3 create after force-update to target base: {e:#}\n\
+                 This may be the production bug — two branches claiming the same base commit."
+            );
+        }
+
+        let mut guard = ctx.exclusive_worktree_access();
+        let legacy_result = gitbutler_branch_actions::create_virtual_branch(
+            ctx,
+            &BranchCreateRequest::default(),
+            guard.write_permission(),
+        );
+        drop(guard);
+        if let Err(e) = &legacy_result {
+            eprintln!("Legacy create after force-update to target base: {e:#}");
+        }
+
+        if let (Err(v3_err), Err(legacy_err)) = (&v3_result, &legacy_result) {
+            panic!(
+                "BOTH create paths failed after force-updating stack ref to target base.\n\
+                 v3: {v3_err}\n\
+                 legacy: {legacy_err}",
+            );
+        }
+    }
+
+    /// BUG REPRODUCTION + FIX: Forces a stack ref to a commit BELOW the target base while
+    /// already in workspace mode (simulating `git branch -f my-stack <old-commit>` from another
+    /// terminal). This is the root cause of "target commit already belongs to another branch"
+    /// (89 PostHog events, 48 users).
+    ///
+    /// The fix: detect the divergence (watcher would trigger this) and resolve it (Exclude)
+    /// before the corrupted state can block new branch creation.
+    #[test]
+    fn force_update_stack_ref_to_earlier_commit_while_outside_then_return_and_create() {
+        use gitbutler_branch_actions::stack_divergence::{
+            DivergenceApproach, DivergenceResolution, DivergenceStatus, DivergenceStatuses,
+        };
+
+        let Test { repo, ctx, .. } = &mut Test::default();
+
+        let (oid_one, stack_entry) = setup_workspace_with_stack(repo, ctx);
+
+        // Force the stack ref below the target base while still in workspace mode.
+        // This simulates someone running `git branch -f my-stack <old-commit>` in another terminal.
+        {
+            let raw_repo = repo.open();
+            raw_repo
+                .reference(
+                    "refs/heads/my-stack",
+                    oid_one,
+                    PreviousValue::Any,
+                    "test: force stack ref to early commit",
+                )
+                .unwrap();
+        }
+
+        // Detect the divergence (this is what the watcher would trigger).
+        let statuses =
+            gitbutler_branch_actions::stack_divergence::detect_diverged_stacks(ctx).unwrap();
+        match &statuses {
+            DivergenceStatuses::DivergedRefs { divergences } => {
+                assert_eq!(divergences.len(), 1);
+                assert_eq!(divergences[0].status, DivergenceStatus::MovedBelowBase);
+            }
+            DivergenceStatuses::UpToDate => {
+                panic!("Expected divergence but got UpToDate");
+            }
+        }
+
+        // Resolve by excluding the corrupted stack.
+        let mut guard = ctx.exclusive_worktree_access();
+        gitbutler_branch_actions::stack_divergence::resolve_diverged_stacks(
+            ctx,
+            &[DivergenceResolution {
+                stack_id: stack_entry.id,
+                approach: DivergenceApproach::Exclude,
+            }],
+            guard.write_permission(),
+        )
+        .unwrap();
+        drop(guard);
+
+        // After resolution, creating a branch succeeds.
+        let v3_result = create_branch_v3(ctx, "new-branch-after-fix");
+        assert!(
+            v3_result.is_ok(),
+            "After divergence resolution, creating branch should work: {:?}",
+            v3_result.unwrap_err()
+        );
+    }
+
+    /// Checking out a branch with the same name as an existing stack (e.g. `git checkout my-stack`),
+    /// making commits on it, then returning — tests whether the name collision between the
+    /// user's branch and GitButler's stack ref causes problems.
+    #[test]
+    fn checkout_branch_with_same_name_as_stack_then_return_and_create() {
+        let Test { repo, ctx, .. } = &mut Test::default();
+
+        let (_oid_one, _stack_entry) = setup_workspace_with_stack(repo, ctx);
+
+        repo.checkout(&"refs/heads/my-stack".parse().unwrap());
+
+        std::fs::write(repo.path().join("diverged.txt"), "diverged content").unwrap();
+        repo.commit_all("diverged commit on my-stack");
+
+        let mut guard = ctx.exclusive_worktree_access();
+        let return_result = gitbutler_branch_actions::set_base_branch(
+            ctx,
+            &"refs/remotes/origin/master".parse().unwrap(),
+            guard.write_permission(),
+        );
+        drop(guard);
+
+        if let Err(e) = &return_result {
+            eprintln!("Return from same-named branch: {e:#}");
+            return;
+        }
+
+        let stacks = stack_details(ctx);
+        eprintln!(
+            "Stacks after returning from same-named branch: {}",
+            stacks.len()
+        );
+
+        let v3_result = create_branch_v3(ctx, "new-branch-after-collision");
+        assert!(
+            v3_result.is_ok(),
+            "Creating branch after name collision return should work: {:?}",
+            v3_result.unwrap_err()
+        );
+    }
+
+    /// With multiple stacks, deleting just one stack's ref while outside should not break
+    /// the workspace — the surviving stack should remain intact and new branches should
+    /// still be creatable.
+    #[test]
+    fn multiple_stacks_delete_one_ref_while_outside_then_return_and_create() {
+        let Test { repo, ctx, .. } = &mut Test::default();
+
+        std::fs::write(repo.path().join("file.txt"), "one").unwrap();
+        let oid_one = repo.commit_all("one");
+        std::fs::write(repo.path().join("file.txt"), "two").unwrap();
+        repo.commit_all("two");
+        repo.push();
+
+        let mut guard = ctx.exclusive_worktree_access();
+        gitbutler_branch_actions::set_base_branch(
+            ctx,
+            &"refs/remotes/origin/master".parse().unwrap(),
+            guard.write_permission(),
+        )
+        .unwrap();
+        drop(guard);
+
+        let mut guard = ctx.exclusive_worktree_access();
+        let stack_a = gitbutler_branch_actions::create_virtual_branch(
+            ctx,
+            &BranchCreateRequest {
+                name: Some("stack-a".into()),
+                ..Default::default()
+            },
+            guard.write_permission(),
+        )
+        .unwrap();
+        drop(guard);
+        std::fs::write(repo.path().join("a.txt"), "a content").unwrap();
+        super::create_commit(ctx, stack_a.id, "commit a").unwrap();
+
+        let mut guard = ctx.exclusive_worktree_access();
+        let _stack_b = gitbutler_branch_actions::create_virtual_branch(
+            ctx,
+            &BranchCreateRequest {
+                name: Some("stack-b".into()),
+                ..Default::default()
+            },
+            guard.write_permission(),
+        )
+        .unwrap();
+        drop(guard);
+        std::fs::write(repo.path().join("b.txt"), "b content").unwrap();
+        super::create_commit(ctx, _stack_b.id, "commit b").unwrap();
+
+        assert_eq!(stack_details(ctx).len(), 2);
+
+        repo.checkout_commit(oid_one);
+
+        {
+            let raw_repo = repo.open();
+            raw_repo
+                .find_reference("refs/heads/stack-a")
+                .unwrap()
+                .delete()
+                .unwrap();
+        }
+
+        let mut guard = ctx.exclusive_worktree_access();
+        let return_result = gitbutler_branch_actions::set_base_branch(
+            ctx,
+            &"refs/remotes/origin/master".parse().unwrap(),
+            guard.write_permission(),
+        );
+        drop(guard);
+
+        if let Err(e) = &return_result {
+            eprintln!("Return after deleting one of two stack refs: {e:#}");
+            return;
+        }
+
+        let v3_result = create_branch_v3(ctx, "stack-c");
+        if let Err(e) = &v3_result {
+            eprintln!("V3 create after partial stack deletion: {e:#}");
+        }
+        assert!(
+            v3_result.is_ok(),
+            "Should be able to create branch after one stack ref deleted: {:?}",
+            v3_result.unwrap_err()
+        );
+    }
+}
+
+/// Tests for the stack divergence detection API.
+mod stack_divergence_detection {
+    use gitbutler_branch::BranchCreateRequest;
+    use gitbutler_branch_actions::stack_divergence::{DivergenceStatus, DivergenceStatuses};
+    use gix::refs::transaction::PreviousValue;
+
+    use super::*;
+
+    /// Helper: set up workspace with one stack, return (early_oid, stack_entry).
+    fn setup_workspace_with_stack(
+        repo: &mut super::TestRepo,
+        ctx: &mut Context,
+    ) -> (gix::ObjectId, but_workspace::legacy::ui::StackEntryNoOpt) {
+        std::fs::write(repo.path().join("file.txt"), "one").unwrap();
+        let oid_one = repo.commit_all("one");
+        std::fs::write(repo.path().join("file.txt"), "two").unwrap();
+        repo.commit_all("two");
+        repo.push();
+
+        let mut guard = ctx.exclusive_worktree_access();
+        gitbutler_branch_actions::set_base_branch(
+            ctx,
+            &"refs/remotes/origin/master".parse().unwrap(),
+            guard.write_permission(),
+        )
+        .unwrap();
+        drop(guard);
+
+        let mut guard = ctx.exclusive_worktree_access();
+        let stack_entry = gitbutler_branch_actions::create_virtual_branch(
+            ctx,
+            &BranchCreateRequest {
+                name: Some("my-stack".into()),
+                ..Default::default()
+            },
+            guard.write_permission(),
+        )
+        .unwrap();
+        drop(guard);
+
+        std::fs::write(repo.path().join("another_file.txt"), "stack work").unwrap();
+        super::create_commit(ctx, stack_entry.id, "stack commit").unwrap();
+
+        (oid_one, stack_entry)
+    }
+
+    /// When no refs have moved, detection should return UpToDate.
+    #[test]
+    fn no_divergence_returns_up_to_date() {
+        let Test { repo, ctx, .. } = &mut Test::default();
+        let (_oid_one, _stack_entry) = setup_workspace_with_stack(repo, ctx);
+
+        let result = gitbutler_branch_actions::stack_divergence::detect_diverged_stacks(ctx);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), DivergenceStatuses::UpToDate);
+    }
+
+    /// When a stack ref is force-pushed below the target base, detection should
+    /// report MovedBelowBase.
+    #[test]
+    fn ref_moved_below_base_detected() {
+        let Test { repo, ctx, .. } = &mut Test::default();
+        let (oid_one, _stack_entry) = setup_workspace_with_stack(repo, ctx);
+
+        // Force my-stack ref to point below the target base.
+        {
+            let raw_repo = repo.open();
+            raw_repo
+                .reference(
+                    "refs/heads/my-stack",
+                    oid_one,
+                    PreviousValue::Any,
+                    "test: force below base",
+                )
+                .unwrap();
+        }
+
+        let result =
+            gitbutler_branch_actions::stack_divergence::detect_diverged_stacks(ctx).unwrap();
+        match result {
+            DivergenceStatuses::DivergedRefs { divergences } => {
+                assert_eq!(divergences.len(), 1);
+                assert_eq!(divergences[0].actual_oid, Some(oid_one));
+                assert_eq!(divergences[0].status, DivergenceStatus::MovedBelowBase);
+            }
+            DivergenceStatuses::UpToDate => {
+                panic!("Expected divergence but got UpToDate");
+            }
+        }
+    }
+
+    /// When a stack ref is deleted, detection should report Deleted.
+    #[test]
+    fn ref_deleted_detected() {
+        let Test { repo, ctx, .. } = &mut Test::default();
+        let (_oid_one, _stack_entry) = setup_workspace_with_stack(repo, ctx);
+
+        // Delete the stack ref.
+        {
+            let raw_repo = repo.open();
+            raw_repo
+                .find_reference("refs/heads/my-stack")
+                .unwrap()
+                .delete()
+                .unwrap();
+        }
+
+        let result =
+            gitbutler_branch_actions::stack_divergence::detect_diverged_stacks(ctx).unwrap();
+        match result {
+            DivergenceStatuses::DivergedRefs { divergences } => {
+                assert_eq!(divergences.len(), 1);
+                assert_eq!(divergences[0].actual_oid, None);
+                assert_eq!(divergences[0].status, DivergenceStatus::Deleted);
+            }
+            DivergenceStatuses::UpToDate => {
+                panic!("Expected divergence but got UpToDate");
+            }
+        }
+    }
+
+    /// When a stack ref moves but the tree at the new position is identical,
+    /// detection should report MovedToSameTree.
+    #[test]
+    fn ref_moved_to_same_tree_detected() {
+        let Test { repo, ctx, .. } = &mut Test::default();
+        let (_oid_one, _stack_entry) = setup_workspace_with_stack(repo, ctx);
+
+        // Create another commit with the same tree but different message, then force-update the ref.
+        let new_oid = {
+            let raw_repo = repo.open();
+            // Resolve the current head of my-stack (stack_entry.tip is stale — from before create_commit).
+            let current_head = raw_repo
+                .find_reference("refs/heads/my-stack")
+                .unwrap()
+                .peel_to_commit()
+                .unwrap()
+                .id;
+            let old_commit = raw_repo.find_commit(current_head).unwrap();
+            let tree_id = old_commit.tree_id().unwrap().detach();
+            let parent_ids: Vec<gix::ObjectId> =
+                old_commit.parent_ids().map(|id| id.detach()).collect();
+            let committer: gix::actor::Signature = old_commit.committer().unwrap().into();
+            let author: gix::actor::Signature = old_commit.author().unwrap().into();
+            let commit = gix::objs::Commit {
+                tree: tree_id,
+                parents: parent_ids.into(),
+                author,
+                committer,
+                encoding: None,
+                message: "same tree, different message".into(),
+                extra_headers: vec![],
+            };
+            let new_oid = raw_repo.write_object(&commit).unwrap().detach();
+            raw_repo
+                .reference(
+                    "refs/heads/my-stack",
+                    new_oid,
+                    gix::refs::transaction::PreviousValue::Any,
+                    "test: move to same-tree commit",
+                )
+                .unwrap();
+            new_oid
+        };
+
+        let result =
+            gitbutler_branch_actions::stack_divergence::detect_diverged_stacks(ctx).unwrap();
+        match result {
+            DivergenceStatuses::DivergedRefs { divergences } => {
+                assert_eq!(divergences.len(), 1);
+                assert_eq!(divergences[0].actual_oid, Some(new_oid));
+                assert_eq!(divergences[0].status, DivergenceStatus::MovedToSameTree);
+            }
+            DivergenceStatuses::UpToDate => {
+                panic!("Expected divergence but got UpToDate");
+            }
+        }
+    }
+
+    /// When a stack ref is moved to a new commit above the base with different content,
+    /// detection should report MovedAboveBase.
+    #[test]
+    fn ref_moved_above_base_detected() {
+        let Test { repo, ctx, .. } = &mut Test::default();
+        let (_oid_one, _stack_entry) = setup_workspace_with_stack(repo, ctx);
+
+        // Create a new commit above the base with different tree content,
+        // then force-update the ref.
+        {
+            let raw_repo = repo.open();
+            let current_head = raw_repo
+                .find_reference("refs/heads/my-stack")
+                .unwrap()
+                .peel_to_commit()
+                .unwrap()
+                .id;
+            let old_commit = raw_repo.find_commit(current_head).unwrap();
+            let parent_ids: Vec<gix::ObjectId> =
+                old_commit.parent_ids().map(|id| id.detach()).collect();
+
+            // Write a new blob and tree that differs from the original.
+            let blob_id = raw_repo.write_blob("different content").unwrap().detach();
+            let mut editor = raw_repo.edit_tree(old_commit.tree_id().unwrap()).unwrap();
+            editor
+                .upsert(
+                    "changed_file.txt",
+                    gix::object::tree::EntryKind::Blob,
+                    blob_id,
+                )
+                .unwrap();
+            let new_tree = editor.write().unwrap().detach();
+
+            let committer: gix::actor::Signature = old_commit.committer().unwrap().into();
+            let author: gix::actor::Signature = old_commit.author().unwrap().into();
+            let commit = gix::objs::Commit {
+                tree: new_tree,
+                parents: parent_ids.into(),
+                author,
+                committer,
+                encoding: None,
+                message: "moved above base with different tree".into(),
+                extra_headers: vec![],
+            };
+            let new_oid = raw_repo.write_object(&commit).unwrap().detach();
+            raw_repo
+                .reference(
+                    "refs/heads/my-stack",
+                    new_oid,
+                    gix::refs::transaction::PreviousValue::Any,
+                    "test: move above base with new tree",
+                )
+                .unwrap();
+        }
+
+        let result =
+            gitbutler_branch_actions::stack_divergence::detect_diverged_stacks(ctx).unwrap();
+        match result {
+            DivergenceStatuses::DivergedRefs { divergences } => {
+                assert_eq!(divergences.len(), 1);
+                assert!(
+                    matches!(
+                        divergences[0].status,
+                        DivergenceStatus::MovedAboveBase { .. }
+                    ),
+                    "Expected MovedAboveBase, got {:?}",
+                    divergences[0].status
+                );
+            }
+            DivergenceStatuses::UpToDate => {
+                panic!("Expected divergence but got UpToDate");
+            }
+        }
+    }
+}
+
+/// Tests for the stack divergence resolution API.
+mod stack_divergence_resolution {
+    use gitbutler_branch::BranchCreateRequest;
+    use gitbutler_branch_actions::stack_divergence::{
+        DivergenceApproach, DivergenceResolution, DivergenceStatuses,
+    };
+    use gix::refs::transaction::PreviousValue;
+
+    use super::*;
+
+    /// Helper: set up workspace with one stack, return (early_oid, stack_entry).
+    fn setup_workspace_with_stack(
+        repo: &mut super::TestRepo,
+        ctx: &mut Context,
+    ) -> (gix::ObjectId, but_workspace::legacy::ui::StackEntryNoOpt) {
+        std::fs::write(repo.path().join("file.txt"), "one").unwrap();
+        let oid_one = repo.commit_all("one");
+        std::fs::write(repo.path().join("file.txt"), "two").unwrap();
+        repo.commit_all("two");
+        repo.push();
+
+        let mut guard = ctx.exclusive_worktree_access();
+        gitbutler_branch_actions::set_base_branch(
+            ctx,
+            &"refs/remotes/origin/master".parse().unwrap(),
+            guard.write_permission(),
+        )
+        .unwrap();
+        drop(guard);
+
+        let mut guard = ctx.exclusive_worktree_access();
+        let stack_entry = gitbutler_branch_actions::create_virtual_branch(
+            ctx,
+            &BranchCreateRequest {
+                name: Some("my-stack".into()),
+                ..Default::default()
+            },
+            guard.write_permission(),
+        )
+        .unwrap();
+        drop(guard);
+
+        std::fs::write(repo.path().join("another_file.txt"), "stack work").unwrap();
+        super::create_commit(ctx, stack_entry.id, "stack commit").unwrap();
+
+        (oid_one, stack_entry)
+    }
+
+    /// Resolving a diverged ref with Exclude should unapply the stack
+    /// and leave the workspace functional.
+    #[test]
+    fn exclude_unapplies_stack() {
+        let Test { repo, ctx, .. } = &mut Test::default();
+        let (oid_one, stack_entry) = setup_workspace_with_stack(repo, ctx);
+
+        // Force ref below base to trigger divergence.
+        {
+            let raw_repo = repo.open();
+            raw_repo
+                .reference(
+                    "refs/heads/my-stack",
+                    oid_one,
+                    PreviousValue::Any,
+                    "test: force below base",
+                )
+                .unwrap();
+        }
+
+        // Verify divergence is detected.
+        let statuses =
+            gitbutler_branch_actions::stack_divergence::detect_diverged_stacks(ctx).unwrap();
+        assert!(matches!(statuses, DivergenceStatuses::DivergedRefs { .. }));
+
+        // Resolve by excluding.
+        let mut guard = ctx.exclusive_worktree_access();
+        gitbutler_branch_actions::stack_divergence::resolve_diverged_stacks(
+            ctx,
+            &[DivergenceResolution {
+                stack_id: stack_entry.id,
+                approach: DivergenceApproach::Exclude,
+            }],
+            guard.write_permission(),
+        )
+        .unwrap();
+        drop(guard);
+
+        // Stack should no longer be in workspace.
+        let stacks = stack_details(ctx);
+        assert!(
+            stacks.is_empty() || stacks.iter().all(|(id, _)| *id != stack_entry.id),
+            "Excluded stack should not be in workspace"
+        );
+    }
+
+    /// Resolving with IncludeAsIs should rebuild the workspace commit
+    /// accepting the ref at its new position.
+    #[test]
+    fn include_as_is_rebuilds_workspace() {
+        let Test { repo, ctx, .. } = &mut Test::default();
+        let (_oid_one, _stack_entry) = setup_workspace_with_stack(repo, ctx);
+
+        // Move the ref to a new commit with different content (above base).
+        {
+            let raw_repo = repo.open();
+            let current_head = raw_repo
+                .find_reference("refs/heads/my-stack")
+                .unwrap()
+                .peel_to_commit()
+                .unwrap()
+                .id;
+            let old_commit = raw_repo.find_commit(current_head).unwrap();
+            let parent_ids: Vec<gix::ObjectId> =
+                old_commit.parent_ids().map(|id| id.detach()).collect();
+
+            let blob_id = raw_repo.write_blob("new content").unwrap().detach();
+            let mut editor = raw_repo.edit_tree(old_commit.tree_id().unwrap()).unwrap();
+            editor
+                .upsert("new_file.txt", gix::object::tree::EntryKind::Blob, blob_id)
+                .unwrap();
+            let new_tree = editor.write().unwrap().detach();
+
+            let committer: gix::actor::Signature = old_commit.committer().unwrap().into();
+            let author: gix::actor::Signature = old_commit.author().unwrap().into();
+            let commit = gix::objs::Commit {
+                tree: new_tree,
+                parents: parent_ids.into(),
+                author,
+                committer,
+                encoding: None,
+                message: "diverged commit".into(),
+                extra_headers: vec![],
+            };
+            let new_oid = raw_repo.write_object(&commit).unwrap().detach();
+            raw_repo
+                .reference(
+                    "refs/heads/my-stack",
+                    new_oid,
+                    PreviousValue::Any,
+                    "test: diverge above base",
+                )
+                .unwrap();
+        }
+
+        // Verify divergence is detected.
+        let statuses =
+            gitbutler_branch_actions::stack_divergence::detect_diverged_stacks(ctx).unwrap();
+        assert!(matches!(statuses, DivergenceStatuses::DivergedRefs { .. }));
+
+        let stack_id = match &statuses {
+            DivergenceStatuses::DivergedRefs { divergences } => divergences[0].stack_id,
+            _ => unreachable!(),
+        };
+
+        // Resolve by including as-is.
+        let mut guard = ctx.exclusive_worktree_access();
+        gitbutler_branch_actions::stack_divergence::resolve_diverged_stacks(
+            ctx,
+            &[DivergenceResolution {
+                stack_id,
+                approach: DivergenceApproach::IncludeAsIs,
+            }],
+            guard.write_permission(),
+        )
+        .unwrap();
+        drop(guard);
+
+        // After resolution, workspace should be up-to-date (no more divergence).
+        let statuses =
+            gitbutler_branch_actions::stack_divergence::detect_diverged_stacks(ctx).unwrap();
+        assert_eq!(
+            statuses,
+            DivergenceStatuses::UpToDate,
+            "After IncludeAsIs resolution, workspace should be up-to-date"
+        );
+
+        // The new file should be present in the worktree (checkout happened).
+        assert!(
+            repo.path().join("new_file.txt").exists(),
+            "new_file.txt should exist after including diverged ref"
+        );
+    }
+
+    /// After resolving with IncludeAsIs, creating new branches should work
+    /// (this is the fix for the production "already belongs to another branch" error).
+    #[test]
+    fn include_as_is_below_base_then_create_branch_works() {
+        let Test { repo, ctx, .. } = &mut Test::default();
+        let (oid_one, stack_entry) = setup_workspace_with_stack(repo, ctx);
+
+        // Force ref below base — this is the bug scenario.
+        {
+            let raw_repo = repo.open();
+            raw_repo
+                .reference(
+                    "refs/heads/my-stack",
+                    oid_one,
+                    PreviousValue::Any,
+                    "test: force below base",
+                )
+                .unwrap();
+        }
+
+        // Resolve by excluding the broken stack.
+        let mut guard = ctx.exclusive_worktree_access();
+        gitbutler_branch_actions::stack_divergence::resolve_diverged_stacks(
+            ctx,
+            &[DivergenceResolution {
+                stack_id: stack_entry.id,
+                approach: DivergenceApproach::Exclude,
+            }],
+            guard.write_permission(),
+        )
+        .unwrap();
+        drop(guard);
+
+        // Now creating a new branch should succeed (the bug is fixed).
+        let mut guard = ctx.exclusive_worktree_access();
+        let result = gitbutler_branch_actions::create_virtual_branch(
+            ctx,
+            &BranchCreateRequest::default(),
+            guard.write_permission(),
+        );
+        assert!(
+            result.is_ok(),
+            "Creating branch after resolving diverged stack should work: {:?}",
+            result.unwrap_err()
+        );
+    }
+}
+
 mod behind_count {
     use super::*;
 

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -364,6 +364,8 @@ fn main() -> anyhow::Result<()> {
                 legacy::virtual_branches::tauri_upstream_integration_statuses::upstream_integration_statuses,
                 legacy::virtual_branches::tauri_integrate_upstream::integrate_upstream,
                 legacy::virtual_branches::tauri_resolve_upstream_integration::resolve_upstream_integration,
+                legacy::virtual_branches::tauri_check_workspace_divergence::check_workspace_divergence,
+                legacy::virtual_branches::tauri_resolve_workspace_divergence::resolve_workspace_divergence,
                 legacy::stack::tauri_create_reference::create_reference,
                 legacy::stack::tauri_create_branch::create_branch,
                 legacy::stack::tauri_remove_branch::remove_branch,

--- a/crates/gitbutler-tauri/src/window.rs
+++ b/crates/gitbutler-tauri/src/window.rs
@@ -48,6 +48,10 @@ pub(crate) mod state {
                         name: format!("project://{project_id}/git/remote-activity"),
                         payload: serde_json::json!({}),
                     },
+                    Change::WorkspaceStackRefChanged { project_id } => ChangeForFrontend {
+                        name: format!("project://{project_id}/git/workspace-ref-changed"),
+                        payload: serde_json::json!({}),
+                    },
                     Change::WorktreeChanges {
                         project_id,
                         changes,

--- a/crates/gitbutler-watcher/src/events.rs
+++ b/crates/gitbutler-watcher/src/events.rs
@@ -22,4 +22,9 @@ pub enum Change {
         project_id: ProjectHandleOrLegacyProjectId,
         changes: but_hunk_assignment::WorktreeChanges,
     },
+    /// A workspace stack ref was changed externally (e.g. `git branch -f`).
+    /// The frontend should check for divergence and prompt the user.
+    WorkspaceStackRefChanged {
+        project_id: ProjectHandleOrLegacyProjectId,
+    },
 }

--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -173,12 +173,25 @@ impl Handler {
                 FETCH_HEAD => {
                     self.emit_app_event(Change::GitFetch(project_id.clone()))?;
                 }
-                // Watch all local branches. Only emit activity if the HEAD points to that ref.
+                // Watch all local branches. Emit activity if HEAD points to that ref,
+                // or workspace divergence if in workspace mode and it's a different ref.
                 _ if file_name.starts_with(LOCAL_REFS_DIR) && file_name == head_ref_name => {
                     self.emit_app_event(Change::GitActivity {
                         project_id: project_id.clone(),
                         head_sha: head_sha.clone(),
                     })?;
+                }
+                // A local branch ref changed that isn't HEAD — may be a workspace stack ref
+                // that was modified externally (e.g. `git branch -f`).
+                _ if file_name.starts_with(LOCAL_REFS_DIR) => {
+                    if matches!(
+                        operating_mode(ctx, perm.read_permission()),
+                        Ok(gitbutler_operating_modes::OperatingMode::OpenWorkspace)
+                    ) {
+                        self.emit_app_event(Change::WorkspaceStackRefChanged {
+                            project_id: project_id.clone(),
+                        })?;
+                    }
                 }
                 // Track remote ref changes to emit a single event after the loop.
                 _ if file_name.starts_with(REMOTE_REFS_DIR) => {

--- a/e2e/playwright/scripts/move-stack-ref-below-base.sh
+++ b/e2e/playwright/scripts/move-stack-ref-below-base.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Move the given stack's ref to the target base commit (i.e. below the workspace),
+# simulating an external tool corrupting the ref.
+#
+# Usage: move-stack-ref-below-base.sh <branch-name> <directory>
+#
+# This must be run AFTER the workspace is already set up and the branch is applied.
+
+set -euo pipefail
+
+BRANCH_NAME="$1"
+DIR="$2"
+
+echo "Moving ref '$BRANCH_NAME' below base in $DIR"
+
+pushd "$DIR"
+  # Find the target base commit (origin/master tip).
+  BASE_OID="$(git rev-parse origin/master)"
+  echo "Target base OID: $BASE_OID"
+
+  # Force-update the stack ref to point at the base commit.
+  git update-ref "refs/heads/$BRANCH_NAME" "$BASE_OID"
+  echo "Updated refs/heads/$BRANCH_NAME -> $BASE_OID"
+popd

--- a/e2e/playwright/scripts/move-stack-ref-to-conflicting-commit.sh
+++ b/e2e/playwright/scripts/move-stack-ref-to-conflicting-commit.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Move a branch ref to a NEW commit that conflicts with the target base tree.
+# This simulates an external force-push that introduces conflicting content.
+#
+# Usage: move-stack-ref-to-conflicting-commit.sh <branch-name> <directory>
+#
+# Creates a commit (not on any branch) whose tree conflicts with a_file at
+# the base, then moves the given ref to point at it.
+
+set -euo pipefail
+
+BRANCH_NAME="$1"
+DIR="$2"
+
+echo "Moving ref '$BRANCH_NAME' to a conflicting commit in $DIR"
+
+pushd "$DIR"
+  BASE_OID="$(git rev-parse origin/master)"
+
+  # Create a conflicting blob: overwrite a_file with different content.
+  CONFLICT_BLOB="$(echo 'CONFLICTING CONTENT' | git hash-object -w --stdin)"
+
+  # Build a tree that replaces a_file with the conflicting blob.
+  BASE_TREE="$(git rev-parse "${BASE_OID}^{tree}")"
+  NEW_TREE="$(git ls-tree "$BASE_TREE" | sed "s|[0-9a-f]\{40\}\ta_file|${CONFLICT_BLOB}\ta_file|" | git mktree)"
+
+  # Create a commit with this tree, parented on the base.
+  NEW_COMMIT="$(git commit-tree "$NEW_TREE" -p "$BASE_OID" -m 'external: conflicting change to a_file')"
+
+  git update-ref "refs/heads/$BRANCH_NAME" "$NEW_COMMIT"
+  echo "Updated refs/heads/$BRANCH_NAME -> $NEW_COMMIT (conflicts with base)"
+popd

--- a/e2e/playwright/scripts/move-stack-ref-to-inter-stack-conflict.sh
+++ b/e2e/playwright/scripts/move-stack-ref-to-inter-stack-conflict.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Move a branch ref to a new commit that conflicts with ANOTHER applied stack's changes.
+# This simulates a force-push that creates an inter-stack merge conflict.
+#
+# Usage: move-stack-ref-to-inter-stack-conflict.sh <branch-name> <directory>
+#
+# Creates a commit that appends different content to a_file at the same position
+# where branch1 also appends. This forces a true 3-way merge conflict when both
+# stacks are applied to the workspace.
+
+set -euo pipefail
+
+BRANCH_NAME="$1"
+DIR="$2"
+
+echo "Moving ref '$BRANCH_NAME' to an inter-stack conflicting commit in $DIR"
+
+pushd "$DIR"
+  BASE_OID="$(git rev-parse origin/master)"
+
+  # branch1 appends "branch1 commit 1" etc. to a_file starting at line 4.
+  # We also append at line 4, creating overlapping changes → real merge conflict.
+  BASE_TREE="$(git rev-parse "${BASE_OID}^{tree}")"
+
+  # Get base a_file content and append conflicting lines at the same position.
+  BASE_A_FILE="$(git cat-file -p "${BASE_TREE}:a_file")"
+  CONFLICT_BLOB="$(printf '%s\nINTER-STACK CONFLICT LINE\n' "$BASE_A_FILE" | git hash-object -w --stdin)"
+
+  # Build a tree with the modified a_file.
+  NEW_TREE="$(git ls-tree "$BASE_TREE" | sed "s|[0-9a-f]\{40\}\ta_file|${CONFLICT_BLOB}\ta_file|" | git mktree)"
+
+  # Create a commit with this tree, parented on the base.
+  NEW_COMMIT="$(git commit-tree "$NEW_TREE" -p "$BASE_OID" -m 'external: inter-stack conflicting change to a_file')"
+
+  git update-ref "refs/heads/$BRANCH_NAME" "$NEW_COMMIT"
+  echo "Updated refs/heads/$BRANCH_NAME -> $NEW_COMMIT (inter-stack conflict)"
+popd

--- a/e2e/playwright/scripts/project-with-diverged-stack-ref.sh
+++ b/e2e/playwright/scripts/project-with-diverged-stack-ref.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Setup a project where a stack ref has been moved below the target base,
+# simulating external ref corruption that triggers workspace divergence detection.
+#
+# This reproduces the production bug: "Branch cannot be created: target commit
+# already belongs to another branch."
+
+set -euo pipefail
+
+echo "GIT CONFIG $GIT_CONFIG_GLOBAL"
+echo "DATA DIR $E2E_TEST_APP_DATA_DIR"
+echo "BUT $BUT"
+
+# Create a remote repo with some history.
+mkdir remote-project
+pushd remote-project
+git init -b master --object-format=sha1
+echo "initial content" >> a_file
+git add a_file
+git commit -m "Initial commit"
+git checkout master
+popd
+
+# Clone it and set up GitButler workspace.
+git clone remote-project local-clone
+pushd local-clone
+  git checkout master
+  target_branch="$(git rev-parse --symbolic-full-name @{u})"
+  target_branch="${target_branch#refs/remotes/}"
+  "$BUT" setup
+  "$BUT" config target "$target_branch"
+popd

--- a/e2e/playwright/tests/workspaceDivergence.spec.ts
+++ b/e2e/playwright/tests/workspaceDivergence.spec.ts
@@ -1,0 +1,493 @@
+import { assertBranch, createNewBranch } from "../src/branch.ts";
+import { getBaseURL, type GitButler, startGitButler } from "../src/setup.ts";
+import { test } from "../src/test.ts";
+import { clickByTestId, getByTestId, waitForTestId } from "../src/util.ts";
+import { expect } from "@playwright/test";
+import * as fs from "fs";
+import * as path from "path";
+
+let gitbutler: GitButler;
+
+test.use({
+	baseURL: getBaseURL(),
+});
+
+test.afterEach(async () => {
+	await gitbutler?.destroy();
+});
+
+test("should detect diverged stack ref and allow resolution via modal", async ({
+	page,
+	context,
+}, testInfo) => {
+	const workdir = testInfo.outputPath("workdir");
+	const configdir = testInfo.outputPath("config");
+	gitbutler = await startGitButler(workdir, configdir, context);
+
+	// Set up a project with remote branches and apply one to the workspace.
+	await gitbutler.runScript("project-with-remote-branches.sh");
+	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
+
+	await page.goto("/");
+
+	// Workspace should load with one stack.
+	await waitForTestId(page, "workspace-view");
+	const stacks = getByTestId(page, "stack");
+	await expect(stacks).toHaveCount(1);
+
+	// Externally move the stack ref to the base commit (simulates corruption).
+	await gitbutler.runScript("move-stack-ref-below-base.sh", ["branch1", "local-clone"]);
+
+	// Reload the page to trigger fresh divergence detection.
+	await page.reload();
+	await waitForTestId(page, "workspace-view");
+
+	// The divergence modal should appear (may take a moment for the query to complete).
+	const modal = page.getByTestId("workspace-divergence-modal");
+	await modal.waitFor({ timeout: 30_000 });
+	await expect(modal).toBeVisible();
+
+	// There should be one divergence item.
+	const divergenceItems = modal.getByTestId("workspace-divergence-modal-divergence-item");
+	await expect(divergenceItems).toHaveCount(1);
+
+	// Click the Apply button to resolve.
+	await clickByTestId(page, "workspace-divergence-modal-action-button");
+
+	// Modal should close.
+	await expect(modal).not.toBeVisible();
+});
+
+test("should detect multiple diverged refs when several stacks are corrupted", async ({
+	page,
+	context,
+}, testInfo) => {
+	const workdir = testInfo.outputPath("workdir");
+	const configdir = testInfo.outputPath("config");
+	gitbutler = await startGitButler(workdir, configdir, context);
+
+	// Set up with independent branches and apply two of them.
+	await gitbutler.runScript("project-with-stacks.sh");
+	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
+	await gitbutler.runScript("apply-upstream-branch.sh", ["branch2", "local-clone"]);
+
+	await page.goto("/");
+
+	await waitForTestId(page, "workspace-view");
+	await expect(getByTestId(page, "stack")).toHaveCount(2);
+
+	// Move both refs below base (simulates external corruption of multiple stacks).
+	await gitbutler.runScript("move-stack-ref-below-base.sh", ["branch1", "local-clone"]);
+	await gitbutler.runScript("move-stack-ref-below-base.sh", ["branch2", "local-clone"]);
+
+	// Reload to trigger fresh divergence detection.
+	await page.reload();
+	await waitForTestId(page, "workspace-view");
+
+	// The modal should show both diverged stacks.
+	const modal = page.getByTestId("workspace-divergence-modal");
+	await modal.waitFor({ timeout: 30_000 });
+	await expect(modal).toBeVisible();
+
+	const divergenceItems = modal.getByTestId("workspace-divergence-modal-divergence-item");
+	await expect(divergenceItems).toHaveCount(2);
+
+	// Resolve both (default is Exclude for below-base).
+	await clickByTestId(page, "workspace-divergence-modal-action-button");
+
+	// Modal should close and both stacks should be excluded.
+	await expect(modal).not.toBeVisible();
+	await expect(getByTestId(page, "stack")).toHaveCount(0);
+
+	// Workspace should still be functional — create a new branch.
+	await createNewBranch(page, "fresh-branch");
+	await expect(getByTestId(page, "stack")).toHaveCount(1);
+});
+
+test("should allow creating a new branch after resolving divergence", async ({
+	page,
+	context,
+}, testInfo) => {
+	const workdir = testInfo.outputPath("workdir");
+	const configdir = testInfo.outputPath("config");
+	gitbutler = await startGitButler(workdir, configdir, context);
+
+	await gitbutler.runScript("project-with-remote-branches.sh");
+	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
+
+	await page.goto("/");
+
+	await waitForTestId(page, "workspace-view");
+	await expect(getByTestId(page, "stack")).toHaveCount(1);
+
+	// Corrupt the ref.
+	await gitbutler.runScript("move-stack-ref-below-base.sh", ["branch1", "local-clone"]);
+
+	// Reload to trigger divergence detection.
+	await page.reload();
+	await waitForTestId(page, "workspace-view");
+
+	// Wait for the divergence modal and resolve with default (Exclude for below-base).
+	await waitForTestId(page, "workspace-divergence-modal");
+	await clickByTestId(page, "workspace-divergence-modal-action-button");
+
+	// After excluding the diverged stack, workspace should have no stacks.
+	await expect(getByTestId(page, "stack")).toHaveCount(0);
+
+	// The key assertion: creating a new branch should succeed
+	// (this is the operation that previously failed with "target commit already belongs to another branch").
+	await createNewBranch(page, "fresh-branch");
+	await expect(getByTestId(page, "stack")).toHaveCount(1);
+});
+
+test("should show divergence modal with multiple refs when switching back to workspace", async ({
+	page,
+	context,
+}, testInfo) => {
+	const workdir = testInfo.outputPath("workdir");
+	const configdir = testInfo.outputPath("config");
+	gitbutler = await startGitButler(workdir, configdir, context);
+
+	// Set up workspace with two independent stacks.
+	await gitbutler.runScript("project-with-stacks.sh");
+	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
+	await gitbutler.runScript("apply-upstream-branch.sh", ["branch2", "local-clone"]);
+
+	await page.goto("/");
+	await waitForTestId(page, "workspace-view");
+	await expect(getByTestId(page, "stack")).toHaveCount(2);
+
+	// Leave workspace.
+	await gitbutler.runScript("project-with-remote-branches__checkout-master.sh", ["local-clone"]);
+	await assertBranch("master", workdir + "/local-clone");
+
+	// Move both refs below base while outside workspace (simulates CI force-push).
+	await gitbutler.runScript("move-stack-ref-below-base.sh", ["branch1", "local-clone"]);
+	await gitbutler.runScript("move-stack-ref-below-base.sh", ["branch2", "local-clone"]);
+
+	// Click "Back to workspace".
+	const switchButton = await waitForTestId(page, "chrome-header-switch-back-to-workspace-button");
+	await switchButton.click();
+
+	// Modal should appear with both diverged stacks.
+	const modal = page.getByTestId("workspace-divergence-modal");
+	await modal.waitFor({ timeout: 30_000 });
+	const divergenceItems = modal.getByTestId("workspace-divergence-modal-divergence-item");
+	await expect(divergenceItems).toHaveCount(2);
+
+	// Resolve both and verify workspace loads with no stacks.
+	await clickByTestId(page, "workspace-divergence-modal-action-button");
+	await expect(modal).not.toBeVisible();
+	await waitForTestId(page, "workspace-view");
+	await assertBranch("gitbutler/workspace", workdir + "/local-clone");
+	await expect(getByTestId(page, "stack")).toHaveCount(0);
+});
+
+test("should only show divergence for the affected stack when one of two is moved", async ({
+	page,
+	context,
+}, testInfo) => {
+	const workdir = testInfo.outputPath("workdir");
+	const configdir = testInfo.outputPath("config");
+	gitbutler = await startGitButler(workdir, configdir, context);
+
+	// Set up workspace with two independent stacks.
+	await gitbutler.runScript("project-with-stacks.sh");
+	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
+	await gitbutler.runScript("apply-upstream-branch.sh", ["branch2", "local-clone"]);
+
+	await page.goto("/");
+	await waitForTestId(page, "workspace-view");
+	await expect(getByTestId(page, "stack")).toHaveCount(2);
+
+	// Leave workspace.
+	await gitbutler.runScript("project-with-remote-branches__checkout-master.sh", ["local-clone"]);
+	await assertBranch("master", workdir + "/local-clone");
+
+	// Only move branch1 — branch2 stays where it was.
+	await gitbutler.runScript("move-stack-ref-below-base.sh", ["branch1", "local-clone"]);
+
+	// Click "Back to workspace".
+	const switchButton = await waitForTestId(page, "chrome-header-switch-back-to-workspace-button");
+	await switchButton.click();
+
+	// Modal should appear with only one diverged stack.
+	const modal = page.getByTestId("workspace-divergence-modal");
+	await modal.waitFor({ timeout: 30_000 });
+	const divergenceItems = modal.getByTestId("workspace-divergence-modal-divergence-item");
+	await expect(divergenceItems).toHaveCount(1);
+
+	// Resolve and verify workspace loads. branch2 should survive (it wasn't diverged).
+	await clickByTestId(page, "workspace-divergence-modal-action-button");
+	await expect(modal).not.toBeVisible();
+	await waitForTestId(page, "workspace-view");
+	await assertBranch("gitbutler/workspace", workdir + "/local-clone");
+	await expect(getByTestId(page, "stack")).toHaveCount(1);
+});
+
+test("should show divergence modal when switching back to workspace with diverged refs", async ({
+	page,
+	context,
+}, testInfo) => {
+	const workdir = testInfo.outputPath("workdir");
+	const configdir = testInfo.outputPath("config");
+	gitbutler = await startGitButler(workdir, configdir, context);
+
+	// Set up a project with a remote branch applied to the workspace.
+	await gitbutler.runScript("project-with-remote-branches.sh");
+	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
+
+	await page.goto("/");
+	await waitForTestId(page, "workspace-view");
+	await expect(getByTestId(page, "stack")).toHaveCount(1);
+
+	// Switch to master branch (leaving workspace).
+	await gitbutler.runScript("project-with-remote-branches__checkout-master.sh", ["local-clone"]);
+	await assertBranch("master", workdir + "/local-clone");
+
+	// Move the stack ref below base while outside workspace.
+	await gitbutler.runScript("move-stack-ref-below-base.sh", ["branch1", "local-clone"]);
+
+	// The "Back to workspace" button should appear.
+	const switchButton = await waitForTestId(page, "chrome-header-switch-back-to-workspace-button");
+	await switchButton.click();
+
+	// The divergence modal should appear instead of silently switching back.
+	const modal = page.getByTestId("workspace-divergence-modal");
+	await modal.waitFor({ timeout: 30_000 });
+	await expect(modal).toBeVisible();
+
+	// There should be one divergence item for branch1.
+	const divergenceItems = modal.getByTestId("workspace-divergence-modal-divergence-item");
+	await expect(divergenceItems).toHaveCount(1);
+
+	// Resolve (default for below-base is Exclude) and verify we're back in workspace.
+	await clickByTestId(page, "workspace-divergence-modal-action-button");
+	await expect(modal).not.toBeVisible();
+
+	// Wait for workspace to fully reload after resolution.
+	await waitForTestId(page, "workspace-view");
+
+	// Should be back on workspace with no stacks (the diverged one was excluded).
+	await assertBranch("gitbutler/workspace", workdir + "/local-clone");
+	await expect(getByTestId(page, "stack")).toHaveCount(0);
+});
+
+test("excluding a diverged stack removes its files from the working directory", async ({
+	page,
+	context,
+}, testInfo) => {
+	const workdir = testInfo.outputPath("workdir");
+	const configdir = testInfo.outputPath("config");
+	gitbutler = await startGitButler(workdir, configdir, context);
+
+	// project-with-stacks: branch2 creates b_file (independent from branch1's a_file).
+	await gitbutler.runScript("project-with-stacks.sh");
+	await gitbutler.runScript("apply-upstream-branch.sh", ["branch2", "local-clone"]);
+
+	await page.goto("/");
+	await waitForTestId(page, "workspace-view");
+	await expect(getByTestId(page, "stack")).toHaveCount(1);
+
+	const repoDir = path.join(workdir, "local-clone");
+
+	// b_file should exist in the working directory (branch2's content).
+	expect(fs.existsSync(path.join(repoDir, "b_file"))).toBe(true);
+
+	// Leave workspace and move the ref below base.
+	await gitbutler.runScript("project-with-remote-branches__checkout-master.sh", ["local-clone"]);
+	await gitbutler.runScript("move-stack-ref-below-base.sh", ["branch2", "local-clone"]);
+
+	// Switch back — modal should appear.
+	const switchButton = await waitForTestId(page, "chrome-header-switch-back-to-workspace-button");
+	await switchButton.click();
+
+	const modal = page.getByTestId("workspace-divergence-modal");
+	await modal.waitFor({ timeout: 30_000 });
+	await expect(modal.getByTestId("workspace-divergence-modal-divergence-item")).toHaveCount(1);
+
+	// Resolve with Exclude (default for below-base).
+	await clickByTestId(page, "workspace-divergence-modal-action-button");
+	await expect(modal).not.toBeVisible();
+	await waitForTestId(page, "workspace-view");
+
+	// b_file should no longer exist — the excluded branch's changes are gone.
+	expect(fs.existsSync(path.join(repoDir, "b_file"))).toBe(false);
+	// a_file should still exist (base content).
+	expect(fs.existsSync(path.join(repoDir, "a_file"))).toBe(true);
+});
+
+test("excluding one diverged stack preserves the healthy stack's files", async ({
+	page,
+	context,
+}, testInfo) => {
+	const workdir = testInfo.outputPath("workdir");
+	const configdir = testInfo.outputPath("config");
+	gitbutler = await startGitButler(workdir, configdir, context);
+
+	// branch2 creates b_file, branch3 creates c_file — independent files.
+	await gitbutler.runScript("project-with-stacks.sh");
+	await gitbutler.runScript("apply-upstream-branch.sh", ["branch2", "local-clone"]);
+	await gitbutler.runScript("apply-upstream-branch.sh", ["branch3", "local-clone"]);
+
+	await page.goto("/");
+	await waitForTestId(page, "workspace-view");
+	await expect(getByTestId(page, "stack")).toHaveCount(2);
+
+	const repoDir = path.join(workdir, "local-clone");
+
+	// Both stacks' files should be present.
+	expect(fs.existsSync(path.join(repoDir, "b_file"))).toBe(true);
+	expect(fs.existsSync(path.join(repoDir, "c_file"))).toBe(true);
+
+	// Leave workspace and move branch3's ref below base.
+	await gitbutler.runScript("project-with-remote-branches__checkout-master.sh", ["local-clone"]);
+	await gitbutler.runScript("move-stack-ref-below-base.sh", ["branch3", "local-clone"]);
+
+	// Switch back — modal shows diverged stacks. branch3 was moved below base (Exclude),
+	// branch2 may also appear as diverged if `but apply` rebased its commits (Include as-is).
+	const switchButton = await waitForTestId(page, "chrome-header-switch-back-to-workspace-button");
+	await switchButton.click();
+
+	const modal = page.getByTestId("workspace-divergence-modal");
+	await modal.waitFor({ timeout: 30_000 });
+
+	// Accept defaults: branch3 → Exclude, branch2 → Include as-is (if present).
+	await clickByTestId(page, "workspace-divergence-modal-action-button");
+	await expect(modal).not.toBeVisible();
+	await waitForTestId(page, "workspace-view");
+
+	// branch2 was included — b_file should still exist with its content.
+	expect(fs.existsSync(path.join(repoDir, "b_file"))).toBe(true);
+	const bFileContent = fs.readFileSync(path.join(repoDir, "b_file"), "utf-8");
+	expect(bFileContent).toContain("branch2 commit 1");
+
+	// branch3 was excluded — c_file should be gone.
+	expect(fs.existsSync(path.join(repoDir, "c_file"))).toBe(false);
+
+	// At least one stack remaining (branch2 survived).
+	await expect(getByTestId(page, "stack")).toHaveCount(1);
+});
+
+test("ref moved to different commit shows moved status and excluding removes its content", async ({
+	page,
+	context,
+}, testInfo) => {
+	const workdir = testInfo.outputPath("workdir");
+	const configdir = testInfo.outputPath("config");
+	gitbutler = await startGitButler(workdir, configdir, context);
+
+	// branch1 modifies a_file; we'll move its ref to a commit that also modifies
+	// a_file differently, simulating an external force-push.
+	await gitbutler.runScript("project-with-remote-branches.sh");
+	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
+
+	await page.goto("/");
+	await waitForTestId(page, "workspace-view");
+	await expect(getByTestId(page, "stack")).toHaveCount(1);
+
+	const repoDir = path.join(workdir, "local-clone");
+	const aFileBefore = fs.readFileSync(path.join(repoDir, "a_file"), "utf-8");
+	expect(aFileBefore).toContain("branch1 commit 1");
+
+	// Leave workspace.
+	await gitbutler.runScript("project-with-remote-branches__checkout-master.sh", ["local-clone"]);
+
+	// Move the ref to a commit with different content.
+	await gitbutler.runScript("move-stack-ref-to-conflicting-commit.sh", ["branch1", "local-clone"]);
+
+	// Switch back — modal should show the divergence.
+	const switchButton = await waitForTestId(page, "chrome-header-switch-back-to-workspace-button");
+	await switchButton.click();
+
+	const modal = page.getByTestId("workspace-divergence-modal");
+	await modal.waitFor({ timeout: 30_000 });
+
+	const divergenceItems = modal.getByTestId("workspace-divergence-modal-divergence-item");
+	await expect(divergenceItems).toHaveCount(1);
+
+	// The item should indicate the branch has moved.
+	await expect(divergenceItems.first()).toContainText(/Moved/);
+
+	// Explicitly select "Exclude" from the resolution dropdown.
+	const selectTrigger = divergenceItems.first().getByRole("textbox");
+	await selectTrigger.click();
+	const excludeOption = page.getByRole("listbox").getByText("Exclude", { exact: true });
+	await excludeOption.click();
+
+	// Resolve and verify the external content is NOT in the workspace.
+	await clickByTestId(page, "workspace-divergence-modal-action-button");
+	await expect(modal).not.toBeVisible();
+	await waitForTestId(page, "workspace-view");
+
+	// After excluding, a_file should have the base content only — no branch content.
+	const aFileAfter = fs.readFileSync(path.join(repoDir, "a_file"), "utf-8");
+	expect(aFileAfter).not.toContain("branch1 commit 1");
+	expect(aFileAfter).not.toContain("CONFLICTING CONTENT");
+	await expect(getByTestId(page, "stack")).toHaveCount(0);
+});
+
+test("inter-stack conflict: moved ref conflicting with another stack defaults to exclude", async ({
+	page,
+	context,
+}, testInfo) => {
+	const workdir = testInfo.outputPath("workdir");
+	const configdir = testInfo.outputPath("config");
+	gitbutler = await startGitButler(workdir, configdir, context);
+
+	// branch1 modifies a_file, branch2 creates b_file — independent.
+	await gitbutler.runScript("project-with-stacks.sh");
+	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
+	await gitbutler.runScript("apply-upstream-branch.sh", ["branch2", "local-clone"]);
+
+	await page.goto("/");
+	await waitForTestId(page, "workspace-view");
+	await expect(getByTestId(page, "stack")).toHaveCount(2);
+
+	const repoDir = path.join(workdir, "local-clone");
+
+	// branch1's changes should be present in a_file.
+	expect(fs.readFileSync(path.join(repoDir, "a_file"), "utf-8")).toContain("branch1 commit 1");
+	// branch2's b_file should exist.
+	expect(fs.existsSync(path.join(repoDir, "b_file"))).toBe(true);
+
+	// Leave workspace.
+	await gitbutler.runScript("project-with-remote-branches__checkout-master.sh", ["local-clone"]);
+	await assertBranch("master", repoDir);
+
+	// Move branch2's ref to a commit that appends different content to a_file at the
+	// same position where branch1 also appends. Both sides add at line 4, creating a
+	// true 3-way merge conflict between the two stacks.
+	await gitbutler.runScript("move-stack-ref-to-inter-stack-conflict.sh", [
+		"branch2",
+		"local-clone",
+	]);
+
+	// Switch back — divergence modal should appear.
+	const switchButton = await waitForTestId(page, "chrome-header-switch-back-to-workspace-button");
+	await switchButton.click();
+
+	const modal = page.getByTestId("workspace-divergence-modal");
+	await modal.waitFor({ timeout: 30_000 });
+
+	// At least one divergence item should mention conflict (branch2's inter-stack conflict).
+	const hasConflictLabel = await modal.getByText(/conflict/i).count();
+	expect(hasConflictLabel).toBeGreaterThan(0);
+
+	// Resolve with defaults — conflicted stacks default to Exclude.
+	await clickByTestId(page, "workspace-divergence-modal-action-button");
+	await expect(modal).not.toBeVisible();
+	await waitForTestId(page, "workspace-view");
+	await assertBranch("gitbutler/workspace", repoDir);
+
+	// branch1 should survive — its a_file content should be present.
+	const aFileContent = fs.readFileSync(path.join(repoDir, "a_file"), "utf-8");
+	expect(aFileContent).toContain("branch1 commit 1");
+	// The conflicting content from the moved branch2 should NOT be present.
+	expect(aFileContent).not.toContain("INTER-STACK CONFLICT LINE");
+	// b_file should be gone — branch2's original content was excluded.
+	expect(fs.existsSync(path.join(repoDir, "b_file"))).toBe(false);
+
+	// At least one stack (branch1) should remain.
+	await expect(getByTestId(page, "stack")).toHaveCount(1);
+});

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -940,6 +940,43 @@ export type DiffSpec = {
   hunkHeaders: Array<HunkHeader>;
 };
 
+/** What the user wants to do with a diverged stack. */
+export type DivergenceApproach = {
+  type: "includeAsIs";
+} | {
+  type: "includeRebase";
+} | {
+  type: "exclude";
+};
+
+/** A user's chosen resolution for a single diverged stack. */
+export type DivergenceResolution = {
+  stackId: string;
+  approach: DivergenceApproach;
+};
+
+/** How a stack ref has diverged from its expected position. */
+export type DivergenceStatus = {
+  type: "deleted";
+} | {
+  conflicted: boolean;
+  type: "movedAboveBase";
+} | {
+  type: "movedBelowBase";
+} | {
+  type: "movedToSameTree";
+};
+
+/** Top-level result of divergence detection. */
+export type DivergenceStatuses = {
+  type: "upToDate";
+} | {
+  type: "divergedRefs";
+  subject: {
+    divergences: Array<StackRefDivergence>;
+  };
+};
+
 /** Holds relevant state required to switch to and from edit mode */
 export type EditModeMetadata = {
   /** The sha of the commit getting edited. */
@@ -1256,6 +1293,8 @@ export type GixTime = {
 export type HeadAndMode = {
   head: string | null;
   operatingMode: OperatingMode;
+  /** Divergence detection result, populated only when in workspace mode. */
+  divergence: DivergenceStatuses | null;
 };
 
 export type HeadSha = {
@@ -1836,6 +1875,20 @@ export type StackHeadInfo = {
   isCheckedOut: boolean;
 };
 
+/** Per-stack divergence info returned to the frontend. */
+export type StackRefDivergence = {
+  /** The stack that diverged. */
+  stackId: string;
+  /** The branch ref name (tip of the stack). */
+  refName: string;
+  /** Where the workspace commit expected this stack's head to be. */
+  expectedOid: string;
+  /** Where the ref actually points now (`None` if the ref was deleted). */
+  actualOid: string | null;
+  /** Classification of the divergence. */
+  status: DivergenceStatus;
+};
+
 /** Represents a reference to an associated virtual branch */
 export type StackReference = {
   /** A non-normalized name of the branch, set by the user */
@@ -1866,6 +1919,22 @@ export type StackStatuses = {
     worktreeConflicts: Array<string>;
     statuses: Array<[string | null, StackStatus]>;
   };
+};
+
+/**
+ * Result of attempting to switch back to the workspace.
+ *
+ * When no divergence is detected (or resolutions were provided and applied),
+ * returns `Ok` with the base branch data. When divergence is detected and
+ * no resolutions were provided, returns `Diverged` so the frontend can
+ * present resolution options before retrying.
+ */
+export type SwitchBackToWorkspaceResult = {
+  baseBranch: BaseBranch;
+  type: "ok";
+} | {
+  divergences: Array<StackRefDivergence>;
+  type: "diverged";
 };
 
 /** Information about the target reference, the one we want to integrate with. */

--- a/packages/ui/src/lib/utils/testIds.ts
+++ b/packages/ui/src/lib/utils/testIds.ts
@@ -168,6 +168,9 @@ export enum TestId {
 	DiscardFileChangesConfirmationModal = "discard-file-changes-confirmation-modal",
 	DiscardFileChangesConfirmationModal_Cancel = "discard-file-changes-confirmation-modal-cancel",
 	DiscardFileChangesConfirmationModal_Discard = "discard-file-changes-confirmation-modal-discard",
+	WorkspaceDivergenceModal = "workspace-divergence-modal",
+	WorkspaceDivergenceModal_DivergenceItem = "workspace-divergence-modal-divergence-item",
+	WorkspaceDivergenceModal_ActionButton = "workspace-divergence-modal-action-button",
 }
 
 export enum ElementId {


### PR DESCRIPTION
## Problem

Fix: "Branch cannot be created: target commit already belongs to
another branch".

The workspace commit records each stack's head OID as a parent.
When a branch ref moves externally (CI force-push, another git
client, rebase) the parent becomes stale:

    workspace commit parents      actual refs
    ├── origin/master             origin/master
    ├── stack A  →  abc123        refs/heads/branchA  →  xyz789  ← moved!
    └── stack B  →  def456        refs/heads/branchB  →  def456  ✓

This stale state corrupts the commit graph, causing branch-creation
and workspace-update failures.

## Solution

Two-phase detect → resolve flow, surfaced via a modal or auto-resolved
in the CLI.

**Phase 1 — Detection** (`detect_diverged_stacks`):
Compare each workspace parent against its ref and classify the
divergence:

    Status              Meaning                          Default
    ────────────────────────────────────────────────────────────────
    Deleted             ref no longer exists              Exclude
    MovedBelowBase      ref at or below target base       Exclude
    MovedAboveBase      ref moved, still has commits      IncludeAsIs
      conflicted=true     …and conflicts with workspace  Exclude
    MovedToSameTree     ref moved, tree is identical      IncludeAsIs

A second pass (`check_inter_stack_conflicts`) catches cases where a
moved ref doesn't conflict with the base but DOES conflict with
another applied stack, by simulating the workspace merge per-stack.

**Phase 2 — Resolution** (user picks per stack):
- IncludeAsIs — keep ref at its new position
- IncludeRebase — rebase stack commits onto target base
- Exclude — unapply the stack

**Entry points:**
- Desktop: "Back to workspace" button → modal
- In-workspace: watcher detects ref change → modal
- CLI: `but setup` → auto-exclude diverged stacks

## Frontend integration

Divergence data is embedded in the `HeadAndMode` response (the
existing `operating_mode` endpoint) rather than a separate query.
The `headAndMode` cache re-invokes on both `git/head` and
`workspace-ref-changed` events, so divergence updates arrive
automatically alongside mode changes.

## Testing

10 Playwright e2e tests covering single/multiple diverged refs,
partial divergence, file-content assertions, conflicting content,
inter-stack merge conflicts, and both in-workspace and switch-back
flows. Plus a Rust integration test suite in `create_reference.rs`.

## E2E Video

[video.webm](https://github.com/user-attachments/assets/5bf48267-2de7-4577-9556-de03106e9ab9)
