### PR TITLE
editor: merge commit changes into tree

### DIFF
--- a/crates/but-core/src/commit/mod.rs
+++ b/crates/but-core/src/commit/mod.rs
@@ -6,6 +6,7 @@ use anyhow::{Context as _, bail};
 use bstr::{BStr, BString, ByteSlice};
 use but_error::Code;
 use gix::objs::WriteTo;
+use gix::objs::tree::EntryKind;
 use gix::prelude::ObjectIdExt;
 use serde::{Deserialize, Serialize};
 
@@ -703,3 +704,62 @@ pub use conflict::{
     add_conflict_markers, is_conflicted, message_is_conflicted,
     rewrite_conflict_markers_on_message_change, strip_conflict_markers,
 };
+
+/// Write a GitButler conflicted tree that wraps `resolved_tree_id` together
+/// with the conflict side trees and conflict file list.
+///
+/// - `repo` - is the repository that owns all tree objects involved and receives
+///   the newly written conflicted tree.
+///
+/// - `resolved_tree_id` - is the visible auto-resolved tree that callers want to
+///   present as the conflicted commit's main tree.
+///
+/// - `base_tree_id` - is the merge-base tree used for the conflicted merge step.
+///
+/// - `ours_tree_id` - is the accumulated tree on the "ours" side of the conflict.
+///
+/// - `theirs_tree_id` - is the incoming tree on the "theirs" side of the conflict.
+///
+/// - `conflict_entries` - lists the paths that should be recorded as conflicted in
+///   the synthetic GitButler tree metadata.
+pub fn write_conflicted_tree(
+    repo: &gix::Repository,
+    resolved_tree_id: gix::ObjectId,
+    base_tree_id: gix::ObjectId,
+    ours_tree_id: gix::ObjectId,
+    theirs_tree_id: gix::ObjectId,
+    conflict_entries: &ConflictEntries,
+) -> anyhow::Result<gix::ObjectId> {
+    let conflicted_files_string = toml::to_string(conflict_entries)?;
+    let conflicted_files_blob = repo.write_blob(conflicted_files_string.as_bytes())?;
+
+    let mut tree = repo.find_tree(resolved_tree_id)?.edit()?;
+    tree.upsert(
+        TreeKind::Ours.as_tree_entry_name(),
+        EntryKind::Tree,
+        ours_tree_id,
+    )?;
+    tree.upsert(
+        TreeKind::Theirs.as_tree_entry_name(),
+        EntryKind::Tree,
+        theirs_tree_id,
+    )?;
+    tree.upsert(
+        TreeKind::Base.as_tree_entry_name(),
+        EntryKind::Tree,
+        base_tree_id,
+    )?;
+    tree.upsert(
+        TreeKind::AutoResolution.as_tree_entry_name(),
+        EntryKind::Tree,
+        resolved_tree_id,
+    )?;
+    tree.upsert(
+        TreeKind::ConflictFiles.as_tree_entry_name(),
+        EntryKind::Blob,
+        conflicted_files_blob,
+    )?;
+    tree.write()
+        .context("failed to write conflicted tree")
+        .map(|tree_id| tree_id.detach())
+}

--- a/crates/but-core/src/commit/mod.rs
+++ b/crates/but-core/src/commit/mod.rs
@@ -699,6 +699,88 @@ impl ConflictEntries {
     }
 }
 
+/// Derive GitButler conflict entry metadata from a `gix` tree-merge outcome.
+///
+/// This is the shared translation used when a merge is auto-resolved but still
+/// has unresolved conflicts that must be persisted in a conflicted commit/tree.
+/// It first asks `gix` to materialize conflict stages into an index view of the
+/// merged tree. If that yields no staged conflict paths, it falls back to the
+/// unresolved conflict list from the merge outcome itself, which is important
+/// for force-resolved merges where Git would otherwise omit index stages.
+///
+/// - `repo` - is the repository that owns `merged_tree_id` and provides the index
+///   machinery used to derive stage entries from the merge result.
+///
+/// - `merged_tree_id` - is the tree written from the merge result's auto-resolved
+///   output, which is reloaded so conflict stages can be inspected.
+///
+/// - `merge_result` - is the original `gix` merge outcome whose unresolved
+///   conflicts are translated into GitButler conflict-entry metadata.
+///
+/// - `treat_as_unresolved` - decides which conflicts should still be treated as
+///   unresolved when scanning both staged entries and fallback conflict records.
+pub fn conflict_entries_from_merge_outcome(
+    repo: &gix::Repository,
+    merged_tree_id: gix::ObjectId,
+    merge_result: &gix::merge::tree::Outcome<'_>,
+    treat_as_unresolved: gix::merge::tree::TreatAsUnresolved,
+) -> anyhow::Result<ConflictEntries> {
+    use gix::index::entry::Stage;
+
+    let mut index = repo.index_from_tree(&merged_tree_id.attach(repo))?;
+    merge_result.index_changed_after_applying_conflicts(
+        &mut index,
+        treat_as_unresolved,
+        gix::merge::tree::apply_index_entries::RemovalMode::Mark,
+    );
+
+    let (mut ancestor_entries, mut our_entries, mut their_entries) =
+        (Vec::new(), Vec::new(), Vec::new());
+    for entry in index.entries() {
+        let storage = match entry.stage() {
+            Stage::Unconflicted => continue,
+            Stage::Base => &mut ancestor_entries,
+            Stage::Ours => &mut our_entries,
+            Stage::Theirs => &mut their_entries,
+        };
+        storage.push(gix::path::from_bstr(entry.path(&index)).into_owned());
+    }
+
+    let mut out = ConflictEntries {
+        ancestor_entries,
+        our_entries,
+        their_entries,
+    };
+
+    if !out.has_entries() {
+        fn push_unique(v: &mut Vec<PathBuf>, change: &gix::diff::tree_with_rewrites::Change) {
+            let path = gix::path::from_bstr(change.location()).into_owned();
+            if !v.contains(&path) {
+                v.push(path);
+            }
+        }
+
+        for conflict in merge_result
+            .conflicts
+            .iter()
+            .filter(|c| c.is_unresolved(treat_as_unresolved))
+        {
+            let (ours, theirs) = conflict.changes_in_resolution();
+            push_unique(&mut out.our_entries, ours);
+            push_unique(&mut out.their_entries, theirs);
+        }
+    }
+
+    assert_eq!(
+        out.has_entries(),
+        merge_result.has_unresolved_conflicts(treat_as_unresolved),
+        "Must have entries to indicate conflicting files, or bad things will happen later: {:#?}",
+        merge_result.conflicts
+    );
+
+    Ok(out)
+}
+
 mod conflict;
 pub use conflict::{
     add_conflict_markers, is_conflicted, message_is_conflicted,

--- a/crates/but-rebase/docs/merge_commit_changes.md
+++ b/crates/but-rebase/docs/merge_commit_changes.md
@@ -1,0 +1,67 @@
+# Merge Commit Changes
+
+This module contains the editor helpers for combining selected commit changes
+into a single tree and for planning those changes as mergeable `base..commit`
+ranges.
+
+## `merge_commit_changes_to_tree`
+
+`Editor::merge_commit_changes_to_tree(target, subjects, merge_options)` builds a
+tree by:
+
+1. using the target commit's full visible tree as the baseline,
+2. asking the planner to normalize the selected subject commits into mergeable
+   change ranges,
+3. merging those planned `base_tree_id -> commit^{tree}` ranges into the
+   accumulated tree in planner-defined order, and
+4. stopping at the first unresolved merge conflict while returning the
+   auto-resolved tree plus conflict metadata.
+
+The target contributes its whole tree. Subject commits contribute only their
+selected change ranges.
+
+## `plan_commit_changes_for_merge`
+
+`Editor::plan_commit_changes_for_merge(target, subjects)` turns a set of
+selected subject commits into emitted `PlannedCommitChange` entries.
+
+The planner uses a single traversal of the editor graph, rooted from the same
+child-most entrypoints used by commit parentage ordering. During that traversal
+it derives:
+
+- canonical subject order from editor parentage,
+- selected first-parent relationships for contiguous-chain collapse, and
+- the target ancestry cone for pruning.
+
+The planner then emits only non-pruned selected-chain tips.
+
+Even though traversal and pruning are driven by the editor step graph, the
+planner still takes first-parent and tree semantics from the commit objects in
+the editor's in-memory repository. In other words:
+
+- the in-memory repository is the source of truth for commit parents, trees,
+  and SHAs,
+- the step graph is used only to walk the selected region deterministically and
+  to discover the target ancestry cone quickly, and
+- callers are expected to keep those two views aligned before using these
+  helpers.
+
+## Design Decisions
+
+- The planner is the sole source of truth for subject ordering. Call-sites
+  should pass raw selected subject IDs and not pre-order them.
+- Subject ordering is canonicalized from the editor graph, not from caller
+  input order.
+- Duplicate subject IDs are deduplicated by commit ID only.
+- Pruning uses full target ancestry across any parent edge.
+- Collapse uses only selected first-parent chains.
+- Pruned commits are never emitted as merge picks.
+- A pruned selected first parent may still define the `base_tree_id` boundary
+  for a surviving descendant, so a surviving tip can emit `B..C` even when `B`
+  is pruned.
+- The editor step graph is expected to represent the same topology as the
+  editor's in-memory repository. These helpers do not treat step-graph rewiring
+  as a new source of commit parent truth.
+- The editor is assumed to already be normalized and up to date before calling
+  these helpers. Callers chaining earlier editor mutations should normalize via
+  `editor.rebase()?.into_editor()` first.

--- a/crates/but-rebase/src/cherry_pick.rs
+++ b/crates/but-rebase/src/cherry_pick.rs
@@ -22,14 +22,13 @@ pub enum EmptyCommit {
     UsePrevious,
 }
 
-use std::path::PathBuf;
-
 use anyhow::{Context as _, bail};
 use bstr::BString;
-use but_core::commit::{HEADERS_CONFLICTED_FIELD, Headers, SignCommit, TreeKind};
+use but_core::commit::{
+    HEADERS_CONFLICTED_FIELD, Headers, SignCommit, TreeKind, conflict_entries_from_merge_outcome,
+};
 use but_error::bail_precondition;
 use gix::{object::tree::EntryKind, prelude::ObjectIdExt};
-use serde::Serialize;
 
 use crate::commit::DateMode;
 
@@ -197,8 +196,12 @@ fn commit_from_conflicted_tree<'repo>(
 ) -> anyhow::Result<gix::Id<'repo>> {
     let repo = resolved_tree_id.repo;
 
-    let conflicted_files =
-        extract_conflicted_files(resolved_tree_id, cherry_pick, treat_as_unresolved)?;
+    let conflicted_files = conflict_entries_from_merge_outcome(
+        repo,
+        resolved_tree_id.detach(),
+        &cherry_pick,
+        treat_as_unresolved,
+    )?;
 
     // convert files into a string and save as a blob
     let conflicted_files_string = toml::to_string(&conflicted_files)?;
@@ -249,86 +252,4 @@ fn commit_from_conflicted_tree<'repo>(
         SignCommit::IfSignCommitsEnabled,
     )?
     .attach(repo))
-}
-
-fn extract_conflicted_files(
-    merged_tree_id: gix::Id<'_>,
-    merge_result: gix::merge::tree::Outcome<'_>,
-    treat_as_unresolved: gix::merge::tree::TreatAsUnresolved,
-) -> anyhow::Result<ConflictEntries> {
-    use gix::index::entry::Stage;
-    let repo = merged_tree_id.repo;
-    let mut index = repo.index_from_tree(&merged_tree_id)?;
-    merge_result.index_changed_after_applying_conflicts(
-        &mut index,
-        treat_as_unresolved,
-        gix::merge::tree::apply_index_entries::RemovalMode::Mark,
-    );
-    let (mut ancestor_entries, mut our_entries, mut their_entries) =
-        (Vec::new(), Vec::new(), Vec::new());
-    for entry in index.entries() {
-        let stage = entry.stage();
-        let storage = match stage {
-            Stage::Unconflicted => {
-                continue;
-            }
-            Stage::Base => &mut ancestor_entries,
-            Stage::Ours => &mut our_entries,
-            Stage::Theirs => &mut their_entries,
-        };
-
-        let path = entry.path(&index);
-        storage.push(gix::path::from_bstr(path).into_owned());
-    }
-    let mut out = ConflictEntries {
-        ancestor_entries,
-        our_entries,
-        their_entries,
-    };
-
-    // Since we typically auto-resolve with 'ours', it maybe that conflicting entries don't have an
-    // unconflicting counterpart anymore, so they are not applied (which is also what Git does).
-    // So to have something to show for - we *must* produce a conflict, extract paths manually.
-    // TODO(ST): instead of doing this, don't pre-record the paths. Instead redo the merge without
-    //           merge-strategy so that the index entries can be used instead.
-    if !out.has_entries() {
-        fn push_unique(v: &mut Vec<PathBuf>, change: &gix::diff::tree_with_rewrites::Change) {
-            let path = gix::path::from_bstr(change.location()).into_owned();
-            if !v.contains(&path) {
-                v.push(path);
-            }
-        }
-        for conflict in merge_result
-            .conflicts
-            .iter()
-            .filter(|c| c.is_unresolved(treat_as_unresolved))
-        {
-            let (ours, theirs) = conflict.changes_in_resolution();
-            push_unique(&mut out.our_entries, ours);
-            push_unique(&mut out.their_entries, theirs);
-        }
-    }
-    assert_eq!(
-        out.has_entries(),
-        merge_result.has_unresolved_conflicts(treat_as_unresolved),
-        "Must have entries to indicate conflicting files, or bad things will happen later: {:#?}",
-        merge_result.conflicts
-    );
-    Ok(out)
-}
-
-#[derive(Default, Debug, Clone, Serialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct ConflictEntries {
-    pub(crate) ancestor_entries: Vec<PathBuf>,
-    pub(crate) our_entries: Vec<PathBuf>,
-    pub(crate) their_entries: Vec<PathBuf>,
-}
-
-impl ConflictEntries {
-    pub(crate) fn has_entries(&self) -> bool {
-        !self.ancestor_entries.is_empty()
-            || !self.our_entries.is_empty()
-            || !self.their_entries.is_empty()
-    }
 }

--- a/crates/but-rebase/src/graph_rebase/cherry_pick.rs
+++ b/crates/but-rebase/src/graph_rebase/cherry_pick.rs
@@ -1,16 +1,16 @@
 //! Cherry picking generalised for N to M cases.
 
-use std::path::PathBuf;
-
+use crate::commit::DateMode;
 use anyhow::{Context as _, Result, bail};
 use bstr::BString;
 use but_core::{
     RepositoryExt as _,
-    commit::{HEADERS_CONFLICTED_FIELD, Headers, SignCommit, TreeKind},
+    commit::{
+        HEADERS_CONFLICTED_FIELD, Headers, SignCommit, TreeKind,
+        conflict_entries_from_merge_outcome,
+    },
 };
 use gix::{objs::tree::EntryKind, prelude::ObjectIdExt as _};
-
-use crate::{cherry_pick::ConflictEntries, commit::DateMode};
 
 /// Describes the outcome of cherrypick.
 #[derive(Debug, Clone)]
@@ -380,8 +380,12 @@ fn commit_from_conflicted_tree<'repo>(
 ) -> anyhow::Result<gix::Id<'repo>> {
     let repo = resolved_tree_id.repo;
 
-    let conflicted_files =
-        extract_conflicted_files(resolved_tree_id, cherry_pick, treat_as_unresolved)?;
+    let conflicted_files = conflict_entries_from_merge_outcome(
+        repo,
+        resolved_tree_id.detach(),
+        &cherry_pick,
+        treat_as_unresolved,
+    )?;
 
     // convert files into a string and save as a blob
     let conflicted_files_string = toml::to_string(&conflicted_files)?;
@@ -430,70 +434,4 @@ fn commit_from_conflicted_tree<'repo>(
         sign_commit,
     )?
     .attach(repo))
-}
-
-fn extract_conflicted_files(
-    merged_tree_id: gix::Id<'_>,
-    merge_result: gix::merge::tree::Outcome<'_>,
-    treat_as_unresolved: gix::merge::tree::TreatAsUnresolved,
-) -> anyhow::Result<ConflictEntries> {
-    use gix::index::entry::Stage;
-    let repo = merged_tree_id.repo;
-    let mut index = repo.index_from_tree(&merged_tree_id)?;
-    merge_result.index_changed_after_applying_conflicts(
-        &mut index,
-        treat_as_unresolved,
-        gix::merge::tree::apply_index_entries::RemovalMode::Mark,
-    );
-    let (mut ancestor_entries, mut our_entries, mut their_entries) =
-        (Vec::new(), Vec::new(), Vec::new());
-    for entry in index.entries() {
-        let stage = entry.stage();
-        let storage = match stage {
-            Stage::Unconflicted => {
-                continue;
-            }
-            Stage::Base => &mut ancestor_entries,
-            Stage::Ours => &mut our_entries,
-            Stage::Theirs => &mut their_entries,
-        };
-
-        let path = entry.path(&index);
-        storage.push(gix::path::from_bstr(path).into_owned());
-    }
-    let mut out = ConflictEntries {
-        ancestor_entries,
-        our_entries,
-        their_entries,
-    };
-
-    // Since we typically auto-resolve with 'ours', it maybe that conflicting entries don't have an
-    // unconflicting counterpart anymore, so they are not applied (which is also what Git does).
-    // So to have something to show for - we *must* produce a conflict, extract paths manually.
-    // TODO(ST): instead of doing this, don't pre-record the paths. Instead redo the merge without
-    //           merge-strategy so that the index entries can be used instead.
-    if !out.has_entries() {
-        fn push_unique(v: &mut Vec<PathBuf>, change: &gix::diff::tree_with_rewrites::Change) {
-            let path = gix::path::from_bstr(change.location()).into_owned();
-            if !v.contains(&path) {
-                v.push(path);
-            }
-        }
-        for conflict in merge_result
-            .conflicts
-            .iter()
-            .filter(|c| c.is_unresolved(treat_as_unresolved))
-        {
-            let (ours, theirs) = conflict.changes_in_resolution();
-            push_unique(&mut out.our_entries, ours);
-            push_unique(&mut out.their_entries, theirs);
-        }
-    }
-    assert_eq!(
-        out.has_entries(),
-        merge_result.has_unresolved_conflicts(treat_as_unresolved),
-        "Must have entries to indicate conflicting files, or bad things will happen later: {:#?}",
-        merge_result.conflicts
-    );
-    Ok(out)
 }

--- a/crates/but-rebase/src/graph_rebase/creation.rs
+++ b/crates/but-rebase/src/graph_rebase/creation.rs
@@ -349,7 +349,11 @@ impl<'ws, 'meta, M: RefMetadata> Editor<'ws, 'meta, M> {
 }
 
 impl<'ws, 'meta, M: RefMetadata> SuccessfulRebase<'ws, 'meta, M> {
-    /// Converts a SuccessfulRebase back into another editor for multi-step operations
+    /// Converts a SuccessfulRebase back into another editor for multi-step operations.
+    ///
+    /// This is the normalization path for callers that want to chain
+    /// additional editor-based operations and need the editor graph plus
+    /// in-memory repository to agree on ancestry.
     pub fn into_editor(self) -> Editor<'ws, 'meta, M> {
         Editor {
             graph: self.graph,

--- a/crates/but-rebase/src/graph_rebase/merge_commit_changes.rs
+++ b/crates/but-rebase/src/graph_rebase/merge_commit_changes.rs
@@ -1,0 +1,416 @@
+#![doc = include_str!("../../docs/merge_commit_changes.md")]
+
+use std::collections::{HashMap, HashSet};
+
+use anyhow::{Context, Result, bail};
+use but_core::{RefMetadata, RepositoryExt};
+use gix::prelude::ObjectIdExt;
+use petgraph::Direction;
+
+use crate::graph_rebase::{Editor, Pick, Step, StepGraphIndex, util::collect_ordered_parents};
+
+/// A selected commit change range that should be merged into an accumulated
+/// tree.
+///
+/// `base_tree_id` is the tree from which `commit_id`'s contribution should be
+/// measured. Merging `base_tree_id..commit_id^{tree}` applies only that
+/// commit's selected change range, not all tree state reachable through its
+/// parents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PlannedCommitChange {
+    /// The selected commit whose change range should be merged.
+    pub commit_id: gix::ObjectId,
+    /// The tree that acts as the base for `commit_id`'s contribution.
+    pub base_tree_id: gix::ObjectId,
+}
+
+/// The result of merging selected commit changes into one tree.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MergeCommitChangesOutcome {
+    /// The resulting tree.
+    ///
+    /// If [`Self::conflict`] is `Some`, this is the auto-resolved tree that
+    /// should be presented as the conflicted commit's visible tree.
+    pub tree_id: gix::ObjectId,
+    /// Details about the last unresolved merge encountered while producing
+    /// [`Self::tree_id`].
+    pub conflict: Option<MergeCommitChangesConflict>,
+}
+
+/// Conflict metadata needed to persist a GitButler conflicted commit from a
+/// merged change-range result.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MergeCommitChangesConflict {
+    /// The merge base tree for the conflicted merge step.
+    pub base_tree_id: gix::ObjectId,
+    /// The accumulated tree on the "ours" side of the conflicted merge step.
+    pub ours_tree_id: gix::ObjectId,
+    /// The selected commit tree on the "theirs" side of the conflicted merge step.
+    pub theirs_tree_id: gix::ObjectId,
+    /// The paths that remained conflicted after auto-resolution.
+    pub conflict_entries: but_core::commit::ConflictEntries,
+}
+
+impl<M: RefMetadata> Editor<'_, '_, M> {
+    /// Return the tree produced by preserving the target commit's full tree
+    /// and then merging only the surviving selected commits' own change
+    /// ranges into it.
+    ///
+    /// See the module docs for the planner and merge semantics.
+    pub fn merge_commit_changes_to_tree(
+        &self,
+        target_commit_id: gix::ObjectId,
+        subject_commit_ids: Vec<gix::ObjectId>,
+        merge_options: gix::merge::tree::Options,
+    ) -> Result<MergeCommitChangesOutcome> {
+        let target_commit = but_core::Commit::from_id(target_commit_id.attach(&self.repo))?;
+        let target_tree_id = target_commit.tree_id_or_auto_resolution()?.detach();
+        let merge_plan =
+            self.plan_commit_changes_for_merge(target_commit_id, subject_commit_ids)?;
+        if merge_plan.is_empty() {
+            let tree_id = target_tree_id;
+            let conflict = if target_commit.is_conflicted() {
+                let (base_tree_id, ours_tree_id, theirs_tree_id) = target_commit
+                    .conflicted_tree_ids()?
+                    .context("conflicted commit is missing conflicted tree sides")?;
+                Some(MergeCommitChangesConflict {
+                    base_tree_id: base_tree_id.detach(),
+                    ours_tree_id: ours_tree_id.detach(),
+                    theirs_tree_id: theirs_tree_id.detach(),
+                    conflict_entries: target_commit
+                        .conflict_entries()?
+                        .context("conflicted commit is missing conflict entries")?,
+                })
+            } else {
+                None
+            };
+            return Ok(MergeCommitChangesOutcome { tree_id, conflict });
+        }
+
+        let mut ours = target_tree_id;
+        let mut conflict = None;
+        let conflict_kind = gix::merge::tree::TreatAsUnresolved::forced_resolution();
+
+        for change in merge_plan {
+            let theirs = but_core::Commit::from_id(change.commit_id.attach(&self.repo))?
+                .tree_id_or_auto_resolution()?
+                .detach();
+            let mut merge = self
+                .repo
+                .merge_trees(
+                    change.base_tree_id,
+                    ours,
+                    theirs,
+                    self.repo.default_merge_labels(),
+                    merge_options.clone(),
+                )
+                .context("failed to merge commit trees")?;
+            let merged_tree_id = merge.tree.write()?.detach();
+            if merge.has_unresolved_conflicts(conflict_kind) {
+                conflict = Some(MergeCommitChangesConflict {
+                    base_tree_id: change.base_tree_id,
+                    ours_tree_id: ours,
+                    theirs_tree_id: theirs,
+                    conflict_entries: but_core::commit::conflict_entries_from_merge_outcome(
+                        &self.repo,
+                        merged_tree_id,
+                        &merge,
+                        conflict_kind,
+                    )?,
+                });
+                ours = merged_tree_id;
+                break;
+            }
+            ours = merged_tree_id;
+        }
+
+        Ok(MergeCommitChangesOutcome {
+            tree_id: ours,
+            conflict,
+        })
+    }
+
+    /// Turn the selected commits into mergeable `base..commit` change ranges
+    /// relative to a target commit.
+    ///
+    /// This planner assumes the editor step graph and the editor's in-memory
+    /// repository describe the same commit topology. The step graph is used to
+    /// traverse selected commits deterministically and to find the target's
+    /// ancestry cone quickly, while first-parent/base semantics still come
+    /// from the commit objects stored in the in-memory repository.
+    ///
+    /// See the module docs for the planner semantics and invariants.
+    ///
+    ///
+    /// Returns a vector of [PlannedCommitChange].
+    pub fn plan_commit_changes_for_merge(
+        &self,
+        target_commit_id: gix::ObjectId,
+        subject_commit_ids: Vec<gix::ObjectId>,
+    ) -> Result<Vec<PlannedCommitChange>> {
+        self.try_select_commit(target_commit_id).with_context(|| {
+            format!("Failed to find commit {target_commit_id} in rebase editor")
+        })?;
+        let selected_commit_ids = deduplicate_commit_ids(subject_commit_ids);
+        if selected_commit_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let selected_commit_set = selected_commit_ids.iter().copied().collect::<HashSet<_>>();
+        let traversal = traverse_graph_for_planning(self, target_commit_id, &selected_commit_set)?;
+
+        for commit_id in &selected_commit_ids {
+            if !traversal
+                .selected_metadata_by_commit
+                .contains_key(commit_id)
+            {
+                bail!("Failed to find commit {commit_id} in rebase editor");
+            }
+        }
+
+        let mut selected_child_count = HashMap::<gix::ObjectId, usize>::with_capacity(
+            traversal.ordered_selected_commit_ids.len(),
+        );
+        for commit_id in traversal.ordered_selected_commit_ids.iter().copied() {
+            selected_child_count.insert(commit_id, 0);
+        }
+        for selected_parent_id in traversal
+            .selected_metadata_by_commit
+            .values()
+            .filter_map(|metadata| metadata.selected_first_parent_id)
+        {
+            if let Some(child_count) = selected_child_count.get_mut(&selected_parent_id) {
+                *child_count += 1;
+            }
+        }
+
+        let mut planned_commit_changes = Vec::new();
+        for commit_id in traversal.ordered_selected_commit_ids {
+            let is_selected_chain_tip = selected_child_count
+                .get(&commit_id)
+                .copied()
+                .unwrap_or_default()
+                == 0;
+            if !is_selected_chain_tip || traversal.target_ancestor_commit_ids.contains(&commit_id) {
+                continue;
+            }
+
+            let base_tree_id = base_tree_id_for_emitted_tip(
+                self,
+                commit_id,
+                &traversal.selected_metadata_by_commit,
+                &traversal.target_ancestor_commit_ids,
+            )?;
+            planned_commit_changes.push(PlannedCommitChange {
+                commit_id,
+                base_tree_id,
+            });
+        }
+
+        Ok(planned_commit_changes)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SelectedCommitPlanningMetadata {
+    first_parent_id: Option<gix::ObjectId>,
+    selected_first_parent_id: Option<gix::ObjectId>,
+}
+
+#[derive(Debug, Default)]
+struct SelectedCommitPlanningTraversal {
+    ordered_selected_commit_ids: Vec<gix::ObjectId>,
+    selected_metadata_by_commit: HashMap<gix::ObjectId, SelectedCommitPlanningMetadata>,
+    target_ancestor_commit_ids: HashSet<gix::ObjectId>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+enum TraversalMode {
+    #[default]
+    Normal,
+    MarkTargetAncestors,
+}
+
+/// Traverse the editor graph and return information relevant for the planning.
+///
+/// The traversal collects information about:
+/// - Which commits are ancestors of the target commit.
+/// - The deterministic order in which selected commits should be considered.
+///
+/// This walk intentionally uses the editor step graph only as a traversal
+/// structure. Parent/tree semantics are still read from the in-memory
+/// repository commits, so callers must only use this planner when the editor
+/// graph and the in-memory repository represent the same commit topology.
+///
+/// Returns [SelectedCommitPlanningTraversal].
+fn traverse_graph_for_planning<M: RefMetadata>(
+    editor: &Editor<'_, '_, M>,
+    target_commit_id: gix::ObjectId,
+    selected_commit_ids: &HashSet<gix::ObjectId>,
+) -> Result<SelectedCommitPlanningTraversal> {
+    let mut traversal = SelectedCommitPlanningTraversal::default();
+    let mut seen_selected_commit_ids = HashSet::new();
+    let mut seen_normal = HashSet::<StepGraphIndex>::new();
+    let mut seen_target_ancestor_walk = HashSet::<StepGraphIndex>::new();
+
+    let mut roots = editor
+        .graph
+        .externals(Direction::Incoming)
+        .collect::<Vec<StepGraphIndex>>();
+    roots.sort_unstable_by_key(|idx| idx.index());
+
+    for root in roots {
+        let mut stack = vec![(root, false, TraversalMode::Normal)];
+        while let Some((node, expanded, mode)) = stack.pop() {
+            match mode {
+                TraversalMode::Normal => {
+                    if expanded {
+                        if let Step::Pick(Pick { id, .. }) = editor.graph[node] {
+                            if let Some(selected_metadata) = selected_metadata_for_traversed_pick(
+                                editor,
+                                id,
+                                selected_commit_ids,
+                            )? {
+                                traversal
+                                    .selected_metadata_by_commit
+                                    .insert(id, selected_metadata);
+                                if seen_selected_commit_ids.insert(id) {
+                                    traversal.ordered_selected_commit_ids.push(id);
+                                }
+                            }
+
+                            if id == target_commit_id {
+                                traversal.target_ancestor_commit_ids.insert(id);
+                                for parent_idx in collect_ordered_parents(&editor.graph, node) {
+                                    stack.push((
+                                        parent_idx,
+                                        false,
+                                        TraversalMode::MarkTargetAncestors,
+                                    ));
+                                }
+                            }
+                        }
+                        continue;
+                    }
+
+                    if !seen_normal.insert(node) {
+                        continue;
+                    }
+
+                    let parents = collect_ordered_parents(&editor.graph, node);
+                    stack.push((node, true, TraversalMode::Normal));
+                    for parent_idx in parents.into_iter() {
+                        stack.push((parent_idx, false, TraversalMode::Normal));
+                    }
+                }
+                TraversalMode::MarkTargetAncestors => {
+                    if !seen_target_ancestor_walk.insert(node) {
+                        continue;
+                    }
+
+                    if let Step::Pick(Pick { id, .. }) = editor.graph[node] {
+                        traversal.target_ancestor_commit_ids.insert(id);
+                    }
+
+                    for parent_idx in collect_ordered_parents(&editor.graph, node) {
+                        stack.push((parent_idx, false, TraversalMode::MarkTargetAncestors));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(traversal)
+}
+
+/// Pick repository-backed first-parent metadata for a selected commit.
+///
+/// This intentionally reads the commit object from the editor's in-memory
+/// repository instead of inferring first-parent semantics from the step graph.
+/// The step graph only provides deterministic traversal order and fast target
+/// ancestry discovery. The actual `base..commit` merge ranges must match the
+/// commit DAG that owns the trees and SHAs being merged, so callers are
+/// expected to keep the editor step graph aligned with that in-memory
+/// repository topology.
+fn selected_metadata_for_traversed_pick<M: RefMetadata>(
+    editor: &Editor<'_, '_, M>,
+    commit_id: gix::ObjectId,
+    selected_commit_ids: &HashSet<gix::ObjectId>,
+) -> Result<Option<SelectedCommitPlanningMetadata>> {
+    if !selected_commit_ids.contains(&commit_id) {
+        return Ok(None);
+    }
+
+    let commit = but_core::Commit::from_id(commit_id.attach(&editor.repo))?;
+    let first_parent_id = commit.inner.parents.first().copied();
+    let selected_first_parent_id =
+        first_parent_id.filter(|parent_id| selected_commit_ids.contains(parent_id));
+
+    Ok(Some(SelectedCommitPlanningMetadata {
+        first_parent_id,
+        selected_first_parent_id,
+    }))
+}
+
+/// Get the base tree ID to use for the merger of the given commit.
+///
+/// This function is reponsible for determining the base in the following way:
+/// 1. If the first parent of the commit is an ancestor of the target commit, we return its tree.
+/// 2. If the first parent of the commit is part of the selected commits but is not an ancestor of
+///    the target commit, we check the second parent. We continue until we find a parent that's either
+///    not in the selected commits or is an ancestor of the target commit.
+/// 3. If there is no parent, we return an empty tree.
+fn base_tree_id_for_emitted_tip<M: RefMetadata>(
+    editor: &Editor<'_, '_, M>,
+    tip_commit_id: gix::ObjectId,
+    selected_metadata_by_commit: &HashMap<gix::ObjectId, SelectedCommitPlanningMetadata>,
+    target_ancestor_commit_ids: &HashSet<gix::ObjectId>,
+) -> Result<gix::ObjectId> {
+    let mut current_commit_id = tip_commit_id;
+
+    loop {
+        let metadata = selected_metadata_by_commit
+            .get(&current_commit_id)
+            .with_context(|| {
+                format!("BUG: missing planning metadata for selected commit {current_commit_id}")
+            })?;
+
+        match metadata.selected_first_parent_id {
+            Some(selected_parent_id)
+                if target_ancestor_commit_ids.contains(&selected_parent_id) =>
+            {
+                return tree_id_for_commit(editor, selected_parent_id);
+            }
+            Some(selected_parent_id) => {
+                current_commit_id = selected_parent_id;
+            }
+            None => {
+                return match metadata.first_parent_id {
+                    Some(parent_id) => tree_id_for_commit(editor, parent_id),
+                    None => Ok(gix::ObjectId::empty_tree(editor.repo.object_hash())),
+                };
+            }
+        }
+    }
+}
+
+fn tree_id_for_commit<M: RefMetadata>(
+    editor: &Editor<'_, '_, M>,
+    commit_id: gix::ObjectId,
+) -> Result<gix::ObjectId> {
+    Ok(but_core::Commit::from_id(commit_id.attach(&editor.repo))?
+        .tree_id_or_auto_resolution()?
+        .detach())
+}
+
+/// Remove exact duplicate commit IDs.
+fn deduplicate_commit_ids(commit_ids: Vec<gix::ObjectId>) -> Vec<gix::ObjectId> {
+    let mut seen = HashSet::with_capacity(commit_ids.len());
+    let mut deduplicated = Vec::with_capacity(commit_ids.len());
+    for commit_id in commit_ids {
+        if seen.insert(commit_id) {
+            deduplicated.push(commit_id);
+        }
+    }
+    deduplicated
+}

--- a/crates/but-rebase/src/graph_rebase/mod.rs
+++ b/crates/but-rebase/src/graph_rebase/mod.rs
@@ -20,6 +20,7 @@ use crate::graph_rebase::cherry_pick::{PickMode, TreeMergeMode};
 pub mod cherry_pick;
 pub mod commit;
 pub mod materialize;
+pub mod merge_commit_changes;
 pub mod mutate;
 pub mod ordering;
 pub(crate) mod util;

--- a/crates/but-rebase/tests/fixtures/scenario/merge-commit-changes-fail-fast-after-conflict-visible.sh
+++ b/crates/but-rebase/tests/fixtures/scenario/merge-commit-changes-fail-fast-after-conflict-visible.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### Description
+# A visible-history variant of the fail-fast-after-conflict fixture.
+# `HEAD` includes branches `A`, `B`, and `C` in its ancestry, but the
+# `A` and `B` changes still conflict when merged independently.
+
+git init
+
+tick
+echo base >shared.txt
+git add shared.txt
+git commit -m base
+
+git branch B
+git branch C
+
+git checkout -b A
+tick
+echo A >shared.txt
+git add shared.txt
+git commit -m A
+
+git checkout B
+tick
+echo B >shared.txt
+git add shared.txt
+git commit -m B
+
+git checkout C
+tick
+echo c >file-c
+git add file-c
+git commit -m C
+
+git checkout main
+tick
+git merge --no-ff -m merge-A A
+tick
+git merge --no-ff -X ours -m merge-B B
+tick
+git merge --no-ff -m merge-C C

--- a/crates/but-rebase/tests/fixtures/scenario/merge-commit-changes-fail-fast-after-conflict.sh
+++ b/crates/but-rebase/tests/fixtures/scenario/merge-commit-changes-fail-fast-after-conflict.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### Description
+# Three branches on top of a shared base:
+# - `A` changes `shared.txt` to "A"
+# - `B` changes `shared.txt` to "B" and conflicts with `A`
+# - `C` adds `file-c`
+#
+# This is used to verify that merging `A`, `B`, and `C` stops folding after
+# the `A` vs `B` conflict instead of also applying `C`.
+
+git init
+
+tick
+echo base >shared.txt
+git add shared.txt
+git commit -m base
+
+git branch B
+git branch C
+
+git checkout -b A
+tick
+echo A >shared.txt
+git add shared.txt
+git commit -m A
+
+git checkout B
+tick
+echo B >shared.txt
+git add shared.txt
+git commit -m B
+
+git checkout C
+tick
+echo c >file-c
+git add file-c
+git commit -m C

--- a/crates/but-rebase/tests/fixtures/scenario/merge-commits-excludes-unselected-parent-visible.sh
+++ b/crates/but-rebase/tests/fixtures/scenario/merge-commits-excludes-unselected-parent-visible.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### Description
+# A visible merge-history variant of the unselected-parent fixture.
+# `HEAD` is a merge commit that contains both:
+# - branch `A` with commit `A`
+# - branch `C` with commits `B -> C`
+# This lets the editor see both branches while verifying that selecting `A`
+# and `C` does not pull in `B`.
+
+git init
+
+tick
+echo base >base
+git add base
+git commit -m M
+
+git checkout -b A
+tick
+echo a >file-a
+git add file-a
+git commit -m A
+
+git checkout main
+git checkout -b B
+tick
+echo b >file-b
+git add file-b
+git commit -m B
+
+git checkout -b C
+tick
+echo c >file-c
+git add file-c
+git commit -m C
+
+git checkout main
+tick
+git merge --no-ff -m merge A C

--- a/crates/but-rebase/tests/fixtures/scenario/merge-commits-excludes-unselected-parent.sh
+++ b/crates/but-rebase/tests/fixtures/scenario/merge-commits-excludes-unselected-parent.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### Description
+# Two branches on top of a shared base:
+# - `A` adds file-a
+# - `B` adds file-b and `C` adds file-c on top of it
+# This is used to verify that merging A and C does not implicitly pull in B.
+
+git init
+
+tick
+echo base >base
+git add base
+git commit -m M
+
+git branch B
+git checkout -b A
+
+tick
+echo a >file-a
+git add file-a
+git commit -m A
+
+git checkout B
+
+tick
+echo b >file-b
+git add file-b
+git commit -m B
+
+git checkout -b C
+
+tick
+echo c >file-c
+git add file-c
+git commit -m C

--- a/crates/but-rebase/tests/fixtures/scenario/merge-commits-preserve-anchor-tree-visible.sh
+++ b/crates/but-rebase/tests/fixtures/scenario/merge-commits-preserve-anchor-tree-visible.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### Description
+# A visible merge-history fixture where the first selected commit has its own
+# parent chain that must be preserved.
+# `HEAD` is a merge commit that contains both:
+# - branch `D` with commits `A -> D`
+# - branch `E` with commits `B -> C -> E`
+# This lets the editor verify that selecting `D` and `E` keeps the first
+# selected commit's full tree (`file-a`, `file-d`) while only applying `E`'s
+# own delta (`file-e`) from the other branch.
+
+git init
+
+tick
+echo base >base
+git add base
+git commit -m M
+
+git checkout -b A
+tick
+echo a >file-a
+git add file-a
+git commit -m A
+
+git checkout -b D
+tick
+echo d >file-d
+git add file-d
+git commit -m D
+
+git checkout main
+git checkout -b B
+tick
+echo b >file-b
+git add file-b
+git commit -m B
+
+git checkout -b C
+tick
+echo c >file-c
+git add file-c
+git commit -m C
+
+git checkout -b E
+tick
+echo e >file-e
+git add file-e
+git commit -m E
+
+git checkout main
+tick
+git merge --no-ff -m merge D E

--- a/crates/but-rebase/tests/fixtures/scenario/merge-commits-preserve-noncontiguous-selected-changes-visible.sh
+++ b/crates/but-rebase/tests/fixtures/scenario/merge-commits-preserve-noncontiguous-selected-changes-visible.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### Description
+# A visible merge-history variant of the noncontiguous-selection fixture.
+# `HEAD` is a merge commit over:
+# - branch `A` with commit `A`
+# - branch `D` with commits `B -> C -> D`
+# This lets the editor see both sides while verifying that selecting `A`, `B`,
+# and `D` keeps `B` and `D` but excludes `C`.
+
+git init
+
+tick
+echo base >base
+git add base
+git commit -m M
+
+git checkout -b A
+tick
+echo a >file-a
+git add file-a
+git commit -m A
+
+git checkout main
+git checkout -b B
+tick
+echo b >file-b
+git add file-b
+git commit -m B
+
+tick
+echo c >file-c
+git add file-c
+git commit -m C
+
+tick
+echo d >file-d
+git add file-d
+git commit -m D
+
+git checkout main
+tick
+git merge --no-ff -m merge A B

--- a/crates/but-rebase/tests/fixtures/scenario/merge-commits-preserve-noncontiguous-selected-changes.sh
+++ b/crates/but-rebase/tests/fixtures/scenario/merge-commits-preserve-noncontiguous-selected-changes.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### Description
+# Two branches on top of a shared base:
+# - `A` adds file-a
+# - `B` adds file-b
+# - `C` adds file-c on top of `B`
+# - `D` adds file-d on top of `C`
+#
+# This is used to verify that selecting `A`, `B`, and `D` keeps the changes
+# from `B` and `D` while excluding `C`.
+
+git init
+
+tick
+echo base >base
+git add base
+git commit -m M
+
+git branch B
+git checkout -b A
+
+tick
+echo a >file-a
+git add file-a
+git commit -m A
+
+git checkout B
+
+tick
+echo b >file-b
+git add file-b
+git commit -m B
+
+tick
+echo c >file-c
+git add file-c
+git commit -m C
+
+tick
+echo d >file-d
+git add file-d
+git commit -m D

--- a/crates/but-rebase/tests/fixtures/scenario/merge-with-two-branches-conflict.sh
+++ b/crates/but-rebase/tests/fixtures/scenario/merge-with-two-branches-conflict.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+### Description
+# Two branches on top of a common base, one commit each, with conflicting content.
+# The merge is conflicting, the worktree is left in that state as well.
+set -eu -o pipefail
+
+git init
+touch file
+git add . && git commit -m init
+
+git branch B
+git checkout -b A
+seq 10 20 >file && git commit -am "10 to 20"
+
+git checkout B
+seq 20 30 >file && git commit -am "20 to 30"
+
+git checkout -b merge
+git merge -m "merge A and B - conflicting" A || :

--- a/crates/but-rebase/tests/fixtures/scenario/octopus-merge-with-redundant-input.sh
+++ b/crates/but-rebase/tests/fixtures/scenario/octopus-merge-with-redundant-input.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### Description
+# A shared base with `left` and `right` branches. `left` has two commits, and
+# `right` has one. `main` performs an octopus merge of `left` and `right`.
+
+git init
+
+tick
+echo base >shared.txt
+git add shared.txt
+git commit -m base
+
+git checkout -b left
+
+tick
+echo left-one >left.txt
+git add left.txt
+git commit -m left-1
+
+tick
+echo left-two >left.txt
+git add left.txt
+git commit -m left-2
+
+git checkout main
+git checkout -b right
+
+tick
+echo right >right.txt
+git add right.txt
+git commit -m right
+
+git checkout main
+
+tick
+git merge --no-ff --strategy octopus -m octopus left right

--- a/crates/but-rebase/tests/fixtures/scenario/shared.sh
+++ b/crates/but-rebase/tests/fixtures/scenario/shared.sh
@@ -1,5 +1,16 @@
 set -eu -o pipefail
 
+function tick () {
+  if test -z "${tick+set}"; then
+    tick=1675176957
+  else
+    tick=$(($tick + 60))
+  fi
+  GIT_COMMITTER_DATE="$tick +0100"
+  GIT_AUTHOR_DATE="$tick +0100"
+  export GIT_COMMITTER_DATE GIT_AUTHOR_DATE
+}
+
 function create_workspace_commit_once() {
   local workspace_commit_subject="GitButler Workspace Commit"
 

--- a/crates/but-rebase/tests/fixtures/scenario/three-branches-three-commits-visible.sh
+++ b/crates/but-rebase/tests/fixtures/scenario/three-branches-three-commits-visible.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### Description
+# A visible merge-history variant of the three-branch planning fixture.
+# `main`, `left`, and `right` each have three commits on top of a shared base,
+# and `HEAD` is an octopus merge of `left` and `right` into `main`.
+
+git init
+
+tick
+echo base >base.txt
+git add base.txt
+git commit -m base
+
+tick
+echo main-1 >main.txt
+git add main.txt
+git commit -m main-1
+
+tick
+echo main-2 >main.txt
+git add main.txt
+git commit -m main-2
+
+tick
+echo main-3 >main.txt
+git add main.txt
+git commit -m main-3
+
+git checkout -b left HEAD~3
+
+tick
+echo left-1 >left.txt
+git add left.txt
+git commit -m left-1
+
+tick
+echo left-2 >left.txt
+git add left.txt
+git commit -m left-2
+
+tick
+echo left-3 >left.txt
+git add left.txt
+git commit -m left-3
+
+git checkout -b right main~3
+
+tick
+echo right-1 >right.txt
+git add right.txt
+git commit -m right-1
+
+tick
+echo right-2 >right.txt
+git add right.txt
+git commit -m right-2
+
+tick
+echo right-3 >right.txt
+git add right.txt
+git commit -m right-3
+
+git checkout main
+tick
+git merge --no-ff --strategy octopus -m merged left right

--- a/crates/but-rebase/tests/fixtures/scenario/three-branches-three-commits.sh
+++ b/crates/but-rebase/tests/fixtures/scenario/three-branches-three-commits.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### Description
+# Three branches on top of a shared base. `main`, `left`, and `right` each have
+# three commits, with `left` and `right` branching off from the base commit.
+
+git init
+
+tick
+echo base >base.txt
+git add base.txt
+git commit -m base
+
+tick
+echo main-1 >main.txt
+git add main.txt
+git commit -m main-1
+
+tick
+echo main-2 >main.txt
+git add main.txt
+git commit -m main-2
+
+tick
+echo main-3 >main.txt
+git add main.txt
+git commit -m main-3
+
+git checkout -b left HEAD~3
+
+tick
+echo left-1 >left.txt
+git add left.txt
+git commit -m left-1
+
+tick
+echo left-2 >left.txt
+git add left.txt
+git commit -m left-2
+
+tick
+echo left-3 >left.txt
+git add left.txt
+git commit -m left-3
+
+git checkout -b right main~3
+
+tick
+echo right-1 >right.txt
+git add right.txt
+git commit -m right-1
+
+tick
+echo right-2 >right.txt
+git add right.txt
+git commit -m right-2
+
+tick
+echo right-3 >right.txt
+git add right.txt
+git commit -m right-3

--- a/crates/but-rebase/tests/rebase/graph_rebase/merge_commit_changes.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/merge_commit_changes.rs
@@ -1,0 +1,683 @@
+use anyhow::Result;
+use bstr::ByteSlice as _;
+use but_core::RepositoryExt;
+use but_graph::Graph;
+use but_rebase::{
+    commit::DateMode,
+    graph_rebase::{Editor, LookupStep as _, Step},
+};
+use but_testsupport::visualize_commit_graph_all;
+use gix::prelude::ObjectIdExt;
+use std::mem::ManuallyDrop;
+
+use crate::utils::{fixture, fixture_writable, standard_options};
+
+#[test]
+fn matches_clean_octopus_merge() -> Result<()> {
+    let (repo, mut meta) = fixture("octopus-merge-with-redundant-input")?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *-.   a7dcd9f (HEAD -> main) octopus
+    |\ \  
+    | | * 2a5954a (right) right
+    | |/  
+    |/|   
+    | * cbaa825 (left) left-2
+    | * 777f2d5 left-1
+    |/  
+    * 66df43d base
+    ");
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let left_1 = repo.rev_parse_single("left~1")?.detach();
+    let left_2 = repo.rev_parse_single("left")?.detach();
+    let right = repo.rev_parse_single("right")?.detach();
+    let expected_tree = repo.rev_parse_single("main^{tree}")?.detach();
+
+    let actual_tree = editor.merge_commit_changes_to_tree(
+        left_1,
+        vec![left_2, right],
+        editor.repo().merge_options_fail_fast()?.0,
+    )?;
+
+    assert_eq!(
+        actual_tree.tree_id, expected_tree,
+        "the target tree should anchor the merged tree while later ranges add their own deltas"
+    );
+    assert!(actual_tree.conflict.is_none());
+    Ok(())
+}
+
+#[test]
+fn excludes_unselected_parent_changes() -> Result<()> {
+    let (repo, mut meta) = fixture("merge-commits-excludes-unselected-parent-visible")?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *-.   e8da81c (HEAD -> main) merge
+    |\ \  
+    | | * fa946b5 (C) C
+    | | * 2eb5a0f (B) B
+    | |/  
+    |/|   
+    | * cec649d (A) A
+    |/  
+    * b301433 M
+    ");
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let a_commit = repo.rev_parse_single("A")?.detach();
+    let c_commit = repo.rev_parse_single("C")?.detach();
+    let merged_tree = editor.merge_commit_changes_to_tree(
+        a_commit,
+        vec![c_commit],
+        editor.repo().merge_options_fail_fast()?.0,
+    )?;
+
+    let file_a = editor
+        .repo()
+        .find_tree(merged_tree.tree_id)?
+        .lookup_entry_by_path("file-a")?
+        .expect("file-a should be present")
+        .object()?;
+    assert_eq!(file_a.data.as_bstr(), "a\n");
+
+    let file_c = editor
+        .repo()
+        .find_tree(merged_tree.tree_id)?
+        .lookup_entry_by_path("file-c")?
+        .expect("file-c should be present")
+        .object()?;
+    assert_eq!(file_c.data.as_bstr(), "c\n");
+
+    assert!(
+        editor
+            .repo()
+            .find_tree(merged_tree.tree_id)?
+            .lookup_entry_by_path("file-b")?
+            .is_none(),
+        "file-b should not be pulled in from C's unselected parent"
+    );
+    assert!(merged_tree.conflict.is_none());
+
+    Ok(())
+}
+
+#[test]
+fn reports_conflicts() -> Result<()> {
+    let (repo, mut meta) = fixture("merge-commit-changes-fail-fast-after-conflict-visible")?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   9b1de89 (HEAD -> main) merge-C
+    |\  
+    | * ea9d91a (C) C
+    * |   669016a merge-B
+    |\ \  
+    | * | a1163f7 (B) B
+    | |/  
+    * |   468ee64 merge-A
+    |\ \  
+    | |/  
+    |/|   
+    | * 332e45d (A) A
+    |/  
+    * 66df43d base
+    ");
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let a_commit = repo.rev_parse_single("A")?.detach();
+    let b_commit = repo.rev_parse_single("B")?.detach();
+    let merged = editor.merge_commit_changes_to_tree(
+        a_commit,
+        vec![b_commit],
+        editor.repo().merge_options_force_ours()?,
+    )?;
+
+    let conflict = merged
+        .conflict
+        .expect("conflicting merge should report conflict metadata");
+    assert_eq!(
+        conflict.base_tree_id,
+        repo.rev_parse_single("A~1^{tree}")?.detach()
+    );
+    assert_eq!(
+        conflict.ours_tree_id,
+        repo.rev_parse_single("A^{tree}")?.detach()
+    );
+    assert_eq!(
+        conflict.theirs_tree_id,
+        repo.rev_parse_single("B^{tree}")?.detach()
+    );
+    assert!(conflict.conflict_entries.has_entries());
+
+    let merged_file = editor
+        .repo()
+        .find_tree(merged.tree_id)?
+        .lookup_entry_by_path("shared.txt")?
+        .expect("merged shared file should be present")
+        .object()?;
+    assert_eq!(merged_file.data.as_bstr(), "A\n");
+
+    Ok(())
+}
+
+#[test]
+fn stops_folding_after_first_conflict() -> Result<()> {
+    let (repo, mut meta) = fixture("merge-commit-changes-fail-fast-after-conflict-visible")?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   9b1de89 (HEAD -> main) merge-C
+    |\  
+    | * ea9d91a (C) C
+    * |   669016a merge-B
+    |\ \  
+    | * | a1163f7 (B) B
+    | |/  
+    * |   468ee64 merge-A
+    |\ \  
+    | |/  
+    |/|   
+    | * 332e45d (A) A
+    |/  
+    * 66df43d base
+    ");
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let a_commit = repo.rev_parse_single("A")?.detach();
+    let b_commit = repo.rev_parse_single("B")?.detach();
+    let c_commit = repo.rev_parse_single("C")?.detach();
+    let merged = editor.merge_commit_changes_to_tree(
+        a_commit,
+        vec![b_commit, c_commit],
+        editor.repo().merge_options_force_ours()?,
+    )?;
+
+    assert!(
+        merged.conflict.is_some(),
+        "the A/B merge should report a conflict"
+    );
+
+    let tree = editor.repo().find_tree(merged.tree_id)?;
+    let shared = tree
+        .lookup_entry_by_path("shared.txt")?
+        .expect("shared.txt should be present")
+        .object()?;
+    assert_eq!(shared.data.as_bstr(), "A\n");
+
+    assert!(
+        tree.lookup_entry_by_path("file-c")?.is_some(),
+        "canonical planner ordering should apply C before the conflicting B range"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn preserves_noncontiguous_selected_changes() -> Result<()> {
+    let (repo, mut meta) =
+        fixture("merge-commits-preserve-noncontiguous-selected-changes-visible")?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *-.   1c47eb3 (HEAD -> main) merge
+    |\ \  
+    | | * bf7c931 (B) D
+    | | * fa946b5 C
+    | | * 2eb5a0f B
+    | |/  
+    |/|   
+    | * cec649d (A) A
+    |/  
+    * b301433 M
+    ");
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let a_commit = repo.rev_parse_single("A")?.detach();
+    let b_commit = repo.rev_parse_single("B~2")?.detach();
+    let d_commit = repo.rev_parse_single("B")?.detach();
+    let merged_tree = editor.merge_commit_changes_to_tree(
+        a_commit,
+        vec![b_commit, d_commit],
+        editor.repo().merge_options_fail_fast()?.0,
+    )?;
+
+    let tree = editor.repo().find_tree(merged_tree.tree_id)?;
+
+    let file_a = tree
+        .lookup_entry_by_path("file-a")?
+        .expect("file-a should be present")
+        .object()?;
+    assert_eq!(file_a.data.as_bstr(), "a\n");
+
+    let file_b = tree
+        .lookup_entry_by_path("file-b")?
+        .expect("file-b should be present")
+        .object()?;
+    assert_eq!(file_b.data.as_bstr(), "b\n");
+
+    let file_d = tree
+        .lookup_entry_by_path("file-d")?
+        .expect("file-d should be present")
+        .object()?;
+    assert_eq!(file_d.data.as_bstr(), "d\n");
+
+    assert!(
+        tree.lookup_entry_by_path("file-c")?.is_none(),
+        "file-c should not be pulled in when only B and D are selected"
+    );
+    assert!(merged_tree.conflict.is_none());
+
+    Ok(())
+}
+
+#[test]
+fn preserves_first_selected_commit_tree_while_applying_later_selected_ranges() -> Result<()> {
+    let (repo, mut meta) = fixture("merge-commits-preserve-anchor-tree-visible")?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *-.   e84cecd (HEAD -> main) merge
+    |\ \  
+    | | * e105958 (E) E
+    | | * 739244f (C) C
+    | | * 7f69bb3 (B) B
+    | |/  
+    |/|   
+    | * 06e6d84 (D) D
+    | * cec649d (A) A
+    |/  
+    * b301433 M
+    ");
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let d_commit = repo.rev_parse_single("D")?.detach();
+    let e_commit = repo.rev_parse_single("E")?.detach();
+    let merged_tree = editor.merge_commit_changes_to_tree(
+        d_commit,
+        vec![e_commit],
+        editor.repo().merge_options_fail_fast()?.0,
+    )?;
+
+    let tree = editor.repo().find_tree(merged_tree.tree_id)?;
+
+    let file_a = tree
+        .lookup_entry_by_path("file-a")?
+        .expect("file-a should be present from the anchor commit tree")
+        .object()?;
+    assert_eq!(file_a.data.as_bstr(), "a\n");
+
+    let file_d = tree
+        .lookup_entry_by_path("file-d")?
+        .expect("file-d should be present from the anchor commit tree")
+        .object()?;
+    assert_eq!(file_d.data.as_bstr(), "d\n");
+
+    let file_e = tree
+        .lookup_entry_by_path("file-e")?
+        .expect("file-e should be present from the later selected range")
+        .object()?;
+    assert_eq!(file_e.data.as_bstr(), "e\n");
+
+    assert!(
+        tree.lookup_entry_by_path("file-b")?.is_none(),
+        "file-b should not be pulled in from E's unselected ancestors"
+    );
+    assert!(
+        tree.lookup_entry_by_path("file-c")?.is_none(),
+        "file-c should not be pulled in from E's unselected ancestors"
+    );
+    assert!(merged_tree.conflict.is_none());
+
+    Ok(())
+}
+
+#[test]
+fn planning_preserves_noncontiguous_selected_changes() -> Result<()> {
+    let (repo, mut meta) =
+        fixture("merge-commits-preserve-noncontiguous-selected-changes-visible")?;
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let a_commit = repo.rev_parse_single("A")?.detach();
+    let b_commit = repo.rev_parse_single("B~2")?.detach();
+    let d_commit = repo.rev_parse_single("B")?.detach();
+
+    let target = repo.rev_parse_single("A~1")?.detach();
+    let plan = editor.plan_commit_changes_for_merge(target, vec![a_commit, b_commit, d_commit])?;
+
+    insta::assert_snapshot!(labeled_plan_entries(&repo, &plan), @"
+    B <- M
+    D <- C
+    A <- M
+    ");
+    Ok(())
+}
+
+#[test]
+fn planning_fixture_graph() -> Result<()> {
+    let fixture = simplify_fixture()?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&fixture.repo)?, @r"
+    *-.   d0949aa (HEAD -> main) merged
+    |\ \  
+    | | * 8259b01 (right) right-3
+    | | * 0a63ea6 right-2
+    | | * 26b0bd5 right-1
+    | * | feaa00d (left) left-3
+    | * | 07bba81 left-2
+    | * | 4b6a0f2 left-1
+    | |/  
+    * | f1b6511 main-3
+    * | 6bbd9db main-2
+    * | 257ee22 main-1
+    |/  
+    * 6dbc49d base
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn planning_collapses_contiguous_selected_chain() -> Result<()> {
+    let mut fixture = simplify_fixture()?;
+    let editor = Editor::create(&mut fixture.ws, &mut *fixture.meta, &fixture.repo)?;
+
+    let plan = editor.plan_commit_changes_for_merge(
+        fixture.base,
+        vec![fixture.left_1, fixture.left_2, fixture.left_3],
+    )?;
+
+    insta::assert_snapshot!(labeled_plan_entries(&fixture.repo, &plan), @"left-3 <- base");
+    Ok(())
+}
+
+#[test]
+fn planning_preserves_unrelated_branch_tips() -> Result<()> {
+    let mut fixture = simplify_fixture()?;
+    let editor = Editor::create(&mut fixture.ws, &mut *fixture.meta, &fixture.repo)?;
+
+    let plan = editor.plan_commit_changes_for_merge(
+        fixture.base,
+        vec![
+            fixture.left_1,
+            fixture.left_3,
+            fixture.main_2,
+            fixture.right_1,
+            fixture.right_3,
+        ],
+    )?;
+
+    insta::assert_snapshot!(labeled_plan_entries(&fixture.repo, &plan), @"
+    right-1 <- base
+    right-3 <- right-2
+    left-1 <- base
+    left-3 <- left-2
+    main-2 <- main-1
+    ");
+    Ok(())
+}
+
+#[test]
+fn planning_deduplicates_and_keeps_order_of_survivors() -> Result<()> {
+    let mut fixture = simplify_fixture()?;
+    let editor = Editor::create(&mut fixture.ws, &mut *fixture.meta, &fixture.repo)?;
+
+    let plan = editor.plan_commit_changes_for_merge(
+        fixture.base,
+        vec![
+            fixture.main_3,
+            fixture.left_2,
+            fixture.main_2,
+            fixture.left_2,
+            fixture.right_3,
+            fixture.left_3,
+            fixture.right_1,
+        ],
+    )?;
+
+    insta::assert_snapshot!(labeled_plan_entries(&fixture.repo, &plan), @"
+    right-1 <- base
+    right-3 <- right-2
+    left-3 <- left-1
+    main-3 <- main-1
+    ");
+    Ok(())
+}
+
+#[test]
+fn uses_editor_visible_commits_not_only_original_workspace_graph() -> Result<()> {
+    let (repo, _tmp, mut meta) = fixture_writable("four-commits")?;
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let head = repo.rev_parse_single("HEAD")?.detach();
+    let mut head_commit = editor.find_commit(head)?;
+    head_commit.inner.message = "HEAD rewritten inside editor".into();
+    let rewritten_head =
+        editor.new_commit_untracked(head_commit, DateMode::CommitterUpdateAuthorKeep)?;
+
+    let head_selector = editor.select_commit(head)?;
+    editor.replace(head_selector, Step::new_pick(rewritten_head))?;
+
+    let merged = editor.merge_commit_changes_to_tree(
+        rewritten_head,
+        Vec::new(),
+        editor.repo().merge_options_fail_fast()?.0,
+    )?;
+    let expected_tree = but_core::Commit::from_id(rewritten_head.attach(editor.repo()))?
+        .tree_id_or_auto_resolution()?
+        .detach();
+
+    assert_eq!(merged.tree_id, expected_tree);
+    assert!(merged.conflict.is_none());
+    Ok(())
+}
+
+#[test]
+fn planning_prunes_subjects_reachable_from_target_first_parent_lineage() -> Result<()> {
+    let (repo, mut meta) = fixture("merge-commits-preserve-anchor-tree-visible")?;
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let d_commit = repo.rev_parse_single("D")?.detach();
+    let a_commit = repo.rev_parse_single("A")?.detach();
+
+    let plan = editor.plan_commit_changes_for_merge(d_commit, vec![a_commit])?;
+
+    insta::assert_snapshot!(labeled_plan_entries(&repo, &plan), @"");
+    Ok(())
+}
+
+#[test]
+fn planning_prunes_subjects_reachable_from_target_merge_parent_lineage() -> Result<()> {
+    let (repo, mut meta) = fixture("three-branches-merged")?;
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let merge_commit = repo.rev_parse_single("main")?.detach();
+    let b_commit = repo.rev_parse_single("B")?.detach();
+
+    let plan = editor.plan_commit_changes_for_merge(merge_commit, vec![b_commit])?;
+
+    insta::assert_snapshot!(labeled_plan_entries(&repo, &plan), @"");
+    Ok(())
+}
+
+#[test]
+fn planning_prunes_target_ancestors_and_keeps_external_subject_order() -> Result<()> {
+    let mut fixture = simplify_fixture()?;
+    let editor = Editor::create(&mut fixture.ws, &mut *fixture.meta, &fixture.repo)?;
+
+    let plan = editor.plan_commit_changes_for_merge(
+        fixture.main_3,
+        vec![
+            fixture.left_1,
+            fixture.main_2,
+            fixture.right_3,
+            fixture.left_3,
+            fixture.right_1,
+        ],
+    )?;
+
+    insta::assert_snapshot!(labeled_plan_entries(&fixture.repo, &plan), @"
+    right-1 <- base
+    right-3 <- right-2
+    left-1 <- base
+    left-3 <- left-2
+    ");
+    Ok(())
+}
+
+#[test]
+fn planning_uses_pruned_selected_first_parent_tree_as_base_boundary() -> Result<()> {
+    let (repo, _tmpdir, mut meta) = fixture_writable("two-branches-shared-bottom-two")?;
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let base = repo.rev_parse_single("right~2")?.detach();
+    let shared = repo.rev_parse_single("right~1")?.detach();
+    let left = repo.rev_parse_single("left")?.detach();
+    let right = repo.rev_parse_single("right")?.detach();
+
+    let plan = editor.plan_commit_changes_for_merge(right, vec![base, shared, left])?;
+
+    insta::assert_snapshot!(labeled_plan_entries(&repo, &plan), @"left: head <- shared");
+    Ok(())
+}
+
+#[test]
+fn planning_works_after_normalizing_chained_editor_mutations() -> Result<()> {
+    let (repo, _tmp, mut meta) = fixture_writable("four-commits")?;
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let head = repo.rev_parse_single("HEAD")?.detach();
+    let head_parent = repo.rev_parse_single("HEAD~1")?.detach();
+    let mut rewritten_head = editor.find_commit(head)?;
+    rewritten_head.inner.message = "HEAD rewritten inside editor".into();
+    let rewritten_head =
+        editor.new_commit_untracked(rewritten_head, DateMode::CommitterUpdateAuthorKeep)?;
+
+    let head_selector = editor.select_commit(head)?;
+    editor.replace(head_selector, Step::new_pick(rewritten_head))?;
+    let editor = editor.rebase()?.into_editor();
+    let rewritten_head = editor.lookup_pick(head_selector)?;
+
+    let plan = editor.plan_commit_changes_for_merge(rewritten_head, vec![head_parent])?;
+
+    insta::assert_snapshot!(labeled_plan_entries(&repo, &plan), @"");
+    Ok(())
+}
+
+struct SimplifyFixture {
+    repo: gix::Repository,
+    meta: ManuallyDrop<but_meta::VirtualBranchesTomlMetadata>,
+    ws: but_graph::Workspace,
+    base: gix::ObjectId,
+    main_2: gix::ObjectId,
+    main_3: gix::ObjectId,
+    left_1: gix::ObjectId,
+    left_2: gix::ObjectId,
+    left_3: gix::ObjectId,
+    right_1: gix::ObjectId,
+    right_3: gix::ObjectId,
+}
+
+fn simplify_fixture() -> Result<SimplifyFixture> {
+    let (repo, meta) = fixture("three-branches-three-commits-visible")?;
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let ws = graph.into_workspace()?;
+
+    let base = repo.rev_parse_single("main~4")?.detach();
+    let main_2 = repo.rev_parse_single("main~2")?.detach();
+    let main_3 = repo.rev_parse_single("main~1")?.detach();
+    let left_1 = repo.rev_parse_single("left~2")?.detach();
+    let left_2 = repo.rev_parse_single("left~1")?.detach();
+    let left_3 = repo.rev_parse_single("left")?.detach();
+    let right_1 = repo.rev_parse_single("right~2")?.detach();
+    let right_3 = repo.rev_parse_single("right")?.detach();
+
+    Ok(SimplifyFixture {
+        repo,
+        meta,
+        ws,
+        base,
+        main_2,
+        main_3,
+        left_1,
+        left_2,
+        left_3,
+        right_1,
+        right_3,
+    })
+}
+
+fn labeled_plan_entries(
+    repo: &gix::Repository,
+    plan: &[but_rebase::graph_rebase::merge_commit_changes::PlannedCommitChange],
+) -> String {
+    plan.iter()
+        .map(|entry| {
+            let commit =
+                label_commit_by_subject(repo, entry.commit_id).unwrap_or_else(|| "unknown".into());
+            let base =
+                label_tree_by_subject(repo, entry.base_tree_id).unwrap_or_else(|| "unknown".into());
+            format!("{commit} <- {base}")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n"
+}
+
+fn label_commit_by_subject(repo: &gix::Repository, commit_id: gix::ObjectId) -> Option<String> {
+    let commit = repo.find_commit(commit_id).ok()?;
+    commit_subject(commit.message_raw().ok()?)
+}
+
+fn label_tree_by_subject(repo: &gix::Repository, tree_id: gix::ObjectId) -> Option<String> {
+    if tree_id == gix::ObjectId::empty_tree(repo.object_hash()) {
+        return Some("empty".into());
+    }
+
+    [
+        "main", "main~1", "main~2", "main~3", "main~4", "left", "left~1", "left~2", "left~3",
+        "right", "right~1", "right~2", "right~3", "A", "A~1", "B", "B~1", "B~2", "C", "D", "E",
+    ]
+    .into_iter()
+    .find_map(|spec| {
+        let commit_id = repo.rev_parse_single(spec).ok()?.detach();
+        let commit = repo.find_commit(commit_id).ok()?;
+        let commit_tree = commit.tree_id().ok()?.detach();
+        if commit_tree == tree_id {
+            commit_subject(commit.message_raw().ok()?)
+        } else {
+            None
+        }
+    })
+}
+
+fn commit_subject(message: &[u8]) -> Option<String> {
+    let subject = std::str::from_utf8(message).ok()?.lines().next()?.trim();
+    Some(subject.to_string())
+}

--- a/crates/but-rebase/tests/rebase/graph_rebase/mod.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/mod.rs
@@ -14,6 +14,7 @@ mod editor_creation;
 mod insert;
 mod insert_segment;
 mod materialize;
+mod merge_commit_changes;
 mod multiple_operations;
 mod order_commit_selectors_by_parentage;
 mod rebase_identities;

--- a/crates/gitbutler-repo/src/rebase.rs
+++ b/crates/gitbutler-repo/src/rebase.rs
@@ -1,79 +1,11 @@
-use std::path::PathBuf;
-
 use anyhow::{Context as _, Result};
 use bstr::ByteSlice as _;
 use but_core::{
     RepositoryExt,
-    commit::{ConflictEntries, Headers},
+    commit::{Headers, conflict_entries_from_merge_outcome},
 };
 use but_oxidize::{ObjectIdExt as _, OidExt as _};
 use gitbutler_cherry_pick::{ConflictedTreeKey, GixRepositoryExt as _};
-
-fn extract_conflicted_files(
-    merged_tree_id: gix::Id<'_>,
-    merge_result: gix::merge::tree::Outcome<'_>,
-    treat_as_unresolved: gix::merge::tree::TreatAsUnresolved,
-) -> Result<ConflictEntries> {
-    use gix::index::entry::Stage;
-    let repo = merged_tree_id.repo;
-    let mut index = repo.index_from_tree(&merged_tree_id)?;
-    merge_result.index_changed_after_applying_conflicts(
-        &mut index,
-        treat_as_unresolved,
-        gix::merge::tree::apply_index_entries::RemovalMode::Mark,
-    );
-    let (mut ancestor_entries, mut our_entries, mut their_entries) =
-        (Vec::new(), Vec::new(), Vec::new());
-    for entry in index.entries() {
-        let stage = entry.stage();
-        let storage = match stage {
-            Stage::Unconflicted => {
-                continue;
-            }
-            Stage::Base => &mut ancestor_entries,
-            Stage::Ours => &mut our_entries,
-            Stage::Theirs => &mut their_entries,
-        };
-
-        let path = entry.path(&index);
-        storage.push(gix::path::from_bstr(path).into_owned());
-    }
-    let mut out = ConflictEntries {
-        ancestor_entries,
-        our_entries,
-        their_entries,
-    };
-
-    // Since we typically auto-resolve with 'ours', it maybe that conflicting entries don't have an
-    // unconflicting counterpart anymore, so they are not applied (which is also what Git does).
-    // So to have something to show for - we *must* produce a conflict, extract paths manually.
-    // TODO(ST): instead of doing this, don't pre-record the paths. Instead redo the merge without
-    //           merge-strategy so that the index entries can be used instead.
-    if !out.has_entries() {
-        fn push_unique(v: &mut Vec<PathBuf>, change: &gix::diff::tree_with_rewrites::Change) {
-            let path = gix::path::from_bstr(change.location()).into_owned();
-            if !v.contains(&path) {
-                v.push(path);
-            }
-        }
-        for conflict in merge_result
-            .conflicts
-            .iter()
-            .filter(|c| c.is_unresolved(treat_as_unresolved))
-        {
-            let (ours, theirs) = conflict.changes_in_resolution();
-            push_unique(&mut out.our_entries, ours);
-            push_unique(&mut out.their_entries, theirs);
-        }
-    }
-    assert_eq!(
-        out.has_entries(),
-        merge_result.has_unresolved_conflicts(treat_as_unresolved),
-        "Must have entries to indicate conflicting files, or bad things will happen later: {:#?}",
-        merge_result.conflicts
-    );
-    Ok(out)
-}
 
 /// Merge two commits together
 ///
@@ -114,8 +46,12 @@ pub fn merge_commits(
     let tree_oid;
     let forced_resolution = gix::merge::tree::TreatAsUnresolved::forced_resolution();
     let is_conflicted = if merge_result.has_unresolved_conflicts(forced_resolution) {
-        let conflicted_files =
-            extract_conflicted_files(merged_tree_id, merge_result, forced_resolution)?;
+        let conflicted_files = conflict_entries_from_merge_outcome(
+            gix_repository,
+            merged_tree_id.detach(),
+            &merge_result,
+            forced_resolution,
+        )?;
 
         // convert files into a string and save as a blob
         let conflicted_files_string = toml::to_string(&conflicted_files)?;


### PR DESCRIPTION
~~Add a `but-core` repository helper for combining the changes introduced by selected commits into a single tree, along with support for writing GitButler conflicted trees.~~

Add a **Editor** helper to merge the changes from different commits into a tree that can be used for a new commit.

This introduces the low-level building blocks needed for squash-style operations that should merge only the selected commit changes, without accidentally pulling in unrelated parent state.

## How is this done?

The first relevant function is `plan_commit_changes_for_merge`.
This function iterates over the selected commits, and figures out which base to use for the merge ops.
**At this step, we simplify the merges down to only the necessary ones.**

The second (and main function) is `merge_commit_changes_to_tree`.
This function calls `plan_commit_changes_for_merge`, and executes the merge ops in order.
Starting with the common merge base of all commits to be merged. 
**If there is a conflict encountered, we stop and return where we stopped**

## Why

This enables us to bypass having to sort the subject commits of a squash around the target, and just grabbing the actual changes to produce the tree of the squash commit.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #13881 
- <kbd>&nbsp;2&nbsp;</kbd> #13873 
- <kbd>&nbsp;1&nbsp;</kbd> #13765 👈 
<!-- GitButler Footer Boundary Bottom -->

