### PR TITLE
tui: fix cursor movement bug

### DIFF
--- a/crates/but/src/command/legacy/status/tui/cursor/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         FilesStatusFlag, StatusOutputLine,
         output::StatusOutputLineData,
         tui::{
-            Mode, SelectAfterReload,
+            Mode, MoveSource, SelectAfterReload,
             render::{commit_operation_display, move_operation_display},
         },
     },
@@ -316,7 +316,7 @@ impl Cursor {
             .enumerate()
             .rev()
             .skip(lines.len() - self.0)
-            .find(|(_, line)| is_selectable_in_mode(line, mode, show_files))?;
+            .find(|(_, line)| is_cursor_selectable_in_mode(line, lines, mode, show_files))?;
         Some(Self(idx))
     }
 
@@ -335,7 +335,7 @@ impl Cursor {
             .iter()
             .enumerate()
             .skip(self.0 + 1)
-            .find(|(_, line)| is_selectable_in_mode(line, mode, show_files))?;
+            .find(|(_, line)| is_cursor_selectable_in_mode(line, lines, mode, show_files))?;
         Some(Self(idx))
     }
 
@@ -359,7 +359,7 @@ impl Cursor {
             .enumerate()
             .skip(self.0 + 1)
             .take(next_section_start.saturating_sub(self.0 + 1))
-            .find(|(_, line)| is_selectable_in_mode(line, mode, show_files))?;
+            .find(|(_, line)| is_cursor_selectable_in_mode(line, lines, mode, show_files))?;
         Some(Self(idx))
     }
 
@@ -484,7 +484,7 @@ fn first_selectable_in_section(
         .enumerate()
         .skip(section_start)
         .take(next_section_start.saturating_sub(section_start))
-        .find(|(_, line)| is_selectable_in_mode(line, mode, show_files))
+        .find(|(_, line)| is_cursor_selectable_in_mode(line, lines, mode, show_files))
         .map(|(idx, _)| idx)
 }
 
@@ -536,6 +536,103 @@ fn is_section_header(line: &StatusOutputLine, mode: &Mode) -> bool {
                     | StatusOutputLineData::MergeBase
             )
         }
+    }
+}
+
+fn is_cursor_selectable_in_mode(
+    line: &StatusOutputLine,
+    lines: &[StatusOutputLine],
+    mode: &Mode,
+    show_files_flag: FilesStatusFlag,
+) -> bool {
+    is_selectable_in_mode(line, mode, show_files_flag)
+        && !is_forbidden_move_commit_target(line, lines, mode)
+}
+
+pub(super) fn is_forbidden_move_commit_target(
+    line: &StatusOutputLine,
+    lines: &[StatusOutputLine],
+    mode: &Mode,
+) -> bool {
+    let Some(cli_id) = line.data.cli_id() else {
+        return false;
+    };
+
+    forbidden_move_target(lines, mode).is_some_and(|target| **cli_id == **target)
+}
+
+fn forbidden_move_target<'a>(lines: &'a [StatusOutputLine], mode: &Mode) -> Option<&'a Arc<CliId>> {
+    let Mode::Move(move_mode) = mode else {
+        return None;
+    };
+    let MoveSource::Commit { .. } = &*move_mode.source else {
+        return None;
+    };
+
+    let source_idx = lines.iter().position(|line| {
+        line.data
+            .cli_id()
+            .is_some_and(|cli_id| *move_mode.source == **cli_id)
+    })?;
+
+    commit_before(lines, source_idx).or_else(|| source_branch_if_top_commit(lines, source_idx))
+}
+
+fn commit_before(lines: &[StatusOutputLine], source_idx: usize) -> Option<&Arc<CliId>> {
+    lines[..source_idx]
+        .iter()
+        .rev()
+        .take_while(|line| !is_discard_commit_boundary(line))
+        .find_map(commit_cli_id)
+}
+
+fn source_branch_if_top_commit(
+    lines: &[StatusOutputLine],
+    source_idx: usize,
+) -> Option<&Arc<CliId>> {
+    lines[..source_idx]
+        .iter()
+        .rev()
+        .find(|line| is_discard_commit_boundary(line))
+        .and_then(|line| match &line.data {
+            StatusOutputLineData::Branch { cli_id } => Some(cli_id),
+            StatusOutputLineData::StagedChanges { .. }
+            | StatusOutputLineData::UnassignedChanges { .. }
+            | StatusOutputLineData::MergeBase => None,
+            StatusOutputLineData::UpdateNotice
+            | StatusOutputLineData::Connector
+            | StatusOutputLineData::StagedFile { .. }
+            | StatusOutputLineData::UnassignedFile { .. }
+            | StatusOutputLineData::Commit { .. }
+            | StatusOutputLineData::CommitMessage
+            | StatusOutputLineData::EmptyCommitMessage
+            | StatusOutputLineData::File { .. }
+            | StatusOutputLineData::UpstreamChanges
+            | StatusOutputLineData::Warning
+            | StatusOutputLineData::Hint
+            | StatusOutputLineData::NoAssignmentsUnstaged => None,
+        })
+}
+
+fn commit_cli_id(line: &StatusOutputLine) -> Option<&Arc<CliId>> {
+    match &line.data {
+        StatusOutputLineData::Commit { cli_id, .. } if line.is_selectable() => Some(cli_id),
+        StatusOutputLineData::UpdateNotice
+        | StatusOutputLineData::Connector
+        | StatusOutputLineData::StagedChanges { .. }
+        | StatusOutputLineData::StagedFile { .. }
+        | StatusOutputLineData::UnassignedChanges { .. }
+        | StatusOutputLineData::Commit { .. }
+        | StatusOutputLineData::UnassignedFile { .. }
+        | StatusOutputLineData::Branch { .. }
+        | StatusOutputLineData::CommitMessage
+        | StatusOutputLineData::EmptyCommitMessage
+        | StatusOutputLineData::File { .. }
+        | StatusOutputLineData::MergeBase
+        | StatusOutputLineData::UpstreamChanges
+        | StatusOutputLineData::Warning
+        | StatusOutputLineData::Hint
+        | StatusOutputLineData::NoAssignmentsUnstaged => None,
     }
 }
 

--- a/crates/but/src/command/legacy/status/tui/cursor/tests.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/tests.rs
@@ -11,8 +11,9 @@ use crate::{
         CommitClassification, FilesStatusFlag,
         output::{StatusOutputContent, StatusOutputLine, StatusOutputLineData},
         tui::{
-            CommitMessageComposer, CommitMode, CommitSource, InlineRewordMode, Mode, NormalMode,
-            RubMode, RubSource, SelectAfterReload, mode::UnassignedCommitSource,
+            CommitMessageComposer, CommitMode, CommitSource, InlineRewordMode, Mode, MoveMode,
+            MoveSource, NormalMode, RubMode, RubSource, SelectAfterReload,
+            mode::UnassignedCommitSource,
         },
     },
 };
@@ -53,6 +54,37 @@ fn branch_cli_id(name: &str, id: &str, stack_id: Option<StackId>) -> Arc<CliId> 
         name: name.into(),
         id: id.into(),
         stack_id,
+    })
+}
+
+fn branch_line(name: &str, id: &str) -> StatusOutputLine {
+    line(StatusOutputLineData::Branch {
+        cli_id: branch_cli_id(name, id, None),
+    })
+}
+
+fn commit_line(hex: &str, id: &str) -> StatusOutputLine {
+    commit_line_with_classification(hex, id, CommitClassification::LocalOnly)
+}
+
+fn commit_line_with_classification(
+    hex: &str,
+    id: &str,
+    classification: CommitClassification,
+) -> StatusOutputLine {
+    line(StatusOutputLineData::Commit {
+        cli_id: commit_cli_id(hex, id),
+        stack_id: None,
+        classification,
+    })
+}
+
+fn move_commit_mode(hex: &str, id: &str) -> Mode {
+    Mode::Move(MoveMode {
+        source: Arc::new(MoveSource::Commit {
+            commit_id: commit_id(hex),
+            id: id.into(),
+        }),
     })
 }
 
@@ -1593,6 +1625,79 @@ fn is_selectable_in_rub_mode_requires_available_target() {
         &mode,
         FilesStatusFlag::All
     ));
+}
+
+#[test]
+fn move_up_skips_commit_directly_above_move_source() {
+    let source_hex = "2222222222222222222222222222222222222222";
+    let lines = vec![
+        branch_line("A", "b0"),
+        commit_line("1111111111111111111111111111111111111111", "c0"),
+        commit_line(source_hex, "c1"),
+        commit_line("3333333333333333333333333333333333333333", "c2"),
+    ];
+    let mode = move_commit_mode(source_hex, "c1");
+
+    assert_eq!(
+        Cursor(2).move_up(&lines, &mode, FilesStatusFlag::All),
+        Some(Cursor(0))
+    );
+}
+
+#[test]
+fn move_down_from_move_source_selects_commit_below_source() {
+    let source_hex = "2222222222222222222222222222222222222222";
+    let lines = vec![
+        branch_line("A", "b0"),
+        commit_line("1111111111111111111111111111111111111111", "c0"),
+        commit_line(source_hex, "c1"),
+        commit_line("3333333333333333333333333333333333333333", "c2"),
+    ];
+    let mode = move_commit_mode(source_hex, "c1");
+
+    assert_eq!(
+        Cursor(2).move_down(&lines, &mode, FilesStatusFlag::All),
+        Some(Cursor(3))
+    );
+}
+
+#[test]
+fn move_up_from_top_move_source_skips_source_branch() {
+    let source_hex = "2222222222222222222222222222222222222222";
+    let lines = vec![
+        branch_line("A", "b0"),
+        commit_line("1111111111111111111111111111111111111111", "c0"),
+        branch_line("B", "b1"),
+        commit_line(source_hex, "c1"),
+    ];
+    let mode = move_commit_mode(source_hex, "c1");
+
+    assert_eq!(
+        Cursor(3).move_up(&lines, &mode, FilesStatusFlag::All),
+        Some(Cursor(1))
+    );
+}
+
+#[test]
+fn move_up_from_top_move_source_skips_source_branch_after_unselectable_commit() {
+    let source_hex = "3333333333333333333333333333333333333333";
+    let lines = vec![
+        branch_line("A", "b0"),
+        commit_line("1111111111111111111111111111111111111111", "c0"),
+        branch_line("B", "b1"),
+        commit_line_with_classification(
+            "2222222222222222222222222222222222222222",
+            "c1",
+            CommitClassification::Upstream,
+        ),
+        commit_line(source_hex, "c2"),
+    ];
+    let mode = move_commit_mode(source_hex, "c2");
+
+    assert_eq!(
+        Cursor(4).move_up(&lines, &mode, FilesStatusFlag::All),
+        Some(Cursor(1))
+    );
 }
 
 #[test]

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -1919,6 +1919,10 @@ impl App {
             return Ok(());
         }
 
+        if cursor::is_forbidden_move_commit_target(selection, &self.status_lines, &self.mode) {
+            return Ok(());
+        }
+
         let target = match &selection.data {
             StatusOutputLineData::Branch { cli_id } => {
                 if let CliId::Branch { name, .. } = &**cli_id {

--- a/crates/but/src/command/legacy/status/tui/tests/move_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/move_tests.rs
@@ -84,7 +84,7 @@ fn move_commit_above_other_commit_reorders_tui() {
     tui.input_then_render('m')
         .assert_current_line_eq(str!["┊●   << source >> << noop >> [..] add A"]);
 
-    tui.input_then_render([KeyCode::Up, KeyCode::Up])
+    tui.input_then_render(KeyCode::Up)
         .assert_current_line_eq(str!["┊│   << move commit >>"]);
 
     tui.input_then_render(KeyCode::Up)
@@ -98,6 +98,56 @@ fn move_commit_above_other_commit_reorders_tui() {
         .assert_rendered_term_svg_eq(file![
             "snapshots/move_commit_above_other_commit_reorders_tui_final.svg"
         ]);
+}
+
+#[test]
+fn move_commit_down_from_source_selects_next_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    let mut tui = test_tui(env);
+
+    tui.input_then_render(KeyCode::Down)
+        .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
+
+    tui.input_then_render('n')
+        .assert_current_line_eq(str!["┊●   [..] (no commit message) (no changes)"]);
+
+    tui.input_then_render('n')
+        .assert_current_line_eq(str!["┊●   [..] (no commit message) (no changes)"]);
+
+    tui.input_then_render(KeyCode::Down)
+        .assert_current_line_eq(str!["┊●   [..] (no commit message) (no changes)"]);
+
+    tui.input_then_render('m').assert_current_line_eq(str![
+        "┊●   << source >> << noop >> [..] (no commit message) (no changes)"
+    ]);
+
+    tui.input_then_render(KeyCode::Down)
+        .assert_current_line_eq(str!["┊│   << move commit >>"]);
+}
+
+#[test]
+fn move_commit_up_from_top_commit_skips_source_branch() {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings(
+        "two-stacks-one-single-and-ready-to-mingle-one-double",
+    )
+    .unwrap();
+    env.setup_metadata(&["A", "B"]).unwrap();
+
+    let mut tui = test_tui(env);
+
+    tui.input_then_render([KeyCode::Down, KeyCode::Down, KeyCode::Down])
+        .assert_current_line_eq(str!["┊╭┄h0 [C]"]);
+
+    tui.input_then_render(KeyCode::Down)
+        .assert_current_line_eq(str!["┊●   [..] add C"]);
+
+    tui.input_then_render('m')
+        .assert_current_line_eq(str!["┊●   << source >> << noop >> [..] add C"]);
+
+    tui.input_then_render(KeyCode::Up)
+        .assert_current_line_eq(str!["┊│   << move commit >>"]);
 }
 
 #[test]


### PR DESCRIPTION
If you entered moved mode on a commit and pressed `k` to move the cursor up once you'd select the line in between the source commit and the commit above:

```
commit a
<< source >> << noop >> commit b
commit c
```

Pressing `k` in that state would take you to

```
commit a
<< move commit >>
<< source >> commit b
commit c
```

however pressing enter there would place the commit in the same place it already was

this fixes that so instead the cursor is moved up twice:

```
<< move commit >>
commit a
<< source >> commit b
commit c
```

which is consistent with that happens when you press `j`:

```
commit a
<< source >> commit b
commit c
<< move commit >>
```