### PR TITLE
Rename `diverged` base branch property

### DIFF
--- a/apps/desktop/src/components/upstream/IntegrateUpstreamModal.svelte
+++ b/apps/desktop/src/components/upstream/IntegrateUpstreamModal.svelte
@@ -79,7 +79,7 @@
 	let filteredReviews = $state<PullRequest[]>([]);
 	const reviewMap = $derived(new Map(filteredReviews?.map((r) => [r.sourceBranch, r])));
 
-	const isDivergedResolved = $derived(base?.diverged && !baseResolutionApproach);
+	const isDivergedResolved = $derived(base?.targetShaAheadOfRef && !baseResolutionApproach);
 	const [integrateUpstream] = $derived(upstreamIntegrationService.integrateUpstream());
 
 	function someBranchesShouldNotBeDeleted(branchNames: string[]): boolean {
@@ -134,7 +134,7 @@
 	// approach is changed
 	$effect(() => {
 		if (!modal?.imports.open) return;
-		if (base?.diverged && baseResolutionApproach) {
+		if (base?.targetShaAheadOfRef && baseResolutionApproach) {
 			upstreamIntegrationService
 				.resolveUpstreamIntegrationMutation({
 					projectId,
@@ -396,7 +396,7 @@
 			</div>
 		{/if}
 		<!-- DIVERGED -->
-		{#if base?.diverged}
+		{#if base?.targetShaAheadOfRef}
 			<div class="target-divergence">
 				<img class="target-icon" src="/images/domain-icons/trunk.svg" alt="" />
 

--- a/apps/desktop/src/lib/testing/mockBaseBranch.ts
+++ b/apps/desktop/src/lib/testing/mockBaseBranch.ts
@@ -14,9 +14,7 @@ export function getMockBaseBranch(): BaseBranch {
 		recentCommits: [],
 		lastFetchedMs: null,
 		conflicted: false,
-		diverged: false,
-		divergedAhead: [],
-		divergedBehind: [],
+		targetShaAheadOfRef: false,
 		shortName: "mock-branch",
 	};
 }

--- a/crates/but/src/command/legacy/workspace_target.rs
+++ b/crates/but/src/command/legacy/workspace_target.rs
@@ -203,9 +203,7 @@ mod tests {
             recent_commits: vec![],
             last_fetched_ms: None,
             conflicted: false,
-            diverged: false,
-            diverged_ahead: vec![],
-            diverged_behind: vec![],
+            target_sha_ahead_of_ref: false,
             short_name: "main".to_string(),
         }
     }

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -49,19 +49,7 @@ pub struct BaseBranch {
     pub recent_commits: Vec<RemoteCommit>,
     pub last_fetched_ms: Option<u128>,
     pub conflicted: bool,
-    pub diverged: bool,
-    #[serde(with = "but_serde::object_id_vec")]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::object_id_vec")
-    )]
-    pub diverged_ahead: Vec<gix::ObjectId>,
-    #[serde(with = "but_serde::object_id_vec")]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::object_id_vec")
-    )]
-    pub diverged_behind: Vec<gix::ObjectId>,
+    pub target_sha_ahead_of_ref: bool,
     pub short_name: String,
 }
 #[cfg(feature = "export-schema")]
@@ -356,23 +344,18 @@ fn set_exclude_decoration(ctx: &Context) -> Result<()> {
 
 pub(crate) fn target_to_base_branch(ctx: &Context, target: &Target) -> Result<BaseBranch> {
     let repo = &*ctx.repo.get()?;
-    let target_commit_id = repo
+    let target_ref_commit = repo
         .find_reference(&target.branch.to_string())?
         .peel_to_commit()?
         .id;
-    let cache = repo.commit_graph_if_enabled()?;
-    let mut graph = repo.revision_graph(cache.as_ref());
-    let merge_base = repo
-        .merge_base_with_graph(target.sha, target_commit_id, &mut graph)?
-        .detach();
 
-    let diverged_ahead = first_parent_commit_ids_until(repo, target.sha, merge_base)
+    // The old integrate_upstream function cares about whether the target sha
+    // is ahead of the target ref.
+    //
+    // The old function provided some options for how to resolve this.
+    let target_sha_not_ref = first_parent_commit_ids_until(repo, target.sha, target_ref_commit)
         .context("failed to get fork point")?;
-    let diverged_behind = first_parent_commit_ids_until(repo, target_commit_id, merge_base)
-        .context("failed to get fork point")?;
-
-    // if there are commits ahead of the base branch consider it diverged
-    let diverged = !diverged_ahead.is_empty();
+    let target_sha_ahead_of_ref = !target_sha_not_ref.is_empty();
 
     // Compute the lowest merge base across all workspace stacks and the target.
     // Read the workspace ref directly rather than HEAD, since HEAD may not point
@@ -389,7 +372,7 @@ pub(crate) fn target_to_base_branch(ctx: &Context, target: &Target) -> Result<Ba
             Some(target.sha)
         } else {
             let base = repo
-                .merge_base_octopus([heads.as_slice(), &[target_commit_id]].concat())
+                .merge_base_octopus([heads.as_slice(), &[target_ref_commit]].concat())
                 .context("failed to compute octopus merge-base for workspace stacks")?;
             Some(base.object()?.id().detach())
         }
@@ -397,7 +380,7 @@ pub(crate) fn target_to_base_branch(ctx: &Context, target: &Target) -> Result<Ba
 
     // Commits on the target branch between its tip and the lowest merge base.
     let upstream_commit_ids = lowest_merge_base
-        .map(|lb| first_parent_commit_ids_until(repo, target_commit_id, lb))
+        .map(|lb| first_parent_commit_ids_until(repo, target_ref_commit, lb))
         .transpose()
         .context("failed to get upstream commits")?
         .unwrap_or_default();
@@ -456,7 +439,7 @@ pub(crate) fn target_to_base_branch(ctx: &Context, target: &Target) -> Result<Ba
         push_remote_name,
         push_remote_url,
         base_sha: target.sha,
-        current_sha: target_commit_id,
+        current_sha: target_ref_commit,
         behind,
         upstream_commits,
         recent_commits,
@@ -467,9 +450,7 @@ pub(crate) fn target_to_base_branch(ctx: &Context, target: &Target) -> Result<Ba
             .map(FetchResult::timestamp)
             .map(|t| t.duration_since(time::UNIX_EPOCH).unwrap().as_millis()),
         conflicted,
-        diverged,
-        diverged_ahead,
-        diverged_behind,
+        target_sha_ahead_of_ref,
         short_name,
     };
     Ok(base)

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -455,9 +455,7 @@ export type BaseBranch = {
   recentCommits: Array<RemoteCommit>;
   lastFetchedMs: number | null;
   conflicted: boolean;
-  diverged: boolean;
-  divergedAhead: Array<string>;
-  divergedBehind: Array<string>;
+  targetShaAheadOfRef: boolean;
   shortName: string;
 };
 


### PR DESCRIPTION
The `diverged_ahead` and `diverged_behind` properties tell us about divergence between the target ref and the taret sha.

This information is perhaps less important than initially thought.

The target sha is really only important when it comes to trying to hide what is in the workspace.

Divergence between the target ref and target sha should almost be considered normal. Updating the workspace (or integrate upstream) should always be considered the operation of taking the contents of your workspace (`HEAD ^target.sha`) and rebasing them on top of target_ref. In this process `target.sha` get’s updated to `target ref`. The metric for when we care to do the rebase however is when there are changes in `target_ref ^HEAD`. Whether or not there are changes in `target_ref ^target.sha` is irrelevant.