### PR TITLE
Persist change id in lower level commit function

### DIFF
--- a/crates/but-core/src/commit/mod.rs
+++ b/crates/but-core/src/commit/mod.rs
@@ -34,6 +34,16 @@ pub struct Headers {
 
 /// Lifecycle
 impl Headers {
+    /// Create a headers structure with both change_id and conflicted unset.
+    ///
+    /// This is only useful if you're going to set one of the properties right after. You _probably_ want to
+    pub fn empty() -> Self {
+        Self {
+            change_id: None,
+            conflicted: None,
+        }
+    }
+
     /// Derive a deterministic synthetic change-id from `commit_id`.
     ///
     /// Useful for when [`Self::change_id`] is `None`.

--- a/crates/but-rebase/src/cherry_pick.rs
+++ b/crates/but-rebase/src/cherry_pick.rs
@@ -183,6 +183,7 @@ fn commit_from_unconflicted_tree<'repo>(
         new_commit,
         DateMode::CommitterUpdateAuthorKeep,
         SignCommit::IfSignCommitsEnabled,
+        None,
     )?
     .attach(repo))
 }
@@ -250,6 +251,7 @@ fn commit_from_conflicted_tree<'repo>(
         to_rebase.inner,
         DateMode::CommitterUpdateAuthorKeep,
         SignCommit::IfSignCommitsEnabled,
+        None,
     )?
     .attach(repo))
 }

--- a/crates/but-rebase/src/commit.rs
+++ b/crates/but-rebase/src/commit.rs
@@ -1,6 +1,9 @@
 use anyhow::{Context as _, bail};
 use bstr::BStr;
-use but_core::{RepositoryExt, commit::SignCommit};
+use but_core::{
+    ChangeId, RepositoryExt,
+    commit::{Headers, SignCommit},
+};
 use gix::config::Source;
 
 /// What to do with the committer (actor) and the commit time when [creating a new commit](create()).
@@ -82,11 +85,15 @@ pub fn save_author_if_unset_in_repo<'a, 'b>(
 ///
 /// Signatures will be removed automatically if signing is disabled to prevent an amended commit
 /// to use the old signature.
+///
+/// change_id can be used to either ste or override the existing change_id
+/// header.
 pub fn create(
     repo: &gix::Repository,
     mut commit: gix::objs::Commit,
     committer: DateMode,
     sign_commit: SignCommit,
+    change_id: Option<ChangeId>,
 ) -> anyhow::Result<gix::ObjectId> {
     match committer {
         DateMode::CommitterUpdateAuthorKeep => {
@@ -102,6 +109,14 @@ pub fn create(
     if settings.gitbutler_gerrit_mode.unwrap_or(false) {
         but_gerrit::set_trailers(&mut commit);
     }
+
+    if let Some(change_id) = change_id {
+        let mut headers = Headers::try_from_commit(&commit).unwrap_or_else(Headers::empty);
+        headers.change_id = Some(change_id);
+
+        headers.set_in_commit(&mut commit);
+    }
+
     but_core::commit::create(repo, commit, None, sign_commit)
 }
 

--- a/crates/but-rebase/src/graph_rebase/cherry_pick.rs
+++ b/crates/but-rebase/src/graph_rebase/cherry_pick.rs
@@ -2,7 +2,6 @@
 
 use crate::commit::DateMode;
 use anyhow::{Context as _, Result, bail};
-use bstr::BString;
 use but_core::{
     RepositoryExt as _,
     commit::{
@@ -129,11 +128,13 @@ pub fn cherry_pick(
             // point, it's safe to simply recreate that commit outright.
             //
             // Currently, the only known use case for this is to forcibly sign/unsign root commits.
+            let change_id = target.change_id();
             let commit = crate::commit::create(
                 repo,
                 target.inner,
                 DateMode::CommitterUpdateAuthorKeep,
                 sign_commit,
+                Some(change_id),
             )?;
             Ok(CherryPickOutcome::Commit(commit))
         }
@@ -452,7 +453,6 @@ fn commit_from_unconflicted_tree<'repo>(
 ) -> anyhow::Result<gix::Id<'repo>> {
     let repo = to_rebase.id.repo;
 
-    let headers = to_rebase.headers();
     let change_id = to_rebase.change_id();
     let mut new_commit = to_rebase.inner;
     new_commit.tree = resolved_tree_id.detach();
@@ -464,11 +464,6 @@ fn commit_from_unconflicted_tree<'repo>(
         .find_pos(HEADERS_CONFLICTED_FIELD)
     {
         new_commit.extra_headers.remove(pos);
-    } else if headers.is_none() {
-        let headers = Headers::from_change_id(change_id);
-        new_commit
-            .extra_headers
-            .extend(Vec::<(BString, BString)>::from(&headers));
     }
 
     new_commit.parents = parents.into();
@@ -478,6 +473,7 @@ fn commit_from_unconflicted_tree<'repo>(
         new_commit,
         DateMode::CommitterUpdateAuthorKeep,
         sign_commit,
+        Some(change_id),
     )?
     .attach(repo))
 }
@@ -541,13 +537,15 @@ fn commit_from_conflicted_tree<'repo>(
     // Add conflict markers to the commit message
     to_rebase.inner.message =
         but_core::commit::add_conflict_markers(to_rebase.inner.message.as_ref());
-
     to_rebase.set_headers(&headers);
+
+    let change_id = to_rebase.change_id();
     Ok(crate::commit::create(
         repo,
         to_rebase.inner,
         DateMode::CommitterUpdateAuthorKeep,
         sign_commit,
+        Some(change_id),
     )?
     .attach(repo))
 }

--- a/crates/but-rebase/src/graph_rebase/commit.rs
+++ b/crates/but-rebase/src/graph_rebase/commit.rs
@@ -87,11 +87,13 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
         commit: but_core::CommitOwned,
         date_mode: DateMode,
     ) -> Result<gix::ObjectId> {
+        let change_id = commit.change_id();
         create(
             &self.repo,
             commit.inner,
             date_mode,
             SignCommit::IfSignCommitsEnabled,
+            Some(change_id),
         )
     }
 

--- a/crates/but-rebase/src/lib.rs
+++ b/crates/but-rebase/src/lib.rs
@@ -297,6 +297,7 @@ fn rebase(
                                 new_commit,
                                 DateMode::CommitterUpdateAuthorKeep,
                                 SignCommit::IfSignCommitsEnabled,
+                                None,
                             )?);
                         }
                         None => {
@@ -340,6 +341,7 @@ fn rebase(
                     new_commit,
                     DateMode::CommitterUpdateAuthorKeep,
                     SignCommit::IfSignCommitsEnabled,
+                    None,
                 )?;
             }
             RebaseStep::Reference(reference) => {
@@ -388,6 +390,7 @@ fn reword_commit(
         new_commit,
         DateMode::CommitterUpdateAuthorKeep,
         SignCommit::IfSignCommitsEnabled,
+        None,
     )?)
 }
 
@@ -404,6 +407,7 @@ pub fn replace_commit_tree(
         new_commit,
         DateMode::CommitterUpdateAuthorKeep,
         SignCommit::IfSignCommitsEnabled,
+        None,
     )?)
 }
 

--- a/crates/but-rebase/src/merge.rs
+++ b/crates/but-rebase/src/merge.rs
@@ -27,7 +27,7 @@ use crate::commit::DateMode;
 /// remain unsigned.
 /// However, if we re-merge a commit that was signed before it's likely a user-commit that should be treated accordingly.
 /// Thanks to this logic, the caller shouldn't have to steer signing.
-pub fn octopus(
+pub(crate) fn octopus(
     repo: &gix::Repository,
     mut target_merge_commit: gix::objs::Commit,
     graph: &mut gix::revwalk::Graph<
@@ -99,6 +99,7 @@ pub fn octopus(
             target_merge_commit,
             DateMode::CommitterUpdateAuthorKeep,
             SignCommit::IfSignCommitsEnabled,
+            None,
         )
     } else {
         crate::commit::update_committer(repo, &mut target_merge_commit)?;

--- a/crates/but-rebase/tests/rebase/graph_rebase/sha256.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/sha256.rs
@@ -63,10 +63,10 @@ Sha256
         snapbox::str![[r#"
 
 └── 👉►:0[0]:with-inner-merge[🌳]
-    ├── ·f6ce7ad (⌂|1)
-    └── ·174eb34 (⌂|1)
+    ├── ·d165592 (⌂|1)
+    └── ·526ed5b (⌂|1)
         └── ►:1[1]:anon:
-            └── ·3a9910d (⌂|1)
+            └── ·d261f8f (⌂|1)
                 ├── ►:2[2]:A
                 │   └── ·2ff29ff (⌂|1)
                 │       └── ►:4[3]:main
@@ -83,9 +83,9 @@ Sha256
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* f6ce7ad (HEAD -> with-inner-merge) on top of inner merge
-* 174eb34 Merge branch 'B' into with-inner-merge
-*   3a9910d Commit below the merge commit in SHA-256
+* d165592 (HEAD -> with-inner-merge) on top of inner merge
+* 526ed5b Merge branch 'B' into with-inner-merge
+*   d261f8f Commit below the merge commit in SHA-256
 |\  
 | * 8f04e4a (B) C: new file with 10 lines
 * | 2ff29ff (A) A: 10 lines on top
@@ -100,9 +100,9 @@ Sha256
         outcome.history.commit_mappings().to_debug(),
         snapbox::str![[r#"
 {
-    Sha256(0f01c778cee8081dcfd51d010dfcf6dca150fad6cd58bc269b9aed22587b97fb): Sha256(f6ce7ad57ab7b0c17f7bfc1da6c4edf4aba97cb7f1e67b9d15d92d0f985d6833),
-    Sha256(49d2a9677ccb3458bef260578f9e49d55402d9f80e4db5f2aae26e17b6a9c4f7): Sha256(3a9910d979f9822da26e98e36907138b7b92ef1722e7fc45d4e4fd66cfb669d2),
-    Sha256(8ab779b6d7ff461b6a09a86724e26c18a4d9d66f733a1cf3c927dc98e6eecbec): Sha256(174eb34a99092bf10f71677a4fc5bba1552cbb452585db415cef91768ba58104),
+    Sha256(0f01c778cee8081dcfd51d010dfcf6dca150fad6cd58bc269b9aed22587b97fb): Sha256(d1655921309ddaa17f3ba486f91d53527165826034828f7d69a6a73f07c089ec),
+    Sha256(8ab779b6d7ff461b6a09a86724e26c18a4d9d66f733a1cf3c927dc98e6eecbec): Sha256(526ed5b4cefd8b2667f031dcb5b3697269f262785132501f993ea1378854cd9e),
+    Sha256(f29a682637fe42213f5eaed09fc76c6d7763cbe1feea1c81039948c352b9b0cf): Sha256(d261f8fae18b61c4ab433516116362020c64b05ea218649dbf85eacbc4ab131d),
 }
 
 "#]]
@@ -162,11 +162,11 @@ Sha256
         snapbox::str![[r#"
 
 └── 👉►:0[0]:with-inner-merge[🌳]
-    └── ·f6f0125 (⌂|1)
+    └── ·d050214 (⌂|1)
         └── ►:1[1]:anon:
-            └── ·fccb3fd (⌂|1)
+            └── ·8b1722f (⌂|1)
                 ├── ►:2[2]:A
-                │   └── ·b5c16ab (⌂|1)
+                │   └── ·546b14b (⌂|1)
                 │       └── ►:4[3]:main
                 │           └── 🏁·8dcf66f (⌂|1) ►tags/base
                 └── ►:3[2]:B
@@ -181,11 +181,11 @@ Sha256
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* f6f0125 (HEAD -> with-inner-merge) on top of inner merge
-*   fccb3fd Merge branch 'B' into with-inner-merge
+* d050214 (HEAD -> with-inner-merge) on top of inner merge
+*   8b1722f Merge branch 'B' into with-inner-merge
 |\  
 | * 8f04e4a (B) C: new file with 10 lines
-* | b5c16ab (A) A: SHA-256 reworded
+* | 546b14b (A) A: SHA-256 reworded
 |/  
 * 8dcf66f (tag: base, main) base
 
@@ -197,9 +197,9 @@ Sha256
         outcome.history.commit_mappings().to_debug(),
         snapbox::str![[r#"
 {
-    Sha256(0f01c778cee8081dcfd51d010dfcf6dca150fad6cd58bc269b9aed22587b97fb): Sha256(f6f0125b1f12060e754ba973e8e630cdb51622c06fa9ebdc76afa5510817e2d3),
-    Sha256(2ff29ffab0c95397a8da853ee4ee8bdad788b23a55a1071edf3f218a13c3e10e): Sha256(b5c16abf204e78c0c7cf47a75e5532e31ae40129cdb181739f3742ab31e09f44),
-    Sha256(8ab779b6d7ff461b6a09a86724e26c18a4d9d66f733a1cf3c927dc98e6eecbec): Sha256(fccb3fdbafb315097348b7c66fa86a745d923f0f59574cc31650b52f5f1390a2),
+    Sha256(0f01c778cee8081dcfd51d010dfcf6dca150fad6cd58bc269b9aed22587b97fb): Sha256(d0502143e9c3dd325182004472511cde469772f5dc91d1c50792ab681607c125),
+    Sha256(2ff29ffab0c95397a8da853ee4ee8bdad788b23a55a1071edf3f218a13c3e10e): Sha256(546b14b8d04ff7b4be2c3cc6251b85a1a47bf026d0fbff6a2756e3dd6bb010df),
+    Sha256(8ab779b6d7ff461b6a09a86724e26c18a4d9d66f733a1cf3c927dc98e6eecbec): Sha256(8b1722f890ea9892fb2989a24a3dc685908b85556e9020d8b16a74b399dd6c01),
 }
 
 "#]]

--- a/crates/but-transaction/src/tests.rs
+++ b/crates/but-transaction/src/tests.rs
@@ -89,8 +89,8 @@ fn squashing_three_commits() {
     snapbox::assert_data_eq!(
         env.git_log(),
         snapbox::str![[r#"
-* ec6f55f (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* a2fc6dc (branch) squashed
+* 12cb130 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* c0462e6 (branch) squashed
 * 6674d4f (origin/main, origin/HEAD, main, gitbutler/target) add random-file
 
 "#]]

--- a/crates/but-workspace/src/commit_engine/mod.rs
+++ b/crates/but-workspace/src/commit_engine/mod.rs
@@ -192,11 +192,13 @@ pub fn create_commit(
                 if let Some(message) = new_message {
                     commit.message = message.into();
                 }
+                let change_id = commit.change_id();
                 Some(but_rebase::commit::create(
                     repo,
                     commit.inner,
                     DateMode::CommitterUpdateAuthorKeep,
                     SignCommit::IfSignCommitsEnabled,
+                    Some(change_id),
                 )?)
             }
         }
@@ -239,5 +241,6 @@ fn create_possibly_signed_commit(
         commit,
         DateMode::CommitterKeepAuthorKeep,
         SignCommit::IfSignCommitsEnabled,
+        None,
     )
 }

--- a/crates/but-workspace/tests/workspace/branch/integrate_branch_upstream.rs
+++ b/crates/but-workspace/tests/workspace/branch/integrate_branch_upstream.rs
@@ -2117,8 +2117,8 @@ fn integrate_upstream_commits_into_local_with_squashed_local_commits() -> Result
     snapbox::assert_data_eq!(
         normalized_graph_snapshot(&repo)?,
         snapbox::str![[r#"
-* 5ef31c2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* c297225 (A) squashed local commits
+* d40c966 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* fb4b9eb (A) squashed local commits
 * 6a17628 (origin/A) remote change in A 2
 * 715d7b0 remote change in A 1
 * 621b98a shared local/remote
@@ -2177,8 +2177,8 @@ fn integrate_upstream_commits_into_local_with_squashed_remote_commits() -> Resul
     snapbox::assert_data_eq!(
         normalized_graph_snapshot(&repo)?,
         snapbox::str![[r#"
-* 3699070 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 3838b79 (A) squashed remote commits
+* 93f69a1 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 1577fe9 (A) squashed remote commits
 * 8347946 local change in A 2
 * 86838ae local change in A 1
 | * 6a17628 (origin/A) remote change in A 2
@@ -2238,9 +2238,9 @@ fn integrate_upstream_commits_into_local_with_squashed_remote_into_local_commits
     snapbox::assert_data_eq!(
         normalized_graph_snapshot(&repo)?,
         snapbox::str![[r#"
-* 8a9dd44 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* c6b942b (A) squash commits 2
-* a524f0a squash commits 1
+* b3a4b49 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* b5f69de (A) squash commits 2
+* a9e262f squash commits 1
 | * 6a17628 (origin/A) remote change in A 2
 | * 715d7b0 remote change in A 1
 |/
@@ -2299,8 +2299,8 @@ fn integrate_upstream_commits_into_local_with_squashed_remote_into_local_conflic
         normalized_graph_snapshot(&repo)?,
         snapbox::str![[r#"
 * f03fc2c (origin/A, new-origin) remote change in A 1
-| * 1b052b4 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-| * 20ebfcc (A) [conflict] squashed conflicting commits
+| * 19567a9 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+| * 9e257ee (A) [conflict] squashed conflicting commits
 |/
 * 2b73dee (origin/main, main) init-integration
 "#]]

--- a/crates/but-workspace/tests/workspace/commit/move_changes.rs
+++ b/crates/but-workspace/tests/workspace/commit/move_changes.rs
@@ -118,8 +118,8 @@ aac5238
         materialized.history.commit_mappings().to_debug(),
         snapbox::str![[r#"
 {
-    Sha1(16fd22163adbb1118551777970db5fb4b59f6b9d): Sha1(88ba151b2f14a87051cdbeb3bdf850a6175eb8fe),
-    Sha1(c9f444cbd4d94f5b90aaa3e6e2e388c876cdbdae): Sha1(5f79d8bc78f0fc157cf33456412cfa443c0ae4fc),
+    Sha1(16fd22163adbb1118551777970db5fb4b59f6b9d): Sha1(198bf421399ca45dfc033777ed30ea2241c55ff4),
+    Sha1(c9f444cbd4d94f5b90aaa3e6e2e388c876cdbdae): Sha1(7cb368cce7a1e76a623c8d7dcd03bcff3145f06a),
 }
 
 "#]]
@@ -129,8 +129,8 @@ aac5238
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* 5f79d8b (HEAD -> three) commit three
-* 88ba151 (two) commit two
+* 7cb368c (HEAD -> three) commit three
+* 198bf42 (two) commit two
 | * 16fd221 (origin/two) commit two
 |/  
 * 8b426d0 (one) commit one
@@ -206,8 +206,8 @@ fn move_file_from_parent_to_head() -> Result<()> {
         materialized.history.commit_mappings().to_debug(),
         snapbox::str![[r#"
 {
-    Sha1(16fd22163adbb1118551777970db5fb4b59f6b9d): Sha1(0f198e0be723143e843ec2e2f9538f4ba815cd62),
-    Sha1(c9f444cbd4d94f5b90aaa3e6e2e388c876cdbdae): Sha1(cffb8daaedf92594a000665b3990714ad04115c7),
+    Sha1(16fd22163adbb1118551777970db5fb4b59f6b9d): Sha1(ebc7217ab9e33830c4f09601dfda826eb2e9fed0),
+    Sha1(c9f444cbd4d94f5b90aaa3e6e2e388c876cdbdae): Sha1(f56f108a3b4bf2a67e554d22deb7a22bd7e93955),
 }
 
 "#]]
@@ -217,8 +217,8 @@ fn move_file_from_parent_to_head() -> Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* cffb8da (HEAD -> three) commit three
-* 0f198e0 (two) commit two
+* f56f108 (HEAD -> three) commit three
+* ebc7217 (two) commit two
 | * 16fd221 (origin/two) commit two
 |/  
 * 8b426d0 (one) commit one
@@ -292,9 +292,9 @@ fn move_file_between_non_adjacent_commits() -> Result<()> {
         materialized.history.commit_mappings().to_debug(),
         snapbox::str![[r#"
 {
-    Sha1(16fd22163adbb1118551777970db5fb4b59f6b9d): Sha1(d9e603c74228d57e22e16431db09647bc281b65a),
-    Sha1(8b426d09509e2a1e924d939055e1e3eb4b6e7fb4): Sha1(9bc8248dd9ea42b08f66103cd43352fcd2f45f3d),
-    Sha1(c9f444cbd4d94f5b90aaa3e6e2e388c876cdbdae): Sha1(cda98e06158943a26336b4584f016938ae72864b),
+    Sha1(16fd22163adbb1118551777970db5fb4b59f6b9d): Sha1(d5ac8ac48b1eb997e273a131a88d57e4b8ae970d),
+    Sha1(8b426d09509e2a1e924d939055e1e3eb4b6e7fb4): Sha1(4ae70a4fccb46431274b7c89b04600d0fe124b0b),
+    Sha1(c9f444cbd4d94f5b90aaa3e6e2e388c876cdbdae): Sha1(114c8f7e7527abaa7f35faaeb0c38c2d7db2c93e),
 }
 
 "#]]
@@ -304,9 +304,9 @@ fn move_file_between_non_adjacent_commits() -> Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* cda98e0 (HEAD -> three) commit three
-* d9e603c (two) commit two
-* 9bc8248 (one) commit one
+* 114c8f7 (HEAD -> three) commit three
+* d5ac8ac (two) commit two
+* 4ae70a4 (one) commit one
 * 16fd221 (origin/two) commit two
 * 8b426d0 commit one
 

--- a/crates/but-workspace/tests/workspace/commit/reword.rs
+++ b/crates/but-workspace/tests/workspace/commit/reword.rs
@@ -30,7 +30,7 @@ fn reword_head_commit() -> Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* f0a8655 (HEAD -> three) New name
+* bee1f03 (HEAD -> three) New name
 * 16fd221 (origin/two, two) commit two
 * 8b426d0 (one) commit one
 
@@ -67,8 +67,8 @@ fn reword_middle_commit() -> Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* d8b7d8a (HEAD -> three) commit three
-* ada51de (two) New name
+* 555bf78 (HEAD -> three) commit three
+* 5608218 (two) New name
 | * 16fd221 (origin/two) commit two
 |/  
 * 8b426d0 (one) commit one
@@ -108,9 +108,9 @@ fn reword_base_commit() -> Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* 9a3264d (HEAD -> three) commit three
-* 86c4bef (two) commit two
-* 1121ebc (one) New name
+* 93151df (HEAD -> three) commit three
+* fc0e8de (two) commit two
+* f1db5b0 (one) New name
 * 16fd221 (origin/two) commit two
 * 8b426d0 commit one
 

--- a/crates/but-workspace/tests/workspace/commit/squash_commits.rs
+++ b/crates/but-workspace/tests/workspace/commit/squash_commits.rs
@@ -67,7 +67,7 @@ fn squash_top_commit_into_parent() -> Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* 655b033 (HEAD -> three, two) commit two
+* 38b3243 (HEAD -> three, two) commit two
 | * 16fd221 (origin/two) commit two
 |/  
 * 8b426d0 (one) commit one
@@ -205,7 +205,7 @@ fn squash_reorders_when_subject_is_not_on_top() -> Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* 6426178 (HEAD -> three) commit three
+* 7ec20cb (HEAD -> three) commit three
 | * 16fd221 (origin/two) commit two
 |/  
 * 8b426d0 (two, one) commit one
@@ -356,7 +356,7 @@ fn squash_down_keeps_topmost_tree_for_shared_file_lineage() -> Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* 69e6e54 (HEAD -> three, two) commit two
+* 0ce39ca (HEAD -> three, two) commit two
 * 8df0fa3 (one) commit one
 
 "#]]
@@ -408,7 +408,7 @@ fn squash_move_subject_below_target_for_shared_file_lineage() -> Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* 4fbac4b (HEAD -> three) commit three
+* 56f600f (HEAD -> three) commit three
 * 8df0fa3 (two, one) commit one
 
 "#]]
@@ -521,9 +521,9 @@ fn squash_across_stacks_subject_into_target() -> Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-*   e9ad17f (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+*   5eaffd7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
 |\  
-* | 82d6f41 (B) B
+* | a2dc4c7 (B) B
 |/  
 * 85efbe4 (origin/main, main, A) M
 
@@ -538,7 +538,7 @@ fn squash_across_stacks_subject_into_target() -> Result<()> {
 │   └── 📙:4:A
 └── ≡📙:3:B on 85efbe4 {2}
     └── 📙:3:B
-        └── ·82d6f41 (🏘️)
+        └── ·a2dc4c7 (🏘️)
 
 "#]]
     );
@@ -607,9 +607,9 @@ fn squash_across_stacks_target_into_subject() -> Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-*   b7ec700 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+*   2e7b9b5 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
 |\  
-| * 17e27b0 (A) A
+| * 80db672 (A) A
 |/  
 * 85efbe4 (origin/main, main, B) M
 
@@ -622,7 +622,7 @@ fn squash_across_stacks_target_into_subject() -> Result<()> {
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
 ├── ≡📙:3:A on 85efbe4 {1}
 │   └── 📙:3:A
-│       └── ·17e27b0 (🏘️)
+│       └── ·80db672 (🏘️)
 └── ≡📙:4:B on 85efbe4 {2}
     └── 📙:4:B
 
@@ -749,9 +749,9 @@ fn squash_cross_stack_commit_with_deeper_stacks_does_not_pull_in_ancestor_tree_s
     snapbox::assert_data_eq!(
         normalized,
         snapbox::str![[r#"
-*   7dd4136 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+*   c9040ff (HEAD -> gitbutler/workspace) GitButler Workspace Commit
 |\
-| * 62c025c (D) D
+| * 56cb644 (D) D
 | * 26e45af (A) A
 * | 356de85 (E, C) C
 * | f25f65c (B) B

--- a/crates/but-workspace/tests/workspace/commit/uncommit_changes.rs
+++ b/crates/but-workspace/tests/workspace/commit/uncommit_changes.rs
@@ -148,7 +148,7 @@ e0495e9
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* 832a93c (HEAD -> three) commit three
+* 298ab48 (HEAD -> three) commit three
 * 16fd221 (origin/two, two) commit two
 * 8b426d0 (one) commit one
 
@@ -212,8 +212,8 @@ aac5238
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* 300f366 (HEAD -> three) commit three
-* 0f198e0 (two) commit two
+* b5e5f88 (HEAD -> three) commit three
+* ebc7217 (two) commit two
 | * 16fd221 (origin/two) commit two
 |/  
 * 8b426d0 (one) commit one
@@ -290,9 +290,9 @@ fn uncommit_file_from_root_commit() -> Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* 95fb0e5 (HEAD -> three) commit three
-* 910d5b1 (two) commit two
-* 7fcda42 (one) commit one
+* 5dbf8bd (HEAD -> three) commit three
+* 9d299c1 (two) commit two
+* c124928 (one) commit one
 * 16fd221 (origin/two) commit two
 * 8b426d0 commit one
 
@@ -368,7 +368,7 @@ fn uncommit_empty_changes_is_noop() -> Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* fbb2bd1 (HEAD -> three) commit three
+* c389dc7 (HEAD -> three) commit three
 * 16fd221 (origin/two, two) commit two
 * 8b426d0 (one) commit one
 

--- a/crates/but/src/command/legacy/status/tui/tests/commit_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/commit_tests.rs
@@ -365,7 +365,7 @@ fn commit_mode_from_staged_changes_stays_within_current_stack() {
         .assert_current_line_eq(str!["┊●   << amend >> 9477ae7 add A"]);
 
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   8474410 add A"]);
+        .assert_current_line_eq(str!["┊●   tpm add A"]);
 
     tui.input([KeyCode::Up, KeyCode::Up])
         .assert_current_line_eq(str!["╭┄zz [uncommitted] (no changes)"]);
@@ -378,7 +378,7 @@ fn commit_mode_from_staged_changes_stays_within_current_stack() {
         .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
 
     tui.input(KeyCode::Down)
-        .assert_current_line_eq(str!["┊●   8474410 add A"])
+        .assert_current_line_eq(str!["┊●   tpm add A"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/commit_mode_from_staged_changes_stays_within_current_stack_001.svg"
         ]);

--- a/crates/but/src/command/legacy/status/tui/tests/discard_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/discard_tests.rs
@@ -162,7 +162,7 @@ fn discard_stack_confirm_yes_discards_staged_changes() {
         .assert_current_line_eq(str!["┊●   << amend >> 9477ae7 add A"]);
 
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   8474410 add A"]);
+        .assert_current_line_eq(str!["┊●   tpm add A"]);
 
     tui.input([KeyCode::Up, KeyCode::Up])
         .assert_current_line_eq(str!["╭┄zz [uncommitted] (no changes)"]);

--- a/crates/but/src/command/legacy/status/tui/tests/marking_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/marking_tests.rs
@@ -96,7 +96,7 @@ fn multi_squash_marked_commits_into_selected_marked_target() {
         .assert_current_line_eq(str!["┊✔︎   << source >> << squash >> d3e2ba3 add B"]);
 
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   377fa8b add B"])
+        .assert_current_line_eq(str!["┊●   lrm add B"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/multi_squash_marked_commits_into_selected_marked_target_final.svg"
         ]);

--- a/crates/but/src/command/legacy/status/tui/tests/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/mod.rs
@@ -622,7 +622,7 @@ fn inline_reword_open_editor_keeps_inline_message_when_editor_makes_no_changes()
 
     with_var("GIT_EDITOR", Some(editor_command), || {
         tui.input((KeyModifiers::ALT, 'e'))
-            .assert_current_line_eq(str!["┊●   711ccd7 add A updated"]);
+            .assert_current_line_eq(str!["┊●   tpm add A updated"]);
     });
 }
 

--- a/crates/but/src/command/legacy/status/tui/tests/rub_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/rub_tests.rs
@@ -68,7 +68,7 @@ fn rub_api_uncommitted_to_commit_preserves_global_file_list() {
         .assert_current_line_eq(str!["┊●   << amend >> 9477ae7 add A"]);
 
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   8474410 add A"])
+        .assert_current_line_eq(str!["┊●   tpm add A"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/rub_api_uncommitted_to_commit_preserves_global_file_list_final.svg"
         ]);
@@ -141,7 +141,7 @@ fn mark_and_rub_multiple_uncommitted_files() {
         .assert_current_line_eq(str!["┊●   << amend >> 9477ae7 add A"]);
 
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   91784b3 add A"]);
+        .assert_current_line_eq(str!["┊●   tpm add A"]);
 
     let status = tui.env().invoke_git("status --porcelain");
     assert_eq!(
@@ -326,7 +326,7 @@ fn rub_api_squash_commits_can_keep_target_message() {
         .assert_current_line_eq(str!["┊●   << squash (use this message) >> d3e2ba3 add B"]);
 
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   4788772 add B"]);
+        .assert_current_line_eq(str!["┊●   lrm add B"]);
 }
 
 #[test]
@@ -351,7 +351,7 @@ fn rub_api_squash_commits_can_keep_source_message() {
         ]);
 
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   75eb901 add A"]);
+        .assert_current_line_eq(str!["┊●   lrm add A"]);
 }
 
 // Tests RubOperation::CommittedFileToCommit.
@@ -432,7 +432,7 @@ fn rub_api_uncommitted_area_to_stack_operation() {
         .assert_current_line_eq(str!["┊●   << amend >> 9477ae7 add A"]);
 
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   55d8e41 add A"]);
+        .assert_current_line_eq(str!["┊●   tpm add A"]);
 }
 
 // Tests RubOperation::UncommittedToStack.
@@ -459,7 +459,7 @@ fn rub_api_uncommitted_hunk_to_stack_operation() {
         .assert_current_line_eq(str!["┊●   << amend >> 9477ae7 add A"]);
 
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   55d8e41 add A"]);
+        .assert_current_line_eq(str!["┊●   tpm add A"]);
 }
 
 // Tests RubOperation::StackToUncommittedArea.
@@ -485,7 +485,7 @@ fn rub_api_stack_to_uncommitted_operation() {
         .assert_current_line_eq(str!["┊●   << amend >> 9477ae7 add A"]);
 
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   8474410 add A"]);
+        .assert_current_line_eq(str!["┊●   tpm add A"]);
 }
 
 // Tests RubOperation::StackToStack.
@@ -512,7 +512,7 @@ fn rub_api_stack_to_stack_operation() {
         .assert_current_line_eq(str!["┊●   << amend >> 9477ae7 add A"]);
 
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   056a77b add A"]);
+        .assert_current_line_eq(str!["┊●   tpm add A"]);
 
     tui.input([
         KeyCode::Up,
@@ -535,7 +535,7 @@ fn rub_api_stack_to_stack_operation() {
         .assert_current_line_eq(str!["┊●   << amend >> d3e2ba3 add B"]);
 
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   7f2e16d add B"]);
+        .assert_current_line_eq(str!["┊●   lrm add B"]);
 
     tui.input((KeyModifiers::SHIFT, 'K'))
         .assert_current_line_eq(str!["┊╭┄h0 [B]"]);

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_message_wraps_in_details_view_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_message_wraps_in_details_view_005.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="660" height="416" viewBox="0 0 660 416">
   <rect x="0" y="0" width="660" height="416" fill="#000000" />
   <rect x="10" y="64" width="320" height="18" fill="#45475A" />
-  <rect x="338" y="316" width="312" height="18" fill="#004100" />
+  <rect x="338" y="334" width="312" height="18" fill="#004100" />
   <rect x="10" y="388" width="80" height="18" fill="#555555" />
   <g font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">
     <text x="10 18" y="24" style="fill:#CCCCCC;">╭┄</text>
@@ -14,50 +14,48 @@
     <text x="330" y="24" style="fill:#555555;">│</text>
     <text x="338 346 354 362 370 378" y="24" style="fill:#CCCCCC;">Commit</text>
     <text x="394 402 410" y="24" style="fill:#CCCCCC;">ID:</text>
-    <text x="426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642" y="24" style="fill:#00AAAA;">2c4ba3e5b1cbf245cae9297dcbab</text>
+    <text x="426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642" y="24" style="fill:#00AAAA;">0bc8ffa2a64ccc30d282c272a13c</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="330" y="42" style="fill:#555555;">│</text>
-    <text x="338 346 354 362 370 378 386" y="42" style="fill:#CCCCCC;">Author:</text>
-    <text x="426 434 442 450 458 466" y="42" style="fill:#FFFF55;">author</text>
-    <text x="482" y="42" style="fill:#CCCCCC;">&lt;</text>
-    <text x="490 498 506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626" y="42" style="fill:#FFFF55;">author@example.com</text>
-    <text x="634" y="42" style="fill:#CCCCCC;">&gt;</text>
+    <text x="338 346 354 362 370 378" y="42" style="fill:#CCCCCC;">Change</text>
+    <text x="394 402 410" y="42" style="fill:#CCCCCC;">ID:</text>
+    <text x="426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642" y="42" style="fill:#AA00AA;">tpmktkqkknswxzyszlkxlrzoqorv</text>
     <text x="10 18 26" y="60" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="34 42" y="60" style="fill:#0000AA;font-weight:bold;">g0</text>
     <text x="58" y="60" style="fill:#CCCCCC;">[</text>
     <text x="66" y="60" style="fill:#00AA00;">A</text>
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="330" y="60" style="fill:#555555;">│</text>
-    <text x="338 346 354 362 370 378 386 394 402 410" y="60" style="fill:#CCCCCC;">Committer:</text>
-    <text x="426 434 442 450 458 466 474 482 490" y="60" style="fill:#FFFF55;">committer</text>
-    <text x="506" y="60" style="fill:#CCCCCC;">&lt;</text>
-    <text x="514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642" y="60" style="fill:#FFFF55;">committer@example</text>
+    <text x="338 346 354 362 370 378 386" y="60" style="fill:#CCCCCC;">Author:</text>
+    <text x="426 434 442 450 458 466" y="60" style="fill:#FFFF55;">author</text>
+    <text x="482" y="60" style="fill:#CCCCCC;">&lt;</text>
+    <text x="490 498 506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626" y="60" style="fill:#FFFF55;">author@example.com</text>
+    <text x="634" y="60" style="fill:#CCCCCC;">&gt;</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">2</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">c4ba3e</text>
-    <text x="114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;">add</text>
-    <text x="146" y="78" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="162 170 178 186" y="78" style="fill:#FFFFFF;font-weight:bold;">this</text>
-    <text x="202 210 218 226 234 242" y="78" style="fill:#FFFFFF;font-weight:bold;">commit</text>
-    <text x="258 266 274 282 290 298 306" y="78" style="fill:#FFFFFF;font-weight:bold;">message</text>
-    <text x="322" y="78" style="fill:#FFFFFF;font-weight:bold;">i</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">t</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">pm</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;">add</text>
+    <text x="114" y="78" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;">this</text>
+    <text x="170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;">commit</text>
+    <text x="226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;">message</text>
+    <text x="290 298" y="78" style="fill:#FFFFFF;font-weight:bold;">is</text>
+    <text x="314 322" y="78" style="fill:#FFFFFF;font-weight:bold;">in</text>
     <text x="330" y="78" style="fill:#555555;">│</text>
+    <text x="338 346 354 362 370 378 386 394 402 410" y="78" style="fill:#CCCCCC;">Committer:</text>
+    <text x="426 434 442 450 458 466 474 482 490" y="78" style="fill:#FFFF55;">committer</text>
+    <text x="506" y="78" style="fill:#CCCCCC;">&lt;</text>
+    <text x="514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642" y="78" style="fill:#FFFF55;">committer@example</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">├╯</text>
     <text x="330" y="96" style="fill:#555555;">│</text>
-    <text x="338 346 354" y="96" style="fill:#CCCCCC;">add</text>
-    <text x="370" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="386 394 402 410" y="96" style="fill:#CCCCCC;">this</text>
-    <text x="426 434 442 450 458 466" y="96" style="fill:#CCCCCC;">commit</text>
-    <text x="482 490 498 506 514 522 530" y="96" style="fill:#CCCCCC;">message</text>
-    <text x="546 554" y="96" style="fill:#CCCCCC;">is</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="330" y="114" style="fill:#555555;">│</text>
-    <text x="338 346 354 362 370 378 386 394 402 410 418 426 434" y="114" style="fill:#CCCCCC;">intentionally</text>
-    <text x="450 458 466 474" y="114" style="fill:#CCCCCC;">long</text>
-    <text x="490 498" y="114" style="fill:#CCCCCC;">so</text>
-    <text x="514 522 530" y="114" style="fill:#CCCCCC;">the</text>
-    <text x="546 554 562 570 578 586 594" y="114" style="fill:#CCCCCC;">details</text>
-    <text x="610 618 626 634" y="114" style="fill:#CCCCCC;">pane</text>
+    <text x="338 346 354" y="114" style="fill:#CCCCCC;">add</text>
+    <text x="370" y="114" style="fill:#CCCCCC;">A</text>
+    <text x="386 394 402 410" y="114" style="fill:#CCCCCC;">this</text>
+    <text x="426 434 442 450 458 466" y="114" style="fill:#CCCCCC;">commit</text>
+    <text x="482 490 498 506 514 522 530" y="114" style="fill:#CCCCCC;">message</text>
+    <text x="546 554" y="114" style="fill:#CCCCCC;">is</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┴</text>
     <text x="26 34 42 50 58 66 74" y="132" style="fill:#CCCCCC;opacity:0.75;">0dc3733</text>
     <text x="90 98 106 114 122 130 138" y="132" style="fill:#CCCCCC;">(common</text>
@@ -66,44 +64,50 @@
     <text x="290 298 306" y="132" style="fill:#CCCCCC;">add</text>
     <text x="322" y="132" style="fill:#CCCCCC;">M</text>
     <text x="330" y="132" style="fill:#555555;">│</text>
-    <text x="338 346 354" y="132" style="fill:#CCCCCC;">has</text>
-    <text x="370 378" y="132" style="fill:#CCCCCC;">to</text>
-    <text x="394 402 410 418" y="132" style="fill:#CCCCCC;">wrap</text>
-    <text x="434 442 450" y="132" style="fill:#CCCCCC;">the</text>
-    <text x="466 474 482 490" y="132" style="fill:#CCCCCC;">text</text>
-    <text x="506 514 522 530 538 546" y="132" style="fill:#CCCCCC;">across</text>
-    <text x="562 570 578 586 594 602 610 618" y="132" style="fill:#CCCCCC;">multiple</text>
+    <text x="338 346 354 362 370 378 386 394 402 410 418 426 434" y="132" style="fill:#CCCCCC;">intentionally</text>
+    <text x="450 458 466 474" y="132" style="fill:#CCCCCC;">long</text>
+    <text x="490 498" y="132" style="fill:#CCCCCC;">so</text>
+    <text x="514 522 530" y="132" style="fill:#CCCCCC;">the</text>
+    <text x="546 554 562 570 578 586 594" y="132" style="fill:#CCCCCC;">details</text>
+    <text x="610 618 626 634" y="132" style="fill:#CCCCCC;">pane</text>
     <text x="330" y="150" style="fill:#555555;">│</text>
-    <text x="338 346 354 362 370 378" y="150" style="fill:#CCCCCC;">visual</text>
-    <text x="394 402 410 418 426" y="150" style="fill:#CCCCCC;">lines</text>
+    <text x="338 346 354" y="150" style="fill:#CCCCCC;">has</text>
+    <text x="370 378" y="150" style="fill:#CCCCCC;">to</text>
+    <text x="394 402 410 418" y="150" style="fill:#CCCCCC;">wrap</text>
+    <text x="434 442 450" y="150" style="fill:#CCCCCC;">the</text>
+    <text x="466 474 482 490" y="150" style="fill:#CCCCCC;">text</text>
+    <text x="506 514 522 530 538 546" y="150" style="fill:#CCCCCC;">across</text>
+    <text x="562 570 578 586 594 602 610 618" y="150" style="fill:#CCCCCC;">multiple</text>
     <text x="330" y="168" style="fill:#555555;">│</text>
+    <text x="338 346 354 362 370 378" y="168" style="fill:#CCCCCC;">visual</text>
+    <text x="394 402 410 418 426" y="168" style="fill:#CCCCCC;">lines</text>
     <text x="330" y="186" style="fill:#555555;">│</text>
-    <text x="338" y="186" style="fill:#CCCCCC;">1</text>
-    <text x="354 362 370 378" y="186" style="fill:#CCCCCC;">file</text>
-    <text x="394 402 410 418 426 434 442 450" y="186" style="fill:#CCCCCC;">changed,</text>
-    <text x="466 474" y="186" style="fill:#00AA00;">+1</text>
-    <text x="490 498" y="186" style="fill:#AA0000;">-0</text>
     <text x="330" y="204" style="fill:#555555;">│</text>
-    <text x="330 338 346 354 362 370 378 386 394 402 410" y="222" style="fill:#555555;">│─────────╮</text>
-    <text x="330" y="240" style="fill:#555555;">│</text>
-    <text x="346 354 362 370 378" y="240" style="fill:#00AA00;">added</text>
-    <text x="394" y="240" style="fill:#CCCCCC;">A</text>
-    <text x="410" y="240" style="fill:#555555;">│</text>
-    <text x="330 338 346 354 362 370 378 386 394 402 410" y="258" style="fill:#555555;">│─────────╯</text>
-    <text x="330" y="276" style="fill:#555555;">│</text>
+    <text x="338" y="204" style="fill:#CCCCCC;">1</text>
+    <text x="354 362 370 378" y="204" style="fill:#CCCCCC;">file</text>
+    <text x="394 402 410 418 426 434 442 450" y="204" style="fill:#CCCCCC;">changed,</text>
+    <text x="466 474" y="204" style="fill:#00AA00;">+1</text>
+    <text x="490 498" y="204" style="fill:#AA0000;">-0</text>
+    <text x="330" y="222" style="fill:#555555;">│</text>
+    <text x="330 338 346 354 362 370 378 386 394 402 410" y="240" style="fill:#555555;">│─────────╮</text>
+    <text x="330" y="258" style="fill:#555555;">│</text>
+    <text x="346 354 362 370 378" y="258" style="fill:#00AA00;">added</text>
+    <text x="394" y="258" style="fill:#CCCCCC;">A</text>
+    <text x="410" y="258" style="fill:#555555;">│</text>
+    <text x="330 338 346 354 362 370 378 386 394 402 410" y="276" style="fill:#555555;">│─────────╯</text>
     <text x="330" y="294" style="fill:#555555;">│</text>
-    <text x="338 346" y="294" style="fill:#CCCCCC;opacity:0.75;">@@</text>
-    <text x="362 370 378 386" y="294" style="fill:#CCCCCC;opacity:0.75;">-1,0</text>
-    <text x="402 410 418 426" y="294" style="fill:#CCCCCC;opacity:0.75;">+1,1</text>
-    <text x="442 450" y="294" style="fill:#CCCCCC;opacity:0.75;">@@</text>
-    <text x="330 338 346 354 362 370 378 386 394 402 410 418 426 434 442 450" y="312" style="fill:#555555;">│───────────────</text>
-    <text x="330" y="330" style="fill:#555555;">│</text>
-    <text x="354" y="330" style="fill:#555555;">┊</text>
-    <text x="370" y="330" style="fill:#00AA00;">1</text>
-    <text x="386" y="330" style="fill:#555555;">│</text>
-    <text x="402" y="330" style="fill:#CCCCCC;">+</text>
-    <text x="410" y="330" style="fill:#F8F8F2;">A</text>
+    <text x="330" y="312" style="fill:#555555;">│</text>
+    <text x="338 346" y="312" style="fill:#CCCCCC;opacity:0.75;">@@</text>
+    <text x="362 370 378 386" y="312" style="fill:#CCCCCC;opacity:0.75;">-1,0</text>
+    <text x="402 410 418 426" y="312" style="fill:#CCCCCC;opacity:0.75;">+1,1</text>
+    <text x="442 450" y="312" style="fill:#CCCCCC;opacity:0.75;">@@</text>
+    <text x="330 338 346 354 362 370 378 386 394 402 410 418 426 434 442 450" y="330" style="fill:#555555;">│───────────────</text>
     <text x="330" y="348" style="fill:#555555;">│</text>
+    <text x="354" y="348" style="fill:#555555;">┊</text>
+    <text x="370" y="348" style="fill:#00AA00;">1</text>
+    <text x="386" y="348" style="fill:#555555;">│</text>
+    <text x="402" y="348" style="fill:#CCCCCC;">+</text>
+    <text x="410" y="348" style="fill:#F8F8F2;">A</text>
     <text x="330" y="366" style="fill:#555555;">│</text>
     <text x="330" y="384" style="fill:#555555;">│</text>
     <text x="26 34 42 50 58 66" y="402" style="fill:#FFFFFF;">normal</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_mode_from_staged_changes_stays_within_current_stack_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_mode_from_staged_changes_stays_within_current_stack_001.svg
@@ -24,10 +24,10 @@
     <text x="66" y="60" style="fill:#00AA00;">A</text>
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">8</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">474410</text>
-    <text x="114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;">add</text>
-    <text x="146" y="78" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">t</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">pm</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;">add</text>
+    <text x="114" y="78" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="50 58" y="96" style="fill:#000000;font-weight:bold;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="96" style="fill:#000000;font-weight:bold;">commit</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_mode_from_staged_changes_stays_within_current_stack_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_mode_from_staged_changes_stays_within_current_stack_final.svg
@@ -24,10 +24,10 @@
     <text x="66" y="60" style="fill:#00AA00;">A</text>
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">8</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">474410</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;">add</text>
-    <text x="146" y="78" style="fill:#CCCCCC;">A</text>
+    <text x="50" y="78" style="fill:#AA00AA;">t</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">pm</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;">add</text>
+    <text x="114" y="78" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="132" style="fill:#FFFFFF;font-weight:bold;">┊╭┄</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_stack_confirm_yes_discards_staged_changes_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_stack_confirm_yes_discards_staged_changes_final.svg
@@ -17,10 +17,10 @@
     <text x="66" y="60" style="fill:#00AA00;">A</text>
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">8</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">474410</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;">add</text>
-    <text x="146" y="78" style="fill:#CCCCCC;">A</text>
+    <text x="50" y="78" style="fill:#AA00AA;">t</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">pm</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;">add</text>
+    <text x="114" y="78" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/global_file_list_stays_open_after_discarding_the_last_file_in_a_commit_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/global_file_list_stays_open_after_discarding_the_last_file_in_a_commit_002.svg
@@ -17,12 +17,12 @@
     <text x="66" y="60" style="fill:#00AA00;">A</text>
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">7</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">105f6d</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;">add</text>
-    <text x="146" y="78" style="fill:#CCCCCC;">A</text>
-    <text x="162 170 178" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="194 202 210 218 226 234 242 250" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50" y="78" style="fill:#AA00AA;">t</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">pm</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;">add</text>
+    <text x="114" y="78" style="fill:#CCCCCC;">A</text>
+    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202 210 218" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="132" style="fill:#CCCCCC;">┊╭┄</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/global_file_list_stays_open_after_marking_and_discarding_all_files_in_a_commit_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/global_file_list_stays_open_after_marking_and_discarding_all_files_in_a_commit_002.svg
@@ -17,12 +17,12 @@
     <text x="66" y="60" style="fill:#00AA00;">A</text>
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">7</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">105f6d</text>
-    <text x="114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;">add</text>
-    <text x="146" y="78" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="162 170 178" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="194 202 210 218 226 234 242 250" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">t</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">pm</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;">add</text>
+    <text x="114" y="78" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202 210 218" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="132" style="fill:#CCCCCC;">┊╭┄</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/multi_squash_marked_commits_into_selected_marked_target_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/multi_squash_marked_commits_into_selected_marked_target_final.svg
@@ -26,10 +26,10 @@
     <text x="66" y="114" style="fill:#00AA00;">B</text>
     <text x="74" y="114" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="132" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="132" style="fill:#0000AA;font-weight:bold;">3</text>
-    <text x="58 66 74 82 90 98" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">77fa8b</text>
-    <text x="114 122 130" y="132" style="fill:#FFFFFF;font-weight:bold;">add</text>
-    <text x="146" y="132" style="fill:#FFFFFF;font-weight:bold;">B</text>
+    <text x="50" y="132" style="fill:#AA00AA;font-weight:bold;">l</text>
+    <text x="58 66" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">rm</text>
+    <text x="82 90 98" y="132" style="fill:#FFFFFF;font-weight:bold;">add</text>
+    <text x="114" y="132" style="fill:#FFFFFF;font-weight:bold;">B</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/rub_api_uncommitted_to_commit_preserves_global_file_list_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/rub_api_uncommitted_to_commit_preserves_global_file_list_final.svg
@@ -17,16 +17,16 @@
     <text x="66" y="60" style="fill:#00AA00;">A</text>
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">8</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">474410</text>
-    <text x="114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;">add</text>
-    <text x="146" y="78" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">t</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">pm</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;">add</text>
+    <text x="114" y="78" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">8:t</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">t:t</text>
     <text x="98" y="96" style="fill:#CCCCCC;">A</text>
     <text x="114" y="96" style="fill:#00AA00;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">8:v</text>
+    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">t:v</text>
     <text x="98" y="114" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130 138 146 154 162 170" y="114" style="fill:#00AA00;">test.txt</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/rubbing_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/rubbing_003.svg
@@ -24,16 +24,16 @@
     <text x="226 234 242" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="258 266 274 282 290 298 306 314" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">8</text>
-    <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">474410</text>
-    <text x="114 122 130" y="96" style="fill:#CCCCCC;">add</text>
-    <text x="146" y="96" style="fill:#CCCCCC;">A</text>
+    <text x="50" y="96" style="fill:#AA00AA;">t</text>
+    <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">pm</text>
+    <text x="82 90 98" y="96" style="fill:#CCCCCC;">add</text>
+    <text x="114" y="96" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">8:t</text>
+    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">t:t</text>
     <text x="98" y="114" style="fill:#CCCCCC;">A</text>
     <text x="114" y="114" style="fill:#00AA00;">A</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">8:v</text>
+    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">t:v</text>
     <text x="98" y="132" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130 138 146 154 162 170" y="132" style="fill:#00AA00;">test.txt</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/tests/but/command/move2.rs
+++ b/crates/but/tests/but/command/move2.rs
@@ -1016,7 +1016,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 1 changes from fe12bcd to new commit c019027 above commit 9ac4652
+Moved 1 changes from fe12bcd to new commit c15e460 above commit 9ac4652
 
 "#]]);
 
@@ -1031,7 +1031,7 @@ Moved 1 changes from fe12bcd to new commit c019027 above commit 9ac4652
 ┊│     1:l A first
 ┊●   ywx add second
 ┊│     ywx:w A second
-┊●   d8dfd0f add first (no changes)
+┊●   zll add first (no changes)
 ├╯
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
@@ -1124,7 +1124,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 1 changes from fe12bcd to new commit c019027 on new branch 'a-branch-1' above branch 'A'
+Moved 1 changes from fe12bcd to new commit c15e460 on new branch 'a-branch-1' above branch 'A'
 
 "#]]);
 
@@ -1141,7 +1141,7 @@ Moved 1 changes from fe12bcd to new commit c019027 on new branch 'a-branch-1' ab
 ┊├┄g0 [A]
 ┊●   ywx add second
 ┊│     ywx:w A second
-┊●   d8dfd0f add first (no changes)
+┊●   zll add first (no changes)
 ├╯
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
@@ -1196,11 +1196,11 @@ Moved 1 changes from d3e2ba3 to new commit be174de to the tip of branch 'A'
 ┊●   1 (no commit message)
 ┊│     1:p A B
 ┊●   9477ae7 add A
-┊│     9:t A A
+┊│     94:t A A
 ├╯
 ┊
 ┊╭┄h0 [B]
-┊●   5bbe27c add B (no changes)
+┊●   lrm add B (no changes)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1254,7 +1254,7 @@ Moved 1 changes from 9ac4652 to new commit 8e35f84 on new branch 'new-branch'
 ├╯
 ┊
 ┊╭┄g0 [A]
-┊●   810e515 add second (no changes)
+┊●   ywx add second (no changes)
 ┊●   fe12bcd add first
 ┊│     f:l A first
 ├╯
@@ -1310,7 +1310,7 @@ Moved 1 changes from 9ac4652 to new commit 8e35f84 on new branch 'a-branch-1'
 ├╯
 ┊
 ┊╭┄g0 [A]
-┊●   810e515 add second (no changes)
+┊●   ywx add second (no changes)
 ┊●   fe12bcd add first
 ┊│     f:l A first
 ├╯

--- a/crates/but/tests/but/command/reword.rs
+++ b/crates/but/tests/but/command/reword.rs
@@ -30,8 +30,8 @@ Updated commit message for [..]
     snapbox::assert_data_eq!(
         env.git_log(),
         snapbox::str![[r#"
-* 8c69cf9 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 2f7c570 (A) Updated commit message
+* 95614cf (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* dfe058b (A) Updated commit message
 * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
 
 "#]]
@@ -85,8 +85,8 @@ Updated commit message for [..]
     snapbox::assert_data_eq!(
         env.git_log(),
         snapbox::str![[r#"
-* e6bde18 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* cdf2c74 (A) First line
+* 71a85cb (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 3ffa6ce (A) First line
 * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
 
 "#]]
@@ -252,8 +252,8 @@ fn reword_commit_with_json_flag() {
     snapbox::assert_data_eq!(
         env.git_log(),
         snapbox::str![[r#"
-* 8c69cf9 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 2f7c570 (A) Updated commit message
+* 95614cf (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* dfe058b (A) Updated commit message
 * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
 
 "#]]

--- a/crates/but/tests/but/command/undo.rs
+++ b/crates/but/tests/but/command/undo.rs
@@ -487,7 +487,7 @@ fn can_undo_but_squash_with_branch() {
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-b4f79ed 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Squashed commit (32bd7b0)
+7363841 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Squashed commit (32bd7b0)
 32bd7b0 2000-01-02 00:00:00 [SQUASH] Squashed commit
 68ab82c 2000-01-02 00:00:00 [REWORD] Updated commit message
 39c0943 2000-01-02 00:00:00 [INSERT_COMMIT] Inserted blank commit
@@ -517,7 +517,7 @@ fn can_undo_but_squash_with_branch_and_drop_message() {
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-64f3cfa 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Squashed commit (32bd7b0)
+a3912d3 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Squashed commit (32bd7b0)
 32bd7b0 2000-01-02 00:00:00 [SQUASH] Squashed commit
 68ab82c 2000-01-02 00:00:00 [REWORD] Updated commit message
 39c0943 2000-01-02 00:00:00 [INSERT_COMMIT] Inserted blank commit

--- a/crates/but/tests/but/command/undo/undo_redo.rs
+++ b/crates/but/tests/but/command/undo/undo_redo.rs
@@ -105,9 +105,9 @@ fn can_undo_repeatedly() {
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
-e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
-90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+5129db9 2000-01-02 00:00:00 [REWORD] Updated commit message
+da67dd1 2000-01-02 00:00:00 [REWORD] Updated commit message
+e23e4fa 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 "#]]);
@@ -115,7 +115,7 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
     undo(
         &env,
         OperationKind::UpdateCommitMessage,
-        "f4e985f",
+        "5129db9",
         &status_three,
     );
 
@@ -126,10 +126,10 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
-f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
-e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
-90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+94d85c5 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (5129db9)
+5129db9 2000-01-02 00:00:00 [REWORD] Updated commit message
+da67dd1 2000-01-02 00:00:00 [REWORD] Updated commit message
+e23e4fa 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 "#]]);
@@ -137,7 +137,7 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
     undo(
         &env,
         OperationKind::UpdateCommitMessage,
-        "e637109",
+        "da67dd1",
         &status_two,
     );
 
@@ -148,11 +148,11 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
-f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
-e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
-90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+5e5fe67 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (da67dd1)
+94d85c5 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (5129db9)
+5129db9 2000-01-02 00:00:00 [REWORD] Updated commit message
+da67dd1 2000-01-02 00:00:00 [REWORD] Updated commit message
+e23e4fa 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 "#]]);
@@ -160,7 +160,7 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
     undo(
         &env,
         OperationKind::UpdateCommitMessage,
-        "90c8e9b",
+        "e23e4fa",
         &status_one,
     );
 
@@ -171,12 +171,12 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-800274e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (90c8e9b)
-8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
-f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
-e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
-90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+0d7b714 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e23e4fa)
+5e5fe67 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (da67dd1)
+94d85c5 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (5129db9)
+5129db9 2000-01-02 00:00:00 [REWORD] Updated commit message
+da67dd1 2000-01-02 00:00:00 [REWORD] Updated commit message
+e23e4fa 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 "#]]);
@@ -199,14 +199,14 @@ fn can_undo_explicit_restore() {
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
-e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
-90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+5129db9 2000-01-02 00:00:00 [REWORD] Updated commit message
+da67dd1 2000-01-02 00:00:00 [REWORD] Updated commit message
+e23e4fa 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 "#]]);
 
-    restore(&env, "e637109", &status_two);
+    restore(&env, "da67dd1", &status_two);
 
     env.but("oplog")
         .args(["list"])
@@ -215,10 +215,10 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-10e3b45 2000-01-02 00:00:00 [RESTORE] Restored from snapshot: Updated commit message (e637109)
-f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
-e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
-90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+8b4f09e 2000-01-02 00:00:00 [RESTORE] Restored from snapshot: Updated commit message (da67dd1)
+5129db9 2000-01-02 00:00:00 [REWORD] Updated commit message
+da67dd1 2000-01-02 00:00:00 [REWORD] Updated commit message
+e23e4fa 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 "#]]);
@@ -226,7 +226,7 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
     undo(
         &env,
         OperationKind::RestoreFromSnapshot,
-        "10e3b45",
+        "8b4f09e",
         &status_four,
     );
 
@@ -237,11 +237,11 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-a875d2c 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
-10e3b45 2000-01-02 00:00:00 [RESTORE] Restored from snapshot: Updated commit message (e637109)
-f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
-e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
-90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+2c3576c 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (da67dd1)
+8b4f09e 2000-01-02 00:00:00 [RESTORE] Restored from snapshot: Updated commit message (da67dd1)
+5129db9 2000-01-02 00:00:00 [REWORD] Updated commit message
+da67dd1 2000-01-02 00:00:00 [REWORD] Updated commit message
+e23e4fa 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 "#]]);
@@ -264,9 +264,9 @@ fn can_undo_perform_operation_then_undo_again() {
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
-e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
-90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+5129db9 2000-01-02 00:00:00 [REWORD] Updated commit message
+da67dd1 2000-01-02 00:00:00 [REWORD] Updated commit message
+e23e4fa 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 "#]]);
@@ -274,7 +274,7 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
     undo(
         &env,
         OperationKind::UpdateCommitMessage,
-        "f4e985f",
+        "5129db9",
         &status_three,
     );
 
@@ -287,11 +287,11 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-3b50353 2000-01-02 00:00:00 [REWORD] Updated commit message
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
-f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
-e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
-90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+22e0417 2000-01-02 00:00:00 [REWORD] Updated commit message
+94d85c5 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (5129db9)
+5129db9 2000-01-02 00:00:00 [REWORD] Updated commit message
+da67dd1 2000-01-02 00:00:00 [REWORD] Updated commit message
+e23e4fa 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 "#]]);
@@ -299,7 +299,7 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
     undo(
         &env,
         OperationKind::UpdateCommitMessage,
-        "3b50353",
+        "22e0417",
         &status_three,
     );
 
@@ -310,12 +310,12 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-c00e67a 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (3b50353)
-3b50353 2000-01-02 00:00:00 [REWORD] Updated commit message
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
-f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
-e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
-90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+aac925c 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (22e0417)
+22e0417 2000-01-02 00:00:00 [REWORD] Updated commit message
+94d85c5 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (5129db9)
+5129db9 2000-01-02 00:00:00 [REWORD] Updated commit message
+da67dd1 2000-01-02 00:00:00 [REWORD] Updated commit message
+e23e4fa 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 "#]]);
@@ -323,7 +323,7 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
     undo(
         &env,
         OperationKind::UpdateCommitMessage,
-        "e637109",
+        "da67dd1",
         &status_two,
     );
 }
@@ -344,7 +344,7 @@ fn undoing_past_end_of_oplog() {
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+e23e4fa 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 "#]]);
@@ -352,7 +352,7 @@ Operations History
     undo(
         &env,
         OperationKind::UpdateCommitMessage,
-        "90c8e9b",
+        "e23e4fa",
         &status_one,
     );
 
@@ -363,8 +363,8 @@ Operations History
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-1c40c14 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (90c8e9b)
-90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+aecc993 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e23e4fa)
+e23e4fa 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 "#]]);
@@ -383,9 +383,9 @@ Operations History
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-092cc32 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (7665ea7)
-1c40c14 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (90c8e9b)
-90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+f47dc34 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (7665ea7)
+aecc993 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e23e4fa)
+e23e4fa 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 "#]]);
@@ -413,9 +413,9 @@ fn can_redo() {
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
-e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
-90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+5129db9 2000-01-02 00:00:00 [REWORD] Updated commit message
+da67dd1 2000-01-02 00:00:00 [REWORD] Updated commit message
+e23e4fa 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 "#]]);
@@ -423,7 +423,7 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
     undo(
         &env,
         OperationKind::UpdateCommitMessage,
-        "f4e985f",
+        "5129db9",
         &status_three,
     );
 
@@ -434,10 +434,10 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
-f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
-e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
-90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+94d85c5 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (5129db9)
+5129db9 2000-01-02 00:00:00 [REWORD] Updated commit message
+da67dd1 2000-01-02 00:00:00 [REWORD] Updated commit message
+e23e4fa 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 "#]]);
@@ -445,7 +445,7 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
     redo(
         &env,
         OperationKind::RestoreFromSnapshotViaUndo,
-        "0a0795e",
+        "94d85c5",
         &status_four,
     );
 
@@ -456,11 +456,11 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-b57a0e1 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (f4e985f)
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
-f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
-e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
-90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+54c81c6 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (5129db9)
+94d85c5 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (5129db9)
+5129db9 2000-01-02 00:00:00 [REWORD] Updated commit message
+da67dd1 2000-01-02 00:00:00 [REWORD] Updated commit message
+e23e4fa 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 "#]]);
@@ -488,9 +488,9 @@ fn can_mix_undo_and_redo() {
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
-e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
-90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+5129db9 2000-01-02 00:00:00 [REWORD] Updated commit message
+da67dd1 2000-01-02 00:00:00 [REWORD] Updated commit message
+e23e4fa 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 "#]]);
@@ -498,13 +498,13 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
     undo(
         &env,
         OperationKind::UpdateCommitMessage,
-        "f4e985f",
+        "5129db9",
         &status_three,
     );
     undo(
         &env,
         OperationKind::UpdateCommitMessage,
-        "e637109",
+        "da67dd1",
         &status_two,
     );
 
@@ -515,11 +515,11 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
-f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
-e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
-90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+5e5fe67 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (da67dd1)
+94d85c5 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (5129db9)
+5129db9 2000-01-02 00:00:00 [REWORD] Updated commit message
+da67dd1 2000-01-02 00:00:00 [REWORD] Updated commit message
+e23e4fa 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 "#]]);
@@ -527,7 +527,7 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
     redo(
         &env,
         OperationKind::RestoreFromSnapshotViaUndo,
-        "8b8b27a",
+        "5e5fe67",
         &status_three,
     );
 
@@ -538,12 +538,12 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-d07be52 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (e637109)
-8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
-f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
-e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
-90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+82f0c86 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (da67dd1)
+5e5fe67 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (da67dd1)
+94d85c5 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (5129db9)
+5129db9 2000-01-02 00:00:00 [REWORD] Updated commit message
+da67dd1 2000-01-02 00:00:00 [REWORD] Updated commit message
+e23e4fa 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 "#]]);
@@ -551,7 +551,7 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
     undo(
         &env,
         OperationKind::RestoreFromSnapshotViaRedo,
-        "d07be52",
+        "82f0c86",
         &status_two,
     );
 
@@ -562,13 +562,13 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-4769e9f 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
-d07be52 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (e637109)
-8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
-f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
-e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
-90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+5e83f80 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (da67dd1)
+82f0c86 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (da67dd1)
+5e5fe67 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (da67dd1)
+94d85c5 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (5129db9)
+5129db9 2000-01-02 00:00:00 [REWORD] Updated commit message
+da67dd1 2000-01-02 00:00:00 [REWORD] Updated commit message
+e23e4fa 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 "#]]);
@@ -576,7 +576,7 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
     undo(
         &env,
         OperationKind::UpdateCommitMessage,
-        "90c8e9b",
+        "e23e4fa",
         &status_one,
     );
 
@@ -587,14 +587,14 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-5ffc4e1 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (90c8e9b)
-4769e9f 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
-d07be52 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (e637109)
-8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
-f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
-e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
-90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+d778c06 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e23e4fa)
+5e83f80 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (da67dd1)
+82f0c86 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (da67dd1)
+5e5fe67 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (da67dd1)
+94d85c5 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (5129db9)
+5129db9 2000-01-02 00:00:00 [REWORD] Updated commit message
+da67dd1 2000-01-02 00:00:00 [REWORD] Updated commit message
+e23e4fa 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 "#]]);
@@ -602,7 +602,7 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
     redo(
         &env,
         OperationKind::RestoreFromSnapshotViaUndo,
-        "5ffc4e1",
+        "d778c06",
         &status_two,
     );
 
@@ -613,15 +613,15 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-6ba0709 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (90c8e9b)
-5ffc4e1 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (90c8e9b)
-4769e9f 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
-d07be52 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (e637109)
-8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
-f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
-e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
-90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+2acbef2 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (e23e4fa)
+d778c06 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e23e4fa)
+5e83f80 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (da67dd1)
+82f0c86 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (da67dd1)
+5e5fe67 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (da67dd1)
+94d85c5 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (5129db9)
+5129db9 2000-01-02 00:00:00 [REWORD] Updated commit message
+da67dd1 2000-01-02 00:00:00 [REWORD] Updated commit message
+e23e4fa 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 "#]]);
@@ -629,7 +629,7 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
     redo(
         &env,
         OperationKind::RestoreFromSnapshotViaUndo,
-        "4769e9f",
+        "5e83f80",
         &status_three,
     );
 
@@ -640,16 +640,16 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-62ccc54 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (e637109)
-6ba0709 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (90c8e9b)
-5ffc4e1 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (90c8e9b)
-4769e9f 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
-d07be52 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (e637109)
-8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
-f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
-e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
-90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+41af71d 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (da67dd1)
+2acbef2 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (e23e4fa)
+d778c06 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e23e4fa)
+5e83f80 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (da67dd1)
+82f0c86 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (da67dd1)
+5e5fe67 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (da67dd1)
+94d85c5 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (5129db9)
+5129db9 2000-01-02 00:00:00 [REWORD] Updated commit message
+da67dd1 2000-01-02 00:00:00 [REWORD] Updated commit message
+e23e4fa 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 "#]]);
@@ -657,7 +657,7 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
     redo(
         &env,
         OperationKind::RestoreFromSnapshotViaUndo,
-        "0a0795e",
+        "94d85c5",
         &status_four,
     );
 
@@ -668,17 +668,17 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-9306108 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (f4e985f)
-62ccc54 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (e637109)
-6ba0709 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (90c8e9b)
-5ffc4e1 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (90c8e9b)
-4769e9f 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
-d07be52 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (e637109)
-8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
-f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
-e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
-90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+71a02c9 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (5129db9)
+41af71d 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (da67dd1)
+2acbef2 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (e23e4fa)
+d778c06 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e23e4fa)
+5e83f80 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (da67dd1)
+82f0c86 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (da67dd1)
+5e5fe67 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (da67dd1)
+94d85c5 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (5129db9)
+5129db9 2000-01-02 00:00:00 [REWORD] Updated commit message
+da67dd1 2000-01-02 00:00:00 [REWORD] Updated commit message
+e23e4fa 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 "#]]);

--- a/crates/but/tests/but/command/undo/undo_rub.rs
+++ b/crates/but/tests/but/command/undo/undo_rub.rs
@@ -21,7 +21,7 @@ fn undo_squash_commits() {
             .arg("fe")
             .assert()
             .success()
-            .stdout_eq("Squashed 9ac4652 → f66c907\n")
+            .stdout_eq("Squashed 9ac4652 → zll\n")
             .stderr_eq("");
     });
 }

--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -337,6 +337,7 @@ pub(crate) fn save_and_return_to_workspace(ctx: &Context, perm: &mut RepoExclusi
             },
             but_rebase::commit::DateMode::CommitterUpdateAuthorKeep,
             SignCommit::IfSignCommitsEnabled,
+            None,
         )?
     };
 


### PR DESCRIPTION
By persisting the determined change id in the commit.rs `create` function, we’re able to handle it well in the `new_commit` function, which means that operations like reword will persist their change ids as well