### PR TITLE
Downgrade hook failure toasts from error to warning

### DIFF
--- a/apps/desktop/src/components/commit/NewCommitView.svelte
+++ b/apps/desktop/src/components/commit/NewCommitView.svelte
@@ -3,7 +3,7 @@
 	import { COMMIT_ANALYTICS } from "$lib/analytics/commitAnalytics";
 	import { projectRunCommitHooks } from "$lib/config/config";
 	import { showError } from "$lib/error/showError";
-	import { HOOKS_SERVICE } from "$lib/git/hooksService";
+	import { HookFailedError, HOOKS_SERVICE } from "$lib/git/hooksService";
 	import { showToast } from "$lib/notifications/toasts";
 	import { FILE_SELECTION_MANAGER } from "$lib/selection/fileSelectionManager.svelte";
 	import { createWorktreeSelection } from "$lib/selection/key";
@@ -186,7 +186,9 @@
 		try {
 			await createCommit(message);
 		} catch (err: unknown) {
-			showError("Failed to commit", err);
+			if (!(err instanceof HookFailedError)) {
+				showError("Failed to commit", err);
+			}
 		}
 	}
 

--- a/apps/desktop/src/lib/dragging/dropHandlers/commitDropHandler.ts
+++ b/apps/desktop/src/lib/dragging/dropHandlers/commitDropHandler.ts
@@ -6,7 +6,7 @@ import {
 	type ChangeDropData,
 } from "$lib/dragging/draggables";
 import { parseError } from "$lib/error/parser";
-import { HOOKS_SERVICE } from "$lib/git/hooksService";
+import { HookFailedError, HOOKS_SERVICE } from "$lib/git/hooksService";
 import { toCommitMovePlacement } from "$lib/stacks/commitMovePlacement";
 import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 import { UI_STATE, withStackBusy, type UiState } from "$lib/state/uiState.svelte";
@@ -178,6 +178,7 @@ export class AmendCommitWithChangeDzHandler implements DropzoneHandler {
 					try {
 						await this.hooksService.runPreCommitHooks(this.projectId, worktreeChanges);
 					} catch (err) {
+						if (err instanceof HookFailedError) return { type: "ok" };
 						return { type: "error", title: "Git hook failed", error: err };
 					}
 				}
@@ -200,10 +201,13 @@ export class AmendCommitWithChangeDzHandler implements DropzoneHandler {
 					try {
 						await this.hooksService.runPostCommitHooks(this.projectId);
 					} catch (err) {
-						if (!rejectionResult) {
+						if (err instanceof HookFailedError) {
+							if (!rejectionResult) return { type: "ok" };
+						} else if (!rejectionResult) {
 							return { type: "error", title: "Git hook failed", error: err };
+						} else {
+							console.error("Post-commit hook failed (rejected changes take priority):", err);
 						}
-						console.error("Post-commit hook failed (rejected changes take priority):", err);
 					}
 				}
 
@@ -425,6 +429,7 @@ export class AmendCommitWithHunkDzHandler implements DropzoneHandler {
 				try {
 					await this.hooksService.runPreCommitHooks(projectId, worktreeChanges);
 				} catch (err) {
+					if (err instanceof HookFailedError) return { type: "ok" };
 					return { type: "error", title: "Git hook failed", error: err };
 				}
 			}
@@ -442,10 +447,13 @@ export class AmendCommitWithHunkDzHandler implements DropzoneHandler {
 				try {
 					await this.hooksService.runPostCommitHooks(projectId);
 				} catch (err) {
-					if (!rejectionResult) {
+					if (err instanceof HookFailedError) {
+						if (!rejectionResult) return { type: "ok" };
+					} else if (!rejectionResult) {
 						return { type: "error", title: "Git hook failed", error: err };
+					} else {
+						console.error("Post-commit hook failed (rejected changes take priority):", err);
 					}
-					console.error("Post-commit hook failed (rejected changes take priority):", err);
 				}
 			}
 

--- a/apps/desktop/src/lib/git/hooksService.ts
+++ b/apps/desktop/src/lib/git/hooksService.ts
@@ -1,3 +1,4 @@
+import { showWarning } from "$lib/notifications/toasts";
 import { InjectionToken } from "@gitbutler/core/context";
 import { chipToasts } from "@gitbutler/ui";
 import type { BackendApi } from "$lib/state/backendApi";
@@ -24,7 +25,8 @@ export class HooksService {
 
 			if (result?.status === "failure") {
 				chipToasts.removeChipToast(loadingToastId);
-				throw newHookError(formatError(result.error));
+				showWarning("Pre-commit hook failed", formatError(result.error));
+				throw new HookFailedError();
 			}
 
 			chipToasts.removeChipToast(loadingToastId);
@@ -45,7 +47,8 @@ export class HooksService {
 
 			if (result?.status === "failure") {
 				chipToasts.removeChipToast(loadingToastId);
-				throw newHookError(formatError(result.error));
+				showWarning("Post-commit hook failed", formatError(result.error));
+				throw new HookFailedError();
 			}
 
 			chipToasts.removeChipToast(loadingToastId);
@@ -57,10 +60,15 @@ export class HooksService {
 	}
 }
 
-function newHookError(message: string): Error {
-	const error = new Error(message);
-	error.name = "Git hook failed";
-	return error;
+/**
+ * Thrown after a hook failure warning has already been shown.
+ * Callers should catch this to abort the operation without showing a second toast.
+ */
+export class HookFailedError extends Error {
+	constructor() {
+		super("Git hook failed");
+		this.name = "HookFailedError";
+	}
 }
 
 function formatError(error: string): string {


### PR DESCRIPTION
## Summary

- Replace error toasts for git hook failures (pre-commit, post-commit) with warning toasts, since hook failures are non-fatal and shouldn't alarm users.
- Introduce a `HookFailedError` class so callers can distinguish hook failures from real errors and silently abort without showing a redundant error toast.

## Test plan

- [x] Configure a pre-commit hook that fails and verify a warning toast is shown (not an error toast)
- [x] Verify the commit operation is still aborted when the pre-commit hook fails
- [x] Drag-and-drop amend with a failing hook should show a warning and not proceed
- [x] Post-commit hook failure should show a warning but not block the commit