### PR TITLE
Launch WSL editor URLs via CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,6 +956,7 @@ dependencies = [
  "boolean-enums",
  "bstr",
  "but-action",
+ "but-api",
  "but-api-macros",
  "but-askpass",
  "but-cherry-apply",

--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -143,6 +143,7 @@ which = "8.0.2"
 but-schemars.workspace = true
 
 [dev-dependencies]
+but-api = { path = ".", features = ["legacy"]}
 insta.workspace = true
 tempfile.workspace = true
 

--- a/crates/but-api/src/legacy/open.rs
+++ b/crates/but-api/src/legacy/open.rs
@@ -25,6 +25,11 @@ pub(crate) fn open_that(target_url: &Url) -> anyhow::Result<()> {
         bail!("Invalid path scheme: {}", target_url.scheme());
     }
 
+    #[cfg(target_os = "linux")]
+    if open_wsl_editor_url(target_url) {
+        return Ok(());
+    }
+
     fn clean_env_vars<'a, 'b>(
         var_names: &'a [&'b str],
     ) -> impl Iterator<Item = (&'b str, String)> + 'a {
@@ -92,6 +97,150 @@ pub(crate) fn open_that(target_url: &Url) -> anyhow::Result<()> {
         bail!("Errors occurred: {cmd_errors:?}");
     }
     Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn open_wsl_editor_url(target_url: &Url) -> bool {
+    use std::process::Command;
+
+    if !is_wsl() {
+        return false;
+    }
+
+    let Some((command, args)) = wsl_editor_invocation(target_url) else {
+        return false;
+    };
+
+    let mut cmd = Command::new(command);
+    cmd.args(args);
+    tracing::info!(?cmd, "editor command");
+    matches!(cmd.status(), Ok(status) if status.success())
+}
+
+#[cfg(target_os = "linux")]
+fn is_wsl() -> bool {
+    env::var_os("WSL_DISTRO_NAME").is_some() || env::var_os("WSL_INTEROP").is_some()
+}
+
+#[cfg(target_os = "linux")]
+fn wsl_editor_invocation(target_url: &Url) -> Option<(&'static str, Vec<String>)> {
+    let command = wsl_editor_command(target_url.scheme())?;
+    if target_url.host_str() != Some("file") {
+        return None;
+    }
+
+    let path = editor_url_path(target_url)?;
+    if path.is_empty() {
+        return None;
+    }
+
+    let mut args = Vec::new();
+    if target_url
+        .query_pairs()
+        .any(|(key, value)| key == "windowId" && value == "_blank")
+    {
+        args.push("--new-window".to_owned());
+    }
+
+    if path_has_position(&path) {
+        args.push("--goto".to_owned());
+    }
+    args.push(path);
+
+    Some((command, args))
+}
+
+#[cfg(target_os = "linux")]
+fn wsl_editor_command(scheme: &str) -> Option<&'static str> {
+    match scheme {
+        "vscode" => Some("code"),
+        "vscode-insiders" => Some("code-insiders"),
+        "vscodium" => Some("codium"),
+        "cursor" => Some("cursor"),
+        "windsurf" => Some("windsurf"),
+        "trae" => Some("trae"),
+        _ => None,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn editor_url_path(target_url: &Url) -> Option<String> {
+    let file_url = Url::parse(&format!("file://{}", target_url.path())).ok()?;
+    file_url
+        .to_file_path()
+        .ok()?
+        .into_os_string()
+        .into_string()
+        .ok()
+}
+
+#[cfg(target_os = "linux")]
+fn path_has_position(path: &str) -> bool {
+    let Some((_, line_or_column)) = path.rsplit_once(':') else {
+        return false;
+    };
+
+    line_or_column.parse::<u32>().is_ok()
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cursor_editor_url_becomes_goto_cli_invocation() {
+        let url = Url::parse("cursor://file/home/example/project/src/main.rs:42:7").unwrap();
+
+        assert_eq!(
+            wsl_editor_invocation(&url),
+            Some((
+                "cursor",
+                vec![
+                    "--goto".to_owned(),
+                    "/home/example/project/src/main.rs:42:7".to_owned(),
+                ],
+            ))
+        );
+    }
+
+    #[test]
+    fn vscode_project_url_becomes_new_window_cli_invocation() {
+        let url = Url::parse("vscode://file/home/example/project?windowId=_blank").unwrap();
+
+        assert_eq!(
+            wsl_editor_invocation(&url),
+            Some((
+                "code",
+                vec![
+                    "--new-window".to_owned(),
+                    "/home/example/project".to_owned()
+                ]
+            ))
+        );
+    }
+
+    #[test]
+    fn editor_url_paths_are_percent_decoded() {
+        let url = Url::parse("vscode://file/home/example/My%20Project/src/lib.rs:3").unwrap();
+
+        assert_eq!(
+            wsl_editor_invocation(&url),
+            Some((
+                "code",
+                vec![
+                    "--goto".to_owned(),
+                    "/home/example/My Project/src/lib.rs:3".to_owned(),
+                ],
+            ))
+        );
+    }
+
+    #[test]
+    fn unsupported_editor_scheme_falls_back_to_url_handler() {
+        let url = Url::parse("zed://file/home/example/project/src/main.rs:42").unwrap();
+
+        assert_eq!(wsl_editor_invocation(&url), None);
+    }
 }
 
 #[but_api]

--- a/crates/but-api/src/legacy/open.rs
+++ b/crates/but-api/src/legacy/open.rs
@@ -25,8 +25,7 @@ pub(crate) fn open_that(target_url: &Url) -> anyhow::Result<()> {
         bail!("Invalid path scheme: {}", target_url.scheme());
     }
 
-    #[cfg(target_os = "linux")]
-    if open_wsl_editor_url(target_url) {
+    if open_editor_url_as_command_invocation_on_wsl(target_url) {
         return Ok(());
     }
 
@@ -99,8 +98,14 @@ pub(crate) fn open_that(target_url: &Url) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[cfg(target_os = "linux")]
-fn open_wsl_editor_url(target_url: &Url) -> bool {
+/// Opens supported editor URLs directly inside WSL.
+///
+/// The normal URL opener can fail to route `vscode://file/...`-style URLs back
+/// to Linux editor CLIs when GitButler runs in WSL, so this attempts a direct
+/// invocation first. Returns `true` only when a supported editor command was
+/// executed successfully; unsupported URLs and failed launches fall back to the
+/// generic opener.
+fn open_editor_url_as_command_invocation_on_wsl(target_url: &Url) -> bool {
     use std::process::Command;
 
     if !is_wsl() {
@@ -117,41 +122,59 @@ fn open_wsl_editor_url(target_url: &Url) -> bool {
     matches!(cmd.status(), Ok(status) if status.success())
 }
 
-#[cfg(target_os = "linux")]
 fn is_wsl() -> bool {
-    env::var_os("WSL_DISTRO_NAME").is_some() || env::var_os("WSL_INTEROP").is_some()
+    cfg!(target_os = "linux") && env::var_os("WSL_DISTRO_NAME").is_some()
+        || env::var_os("WSL_INTEROP").is_some()
 }
 
-#[cfg(target_os = "linux")]
+/// Builds the editor CLI command needed to open a WSL editor URL.
+///
+/// Returns the executable name and argument list for supported
+/// `editor://file/...` URLs, including `--new-window` and `--goto` when the URL
+/// requests them.
+/// Returns `None` when the URL does not target a supported editor,
+/// is not a file URL, or cannot be converted into a non-empty local path.
 fn wsl_editor_invocation(target_url: &Url) -> Option<(&'static str, Vec<String>)> {
-    let command = wsl_editor_command(target_url.scheme())?;
     if target_url.host_str() != Some("file") {
         return None;
     }
-
+    let command = scheme_to_wsl_editor_command(target_url.scheme())?;
     let path = editor_url_path(target_url)?;
     if path.is_empty() {
         return None;
     }
 
     let mut args = Vec::new();
-    if target_url
-        .query_pairs()
-        .any(|(key, value)| key == "windowId" && value == "_blank")
-    {
-        args.push("--new-window".to_owned());
-    }
+    if is_vscode_or_compatible(target_url.scheme()) {
+        if target_url
+            .query_pairs()
+            .any(|(key, value)| key == "windowId" && value == "_blank")
+        {
+            args.push("--new-window".to_owned());
+        }
 
-    if path_has_position(&path) {
-        args.push("--goto".to_owned());
+        if path_has_position(&path) {
+            args.push("--goto".to_owned());
+        }
     }
     args.push(path);
 
     Some((command, args))
 }
 
-#[cfg(target_os = "linux")]
-fn wsl_editor_command(scheme: &str) -> Option<&'static str> {
+fn is_vscode_or_compatible(scheme: &str) -> bool {
+    matches!(
+        scheme,
+        "vscode" | "vscode-insiders" | "vscodium" | "cursor" | "windsurf" | "trae"
+    )
+}
+
+/// Maps editor URL schemes to the CLI binaries expected in the WSL PATH.
+///
+/// WSL editor URLs use stable protocol schemes such as `vscode://`, but the
+/// Linux launch path needs the editor's command-line executable instead of the
+/// URL scheme. Unsupported schemes are left for the generic URL opener.
+fn scheme_to_wsl_editor_command(scheme: &str) -> Option<&'static str> {
     match scheme {
         "vscode" => Some("code"),
         "vscode-insiders" => Some("code-insiders"),
@@ -159,22 +182,22 @@ fn wsl_editor_command(scheme: &str) -> Option<&'static str> {
         "cursor" => Some("cursor"),
         "windsurf" => Some("windsurf"),
         "trae" => Some("trae"),
-        _ => None,
+        _ => {
+            tracing::warn!(%scheme, "missing WSL editor scheme mapping");
+            None
+        }
     }
 }
 
-#[cfg(target_os = "linux")]
 fn editor_url_path(target_url: &Url) -> Option<String> {
     let file_url = Url::parse(&format!("file://{}", target_url.path())).ok()?;
     file_url
         .to_file_path()
         .ok()?
-        .into_os_string()
-        .into_string()
-        .ok()
+        .to_str()
+        .map(ToOwned::to_owned)
 }
 
-#[cfg(target_os = "linux")]
 fn path_has_position(path: &str) -> bool {
     let Some((_, line_or_column)) = path.rsplit_once(':') else {
         return false;
@@ -183,8 +206,8 @@ fn path_has_position(path: &str) -> bool {
     line_or_column.parse::<u32>().is_ok()
 }
 
-#[cfg(all(test, target_os = "linux"))]
-mod tests {
+#[cfg(test)]
+mod wsl_tests {
     use super::*;
 
     #[test]


### PR DESCRIPTION
  ## Summary

  Fix opening VS Code-compatible editor URLs when GitButler is running inside WSL.

  Before this change, editor URLs such as `vscode://file/...` or `cursor://file/...` did not open the
editor from WSL. They were passed to the normal Linux URL opener and ended up opening the browser
instead.

  For supported editors, GitButler now launches the matching editor CLI directly and keeps the existing
opener as a fallback.

  ## Changes

  - Detect WSL on Linux before using the generic URL opener.
  - Launch supported editor URLs through their CLI:
    - `vscode` -> `code`
    - `vscode-insiders` -> `code-insiders`
    - `vscodium` -> `codium`
    - `cursor` -> `cursor`
    - `windsurf` -> `windsurf`
    - `trae` -> `trae`
  - Preserve `windowId=_blank` with `--new-window`.
  - Preserve line/column targets with `--goto`.
  - No new dependencies.

  ## Validation

  - `cargo fmt --check --all`
  - `cargo test -p but-api --features legacy open::tests --lib`

  Manual WSL check:
  - Built and installed GitButler locally for WSL and Windows.
  - Before: editor URLs opened the browser instead of the editor.
  - After: editor URLs from a WSL-backed project open through the editor CLI.
  - Unsupported schemes still fall back to the existing opener path.

  AI assistance was used while preparing the patch. I reviewed the diff and tested it on a Windows/WSL
setup.