### PR TITLE
Rebuild workspace commit when upstream target is already up-to-date

### DIFF
--- a/crates/but-workspace/tests/fixtures/scenario/merge-commit-head-already-integrated.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/merge-commit-head-already-integrated.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git init --initial-branch=master
+echo "Branch whose head is a merge commit that merged master into feature - already integrated upstream" >.git/description
+
+commit o1
+git branch o1
+
+# Feature branch with one commit
+git checkout -b feature
+commit feature-work
+git branch feature-work
+
+# Master advances
+git checkout master
+commit o2
+
+# Feature merges master into itself (common pattern: "catch up with master")
+git checkout feature
+git merge --no-ff -m "Merge master into feature" master
+
+# Master advances further and also merges the feature branch
+git checkout master
+git merge --no-ff -m "Merge feature" feature
+git branch merged-point
+commit o3
+
+setup_remote_tracking master master
+cat <<EOF >>.git/config
+[remote "origin"]
+	url = ./fake/local/path/which-is-fine-as-we-dont-fetch-or-push
+	fetch = +refs/heads/*:refs/remotes/origin/*
+
+[branch "master"]
+	remote = "origin"
+	merge = refs/heads/master
+EOF
+
+git checkout feature
+create_workspace_commit_once feature

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -568,6 +568,17 @@ pub(crate) fn integrate_upstream(
         let statuses = upstream_integration_statuses(&context)?;
 
         let StackStatuses::UpdatesRequired { statuses, .. } = statuses else {
+            // Even when stacks are up-to-date with the target, the workspace
+            // commit itself may be parented on an older base (e.g. after
+            // `bootstrap_default_target_if_missing` advanced `default_target.sha`
+            // without rebuilding the workspace commit). Rebuild it so the
+            // worktree reflects the current target.
+            let virtual_branches_state = VirtualBranchesHandle::new(ctx.project_data_dir());
+            crate::integration::update_workspace_commit_with_vb_state(
+                &virtual_branches_state,
+                ctx,
+                false,
+            )?;
             return Ok(IntegrationOutcome {
                 deleted_branches: vec![],
             });

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/apply_virtual_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/apply_virtual_branch.rs
@@ -995,3 +995,70 @@ fn integrate_upstream_with_inter_stack_tree_conflict() {
         );
     }
 }
+
+/// Regression test: when `default_target.sha` in TOML already matches the
+/// remote tip (e.g. written by `bootstrap_default_target_if_missing`) but the
+/// workspace commit is still parented on an older base, integrate_upstream
+/// must still rebuild the workspace commit so it sits on top of the target.
+#[test]
+fn integrate_upstream_rebuilds_stale_workspace_commit() {
+    let Test { repo, ctx, .. } = &mut Test::default();
+
+    // Create initial + second commit, push both
+    fs::write(repo.path().join("file.txt"), "initial").unwrap();
+    repo.commit_all("initial");
+    repo.push();
+    fs::write(repo.path().join("file.txt"), "second").unwrap();
+    let upstream_head = repo.commit_all("second commit");
+    repo.push();
+
+    // Reset local back so set_base_branch sees a delta
+    repo.reset_hard(Some(
+        but_testsupport::open_repo(repo.path())
+            .unwrap()
+            .rev_parse_single("HEAD~1")
+            .unwrap()
+            .detach(),
+    ));
+
+    // Set up GitButler — workspace commit will be parented on `initial`
+    let mut guard = ctx.exclusive_worktree_access();
+    gitbutler_branch_actions::set_base_branch(
+        ctx,
+        &"refs/remotes/origin/master".parse().unwrap(),
+        guard.write_permission(),
+    )
+    .unwrap();
+    drop(guard);
+
+    // Now simulate the bug condition: advance TOML target.sha to match
+    // origin/master without rebuilding the workspace commit. This is what
+    // bootstrap_default_target_if_missing does.
+    {
+        let mut meta = ctx.legacy_meta().unwrap();
+        let mut target = meta.data().default_target.clone().unwrap();
+        target.sha = upstream_head;
+        meta.set_default_target(target).unwrap();
+        ctx.invalidate_workspace_cache().unwrap();
+    }
+
+    // Verify the desync: TOML matches remote, but workspace is on old base
+    let base = gitbutler_branch_actions::base::get_base_branch_data(ctx).unwrap();
+    assert_eq!(base.base_sha, upstream_head, "TOML should be at remote tip");
+    assert!(
+        base.behind > 0,
+        "workspace commit is on old base, should show behind"
+    );
+
+    // Before the fix, this would return UpToDate and leave the workspace stale.
+    // Now it rebuilds the workspace commit even when the target is up-to-date.
+    let review_map = HashMap::new();
+    gitbutler_branch_actions::integrate_upstream(ctx, &[], None, &review_map)
+        .expect("integrate_upstream should succeed");
+
+    let base_after = gitbutler_branch_actions::base::get_base_branch_data(ctx).unwrap();
+    assert_eq!(
+        base_after.behind, 0,
+        "workspace should be rebuilt on current target"
+    );
+}


### PR DESCRIPTION
When `default_target.sha` in TOML already matches origin/master (e.g.
after `bootstrap_default_target_if_missing` writes the remote tip
directly), `integrate_upstream` returned `UpToDate` and skipped
rebuilding the workspace commit. This left the workspace commit
parented on an older base while the UI showed commits behind.

Now we always rebuild the workspace commit in the `UpToDate` path so
the worktree reflects the current target even when the metadata was
already advanced.