### PR TITLE
flyby refactors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,6 +1227,7 @@ dependencies = [
  "clap",
  "gix 0.83.0 (git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd)",
  "tracing",
+ "tracing-forest",
  "tracing-subscriber",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1347,6 +1347,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
+ "boolean-enums",
  "bstr",
  "but-core",
  "but-graph",

--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -80,9 +80,10 @@ pub fn pr_template(
             ctx.workdir_or_fail()?.join(relative_path),
         ));
     }
-    ctx.read_file_from_workspace(&relative_path)?
+    Ok(ctx
+        .read_file_from_workspace(&relative_path)?
         .content
-        .context("PR template was not valid UTF-8")
+        .unwrap_or_default())
 }
 
 /// Information about the project's review template.
@@ -132,7 +133,7 @@ pub fn review_template(ctx: &Context) -> Result<Option<ReviewTemplateInfo>> {
             let content = ctx
                 .read_file_from_workspace(&path)?
                 .content
-                .context("PR template was not valid UTF-8")?;
+                .unwrap_or_default();
 
             Ok(Some(ReviewTemplateInfo {
                 path: template_path,

--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -6,7 +6,7 @@ use but_ctx::{Context, ThreadSafeContext};
 use but_forge::{
     ForgeName, ReviewTemplateFunctions, available_review_templates, get_review_template_functions,
 };
-use gitbutler_repo::RepoCommands;
+use gitbutler_repo::{FileInfo, RepoCommands};
 use tracing::instrument;
 
 pub fn remote_url(meta: &impl RefMetadata, repo: &gix::Repository) -> Result<String> {
@@ -21,6 +21,16 @@ pub fn push_remote_url(meta: &impl RefMetadata, repo: &gix::Repository) -> Resul
     // previous behaviour of calling `get_base_branch_data`.
     let ws = meta.workspace(WORKSPACE_REF_NAME.try_into()?)?;
     ws.push_remote_url(repo)
+}
+
+fn review_template_content(file: FileInfo) -> Result<String> {
+    if file.size.is_none() {
+        return Ok(String::new());
+    }
+    if !file.is_valid_utf8() {
+        anyhow::bail!("PR template exists but must be valid UTF-8 text or markdown");
+    }
+    Ok(file.content.unwrap_or_default())
 }
 
 /// (Deprecated) Get the list of PR template paths for the given project and forge.
@@ -81,10 +91,7 @@ pub fn pr_template(
         ));
     }
     let file = ctx.read_file_from_workspace(&relative_path)?;
-    if !file.is_valid_utf8() {
-        anyhow::bail!("PR template must be UTF-8 text or markdown");
-    }
-    Ok(file.content.unwrap_or_default())
+    review_template_content(file)
 }
 
 /// Information about the project's review template.
@@ -132,10 +139,7 @@ pub fn review_template(ctx: &Context) -> Result<Option<ReviewTemplateInfo>> {
                 ));
             }
             let file = ctx.read_file_from_workspace(&path)?;
-            if !file.is_valid_utf8() {
-                anyhow::bail!("PR template must be UTF-8 text or markdown");
-            }
-            let content = file.content.unwrap_or_default();
+            let content = review_template_content(file)?;
 
             Ok(Some(ReviewTemplateInfo {
                 path: template_path,
@@ -205,6 +209,30 @@ pub fn list_reviews(
         db,
         cache_config,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_review_template_returns_empty_content() {
+        let content =
+            review_template_content(FileInfo::default()).expect("missing template is allowed");
+
+        assert_eq!(content, "");
+    }
+
+    #[test]
+    fn binary_review_template_errors_as_non_utf8() {
+        let err = review_template_content(FileInfo::binary("PULL_REQUEST_TEMPLATE.md".as_ref(), 4))
+            .expect_err("binary template must be rejected");
+
+        assert_eq!(
+            err.to_string(),
+            "PR template exists but must be valid UTF-8 text or markdown"
+        );
+    }
 }
 
 #[but_api(napi)]

--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -80,10 +80,11 @@ pub fn pr_template(
             ctx.workdir_or_fail()?.join(relative_path),
         ));
     }
-    Ok(ctx
-        .read_file_from_workspace(&relative_path)?
-        .content
-        .unwrap_or_default())
+    let file = ctx.read_file_from_workspace(&relative_path)?;
+    if !file.is_valid_utf8() {
+        anyhow::bail!("PR template must be UTF-8 text or markdown");
+    }
+    Ok(file.content.unwrap_or_default())
 }
 
 /// Information about the project's review template.
@@ -130,10 +131,11 @@ pub fn review_template(ctx: &Context) -> Result<Option<ReviewTemplateInfo>> {
                     ctx.workdir_or_fail()?.join(path),
                 ));
             }
-            let content = ctx
-                .read_file_from_workspace(&path)?
-                .content
-                .unwrap_or_default();
+            let file = ctx.read_file_from_workspace(&path)?;
+            if !file.is_valid_utf8() {
+                anyhow::bail!("PR template must be UTF-8 text or markdown");
+            }
+            let content = file.content.unwrap_or_default();
 
             Ok(Some(ReviewTemplateInfo {
                 path: template_path,

--- a/crates/but-db/src/cache/handle.rs
+++ b/crates/but-db/src/cache/handle.rs
@@ -14,7 +14,7 @@ impl AppCacheHandle {
     }
 
     /// Create a new instance at `path`.
-    #[instrument(name = "AppCacheHandle::new_at_path", level = "debug", skip(path))]
+    #[instrument(name = "AppCacheHandle::new_at_path", level = "trace", skip(path))]
     pub fn new_at_path(path: impl Into<PathBuf>) -> Self {
         let path = path.into();
         let (conn, path) = crate::cache::open_with_migrations_infallible(
@@ -58,7 +58,7 @@ impl CacheHandle {
     }
 
     /// Create a new instance at `path`.
-    #[instrument(name = "CacheHandle::new_at_path", level = "debug", skip(path))]
+    #[instrument(name = "CacheHandle::new_at_path", level = "trace", skip(path))]
     pub fn new_at_path(path: impl Into<PathBuf>) -> Self {
         let path = path.into();
         let (conn, path) = crate::cache::open_with_migrations_infallible(

--- a/crates/but-db/src/handle.rs
+++ b/crates/but-db/src/handle.rs
@@ -28,7 +28,7 @@ impl DbHandle {
     /// A new instance connecting to the project database at the given `path`.
     #[instrument(
         name = "DbHandle::new_at_path",
-        level = "debug",
+        level = "trace",
         skip(path),
         err(Debug)
     )]

--- a/crates/but-debug/Cargo.toml
+++ b/crates/but-debug/Cargo.toml
@@ -28,6 +28,7 @@ clap = { workspace = true, features = [
 ] }
 gix.workspace = true
 tracing.workspace = true
+tracing-forest.workspace = true
 tracing-subscriber = { workspace = true, features = ["std", "fmt"] }
 
 [lints]

--- a/crates/but-debug/src/args.rs
+++ b/crates/but-debug/src/args.rs
@@ -26,6 +26,9 @@ pub struct Args {
 pub enum Subcommands {
     /// Return a segmented graph starting from `HEAD`.
     Graph(GraphArgs),
+    /// Compute the octopus merge-base for two or more revisions.
+    #[command(name = "merge-base")]
+    MergeBase(MergeBaseArgs),
 }
 
 /// Arguments for the `graph` debugging subcommand.
@@ -71,14 +74,62 @@ pub struct GraphArgs {
     pub ref_name: Option<String>,
 }
 
+/// Arguments for the `merge-base` debugging subcommand.
+#[derive(Debug, clap::Args)]
+pub struct MergeBaseArgs {
+    /// The named reference to use as the workspace target during graph traversal.
+    #[arg(long)]
+    pub target_ref: Option<String>,
+    /// The rev-spec of the extra target to provide for graph traversal.
+    #[arg(long)]
+    pub extra_target: Option<String>,
+    /// The rev-specs whose octopus merge-base should be computed.
+    #[arg(required = true, num_args = 2.., value_name = "REV")]
+    pub revisions: Vec<String>,
+}
+
 #[cfg(test)]
 mod tests {
-    use clap::CommandFactory as _;
+    use clap::{CommandFactory as _, Parser as _};
 
-    use super::Args;
+    use super::{Args, Subcommands};
 
     #[test]
     fn clap_configuration_is_valid() {
         Args::command().debug_assert();
+    }
+
+    #[test]
+    fn merge_base_requires_at_least_two_revisions() {
+        assert!(Args::try_parse_from(["but-debug", "merge-base", "main"]).is_err());
+
+        let args = Args::parse_from(["but-debug", "merge-base", "main", "feature"]);
+        match args.cmd {
+            Subcommands::MergeBase(args) => assert_eq!(args.revisions, ["main", "feature"]),
+            _ => panic!("expected merge-base command"),
+        }
+    }
+
+    #[test]
+    fn merge_base_accepts_target_options() {
+        let args = Args::parse_from([
+            "but-debug",
+            "merge-base",
+            "--target-ref",
+            "refs/remotes/origin/main",
+            "--extra-target",
+            "origin/main~1",
+            "main",
+            "feature",
+        ]);
+
+        match args.cmd {
+            Subcommands::MergeBase(args) => {
+                assert_eq!(args.target_ref.as_deref(), Some("refs/remotes/origin/main"));
+                assert_eq!(args.extra_target.as_deref(), Some("origin/main~1"));
+                assert_eq!(args.revisions, ["main", "feature"]);
+            }
+            _ => panic!("expected merge-base command"),
+        }
     }
 }

--- a/crates/but-debug/src/args.rs
+++ b/crates/but-debug/src/args.rs
@@ -26,9 +26,9 @@ pub struct Args {
 pub enum Subcommands {
     /// Return a segmented graph starting from `HEAD`.
     Graph(GraphArgs),
-    /// Compute the octopus merge-base for two or more revisions.
-    #[command(name = "merge-base")]
-    MergeBase(MergeBaseArgs),
+    /// Debug revision graph operations.
+    #[clap(visible_alias = "rev")]
+    Revision(RevisionArgs),
 }
 
 /// Arguments for the `graph` debugging subcommand.
@@ -74,15 +74,51 @@ pub struct GraphArgs {
     pub ref_name: Option<String>,
 }
 
-/// Arguments for the `merge-base` debugging subcommand.
+/// Arguments for the `revision` subcommand.
 #[derive(Debug, clap::Args)]
-pub struct MergeBaseArgs {
+pub struct RevisionArgs {
+    /// The revision debugging command to run.
+    #[command(subcommand)]
+    pub cmd: RevisionSubcommands,
+}
+
+/// The debugging subcommands supported by `but-debug revision`.
+#[derive(Debug, clap::Subcommand)]
+pub enum RevisionSubcommands {
+    /// Print commits reachable by a rev-spec.
+    Log(LogArgs),
+    /// Compute the octopus merge-base for two or more revisions.
+    #[command(name = "merge-base")]
+    MergeBase(MergeBaseArgs),
+}
+
+/// Graph construction options shared by revision debugging subcommands.
+#[derive(Debug, clap::Args)]
+pub struct RevisionGraphArgs {
     /// The named reference to use as the workspace target during graph traversal.
     #[arg(long)]
     pub target_ref: Option<String>,
     /// The rev-spec of the extra target to provide for graph traversal.
     #[arg(long)]
     pub extra_target: Option<String>,
+}
+
+/// Arguments for the `revision log` debugging subcommand.
+#[derive(Debug, clap::Args)]
+pub struct LogArgs {
+    /// Shared graph construction options.
+    #[command(flatten)]
+    pub graph: RevisionGraphArgs,
+    /// The rev-spec to log. Exclusive ranges like `main..branch` are supported.
+    pub rev_spec: String,
+}
+
+/// Arguments for the `revision merge-base` debugging subcommand.
+#[derive(Debug, clap::Args)]
+pub struct MergeBaseArgs {
+    /// Shared graph construction options.
+    #[command(flatten)]
+    pub graph: RevisionGraphArgs,
     /// The rev-specs whose octopus merge-base should be computed.
     #[arg(required = true, num_args = 2.., value_name = "REV")]
     pub revisions: Vec<String>,
@@ -92,7 +128,7 @@ pub struct MergeBaseArgs {
 mod tests {
     use clap::{CommandFactory as _, Parser as _};
 
-    use super::{Args, Subcommands};
+    use super::{Args, RevisionSubcommands, Subcommands};
 
     #[test]
     fn clap_configuration_is_valid() {
@@ -101,12 +137,17 @@ mod tests {
 
     #[test]
     fn merge_base_requires_at_least_two_revisions() {
-        assert!(Args::try_parse_from(["but-debug", "merge-base", "main"]).is_err());
+        assert!(Args::try_parse_from(["but-debug", "revision", "merge-base", "main"]).is_err());
 
-        let args = Args::parse_from(["but-debug", "merge-base", "main", "feature"]);
+        let args = Args::parse_from(["but-debug", "revision", "merge-base", "main", "feature"]);
         match args.cmd {
-            Subcommands::MergeBase(args) => assert_eq!(args.revisions, ["main", "feature"]),
-            _ => panic!("expected merge-base command"),
+            Subcommands::Revision(revision_args) => match revision_args.cmd {
+                RevisionSubcommands::MergeBase(args) => {
+                    assert_eq!(args.revisions, ["main", "feature"])
+                }
+                _ => panic!("expected merge-base command"),
+            },
+            _ => panic!("expected revision command"),
         }
     }
 
@@ -114,6 +155,7 @@ mod tests {
     fn merge_base_accepts_target_options() {
         let args = Args::parse_from([
             "but-debug",
+            "revision",
             "merge-base",
             "--target-ref",
             "refs/remotes/origin/main",
@@ -124,12 +166,31 @@ mod tests {
         ]);
 
         match args.cmd {
-            Subcommands::MergeBase(args) => {
-                assert_eq!(args.target_ref.as_deref(), Some("refs/remotes/origin/main"));
-                assert_eq!(args.extra_target.as_deref(), Some("origin/main~1"));
-                assert_eq!(args.revisions, ["main", "feature"]);
-            }
-            _ => panic!("expected merge-base command"),
+            Subcommands::Revision(revision_args) => match revision_args.cmd {
+                RevisionSubcommands::MergeBase(args) => {
+                    assert_eq!(
+                        args.graph.target_ref.as_deref(),
+                        Some("refs/remotes/origin/main")
+                    );
+                    assert_eq!(args.graph.extra_target.as_deref(), Some("origin/main~1"));
+                    assert_eq!(args.revisions, ["main", "feature"]);
+                }
+                _ => panic!("expected merge-base command"),
+            },
+            _ => panic!("expected revision command"),
+        }
+    }
+
+    #[test]
+    fn revision_log_accepts_exclusive_range() {
+        let args = Args::parse_from(["but-debug", "revision", "log", "main..feature"]);
+
+        match args.cmd {
+            Subcommands::Revision(revision_args) => match revision_args.cmd {
+                RevisionSubcommands::Log(args) => assert_eq!(args.rev_spec, "main..feature"),
+                _ => panic!("expected log command"),
+            },
+            _ => panic!("expected revision command"),
         }
     }
 }

--- a/crates/but-debug/src/args.rs
+++ b/crates/but-debug/src/args.rs
@@ -109,6 +109,9 @@ pub struct LogArgs {
     /// Shared graph construction options.
     #[command(flatten)]
     pub graph: RevisionGraphArgs,
+    /// Follow only the first parent when traversing merge commits.
+    #[arg(long)]
+    pub first_parent: bool,
     /// The rev-spec to log. Exclusive ranges like `main..branch` are supported.
     pub rev_spec: String,
 }
@@ -126,71 +129,12 @@ pub struct MergeBaseArgs {
 
 #[cfg(test)]
 mod tests {
-    use clap::{CommandFactory as _, Parser as _};
+    use clap::CommandFactory;
 
-    use super::{Args, RevisionSubcommands, Subcommands};
+    use super::Args;
 
     #[test]
     fn clap_configuration_is_valid() {
         Args::command().debug_assert();
-    }
-
-    #[test]
-    fn merge_base_requires_at_least_two_revisions() {
-        assert!(Args::try_parse_from(["but-debug", "revision", "merge-base", "main"]).is_err());
-
-        let args = Args::parse_from(["but-debug", "revision", "merge-base", "main", "feature"]);
-        match args.cmd {
-            Subcommands::Revision(revision_args) => match revision_args.cmd {
-                RevisionSubcommands::MergeBase(args) => {
-                    assert_eq!(args.revisions, ["main", "feature"])
-                }
-                _ => panic!("expected merge-base command"),
-            },
-            _ => panic!("expected revision command"),
-        }
-    }
-
-    #[test]
-    fn merge_base_accepts_target_options() {
-        let args = Args::parse_from([
-            "but-debug",
-            "revision",
-            "merge-base",
-            "--target-ref",
-            "refs/remotes/origin/main",
-            "--extra-target",
-            "origin/main~1",
-            "main",
-            "feature",
-        ]);
-
-        match args.cmd {
-            Subcommands::Revision(revision_args) => match revision_args.cmd {
-                RevisionSubcommands::MergeBase(args) => {
-                    assert_eq!(
-                        args.graph.target_ref.as_deref(),
-                        Some("refs/remotes/origin/main")
-                    );
-                    assert_eq!(args.graph.extra_target.as_deref(), Some("origin/main~1"));
-                    assert_eq!(args.revisions, ["main", "feature"]);
-                }
-                _ => panic!("expected merge-base command"),
-            },
-            _ => panic!("expected revision command"),
-        }
-    }
-
-    #[test]
-    fn revision_log_accepts_exclusive_range() {
-        let args = Args::parse_from(["but-debug", "revision", "log", "main..feature"]);
-
-        match args.cmd {
-            Subcommands::Revision(revision_args) => match revision_args.cmd {
-                RevisionSubcommands::Log(args) => assert_eq!(args.rev_spec, "main..feature"),
-                _ => panic!("expected log command"),
-            },
-            _ => panic!("expected revision command"),
-        }
     }
 }

--- a/crates/but-debug/src/command/merge_base.rs
+++ b/crates/but-debug/src/command/merge_base.rs
@@ -1,0 +1,182 @@
+//! Implementation of the `merge-base` debug command.
+
+use anyhow::{Context as _, Result, bail, ensure};
+use but_core::ref_metadata::{
+    StackId, Workspace, WorkspaceCommitRelation, WorkspaceStack, WorkspaceStackBranch,
+};
+use gix::{odb::store::RefreshMode, reference::Category, refs::Target};
+
+use crate::{
+    args::{Args, MergeBaseArgs},
+    metadata::EmptyRefMetadata,
+    setup,
+};
+
+/// Execute the `merge-base` subcommand.
+pub(crate) fn run(args: &Args, merge_base_args: &MergeBaseArgs) -> Result<()> {
+    let mut repo = setup::repo_from_args(args)?;
+    repo.objects.refresh = RefreshMode::Never;
+    let meta = EmptyRefMetadata;
+
+    let commits = {
+        let _span = tracing::info_span!(
+            "resolve revisions",
+            revision_count = merge_base_args.revisions.len()
+        )
+        .entered();
+        merge_base_args
+            .revisions
+            .iter()
+            .map(|rev| {
+                repo.rev_parse_single(rev.as_str())
+                    .map(|id| id.detach())
+                    .with_context(|| format!("Failed to resolve revision '{rev}'"))
+            })
+            .collect::<Result<Vec<_>>>()?
+    };
+
+    let target_ref = {
+        merge_base_args
+            .target_ref
+            .as_deref()
+            .map(|target_ref| {
+                let reference = repo
+                    .find_reference(target_ref)
+                    .with_context(|| format!("Failed to find target ref '{target_ref}'"))?;
+                let name = reference.name().to_owned();
+                ensure!(
+                    name.category() == Some(Category::RemoteBranch),
+                    "Target ref '{name}' resolved from '{target_ref}' is not a remote-tracking branch; use --extra-target for arbitrary revisions"
+                );
+                Ok(name)
+            })
+            .transpose()?
+    };
+
+    let extra_target = {
+        merge_base_args
+            .extra_target
+            .as_deref()
+            .map(|rev| {
+                repo.rev_parse_single(rev)
+                    .map(|id| id.detach())
+                    .with_context(|| format!("Failed to resolve extra target '{rev}'"))
+            })
+            .transpose()?
+    };
+
+    let graph = {
+        let _span = tracing::info_span!("build graph", commit_count = commits.len()).entered();
+        graph_for_octopus_merge_base(&repo, &meta, &commits, target_ref, extra_target)?
+    };
+
+    let segments = {
+        let _span = tracing::info_span!("map commit ids to segments", commit_count = commits.len())
+            .entered();
+        commits
+            .iter()
+            .copied()
+            .map(|commit_id| graph.commit_id_to_segment_id(commit_id))
+            .collect::<Result<Vec<_>>>()
+            .context("Failed to map commit ids to graph segments")?
+    };
+
+    let merge_base = {
+        let _span = tracing::info_span!("compute octopus merge-base", commit_count = commits.len())
+            .entered();
+        graph
+            .find_merge_base_octopus(segments)
+            .map(|segment_id| {
+                graph
+                    .tip_skip_empty(segment_id)
+                    .map(|commit| commit.id)
+                    .with_context(|| {
+                        format!(
+                            "BUG: Segment {segment_id:?} does not contain a reachable tip commit"
+                        )
+                    })
+            })
+            .transpose()
+            .context("Failed to compute octopus merge-base from graph")?
+    };
+
+    let Some(merge_base) = merge_base else {
+        bail!(
+            "No merge-base found for revisions: {}",
+            merge_base_args.revisions.join(", ")
+        );
+    };
+    println!("{merge_base}");
+
+    Ok(())
+}
+
+fn graph_for_octopus_merge_base(
+    repo: &gix::Repository,
+    meta: &EmptyRefMetadata,
+    commits: &[gix::ObjectId],
+    target_ref: Option<gix::refs::FullName>,
+    extra_target: Option<gix::ObjectId>,
+) -> Result<but_graph::Graph> {
+    let first = *commits
+        .first()
+        .context("BUG: clap requires at least two revisions")?;
+    let options = but_graph::init::Options {
+        collect_tags: false,
+        commits_limit_hint: None,
+        extra_target_commit_id: extra_target,
+        ..Default::default()
+    };
+    let mut graph = but_graph::Graph::default();
+    graph.options = options;
+
+    let workspace_ref_name = synthetic_ref_name("workspace")?;
+    let input_ref_names = (0..commits.len())
+        .map(|idx| synthetic_ref_name(&format!("input-{idx}")))
+        .collect::<Result<Vec<_>>>()?;
+
+    let refs = std::iter::once(gix::refs::Reference {
+        name: workspace_ref_name.clone(),
+        target: Target::Object(first),
+        peeled: Some(first),
+    })
+    .chain(
+        input_ref_names
+            .iter()
+            .cloned()
+            .zip(commits.iter().copied())
+            .map(|(name, id)| gix::refs::Reference {
+                name,
+                target: Target::Object(id),
+                peeled: Some(id),
+            }),
+    );
+    let workspace = Workspace {
+        stacks: input_ref_names
+            .iter()
+            .enumerate()
+            .map(|(idx, ref_name)| WorkspaceStack {
+                id: StackId::from_number_for_testing(1000 + idx as u128),
+                branches: vec![WorkspaceStackBranch {
+                    ref_name: ref_name.clone(),
+                    archived: false,
+                }],
+                workspacecommit_relation: WorkspaceCommitRelation::Merged,
+            })
+            .collect(),
+        target_ref,
+        ..Default::default()
+    };
+    let overlay = but_graph::init::Overlay::default()
+        .with_entrypoint(first, Some(workspace_ref_name.clone()))
+        .with_references(refs)
+        .with_workspace_metadata_override(Some((workspace_ref_name, workspace)));
+
+    graph.redo_traversal_with_overlay(repo, meta, overlay)
+}
+
+fn synthetic_ref_name(suffix: &str) -> Result<gix::refs::FullName> {
+    format!("refs/heads/but-debug/merge-base/{suffix}")
+        .try_into()
+        .with_context(|| format!("BUG: invalid synthetic ref suffix '{suffix}'"))
+}

--- a/crates/but-debug/src/command/mod.rs
+++ b/crates/but-debug/src/command/mod.rs
@@ -1,4 +1,4 @@
 //! A place for each `but-debug` command implementation.
 
 pub(crate) mod graph;
-pub(crate) mod merge_base;
+pub(crate) mod revision;

--- a/crates/but-debug/src/command/mod.rs
+++ b/crates/but-debug/src/command/mod.rs
@@ -1,3 +1,4 @@
 //! A place for each `but-debug` command implementation.
 
 pub(crate) mod graph;
+pub(crate) mod merge_base;

--- a/crates/but-debug/src/command/revision.rs
+++ b/crates/but-debug/src/command/revision.rs
@@ -1,23 +1,91 @@
-//! Implementation of the `merge-base` debug command.
+//! Implementation of the `revision` debug commands.
+
+use std::io::Write;
 
 use anyhow::{Context as _, Result, bail, ensure};
 use but_core::ref_metadata::{
     StackId, Workspace, WorkspaceCommitRelation, WorkspaceStack, WorkspaceStackBranch,
 };
-use gix::{odb::store::RefreshMode, reference::Category, refs::Target};
+use gix::{
+    bstr::ByteVec, odb::store::RefreshMode, reference::Category, refs::Target,
+    revision::plumbing::Spec,
+};
 
 use crate::{
-    args::{Args, MergeBaseArgs},
+    args::{Args, LogArgs, MergeBaseArgs, RevisionArgs, RevisionGraphArgs, RevisionSubcommands},
     metadata::EmptyRefMetadata,
     setup,
 };
 
-/// Execute the `merge-base` subcommand.
-pub(crate) fn run(args: &Args, merge_base_args: &MergeBaseArgs) -> Result<()> {
+/// Execute the `revision` subcommand.
+pub(crate) fn run(args: &Args, revision_args: &RevisionArgs) -> Result<()> {
     let mut repo = setup::repo_from_args(args)?;
     repo.objects.refresh = RefreshMode::Never;
     let meta = EmptyRefMetadata;
 
+    match &revision_args.cmd {
+        RevisionSubcommands::Log(log_args) => log(&repo, &meta, log_args),
+        RevisionSubcommands::MergeBase(merge_base_args) => {
+            merge_base(&repo, &meta, merge_base_args)
+        }
+    }
+}
+
+fn log(repo: &gix::Repository, meta: &EmptyRefMetadata, log_args: &LogArgs) -> Result<()> {
+    let parsed = repo
+        .rev_parse(log_args.rev_spec.as_str())
+        .with_context(|| format!("Failed to parse rev-spec '{}'", log_args.rev_spec))?
+        .detach();
+
+    let (included, excluded) = match parsed {
+        Spec::Include(commit_id) => (commit_id, None),
+        Spec::Range { from, to } => (to, Some(from)),
+        other => bail!("Unsupported rev-spec for revision log: {other}"),
+    };
+    let mut graph_commits = vec![included];
+    graph_commits.extend(excluded);
+
+    let graph_args = resolve_graph_args(repo, &log_args.graph)?;
+    let graph = {
+        let _span =
+            tracing::info_span!("build graph", commit_count = graph_commits.len()).entered();
+        graph_for_revisions(repo, meta, &graph_commits, graph_args)?
+    };
+
+    let _span = tracing::info_span!("traverse graph").entered();
+    let commits = if let Some(excluded) = excluded {
+        graph.find_commit_ids_reachable_from_a_not_b(included, excluded)?
+    } else {
+        let included_segment = graph.commit_id_to_segment_id(included).with_context(|| {
+            format!("Failed to map included commit {included} to a graph segment")
+        })?;
+        let mut commits = Vec::new();
+        graph.visit_all_segments_including_start_until(
+            included_segment,
+            but_graph::petgraph::Direction::Outgoing,
+            |segment| {
+                commits.extend(segment.commits.iter().map(|commit| commit.id));
+                false
+            },
+        );
+        commits
+    };
+
+    let mut out = Vec::with_capacity(512);
+    for commit_id in commits {
+        commit_id.write_hex_to(&mut out)?;
+        out.push_byte(b'\n');
+    }
+
+    std::io::stdout().write_all(&out)?;
+    Ok(())
+}
+
+fn merge_base(
+    repo: &gix::Repository,
+    meta: &EmptyRefMetadata,
+    merge_base_args: &MergeBaseArgs,
+) -> Result<()> {
     let commits = {
         let _span = tracing::info_span!(
             "resolve revisions",
@@ -35,39 +103,10 @@ pub(crate) fn run(args: &Args, merge_base_args: &MergeBaseArgs) -> Result<()> {
             .collect::<Result<Vec<_>>>()?
     };
 
-    let target_ref = {
-        merge_base_args
-            .target_ref
-            .as_deref()
-            .map(|target_ref| {
-                let reference = repo
-                    .find_reference(target_ref)
-                    .with_context(|| format!("Failed to find target ref '{target_ref}'"))?;
-                let name = reference.name().to_owned();
-                ensure!(
-                    name.category() == Some(Category::RemoteBranch),
-                    "Target ref '{name}' resolved from '{target_ref}' is not a remote-tracking branch; use --extra-target for arbitrary revisions"
-                );
-                Ok(name)
-            })
-            .transpose()?
-    };
-
-    let extra_target = {
-        merge_base_args
-            .extra_target
-            .as_deref()
-            .map(|rev| {
-                repo.rev_parse_single(rev)
-                    .map(|id| id.detach())
-                    .with_context(|| format!("Failed to resolve extra target '{rev}'"))
-            })
-            .transpose()?
-    };
-
+    let graph_args = resolve_graph_args(repo, &merge_base_args.graph)?;
     let graph = {
         let _span = tracing::info_span!("build graph", commit_count = commits.len()).entered();
-        graph_for_octopus_merge_base(&repo, &meta, &commits, target_ref, extra_target)?
+        graph_for_revisions(repo, meta, &commits, graph_args)?
     };
 
     let segments = {
@@ -111,20 +150,57 @@ pub(crate) fn run(args: &Args, merge_base_args: &MergeBaseArgs) -> Result<()> {
     Ok(())
 }
 
-fn graph_for_octopus_merge_base(
+struct GraphArgs {
+    target_ref: Option<gix::refs::FullName>,
+    extra_target: Option<gix::ObjectId>,
+}
+
+fn resolve_graph_args(repo: &gix::Repository, graph_args: &RevisionGraphArgs) -> Result<GraphArgs> {
+    let target_ref = graph_args
+        .target_ref
+        .as_deref()
+        .map(|target_ref| {
+            let reference = repo
+                .find_reference(target_ref)
+                .with_context(|| format!("Failed to find target ref '{target_ref}'"))?;
+            let name = reference.name().to_owned();
+            ensure!(
+                name.category() == Some(Category::RemoteBranch),
+                "Target ref '{name}' resolved from '{target_ref}' is not a remote-tracking branch; use --extra-target for arbitrary revisions"
+            );
+            Ok(name)
+        })
+        .transpose()?;
+
+    let extra_target = graph_args
+        .extra_target
+        .as_deref()
+        .map(|rev| {
+            repo.rev_parse_single(rev)
+                .map(|id| id.detach())
+                .with_context(|| format!("Failed to resolve extra target '{rev}'"))
+        })
+        .transpose()?;
+
+    Ok(GraphArgs {
+        target_ref,
+        extra_target,
+    })
+}
+
+fn graph_for_revisions(
     repo: &gix::Repository,
     meta: &EmptyRefMetadata,
     commits: &[gix::ObjectId],
-    target_ref: Option<gix::refs::FullName>,
-    extra_target: Option<gix::ObjectId>,
+    graph_args: GraphArgs,
 ) -> Result<but_graph::Graph> {
     let first = *commits
         .first()
-        .context("BUG: clap requires at least two revisions")?;
+        .context("BUG: revision graph requires at least one commit")?;
     let options = but_graph::init::Options {
         collect_tags: false,
         commits_limit_hint: None,
-        extra_target_commit_id: extra_target,
+        extra_target_commit_id: graph_args.extra_target,
         ..Default::default()
     };
     let mut graph = but_graph::Graph::default();
@@ -164,7 +240,7 @@ fn graph_for_octopus_merge_base(
                 workspacecommit_relation: WorkspaceCommitRelation::Merged,
             })
             .collect(),
-        target_ref,
+        target_ref: graph_args.target_ref,
         ..Default::default()
     };
     let overlay = but_graph::init::Overlay::default()
@@ -176,7 +252,7 @@ fn graph_for_octopus_merge_base(
 }
 
 fn synthetic_ref_name(suffix: &str) -> Result<gix::refs::FullName> {
-    format!("refs/heads/but-debug/merge-base/{suffix}")
+    format!("refs/heads/but-debug/revision/{suffix}")
         .try_into()
         .with_context(|| format!("BUG: invalid synthetic ref suffix '{suffix}'"))
 }

--- a/crates/but-debug/src/command/revision.rs
+++ b/crates/but-debug/src/command/revision.rs
@@ -54,21 +54,9 @@ fn log(repo: &gix::Repository, meta: &EmptyRefMetadata, log_args: &LogArgs) -> R
 
     let _span = tracing::info_span!("traverse graph").entered();
     let commits = if let Some(excluded) = excluded {
-        graph.find_commit_ids_reachable_from_a_not_b(included, excluded)?
+        graph.find_commit_ids_reachable_from_a_not_b(included, excluded, log_args.first_parent)?
     } else {
-        let included_segment = graph.commit_id_to_segment_id(included).with_context(|| {
-            format!("Failed to map included commit {included} to a graph segment")
-        })?;
-        let mut commits = Vec::new();
-        graph.visit_all_segments_including_start_until(
-            included_segment,
-            but_graph::petgraph::Direction::Outgoing,
-            |segment| {
-                commits.extend(segment.commits.iter().map(|commit| commit.id));
-                false
-            },
-        );
-        commits
+        bail!("Need to specify a rev-spec of form `a..b` to indicate an exclusion for now.")
     };
 
     let mut out = Vec::with_capacity(512);

--- a/crates/but-debug/src/command/revision.rs
+++ b/crates/but-debug/src/command/revision.rs
@@ -6,6 +6,7 @@ use anyhow::{Context as _, Result, bail, ensure};
 use but_core::ref_metadata::{
     StackId, Workspace, WorkspaceCommitRelation, WorkspaceStack, WorkspaceStackBranch,
 };
+use but_graph::FirstParent;
 use gix::{
     bstr::ByteVec, odb::store::RefreshMode, reference::Category, refs::Target,
     revision::plumbing::Spec,
@@ -54,7 +55,11 @@ fn log(repo: &gix::Repository, meta: &EmptyRefMetadata, log_args: &LogArgs) -> R
 
     let _span = tracing::info_span!("traverse graph").entered();
     let commits = if let Some(excluded) = excluded {
-        graph.find_commit_ids_reachable_from_a_not_b(included, excluded, log_args.first_parent)?
+        graph.find_commit_ids_reachable_from_a_not_b(
+            included,
+            excluded,
+            FirstParent::from(log_args.first_parent),
+        )?
     } else {
         bail!("Need to specify a rev-spec of form `a..b` to indicate an exclusion for now.")
     };

--- a/crates/but-debug/src/lib.rs
+++ b/crates/but-debug/src/lib.rs
@@ -19,7 +19,9 @@ pub fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     let args = Args::parse_from(args);
     trace::init(args.trace)?;
 
+    let _span = tracing::info_span!("run").entered();
     match &args.cmd {
         Subcommands::Graph(graph_args) => command::graph::run(&args, graph_args),
+        Subcommands::MergeBase(merge_base_args) => command::merge_base::run(&args, merge_base_args),
     }
 }

--- a/crates/but-debug/src/lib.rs
+++ b/crates/but-debug/src/lib.rs
@@ -22,6 +22,6 @@ pub fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     let _span = tracing::info_span!("run").entered();
     match &args.cmd {
         Subcommands::Graph(graph_args) => command::graph::run(&args, graph_args),
-        Subcommands::MergeBase(merge_base_args) => command::merge_base::run(&args, merge_base_args),
+        Subcommands::Revision(revision_args) => command::revision::run(&args, revision_args),
     }
 }

--- a/crates/but-debug/src/trace.rs
+++ b/crates/but-debug/src/trace.rs
@@ -1,6 +1,14 @@
 //! Tracing setup for `but-debug`.
 
 use anyhow::Result;
+use tracing::Level;
+use tracing_subscriber::{
+    Layer,
+    filter::DynFilterFn,
+    fmt::{format::FmtSpan, writer::BoxMakeWriter},
+    layer::SubscriberExt,
+    util::SubscriberInitExt,
+};
 
 /// Initialize tracing output according to the requested verbosity.
 pub(crate) fn init(trace_level: u8) -> Result<()> {
@@ -9,14 +17,54 @@ pub(crate) fn init(trace_level: u8) -> Result<()> {
     }
 
     let level = match trace_level {
-        1 => tracing::metadata::LevelFilter::INFO,
-        2 => tracing::metadata::LevelFilter::DEBUG,
-        _ => tracing::metadata::LevelFilter::TRACE,
+        1 => Level::INFO,
+        2 => Level::DEBUG,
+        _ => Level::TRACE,
     };
 
-    tracing_subscriber::fmt()
-        .with_writer(std::io::stderr)
-        .with_max_level(level)
-        .init();
+    let filter = DynFilterFn::new(move |meta, _cx| {
+        if *meta.level() > level {
+            return false;
+        }
+        if level > Level::DEBUG {
+            return true;
+        }
+        if level > Level::INFO
+            && meta
+                .module_path()
+                .is_some_and(|p| p.starts_with("gitbutler_"))
+        {
+            return true;
+        }
+        if meta.module_path().is_some_and(|p| {
+            p == "but_debug" || p.starts_with("but_debug::") || p.starts_with("but_")
+        }) {
+            return true;
+        }
+        false
+    });
+
+    let make_writer = BoxMakeWriter::new(std::io::stderr);
+    if trace_level >= 4 {
+        tracing_subscriber::registry()
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .compact()
+                    .with_span_events(FmtSpan::CLOSE)
+                    .with_writer(make_writer)
+                    .with_filter(filter),
+            )
+            .init();
+    } else {
+        tracing_subscriber::registry()
+            .with(
+                tracing_forest::ForestLayer::from(
+                    tracing_forest::printer::PrettyPrinter::new().writer(make_writer),
+                )
+                .with_filter(filter),
+            )
+            .init();
+    }
+
     Ok(())
 }

--- a/crates/but-forge/Cargo.toml
+++ b/crates/but-forge/Cargo.toml
@@ -25,6 +25,7 @@ but-gitlab.workspace = true
 but-forge-storage.workspace = true
 but-db.workspace = true
 but-path.workspace = true
+but-schemars = { workspace = true, optional = true }
 
 chrono.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
@@ -34,7 +35,6 @@ serde.workspace = true
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
 anyhow.workspace = true
 schemars = { workspace = true, optional = true }
-but-schemars = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/crates/but-graph/Cargo.toml
+++ b/crates/but-graph/Cargo.toml
@@ -23,6 +23,7 @@ bstr.workspace = true
 petgraph.workspace = true
 anyhow.workspace = true
 bitflags.workspace = true
+boolean-enums.workspace = true
 tracing.workspace = true
 itertools.workspace = true
 

--- a/crates/but-graph/src/api.rs
+++ b/crates/but-graph/src/api.rs
@@ -159,51 +159,167 @@ impl Graph {
     /// `included` towards history.
     ///
     /// Unlike Git's revision walk, this does not sort pending commits by date or enforce
-    /// global topo-order across segments: it uses FIFO segment traversal and emits each
-    /// segment's commits in their stored tip-to-base order.
-    ///
-    /// It also eagerly marks all segments reachable from `excluded` before walking `included`,
-    /// which can visit more of the excluded side than Git would for small reachable differences.
-    pub fn find_commits_reachable_from_a_not_b(
+    /// global topo-order across commits. It walks segments by their graph generation,
+    /// emits each segment's commits in stored tip-to-base order, and lazily paints the
+    /// excluded side only as far as needed to prove emitted segments are not hidden.
+    pub fn find_segments_reachable_from_a_not_b(
         &self,
         included: SegmentIndex,
         excluded: SegmentIndex,
     ) -> Vec<&Commit> {
         let mut flags = SegmentTable::new(self.inner.node_bound(), SegmentFlags::empty());
-        self.paint_down_to_reachable_eagerly(excluded, SegmentFlags::SEGMENT2, &mut flags);
+        let mut queue = BinaryHeap::new();
+        let mut sequence = 0;
+        self.queue_segment_for_reachable_difference(
+            included,
+            false,
+            &mut flags,
+            &mut queue,
+            &mut sequence,
+        );
+        self.queue_segment_for_reachable_difference(
+            excluded,
+            true,
+            &mut flags,
+            &mut queue,
+            &mut sequence,
+        );
 
-        let mut queue = VecDeque::new();
-        queue.push_back(included);
-
-        let mut commits = Vec::new();
-        while let Some(segment_id) = queue.pop_front() {
-            let segment_flags = flags.get_mut(segment_id);
-            if segment_flags.contains(SegmentFlags::SEGMENT1) {
-                continue;
-            }
-            segment_flags.insert(SegmentFlags::SEGMENT1);
-
-            if segment_flags.contains(SegmentFlags::SEGMENT2) {
-                continue;
-            }
-
-            let segment = &self[segment_id];
-            commits.extend(segment.commits.iter());
-            queue.extend(
-                self.inner
+        let mut segments = Vec::new();
+        let mut max_emitted_generation = None;
+        while let Some((_, _, is_excluded, segment_id)) = queue.pop() {
+            if is_excluded {
+                for parent_id in self
+                    .inner
                     .edges_directed(segment_id, Direction::Outgoing)
-                    .map(|edge| edge.target()),
-            );
+                    .map(|edge| edge.target())
+                {
+                    self.queue_segment_for_reachable_difference(
+                        parent_id,
+                        true,
+                        &mut flags,
+                        &mut queue,
+                        &mut sequence,
+                    );
+                }
+                if self.excluded_frontier_is_past_emitted_segments(
+                    &queue,
+                    &flags,
+                    max_emitted_generation,
+                ) {
+                    break;
+                }
+                continue;
+            }
+
+            if flags.get(segment_id).contains(SegmentFlags::SEGMENT2) {
+                continue;
+            }
+
+            let generation = self[segment_id].generation;
+            max_emitted_generation =
+                Some(max_emitted_generation.map_or(generation, |max| max.max(generation)));
+            segments.push(segment_id);
+            for parent_id in self
+                .inner
+                .edges_directed(segment_id, Direction::Outgoing)
+                .map(|edge| edge.target())
+            {
+                self.queue_segment_for_reachable_difference(
+                    parent_id,
+                    false,
+                    &mut flags,
+                    &mut queue,
+                    &mut sequence,
+                );
+            }
         }
 
-        commits
+        segments
+            .into_iter()
+            .filter(|segment_id| !flags.get(*segment_id).contains(SegmentFlags::SEGMENT2))
+            .flat_map(|segment_id| self[segment_id].commits.iter())
+            .collect()
+    }
+
+    /// Queue `segment_id` for the reachable-difference walk if this side has not seen it yet.
+    ///
+    /// `SEGMENT1` tracks the included side, `SEGMENT2` tracks the excluded side, and `STALE`
+    /// is reused here as the excluded-side queued/processed bit. Included segments that are
+    /// already known to be excluded are not queued because they cannot contribute to the result.
+    /// Queue keys sort by ascending generation and then insertion order so both frontiers advance
+    /// from tips toward history in a deterministic segment order.
+    fn queue_segment_for_reachable_difference(
+        &self,
+        segment_id: SegmentIndex,
+        is_excluded: bool,
+        flags: &mut SegmentTable<SegmentFlags>,
+        queue: &mut BinaryHeap<(Reverse<usize>, Reverse<usize>, bool, SegmentIndex)>,
+        sequence: &mut usize,
+    ) {
+        let segment_flags = flags.get_mut(segment_id);
+        if is_excluded {
+            segment_flags.insert(SegmentFlags::SEGMENT2);
+            if segment_flags.contains(SegmentFlags::STALE) {
+                return;
+            }
+            segment_flags.insert(SegmentFlags::STALE);
+        } else {
+            if segment_flags.intersects(SegmentFlags::SEGMENT1 | SegmentFlags::SEGMENT2) {
+                return;
+            }
+            segment_flags.insert(SegmentFlags::SEGMENT1);
+        }
+
+        queue.push((
+            Reverse(self[segment_id].generation),
+            Reverse(*sequence),
+            is_excluded,
+            segment_id,
+        ));
+        *sequence += 1;
+    }
+
+    /// Return `true` once the excluded-side frontier cannot still hide any segment already emitted.
+    ///
+    /// Segment generations are topological: edges point from lower generations toward higher
+    /// generations. After all non-hidden included work has left the queue, an excluded frontier
+    /// whose minimum generation is greater than the maximum emitted generation can only paint
+    /// deeper ancestors, not any emitted segment. At that point the caller may stop walking the
+    /// excluded side and filter the segments that were already marked hidden.
+    fn excluded_frontier_is_past_emitted_segments(
+        &self,
+        queue: &BinaryHeap<(Reverse<usize>, Reverse<usize>, bool, SegmentIndex)>,
+        flags: &SegmentTable<SegmentFlags>,
+        max_emitted_generation: Option<usize>,
+    ) -> bool {
+        if queue.iter().any(|(_, _, is_excluded, segment_id)| {
+            !*is_excluded && !flags.get(*segment_id).contains(SegmentFlags::SEGMENT2)
+        }) {
+            return false;
+        }
+
+        let Some(max_emitted_generation) = max_emitted_generation else {
+            return true;
+        };
+        let Some(min_excluded_generation) = queue
+            .iter()
+            .filter_map(|(_, _, is_excluded, segment_id)| {
+                is_excluded.then_some(self[*segment_id].generation)
+            })
+            .min()
+        else {
+            return true;
+        };
+
+        min_excluded_generation > max_emitted_generation
     }
 
     /// Return all commit ids reachable from `included`, but not reachable from `excluded`.
     ///
     /// This is a convenience wrapper around
-    /// [`Self::find_commits_reachable_from_a_not_b()`], taking object ids of commits.
-    pub fn find_commit_ids_from_a_not_b(
+    /// [`Self::find_segments_reachable_from_a_not_b()`], taking object ids of commits.
+    pub fn find_commit_ids_reachable_from_a_not_b(
         &self,
         included: gix::ObjectId,
         excluded: gix::ObjectId,
@@ -211,7 +327,7 @@ impl Graph {
         let included = self.commit_id_to_segment_id(included)?;
         let excluded = self.commit_id_to_segment_id(excluded)?;
         Ok(self
-            .find_commits_reachable_from_a_not_b(included, excluded)
+            .find_segments_reachable_from_a_not_b(included, excluded)
             .into_iter()
             .map(|commit| commit.id)
             .collect())
@@ -338,31 +454,6 @@ impl Graph {
         }
 
         out
-    }
-
-    /// Paint every segment reachable from `start` with `flag`.
-    fn paint_down_to_reachable_eagerly(
-        &self,
-        start: SegmentIndex,
-        flag: SegmentFlags,
-        flags: &mut SegmentTable<SegmentFlags>,
-    ) {
-        let mut queue = VecDeque::new();
-        flags.get_mut(start).insert(flag);
-        queue.push_back(start);
-
-        while let Some(segment_id) = queue.pop_front() {
-            for parent_id in self
-                .inner
-                .neighbors_directed(segment_id, Direction::Outgoing)
-            {
-                let parent_flags = flags.get_mut(parent_id);
-                if !parent_flags.contains(flag) {
-                    parent_flags.insert(flag);
-                    queue.push_back(parent_id);
-                }
-            }
-        }
     }
 
     /// Remove all those segments from `segments` if they are in the history of another segment in `segments`.

--- a/crates/but-graph/src/api.rs
+++ b/crates/but-graph/src/api.rs
@@ -18,6 +18,8 @@ use crate::{
     projection::commit::is_managed_workspace_by_message, utils::SegmentTable,
 };
 
+boolean_enums::gen_boolean_enum!(pub FirstParent);
+
 /// Mutation
 impl Graph {
     /// Insert `segment` to the graph so that it's not connected to any other segment, and return its index.
@@ -163,14 +165,15 @@ impl Graph {
     /// emits each segment's commits in stored tip-to-base order, and lazily paints the
     /// excluded side only as far as needed to prove emitted segments are not hidden.
     ///
-    /// If `first_parent_only` is true, both the included and excluded traversals follow
+    /// If `first_parent` is [`FirstParent::Yes`], both the included and excluded traversals follow
     /// only segment edges with `parent_order == 0`.
     pub fn find_segments_reachable_from_a_not_b(
         &self,
         included: SegmentIndex,
         excluded: SegmentIndex,
-        first_parent_only: bool,
+        first_parent: FirstParent,
     ) -> Vec<&Commit> {
+        let first_parent: bool = first_parent.into();
         let mut flags = SegmentTable::new(self.inner.node_bound(), SegmentFlags::empty());
         let mut queue = BinaryHeap::new();
         let mut sequence = 0;
@@ -194,7 +197,7 @@ impl Graph {
         while let Some((_, _, is_excluded, segment_id)) = queue.pop() {
             if is_excluded {
                 let parent_ids =
-                    self.parent_segments_for_reachable_difference(segment_id, first_parent_only);
+                    self.parent_segments_for_reachable_difference(segment_id, first_parent);
                 for parent_id in parent_ids {
                     self.queue_segment_for_reachable_difference(
                         parent_id,
@@ -223,7 +226,7 @@ impl Graph {
                 Some(max_emitted_generation.map_or(generation, |max| max.max(generation)));
             segments.push(segment_id);
             let parent_ids =
-                self.parent_segments_for_reachable_difference(segment_id, first_parent_only);
+                self.parent_segments_for_reachable_difference(segment_id, first_parent);
             for parent_id in parent_ids {
                 self.queue_segment_for_reachable_difference(
                     parent_id,
@@ -334,17 +337,17 @@ impl Graph {
     ///
     /// This is a convenience wrapper around
     /// [`Self::find_segments_reachable_from_a_not_b()`], taking object ids of commits.
-    /// If `first_parent_only` is true, both traversals follow only first-parent edges.
+    /// If `first_parent` is [`FirstParent::Yes`], both traversals follow only first-parent edges.
     pub fn find_commit_ids_reachable_from_a_not_b(
         &self,
         included: gix::ObjectId,
         excluded: gix::ObjectId,
-        first_parent_only: bool,
+        first_parent: FirstParent,
     ) -> anyhow::Result<Vec<gix::ObjectId>> {
         let included = self.commit_id_to_segment_id(included)?;
         let excluded = self.commit_id_to_segment_id(excluded)?;
         Ok(self
-            .find_segments_reachable_from_a_not_b(included, excluded, first_parent_only)
+            .find_segments_reachable_from_a_not_b(included, excluded, first_parent)
             .into_iter()
             .map(|commit| commit.id)
             .collect())

--- a/crates/but-graph/src/api.rs
+++ b/crates/but-graph/src/api.rs
@@ -233,12 +233,22 @@ impl Graph {
 
         let mut out = Vec::new();
 
-        // Process the priority queue until exhausted, skipping stale entries on pop.
-        while let Some((Reverse(generation), segment_id)) = queue.pop() {
+        // Keep processing while there are potentially useful entries.
+        //
+        // Stale entries still need to propagate their stale marker to their
+        // parents if other non-stale queue entries remain. Once everything left
+        // in the queue is stale, no better merge-base can be found.
+        while queue.iter().any(|(_, segment_id)| {
+            !flags
+                .get(segment_id)
+                .copied()
+                .unwrap_or_default()
+                .contains(SegmentFlags::STALE)
+        }) {
+            let Some((Reverse(generation), segment_id)) = queue.pop() else {
+                break;
+            };
             let segment_flags = flags.get(&segment_id).copied().unwrap_or_default();
-            if segment_flags.contains(SegmentFlags::STALE) {
-                continue;
-            }
 
             let mut flags_without_result = segment_flags
                 & (SegmentFlags::SEGMENT1 | SegmentFlags::SEGMENT2 | SegmentFlags::STALE);

--- a/crates/but-graph/src/api.rs
+++ b/crates/but-graph/src/api.rs
@@ -110,8 +110,8 @@ impl Graph {
         commit_a: gix::ObjectId,
         commit_b: gix::ObjectId,
     ) -> anyhow::Result<SegmentRelation> {
-        let a = self.segment_id_by_id(commit_a)?;
-        let b = self.segment_id_by_id(commit_b)?;
+        let a = self.commit_id_to_segment_id(commit_a)?;
+        let b = self.commit_id_to_segment_id(commit_b)?;
         Ok(self.relation_between(a, b))
     }
 
@@ -145,8 +145,8 @@ impl Graph {
         commit_a: gix::ObjectId,
         commit_b: gix::ObjectId,
     ) -> anyhow::Result<Option<gix::ObjectId>> {
-        let a = self.segment_id_by_id(commit_a)?;
-        let b = self.segment_id_by_id(commit_b)?;
+        let a = self.commit_id_to_segment_id(commit_a)?;
+        let b = self.commit_id_to_segment_id(commit_b)?;
         self.find_merge_base(a, b)
             .map(|base| self.commit_id_for_segment(base))
             .transpose()
@@ -178,7 +178,7 @@ impl Graph {
     ) -> anyhow::Result<Option<gix::ObjectId>> {
         let mut segments = Vec::new();
         for commit_id in commits {
-            segments.push(self.segment_id_by_id(commit_id)?);
+            segments.push(self.commit_id_to_segment_id(commit_id)?);
         }
         self.find_merge_base_octopus(segments)
             .map(|base| self.commit_id_for_segment(base))
@@ -193,7 +193,12 @@ impl Graph {
             })
     }
 
-    fn segment_id_by_id(&self, commit_id: gix::ObjectId) -> anyhow::Result<SegmentIndex> {
+    /// Return the id of the segment that owns `commit_id`, or error if it wasn't found.
+    /// That is unexpected as the traversal is supposed to find all commits of interest.
+    pub fn commit_id_to_segment_id(
+        &self,
+        commit_id: gix::ObjectId,
+    ) -> anyhow::Result<SegmentIndex> {
         self.inner
             .node_weights()
             .find_map(|s| s.commits.iter().any(|c| c.id == commit_id).then_some(s.id))

--- a/crates/but-graph/src/api.rs
+++ b/crates/but-graph/src/api.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp::Reverse,
-    collections::{BTreeSet, BinaryHeap, HashMap, VecDeque},
+    collections::{BTreeSet, BinaryHeap, VecDeque},
     ops::{Deref, Index, IndexMut},
 };
 
@@ -9,7 +9,7 @@ use petgraph::{
     Direction,
     prelude::EdgeRef,
     stable_graph::EdgeReference,
-    visit::{IntoEdgeReferences, Visitable},
+    visit::{IntoEdgeReferences, NodeIndexable, Visitable},
 };
 
 use crate::{
@@ -127,7 +127,7 @@ impl Graph {
             return Some(a);
         }
 
-        let mut flags: HashMap<SegmentIndex, SegmentFlags> = Default::default();
+        let mut flags = SegmentFlagTable::new(self);
         let bases = self.paint_down_to_common(a, b, &mut flags);
 
         if bases.is_empty() {
@@ -214,7 +214,7 @@ impl Graph {
         &self,
         first: SegmentIndex,
         second: SegmentIndex,
-        flags: &mut HashMap<SegmentIndex, SegmentFlags>,
+        flags: &mut SegmentFlagTable,
     ) -> Vec<(SegmentIndex, usize)> {
         // Priority queue ordered by generation (higher generation = closer to root = lower priority).
         // We use Reverse because BinaryHeap is a max-heap and we want segments with *lower* generation
@@ -222,12 +222,12 @@ impl Graph {
         let mut queue: BinaryHeap<(Reverse<usize>, SegmentIndex)> = BinaryHeap::new();
 
         // Initialize first segment
-        let first_flags = flags.entry(first).or_insert(SegmentFlags::empty());
+        let first_flags = flags.get_mut(first);
         *first_flags |= SegmentFlags::SEGMENT1;
         queue.push((Reverse(self[first].generation), first));
 
         // Initialize second segment
-        let second_flags = flags.entry(second).or_insert(SegmentFlags::empty());
+        let second_flags = flags.get_mut(second);
         *second_flags |= SegmentFlags::SEGMENT2;
         queue.push((Reverse(self[second].generation), second));
 
@@ -238,17 +238,14 @@ impl Graph {
         // Stale entries still need to propagate their stale marker to their
         // parents if other non-stale queue entries remain. Once everything left
         // in the queue is stale, no better merge-base can be found.
-        while queue.iter().any(|(_, segment_id)| {
-            !flags
-                .get(segment_id)
-                .copied()
-                .unwrap_or_default()
-                .contains(SegmentFlags::STALE)
-        }) {
+        while queue
+            .iter()
+            .any(|(_, segment_id)| !flags.get(*segment_id).contains(SegmentFlags::STALE))
+        {
             let Some((Reverse(generation), segment_id)) = queue.pop() else {
                 break;
             };
-            let segment_flags = flags.get(&segment_id).copied().unwrap_or_default();
+            let segment_flags = flags.get(segment_id);
 
             let mut flags_without_result = segment_flags
                 & (SegmentFlags::SEGMENT1 | SegmentFlags::SEGMENT2 | SegmentFlags::STALE);
@@ -256,10 +253,7 @@ impl Graph {
             // If reachable from both sides, it's a merge-base candidate
             if flags_without_result == (SegmentFlags::SEGMENT1 | SegmentFlags::SEGMENT2) {
                 if !segment_flags.contains(SegmentFlags::RESULT) {
-                    flags
-                        .entry(segment_id)
-                        .or_default()
-                        .insert(SegmentFlags::RESULT);
+                    flags.get_mut(segment_id).insert(SegmentFlags::RESULT);
                     out.push((segment_id, generation));
                 }
                 flags_without_result |= SegmentFlags::STALE;
@@ -270,7 +264,7 @@ impl Graph {
                 .inner
                 .neighbors_directed(segment_id, Direction::Outgoing)
             {
-                let parent_flags = flags.entry(parent_id).or_insert(SegmentFlags::empty());
+                let parent_flags = flags.get_mut(parent_id);
                 if (*parent_flags & flags_without_result) != flags_without_result {
                     *parent_flags |= flags_without_result;
                     queue.push((Reverse(self[parent_id].generation), parent_id));
@@ -286,7 +280,7 @@ impl Graph {
     fn remove_redundant(
         &self,
         segments: &[(SegmentIndex, usize)],
-        flags: &mut HashMap<SegmentIndex, SegmentFlags>,
+        flags: &mut SegmentFlagTable,
     ) -> Vec<SegmentIndex> {
         if segments.is_empty() {
             return Vec::new();
@@ -309,10 +303,10 @@ impl Graph {
 
         // Mark all input segments with RESULT and collect their parents for walking
         for (sidx, _) in segments {
-            flags.entry(*sidx).or_default().insert(SegmentFlags::RESULT);
+            flags.get_mut(*sidx).insert(SegmentFlags::RESULT);
 
             for parent_id in self.inner.neighbors_directed(*sidx, Direction::Outgoing) {
-                let parent_flags = flags.entry(parent_id).or_insert(SegmentFlags::empty());
+                let parent_flags = flags.get_mut(parent_id);
                 // Prevent double-addition
                 if !parent_flags.contains(SegmentFlags::STALE) {
                     parent_flags.insert(SegmentFlags::STALE);
@@ -325,9 +319,7 @@ impl Graph {
 
         // Allow walking everything at first (remove STALE from walk_start entries)
         for (sidx, _) in &walk_start {
-            if let Some(f) = flags.get_mut(sidx) {
-                f.remove(SegmentFlags::STALE);
-            }
+            flags.get_mut(*sidx).remove(SegmentFlags::STALE);
         }
 
         let mut count_still_independent = segments.len();
@@ -339,19 +331,14 @@ impl Graph {
             }
 
             stack.clear();
-            flags
-                .entry(segment_id)
-                .or_default()
-                .insert(SegmentFlags::STALE);
+            flags.get_mut(segment_id).insert(SegmentFlags::STALE);
             stack.push((segment_id, segment_gen));
 
             while let Some((current_id, current_gen)) = stack.last().copied() {
-                let current_flags = *flags.get(&current_id).unwrap_or(&SegmentFlags::empty());
+                let current_flags = flags.get(current_id);
 
                 if current_flags.contains(SegmentFlags::RESULT) {
-                    if let Some(f) = flags.get_mut(&current_id) {
-                        f.remove(SegmentFlags::RESULT);
-                    }
+                    flags.get_mut(current_id).remove(SegmentFlags::RESULT);
                     count_still_independent -= 1;
 
                     if count_still_independent <= 1 {
@@ -362,8 +349,8 @@ impl Graph {
                     if current_id == sorted_segments[min_gen_pos].0 {
                         while min_gen_pos < segments.len() - 1
                             && flags
-                                .get(&sorted_segments[min_gen_pos].0)
-                                .is_some_and(|f| f.contains(SegmentFlags::STALE))
+                                .get(sorted_segments[min_gen_pos].0)
+                                .contains(SegmentFlags::STALE)
                         {
                             min_gen_pos += 1;
                         }
@@ -383,7 +370,7 @@ impl Graph {
                     .inner
                     .neighbors_directed(current_id, Direction::Outgoing)
                 {
-                    let parent_flags = flags.entry(parent_id).or_insert(SegmentFlags::empty());
+                    let parent_flags = flags.get_mut(parent_id);
                     if !parent_flags.contains(SegmentFlags::STALE) {
                         parent_flags.insert(SegmentFlags::STALE);
                         stack.push((parent_id, self[parent_id].generation));
@@ -400,12 +387,41 @@ impl Graph {
         segments
             .iter()
             .filter_map(|(sidx, _)| {
-                flags
-                    .get(sidx)
-                    .filter(|f| !f.contains(SegmentFlags::STALE))
-                    .map(|_| *sidx)
+                (!flags.get(*sidx).contains(SegmentFlags::STALE)).then_some(*sidx)
             })
             .collect()
+    }
+}
+
+struct SegmentFlagTable {
+    flags: Vec<SegmentFlags>,
+    touched: Vec<SegmentIndex>,
+}
+
+impl SegmentFlagTable {
+    fn new(graph: &Graph) -> Self {
+        SegmentFlagTable {
+            flags: vec![SegmentFlags::empty(); graph.inner.node_bound()],
+            touched: Vec::new(),
+        }
+    }
+
+    fn clear(&mut self) {
+        for sidx in self.touched.drain(..) {
+            self.flags[sidx.index()] = SegmentFlags::empty();
+        }
+    }
+
+    fn get(&self, sidx: SegmentIndex) -> SegmentFlags {
+        self.flags[sidx.index()]
+    }
+
+    fn get_mut(&mut self, sidx: SegmentIndex) -> &mut SegmentFlags {
+        let index = sidx.index();
+        if self.flags[index].is_empty() {
+            self.touched.push(sidx);
+        }
+        &mut self.flags[index]
     }
 }
 

--- a/crates/but-graph/src/api.rs
+++ b/crates/but-graph/src/api.rs
@@ -127,6 +127,24 @@ impl Graph {
         result.first().copied()
     }
 
+    /// Compute an order-dependent octopus merge-base from multiple `segments`.
+    ///
+    /// The first segment becomes the initial candidate. Each following segment is
+    /// folded into that candidate by computing their pairwise
+    /// [`Self::find_git_merge_base()`]. If a pair does not share history, the
+    /// previous candidate is kept and folding continues.
+    ///
+    /// Returns `None` if `segments` is empty, or if no merge-base could be found.
+    /// If `segments` has one element, it returns that.
+    pub fn find_merge_base_octopus(
+        &self,
+        segments: impl IntoIterator<Item = SegmentIndex>,
+    ) -> Option<SegmentIndex> {
+        segments
+            .into_iter()
+            .reduce(|a, b| self.find_git_merge_base(a, b).unwrap_or(a))
+    }
+
     /// Paint segments reachable from `first` with SEGMENT1 and from `second` with SEGMENT2.
     /// When a segment has both flags, it's a potential merge-base.
     /// Returns all potential merge-bases with their generation numbers.

--- a/crates/but-graph/src/api.rs
+++ b/crates/but-graph/src/api.rs
@@ -15,7 +15,7 @@ use petgraph::{
 use crate::{
     Commit, CommitFlags, CommitIndex, Edge, EntryPoint, EntryPointCommit, Graph, Segment,
     SegmentFlags, SegmentIndex, SegmentRelation, StopCondition, init::PetGraph,
-    projection::commit::is_managed_workspace_by_message,
+    projection::commit::is_managed_workspace_by_message, utils::SegmentTable,
 };
 
 /// Mutation
@@ -127,7 +127,7 @@ impl Graph {
             return Some(a);
         }
 
-        let mut flags = SegmentFlagTable::new(self);
+        let mut flags = SegmentTable::new(self.inner.node_bound(), SegmentFlags::empty());
         let bases = self.paint_down_to_common(a, b, &mut flags);
 
         if bases.is_empty() {
@@ -214,7 +214,7 @@ impl Graph {
         &self,
         first: SegmentIndex,
         second: SegmentIndex,
-        flags: &mut SegmentFlagTable,
+        flags: &mut SegmentTable<SegmentFlags>,
     ) -> Vec<(SegmentIndex, usize)> {
         // Priority queue ordered by generation (higher generation = closer to root = lower priority).
         // We use Reverse because BinaryHeap is a max-heap and we want segments with *lower* generation
@@ -280,7 +280,7 @@ impl Graph {
     fn remove_redundant(
         &self,
         segments: &[(SegmentIndex, usize)],
-        flags: &mut SegmentFlagTable,
+        flags: &mut SegmentTable<SegmentFlags>,
     ) -> Vec<SegmentIndex> {
         if segments.is_empty() {
             return Vec::new();
@@ -390,38 +390,6 @@ impl Graph {
                 (!flags.get(*sidx).contains(SegmentFlags::STALE)).then_some(*sidx)
             })
             .collect()
-    }
-}
-
-struct SegmentFlagTable {
-    flags: Vec<SegmentFlags>,
-    touched: Vec<SegmentIndex>,
-}
-
-impl SegmentFlagTable {
-    fn new(graph: &Graph) -> Self {
-        SegmentFlagTable {
-            flags: vec![SegmentFlags::empty(); graph.inner.node_bound()],
-            touched: Vec::new(),
-        }
-    }
-
-    fn clear(&mut self) {
-        for sidx in self.touched.drain(..) {
-            self.flags[sidx.index()] = SegmentFlags::empty();
-        }
-    }
-
-    fn get(&self, sidx: SegmentIndex) -> SegmentFlags {
-        self.flags[sidx.index()]
-    }
-
-    fn get_mut(&mut self, sidx: SegmentIndex) -> &mut SegmentFlags {
-        let index = sidx.index();
-        if self.flags[index].is_empty() {
-            self.touched.push(sidx);
-        }
-        &mut self.flags[index]
     }
 }
 
@@ -700,13 +668,14 @@ impl Graph {
     ) {
         let mut next = VecDeque::new();
         next.push_back(start);
-        let mut seen = BTreeSet::new();
+        let mut seen = SegmentTable::new(self.inner.node_bound(), false);
+        seen.set(start, true);
         while let Some(next_sidx) = next.pop_front() {
             if !visit_and_prune(&self[next_sidx]) {
                 next.extend(
                     self.inner
                         .neighbors_directed(next_sidx, direction)
-                        .filter(|n| seen.insert(*n)),
+                        .filter(|n| seen.set_if_empty(*n, true)),
                 )
             }
         }
@@ -723,13 +692,14 @@ impl Graph {
     ) {
         let mut next = VecDeque::new();
         next.push_back(start);
-        let mut seen = BTreeSet::new();
+        let mut seen = SegmentTable::new(self.inner.node_bound(), false);
+        seen.set(start, true);
         while let Some(next_sidx) = next.pop_front() {
             if start == next_sidx || !visit_and_prune(&self[next_sidx]) {
                 next.extend(
                     self.inner
                         .neighbors_directed(next_sidx, direction)
-                        .filter(|n| seen.insert(*n)),
+                        .filter(|n| seen.set_if_empty(*n, true)),
                 )
             }
         }

--- a/crates/but-graph/src/api.rs
+++ b/crates/but-graph/src/api.rs
@@ -96,12 +96,23 @@ impl Graph {
             return SegmentRelation::Identity;
         }
 
-        match self.find_git_merge_base(a, b) {
+        match self.find_merge_base(a, b) {
             Some(base) if base == a => SegmentRelation::Ancestor,
             Some(base) if base == b => SegmentRelation::Descendant,
             Some(_) => SegmentRelation::Diverged,
             None => SegmentRelation::Disjoint,
         }
+    }
+
+    /// Like [`Self::relation_between()`], but takes object ids of commits.
+    pub fn relation_between_by_commit_id(
+        &self,
+        commit_a: gix::ObjectId,
+        commit_b: gix::ObjectId,
+    ) -> anyhow::Result<SegmentRelation> {
+        let a = self.segment_id_by_id(commit_a)?;
+        let b = self.segment_id_by_id(commit_b)?;
+        Ok(self.relation_between(a, b))
     }
 
     /// Compute the merge-base just like Git would between segments `a` and `b`, but finding all possible merge-bases of a walk,
@@ -111,7 +122,7 @@ impl Graph {
     ///
     /// Returns `None` if there is no merge-base as `a` and `b` don't share history.
     /// If `a == b`, `Some(a)` is returned immediately.
-    pub fn find_git_merge_base(&self, a: SegmentIndex, b: SegmentIndex) -> Option<SegmentIndex> {
+    pub fn find_merge_base(&self, a: SegmentIndex, b: SegmentIndex) -> Option<SegmentIndex> {
         if a == b {
             return Some(a);
         }
@@ -127,14 +138,28 @@ impl Graph {
         result.first().copied()
     }
 
+    /// Like [`Self::find_merge_base()`], but takes object ids of commits,
+    /// returning the id of the commit that is the merge-base.
+    pub fn find_merge_base_by_commit_id(
+        &self,
+        commit_a: gix::ObjectId,
+        commit_b: gix::ObjectId,
+    ) -> anyhow::Result<Option<gix::ObjectId>> {
+        let a = self.segment_id_by_id(commit_a)?;
+        let b = self.segment_id_by_id(commit_b)?;
+        self.find_merge_base(a, b)
+            .map(|base| self.commit_id_for_segment(base))
+            .transpose()
+    }
+
     /// Compute an order-dependent octopus merge-base from multiple `segments`.
     ///
     /// The first segment becomes the initial candidate. Each following segment is
     /// folded into that candidate by computing their pairwise
-    /// [`Self::find_git_merge_base()`]. If a pair does not share history, the
+    /// [`Self::find_merge_base()`]. If a pair does not share history, the
     /// previous candidate is kept and folding continues.
     ///
-    /// Returns `None` if `segments` is empty, or if no merge-base could be found.
+    /// Returns `None` if `segments` is empty.
     /// If `segments` has one element, it returns that.
     pub fn find_merge_base_octopus(
         &self,
@@ -142,7 +167,39 @@ impl Graph {
     ) -> Option<SegmentIndex> {
         segments
             .into_iter()
-            .reduce(|a, b| self.find_git_merge_base(a, b).unwrap_or(a))
+            .reduce(|a, b| self.find_merge_base(a, b).unwrap_or(a))
+    }
+
+    /// Like [`Self::find_merge_base_octopus()`], but works with object ids of `commits`,
+    /// returning the id of the commit that is the merge-base.
+    pub fn find_merge_base_octopus_by_commit_id(
+        &self,
+        commits: impl IntoIterator<Item = gix::ObjectId>,
+    ) -> anyhow::Result<Option<gix::ObjectId>> {
+        let mut segments = Vec::new();
+        for commit_id in commits {
+            segments.push(self.segment_id_by_id(commit_id)?);
+        }
+        self.find_merge_base_octopus(segments)
+            .map(|base| self.commit_id_for_segment(base))
+            .transpose()
+    }
+
+    fn commit_id_for_segment(&self, segment: SegmentIndex) -> anyhow::Result<gix::ObjectId> {
+        self.tip_skip_empty(segment)
+            .map(|commit| commit.id)
+            .with_context(|| {
+                format!("BUG: Segment {segment:?} does not contain a reachable tip commit")
+            })
+    }
+
+    fn segment_id_by_id(&self, commit_id: gix::ObjectId) -> anyhow::Result<SegmentIndex> {
+        self.inner
+            .node_weights()
+            .find_map(|s| s.commits.iter().any(|c| c.id == commit_id).then_some(s.id))
+            .with_context(|| {
+                format!("Commit {commit_id} not found in any segment, it wasn't traversed")
+            })
     }
 
     /// Paint segments reachable from `first` with SEGMENT1 and from `second` with SEGMENT2.

--- a/crates/but-graph/src/api.rs
+++ b/crates/but-graph/src/api.rs
@@ -162,10 +162,14 @@ impl Graph {
     /// global topo-order across commits. It walks segments by their graph generation,
     /// emits each segment's commits in stored tip-to-base order, and lazily paints the
     /// excluded side only as far as needed to prove emitted segments are not hidden.
+    ///
+    /// If `first_parent_only` is true, both the included and excluded traversals follow
+    /// only segment edges with `parent_order == 0`.
     pub fn find_segments_reachable_from_a_not_b(
         &self,
         included: SegmentIndex,
         excluded: SegmentIndex,
+        first_parent_only: bool,
     ) -> Vec<&Commit> {
         let mut flags = SegmentTable::new(self.inner.node_bound(), SegmentFlags::empty());
         let mut queue = BinaryHeap::new();
@@ -189,11 +193,9 @@ impl Graph {
         let mut max_emitted_generation = None;
         while let Some((_, _, is_excluded, segment_id)) = queue.pop() {
             if is_excluded {
-                for parent_id in self
-                    .inner
-                    .edges_directed(segment_id, Direction::Outgoing)
-                    .map(|edge| edge.target())
-                {
+                let parent_ids =
+                    self.parent_segments_for_reachable_difference(segment_id, first_parent_only);
+                for parent_id in parent_ids {
                     self.queue_segment_for_reachable_difference(
                         parent_id,
                         true,
@@ -220,11 +222,9 @@ impl Graph {
             max_emitted_generation =
                 Some(max_emitted_generation.map_or(generation, |max| max.max(generation)));
             segments.push(segment_id);
-            for parent_id in self
-                .inner
-                .edges_directed(segment_id, Direction::Outgoing)
-                .map(|edge| edge.target())
-            {
+            let parent_ids =
+                self.parent_segments_for_reachable_difference(segment_id, first_parent_only);
+            for parent_id in parent_ids {
                 self.queue_segment_for_reachable_difference(
                     parent_id,
                     false,
@@ -280,6 +280,21 @@ impl Graph {
         *sequence += 1;
     }
 
+    /// Return the parent segments that should be traversed from `segment_id`.
+    ///
+    /// In all-parent mode this returns every outgoing segment edge. In first-parent mode it
+    /// returns only edges whose destination is the source commit's first parent.
+    fn parent_segments_for_reachable_difference(
+        &self,
+        segment_id: SegmentIndex,
+        first_parent_only: bool,
+    ) -> impl Iterator<Item = SegmentIndex> {
+        self.inner
+            .edges_directed(segment_id, Direction::Outgoing)
+            .filter(move |edge| !first_parent_only || edge.weight().parent_order == 0)
+            .map(|edge| edge.target())
+    }
+
     /// Return `true` once the excluded-side frontier cannot still hide any segment already emitted.
     ///
     /// Segment generations are topological: edges point from lower generations toward higher
@@ -319,15 +334,17 @@ impl Graph {
     ///
     /// This is a convenience wrapper around
     /// [`Self::find_segments_reachable_from_a_not_b()`], taking object ids of commits.
+    /// If `first_parent_only` is true, both traversals follow only first-parent edges.
     pub fn find_commit_ids_reachable_from_a_not_b(
         &self,
         included: gix::ObjectId,
         excluded: gix::ObjectId,
+        first_parent_only: bool,
     ) -> anyhow::Result<Vec<gix::ObjectId>> {
         let included = self.commit_id_to_segment_id(included)?;
         let excluded = self.commit_id_to_segment_id(excluded)?;
         Ok(self
-            .find_segments_reachable_from_a_not_b(included, excluded)
+            .find_segments_reachable_from_a_not_b(included, excluded, first_parent_only)
             .into_iter()
             .map(|commit| commit.id)
             .collect())

--- a/crates/but-graph/src/api.rs
+++ b/crates/but-graph/src/api.rs
@@ -350,12 +350,12 @@ impl Graph {
             .collect())
     }
 
-    /// Compute an order-dependent octopus merge-base from multiple `segments`.
+    /// Compute an octopus merge-base from multiple `segments`.
     ///
     /// The first segment becomes the initial candidate. Each following segment is
     /// folded into that candidate by computing their pairwise
-    /// [`Self::find_merge_base()`]. If a pair does not share history, the
-    /// previous candidate is kept and folding continues.
+    /// [`Self::find_merge_base()`]. If any pair does not share history, there
+    /// is no merge-base common to all segments.
     ///
     /// Returns `None` if `segments` is empty.
     /// If `segments` has one element, it returns that.
@@ -363,9 +363,9 @@ impl Graph {
         &self,
         segments: impl IntoIterator<Item = SegmentIndex>,
     ) -> Option<SegmentIndex> {
-        segments
-            .into_iter()
-            .reduce(|a, b| self.find_merge_base(a, b).unwrap_or(a))
+        let mut segments = segments.into_iter();
+        let first = segments.next()?;
+        segments.try_fold(first, |base, segment| self.find_merge_base(base, segment))
     }
 
     /// Like [`Self::find_merge_base_octopus()`], but works with object ids of `commits`,

--- a/crates/but-graph/src/api.rs
+++ b/crates/but-graph/src/api.rs
@@ -152,6 +152,71 @@ impl Graph {
             .transpose()
     }
 
+    /// Return all commits reachable from `included`, but not reachable from `excluded`.
+    ///
+    /// This is equivalent to the reachable set of `excluded..included`, with segment ids
+    /// instead of rev-specs. The returned commits follow the graph traversal order from
+    /// `included` towards history.
+    ///
+    /// Unlike Git's revision walk, this does not sort pending commits by date or enforce
+    /// global topo-order across segments: it uses FIFO segment traversal and emits each
+    /// segment's commits in their stored tip-to-base order.
+    ///
+    /// It also eagerly marks all segments reachable from `excluded` before walking `included`,
+    /// which can visit more of the excluded side than Git would for small reachable differences.
+    pub fn find_commits_reachable_from_a_not_b(
+        &self,
+        included: SegmentIndex,
+        excluded: SegmentIndex,
+    ) -> Vec<&Commit> {
+        let mut flags = SegmentTable::new(self.inner.node_bound(), SegmentFlags::empty());
+        self.paint_down_to_reachable_eagerly(excluded, SegmentFlags::SEGMENT2, &mut flags);
+
+        let mut queue = VecDeque::new();
+        queue.push_back(included);
+
+        let mut commits = Vec::new();
+        while let Some(segment_id) = queue.pop_front() {
+            let segment_flags = flags.get_mut(segment_id);
+            if segment_flags.contains(SegmentFlags::SEGMENT1) {
+                continue;
+            }
+            segment_flags.insert(SegmentFlags::SEGMENT1);
+
+            if segment_flags.contains(SegmentFlags::SEGMENT2) {
+                continue;
+            }
+
+            let segment = &self[segment_id];
+            commits.extend(segment.commits.iter());
+            queue.extend(
+                self.inner
+                    .edges_directed(segment_id, Direction::Outgoing)
+                    .map(|edge| edge.target()),
+            );
+        }
+
+        commits
+    }
+
+    /// Return all commit ids reachable from `included`, but not reachable from `excluded`.
+    ///
+    /// This is a convenience wrapper around
+    /// [`Self::find_commits_reachable_from_a_not_b()`], taking object ids of commits.
+    pub fn find_commit_ids_from_a_not_b(
+        &self,
+        included: gix::ObjectId,
+        excluded: gix::ObjectId,
+    ) -> anyhow::Result<Vec<gix::ObjectId>> {
+        let included = self.commit_id_to_segment_id(included)?;
+        let excluded = self.commit_id_to_segment_id(excluded)?;
+        Ok(self
+            .find_commits_reachable_from_a_not_b(included, excluded)
+            .into_iter()
+            .map(|commit| commit.id)
+            .collect())
+    }
+
     /// Compute an order-dependent octopus merge-base from multiple `segments`.
     ///
     /// The first segment becomes the initial candidate. Each following segment is
@@ -273,6 +338,31 @@ impl Graph {
         }
 
         out
+    }
+
+    /// Paint every segment reachable from `start` with `flag`.
+    fn paint_down_to_reachable_eagerly(
+        &self,
+        start: SegmentIndex,
+        flag: SegmentFlags,
+        flags: &mut SegmentTable<SegmentFlags>,
+    ) {
+        let mut queue = VecDeque::new();
+        flags.get_mut(start).insert(flag);
+        queue.push_back(start);
+
+        while let Some(segment_id) = queue.pop_front() {
+            for parent_id in self
+                .inner
+                .neighbors_directed(segment_id, Direction::Outgoing)
+            {
+                let parent_flags = flags.get_mut(parent_id);
+                if !parent_flags.contains(flag) {
+                    parent_flags.insert(flag);
+                    queue.push_back(parent_id);
+                }
+            }
+        }
     }
 
     /// Remove all those segments from `segments` if they are in the history of another segment in `segments`.

--- a/crates/but-graph/src/init/overlay.rs
+++ b/crates/but-graph/src/init/overlay.rs
@@ -1,6 +1,6 @@
 use std::{
     borrow::Cow,
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
 };
 
 use anyhow::bail;
@@ -256,7 +256,7 @@ impl<'repo> OverlayRepo<'repo> {
         prefixes: impl Iterator<Item = &'a str>,
         workspace_ref_names: &[&gix::refs::FullNameRef],
     ) -> anyhow::Result<RefsById> {
-        let mut seen = BTreeSet::new();
+        let mut seen = HashSet::new();
         let mut ref_filter =
             |r: gix::Reference<'_>| -> Option<(gix::ObjectId, gix::refs::FullName)> {
                 if self.dropped_references.contains(r.name()) {

--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -20,6 +20,7 @@ use crate::{
         walk::{RefsById, WorktreeByBranch, disambiguate_refs_by_branch_metadata},
     },
     projection::workspace,
+    utils::SegmentVisitScratch,
 };
 
 pub(super) struct Context<'a> {
@@ -112,18 +113,27 @@ impl Graph {
     /// `parent_order`. Petgraph traverses edges in reverse creation order, so
     /// edges are re-added from last parent to first parent.
     fn rebuild_edges_in_parent_order(&mut self) {
+        let mut outgoing_edges = Vec::with_capacity(2);
         for sidx in self.segments().collect::<Vec<_>>() {
-            let mut outgoing_edges: Vec<_> = self
-                .inner
-                .edges_directed(sidx, Direction::Outgoing)
-                .map(EdgeOwned::from)
-                .collect();
+            let mut edges = self.inner.edges_directed(sidx, Direction::Outgoing);
+            let Some(first_edge) = edges.next() else {
+                continue;
+            };
+            let Some(second_edge) = edges.next() else {
+                continue;
+            };
+
+            outgoing_edges.clear();
+            outgoing_edges.push(EdgeOwned::from(first_edge));
+            outgoing_edges.push(EdgeOwned::from(second_edge));
+            outgoing_edges.extend(edges.map(EdgeOwned::from));
+
             outgoing_edges.sort_by_key(|e| std::cmp::Reverse(e.weight.parent_order));
 
             for edge in &outgoing_edges {
                 self.inner.remove_edge(edge.id);
             }
-            for edge in outgoing_edges {
+            for edge in &outgoing_edges {
                 self.inner.add_edge(edge.source, edge.target, edge.weight);
             }
         }
@@ -910,6 +920,7 @@ impl Graph {
                     .flat_map(|s| s.commits_by_segment.iter().map(|(sidx, _)| *sidx))
             })
             .collect();
+        let mut segment_visit_scratch = SegmentVisitScratch::new(self);
         for &sidx in &unique_ws_segment_ids {
             // The workspace might be stale by now as we delete empty segments.
             // Thus, be careful, and ignore non-existing ones - after all our workspace
@@ -931,25 +942,30 @@ impl Graph {
             }
 
             let mut named_segment_id = None;
-            self.visit_all_segments_excluding_start_until(sidx, Direction::Incoming, |s| {
-                let prune = true;
-                if named_segment_id.is_some()
-                    || s.commits
-                        .first()
-                        .is_some_and(|c| c.flags.contains(CommitFlags::InWorkspace))
-                {
-                    return prune;
-                }
-
-                s.ref_info.as_ref().is_some_and(|ri| {
-                    let is_known_to_workspace =
-                        ws_data.contains_ref(ri.ref_name.as_ref(), AppliedAndUnapplied);
-                    if is_known_to_workspace {
-                        named_segment_id = Some(s.id);
+            segment_visit_scratch.visit_excluding_start_until(
+                self,
+                sidx,
+                Direction::Incoming,
+                |s| {
+                    let prune = true;
+                    if named_segment_id.is_some()
+                        || s.commits
+                            .first()
+                            .is_some_and(|c| c.flags.contains(CommitFlags::InWorkspace))
+                    {
+                        return prune;
                     }
-                    is_known_to_workspace
-                })
-            });
+
+                    s.ref_info.as_ref().is_some_and(|ri| {
+                        let is_known_to_workspace =
+                            ws_data.contains_ref(ri.ref_name.as_ref(), AppliedAndUnapplied);
+                        if is_known_to_workspace {
+                            named_segment_id = Some(s.id);
+                        }
+                        is_known_to_workspace
+                    })
+                },
+            );
             if let Some(named_sid) = named_segment_id
                 && self[sidx].sibling_segment_id.is_none()
             {
@@ -973,7 +989,8 @@ impl Graph {
                         .any(|n| n == named_sid);
                     let named_direct_parent_has_outside_commits = named_is_direct_parent && {
                         let mut has_outside_commits = false;
-                        self.visit_all_segments_including_start_until(
+                        segment_visit_scratch.visit_including_start_until(
+                            self,
                             named_sid,
                             Direction::Outgoing,
                             |segment| {

--- a/crates/but-graph/src/init/types.rs
+++ b/crates/but-graph/src/init/types.rs
@@ -165,6 +165,7 @@ impl Queue {
             inner: Default::default(),
             count: 0,
             max: limit,
+            sorted: false,
         }
     }
 }
@@ -177,6 +178,8 @@ pub struct Queue {
     count: usize,
     /// The maximum number of queuing operations, each representing one commit.
     max: Option<usize>,
+    /// Whether new items must maintain `inner` in traversal order.
+    sorted: bool,
 }
 
 /// Counted queuing
@@ -190,19 +193,37 @@ impl Queue {
     /// propagation bottleneck. This is true Particularly if a commit-graph exists which typically is the case
     /// where this starts to matter, as it speeds up traversal by factor 8 easily.
     pub fn sort(&mut self) {
-        self.inner
-            .make_contiguous()
-            .sort_by(|a, b| a.0.gen_then_time.cmp(&b.0.gen_then_time));
+        if !self.sorted {
+            self.inner
+                .make_contiguous()
+                .sort_by(|a, b| a.0.gen_then_time.cmp(&b.0.gen_then_time));
+            self.sorted = true;
+        }
     }
     #[must_use]
     pub fn push_back_exhausted(&mut self, item: QueueItem) -> bool {
-        self.inner.push_back(item);
+        if self.sorted {
+            self.insert_sorted(item);
+        } else {
+            self.inner.push_back(item);
+        }
         self.is_exhausted_after_increment()
     }
     #[must_use]
     pub fn push_front_exhausted(&mut self, item: QueueItem) -> bool {
-        self.inner.push_front(item);
+        if self.sorted {
+            self.insert_sorted(item);
+        } else {
+            self.inner.push_front(item);
+        }
         self.is_exhausted_after_increment()
+    }
+
+    fn insert_sorted(&mut self, item: QueueItem) {
+        let index = self
+            .inner
+            .partition_point(|existing| existing.0.gen_then_time <= item.0.gen_then_time);
+        self.inner.insert(index, item);
     }
 
     fn is_exhausted_after_increment(&mut self) -> bool {

--- a/crates/but-graph/src/lib.rs
+++ b/crates/but-graph/src/lib.rs
@@ -206,6 +206,7 @@ pub use segment::{
 };
 
 mod api;
+pub use api::FirstParent;
 /// Produce a graph from a Git repository.
 pub mod init;
 pub mod projection;

--- a/crates/but-graph/src/lib.rs
+++ b/crates/but-graph/src/lib.rs
@@ -209,6 +209,7 @@ mod api;
 /// Produce a graph from a Git repository.
 pub mod init;
 pub mod projection;
+mod utils;
 
 mod statistics;
 pub use statistics::Statistics;

--- a/crates/but-graph/src/projection/workspace/api.rs
+++ b/crates/but-graph/src/projection/workspace/api.rs
@@ -205,7 +205,7 @@ impl Workspace {
 
         let merge_base_segment_index = self
             .graph
-            .find_git_merge_base(commit_segment_index, target_segment_index)?;
+            .find_merge_base(commit_segment_index, target_segment_index)?;
 
         self.graph
             .tip_skip_empty(merge_base_segment_index)

--- a/crates/but-graph/src/projection/workspace/init.rs
+++ b/crates/but-graph/src/projection/workspace/init.rs
@@ -48,7 +48,7 @@ impl Graph {
     /// Typically, that's a previous location of the target segment.
     #[instrument(
         name = "Graph::into_workspace",
-        level = "debug",
+        level = "trace",
         skip(self),
         err(Debug)
     )]

--- a/crates/but-graph/src/projection/workspace/init.rs
+++ b/crates/but-graph/src/projection/workspace/init.rs
@@ -145,10 +145,11 @@ impl Graph {
                 {
                     None
                 } else {
-                    self.inner
-                        .neighbors_directed(ws_tip_segment.id, Direction::Outgoing)
-                        .reduce(|a, b| self.find_git_merge_base(a, b).unwrap_or(a))
-                        .and_then(|base| self[base].commits.first().map(|c| (c.id, base)))
+                    self.find_merge_base_octopus(
+                        self.inner
+                            .neighbors_directed(ws_tip_segment.id, Direction::Outgoing),
+                    )
+                    .and_then(|base| self[base].commits.first().map(|c| (c.id, base)))
                 }
             })
         } else {
@@ -406,9 +407,7 @@ impl Graph {
             .chain(target_commit.map(|t| t.segment_index))
             .chain(additional);
 
-        let base = all_segments
-            .inspect(|_| count += 1)
-            .reduce(|a, b| self.find_git_merge_base(a, b).unwrap_or(a))?;
+        let base = self.find_merge_base_octopus(all_segments.inspect(|_| count += 1))?;
 
         if count < 2 || base == actual_tip {
             match tip {

--- a/crates/but-graph/src/projection/workspace/init.rs
+++ b/crates/but-graph/src/projection/workspace/init.rs
@@ -145,7 +145,7 @@ impl Graph {
                 {
                     None
                 } else {
-                    self.find_merge_base_octopus(
+                    self.find_best_effort_workspace_base(
                         self.inner
                             .neighbors_directed(ws_tip_segment.id, Direction::Outgoing),
                     )
@@ -378,7 +378,10 @@ impl Graph {
     ///
     /// ## Note
     ///
-    /// This is a **merge-base octopus** effectively, and works without generation numbers.
+    /// This is a best-effort merge-base fold for workspace lower-bound compatibility.
+    ///
+    /// It does not use generation numbers to select a globally lowest base across all candidates;
+    /// it preserves the legacy pairwise fold behavior instead.
     // TODO: actually compute the lowest base, see `first_merge_base()` which should be `lowest_merge_base()` by itself,
     //       accounting for finding the lowest of all merge-bases which would be assumed to be reachable by all segments
     //       searching downward, a necessary trait for many search problems.
@@ -407,7 +410,7 @@ impl Graph {
             .chain(target_commit.map(|t| t.segment_index))
             .chain(additional);
 
-        let base = self.find_merge_base_octopus(all_segments.inspect(|_| count += 1))?;
+        let base = self.find_best_effort_workspace_base(all_segments.inspect(|_| count += 1))?;
 
         if count < 2 || base == actual_tip {
             match tip {
@@ -427,6 +430,21 @@ impl Graph {
             self.first_commit_or_find_along_first_parent(base)
                 .map(|(c, sidx)| (c.id, sidx))
         }
+    }
+
+    /// Fold pairwise merge-bases for workspace lower-bound projection.
+    ///
+    /// A workspace lower-bound is used to frame legacy presentation and mutation compatibility.
+    /// Historically, disjoint inputs kept the previous candidate instead of clearing the lower
+    /// bound, so keep that behavior local to workspace projection rather than weakening
+    ///[`Self::find_merge_base_octopus()`].
+    fn find_best_effort_workspace_base(
+        &self,
+        segments: impl IntoIterator<Item = SegmentIndex>,
+    ) -> Option<SegmentIndex> {
+        segments
+            .into_iter()
+            .reduce(|base, segment| self.find_merge_base(base, segment).unwrap_or(base))
     }
 }
 

--- a/crates/but-graph/src/utils.rs
+++ b/crates/but-graph/src/utils.rs
@@ -1,0 +1,226 @@
+use std::collections::VecDeque;
+
+use petgraph::{Direction, visit::NodeIndexable};
+
+use crate::{Graph, Segment, SegmentIndex};
+
+/// Scratch storage keyed directly by [`SegmentIndex`].
+///
+/// Segment indices are dense `petgraph::NodeIndex` values while a graph is alive,
+/// so a vector indexed by `SegmentIndex::index()` is a perfect lookup table and
+/// avoids hash-map overhead in hot graph algorithms. This table is fixed-size:
+/// create it after the graph shape is known and use it only while no newly
+/// inserted segment can be addressed through it.
+///
+/// Instead of clearing the whole vector between phases, it remembers which slots
+/// changed away from `empty` and resets only those slots. This keeps reuse cheap
+/// for walks that touch a small part of a large graph.
+pub(crate) struct SegmentTable<T> {
+    values: Vec<T>,
+    touched: Vec<SegmentIndex>,
+    empty: T,
+}
+
+impl<T: Copy + PartialEq> SegmentTable<T> {
+    /// Create a fixed-size table with one slot for every segment index currently
+    /// representable by `node_bound`.
+    pub(crate) fn new(node_bound: usize, empty: T) -> Self {
+        SegmentTable {
+            values: vec![empty; node_bound],
+            touched: Vec::new(),
+            empty,
+        }
+    }
+
+    /// Reset all slots touched since the last clear back to the `empty` value.
+    pub(crate) fn clear(&mut self) {
+        for sidx in self.touched.drain(..) {
+            self.values[sidx.index()] = self.empty;
+        }
+    }
+
+    /// Return the value stored for `sidx`.
+    pub(crate) fn get(&self, sidx: SegmentIndex) -> T {
+        self.values[sidx.index()]
+    }
+
+    /// Return a mutable slot for `sidx`, marking it for later clearing if it is
+    /// currently `empty`.
+    pub(crate) fn get_mut(&mut self, sidx: SegmentIndex) -> &mut T {
+        let index = sidx.index();
+        if self.values[index] == self.empty {
+            self.touched.push(sidx);
+        }
+        &mut self.values[index]
+    }
+
+    /// Set `sidx` to `value`.
+    ///
+    /// Use this when the caller already knows the slot is empty or doesn't need
+    /// to know whether it changed.
+    pub(crate) fn set(&mut self, sidx: SegmentIndex, value: T) {
+        let index = sidx.index();
+        if self.values[index] == self.empty {
+            self.touched.push(sidx);
+        }
+        self.values[index] = value;
+    }
+
+    /// Set `sidx` to `value` only if it is still `empty`.
+    ///
+    /// Returns `true` if the slot changed. This is useful for visited sets.
+    pub(crate) fn set_if_empty(&mut self, sidx: SegmentIndex, value: T) -> bool {
+        let index = sidx.index();
+        if self.values[index] != self.empty {
+            return false;
+        }
+        self.touched.push(sidx);
+        self.values[index] = value;
+        true
+    }
+}
+
+/// A [`SegmentTable`] that can accommodate segments inserted after construction.
+///
+/// Most algorithms should prefer [`SegmentTable`] because fixed-size direct
+/// indexing makes invalid usage obvious. This wrapper is for longer-lived
+/// scratch state in post-processing, where the graph may grow while the scratch
+/// table is still reused. It preserves the same touched-slot clearing behavior,
+/// but grows before accessing an out-of-range segment index.
+pub(crate) struct GrowingSegmentTable<T> {
+    inner: SegmentTable<T>,
+}
+
+impl<T: Copy + PartialEq> GrowingSegmentTable<T> {
+    /// Create a growable table initially sized for the current graph `node_bound`.
+    pub(crate) fn new(node_bound: usize, empty: T) -> Self {
+        GrowingSegmentTable {
+            inner: SegmentTable::new(node_bound, empty),
+        }
+    }
+
+    /// Reset all touched slots back to the `empty` value.
+    pub(crate) fn clear(&mut self) {
+        self.inner.clear();
+    }
+
+    /// Set `sidx` to `value`, growing first if necessary.
+    pub(crate) fn set(&mut self, sidx: SegmentIndex, value: T) {
+        self.ensure_index(sidx);
+        self.inner.set(sidx, value);
+    }
+
+    /// Set `sidx` to `value` only if it is still `empty`, growing first if
+    /// necessary.
+    pub(crate) fn set_if_empty(&mut self, sidx: SegmentIndex, value: T) -> bool {
+        self.ensure_index(sidx);
+        self.inner.set_if_empty(sidx, value)
+    }
+
+    /// Ensure `sidx` is addressable by the wrapped table.
+    fn ensure_index(&mut self, sidx: SegmentIndex) {
+        let index = sidx.index();
+        if index >= self.inner.values.len() {
+            self.inner.values.resize(index + 1, self.inner.empty);
+        }
+    }
+}
+
+/// Reusable scratch state for repeated segment graph walks during post-processing.
+///
+/// Workspace post-processing may run many short traversals while also inserting
+/// new segments into the graph. Reusing the queue and visited table avoids
+/// allocating a fresh visited set for every walk, and the growable table keeps
+/// the scratch state valid if post-processing creates segment indices that did
+/// not exist when the scratch state was created.
+pub(crate) struct SegmentVisitScratch {
+    seen: GrowingSegmentTable<bool>,
+    next: VecDeque<SegmentIndex>,
+}
+
+impl SegmentVisitScratch {
+    /// Create scratch storage initially sized for the current graph.
+    pub(crate) fn new(graph: &Graph) -> Self {
+        SegmentVisitScratch {
+            seen: GrowingSegmentTable::new(graph.inner.node_bound(), false),
+            next: VecDeque::new(),
+        }
+    }
+
+    /// Visit `start` and all reachable segments in `graph` until `visit_and_prune` returns
+    /// `true` for a segment.
+    ///
+    /// `visit_and_prune` receives each visited segment. Returning `true` stops
+    /// traversal through that segment, pruning its parents or children depending
+    /// on `direction`; returning `false` continues traversal through its
+    /// neighbors.
+    pub(crate) fn visit_including_start_until(
+        &mut self,
+        graph: &Graph,
+        start: SegmentIndex,
+        direction: Direction,
+        mut visit_and_prune: impl FnMut(&Segment) -> bool,
+    ) {
+        self.visit_until(graph, start, direction, true, &mut visit_and_prune);
+    }
+
+    /// Visit all reachable segments in `graph` below or above `start`, excluding `start`
+    /// from the callback.
+    ///
+    /// `visit_and_prune` receives each visited segment except `start`.
+    /// Returning `true` stops traversal through that segment, pruning its
+    /// parents or children depending on `direction`; returning `false`
+    /// continues traversal through its neighbors.
+    ///
+    /// `start` is still marked as seen so it cannot be requeued through a cycle
+    /// or cross-edge.
+    pub(crate) fn visit_excluding_start_until(
+        &mut self,
+        graph: &Graph,
+        start: SegmentIndex,
+        direction: Direction,
+        mut visit_and_prune: impl FnMut(&Segment) -> bool,
+    ) {
+        self.visit_until(graph, start, direction, false, &mut visit_and_prune);
+    }
+
+    /// Shared breadth-first traversal implementation.
+    fn visit_until(
+        &mut self,
+        graph: &Graph,
+        start: SegmentIndex,
+        direction: Direction,
+        include_start: bool,
+        visit_and_prune: &mut impl FnMut(&Segment) -> bool,
+    ) {
+        self.reset();
+        self.mark_known_unseen(start);
+        self.next.push_back(start);
+
+        while let Some(next_sidx) = self.next.pop_front() {
+            if (!include_start && start == next_sidx) || !visit_and_prune(&graph[next_sidx]) {
+                for neighbor in graph.inner.neighbors_directed(next_sidx, direction) {
+                    if self.mark(neighbor) {
+                        self.next.push_back(neighbor);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Clear only the state touched by the previous walk.
+    fn reset(&mut self) {
+        self.next.clear();
+        self.seen.clear();
+    }
+
+    /// Mark `sidx` if it hasn't been seen in the current walk.
+    fn mark(&mut self, sidx: SegmentIndex) -> bool {
+        self.seen.set_if_empty(sidx, true)
+    }
+
+    /// Mark `sidx` when the caller already knows it hasn't been seen.
+    fn mark_known_unseen(&mut self, sidx: SegmentIndex) {
+        self.seen.set(sidx, true);
+    }
+}

--- a/crates/but-graph/tests/graph/merge_base.rs
+++ b/crates/but-graph/tests/graph/merge_base.rs
@@ -1,4 +1,4 @@
-use but_graph::{Graph, SegmentIndex, SegmentRelation};
+use but_graph::{Graph, Segment, SegmentIndex, SegmentRelation};
 use but_testsupport::graph_tree;
 
 use crate::init::{read_only_in_memory_scenario, standard_options};
@@ -14,14 +14,14 @@ fn find_git_merge_base_handles_duplicate_queue_entries_and_redundant_bases() -> 
     let main = segment_id_by_ref_name(&graph, "refs/heads/main")?;
 
     // merged -> (A,C) -> ... -> main causes the walk from merged to queue shared ancestors repeatedly.
-    assert_eq!(graph.find_git_merge_base(merged, main), Some(main));
+    assert_eq!(graph.find_merge_base(merged, main), Some(main));
 
     // For (merged, A), both A and main are common in ancestry, but A is the nearest one.
-    assert_eq!(graph.find_git_merge_base(merged, a), Some(a));
-    assert_ne!(graph.find_git_merge_base(merged, a), Some(main));
+    assert_eq!(graph.find_merge_base(merged, a), Some(a));
+    assert_ne!(graph.find_merge_base(merged, a), Some(main));
 
     // Independent branches under the same merge should converge at main.
-    assert_eq!(graph.find_git_merge_base(a, c), Some(main));
+    assert_eq!(graph.find_merge_base(a, c), Some(main));
     assert_eq!(graph.find_merge_base_octopus([a, c, merged]), Some(main));
 
     insta::assert_snapshot!(graph_tree(&graph), @"
@@ -87,6 +87,72 @@ fn relation_between_matches_merge_base_in_redundant_ancestor_case() -> anyhow::R
                         └── ·ecb1877 (⌂|1)
                             └── →:7: (main)
     ");
+
+    Ok(())
+}
+
+#[test]
+fn relation_between_handles_identity_and_disjoint_segments() -> anyhow::Result<()> {
+    let (repo, meta) = read_only_in_memory_scenario("four-diamond")?;
+    let mut graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+
+    let main = segment_id_by_ref_name(&graph, "refs/heads/main")?;
+    assert_eq!(
+        graph.relation_between(main, main),
+        SegmentRelation::Identity
+    );
+
+    let orphan = graph.insert_segment(Segment {
+        id: SegmentIndex::new(usize::MAX),
+        generation: 0,
+        ref_info: None,
+        remote_tracking_ref_name: None,
+        sibling_segment_id: None,
+        remote_tracking_branch_segment_id: None,
+        commits: Vec::new(),
+        metadata: None,
+    });
+    assert_eq!(
+        graph.relation_between(main, orphan),
+        SegmentRelation::Disjoint
+    );
+
+    Ok(())
+}
+
+#[test]
+fn merge_base_apis_can_resolve_segments_by_first_commit_id() -> anyhow::Result<()> {
+    let (repo, meta) = read_only_in_memory_scenario("four-diamond")?;
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+
+    let merged = segment_id_by_ref_name(&graph, "refs/heads/merged")?;
+    let a = segment_id_by_ref_name(&graph, "refs/heads/A")?;
+    let c = segment_id_by_ref_name(&graph, "refs/heads/C")?;
+    let main = segment_id_by_ref_name(&graph, "refs/heads/main")?;
+
+    let merged_id = graph[merged].tip().expect("commit");
+    let a_id = graph[a].tip().expect("commit");
+    let c_id = graph[c].tip().expect("commit");
+    let main_id = graph[main].tip().expect("commit");
+
+    assert_eq!(
+        graph.relation_between_by_commit_id(a_id, merged_id)?,
+        SegmentRelation::Ancestor
+    );
+    assert_eq!(
+        graph.find_merge_base_by_commit_id(merged_id, a_id)?,
+        Some(a_id)
+    );
+    assert_eq!(
+        graph.find_merge_base_octopus_by_commit_id([a_id, c_id, merged_id])?,
+        Some(main_id)
+    );
+
+    assert!(
+        graph
+            .find_merge_base_by_commit_id(repo.object_hash().null(), main_id)
+            .is_err()
+    );
 
     Ok(())
 }

--- a/crates/but-graph/tests/graph/merge_base.rs
+++ b/crates/but-graph/tests/graph/merge_base.rs
@@ -103,14 +103,8 @@ fn relation_between_handles_identity_and_disjoint_segments() -> anyhow::Result<(
     );
 
     let orphan = graph.insert_segment(Segment {
-        id: SegmentIndex::new(usize::MAX),
         generation: 0,
-        ref_info: None,
-        remote_tracking_ref_name: None,
-        sibling_segment_id: None,
-        remote_tracking_branch_segment_id: None,
-        commits: Vec::new(),
-        metadata: None,
+        ..Default::default()
     });
     assert_eq!(
         graph.relation_between(main, orphan),

--- a/crates/but-graph/tests/graph/merge_base.rs
+++ b/crates/but-graph/tests/graph/merge_base.rs
@@ -1,5 +1,5 @@
 use but_graph::{Graph, Segment, SegmentIndex, SegmentRelation};
-use but_testsupport::graph_tree;
+use but_testsupport::{graph_tree, visualize_commit_graph_all};
 
 use crate::init::{read_only_in_memory_scenario, standard_options};
 
@@ -92,6 +92,51 @@ fn relation_between_matches_merge_base_in_redundant_ancestor_case() -> anyhow::R
 }
 
 #[test]
+fn reachable_difference_returns_commits_in_traversal_order() -> anyhow::Result<()> {
+    let (repo, meta) = read_only_in_memory_scenario("four-diamond")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   8a6c109 (HEAD -> merged) Merge branch 'C' into merged
+    |\  
+    | *   7ed512a (C) Merge branch 'D' into C
+    | |\  
+    | | * ecb1877 (D) D
+    | * | 35ee481 C
+    | |/  
+    * |   62b409a (A) Merge branch 'B' into A
+    |\ \  
+    | * | f16dddf (B) B
+    | |/  
+    * / 592abec A
+    |/  
+    * 965998b (main) base
+    ");
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+
+    let merged_id = repo.rev_parse_single("merged")?.detach();
+    let a_id = repo.rev_parse_single("A")?.detach();
+
+    let ids = graph.find_commit_ids_from_a_not_b(merged_id, a_id)?;
+    assert_eq!(ids, ids_by_revs(&repo, &["merged", "C", "C^1", "C^2"])?);
+
+    let merged = segment_id_by_ref_name(&graph, "refs/heads/merged")?;
+    let a = segment_id_by_ref_name(&graph, "refs/heads/A")?;
+
+    let commits = graph.find_commits_reachable_from_a_not_b(merged, a);
+    assert_eq!(
+        commits.iter().map(|commit| commit.id).collect::<Vec<_>>(),
+        ids
+    );
+
+    assert!(
+        graph.find_commit_ids_from_a_not_b(a_id, a_id)?.is_empty(),
+        "self-exclusion means nothing is returned"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn relation_between_handles_identity_and_disjoint_segments() -> anyhow::Result<()> {
     let (repo, meta) = read_only_in_memory_scenario("four-diamond")?;
     let mut graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
@@ -157,4 +202,10 @@ fn segment_id_by_ref_name(graph: &Graph, name: &str) -> anyhow::Result<SegmentIn
         .named_segment_by_ref_name(full_name.as_ref())
         .map(|s| s.id)
         .ok_or_else(|| anyhow::anyhow!("missing segment for {name}"))
+}
+
+fn ids_by_revs(repo: &gix::Repository, revs: &[&str]) -> anyhow::Result<Vec<gix::ObjectId>> {
+    revs.iter()
+        .map(|rev| Ok(repo.rev_parse_single(*rev)?.detach()))
+        .collect()
 }

--- a/crates/but-graph/tests/graph/merge_base.rs
+++ b/crates/but-graph/tests/graph/merge_base.rs
@@ -116,20 +116,22 @@ fn reachable_difference_returns_commits_in_traversal_order() -> anyhow::Result<(
     let merged_id = repo.rev_parse_single("merged")?.detach();
     let a_id = repo.rev_parse_single("A")?.detach();
 
-    let ids = graph.find_commit_ids_from_a_not_b(merged_id, a_id)?;
+    let ids = graph.find_commit_ids_reachable_from_a_not_b(merged_id, a_id)?;
     assert_eq!(ids, ids_by_revs(&repo, &["merged", "C", "C^1", "C^2"])?);
 
     let merged = segment_id_by_ref_name(&graph, "refs/heads/merged")?;
     let a = segment_id_by_ref_name(&graph, "refs/heads/A")?;
 
-    let commits = graph.find_commits_reachable_from_a_not_b(merged, a);
+    let commits = graph.find_segments_reachable_from_a_not_b(merged, a);
     assert_eq!(
         commits.iter().map(|commit| commit.id).collect::<Vec<_>>(),
         ids
     );
 
     assert!(
-        graph.find_commit_ids_from_a_not_b(a_id, a_id)?.is_empty(),
+        graph
+            .find_commit_ids_reachable_from_a_not_b(a_id, a_id)?
+            .is_empty(),
         "self-exclusion means nothing is returned"
     );
 

--- a/crates/but-graph/tests/graph/merge_base.rs
+++ b/crates/but-graph/tests/graph/merge_base.rs
@@ -22,6 +22,7 @@ fn find_git_merge_base_handles_duplicate_queue_entries_and_redundant_bases() -> 
 
     // Independent branches under the same merge should converge at main.
     assert_eq!(graph.find_git_merge_base(a, c), Some(main));
+    assert_eq!(graph.find_merge_base_octopus([a, c, merged]), Some(main));
 
     insta::assert_snapshot!(graph_tree(&graph), @"
 

--- a/crates/but-graph/tests/graph/merge_base.rs
+++ b/crates/but-graph/tests/graph/merge_base.rs
@@ -1,4 +1,4 @@
-use but_graph::{Graph, Segment, SegmentIndex, SegmentRelation};
+use but_graph::{FirstParent, Graph, Segment, SegmentIndex, SegmentRelation};
 use but_testsupport::{graph_tree, visualize_commit_graph_all};
 
 use crate::init::{read_only_in_memory_scenario, standard_options};
@@ -116,20 +116,22 @@ fn reachable_difference_returns_commits_in_traversal_order() -> anyhow::Result<(
     let merged_id = repo.rev_parse_single("merged")?.detach();
     let a_id = repo.rev_parse_single("A")?.detach();
 
-    let ids = graph.find_commit_ids_reachable_from_a_not_b(merged_id, a_id, false)?;
+    let ids = graph.find_commit_ids_reachable_from_a_not_b(merged_id, a_id, FirstParent::No)?;
     assert_eq!(ids, ids_by_revs(&repo, &["merged", "C", "C^1", "C^2"])?);
-    let first_parent_ids = graph.find_commit_ids_reachable_from_a_not_b(merged_id, a_id, true)?;
+    let first_parent_ids =
+        graph.find_commit_ids_reachable_from_a_not_b(merged_id, a_id, FirstParent::Yes)?;
     assert_eq!(first_parent_ids, ids_by_revs(&repo, &["merged"])?);
 
     let merged = segment_id_by_ref_name(&graph, "refs/heads/merged")?;
     let a = segment_id_by_ref_name(&graph, "refs/heads/A")?;
 
-    let commits = graph.find_segments_reachable_from_a_not_b(merged, a, false);
+    let commits = graph.find_segments_reachable_from_a_not_b(merged, a, FirstParent::No);
     assert_eq!(
         commits.iter().map(|commit| commit.id).collect::<Vec<_>>(),
         ids
     );
-    let first_parent_commits = graph.find_segments_reachable_from_a_not_b(merged, a, true);
+    let first_parent_commits =
+        graph.find_segments_reachable_from_a_not_b(merged, a, FirstParent::Yes);
     assert_eq!(
         first_parent_commits
             .iter()
@@ -139,7 +141,7 @@ fn reachable_difference_returns_commits_in_traversal_order() -> anyhow::Result<(
     );
     assert!(
         graph
-            .find_commit_ids_reachable_from_a_not_b(a_id, a_id, false)?
+            .find_commit_ids_reachable_from_a_not_b(a_id, a_id, FirstParent::No)?
             .is_empty(),
         "self-exclusion means nothing is returned"
     );

--- a/crates/but-graph/tests/graph/merge_base.rs
+++ b/crates/but-graph/tests/graph/merge_base.rs
@@ -153,6 +153,7 @@ fn relation_between_handles_identity_and_disjoint_segments() -> anyhow::Result<(
     let mut graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
 
     let main = segment_id_by_ref_name(&graph, "refs/heads/main")?;
+    let a = segment_id_by_ref_name(&graph, "refs/heads/A")?;
     assert_eq!(
         graph.relation_between(main, main),
         SegmentRelation::Identity
@@ -166,6 +167,8 @@ fn relation_between_handles_identity_and_disjoint_segments() -> anyhow::Result<(
         graph.relation_between(main, orphan),
         SegmentRelation::Disjoint
     );
+    assert_eq!(graph.find_merge_base_octopus([main, orphan]), None);
+    assert_eq!(graph.find_merge_base_octopus([main, orphan, a]), None);
 
     Ok(())
 }

--- a/crates/but-graph/tests/graph/merge_base.rs
+++ b/crates/but-graph/tests/graph/merge_base.rs
@@ -116,21 +116,30 @@ fn reachable_difference_returns_commits_in_traversal_order() -> anyhow::Result<(
     let merged_id = repo.rev_parse_single("merged")?.detach();
     let a_id = repo.rev_parse_single("A")?.detach();
 
-    let ids = graph.find_commit_ids_reachable_from_a_not_b(merged_id, a_id)?;
+    let ids = graph.find_commit_ids_reachable_from_a_not_b(merged_id, a_id, false)?;
     assert_eq!(ids, ids_by_revs(&repo, &["merged", "C", "C^1", "C^2"])?);
+    let first_parent_ids = graph.find_commit_ids_reachable_from_a_not_b(merged_id, a_id, true)?;
+    assert_eq!(first_parent_ids, ids_by_revs(&repo, &["merged"])?);
 
     let merged = segment_id_by_ref_name(&graph, "refs/heads/merged")?;
     let a = segment_id_by_ref_name(&graph, "refs/heads/A")?;
 
-    let commits = graph.find_segments_reachable_from_a_not_b(merged, a);
+    let commits = graph.find_segments_reachable_from_a_not_b(merged, a, false);
     assert_eq!(
         commits.iter().map(|commit| commit.id).collect::<Vec<_>>(),
         ids
     );
-
+    let first_parent_commits = graph.find_segments_reachable_from_a_not_b(merged, a, true);
+    assert_eq!(
+        first_parent_commits
+            .iter()
+            .map(|commit| commit.id)
+            .collect::<Vec<_>>(),
+        first_parent_ids
+    );
     assert!(
         graph
-            .find_commit_ids_reachable_from_a_not_b(a_id, a_id)?
+            .find_commit_ids_reachable_from_a_not_b(a_id, a_id, false)?
             .is_empty(),
         "self-exclusion means nothing is returned"
     );

--- a/crates/but-workspace/src/commit/mod.rs
+++ b/crates/but-workspace/src/commit/mod.rs
@@ -474,7 +474,7 @@ pub mod merge {
         left: SegmentIndex,
         right: SegmentIndex,
     ) -> anyhow::Result<(gix::ObjectId, SegmentIndex)> {
-        let base_sidx = graph.find_git_merge_base(left, right).with_context(|| {
+        let base_sidx = graph.find_merge_base(left, right).with_context(|| {
             format!(
                 "Couldn't find merge-base between segments {l} and {r} - they are disjoint in the commit-graph",
                 l = left.index(),

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -394,19 +394,19 @@ fn skip_reason_for_branch(
 fn log_skipped_branch(branch: &StackBranch, skip_reason: SkipBranchReason) {
     match skip_reason {
         SkipBranchReason::Archived => {
-            tracing::debug!(
+            tracing::info!(
                 branch = branch.name(),
                 "skipping archived branch for pushing"
             );
         }
         SkipBranchReason::HeadAtMergeBase => {
-            tracing::debug!(
+            tracing::info!(
                 branch = branch.name(),
                 "nothing to push as head_oid == merge_base"
             );
         }
         SkipBranchReason::Integrated => {
-            tracing::debug!(
+            tracing::info!(
                 branch = branch.name(),
                 "Skipping push for integrated branch"
             );

--- a/crates/gitbutler-repo/src/commands.rs
+++ b/crates/gitbutler-repo/src/commands.rs
@@ -114,7 +114,7 @@ impl FileInfo {
     }
 }
 
-/// Lifecycle
+/// Utilities
 impl FileInfo {
     /// Returns true when a file is represented as UTF-8 text content.
     ///

--- a/crates/gitbutler-repo/src/commands.rs
+++ b/crates/gitbutler-repo/src/commands.rs
@@ -31,6 +31,7 @@ pub struct FileInfo {
     pub mime_type: Option<String>,
 }
 
+/// Lifecycle
 impl FileInfo {
     pub fn deleted() -> Self {
         Self::default()
@@ -110,6 +111,18 @@ impl FileInfo {
     fn is_binary(content: &[u8]) -> bool {
         let partial_content = &content[..content.len().min(8000)];
         gix::filter::plumbing::eol::Stats::from_bytes(partial_content).is_binary()
+    }
+}
+
+/// Lifecycle
+impl FileInfo {
+    /// Returns true when a file is represented as UTF-8 text content.
+    ///
+    /// `FileInfo` stores valid text in `content` with no `mime_type`. Binary files either have no
+    /// content, or have base64-encoded content plus a MIME type when the content can be displayed,
+    /// such as images. Missing or deleted files also have no content and are not valid text.
+    pub fn is_valid_utf8(&self) -> bool {
+        self.content.is_some() && self.mime_type.is_none()
     }
 }
 


### PR DESCRIPTION
This happened while trying to push a branch and it seemingly silently skipped doing that and I was very confused.
These changes make it easier to detect the issue.
Also somehow it wanted to pick up a PR template that didn't exist and failed hard because it didn't correctly interpret the return value of a function.
I fixed that, but maybe it causes other issues later if an empty PR template is an issue.

**This PR also adds helpers to `but-graph` to compute merge-bases directly, passing object-ids instead of segment ids. This helps to avoid redoing expensive computations on the Repository later.**

**This PR also brings a massive performance improvement for merge-base computations, which are now at their best (40ms down to 311µs, a 130x speedup)**

### Tasks

* [x] add utility for `a ^b` or `b..a` revspecs
* [x] `but-debug rev list` 
* [x] see if it should be faster than 28ms for 26k commits in 402k deep graph and a naive algorithm, now 5x faster with less naive git-like algorithm that leverages generation numbers.