### PR TITLE
Fix "Cannot delete a branch that is applied" error in branches view

### DIFF
--- a/apps/desktop/src/components/views/BranchesView.svelte
+++ b/apps/desktop/src/components/views/BranchesView.svelte
@@ -303,7 +303,7 @@
 										{@const hasLocal = listing.hasLocal}
 										<!-- Apply branch -->
 
-										{#if branchName && !inWorkspace}
+										{#if branchName && inWorkspace !== true}
 											<div class="branch-actions">
 												<AsyncButton
 													testId={TestId.BranchesViewApplyBranchButton}


### PR DESCRIPTION
The apply/delete buttons in `BranchesView.svelte` were guarded by `!inWorkspace`, where `inWorkspace` comes from `branch.stack?.inWorkspace`. When a branch has no stack association (`branch.stack` is `null`), `inWorkspace` is `undefined`, and `!undefined` is truthy — so the buttons appeared for branches the backend still considers applied.

Changed the guard to `inWorkspace !== true`, which correctly hides buttons only when the branch is known to be in the workspace, and shows them when the status is `false` (not applied) or `undefined` (no stack).

