### PR TITLE
Remove dead segment-pruning workarounds from collect_stack_segments

### DIFF
--- a/crates/but-graph/src/projection/workspace/init.rs
+++ b/crates/but-graph/src/projection/workspace/init.rs
@@ -612,7 +612,6 @@ impl Graph {
         mut starts_next_stack_segment: impl FnMut(&Segment) -> bool,
         mut discard_stack: impl FnMut(&StackSegment) -> bool,
     ) -> anyhow::Result<Option<Vec<StackSegment>>> {
-        // TODO: Test what happens if a workspace commit is pointed at by a different ref (which is the entrypoint).
         let mut out = Vec::new();
         let mut next = Some(from);
         while let Some(from) = next.take() {
@@ -639,34 +638,7 @@ impl Graph {
                 .is_none_or(|c| c == Category::LocalBranch)
         }
 
-        // Prune empty invalid ones from the front as cleanup.
-        // This isn't an issue for algorithms as they always see the full version.
-        // TODO: remove this once we don't have remotes in a workspace because traversal logic can do it better.
-        if let Some(end) = out
-            .iter()
-            .enumerate()
-            .take_while(|(_idx, s)| s.commits.is_empty() && !is_entrypoint_or_local(s))
-            .map(|(idx, _s)| idx + 1)
-            .last()
-        {
-            out.drain(..end);
-        }
-
-        // Definitely remove non-local empties from behind.
-        // TODO: revise this
-        if let Some(new_len) = out
-            .iter()
-            .enumerate()
-            .rev()
-            .take_while(|(_idx, s)| s.commits.is_empty() && !is_entrypoint_or_local(s))
-            .last()
-            .map(|(idx, _s)| idx)
-        {
-            out.truncate(new_len);
-        }
-
-        // TODO: remove the hack of avoiding empty segments as special case, remove .is_empty() condition
-        let is_pruned = |s: &StackSegment| !s.commits.is_empty() && !is_entrypoint_or_local(s);
+        let is_pruned = |s: &StackSegment| !is_entrypoint_or_local(s);
         // Prune the whole stack if we start with unwanted segments.
         if out
             .first()
@@ -680,18 +652,6 @@ impl Graph {
             return Ok(None);
         }
 
-        // We may have picked up unwanted segments, if the graph isn't perfectly clean
-        // TODO: remove this to rather assure that non-local branches aren't linked up that way.
-        if let Some(new_len) = out
-            .iter()
-            .enumerate()
-            .rev()
-            .take_while(|(_idx, s)| is_pruned(s))
-            .last()
-            .map(|(idx, _s)| idx)
-        {
-            out.truncate(new_len);
-        }
         Ok((!out.is_empty()).then_some(out))
     }
 

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -1593,7 +1593,8 @@ EOF
 
   # A workspace where the only ref on the branch commits is origin/A (remote).
   # The local branch never existed - only the remote was fetched.
-  # This tests whether a remote-only ref as the first stack segment is pruned.
+  # This tests that a remote-only ref at the top of the stack still produces the
+  # correct workspace output without requiring any special pruning.
   git init remote-ref-as-stack-top
   (cd remote-ref-as-stack-top
     commit init

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -1535,6 +1535,83 @@ EOF
   #
   # With target at "init", A and B are above the target and should be kept
   # even though they're marked integrated.
+  # A ref (tag or branch) points at the workspace commit itself,
+  # and that ref is the entrypoint for traversal.
+  git init entrypoint-on-workspace-commit
+  (cd entrypoint-on-workspace-commit
+    commit init
+    setup_target_to_match_main
+
+    git checkout -b A
+      commit A1
+      commit A2
+
+    create_workspace_commit_once A
+    # Place a tag on the workspace commit so it can be used as entrypoint
+    git tag my-tag HEAD
+  )
+
+  # A workspace where the local branch was deleted, leaving only the remote
+  # tracking branch. The workspace commit still has the old branch tip as parent.
+  # This tests whether a remote-only segment at the start of a stack is handled.
+  git init remote-only-stack-top
+  (cd remote-only-stack-top
+    commit init
+    setup_target_to_match_main
+
+    git checkout -b A
+      commit A1
+      commit A2
+
+    # Copy A to origin/A, then delete local A
+    setup_remote_tracking A A cp
+    create_workspace_commit_once A
+
+    # Delete the local branch (we're on gitbutler/workspace now)
+    git branch -D A
+  )
+
+  # A local branch B stacked on top of a remote-only branch origin/A.
+  # origin/A has commits on the first-parent path between B and main.
+  # This tests whether a remote-only segment trailing a local segment is handled.
+  git init remote-trailing-local-stack
+  (cd remote-trailing-local-stack
+    commit init
+    setup_target_to_match_main
+
+    git checkout -b soon-origin-A
+      commit A1
+      commit A2
+    setup_remote_tracking soon-origin-A A move
+
+    git checkout -b B
+      commit B1
+      commit B2
+
+    create_workspace_commit_once B
+  )
+
+  # A workspace where the only ref on the branch commits is origin/A (remote).
+  # The local branch never existed - only the remote was fetched.
+  # This tests whether a remote-only ref as the first stack segment is pruned.
+  git init remote-ref-as-stack-top
+  (cd remote-ref-as-stack-top
+    commit init
+    setup_target_to_match_main
+
+    # Create commits and move them directly to origin/A (no local branch ever)
+    git checkout -b temp-A
+      commit A1
+      commit A2
+    setup_remote_tracking temp-A A move
+    # temp-A is now gone, only origin/A exists
+
+    # Manually create workspace merging origin/A's commit
+    git checkout main
+    git checkout -b gitbutler/workspace
+    git merge --no-ff -m "GitButler Workspace Commit" origin/A
+  )
+
   git init integrated-above-target
   (cd integrated-above-target
      commit init

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -6838,7 +6838,7 @@ fn remote_trailing_local_stack() -> anyhow::Result<()> {
         └── ►:2[1]:main <> origin/main →:1:
             └── 🏁·fafd9d0 (⌂|✓|10)
     ");
-    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on cb7021b");
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), "this is a weird state as the target is actually disjoint from the workspace - it appears empty now", @"📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on cb7021b");
     Ok(())
 }
 

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -6706,3 +6706,179 @@ fn integrated_commits_above_target_are_kept() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// A non-workspace ref (tag) points at the workspace commit itself,
+/// and that ref is used as the entrypoint for traversal.
+/// This verifies that the entrypoint is correctly identified even when it
+/// coincides with the workspace commit.
+#[test]
+fn entrypoint_on_workspace_commit() -> anyhow::Result<()> {
+    let (repo, mut meta) = read_only_in_memory_scenario("ws/entrypoint-on-workspace-commit")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 3ea2742 (HEAD -> gitbutler/workspace, tag: my-tag) GitButler Workspace Commit
+    * a62b0de (A) A2
+    * 120a217 A1
+    * fafd9d0 (origin/main, main) init
+    ");
+
+    add_workspace(&mut meta);
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    insta::assert_snapshot!(graph_tree(&graph), @"
+
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
+    │   └── ·3ea2742 (⌂|🏘|01) ►tags/my-tag
+    │       └── ►:3[1]:A
+    │           ├── ·a62b0de (⌂|🏘|01)
+    │           └── ·120a217 (⌂|🏘|01)
+    │               └── ►:2[2]:main <> origin/main →:1:
+    │                   └── 🏁·fafd9d0 (⌂|🏘|✓|11)
+    └── ►:1[0]:origin/main →:2:
+        └── →:2: (main →:1:)
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+    └── ≡:3:A on fafd9d0
+        └── :3:A
+            ├── ·a62b0de (🏘️)
+            └── ·120a217 (🏘️)
+    ");
+
+    // Now traverse from the tag that points at the workspace commit.
+    let (id, name) = id_at(&repo, "my-tag");
+    let graph = Graph::from_commit_traversal(id, name, &*meta, standard_options())?.validated()?;
+    insta::assert_snapshot!(graph_tree(&graph), @"
+
+    ├── ►:0[0]:anon:
+    │   └── 👉►:5[1]:tags/my-tag
+    │       └── 📕►►►:1[2]:gitbutler/workspace[🌳]
+    │           └── ·3ea2742 (⌂|🏘|01)
+    │               └── ►:4[3]:A
+    │                   ├── ·a62b0de (⌂|🏘|01)
+    │                   └── ·120a217 (⌂|🏘|01)
+    │                       └── ►:3[4]:main <> origin/main →:2:
+    │                           └── 🏁·fafd9d0 (⌂|🏘|✓|11)
+    └── ►:2[0]:origin/main →:3:
+        └── →:3: (main →:2:)
+    ");
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
+    📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+    └── ≡:4:A on fafd9d0
+        └── :4:A
+            ├── ·a62b0de (🏘️)
+            └── ·120a217 (🏘️)
+    ");
+    Ok(())
+}
+
+/// A workspace where the local branch was deleted, leaving only origin/A.
+/// The workspace commit still references the old branch tip as a parent.
+/// This probes whether a remote-only segment at the top of a stack is handled
+/// correctly (previously protected by front-pruning workaround).
+#[test]
+fn remote_only_stack_top() -> anyhow::Result<()> {
+    let (repo, mut meta) = read_only_in_memory_scenario("ws/remote-only-stack-top")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * 3ea2742 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * a62b0de (origin/A) A2
+    * 120a217 A1
+    * fafd9d0 (origin/main, main) init
+    ");
+
+    add_workspace(&mut meta);
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    insta::assert_snapshot!(graph_tree(&graph), @"
+
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
+    │   └── ·3ea2742 (⌂|🏘|01)
+    │       └── ►:3[1]:anon:
+    │           ├── ·a62b0de (⌂|🏘|01)
+    │           └── ·120a217 (⌂|🏘|01)
+    │               └── ►:2[2]:main <> origin/main →:1:
+    │                   └── 🏁·fafd9d0 (⌂|🏘|✓|11)
+    └── ►:1[0]:origin/main →:2:
+        └── →:2: (main →:1:)
+    ");
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+    └── ≡:3:anon: on fafd9d0
+        └── :3:anon:
+            ├── ·a62b0de (🏘️)
+            └── ·120a217 (🏘️)
+    ");
+    Ok(())
+}
+
+/// A local branch B is stacked on top of a remote-only origin/A (no local A).
+/// origin/A's commits are on the first-parent path between B and main.
+/// This probes whether a remote-only segment appearing after a local segment
+/// in a stack is handled correctly (previously protected by tail-pruning workaround).
+#[test]
+fn remote_trailing_local_stack() -> anyhow::Result<()> {
+    let (repo, mut meta) = read_only_in_memory_scenario("ws/remote-trailing-local-stack")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * 5638b41 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * cb7021b (B) B2
+    * ce3278a B1
+    * a62b0de (origin/A) A2
+    * 120a217 A1
+    * fafd9d0 (origin/main, main) init
+    ");
+
+    add_workspace(&mut meta);
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    insta::assert_snapshot!(graph_tree(&graph), @"
+
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
+    │   └── ·5638b41 (⌂|🏘|01)
+    │       └── ►:3[1]:B
+    │           ├── ·cb7021b (⌂|🏘|01)
+    │           └── 🏁·ce3278a (⌂|🏘|01)
+    └── ►:1[0]:origin/main →:2:
+        └── ►:2[1]:main <> origin/main →:1:
+            └── 🏁·fafd9d0 (⌂|✓|10)
+    ");
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on cb7021b");
+    Ok(())
+}
+
+/// A workspace that merges a remote-only branch (origin/A) with no local counterpart.
+/// Unlike `remote_only_stack_top` where the local was deleted after workspace creation,
+/// here the local never existed. This tests whether the `is_pruned` check correctly
+/// handles a stack that starts with a remote-only segment.
+#[test]
+fn remote_ref_as_stack_top() -> anyhow::Result<()> {
+    let (repo, mut meta) = read_only_in_memory_scenario("ws/remote-ref-as-stack-top")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   21bff1f (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * a62b0de (origin/A) A2
+    | * 120a217 A1
+    |/  
+    * fafd9d0 (origin/main, main) init
+    ");
+
+    add_workspace(&mut meta);
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    insta::assert_snapshot!(graph_tree(&graph), @"
+
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
+    │   └── ·21bff1f (⌂|🏘|01)
+    │       ├── ►:2[2]:main <> origin/main →:1:
+    │       │   └── 🏁·fafd9d0 (⌂|🏘|✓|11)
+    │       └── ►:3[1]:anon:
+    │           ├── ·a62b0de (⌂|🏘|01)
+    │           └── ·120a217 (⌂|🏘|01)
+    │               └── →:2: (main →:1:)
+    └── ►:1[0]:origin/main →:2:
+        └── →:2: (main →:1:)
+    ");
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+    └── ≡:3:anon: on fafd9d0
+        └── :3:anon:
+            ├── ·a62b0de (🏘️)
+            └── ·120a217 (🏘️)
+    ");
+    Ok(())
+}


### PR DESCRIPTION
Remove five TODOs and ~30 lines of workaround code that pruned
remote-only segments from the front, back, and tail of collected
stacks. Also remove the !is_empty() guard from is_pruned that
special-cased empty segments.

These workarounds were dead code: the graph builder always places
remote refs (e.g. origin/A) on their own graph nodes, separate from
the first-parent path. When commits lack a local ref, their segment
becomes anonymous (ref_info: None), which is_entrypoint_or_local
already treats as local via is_none_or. So remote-only segments
never appeared in positions these workarounds would have caught.

Four new test scenarios confirm this:
- entrypoint_on_workspace_commit: tag on workspace commit as entrypoint
- remote_only_stack_top: local branch deleted, only origin/A remains
- remote_trailing_local_stack: local B stacked on remote-only origin/A
- remote_ref_as_stack_top: workspace merges a never-local remote ref

All four produce correct graph/workspace output without the old
pruning, verifying the workarounds were unnecessary.