### PR TITLE
Strongly typed oplog trailers

### DIFF
--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -159,10 +159,8 @@ pub fn apply_with_perm(
     // NOTE: since this is optional by nature, the same would be true if snapshotting/undo would be disabled via `ctx` app settings, for instance.
     let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
         ctx,
-        SnapshotDetails::new(OperationKind::CreateBranch).with_trailers(vec![Trailer {
-            key: "name".into(),
-            value: existing_branch.to_string(),
-        }]),
+        SnapshotDetails::new(OperationKind::CreateBranch)
+            .with_trailers([Trailer::Name(existing_branch.to_string())]),
         perm.read_permission(),
         DryRun::No,
     );

--- a/crates/but-api/src/commit/discard_commit.rs
+++ b/crates/but-api/src/commit/discard_commit.rs
@@ -82,10 +82,8 @@ pub fn commit_discard_with_perm(
     dry_run: DryRun,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitDiscardResult> {
-    let details = SnapshotDetails::new(OperationKind::DiscardCommit).with_trailers(vec![Trailer {
-        key: "sha".to_string(),
-        value: subject_commit_id.to_string(),
-    }]);
+    let details = SnapshotDetails::new(OperationKind::DiscardCommit)
+        .with_trailers([Trailer::Sha(subject_commit_id)]);
     let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
         ctx,
         details,

--- a/crates/but-api/src/commit/uncommit.rs
+++ b/crates/but-api/src/commit/uncommit.rs
@@ -80,15 +80,7 @@ pub fn commit_uncommit_with_perm(
 ) -> anyhow::Result<UncommitResult> {
     let details = SnapshotDetails::new(OperationKind::UndoCommit)
         .with_count(subject_commit_ids.len())
-        .with_trailers(
-            subject_commit_ids
-                .iter()
-                .map(|id| Trailer {
-                    key: "sha".to_string(),
-                    value: id.to_string(),
-                })
-                .collect(),
-        );
+        .with_trailers(subject_commit_ids.iter().copied().map(Trailer::Sha));
     let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
         ctx,
         details,

--- a/crates/but/src/command/legacy/discard.rs
+++ b/crates/but/src/command/legacy/discard.rs
@@ -208,13 +208,7 @@ fn create_snapshot(
     use gitbutler_oplog::entry::Trailer;
 
     // Create trailers with file names
-    let trailers: Vec<Trailer> = file_names
-        .iter()
-        .map(|name| Trailer {
-            key: "file".to_string(),
-            value: name.clone(),
-        })
-        .collect();
+    let trailers = file_names.iter().cloned().map(Trailer::File);
 
     let details = SnapshotDetails::new(operation).with_trailers(trailers);
     let _snapshot = ctx.create_snapshot(details, perm).ok();

--- a/crates/but/src/command/legacy/oplog.rs
+++ b/crates/but/src/command/legacy/oplog.rs
@@ -1,6 +1,6 @@
 use but_api::legacy::oplog::RestoreKind;
 use but_core::RepositoryExt;
-use gitbutler_oplog::entry::{OperationKind, Snapshot};
+use gitbutler_oplog::entry::{OperationKind, Snapshot, Trailer};
 use gix::{date::time::CustomFormat, prelude::ObjectIdExt};
 
 use crate::{
@@ -94,8 +94,13 @@ pub(crate) fn show_oplog(
                         let file_names = details
                             .trailers
                             .iter()
-                            .filter(|t| t.key == "file")
-                            .map(|t| &*t.value)
+                            .filter_map(|t| {
+                                if let Trailer::File(value) = t {
+                                    Some(&**value)
+                                } else {
+                                    None
+                                }
+                            })
                             .collect::<Vec<_>>();
                         if !file_names.is_empty() {
                             format!("{} ({})", details.operation.title(), file_names.join(", "))
@@ -358,8 +363,8 @@ fn restore_to_target_snapshot(
     let target_operation = target_snapshot
         .details
         .as_ref()
-        .map(|d| d.title.as_str())
-        .unwrap_or("Unknown operation");
+        .map(|d| d.operation.title())
+        .unwrap_or_else(|| OperationKind::Unknown.title());
 
     let target_time = snapshot_time_string(&target_snapshot);
 

--- a/crates/but/tests/but/command/undo.rs
+++ b/crates/but/tests/but/command/undo.rs
@@ -1,3 +1,5 @@
+use gitbutler_oplog::entry::OperationKind;
+
 use crate::utils::Sandbox;
 
 mod undo_rub;
@@ -80,15 +82,16 @@ fn reword(
 #[track_caller]
 fn undo(
     env: &Sandbox,
-    operation_reverted_to: &str,
+    operation_reverted_to: OperationKind,
     snapshot_restored_to: &str,
     expected_status: &std::process::Output,
 ) {
     env.but("undo").assert().success().stdout_eq(format!(
         r#"Undoing operation...
-  Reverting to: {operation_reverted_to} (2000-01-02 00:00:00)
+  Reverting to: {} (2000-01-02 00:00:00)
 ✓ Undo completed successfully! Restored to snapshot: {snapshot_restored_to}
-"#
+"#,
+        operation_reverted_to.title()
     ));
 
     env.but("status")
@@ -101,15 +104,16 @@ fn undo(
 #[track_caller]
 fn redo(
     env: &Sandbox,
-    operation_reverted_to: &str,
+    operation_reverted_to: OperationKind,
     snapshot_restored_to: &str,
     expected_status: &std::process::Output,
 ) {
     env.but("redo").assert().success().stdout_eq(format!(
         r#"Redoing operation...
-  Reverting to: {operation_reverted_to} (2000-01-02 00:00:00)
+  Reverting to: {} (2000-01-02 00:00:00)
 ✓ Redo completed successfully! Restored to snapshot: {snapshot_restored_to}
 "#,
+        operation_reverted_to.title()
     ));
 
     env.but("status")
@@ -283,7 +287,12 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
-    undo(&env, "UpdateCommitMessage", "f4e985f", &status_three);
+    undo(
+        &env,
+        OperationKind::UpdateCommitMessage,
+        "f4e985f",
+        &status_three,
+    );
 
     env.but("oplog")
         .args(["list"])
@@ -292,7 +301,7 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
@@ -300,7 +309,12 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
-    undo(&env, "UpdateCommitMessage", "e637109", &status_two);
+    undo(
+        &env,
+        OperationKind::UpdateCommitMessage,
+        "e637109",
+        &status_two,
+    );
 
     env.but("oplog")
         .args(["list"])
@@ -309,8 +323,8 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-d6d5c2e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
@@ -318,7 +332,12 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
-    undo(&env, "UpdateCommitMessage", "90c8e9b", &status_one);
+    undo(
+        &env,
+        OperationKind::UpdateCommitMessage,
+        "90c8e9b",
+        &status_one,
+    );
 
     env.but("oplog")
         .args(["list"])
@@ -327,9 +346,9 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-b7c6717 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-d6d5c2e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+800274e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
@@ -373,7 +392,7 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-37400a2 2000-01-02 00:00:00 [RESTORE] Restored from snapshot
+10e3b45 2000-01-02 00:00:00 [RESTORE] Restored from snapshot
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
@@ -381,7 +400,12 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
-    undo(&env, "RestoreFromSnapshot", "37400a2", &status_four);
+    undo(
+        &env,
+        OperationKind::RestoreFromSnapshot,
+        "10e3b45",
+        &status_four,
+    );
 
     env.but("oplog")
         .args(["list"])
@@ -390,8 +414,8 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-d42878d 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-37400a2 2000-01-02 00:00:00 [RESTORE] Restored from snapshot
+a875d2c 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+10e3b45 2000-01-02 00:00:00 [RESTORE] Restored from snapshot
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
@@ -426,7 +450,12 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
-    undo(&env, "UpdateCommitMessage", "f4e985f", &status_three);
+    undo(
+        &env,
+        OperationKind::UpdateCommitMessage,
+        "f4e985f",
+        &status_three,
+    );
 
     reword(&env, &new_commit, "three-new")?;
 
@@ -437,8 +466,8 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-9deba9a 2000-01-02 00:00:00 [REWORD] Updated commit message
-351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+3b50353 2000-01-02 00:00:00 [REWORD] Updated commit message
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
@@ -446,7 +475,12 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
-    undo(&env, "UpdateCommitMessage", "9deba9a", &status_three);
+    undo(
+        &env,
+        OperationKind::UpdateCommitMessage,
+        "3b50353",
+        &status_three,
+    );
 
     env.but("oplog")
         .args(["list"])
@@ -455,9 +489,9 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-d83358a 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-9deba9a 2000-01-02 00:00:00 [REWORD] Updated commit message
-351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+c00e67a 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+3b50353 2000-01-02 00:00:00 [REWORD] Updated commit message
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
@@ -465,7 +499,12 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
-    undo(&env, "UpdateCommitMessage", "e637109", &status_two);
+    undo(
+        &env,
+        OperationKind::UpdateCommitMessage,
+        "e637109",
+        &status_two,
+    );
 
     Ok(())
 }
@@ -491,7 +530,12 @@ fn undoing_past_end_of_oplog() -> anyhow::Result<()> {
 "#,
         );
 
-    undo(&env, "UpdateCommitMessage", "90c8e9b", &status_one);
+    undo(
+        &env,
+        OperationKind::UpdateCommitMessage,
+        "90c8e9b",
+        &status_one,
+    );
 
     env.but("oplog")
         .args(["list"])
@@ -500,13 +544,18 @@ fn undoing_past_end_of_oplog() -> anyhow::Result<()> {
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-7952170 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+1c40c14 2000-01-02 00:00:00 [UNDO] Restored from snapshot
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
-    undo(&env, "UpdateCommitMessage", "7665ea7", &status_zero);
+    undo(
+        &env,
+        OperationKind::UpdateCommitMessage,
+        "7665ea7",
+        &status_zero,
+    );
 
     env.but("oplog")
         .args(["list"])
@@ -515,8 +564,8 @@ fn undoing_past_end_of_oplog() -> anyhow::Result<()> {
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-dffcebb 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-7952170 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+092cc32 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+1c40c14 2000-01-02 00:00:00 [UNDO] Restored from snapshot
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
@@ -554,7 +603,12 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
-    undo(&env, "UpdateCommitMessage", "f4e985f", &status_three);
+    undo(
+        &env,
+        OperationKind::UpdateCommitMessage,
+        "f4e985f",
+        &status_three,
+    );
 
     env.but("oplog")
         .args(["list"])
@@ -563,7 +617,7 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
@@ -571,7 +625,12 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
-    redo(&env, "RestoreFromSnapshotViaUndo", "351f999", &status_four);
+    redo(
+        &env,
+        OperationKind::RestoreFromSnapshotViaUndo,
+        "0a0795e",
+        &status_four,
+    );
 
     env.but("oplog")
         .args(["list"])
@@ -580,8 +639,8 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-470a391 2000-01-02 00:00:00 [REDO] Restored from snapshot
-351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+b57a0e1 2000-01-02 00:00:00 [REDO] Restored from snapshot
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
@@ -621,8 +680,18 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
-    undo(&env, "UpdateCommitMessage", "f4e985f", &status_three);
-    undo(&env, "UpdateCommitMessage", "e637109", &status_two);
+    undo(
+        &env,
+        OperationKind::UpdateCommitMessage,
+        "f4e985f",
+        &status_three,
+    );
+    undo(
+        &env,
+        OperationKind::UpdateCommitMessage,
+        "e637109",
+        &status_two,
+    );
 
     env.but("oplog")
         .args(["list"])
@@ -631,8 +700,8 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-d6d5c2e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
@@ -640,7 +709,12 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
-    redo(&env, "RestoreFromSnapshotViaUndo", "d6d5c2e", &status_three);
+    redo(
+        &env,
+        OperationKind::RestoreFromSnapshotViaUndo,
+        "8b8b27a",
+        &status_three,
+    );
 
     env.but("oplog")
         .args(["list"])
@@ -649,9 +723,9 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-de4e85a 2000-01-02 00:00:00 [REDO] Restored from snapshot
-d6d5c2e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+d07be52 2000-01-02 00:00:00 [REDO] Restored from snapshot
+8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
@@ -659,7 +733,12 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
-    undo(&env, "RestoreFromSnapshotViaRedo", "de4e85a", &status_two);
+    undo(
+        &env,
+        OperationKind::RestoreFromSnapshotViaRedo,
+        "d07be52",
+        &status_two,
+    );
 
     env.but("oplog")
         .args(["list"])
@@ -668,10 +747,10 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-88d2b33 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-de4e85a 2000-01-02 00:00:00 [REDO] Restored from snapshot
-d6d5c2e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+4769e9f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+d07be52 2000-01-02 00:00:00 [REDO] Restored from snapshot
+8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
@@ -679,7 +758,12 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
-    undo(&env, "UpdateCommitMessage", "90c8e9b", &status_one);
+    undo(
+        &env,
+        OperationKind::UpdateCommitMessage,
+        "90c8e9b",
+        &status_one,
+    );
 
     env.but("oplog")
         .args(["list"])
@@ -688,11 +772,11 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-7a7ac10 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-88d2b33 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-de4e85a 2000-01-02 00:00:00 [REDO] Restored from snapshot
-d6d5c2e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+5ffc4e1 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+4769e9f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+d07be52 2000-01-02 00:00:00 [REDO] Restored from snapshot
+8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
@@ -700,7 +784,12 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
-    redo(&env, "RestoreFromSnapshotViaUndo", "7a7ac10", &status_two);
+    redo(
+        &env,
+        OperationKind::RestoreFromSnapshotViaUndo,
+        "5ffc4e1",
+        &status_two,
+    );
 
     env.but("oplog")
         .args(["list"])
@@ -709,12 +798,12 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-73e2f4f 2000-01-02 00:00:00 [REDO] Restored from snapshot
-7a7ac10 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-88d2b33 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-de4e85a 2000-01-02 00:00:00 [REDO] Restored from snapshot
-d6d5c2e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+6ba0709 2000-01-02 00:00:00 [REDO] Restored from snapshot
+5ffc4e1 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+4769e9f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+d07be52 2000-01-02 00:00:00 [REDO] Restored from snapshot
+8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
@@ -722,7 +811,12 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
-    redo(&env, "RestoreFromSnapshotViaUndo", "88d2b33", &status_three);
+    redo(
+        &env,
+        OperationKind::RestoreFromSnapshotViaUndo,
+        "4769e9f",
+        &status_three,
+    );
 
     env.but("oplog")
         .args(["list"])
@@ -731,13 +825,13 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-d8203df 2000-01-02 00:00:00 [REDO] Restored from snapshot
-73e2f4f 2000-01-02 00:00:00 [REDO] Restored from snapshot
-7a7ac10 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-88d2b33 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-de4e85a 2000-01-02 00:00:00 [REDO] Restored from snapshot
-d6d5c2e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+62ccc54 2000-01-02 00:00:00 [REDO] Restored from snapshot
+6ba0709 2000-01-02 00:00:00 [REDO] Restored from snapshot
+5ffc4e1 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+4769e9f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+d07be52 2000-01-02 00:00:00 [REDO] Restored from snapshot
+8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
@@ -745,7 +839,12 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 "#,
         );
 
-    redo(&env, "RestoreFromSnapshotViaUndo", "351f999", &status_four);
+    redo(
+        &env,
+        OperationKind::RestoreFromSnapshotViaUndo,
+        "0a0795e",
+        &status_four,
+    );
 
     env.but("oplog")
         .args(["list"])
@@ -754,14 +853,14 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .stdout_eq(
             r#"Operations History
 ──────────────────────────────────────────────────
-6f2c4bb 2000-01-02 00:00:00 [REDO] Restored from snapshot
-d8203df 2000-01-02 00:00:00 [REDO] Restored from snapshot
-73e2f4f 2000-01-02 00:00:00 [REDO] Restored from snapshot
-7a7ac10 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-88d2b33 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-de4e85a 2000-01-02 00:00:00 [REDO] Restored from snapshot
-d6d5c2e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-351f999 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+9306108 2000-01-02 00:00:00 [REDO] Restored from snapshot
+62ccc54 2000-01-02 00:00:00 [REDO] Restored from snapshot
+6ba0709 2000-01-02 00:00:00 [REDO] Restored from snapshot
+5ffc4e1 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+4769e9f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+d07be52 2000-01-02 00:00:00 [REDO] Restored from snapshot
+8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -135,14 +135,10 @@ pub fn unapply_stack(
         .context("Unapplying a stack requires open workspace mode")?;
     let stack = ctx.virtual_branches().get_stack_in_workspace(stack_id)?;
 
-    let trailers: Vec<Trailer> = stack
+    let trailers = stack
         .heads
         .iter()
-        .map(|head| Trailer {
-            key: "branch".to_string(),
-            value: head.name.to_string(),
-        })
-        .collect();
+        .map(|head| Trailer::Branch(head.name.clone()));
 
     let details = SnapshotDetails::new(OperationKind::UnapplyBranch).with_trailers(trailers);
     let _snapshot = ctx.create_snapshot(details, perm).ok();

--- a/crates/gitbutler-oplog/src/entry.rs
+++ b/crates/gitbutler-oplog/src/entry.rs
@@ -1,15 +1,13 @@
 use std::{
-    fmt,
-    fmt::{Debug, Display, Formatter},
+    borrow::Cow,
+    fmt::{self, Debug, Display, Formatter},
     str::FromStr,
 };
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-
-const OPERATION_TRAILER_KEY: &str = "Operation";
-const VERSION_TRAILER_KEY: &str = "Version";
+use strum::IntoEnumIterator as _;
 
 /// A snapshot of the repository and virtual branches state that GitButler can restore to.
 /// It captures the state of the working directory, virtual branches and commits.
@@ -62,8 +60,8 @@ impl SnapshotDetails {
         self
     }
 
-    pub fn with_trailers(mut self, trailers: Vec<Trailer>) -> Self {
-        self.trailers = trailers;
+    pub fn with_trailers(mut self, trailers: impl IntoIterator<Item = Trailer>) -> Self {
+        self.trailers.extend(trailers);
         self
     }
 }
@@ -86,20 +84,22 @@ impl FromStr for SnapshotDetails {
 
         let version = trailers
             .iter()
-            .find(|t| t.key == VERSION_TRAILER_KEY)
-            .ok_or(anyhow!("No version found on snapshot commit message"))?
-            .value
-            .parse()?;
+            .find_map(|t| match t {
+                Trailer::Version(version) => Some(*version),
+                _ => None,
+            })
+            .context("No version found on snapshot commit message")?;
 
-        let operation_trailer = &trailers
+        let operation = trailers
             .iter()
-            .find(|t| t.key == OPERATION_TRAILER_KEY)
-            .ok_or(anyhow!("No operation found on snapshot commit message"))?;
-        let operation = OperationKind::parse_persisted_str(&operation_trailer.value)
-            .unwrap_or(OperationKind::Unknown);
+            .find_map(|t| match t {
+                Trailer::Operation(operation_kind) => Some(*operation_kind),
+                _ => None,
+            })
+            .context("No operation found on snapshot commit message")?;
 
         // remove the version and operation attributes from the trailers since they have dedicated fields
-        trailers.retain(|t| t.key != VERSION_TRAILER_KEY && t.key != OPERATION_TRAILER_KEY);
+        trailers.retain(|t| !matches!(t, Trailer::Version(..) | Trailer::Operation(..)));
 
         Ok(SnapshotDetails {
             version,
@@ -117,14 +117,13 @@ impl Display for SnapshotDetails {
         if let Some(body) = &self.body {
             writeln!(f, "{body}\n")?;
         }
-        writeln!(f, "{VERSION_TRAILER_KEY}: {}", self.version)?;
-        writeln!(
-            f,
-            "{OPERATION_TRAILER_KEY}: {}",
-            self.operation.as_persisted_str()
-        )?;
-        for line in &self.trailers {
-            writeln!(f, "{line}")?;
+        writeln!(f, "{}", Trailer::Version(self.version))?;
+        writeln!(f, "{}", Trailer::Operation(self.operation))?;
+        for trailer in &self.trailers {
+            if matches!(trailer, Trailer::Version(..) | Trailer::Operation(..)) {
+                continue;
+            }
+            writeln!(f, "{trailer}")?;
         }
         Ok(())
     }
@@ -442,34 +441,243 @@ impl FromStr for Version {
 
 /// Represents a key value pair stored in a snapshot, like `key: value\n`
 /// Using the git trailer format (<https://git-scm.com/docs/git-interpret-trailers>)
-#[derive(Debug, PartialEq, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Trailer {
-    /// Trailer key
-    pub key: String,
-    /// Trailer value
-    pub value: String,
+#[derive(Debug, PartialEq, Clone, strum::EnumDiscriminants)]
+#[strum_discriminants(derive(strum::EnumIter))]
+pub enum Trailer {
+    Version(Version),
+    Operation(OperationKind),
+    RestoredFrom(gix::ObjectId),
+    RestoredOperation(OperationKind),
+    RestoredDate(i64),
+    File(String),
+    Name(String),
+    Error(String),
+    Message(String),
+    Branch(String),
+    Before(usize),
+    After(usize),
+    Sha(gix::ObjectId),
+    /// Trailer of unknown origin. GitButler should ideally never be generating such trailers but
+    /// we might see them when parsing user data.
+    Other {
+        key: String,
+        value: String,
+    },
+}
+
+impl Trailer {
+    const OPERATION_KEY: &str = "Operation";
+    const VERSION_KEY: &str = "Version";
+    const RESTORED_FROM_KEY: &str = "restored_from";
+    const RESTORED_OPERATION_KEY: &str = "restored_operation";
+    const RESTORED_DATE_KEY: &str = "restored_date";
+    const FILE_KEY: &str = "file";
+    const NAME_KEY: &str = "name";
+    const ERROR_KEY: &str = "error";
+    const BEFORE_KEY: &str = "before";
+    const AFTER_KEY: &str = "after";
+    const SHA_KEY: &str = "sha";
+    const MESSAGE_KEY: &str = "message";
+    const BRANCH_KEY: &str = "branch";
+
+    fn key(&self) -> &str {
+        match self {
+            Trailer::Other { key, .. } => key,
+            Trailer::Version(..) => Self::VERSION_KEY,
+            Trailer::Operation(..) => Self::OPERATION_KEY,
+            Trailer::RestoredFrom(..) => Self::RESTORED_FROM_KEY,
+            Trailer::RestoredOperation(..) => Self::RESTORED_OPERATION_KEY,
+            Trailer::RestoredDate(..) => Self::RESTORED_DATE_KEY,
+            Trailer::File(..) => Self::FILE_KEY,
+            Trailer::Name(..) => Self::NAME_KEY,
+            Trailer::Error(..) => Self::ERROR_KEY,
+            Trailer::Message(..) => Self::MESSAGE_KEY,
+            Trailer::Branch(..) => Self::BRANCH_KEY,
+            Trailer::Before(..) => Self::BEFORE_KEY,
+            Trailer::After(..) => Self::AFTER_KEY,
+            Trailer::Sha(..) => Self::SHA_KEY,
+        }
+    }
+
+    fn value(&self) -> Cow<'_, str> {
+        match self {
+            Trailer::Other { value, .. } => value.into(),
+            Trailer::Version(version) => version.0.to_string().into(),
+            Trailer::Operation(operation_kind) => operation_kind.as_persisted_str().into(),
+            Trailer::RestoredFrom(commit) => commit.to_string().into(),
+            Trailer::RestoredOperation(operation_kind) => operation_kind.as_persisted_str().into(),
+            Trailer::RestoredDate(timestamp) => timestamp.to_string().into(),
+            Trailer::File(name) => name.as_str().into(),
+            Trailer::Name(name) => name.as_str().into(),
+            Trailer::Error(error) => error.as_str().into(),
+            Trailer::Message(message) => message.as_str().into(),
+            Trailer::Branch(branch) => branch.as_str().into(),
+            Trailer::Before(n) => n.to_string().into(),
+            Trailer::After(n) => n.to_string().into(),
+            Trailer::Sha(commit) => commit.to_string().into(),
+        }
+    }
 }
 
 impl Display for Trailer {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let escaped_value = self.value.replace('\n', "\\n");
-        write!(f, "{}: {}", self.key, escaped_value)
+        let value = self.value();
+        let escaped_value = value.replace('\n', "\\n");
+        write!(f, "{}: {escaped_value}", self.key())
     }
 }
 
 impl FromStr for Trailer {
     type Err = anyhow::Error;
+
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts: Vec<&str> = s.splitn(2, ':').collect();
-        if parts.len() != 2 {
-            return Err(anyhow!("Invalid trailer format, expected `key: value`"));
+        let (key, value) = s
+            .split_once(':')
+            .context("Invalid trailer format, expected `key: value`")?;
+        let key = key.trim();
+        let unescaped_value = value.trim().replace("\\n", "\n");
+
+        for d in TrailerDiscriminants::iter() {
+            match d {
+                TrailerDiscriminants::Other => {
+                    // only used if no other variant matches
+                }
+                TrailerDiscriminants::Version => {
+                    if key == Self::VERSION_KEY {
+                        return Ok(Self::Version(
+                            unescaped_value.parse::<Version>().with_context(|| {
+                                format!(
+                                    "invalid version number in {} trailer: {unescaped_value:?}",
+                                    Self::VERSION_KEY
+                                )
+                            })?,
+                        ));
+                    }
+                }
+                TrailerDiscriminants::Operation => {
+                    if key == Self::OPERATION_KEY {
+                        return Ok(Self::Operation(
+                            OperationKind::parse_persisted_str(&unescaped_value)
+                                .unwrap_or(OperationKind::Unknown),
+                        ));
+                    }
+                }
+                TrailerDiscriminants::RestoredFrom => {
+                    if key == Self::RESTORED_FROM_KEY {
+                        return Ok(Self::RestoredFrom(unescaped_value.parse().with_context(
+                            || {
+                                format!(
+                                    "invalid commit in {} in trailer: {unescaped_value:?}",
+                                    Self::RESTORED_FROM_KEY
+                                )
+                            },
+                        )?));
+                    }
+                }
+                TrailerDiscriminants::RestoredOperation => {
+                    if key == Self::RESTORED_OPERATION_KEY {
+                        return Ok(Self::RestoredOperation(
+                            OperationKind::parse_persisted_str(&unescaped_value)
+                                .unwrap_or(OperationKind::Unknown),
+                        ));
+                    }
+                }
+                TrailerDiscriminants::RestoredDate => {
+                    if key == Self::RESTORED_DATE_KEY {
+                        return Ok(Self::RestoredDate(unescaped_value.parse().with_context(
+                            || {
+                                format!(
+                                    "invalid timestamp in {} trailer: {unescaped_value:?}",
+                                    Self::RESTORED_DATE_KEY
+                                )
+                            },
+                        )?));
+                    }
+                }
+                TrailerDiscriminants::File => {
+                    if key == Self::FILE_KEY {
+                        return Ok(Self::File(unescaped_value));
+                    }
+                }
+                TrailerDiscriminants::Name => {
+                    if key == Self::NAME_KEY {
+                        return Ok(Self::Name(unescaped_value));
+                    }
+                }
+                TrailerDiscriminants::Error => {
+                    if key == Self::ERROR_KEY {
+                        return Ok(Self::Error(unescaped_value));
+                    }
+                }
+                TrailerDiscriminants::Before => {
+                    if key == Self::BEFORE_KEY {
+                        return Ok(Self::Before(unescaped_value.parse().with_context(
+                            || {
+                                format!(
+                                    "invalid number in {} trailer: {unescaped_value:?}",
+                                    Self::BEFORE_KEY
+                                )
+                            },
+                        )?));
+                    }
+                }
+                TrailerDiscriminants::After => {
+                    if key == Self::AFTER_KEY {
+                        return Ok(Self::After(unescaped_value.parse().with_context(|| {
+                            format!(
+                                "invalid number in {} trailer: {unescaped_value:?}",
+                                Self::AFTER_KEY
+                            )
+                        })?));
+                    }
+                }
+                TrailerDiscriminants::Sha => {
+                    if key == Self::SHA_KEY {
+                        return Ok(Self::Sha(unescaped_value.parse().with_context(|| {
+                            format!(
+                                "invalid commit in {} trailer: {unescaped_value:?}",
+                                Self::SHA_KEY
+                            )
+                        })?));
+                    }
+                }
+                TrailerDiscriminants::Message => {
+                    if key == Self::MESSAGE_KEY {
+                        return Ok(Self::Message(unescaped_value));
+                    }
+                }
+                TrailerDiscriminants::Branch => {
+                    if key == Self::BRANCH_KEY {
+                        return Ok(Self::Branch(unescaped_value));
+                    }
+                }
+            }
         }
-        let unescaped_value = parts[1].trim().replace("\\n", "\n");
-        Ok(Self {
-            key: parts[0].trim().to_string(),
+
+        Ok(Self::Other {
+            key: key.to_string(),
             value: unescaped_value,
         })
+    }
+}
+
+impl Serialize for Trailer {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct KeyValue<'a> {
+            key: &'a str,
+            value: Cow<'a, str>,
+        }
+
+        KeyValue {
+            key: self.key(),
+            value: self.value(),
+        }
+        .serialize(serializer)
     }
 }
 

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -814,8 +814,8 @@ fn restore_snapshot(
         .to_str()
         .ok()
         .and_then(|msg| SnapshotDetails::from_str(msg).ok())
-        .map(|d| d.operation.title().to_owned())
-        .unwrap_or_default();
+        .map(|d| d.operation)
+        .unwrap_or(OperationKind::Unknown);
 
     // create new snapshot
     let before_restore_snapshot_tree_id = before_restore_snapshot_result?;
@@ -830,20 +830,11 @@ fn restore_snapshot(
         operation,
         title: operation.as_persisted_str().to_owned(),
         body: None,
-        trailers: vec![
-            Trailer {
-                key: "restored_from".to_string(),
-                value: snapshot_commit_id.to_string(),
-            },
-            Trailer {
-                key: "restored_operation".to_string(),
-                value: restored_operation,
-            },
-            Trailer {
-                key: "restored_date".to_string(),
-                value: restored_date_ms.to_string(),
-            },
-        ],
+        trailers: Vec::from([
+            Trailer::RestoredFrom(snapshot_commit_id),
+            Trailer::RestoredOperation(restored_operation),
+            Trailer::RestoredDate(restored_date_ms),
+        ]),
     };
     let repo = ctx.repo.get()?;
     let target = ctx.persisted_default_target()?.sha;

--- a/crates/gitbutler-oplog/src/snapshot.rs
+++ b/crates/gitbutler-oplog/src/snapshot.rs
@@ -1,5 +1,3 @@
-use std::vec;
-
 use anyhow::Result;
 use but_ctx::access::RepoExclusive;
 use gitbutler_branch::BranchUpdateRequest;
@@ -49,11 +47,13 @@ pub trait SnapshotExt {
         branch_name: String,
         perm: &mut RepoExclusive,
     ) -> anyhow::Result<()>;
+
     fn snapshot_branch_deletion(
         &self,
         branch_name: String,
         perm: &mut RepoExclusive,
     ) -> anyhow::Result<()>;
+
     fn snapshot_branch_update(
         &self,
         snapshot_tree: gix::ObjectId,
@@ -62,16 +62,19 @@ pub trait SnapshotExt {
         error: Option<&anyhow::Error>,
         perm: &mut RepoExclusive,
     ) -> anyhow::Result<()>;
+
     fn snapshot_create_dependent_branch(
         &self,
         branch_name: &str,
         perm: &mut RepoExclusive,
     ) -> anyhow::Result<()>;
+
     fn snapshot_remove_dependent_branch(
         &self,
         branch_name: &str,
         perm: &mut RepoExclusive,
     ) -> anyhow::Result<()>;
+
     fn snapshot_update_dependent_branch_name(
         &self,
         new_branch_name: &str,
@@ -87,12 +90,16 @@ impl SnapshotExt for but_ctx::Context {
         result: Result<&ReferenceName, &anyhow::Error>,
         perm: &mut RepoExclusive,
     ) -> anyhow::Result<()> {
-        let result = result.map(|s| Some(s.to_string()));
-        let details = SnapshotDetails::new(OperationKind::UnapplyBranch)
-            .with_trailers(result_trailer(result, "name".to_string()));
+        let result = result.map(|s| s.to_owned());
+        let details =
+            SnapshotDetails::new(OperationKind::UnapplyBranch).with_trailers(match result {
+                Ok(name) => [Trailer::Name(name)],
+                Err(err) => [Trailer::Error(err.to_string())],
+            });
         self.commit_snapshot(snapshot_tree, details, perm)?;
         Ok(())
     }
+
     fn snapshot_commit_undo(
         &self,
         snapshot_tree: gix::ObjectId,
@@ -100,12 +107,14 @@ impl SnapshotExt for but_ctx::Context {
         commit_sha: gix::ObjectId,
         perm: &mut RepoExclusive,
     ) -> anyhow::Result<()> {
-        let result = result.map(|_| Some(commit_sha.to_string()));
-        let details = SnapshotDetails::new(OperationKind::UndoCommit)
-            .with_trailers(result_trailer(result, "sha".to_string()));
+        let details = SnapshotDetails::new(OperationKind::UndoCommit).with_trailers(match result {
+            Ok(_) => [Trailer::Sha(commit_sha)],
+            Err(err) => [Trailer::Error(err.to_string())],
+        });
         self.commit_snapshot(snapshot_tree, details, perm)?;
         Ok(())
     }
+
     fn snapshot_commit_creation(
         &self,
         snapshot_tree: gix::ObjectId,
@@ -115,20 +124,10 @@ impl SnapshotExt for but_ctx::Context {
         perm: &mut RepoExclusive,
     ) -> anyhow::Result<()> {
         let details = SnapshotDetails::new(OperationKind::CreateCommit).with_trailers(
-            [
-                vec![
-                    Trailer {
-                        key: "message".to_string(),
-                        value: commit_message,
-                    },
-                    Trailer {
-                        key: "sha".to_string(),
-                        value: sha.map(|sha| sha.to_string()).unwrap_or_default(),
-                    },
-                ],
-                error_trailer(error),
-            ]
-            .concat(),
+            [Trailer::Message(commit_message)]
+                .into_iter()
+                .chain(sha.map(Trailer::Sha))
+                .chain(error_trailer(error)),
         );
         self.commit_snapshot(snapshot_tree, details, perm)?;
         Ok(())
@@ -139,11 +138,8 @@ impl SnapshotExt for but_ctx::Context {
         branch_name: String,
         perm: &mut RepoExclusive,
     ) -> anyhow::Result<()> {
-        let details =
-            SnapshotDetails::new(OperationKind::StashIntoBranch).with_trailers(vec![Trailer {
-                key: "name".to_string(),
-                value: branch_name,
-            }]);
+        let details = SnapshotDetails::new(OperationKind::StashIntoBranch)
+            .with_trailers([Trailer::Name(branch_name)]);
         self.create_snapshot(details, perm)?;
         Ok(())
     }
@@ -153,28 +149,23 @@ impl SnapshotExt for but_ctx::Context {
         branch_name: String,
         perm: &mut RepoExclusive,
     ) -> anyhow::Result<()> {
-        let details =
-            SnapshotDetails::new(OperationKind::CreateBranch).with_trailers(vec![Trailer {
-                key: "name".to_string(),
-                value: branch_name,
-            }]);
+        let details = SnapshotDetails::new(OperationKind::CreateBranch)
+            .with_trailers([Trailer::Name(branch_name)]);
         self.create_snapshot(details, perm)?;
         Ok(())
     }
+
     fn snapshot_branch_deletion(
         &self,
         branch_name: String,
         perm: &mut RepoExclusive,
     ) -> anyhow::Result<()> {
-        let details =
-            SnapshotDetails::new(OperationKind::DeleteBranch).with_trailers(vec![Trailer {
-                key: "name".to_string(),
-                value: branch_name.to_string(),
-            }]);
-
+        let details = SnapshotDetails::new(OperationKind::DeleteBranch)
+            .with_trailers([Trailer::Name(branch_name)]);
         self.create_snapshot(details, perm)?;
         Ok(())
     }
+
     fn snapshot_branch_update(
         &self,
         snapshot_tree: gix::ObjectId,
@@ -185,20 +176,9 @@ impl SnapshotExt for but_ctx::Context {
     ) -> anyhow::Result<()> {
         let details = if let Some(order) = update.order {
             SnapshotDetails::new(OperationKind::ReorderBranches).with_trailers(
-                [
-                    vec![
-                        Trailer {
-                            key: "before".to_string(),
-                            value: old_order.to_string(),
-                        },
-                        Trailer {
-                            key: "after".to_string(),
-                            value: order.to_string(),
-                        },
-                    ],
-                    error_trailer(error),
-                ]
-                .concat(),
+                [Trailer::Before(old_order), Trailer::After(order)]
+                    .into_iter()
+                    .chain(error_trailer(error)),
             )
         } else {
             SnapshotDetails::new(OperationKind::GenericBranchUpdate)
@@ -206,79 +186,41 @@ impl SnapshotExt for but_ctx::Context {
         self.commit_snapshot(snapshot_tree, details, perm)?;
         Ok(())
     }
+
     fn snapshot_create_dependent_branch(
         &self,
         branch_name: &str,
         perm: &mut RepoExclusive,
     ) -> anyhow::Result<()> {
-        let details =
-            SnapshotDetails::new(OperationKind::CreateDependentBranch).with_trailers(vec![
-                Trailer {
-                    key: "name".to_string(),
-                    value: branch_name.to_string(),
-                },
-            ]);
+        let details = SnapshotDetails::new(OperationKind::CreateDependentBranch)
+            .with_trailers([Trailer::Name(branch_name.to_owned())]);
         self.create_snapshot(details, perm)?;
         Ok(())
     }
+
     fn snapshot_remove_dependent_branch(
         &self,
         branch_name: &str,
         perm: &mut RepoExclusive,
     ) -> anyhow::Result<()> {
-        let details =
-            SnapshotDetails::new(OperationKind::RemoveDependentBranch).with_trailers(vec![
-                Trailer {
-                    key: "name".to_string(),
-                    value: branch_name.to_string(),
-                },
-            ]);
+        let details = SnapshotDetails::new(OperationKind::RemoveDependentBranch)
+            .with_trailers([Trailer::Name(branch_name.to_owned())]);
         self.create_snapshot(details, perm)?;
         Ok(())
     }
+
     fn snapshot_update_dependent_branch_name(
         &self,
         new_branch_name: &str,
         perm: &mut RepoExclusive,
     ) -> anyhow::Result<()> {
-        let details =
-            SnapshotDetails::new(OperationKind::UpdateDependentBranchName).with_trailers(vec![
-                Trailer {
-                    key: "name".to_string(),
-                    value: new_branch_name.to_string(),
-                },
-            ]);
+        let details = SnapshotDetails::new(OperationKind::UpdateDependentBranchName)
+            .with_trailers([Trailer::Name(new_branch_name.to_owned())]);
         self.create_snapshot(details, perm)?;
         Ok(())
     }
 }
 
-fn result_trailer(result: Result<Option<String>, &anyhow::Error>, key: String) -> Vec<Trailer> {
-    match result {
-        Ok(v) => {
-            if let Some(v) = v {
-                vec![Trailer {
-                    key,
-                    value: v.clone(),
-                }]
-            } else {
-                vec![]
-            }
-        }
-        Err(error) => vec![Trailer {
-            key: "error".to_string(),
-            value: error.to_string(),
-        }],
-    }
-}
-
-fn error_trailer(error: Option<&anyhow::Error>) -> Vec<Trailer> {
-    error
-        .map(|e| {
-            vec![Trailer {
-                key: "error".to_string(),
-                value: e.to_string(),
-            }]
-        })
-        .unwrap_or_default()
+fn error_trailer(error: Option<&anyhow::Error>) -> Option<Trailer> {
+    error.map(|e| Trailer::Error(e.to_string()))
 }

--- a/crates/gitbutler-oplog/tests/oplog/main.rs
+++ b/crates/gitbutler-oplog/tests/oplog/main.rs
@@ -6,7 +6,7 @@ mod trailer {
 
     #[test]
     fn display() {
-        let trailer = Trailer {
+        let trailer = Trailer::Other {
             key: "foo".to_string(),
             value: "bar".to_string(),
         };
@@ -17,8 +17,13 @@ mod trailer {
     fn from_str() {
         let s = "foo: bar";
         let trailer = Trailer::from_str(s).unwrap();
-        assert_eq!(trailer.key, "foo");
-        assert_eq!(trailer.value, "bar");
+        assert_eq!(
+            trailer,
+            Trailer::Other {
+                key: "foo".to_owned(),
+                value: "bar".to_owned()
+            }
+        );
     }
 
     #[test]
@@ -37,25 +42,25 @@ mod version {
     #[test]
     fn from_trailer() {
         let s = "Version: 3";
-        let trailer = Trailer::from_str(s).unwrap();
-        let version = Version::from_str(&trailer.value).unwrap();
+        let Trailer::Version(version) = Trailer::from_str(s).unwrap() else {
+            panic!();
+        };
         assert_eq!(version, Version::default());
     }
 
     #[test]
     fn non_default() {
         let s = "Version: 1";
-        let trailer = Trailer::from_str(s).unwrap();
-        let version = Version::from_str(&trailer.value).unwrap();
-        assert_eq!(version, Version::from_str("1").unwrap());
+        let Trailer::Version(version) = Trailer::from_str(s).unwrap() else {
+            panic!();
+        };
+        assert_eq!(version, Version(1));
     }
 
     #[test]
     fn invalid() {
         let s = "Version: -1";
-        let trailer = Trailer::from_str(s).unwrap();
-        let version = Version::from_str(&trailer.value);
-        assert!(version.is_err());
+        assert!(Trailer::from_str(s).is_err());
     }
 }
 
@@ -67,8 +72,9 @@ mod operation_kind {
     #[test]
     fn from_trailer() {
         let s = "Operation: CreateCommit";
-        let trailer = Trailer::from_str(s).unwrap();
-        let operation = OperationKind::parse_persisted_str(&trailer.value).unwrap();
+        let Trailer::Operation(operation) = Trailer::from_str(s).unwrap() else {
+            panic!();
+        };
         assert_eq!(operation, OperationKind::CreateCommit);
     }
 
@@ -85,7 +91,7 @@ mod operation_kind {
         );
         assert_eq!(
             details.trailers,
-            vec![Trailer {
+            vec![Trailer::Other {
                 key: "Foo".to_string(),
                 value: "Bar".to_string(),
             }]
@@ -123,7 +129,7 @@ mod snapshot_details {
         );
         assert_eq!(
             details.trailers,
-            vec![Trailer {
+            vec![Trailer::Other {
                 key: "Foo".to_string(),
                 value: "Bar".to_string(),
             }]
@@ -133,7 +139,7 @@ mod snapshot_details {
 
     #[test]
     fn new_with_newline_in_trailer() {
-        let snapshot_details = new_details(Trailer {
+        let snapshot_details = new_details(Trailer::Other {
             key: "Message".to_string(),
             value: "Header\n\nBody".to_string(),
         });
@@ -148,13 +154,16 @@ mod snapshot_details {
     #[test]
     fn new_with_space_in_trailer_key() {
         for value in ["trailing-space ", " leading-space"] {
-            let trailer = Trailer {
+            let trailer = Trailer::Other {
                 key: value.to_string(),
                 value: "anything".to_string(),
             };
             let mut snapshot_details = new_details(trailer);
-            let trailer = &mut snapshot_details.trailers[0];
-            trailer.key = trailer.key.trim().to_string();
+            if let Trailer::Other { key, .. } = &mut snapshot_details.trailers[0] {
+                *key = key.trim().to_string();
+            } else {
+                panic!()
+            }
 
             let serialized = snapshot_details.to_string();
             let deserialized = SnapshotDetails::from_str(&serialized).unwrap();


### PR DESCRIPTION
We have several places in the code that cares about specific trailers such as the version or operation. This is currently done via string matching which is brittle. I think its nicer to have an actual enum for the kinds of trailers we know about.