### PR TITLE
Lite: unify cut + drag and drop modes ("transfer" mode)

### DIFF
--- a/apps/lite/ui/src/operations/operation.ts
+++ b/apps/lite/ui/src/operations/operation.ts
@@ -567,11 +567,10 @@ export const getOperations = (source: Operand, target: Operand): OperationsByTyp
 export const getOperation = (x: {
 	source: Operand;
 	target: Operand;
-	operationType: OperationType | null;
+	operationType: OperationType;
 }): Operation | null => {
 	const { rub, moveAbove, moveBelow } = getOperations(x.source, x.target);
 	return Match.value(x.operationType).pipe(
-		Match.when(null, () => null),
 		Match.when("rub", () => rub),
 		Match.when("moveAbove", () => moveAbove),
 		Match.when("moveBelow", () => moveBelow),

--- a/apps/lite/ui/src/outline/mode.ts
+++ b/apps/lite/ui/src/outline/mode.ts
@@ -99,17 +99,6 @@ export const getOperationMode = (mode: OutlineMode): OperationMode | null =>
 		Match.orElse(() => null),
 	);
 
-const operationModeToOperationType = (operationMode: OperationMode): OperationType | null =>
-	Match.value(operationMode).pipe(
-		Match.withReturnType<OperationType | null>(),
-		Match.tags({
-			Absorb: () => null,
-			Cut: ({ operationType }) => operationType,
-			DragAndDrop: ({ operationType }) => operationType,
-		}),
-		Match.exhaustive,
-	);
-
 export const isValidOutlineModeForSelection = ({
 	mode,
 	selection,
@@ -127,7 +116,15 @@ export const isValidOutlineModeForSelection = ({
 	);
 
 export const getBinaryOperation = ({ mode, target }: { mode: OperationMode; target: Operand }) => {
-	const operationType = operationModeToOperationType(mode);
+	const operationType = Match.value(mode).pipe(
+		Match.withReturnType<OperationType | null>(),
+		Match.tags({
+			Absorb: () => null,
+			Cut: ({ operationType }) => operationType,
+			DragAndDrop: ({ operationType }) => operationType,
+		}),
+		Match.exhaustive,
+	);
 	if (operationType === null) return null;
 	return getOperation({
 		source: mode.source,

--- a/apps/lite/ui/src/outline/mode.ts
+++ b/apps/lite/ui/src/outline/mode.ts
@@ -17,18 +17,47 @@ export type AbsorbOperationMode = {
 	source: Operand;
 	absorptionPlan: Array<CommitAbsorption>;
 };
+
 /** @public */
-export type CutOperationMode = { source: Operand; operationType: OperationType };
-/** @public */
-export type DragAndDropOperationMode = {
+export type KeyboardTransferOperationMode = {
 	source: Operand;
-	target: Operand | null;
+	operationType: OperationType;
+};
+
+/** @public */
+export type PointerTransferOperationMode = {
+	source: Operand;
 	operationType: OperationType | null;
 };
+
+/** @public */
+export type TransferOperationMode =
+	| ({ _tag: "Keyboard" } & KeyboardTransferOperationMode)
+	| ({ _tag: "Pointer" } & PointerTransferOperationMode);
+
+/** @public */
+export const keyboardTransferOperationMode = ({
+	source,
+	operationType,
+}: KeyboardTransferOperationMode): TransferOperationMode => ({
+	_tag: "Keyboard",
+	source,
+	operationType,
+});
+
+/** @public */
+export const pointerTransferOperationMode = ({
+	source,
+	operationType,
+}: PointerTransferOperationMode): TransferOperationMode => ({
+	_tag: "Pointer",
+	source,
+	operationType,
+});
+
 export type OperationMode =
 	| ({ _tag: "Absorb" } & AbsorbOperationMode)
-	| ({ _tag: "Cut" } & CutOperationMode)
-	| ({ _tag: "DragAndDrop" } & DragAndDropOperationMode);
+	| { _tag: "Transfer"; value: TransferOperationMode };
 
 /** @public */
 export const absorbOperationMode = ({
@@ -41,22 +70,9 @@ export const absorbOperationMode = ({
 });
 
 /** @public */
-export const cutOperationMode = ({ source, operationType }: CutOperationMode): OperationMode => ({
-	_tag: "Cut",
-	source,
-	operationType,
-});
-
-/** @public */
-export const dragAndDropOperationMode = ({
-	source,
-	target,
-	operationType,
-}: DragAndDropOperationMode): OperationMode => ({
-	_tag: "DragAndDrop",
-	source,
-	target,
-	operationType,
+export const transferOperationMode = (value: TransferOperationMode): OperationMode => ({
+	_tag: "Transfer",
+	value,
 });
 
 /** @public */
@@ -115,16 +131,14 @@ export const isValidOutlineModeForSelection = ({
 		}),
 	);
 
-export const getBinaryOperation = ({ mode, target }: { mode: OperationMode; target: Operand }) => {
-	const operationType = Match.value(mode).pipe(
-		Match.withReturnType<OperationType | null>(),
-		Match.tags({
-			Absorb: () => null,
-			Cut: ({ operationType }) => operationType,
-			DragAndDrop: ({ operationType }) => operationType,
-		}),
-		Match.exhaustive,
-	);
+export const getTransferOperation = ({
+	mode,
+	target,
+}: {
+	mode: TransferOperationMode;
+	target: Operand;
+}) => {
+	const { operationType } = mode;
 	if (operationType === null) return null;
 	return getOperation({
 		source: mode.source,
@@ -137,6 +151,14 @@ const hasAnyOperation = (source: Operand, target: Operand) => {
 	const operations = getOperations(source, target);
 	return !!operations.rub || !!operations.moveAbove || !!operations.moveBelow;
 };
+
+const operationModeSource = (mode: OperationMode): Operand =>
+	Match.value(mode).pipe(
+		Match.tagsExhaustive({
+			Absorb: ({ source }) => source,
+			Transfer: ({ value: mode }) => mode.source,
+		}),
+	);
 
 export const isOperationModeCandidateTarget = ({
 	mode,
@@ -151,8 +173,7 @@ export const isOperationModeCandidateTarget = ({
 				absorptionPlan.some(({ stackId, commitId }) =>
 					operandEquals(commitOperand({ stackId, commitId }), target),
 				),
-			DragAndDrop: ({ source }) => hasAnyOperation(source, target),
-			Cut: ({ source }) => hasAnyOperation(source, target),
+			Transfer: ({ value: mode }) => hasAnyOperation(mode.source, target),
 		}),
 	);
 
@@ -170,7 +191,7 @@ export const filterNavigationIndexForOutlineMode = ({
 				filterNavigationIndex(
 					navigationIndexUnfiltered,
 					(operand) =>
-						operandContains(operand, operationMode.source) ||
+						operandContains(operand, operationModeSource(operationMode)) ||
 						isOperationModeCandidateTarget({ mode: operationMode, target: operand }),
 				),
 			RenameBranch: (x) =>

--- a/apps/lite/ui/src/outline/mode.ts
+++ b/apps/lite/ui/src/outline/mode.ts
@@ -126,12 +126,15 @@ export const isValidOutlineModeForSelection = ({
 		}),
 	);
 
-export const getBinaryOperation = ({ mode, target }: { mode: OperationMode; target: Operand }) =>
-	getOperation({
+export const getBinaryOperation = ({ mode, target }: { mode: OperationMode; target: Operand }) => {
+	const operationType = operationModeToOperationType(mode);
+	if (operationType === null) return null;
+	return getOperation({
 		source: mode.source,
 		target,
-		operationType: operationModeToOperationType(mode),
+		operationType,
 	});
+};
 
 const hasAnyOperation = (source: Operand, target: Operand) => {
 	const operations = getOperations(source, target);

--- a/apps/lite/ui/src/panels.ts
+++ b/apps/lite/ui/src/panels.ts
@@ -1,6 +1,7 @@
 import { CommandGroup } from "#ui/commands/groups.ts";
 import { useActiveElement } from "#ui/focus.ts";
 import { type OperationType } from "#ui/operations/operation.ts";
+import { keyboardTransferOperationMode } from "#ui/outline/mode.ts";
 import { changesSectionOperand, type Operand } from "#ui/operands.ts";
 import {
 	projectActions,
@@ -143,12 +144,20 @@ export const useNavigationIndexHotkeys = ({
 
 	const outlineMode = useAppSelector((state) => selectProjectOutlineModeState(state, projectId));
 
-	const enterCutMode = (source: Operand, operationType: OperationType) => {
-		dispatch(projectActions.enterCutMode({ projectId, source, operationType }));
+	const enterTransferMode = (source: Operand, operationType: OperationType) => {
+		dispatch(
+			projectActions.enterTransferMode({
+				projectId,
+				mode: keyboardTransferOperationMode({
+					source,
+					operationType,
+				}),
+			}),
+		);
 		focusPanel("outline");
 	};
 
-	useCommand(() => enterCutMode(selection, "moveAbove"), {
+	useCommand(() => enterTransferMode(selection, "moveAbove"), {
 		group,
 		enabled: focusedPanel === panel && outlineMode._tag === "Default",
 		commandPalette: { label: "Move" },
@@ -156,7 +165,7 @@ export const useNavigationIndexHotkeys = ({
 		hotkeys: [{ hotkey: "M" }],
 	});
 
-	useCommand(() => enterCutMode(selection, "rub"), {
+	useCommand(() => enterTransferMode(selection, "rub"), {
 		group,
 		enabled: focusedPanel === panel && outlineMode._tag === "Default",
 		commandPalette: { label: "Cut" },
@@ -164,7 +173,7 @@ export const useNavigationIndexHotkeys = ({
 		hotkeys: [{ hotkey: "Mod+X", ignoreInputs: true }, { hotkey: "R" }],
 	});
 
-	useCommand(() => enterCutMode(changesSectionOperand, "moveAbove"), {
+	useCommand(() => enterTransferMode(changesSectionOperand, "moveAbove"), {
 		group,
 		enabled: focusedPanel === panel && outlineMode._tag === "Default",
 		commandPalette: { label: "Commit" },

--- a/apps/lite/ui/src/projects/state.ts
+++ b/apps/lite/ui/src/projects/state.ts
@@ -6,6 +6,7 @@ import { type Panel } from "#ui/panels.ts";
 import * as panels from "#ui/panels/state.ts";
 import * as workspace from "#ui/projects/workspace/state.ts";
 import { type OperationType } from "#ui/operations/operation.ts";
+import { type TransferOperationMode } from "#ui/outline/mode.ts";
 
 type Dialog =
 	| { _tag: "None" }
@@ -78,17 +79,13 @@ const projectSlice = createSlice({
 			const projectState = ensureProjectState(state, projectId);
 			workspace.startRenameBranch(projectState.workspace, branch);
 		},
-		enterCutMode: (
+		enterTransferMode: (
 			state,
-			action: PayloadAction<{
-				projectId: string;
-				source: Operand;
-				operationType: OperationType;
-			}>,
+			action: PayloadAction<{ projectId: string; mode: TransferOperationMode }>,
 		) => {
-			const { projectId, source, operationType } = action.payload;
+			const { projectId, mode } = action.payload;
 			const projectState = ensureProjectState(state, projectId);
-			workspace.enterCutMode(projectState.workspace, source, operationType);
+			workspace.enterTransferMode(projectState.workspace, mode);
 		},
 		enterAbsorbMode: (
 			state,
@@ -102,18 +99,7 @@ const projectSlice = createSlice({
 			const projectState = ensureProjectState(state, projectId);
 			workspace.enterAbsorbMode(projectState.workspace, source, absorptionPlan);
 		},
-		enterDragAndDropMode: (
-			state,
-			action: PayloadAction<{
-				projectId: string;
-				source: Operand;
-			}>,
-		) => {
-			const { projectId, source } = action.payload;
-			const projectState = ensureProjectState(state, projectId);
-			workspace.enterDragAndDropMode(projectState.workspace, source);
-		},
-		updateDragAndDropMode: (
+		updatePointerTransfer: (
 			state,
 			action: PayloadAction<{
 				projectId: string;
@@ -123,9 +109,9 @@ const projectSlice = createSlice({
 		) => {
 			const { projectId, target, operationType } = action.payload;
 			const projectState = ensureProjectState(state, projectId);
-			workspace.updateDragAndDropMode(projectState.workspace, target, operationType);
+			workspace.updatePointerTransfer(projectState.workspace, target, operationType);
 		},
-		updateCutMode: (
+		updateTransferOperationType: (
 			state,
 			action: PayloadAction<{
 				projectId: string;
@@ -134,7 +120,7 @@ const projectSlice = createSlice({
 		) => {
 			const { projectId, operationType } = action.payload;
 			const projectState = ensureProjectState(state, projectId);
-			workspace.updateCutMode(projectState.workspace, operationType);
+			workspace.updateTransferOperationType(projectState.workspace, operationType);
 		},
 		exitMode: (state, action: PayloadAction<{ projectId: string }>) => {
 			workspace.exitMode(ensureProjectState(state, action.payload.projectId).workspace);
@@ -226,9 +212,6 @@ export const selectProjectOutlineModeState = (state: RootState, projectId: strin
 
 export const selectProjectOperationModeState = (state: RootState, projectId: string) =>
 	workspace.selectOperationMode(selectProjectWorkspaceState(state, projectId));
-
-export const selectProjectOperationModeTarget = (state: RootState, projectId: string) =>
-	workspace.selectOperationModeTarget(selectProjectWorkspaceState(state, projectId));
 
 export const selectProjectHighlightedCommitIds = (state: RootState, projectId: string) =>
 	workspace.selectHighlightedCommitIds(selectProjectWorkspaceState(state, projectId));

--- a/apps/lite/ui/src/projects/workspace/state.ts
+++ b/apps/lite/ui/src/projects/workspace/state.ts
@@ -12,15 +12,17 @@ import {
 } from "#ui/operands.ts";
 import {
 	absorbOperationMode,
-	cutOperationMode,
 	defaultOutlineMode,
-	dragAndDropOperationMode,
 	getOperationMode,
 	isValidOutlineModeForSelection,
+	keyboardTransferOperationMode,
 	operationOutlineMode,
+	pointerTransferOperationMode,
 	renameBranchOutlineMode,
 	rewordCommitOutlineMode,
+	transferOperationMode,
 	type OutlineMode,
+	type TransferOperationMode,
 } from "#ui/outline/mode.ts";
 
 type SelectionState = {
@@ -51,12 +53,8 @@ export const createInitialState = (): WorkspaceState => ({
 
 export const initialState: WorkspaceState = createInitialState();
 
-export const enterCutMode = (
-	state: WorkspaceState,
-	source: Operand,
-	operationType: OperationType,
-) => {
-	state.mode = operationOutlineMode(cutOperationMode({ source, operationType }));
+export const enterTransferMode = (state: WorkspaceState, mode: TransferOperationMode) => {
+	state.mode = operationOutlineMode(transferOperationMode(mode));
 };
 
 export const enterAbsorbMode = (
@@ -67,43 +65,52 @@ export const enterAbsorbMode = (
 	state.mode = operationOutlineMode(absorbOperationMode({ source, absorptionPlan }));
 };
 
-export const enterDragAndDropMode = (state: WorkspaceState, source: Operand) => {
-	state.mode = operationOutlineMode(
-		dragAndDropOperationMode({ source, target: null, operationType: null }),
-	);
-};
-
-export const updateDragAndDropMode = (
+export const updatePointerTransfer = (
 	state: WorkspaceState,
 	target: Operand | null,
 	operationType: OperationType | null,
 ) => {
 	Match.value(state.mode).pipe(
-		Match.when({ _tag: "Operation", value: { _tag: "DragAndDrop" } }, (mode) => {
-			if (
-				mode.value.operationType === operationType &&
-				((mode.value.target === null && target === null) ||
-					(mode.value.target !== null &&
-						target !== null &&
-						operandEquals(mode.value.target, target)))
-			)
-				return;
+		Match.when(
+			{ _tag: "Operation", value: { _tag: "Transfer", value: { _tag: "Pointer" } } },
+			(mode) => {
+				if (target !== null && !operandEquals(state.selection.outline, target))
+					selectOutline(state, target);
 
-			state.mode = operationOutlineMode(
-				dragAndDropOperationMode({ source: mode.value.source, target, operationType }),
-			);
-		}),
+				if (mode.value.value.operationType === operationType) return;
+
+				state.mode = operationOutlineMode(
+					transferOperationMode(
+						pointerTransferOperationMode({
+							source: mode.value.value.source,
+							operationType,
+						}),
+					),
+				);
+			},
+		),
 		Match.orElse(() => {}),
 	);
 };
 
-export const updateCutMode = (state: WorkspaceState, operationType: OperationType) => {
+export const updateTransferOperationType = (
+	state: WorkspaceState,
+	operationType: OperationType,
+) => {
 	Match.value(state.mode).pipe(
-		Match.when({ _tag: "Operation", value: { _tag: "Cut" } }, (mode) => {
-			state.mode = operationOutlineMode(
-				cutOperationMode({ source: mode.value.source, operationType }),
-			);
-		}),
+		Match.when(
+			{ _tag: "Operation", value: { _tag: "Transfer", value: { _tag: "Keyboard" } } },
+			(mode) => {
+				state.mode = operationOutlineMode(
+					transferOperationMode(
+						keyboardTransferOperationMode({
+							source: mode.value.value.source,
+							operationType,
+						}),
+					),
+				);
+			},
+		),
 		Match.orElse(() => {}),
 	);
 };
@@ -153,17 +160,6 @@ export const selectSelectionFilesState = (state: WorkspaceState): Operand => sta
 export const selectMode = (state: WorkspaceState): OutlineMode => state.mode;
 
 export const selectOperationMode = (state: WorkspaceState) => getOperationMode(state.mode);
-
-export const selectOperationModeTarget = (state: WorkspaceState): Operand | null => {
-	const operationMode = selectOperationMode(state);
-	if (!operationMode) return null;
-
-	return Match.value(operationMode).pipe(
-		Match.withReturnType<Operand | null>(),
-		Match.tags({ DragAndDrop: ({ target }) => target }),
-		Match.orElse(() => selectSelectionOutlineState(state)),
-	);
-};
 
 export const selectHighlightedCommitIds = (state: WorkspaceState): Array<string> =>
 	state.highlightedCommitIds;

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationSourceC.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationSourceC.tsx
@@ -1,4 +1,5 @@
 import { Operand, operandEquals } from "#ui/operands.ts";
+import { pointerTransferOperationMode } from "#ui/outline/mode.ts";
 import styles from "./OperationSourceC.module.css";
 import { OperationSourceLabel } from "./OperationSourceLabel.tsx";
 import { headInfoQueryOptions } from "#ui/api/queries.ts";
@@ -14,6 +15,7 @@ import { centerUnderPointer } from "@atlaskit/pragmatic-drag-and-drop/element/ce
 import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview";
 import { mergeProps, useRender } from "@base-ui/react";
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { Match } from "effect";
 import { FC, type ReactNode, useEffect, useEffectEvent, useRef } from "react";
 import { createRoot } from "react-dom/client";
 
@@ -78,7 +80,15 @@ export const OperationSourceC: FC<
 			getInitialData: (): DragData => ({ source }),
 			onGenerateDragPreview,
 			onDragStart: () => {
-				dispatch(projectActions.enterDragAndDropMode({ projectId, source }));
+				dispatch(
+					projectActions.enterTransferMode({
+						projectId,
+						mode: pointerTransferOperationMode({
+							source,
+							operationType: null,
+						}),
+					}),
+				);
 			},
 			onDrop: () => {
 				dispatch(projectActions.exitMode({ projectId }));
@@ -86,7 +96,12 @@ export const OperationSourceC: FC<
 		});
 	}, [dispatch, projectId, source]);
 
-	const isActiveSource = operationMode?.source && operandEquals(operationMode.source, source);
+	const isActiveSource =
+		operationMode &&
+		Match.value(operationMode).pipe(
+			Match.tag("Transfer", ({ value: mode }) => operandEquals(mode.source, source)),
+			Match.orElse(() => false),
+		);
 
 	return useRender({
 		render,

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationTarget.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationTarget.tsx
@@ -1,4 +1,4 @@
-import { operandEquals, type Operand } from "#ui/operands.ts";
+import { type Operand } from "#ui/operands.ts";
 import { parseDragData } from "./OperationSourceC.tsx";
 import styles from "./OperationTarget.module.css";
 import { OperationTooltip } from "./OperationTooltip.tsx";
@@ -9,11 +9,7 @@ import {
 	useRunOperationMutationOptions,
 } from "#ui/operations/operation.ts";
 import { classes } from "#ui/ui/classes.ts";
-import {
-	projectActions,
-	selectProjectOperationModeState,
-	selectProjectOperationModeTarget,
-} from "#ui/projects/state.ts";
+import { projectActions, selectProjectOperationModeState } from "#ui/projects/state.ts";
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import {
@@ -31,7 +27,6 @@ type GetDataArgs = Parameters<NonNullable<DropTargetParams["getData"]>>[0];
 
 type DropData = {
 	operationType: OperationType;
-	target: Operand;
 };
 
 const parseDropData = (data: unknown): DropData | null => {
@@ -94,7 +89,7 @@ const useOperationDropTarget = ({ target, projectId }: { target: Operand; projec
 		});
 		if (operationType === null) return null;
 
-		return { operationType, target };
+		return { operationType };
 	});
 
 	useEffect(() => {
@@ -114,16 +109,16 @@ const useOperationDropTarget = ({ target, projectId }: { target: Operand; projec
 				const dropData = parseDropData(args.self.data);
 
 				dispatch(
-					projectActions.updateDragAndDropMode({
+					projectActions.updatePointerTransfer({
 						projectId,
-						target: dropData?.target ?? null,
+						target: dropData ? target : null,
 						operationType: dropData?.operationType ?? null,
 					}),
 				);
 			},
 			onDragLeave: () => {
 				dispatch(
-					projectActions.updateDragAndDropMode({
+					projectActions.updatePointerTransfer({
 						projectId,
 						target: null,
 						operationType: null,
@@ -144,7 +139,7 @@ const useOperationDropTarget = ({ target, projectId }: { target: Operand; projec
 
 				const operation = getOperation({
 					source: dragData.source,
-					target: dropData.target,
+					target,
 					operationType: dropData.operationType,
 				});
 				if (!operation) return;
@@ -152,7 +147,7 @@ const useOperationDropTarget = ({ target, projectId }: { target: Operand; projec
 				runOperation(operation);
 			},
 		});
-	}, [dispatch, projectId, runOperation]);
+	}, [dispatch, projectId, runOperation, target]);
 
 	return { dropRef };
 };
@@ -168,22 +163,14 @@ export const OperationTarget: FC<
 	const operationMode = useAppSelector((state) =>
 		selectProjectOperationModeState(state, projectId),
 	);
-	const isActive = useAppSelector((state) => {
-		const activeTarget = selectProjectOperationModeTarget(state, projectId);
-		return activeTarget !== null && operandEquals(activeTarget, target);
-	});
 
 	const insertTargetOperationType = operationMode
 		? Match.value(operationMode).pipe(
 				Match.tagsExhaustive({
 					Absorb: () => null,
-					DragAndDrop: ({ operationType }) =>
-						isActive && (operationType === "moveAbove" || operationType === "moveBelow")
-							? operationType
-							: null,
-					Cut: ({ operationType }) =>
-						isActive && (operationType === "moveAbove" || operationType === "moveBelow")
-							? operationType
+					Transfer: ({ value: mode }) =>
+						isSelected && (mode.operationType === "moveAbove" || mode.operationType === "moveBelow")
+							? mode.operationType
 							: null,
 				}),
 			)
@@ -194,8 +181,7 @@ export const OperationTarget: FC<
 		Match.value(operationMode).pipe(
 			Match.tagsExhaustive({
 				Absorb: () => isOperationModeCandidateTarget({ mode: operationMode, target }),
-				DragAndDrop: ({ operationType }) => isActive && operationType === "rub",
-				Cut: ({ operationType }) => isActive && operationType === "rub",
+				Transfer: ({ value: mode }) => isSelected && mode.operationType === "rub",
 			}),
 		);
 
@@ -204,8 +190,7 @@ export const OperationTarget: FC<
 		Match.value(operationMode).pipe(
 			Match.tagsExhaustive({
 				Absorb: () => isSelected,
-				DragAndDrop: () => isMainTargetActive,
-				Cut: () => isMainTargetActive,
+				Transfer: () => isMainTargetActive,
 			}),
 		);
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationTooltip.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationTooltip.tsx
@@ -18,7 +18,7 @@ import styles from "./OperationTooltip.module.css";
 import { Operand, operandEquals } from "#ui/operands.ts";
 import { useAppDispatch } from "#ui/store.ts";
 import { projectActions } from "#ui/projects/state.ts";
-import { OperationMode, getBinaryOperation } from "#ui/outline/mode.ts";
+import { OperationMode, getTransferOperation } from "#ui/outline/mode.ts";
 import { Match } from "effect";
 import { useCommand } from "#ui/commands/manager.ts";
 import { useMutation } from "@tanstack/react-query";
@@ -77,7 +77,7 @@ const OperationModeControls: FC<{
 	);
 };
 
-const CutOperationControls: FC<{
+const TransferOperationControls: FC<{
 	projectId: string;
 	operations: OperationsByType;
 	operationType: OperationType;
@@ -97,7 +97,7 @@ const CutOperationControls: FC<{
 	const cancel = () => dispatch(projectActions.exitMode({ projectId }));
 
 	const setOperationType = (operationType: OperationType) =>
-		dispatch(projectActions.updateCutMode({ projectId, operationType }));
+		dispatch(projectActions.updateTransferOperationType({ projectId, operationType }));
 
 	const moveAboveCommand = useCommand(() => setOperationType("moveAbove"), {
 		group: "Operation mode",
@@ -213,42 +213,44 @@ export const OperationTooltip: FC<
 								operation={absorptionPlan.length > 0 ? absorbOperation({ absorptionPlan }) : null}
 							/>
 						),
-						DragAndDrop: () => {
-							const operation = getBinaryOperation({
-								mode: operationMode,
-								target,
-							});
-							if (!operation) return null;
+						Transfer: ({ value: mode }) =>
+							Match.value(mode).pipe(
+								Match.tagsExhaustive({
+									Pointer: (mode) => {
+										const operation = getTransferOperation({ mode, target });
+										if (!operation) return null;
 
-							return <>{operationLabel(operation)}</>;
-						},
-						Cut: ({ source, operationType }) => (
-							<>
-								{operandEquals(operationMode.source, target) && <>Select a target</>}
-								<CutOperationControls
-									projectId={projectId}
-									operations={getOperations(source, target)}
-									operationType={operationType}
-								/>
-							</>
-						),
+										return <>{operationLabel(operation)}</>;
+									},
+									Keyboard: (mode) => (
+										<>
+											{operandEquals(mode.source, target) && <>Select a target</>}
+											<TransferOperationControls
+												projectId={projectId}
+												operations={getOperations(mode.source, target)}
+												operationType={mode.operationType}
+											/>
+										</>
+									),
+								}),
+							),
 					}),
 				)
 			: null;
 
 	const trigger = useRender({ render, props });
 
-	const isDragAndDrop =
+	const isPointerTransfer =
 		!!operationMode &&
 		Match.value(operationMode).pipe(
-			Match.tags({ DragAndDrop: () => true }),
+			Match.when({ _tag: "Transfer", value: { _tag: "Pointer" } }, () => true),
 			Match.orElse(() => false),
 		);
 
 	return (
 		<Tooltip.Root
 			open={!!tooltip}
-			disableHoverablePopup={isDragAndDrop}
+			disableHoverablePopup={isPointerTransfer}
 			onOpenChange={(_open, eventDetails) => {
 				eventDetails.allowPropagation();
 			}}

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.tsx
@@ -32,13 +32,16 @@ import {
 	type CommitOperand,
 	type Operand,
 } from "#ui/operands.ts";
-import { filterNavigationIndexForOutlineMode, getBinaryOperation } from "#ui/outline/mode.ts";
+import {
+	filterNavigationIndexForOutlineMode,
+	getTransferOperation,
+	keyboardTransferOperationMode,
+} from "#ui/outline/mode.ts";
 import { focusPanel, useFocusedProjectPanel, useNavigationIndexHotkeys } from "#ui/panels.ts";
 import {
 	projectActions,
 	selectProjectHighlightedCommitIds,
 	selectProjectOperationModeState,
-	selectProjectOperationModeTarget,
 	selectProjectOutlineModeState,
 	selectProjectReplacedCommits,
 	selectProjectSelectionOutline,
@@ -263,13 +266,15 @@ const OutlineTreePanel: FC<PanelProps> = ({ ...panelProps }) => {
 		selectProjectOperationModeState(state, projectId),
 	);
 
-	const dryRunTarget = useAppSelector((state) =>
-		selectProjectOperationModeTarget(state, projectId),
-	);
-	const dryRunOperation =
-		operationMode && dryRunTarget
-			? (getBinaryOperation({ mode: operationMode, target: dryRunTarget }) ?? undefined)
-			: undefined;
+	const dryRunOperation = operationMode
+		? Match.value(operationMode).pipe(
+				Match.tag(
+					"Transfer",
+					({ value: mode }) => getTransferOperation({ mode, target: selection }) ?? undefined,
+				),
+				Match.orElse(() => undefined),
+			)
+		: undefined;
 
 	// TODO: debounce?
 	const dryRunOperationQuery = useDryRunOperation({ projectId, operation: dryRunOperation });
@@ -312,12 +317,12 @@ const OutlineTreePanel: FC<PanelProps> = ({ ...panelProps }) => {
 
 					{Match.value(operationMode).pipe(
 						Match.when(null, () => null),
-						Match.tag("DragAndDrop", () => null),
-						Match.orElse(({ source }) => (
+						Match.when({ _tag: "Transfer", value: { _tag: "Keyboard" } }, (mode) => (
 							<div className={styles.operationModePreview}>
-								<OperationSourceLabel headInfo={headInfo} source={source} />
+								<OperationSourceLabel headInfo={headInfo} source={mode.value.source} />
 							</div>
 						)),
+						Match.orElse(() => null),
 					)}
 				</Panel>
 			</DryRunWorkspaceContext>
@@ -596,7 +601,15 @@ const CommitRow: FC<
 	};
 
 	const cutCommit = () => {
-		dispatch(projectActions.enterCutMode({ projectId, source: operand, operationType: "rub" }));
+		dispatch(
+			projectActions.enterTransferMode({
+				projectId,
+				mode: keyboardTransferOperationMode({
+					source: operand,
+					operationType: "rub",
+				}),
+			}),
+		);
 	};
 
 	const startEditing = () => {
@@ -634,10 +647,12 @@ const CommitRow: FC<
 
 	const amendCommit = () => {
 		dispatch(
-			projectActions.enterCutMode({
+			projectActions.enterTransferMode({
 				projectId,
-				source: changesSectionOperand,
-				operationType: "rub",
+				mode: keyboardTransferOperationMode({
+					source: changesSectionOperand,
+					operationType: "rub",
+				}),
 			}),
 		);
 		focusPanel("outline");


### PR DESCRIPTION
Note behaviour change: for drag and drop, selection now follows the drop target. I think this is desirable because it lets you preview the target e.g. commit you're squashing into, and it aligns with the keyboard behaviour. I think the drop target + selection styles need some design thought, though.