### PR TITLE
Identify all Gpt 5.5 users as Byron

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,6 +1,7 @@
 estib <stron@me.com> Jose Vega <stron@me.com>
 estib <stron@me.com> Esteban Vega <35891811+estib-vega@users.noreply.github.com>
 Byron <sebastian.thiel@icloud.com> chatgpt-codex-connector[bot] <199175422+chatgpt-codex-connector[bot]@users.noreply.github.com> 
+Byron <sebastian.thiel@icloud.com> GPT 5.5 <codex@openai.com>
 Byron <sebastian.thiel@icloud.com> GPT 5.4 <codex@openai.com>
 Byron <sebastian.thiel@icloud.com> Sebastian Thiel <sebastian.thiel@icloud.com> <63622+Byron@users.noreply.github.com>
 Byron <sebastian.thiel@icloud.com> Codex GPT-5 <codex@openai.com>


### PR DESCRIPTION
Because only Byron sets the agent as author if they are the primary author. This doesn't affect reviews or responsibility, but it affects git blame which then shows GPT 5.5, even though one wants to read Byron there.

This mailmap sets this up now for GPT 5.5, which was forgotten previously.
