### PR TITLE
Stop throwing errors on post-commit hook

### DIFF
--- a/apps/desktop/src/lib/dragging/dropHandlers/commitDropHandler.ts
+++ b/apps/desktop/src/lib/dragging/dropHandlers/commitDropHandler.ts
@@ -198,17 +198,7 @@ export class AmendCommitWithChangeDzHandler implements DropzoneHandler {
 				const rejectionResult = toRejectedChangesResult(this.projectId, outcome);
 
 				if (this.runHooks) {
-					try {
-						await this.hooksService.runPostCommitHooks(this.projectId);
-					} catch (err) {
-						if (err instanceof HookFailedError) {
-							if (!rejectionResult) return { type: "ok" };
-						} else if (!rejectionResult) {
-							return { type: "error", title: "Git hook failed", error: err };
-						} else {
-							console.error("Post-commit hook failed (rejected changes take priority):", err);
-						}
-					}
+					await this.hooksService.runPostCommitHooks(this.projectId);
 				}
 
 				return rejectionResult;
@@ -444,17 +434,7 @@ export class AmendCommitWithHunkDzHandler implements DropzoneHandler {
 			const rejectionResult = toRejectedChangesResult(projectId, outcome);
 
 			if (runHooks) {
-				try {
-					await this.hooksService.runPostCommitHooks(projectId);
-				} catch (err) {
-					if (err instanceof HookFailedError) {
-						if (!rejectionResult) return { type: "ok" };
-					} else if (!rejectionResult) {
-						return { type: "error", title: "Git hook failed", error: err };
-					} else {
-						console.error("Post-commit hook failed (rejected changes take priority):", err);
-					}
-				}
+				await this.hooksService.runPostCommitHooks(projectId);
 			}
 
 			return rejectionResult;

--- a/apps/desktop/src/lib/git/hooksService.ts
+++ b/apps/desktop/src/lib/git/hooksService.ts
@@ -48,14 +48,14 @@ export class HooksService {
 			if (result?.status === "failure") {
 				chipToasts.removeChipToast(loadingToastId);
 				showWarning("Post-commit hook failed", formatError(result.error));
-				throw new HookFailedError();
+				return;
 			}
 
 			chipToasts.removeChipToast(loadingToastId);
 			chipToasts.success("Post-commit hooks succeeded");
 		} catch (e: unknown) {
 			chipToasts.removeChipToast(loadingToastId);
-			throw e;
+			console.error("Post-commit hook error:", e);
 		}
 	}
 }


### PR DESCRIPTION
It would only lead to something daft like the preventing the commit
editor from closing automatically.