### PR TITLE
Add humanreadable title to OperationKind

### DIFF
--- a/crates/but/src/command/legacy/oplog.rs
+++ b/crates/but/src/command/legacy/oplog.rs
@@ -89,7 +89,7 @@ pub(crate) fn show_oplog(
                         .as_ref()
                         .filter(|b| !b.is_empty())
                         .cloned()
-                        .unwrap_or_else(|| details.title.clone()),
+                        .unwrap_or_else(|| details.operation.title().to_owned()),
                     OperationKind::Discard => {
                         let file_names = details
                             .trailers
@@ -98,9 +98,9 @@ pub(crate) fn show_oplog(
                             .map(|t| &*t.value)
                             .collect::<Vec<_>>();
                         if !file_names.is_empty() {
-                            format!("{} ({})", details.title, file_names.join(", "))
+                            format!("{} ({})", details.operation.title(), file_names.join(", "))
                         } else {
-                            details.title.clone()
+                            details.operation.title().to_owned()
                         }
                     }
                     OperationKind::CreateCommit
@@ -151,7 +151,7 @@ pub(crate) fn show_oplog(
                     | OperationKind::AutoHandleChangesAfter
                     | OperationKind::SplitBranch
                     | OperationKind::CleanWorkspace
-                    | OperationKind::Unknown => details.title.clone(),
+                    | OperationKind::Unknown => details.operation.title().to_owned(),
                 };
 
                 let display_title = out.truncate_if_unpaged(&display_title, 80);

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -2632,10 +2632,9 @@ impl App {
                 .into_iter()
                 .chain([Span::raw(" "), Span::raw(time).style(self.theme.time)])
                 .chain(target_snapshot.details.iter().flat_map(|details| {
-                    let op_type = details.operation.kind_str();
                     [
                         Span::raw(" "),
-                        Span::raw(op_type).style(self.theme.attention),
+                        Span::raw(details.operation.title()).style(self.theme.attention),
                     ]
                 }))
                 .chain([Span::raw("?")]),

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/undo_opens_confirm_for_latest_snapshot_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/undo_opens_confirm_for_latest_snapshot_001.svg
@@ -100,13 +100,13 @@
   <rect x="786" y="64" width="8" height="18" fill="#45475A" />
   <rect x="794" y="64" width="8" height="18" fill="#45475A" />
   <rect x="802" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="202" y="208" width="8" height="18" fill="#45475A" />
-  <rect x="210" y="208" width="8" height="18" fill="#45475A" />
-  <rect x="218" y="208" width="8" height="18" fill="#45475A" />
-  <rect x="226" y="208" width="8" height="18" fill="#45475A" />
-  <rect x="234" y="208" width="8" height="18" fill="#45475A" />
-  <rect x="242" y="208" width="8" height="18" fill="#45475A" />
-  <rect x="250" y="208" width="8" height="18" fill="#45475A" />
+  <rect x="138" y="208" width="8" height="18" fill="#45475A" />
+  <rect x="146" y="208" width="8" height="18" fill="#45475A" />
+  <rect x="154" y="208" width="8" height="18" fill="#45475A" />
+  <rect x="162" y="208" width="8" height="18" fill="#45475A" />
+  <rect x="170" y="208" width="8" height="18" fill="#45475A" />
+  <rect x="178" y="208" width="8" height="18" fill="#45475A" />
+  <rect x="186" y="208" width="8" height="18" fill="#45475A" />
   <rect x="10" y="352" width="8" height="18" fill="#555555" />
   <rect x="18" y="352" width="8" height="18" fill="#555555" />
   <rect x="26" y="352" width="8" height="18" fill="#555555" />
@@ -218,14 +218,15 @@
   <text x="74" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
   <text x="90" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
   <text x="98" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
-  <text x="106" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
-  <text x="114" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
-  <text x="122" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
-  <text x="130" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
-  <text x="138" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
-  <text x="154" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
-  <text x="162" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="170" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
+  <text x="106" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
+  <text x="114" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="122" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="130" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="138" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="146" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="154" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="162" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="170" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
   <text x="178" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
   <text x="186" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
   <text x="194" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
@@ -285,65 +286,95 @@
   <text x="626" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
   <text x="634" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
   <text x="642" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
-  <text x="650" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╮</text>
-  <text x="170" y="168" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
-  <text x="650" y="168" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
-  <text x="170" y="186" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
-  <text x="202" y="186" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">U</text>
-  <text x="210" y="186" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
-  <text x="218" y="186" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="226" y="186" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
-  <text x="242" y="186" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="250" y="186" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="258" y="186" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="266" y="186" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="274" y="186" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="282" y="186" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="290" y="186" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="306" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">S</text>
-  <text x="314" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="322" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
-  <text x="338" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">J</text>
-  <text x="346" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="354" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
-  <text x="370" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
-  <text x="386" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="394" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="402" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">:</text>
+  <text x="650" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="658" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="666" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="674" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="682" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="690" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="698" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="706" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="714" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╮</text>
+  <text x="106" y="168" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="714" y="168" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="106" y="186" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="138" y="186" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">U</text>
+  <text x="146" y="186" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="154" y="186" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="162" y="186" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="178" y="186" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="186" y="186" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="194" y="186" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="202" y="186" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="210" y="186" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="218" y="186" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="226" y="186" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="242" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">S</text>
+  <text x="250" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="258" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="274" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">J</text>
+  <text x="282" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="290" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="306" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="322" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="330" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="338" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">:</text>
+  <text x="346" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="354" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="362" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">:</text>
+  <text x="370" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="378" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="394" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="402" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
   <text x="410" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
   <text x="418" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="426" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">:</text>
-  <text x="434" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="434" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">+</text>
   <text x="442" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="458" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="450" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="458" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
   <text x="466" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="474" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="482" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="498" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">+</text>
-  <text x="506" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="514" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="522" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="530" y="186" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="546" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">R</text>
-  <text x="554" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">E</text>
-  <text x="562" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">W</text>
-  <text x="570" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">O</text>
-  <text x="578" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">R</text>
-  <text x="586" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">D</text>
-  <text x="594" y="186" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">?</text>
-  <text x="650" y="186" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
-  <text x="170" y="204" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
-  <text x="650" y="204" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
-  <text x="170" y="222" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
-  <text x="218" y="222" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">Y</text>
-  <text x="226" y="222" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
-  <text x="234" y="222" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
-  <text x="274" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">N</text>
-  <text x="282" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
-  <text x="650" y="222" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
-  <text x="170" y="240" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
-  <text x="650" y="240" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
-  <text x="170" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╰</text>
+  <text x="482" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">U</text>
+  <text x="490" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="498" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="506" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="514" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="522" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="530" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="546" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="554" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="562" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="570" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="578" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="586" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="602" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="610" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="618" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="626" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="634" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="642" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="650" y="186" style="fill:#AA5500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="658" y="186" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">?</text>
+  <text x="714" y="186" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="106" y="204" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="714" y="204" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="106" y="222" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="154" y="222" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">Y</text>
+  <text x="162" y="222" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="170" y="222" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="210" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">N</text>
+  <text x="218" y="222" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="714" y="222" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="106" y="240" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="714" y="240" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="106" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╰</text>
+  <text x="114" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="122" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="130" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="138" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="146" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="154" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="162" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="170" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
   <text x="178" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
   <text x="186" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
   <text x="194" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
@@ -403,7 +434,15 @@
   <text x="626" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
   <text x="634" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
   <text x="642" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
-  <text x="650" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
+  <text x="650" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="658" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="666" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="674" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="682" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="690" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="698" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="706" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="714" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
   <text x="10" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
   <text x="18" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
   <text x="26" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -186,7 +186,7 @@ Created new independent branch 'feature-x'
         .stdout_eq(str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-[SHORTHASH] 2000-01-02 00:00:00 [COMMIT] CreateCommit
+[SHORTHASH] 2000-01-02 00:00:00 [COMMIT] Created commit
 
 "#]]);
     Ok(())

--- a/crates/but/tests/but/command/undo.rs
+++ b/crates/but/tests/but/command/undo.rs
@@ -271,10 +271,10 @@ fn can_undo_repeatedly() -> anyhow::Result<()> {
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-f4e985f 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-90c8e9b 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
+e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
+90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
@@ -287,11 +287,11 @@ e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-d9fd48f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-f4e985f 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-90c8e9b 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
+e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
+90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
@@ -304,12 +304,12 @@ e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-7214e58 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-d9fd48f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-f4e985f 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-90c8e9b 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+d6d5c2e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
+e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
+90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
@@ -322,13 +322,13 @@ e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-00c7dd1 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-7214e58 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-d9fd48f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-f4e985f 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-90c8e9b 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+b7c6717 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+d6d5c2e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
+e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
+90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
@@ -352,10 +352,10 @@ fn can_undo_explicit_restore() -> anyhow::Result<()> {
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-f4e985f 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-90c8e9b 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
+e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
+90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
@@ -368,15 +368,15 @@ e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-2859d85 2000-01-02 00:00:00 [RESTORE] Restored from snapshot
-f4e985f 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-90c8e9b 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+37400a2 2000-01-02 00:00:00 [RESTORE] Restored from snapshot
+f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
+e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
+90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
-    undo(&env, "Restored from snapshot", "2859d85", &status_four);
+    undo(&env, "RestoreFromSnapshot", "37400a2", &status_four);
 
     env.but("oplog")
         .args(["list"])
@@ -385,12 +385,12 @@ e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-63bad11 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-2859d85 2000-01-02 00:00:00 [RESTORE] Restored from snapshot
-f4e985f 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-90c8e9b 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+d42878d 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+37400a2 2000-01-02 00:00:00 [RESTORE] Restored from snapshot
+f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
+e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
+90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
@@ -414,10 +414,10 @@ fn can_undo_perform_operation_then_undo_again() -> anyhow::Result<()> {
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-f4e985f 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-90c8e9b 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
+e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
+90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
@@ -432,16 +432,16 @@ e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-f48a8d3 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-d9fd48f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-f4e985f 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-90c8e9b 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+9deba9a 2000-01-02 00:00:00 [REWORD] Updated commit message
+351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
+e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
+90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
-    undo(&env, "UpdateCommitMessage", "f48a8d3", &status_three);
+    undo(&env, "UpdateCommitMessage", "9deba9a", &status_three);
 
     env.but("oplog")
         .args(["list"])
@@ -450,13 +450,13 @@ e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-428645c 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-f48a8d3 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-d9fd48f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-f4e985f 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-90c8e9b 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+d83358a 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+9deba9a 2000-01-02 00:00:00 [REWORD] Updated commit message
+351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
+e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
+90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
@@ -481,8 +481,8 @@ fn undoing_past_end_of_oplog() -> anyhow::Result<()> {
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-90c8e9b 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
@@ -495,9 +495,9 @@ fn undoing_past_end_of_oplog() -> anyhow::Result<()> {
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-56ad039 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-90c8e9b 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+7952170 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
@@ -510,10 +510,10 @@ fn undoing_past_end_of_oplog() -> anyhow::Result<()> {
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-c6dfa5f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-56ad039 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-90c8e9b 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+dffcebb 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+7952170 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
@@ -542,10 +542,10 @@ fn can_redo() -> anyhow::Result<()> {
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-f4e985f 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-90c8e9b 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
+e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
+90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
@@ -558,15 +558,15 @@ e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-d9fd48f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-f4e985f 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-90c8e9b 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
+e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
+90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
-    redo(&env, "Restored from snapshot", "d9fd48f", &status_four);
+    redo(&env, "RestoreFromSnapshotViaUndo", "351f999", &status_four);
 
     env.but("oplog")
         .args(["list"])
@@ -575,12 +575,12 @@ e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-06a99ab 2000-01-02 00:00:00 [REDO] Restored from snapshot
-d9fd48f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-f4e985f 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-90c8e9b 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+470a391 2000-01-02 00:00:00 [REDO] Restored from snapshot
+351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
+e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
+90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
@@ -609,10 +609,10 @@ fn can_mix_undo_and_redo() -> anyhow::Result<()> {
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-f4e985f 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-90c8e9b 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
+e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
+90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
@@ -626,16 +626,16 @@ e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-7214e58 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-d9fd48f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-f4e985f 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-90c8e9b 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+d6d5c2e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
+e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
+90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
-    redo(&env, "Restored from snapshot", "7214e58", &status_three);
+    redo(&env, "RestoreFromSnapshotViaUndo", "d6d5c2e", &status_three);
 
     env.but("oplog")
         .args(["list"])
@@ -644,17 +644,17 @@ e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-95f6f16 2000-01-02 00:00:00 [REDO] Restored from snapshot
-7214e58 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-d9fd48f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-f4e985f 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-90c8e9b 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+de4e85a 2000-01-02 00:00:00 [REDO] Restored from snapshot
+d6d5c2e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
+e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
+90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
-    undo(&env, "Restored from snapshot", "95f6f16", &status_two);
+    undo(&env, "RestoreFromSnapshotViaRedo", "de4e85a", &status_two);
 
     env.but("oplog")
         .args(["list"])
@@ -663,14 +663,14 @@ e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-2cf5b5e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-95f6f16 2000-01-02 00:00:00 [REDO] Restored from snapshot
-7214e58 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-d9fd48f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-f4e985f 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-90c8e9b 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+88d2b33 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+de4e85a 2000-01-02 00:00:00 [REDO] Restored from snapshot
+d6d5c2e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
+e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
+90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
@@ -683,19 +683,19 @@ e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-6d38f68 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-2cf5b5e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-95f6f16 2000-01-02 00:00:00 [REDO] Restored from snapshot
-7214e58 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-d9fd48f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-f4e985f 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-90c8e9b 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+7a7ac10 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+88d2b33 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+de4e85a 2000-01-02 00:00:00 [REDO] Restored from snapshot
+d6d5c2e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
+e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
+90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
-    redo(&env, "Restored from snapshot", "6d38f68", &status_two);
+    redo(&env, "RestoreFromSnapshotViaUndo", "7a7ac10", &status_two);
 
     env.but("oplog")
         .args(["list"])
@@ -704,20 +704,20 @@ e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-7eb783e 2000-01-02 00:00:00 [REDO] Restored from snapshot
-6d38f68 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-2cf5b5e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-95f6f16 2000-01-02 00:00:00 [REDO] Restored from snapshot
-7214e58 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-d9fd48f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-f4e985f 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-90c8e9b 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+73e2f4f 2000-01-02 00:00:00 [REDO] Restored from snapshot
+7a7ac10 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+88d2b33 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+de4e85a 2000-01-02 00:00:00 [REDO] Restored from snapshot
+d6d5c2e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
+e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
+90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
-    redo(&env, "Restored from snapshot", "2cf5b5e", &status_three);
+    redo(&env, "RestoreFromSnapshotViaUndo", "88d2b33", &status_three);
 
     env.but("oplog")
         .args(["list"])
@@ -726,21 +726,21 @@ e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-505fa4a 2000-01-02 00:00:00 [REDO] Restored from snapshot
-7eb783e 2000-01-02 00:00:00 [REDO] Restored from snapshot
-6d38f68 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-2cf5b5e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-95f6f16 2000-01-02 00:00:00 [REDO] Restored from snapshot
-7214e58 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-d9fd48f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-f4e985f 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-90c8e9b 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+d8203df 2000-01-02 00:00:00 [REDO] Restored from snapshot
+73e2f4f 2000-01-02 00:00:00 [REDO] Restored from snapshot
+7a7ac10 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+88d2b33 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+de4e85a 2000-01-02 00:00:00 [REDO] Restored from snapshot
+d6d5c2e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
+e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
+90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
-    redo(&env, "Restored from snapshot", "d9fd48f", &status_four);
+    redo(&env, "RestoreFromSnapshotViaUndo", "351f999", &status_four);
 
     env.but("oplog")
         .args(["list"])
@@ -749,18 +749,18 @@ e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-376d3cb 2000-01-02 00:00:00 [REDO] Restored from snapshot
-505fa4a 2000-01-02 00:00:00 [REDO] Restored from snapshot
-7eb783e 2000-01-02 00:00:00 [REDO] Restored from snapshot
-6d38f68 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-2cf5b5e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-95f6f16 2000-01-02 00:00:00 [REDO] Restored from snapshot
-7214e58 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-d9fd48f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-f4e985f 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-e637109 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-90c8e9b 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
-7665ea7 2000-01-02 00:00:00 [REWORD] UpdateCommitMessage
+6f2c4bb 2000-01-02 00:00:00 [REDO] Restored from snapshot
+d8203df 2000-01-02 00:00:00 [REDO] Restored from snapshot
+73e2f4f 2000-01-02 00:00:00 [REDO] Restored from snapshot
+7a7ac10 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+88d2b33 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+de4e85a 2000-01-02 00:00:00 [REDO] Restored from snapshot
+d6d5c2e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
+e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
+90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
+7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 

--- a/crates/gitbutler-oplog/src/entry.rs
+++ b/crates/gitbutler-oplog/src/entry.rs
@@ -49,7 +49,7 @@ impl SnapshotDetails {
         SnapshotDetails {
             version: Default::default(),
             operation,
-            title: operation.to_string(),
+            title: operation.as_persisted_str().to_string(),
             body: None,
             trailers: vec![],
         }
@@ -95,7 +95,7 @@ impl FromStr for SnapshotDetails {
             .iter()
             .find(|t| t.key == OPERATION_TRAILER_KEY)
             .ok_or(anyhow!("No operation found on snapshot commit message"))?;
-        let operation = OperationKind::parse_persisted(&operation_trailer.value)
+        let operation = OperationKind::parse_persisted_str(&operation_trailer.value)
             .unwrap_or(OperationKind::Unknown);
 
         // remove the version and operation attributes from the trailers since they have dedicated fields
@@ -118,7 +118,11 @@ impl Display for SnapshotDetails {
             writeln!(f, "{body}\n")?;
         }
         writeln!(f, "{VERSION_TRAILER_KEY}: {}", self.version)?;
-        writeln!(f, "{OPERATION_TRAILER_KEY}: {}", self.operation)?;
+        writeln!(
+            f,
+            "{OPERATION_TRAILER_KEY}: {}",
+            self.operation.as_persisted_str()
+        )?;
         for line in &self.trailers {
             writeln!(f, "{line}")?;
         }
@@ -244,7 +248,118 @@ impl OperationKind {
         }
     }
 
-    pub fn parse_persisted(s: &str) -> Option<Self> {
+    pub fn title(self) -> &'static str {
+        match self {
+            OperationKind::CreateCommit => "Created commit",
+            OperationKind::CreateBranch => "Created branch",
+            OperationKind::StashIntoBranch => "Stashed into branch",
+            OperationKind::SetBaseBranch => "Set base branch",
+            OperationKind::MergeUpstream => "Merged upstream",
+            OperationKind::UpdateWorkspaceBase => "Updated workspace base",
+            OperationKind::MoveHunk => "Moved hunk",
+            OperationKind::UpdateBranchName => "Renamed branch",
+            OperationKind::UpdateBranchNotes => "Updated branch notes",
+            OperationKind::ReorderBranches => "Reordered branches",
+            OperationKind::UpdateBranchRemoteName => "Updated branch remote",
+            OperationKind::GenericBranchUpdate => "Updated branch",
+            OperationKind::DeleteBranch => "Deleted branch",
+            OperationKind::ApplyBranch => "Applied branch",
+            OperationKind::DiscardLines => "Discarded lines",
+            OperationKind::DiscardHunk => "Discarded hunk",
+            OperationKind::DiscardFile => "Discarded file",
+            OperationKind::DiscardChanges | OperationKind::Discard => "Discarded changes",
+            OperationKind::AmendCommit => "Amended commit",
+            OperationKind::Absorb => "Absorbed changes",
+            OperationKind::AutoCommit => "Auto-committed changes",
+            OperationKind::UndoCommit => "Undid commit",
+            OperationKind::DiscardCommit => "Discarded commit",
+            OperationKind::UnapplyBranch => "Unapplied branch",
+            OperationKind::CherryPick => "Cherry-picked commit",
+            OperationKind::SquashCommit => "Squashed commit",
+            OperationKind::UpdateCommitMessage => "Updated commit message",
+            OperationKind::MoveCommit => "Moved commit",
+            OperationKind::MoveBranch => "Moved branch",
+            OperationKind::TearOffBranch => "Unstacked branch",
+            OperationKind::RestoreFromSnapshotViaUndo
+            | OperationKind::RestoreFromSnapshotViaRedo
+            | OperationKind::RestoreFromSnapshot => "Restored from snapshot",
+            OperationKind::ReorderCommit => "Reordered commit",
+            OperationKind::InsertBlankCommit => "Inserted blank commit",
+            OperationKind::MoveCommitFile => "Moved file",
+            OperationKind::FileChanges => "Updated file changes",
+            OperationKind::EnterEditMode => "Entered edit mode",
+            OperationKind::SyncWorkspace => "Synced workspace",
+            OperationKind::CreateDependentBranch => "Created branch",
+            OperationKind::RemoveDependentBranch => "Removed branch",
+            OperationKind::UpdateDependentBranchName => "Updated branch name",
+            OperationKind::UpdateDependentBranchDescription => "Updated branch description",
+            OperationKind::UpdateDependentBranchPrNumber => "Updated branch pull request number",
+            OperationKind::AutoHandleChangesBefore => "Handled changes before action",
+            OperationKind::AutoHandleChangesAfter => "Handled changes after action",
+            OperationKind::SplitBranch => "Split branch",
+            OperationKind::CleanWorkspace => "Cleaned workspace",
+            OperationKind::OnDemandSnapshot => "Created snapshot",
+            OperationKind::Unknown => "Unknown operation",
+        }
+    }
+
+    pub fn as_persisted_str(self) -> &'static str {
+        match self {
+            OperationKind::CreateCommit => "CreateCommit",
+            OperationKind::CreateBranch => "CreateBranch",
+            OperationKind::StashIntoBranch => "StashIntoBranch",
+            OperationKind::SetBaseBranch => "SetBaseBranch",
+            OperationKind::MergeUpstream => "MergeUpstream",
+            OperationKind::UpdateWorkspaceBase => "UpdateWorkspaceBase",
+            OperationKind::MoveHunk => "MoveHunk",
+            OperationKind::UpdateBranchName => "UpdateBranchName",
+            OperationKind::UpdateBranchNotes => "UpdateBranchNotes",
+            OperationKind::ReorderBranches => "ReorderBranches",
+            OperationKind::UpdateBranchRemoteName => "UpdateBranchRemoteName",
+            OperationKind::GenericBranchUpdate => "GenericBranchUpdate",
+            OperationKind::DeleteBranch => "DeleteBranch",
+            OperationKind::ApplyBranch => "ApplyBranch",
+            OperationKind::DiscardLines => "DiscardLines",
+            OperationKind::DiscardHunk => "DiscardHunk",
+            OperationKind::DiscardFile => "DiscardFile",
+            OperationKind::DiscardChanges => "DiscardChanges",
+            OperationKind::Discard => "Discard",
+            OperationKind::AmendCommit => "AmendCommit",
+            OperationKind::Absorb => "Absorb",
+            OperationKind::AutoCommit => "AutoCommit",
+            OperationKind::UndoCommit => "UndoCommit",
+            OperationKind::DiscardCommit => "DiscardCommit",
+            OperationKind::UnapplyBranch => "UnapplyBranch",
+            OperationKind::CherryPick => "CherryPick",
+            OperationKind::SquashCommit => "SquashCommit",
+            OperationKind::UpdateCommitMessage => "UpdateCommitMessage",
+            OperationKind::MoveCommit => "MoveCommit",
+            OperationKind::MoveBranch => "MoveBranch",
+            OperationKind::TearOffBranch => "TearOffBranch",
+            OperationKind::RestoreFromSnapshotViaUndo => "RestoreFromSnapshotViaUndo",
+            OperationKind::RestoreFromSnapshotViaRedo => "RestoreFromSnapshotViaRedo",
+            OperationKind::RestoreFromSnapshot => "RestoreFromSnapshot",
+            OperationKind::ReorderCommit => "ReorderCommit",
+            OperationKind::InsertBlankCommit => "InsertBlankCommit",
+            OperationKind::MoveCommitFile => "MoveCommitFile",
+            OperationKind::FileChanges => "FileChanges",
+            OperationKind::EnterEditMode => "EnterEditMode",
+            OperationKind::SyncWorkspace => "SyncWorkspace",
+            OperationKind::CreateDependentBranch => "CreateDependentBranch",
+            OperationKind::RemoveDependentBranch => "RemoveDependentBranch",
+            OperationKind::UpdateDependentBranchName => "UpdateDependentBranchName",
+            OperationKind::UpdateDependentBranchDescription => "UpdateDependentBranchDescription",
+            OperationKind::UpdateDependentBranchPrNumber => "UpdateDependentBranchPrNumber",
+            OperationKind::AutoHandleChangesBefore => "AutoHandleChangesBefore",
+            OperationKind::AutoHandleChangesAfter => "AutoHandleChangesAfter",
+            OperationKind::SplitBranch => "SplitBranch",
+            OperationKind::CleanWorkspace => "CleanWorkspace",
+            OperationKind::OnDemandSnapshot => "OnDemandSnapshot",
+            OperationKind::Unknown => "Unknown",
+        }
+    }
+
+    pub fn parse_persisted_str(s: &str) -> Option<Self> {
         Some(match s {
             "CreateCommit" => Self::CreateCommit,
             "CreateBranch" => Self::CreateBranch,
@@ -299,12 +414,6 @@ impl OperationKind {
             "Unknown" => Self::Unknown,
             _ => return None,
         })
-    }
-}
-
-impl fmt::Display for OperationKind {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        Debug::fmt(self, f)
     }
 }
 

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -814,7 +814,7 @@ fn restore_snapshot(
         .to_str()
         .ok()
         .and_then(|msg| SnapshotDetails::from_str(msg).ok())
-        .map(|d| d.operation.to_string())
+        .map(|d| d.operation.title().to_owned())
         .unwrap_or_default();
 
     // create new snapshot
@@ -828,7 +828,7 @@ fn restore_snapshot(
     let details = SnapshotDetails {
         version: Default::default(),
         operation,
-        title: "Restored from snapshot".to_string(),
+        title: operation.as_persisted_str().to_owned(),
         body: None,
         trailers: vec![
             Trailer {

--- a/crates/gitbutler-oplog/tests/oplog/main.rs
+++ b/crates/gitbutler-oplog/tests/oplog/main.rs
@@ -68,7 +68,7 @@ mod operation_kind {
     fn from_trailer() {
         let s = "Operation: CreateCommit";
         let trailer = Trailer::from_str(s).unwrap();
-        let operation = OperationKind::parse_persisted(&trailer.value).unwrap();
+        let operation = OperationKind::parse_persisted_str(&trailer.value).unwrap();
         assert_eq!(operation, OperationKind::CreateCommit);
     }
 


### PR DESCRIPTION
So instead of

```
0ca46ee34d 2026-05-12 12:04:59 [SQUASH] SquashCommit
```

We now show

```
0ca46ee34d 2026-05-12 12:04:59 [SQUASH] Squashed commit
```

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #13764 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #13763
<!-- GitButler Footer Boundary Bottom -->