### PR TITLE
lite: add scripts for local bundling

### DIFF
--- a/apps/lite/README.md
+++ b/apps/lite/README.md
@@ -72,7 +72,12 @@ Electron + React (Vite) + TanStack Router scaffold.
 - `pnpm --filter @gitbutler/lite dev`: run Vite + Electron
 - `pnpm --filter @gitbutler/lite build`: build renderer and Electron code
 - `pnpm --filter @gitbutler/lite check`: TypeScript checks for both targets
-- `pnpm --filter @gitbutler/lite package`: build and package with Electron Builder
+- `pnpm --filter @gitbutler/lite bundle-local`: build and package with Electron Builder locally
+  - On macOS, this is ad-hoc signed and not notarized, so you may need to jump through some hoops to actually run the app.
+  - To test the auto-updater, the `-dev` suffix on the version in `package.json` must be removed
+  - The `but` CLI is _not_ bundled automatically with this script as there's no known case where it needs to be tested. For it to be bundled, you must manually place a `but` binary in `./resources/bin/but`.
+- `pnpm --filter @gitbutler/lite bundle-local-nightly`: build and package with Electron Builder locally, using production-like settings
+  - Same as `bundle-local`, but slower to build as it builds with release optimizations
 
 ## ESLint
 

--- a/apps/lite/electron/src/updater.ts
+++ b/apps/lite/electron/src/updater.ts
@@ -36,6 +36,18 @@ export const registerUpdater = (mainWindow: BrowserWindow): void => {
 };
 
 export const checkForUpdates = (): void => {
-	if (!app.isPackaged || env.LITE_NO_AUTOUPDATE === "1" || process.platform == "win32") return;
-	void getAutoUpdater().checkForUpdates();
+	const updater = getAutoUpdater();
+
+	if (
+		!app.isPackaged ||
+		env.LITE_NO_AUTOUPDATE === "1" ||
+		process.platform === "win32" ||
+		updater.currentVersion.prerelease.includes("dev")
+	)
+		return;
+
+	void updater.checkForUpdates().catch((error) => {
+		// oxlint-disable-next-line no-console
+		console.error("Failed to check for updates", error);
+	});
 };

--- a/apps/lite/package.json
+++ b/apps/lite/package.json
@@ -6,7 +6,7 @@
 	"license": "FSL-1.1-MIT",
 	"homepage": "https://gitbutler.com",
 	"private": true,
-	"version": "0.0.1",
+	"version": "0.0.0-dev",
 	"type": "module",
 	"main": "dist/electron/main.js",
 	"copyright": "Copyright 2026 GitButler Inc",
@@ -25,6 +25,8 @@
 		"check": "tsgo -p ui/tsconfig.json --noEmit && tsgo -p electron/tsconfig.json --noEmit",
 		"test": "vitest run --config ui/vitest.config.ts --passWithNoTests",
 		"bundle": "pnpm build && electron-builder",
+		"bundle-local": "CHANNEL=${CHANNEL:-} pnpm -F @gitbutler/but-sdk build && CHANNEL=${CHANNEL:-} pnpm bundle -c.mac.entitlements=resources/entitlements.mac.local.plist -c.mac.entitlementsInherit=resources/entitlements.mac.local.plist",
+		"bundle-local-nightly": "CHANNEL=nightly pnpm -F @gitbutler/but-sdk build:release && CHANNEL=nightly pnpm bundle -c.mac.entitlements=resources/entitlements.mac.local.plist -c.mac.entitlementsInherit=resources/entitlements.mac.local.plist",
 		"demos": "storybook dev --no-open -p 6007"
 	},
 	"build": {
@@ -143,6 +145,7 @@
 		"@types/node": "^22.19.15",
 		"@types/react": "^19.2.14",
 		"@types/react-dom": "^19.2.3",
+		"@types/semver": "^7.7.1",
 		"@typescript/native-preview": "7.0.0-dev.20260421.1",
 		"@vitejs/plugin-react": "^5.2.0",
 		"babel-plugin-react-compiler": "^1.0.0",

--- a/apps/lite/resources/entitlements.mac.local.plist
+++ b/apps/lite/resources/entitlements.mac.local.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <!--
+      WARNING: This local entitlements file is for local/ad-hoc development builds only.
+      `com.apple.security.cs.disable-library-validation` weakens the hardened runtime by
+      allowing unsigned or untrusted dynamic libraries to load.
+      Do not use this file for production packaging, release signing, or notarized builds.
+      
+      This is unfortunately necessary for local bundling to be able to load libraries,
+      including the Electron framework itself.
+     -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -19,7 +19,12 @@
 			],
 			"project": ["electron/src/**!", "ui/src/**!"],
 			"includeEntryExports": true,
-			"ignoreDependencies": ["@gitbutler/design-core", "@tanstack/eslint-plugin-query", "electron"],
+			"ignoreDependencies": [
+				"@gitbutler/design-core",
+				"@tanstack/eslint-plugin-query",
+				"electron",
+				"@types/semver",
+			],
 		},
 	},
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -480,6 +480,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.7.1
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260421.1
         version: 7.0.0-dev.20260421.1
@@ -4630,6 +4633,9 @@ packages:
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
+
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
   '@types/sinonjs__fake-timers@8.1.5':
     resolution: {integrity: sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==}
@@ -13595,6 +13601,8 @@ snapshots:
   '@types/responselike@1.0.3':
     dependencies:
       '@types/node': 22.19.15
+
+  '@types/semver@7.7.1': {}
 
   '@types/sinonjs__fake-timers@8.1.5': {}
 


### PR DESCRIPTION
## 🧢 Changes
Adds scripts to facilitate easy local bundling of the Lite app.