### PR TITLE
normalize new branch names with the backend

### DIFF
--- a/apps/desktop/src/components/branch/AddDependentBranchModal.svelte
+++ b/apps/desktop/src/components/branch/AddDependentBranchModal.svelte
@@ -18,17 +18,18 @@
 
 	let modal = $state<Modal>();
 	let branchName = $state<string>();
-	let slugifiedRefName: string | undefined = $state();
+	let normalizedRefName: string | undefined = $state();
+	let isBranchNameValid = $state(false);
 
 	async function handleAddDependentBranch(close: () => void) {
-		if (!slugifiedRefName) return;
+		if (!normalizedRefName) return;
 
 		await createNewBranch({
 			projectId,
 			stackId,
 			request: {
 				targetPatch: undefined,
-				name: slugifiedRefName,
+				name: normalizedRefName,
 			},
 		});
 
@@ -52,7 +53,8 @@
 			placeholder="Branch name"
 			bind:value={branchName}
 			autofocus
-			onslugifiedvalue={(value) => (slugifiedRefName = value)}
+			onnormalizedvalue={(value) => (normalizedRefName = value)}
+			onvalidationchange={(isValid) => (isBranchNameValid = isValid)}
 		/>
 	</div>
 	{#snippet controls(close)}
@@ -61,7 +63,7 @@
 			testId={TestId.BranchHeaderAddDependanttBranchModal_ActionButton}
 			style="pop"
 			type="submit"
-			disabled={!slugifiedRefName}
+			disabled={!isBranchNameValid}
 			loading={branchCreation.current.isLoading}>Add branch</Button
 		>
 	{/snippet}

--- a/apps/desktop/src/components/branch/BranchNameTextbox.svelte
+++ b/apps/desktop/src/components/branch/BranchNameTextbox.svelte
@@ -1,32 +1,91 @@
 <script lang="ts">
-	import { Textbox } from "@gitbutler/ui";
-	import { slugify } from "@gitbutler/ui/utils/string";
+	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
+	import { debounce } from "$lib/utils/debounce";
+	import { inject } from "@gitbutler/core/context";
+	import { Icon, Textbox } from "@gitbutler/ui";
 
 	type Props = {
 		value?: string;
 		helperText?: string;
-		onslugifiedvalue?: (slugified: string | undefined) => void;
+		onnormalizedvalue?: (normalized: string | undefined) => void;
+		onvalidationchange?: (isValid: boolean) => void;
 		[key: string]: any;
 	};
 
 	let {
 		value = $bindable(),
 		helperText,
-
-		onslugifiedvalue,
+		onnormalizedvalue,
+		onvalidationchange,
 		...restProps
 	}: Props = $props();
 
-	let textbox = $state<ReturnType<typeof Textbox>>();
+	const stackService = inject(STACK_SERVICE);
 
-	const slugifiedName = $derived(value && slugify(value));
-	const namesDiverge = $derived(!!value && slugifiedName !== value);
+	let textbox = $state<ReturnType<typeof Textbox>>();
+	let isValidating = $state(false);
+	let validationError = $state<string | undefined>();
+	let validationCounter = $state(0);
+
+	let normalizedResult = $state<{ fromValue: string; normalized: string } | undefined>();
+
+	const isValidState = $derived(
+		!isValidating &&
+			!validationError &&
+			!!value &&
+			!!normalizedResult?.normalized &&
+			normalizedResult.fromValue === value,
+	);
+	$effect(() => {
+		onvalidationchange?.(isValidState);
+	});
+
+	const namesDiverge = $derived(
+		!!normalizedResult && normalizedResult.normalized !== normalizedResult.fromValue,
+	);
 	const computedHelperText = $derived(
-		namesDiverge ? `Will be created as '${slugifiedName}'` : helperText,
+		namesDiverge && normalizedResult
+			? `Will be created as '${normalizedResult.normalized}'`
+			: helperText,
 	);
 
+	const debouncedNormalize = debounce(async (inputValue: string) => {
+		if (!inputValue) {
+			isValidating = false;
+			validationError = undefined;
+			normalizedResult = undefined;
+			onnormalizedvalue?.(undefined);
+			return;
+		}
+
+		const currentValidation = ++validationCounter;
+		isValidating = true;
+		validationError = undefined;
+
+		try {
+			const result = await stackService.normalizeBranchName(inputValue);
+			// Only update if the value hasn't changed during the async call
+			// and no newer validation has started
+			if (value === inputValue && currentValidation === validationCounter) {
+				normalizedResult = { fromValue: inputValue, normalized: result };
+				onnormalizedvalue?.(result);
+				validationError = undefined;
+			}
+		} catch {
+			if (value === inputValue && currentValidation === validationCounter) {
+				normalizedResult = undefined;
+				onnormalizedvalue?.(undefined);
+				validationError = "Invalid branch name";
+			}
+		} finally {
+			if (currentValidation === validationCounter) {
+				isValidating = false;
+			}
+		}
+	}, 100);
+
 	$effect(() => {
-		onslugifiedvalue?.(slugifiedName);
+		debouncedNormalize(value || "");
 	});
 
 	export async function selectAll() {
@@ -34,4 +93,16 @@
 	}
 </script>
 
-<Textbox bind:this={textbox} bind:value helperText={computedHelperText} {...restProps} />
+<Textbox
+	bind:this={textbox}
+	bind:value
+	helperText={computedHelperText}
+	error={validationError}
+	{...restProps}
+>
+	{#snippet customIconRight()}
+		{#if isValidating}
+			<Icon name="spinner" />
+		{/if}
+	{/snippet}
+</Textbox>

--- a/apps/desktop/src/components/branch/BranchNameTextbox.svelte
+++ b/apps/desktop/src/components/branch/BranchNameTextbox.svelte
@@ -3,6 +3,7 @@
 	import { debounce } from "$lib/utils/debounce";
 	import { inject } from "@gitbutler/core/context";
 	import { Icon, Textbox } from "@gitbutler/ui";
+	import { onDestroy } from "svelte";
 
 	type Props = {
 		value?: string;
@@ -26,6 +27,7 @@
 	let isValidating = $state(false);
 	let validationError = $state<string | undefined>();
 	let validationCounter = $state(0);
+	let isDestroyed = false;
 
 	let normalizedResult = $state<{ fromValue: string; normalized: string } | undefined>();
 
@@ -50,6 +52,8 @@
 	);
 
 	const debouncedNormalize = debounce(async (inputValue: string) => {
+		if (isDestroyed) return;
+
 		if (!inputValue) {
 			isValidating = false;
 			validationError = undefined;
@@ -66,19 +70,19 @@
 			const result = await stackService.normalizeBranchName(inputValue);
 			// Only update if the value hasn't changed during the async call
 			// and no newer validation has started
-			if (value === inputValue && currentValidation === validationCounter) {
+			if (!isDestroyed && value === inputValue && currentValidation === validationCounter) {
 				normalizedResult = { fromValue: inputValue, normalized: result };
 				onnormalizedvalue?.(result);
 				validationError = undefined;
 			}
 		} catch {
-			if (value === inputValue && currentValidation === validationCounter) {
+			if (!isDestroyed && value === inputValue && currentValidation === validationCounter) {
 				normalizedResult = undefined;
 				onnormalizedvalue?.(undefined);
 				validationError = "Invalid branch name";
 			}
 		} finally {
-			if (currentValidation === validationCounter) {
+			if (!isDestroyed && currentValidation === validationCounter) {
 				isValidating = false;
 			}
 		}
@@ -91,6 +95,11 @@
 	export async function selectAll() {
 		await textbox?.selectAll();
 	}
+
+	onDestroy(() => {
+		isDestroyed = true;
+		validationCounter++;
+	});
 </script>
 
 <Textbox

--- a/apps/desktop/src/components/branch/BranchRenameModal.svelte
+++ b/apps/desktop/src/components/branch/BranchRenameModal.svelte
@@ -20,7 +20,8 @@
 	const [renameBranch, renameQuery] = stackService.updateBranchName;
 
 	let newName: string | undefined = $state();
-	let slugifiedRefName: string | undefined = $state();
+	let normalizedRefName: string | undefined = $state();
+	let isBranchNameValid = $state(false);
 	let modal: Modal | undefined = $state();
 
 	let branchNameInput = $state<ReturnType<typeof BranchNameTextbox>>();
@@ -40,8 +41,8 @@
 	type={isPushed ? "warning" : "info"}
 	bind:this={modal}
 	onSubmit={async (close) => {
-		if (slugifiedRefName) {
-			renameBranch({ projectId, stackId, laneId, branchName, newName: slugifiedRefName });
+		if (normalizedRefName) {
+			renameBranch({ projectId, stackId, laneId, branchName, newName: normalizedRefName });
 		}
 		close();
 	}}
@@ -52,7 +53,8 @@
 		id={ElementId.NewBranchNameInput}
 		bind:value={newName}
 		autofocus
-		onslugifiedvalue={(value) => (slugifiedRefName = value)}
+		onnormalizedvalue={(value) => (normalizedRefName = value)}
+		onvalidationchange={(isValid) => (isBranchNameValid = isValid)}
 	/>
 
 	{#if isPushed}
@@ -68,7 +70,7 @@
 			testId={TestId.BranchHeaderRenameModal_ActionButton}
 			style="pop"
 			type="submit"
-			disabled={!slugifiedRefName}
+			disabled={!isBranchNameValid}
 			loading={renameQuery.current.isLoading}>Rename</Button
 		>
 	{/snippet}

--- a/apps/desktop/src/components/branch/CreateBranchModal.svelte
+++ b/apps/desktop/src/components/branch/CreateBranchModal.svelte
@@ -42,7 +42,8 @@
 	// Persisted preference for branch placement
 	const addToLeftmost = persisted<boolean>(false, "branch-placement-leftmost");
 
-	let slugifiedRefName: string | undefined = $state();
+	let normalizedRefName: string | undefined = $state();
+	let isBranchNameValid = $state(false);
 
 	// Get all stacks in the workspace
 	const allStacksQuery = $derived(stackService.stacks(projectId));
@@ -91,7 +92,7 @@
 			await createNewStack({
 				projectId,
 				branch: {
-					name: slugifiedRefName,
+					name: normalizedRefName,
 					// If addToLeftmost is true, place at position 0 (leftmost)
 					// Otherwise, leave undefined to append to the right
 					order: $addToLeftmost ? 0 : undefined,
@@ -99,14 +100,14 @@
 			});
 			createRefModal?.close();
 		} else {
-			if (!selectedStackId || !slugifiedRefName) {
+			if (!selectedStackId || !normalizedRefName) {
 				// TODO: Add input validation.
 				return;
 			}
 			await createNewBranch({
 				projectId,
 				stackId: selectedStackId,
-				request: { targetPatch: undefined, name: slugifiedRefName },
+				request: { targetPatch: undefined, name: normalizedRefName },
 			});
 			createRefModal?.close();
 		}
@@ -145,7 +146,8 @@
 			id={ElementId.NewBranchNameInput}
 			value={createRefName}
 			autofocus
-			onslugifiedvalue={(value) => (slugifiedRefName = value)}
+			onnormalizedvalue={(value) => (normalizedRefName = value)}
+			onvalidationchange={(isValid) => (isBranchNameValid = isValid)}
 		/>
 
 		<div class="options-wrap" role="radiogroup" aria-label="Branch type selection">
@@ -269,7 +271,7 @@
 					style="pop"
 					type="submit"
 					onclick={addNew}
-					disabled={!createRefName || (createRefType === "dependent" && !selectedStackId)}
+					disabled={!isBranchNameValid || (createRefType === "dependent" && !selectedStackId)}
 					loading={isAddingNew}
 					testId={TestId.ConfirmSubmit}
 				>

--- a/apps/desktop/src/components/branch/CreateBranchModal.svelte
+++ b/apps/desktop/src/components/branch/CreateBranchModal.svelte
@@ -101,7 +101,6 @@
 			createRefModal?.close();
 		} else {
 			if (!selectedStackId || !normalizedRefName) {
-				// TODO: Add input validation.
 				return;
 			}
 			await createNewBranch({

--- a/apps/desktop/src/components/workspace/StashIntoBranchModal.svelte
+++ b/apps/desktop/src/components/workspace/StashIntoBranchModal.svelte
@@ -38,11 +38,13 @@
 
 	let modal: ReturnType<typeof Modal> | undefined;
 	let stashBranchName = $state<string>();
-	let slugifiedRefName: string | undefined = $state();
+	let normalizedRefName: string | undefined = $state();
+	let isStashBranchNameValid = $state(false);
 	let stashBranchNameInput = $state<ReturnType<typeof BranchNameTextbox>>();
 
 	export async function show(item: ChangedFilesItem) {
-		slugifiedRefName = undefined;
+		normalizedRefName = undefined;
+		isStashBranchNameValid = false;
 		modal?.show(item);
 		stashBranchName = await stackService.fetchNewBranchName(projectId);
 		if ($autoSelectBranchCreationFeature) {
@@ -72,7 +74,8 @@
 				placeholder="Enter your branch name..."
 				bind:value={stashBranchName}
 				autofocus
-				onslugifiedvalue={(value) => (slugifiedRefName = value)}
+				onnormalizedvalue={(value) => (normalizedRefName = value)}
+				onvalidationchange={(isValid) => (isStashBranchNameValid = isValid)}
 			/>
 			<div class="explanation">
 				<p class="primary-text">
@@ -98,10 +101,10 @@
 		<Button kind="outline" type="reset" onclick={close}>Cancel</Button>
 		<AsyncButton
 			style="pop"
-			disabled={!slugifiedRefName}
+			disabled={!isStashBranchNameValid}
 			type="submit"
 			action={async () => {
-				if (isChangedFilesItem(item)) await confirmStashIntoBranch(item, slugifiedRefName);
+				if (isChangedFilesItem(item)) await confirmStashIntoBranch(item, normalizedRefName);
 			}}
 		>
 			Stash into branch


### PR DESCRIPTION
This PR is based on https://github.com/gitbutlerapp/gitbutler/pull/12488 which was waiting for review until it rotted away.
But it's a fix worth having, and I think it's fine to merge despite the complexity that a simple text-box now seems to require.
That's a systemic problem that the PR won't have to solve.

So let's merge this.

### Tasks

* [x] local codex review and fix
* [x] review of the previous PR
* [x] manual testing (I was unable to break it or make it go out of sync)

----

## Summary

Supersedes https://github.com/gitbutlerapp/gitbutler/pull/12488.

This moves branch-name normalization in the desktop UI from the frontend `slugify` helper to the backend branch-name normalization API. The shared branch-name textbox now validates user-entered names through `stackService.normalizeBranchName`, shows validation state in the input, reports invalid names inline, and exposes the normalized branch ref name to parent modals.

The affected create, rename, dependent-branch, and stash-into-branch flows now submit only validated backend-normalized branch names.

## Changes

- Replace frontend `slugify` usage in `BranchNameTextbox` with debounced backend normalization.
- Add validation state handling for empty, pending, valid, and invalid branch names.
- Show the normalized output in helper text when the backend-normalized name differs from the typed value.
- Disable modal submit buttons until the current branch name has validated successfully.
- Use the backend-normalized ref name for:
  - creating a new branch
  - adding a dependent branch
  - renaming a branch
  - stashing changes into a new branch
- Guard async normalization callbacks after component destruction so stale modal instances cannot overwrite parent state.

## Context

PR #12488 introduced the same direction: stop relying on frontend slugification and let backend normalization define valid branch names consistently. This branch supersedes that PR with the current implementation and includes the lifecycle fix for stale async validation callbacks.

Fixes https://github.com/gitbutlerapp/gitbutler/issues/9076  
Related to https://github.com/gitbutlerapp/gitbutler/issues/4786  
Related to https://github.com/gitbutlerapp/gitbutler/pull/12322

## Validation

- `pnpm --filter @gitbutler/desktop check`

