### PR TITLE
Fix stuck UI after unapply failure

### DIFF
--- a/apps/desktop/src/components/branch/BranchHeaderContextMenu.svelte
+++ b/apps/desktop/src/components/branch/BranchHeaderContextMenu.svelte
@@ -342,8 +342,11 @@
 					testId={TestId.BranchHeaderContextMenu_UnapplyBranch}
 					disabled={isReadOnly}
 					onclick={async () => {
-						await stackService.unapply({ projectId, stackId });
-						close();
+						try {
+							await stackService.unapply({ projectId, stackId });
+						} finally {
+							close();
+						}
 					}}
 				/>
 			</ContextMenuSection>

--- a/apps/desktop/src/components/stack/StackDragHandle.svelte
+++ b/apps/desktop/src/components/stack/StackDragHandle.svelte
@@ -88,13 +88,16 @@
 	async function unapplyStack() {
 		if (!stackId) return;
 
-		await stackService.unapply({
-			projectId,
-			stackId,
-		});
-
-		// Refetch to update the UI
-		await stacksQuery.result.refetch();
+		try {
+			await stackService.unapply({
+				projectId,
+				stackId,
+			});
+		} finally {
+			// Always refetch to clear stale stacks from the UI,
+			// even if the unapply failed (e.g. branch already removed).
+			await stacksQuery.result.refetch();
+		}
 	}
 </script>
 


### PR DESCRIPTION
When `stackService.unapply()` fails (e.g. branch already removed, backend error), the UI gets stuck — context menus stay open and stale stacks remain visible because the cleanup code only ran on the success path.

In `BranchHeaderContextMenu.svelte`, `close()` was called sequentially after `await unapply()`, and in `StackDragHandle.svelte`, `stacksQuery.result.refetch()` was likewise awaited after the call. An error in either case meant cleanup never executed.

Wrapped both call sites in `try/finally` so cleanup always runs regardless of whether the backend call succeeds or fails.