### PR TITLE
Keep AI message generation enabled

### DIFF
--- a/apps/desktop/src/components/commit/CommitMessageEditor.svelte
+++ b/apps/desktop/src/components/commit/CommitMessageEditor.svelte
@@ -14,6 +14,7 @@
 	import { UNCOMMITTED_SERVICE } from "$lib/selection/uncommittedService.svelte";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { UI_STATE } from "$lib/state/uiState.svelte";
+	import { USER_SERVICE } from "$lib/user/userService.svelte";
 	import { WORKTREE_SERVICE } from "$lib/worktree/worktreeService.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import { Button, TestId } from "@gitbutler/ui";
@@ -56,6 +57,7 @@
 	const uiState = inject(UI_STATE);
 	const aiService = inject(AI_SERVICE);
 	const promptService = inject(PROMPT_SERVICE);
+	const userService = inject(USER_SERVICE);
 
 	const useFloatingBox = $derived(uiState.global.useFloatingBox);
 
@@ -88,7 +90,7 @@
 	const canUseAI = $derived(aiMacros.canUseAI);
 
 	$effect(() => {
-		aiMacros.setGenAIEnabled($aiGenEnabled);
+		aiMacros.setGenAIEnabled($aiGenEnabled, userService.user?.access_token);
 	});
 
 	let generatedText = $state<string>("");

--- a/apps/desktop/src/lib/ai/macros.svelte.test.ts
+++ b/apps/desktop/src/lib/ai/macros.svelte.test.ts
@@ -1,0 +1,40 @@
+import AIMacros from "$lib/ai/macros.svelte";
+import { expect, test, vi } from "vitest";
+
+function buildMacros(validateConfiguration: () => Promise<boolean>) {
+	return new AIMacros(
+		"project-id",
+		{
+			validateConfiguration,
+		} as unknown as ConstructorParameters<typeof AIMacros>[1],
+		{} as unknown as ConstructorParameters<typeof AIMacros>[2],
+		{} as unknown as ConstructorParameters<typeof AIMacros>[3],
+	);
+}
+
+test("AIMacros keeps the newest AI configuration validation result", async () => {
+	let resolveFirstValidation!: (value: boolean) => void;
+	let resolveSecondValidation!: (value: boolean) => void;
+	const firstValidation = new Promise<boolean>((resolve) => {
+		resolveFirstValidation = resolve;
+	});
+	const secondValidation = new Promise<boolean>((resolve) => {
+		resolveSecondValidation = resolve;
+	});
+	const validateConfiguration = vi
+		.fn()
+		.mockReturnValueOnce(firstValidation)
+		.mockReturnValueOnce(secondValidation);
+	const macros = buildMacros(validateConfiguration);
+
+	const firstUpdate = macros.setGenAIEnabled(true);
+	const secondUpdate = macros.setGenAIEnabled(true);
+
+	resolveSecondValidation(true);
+	await secondUpdate;
+	expect(macros.canUseAI).toBe(true);
+
+	resolveFirstValidation(false);
+	await firstUpdate;
+	expect(macros.canUseAI).toBe(true);
+});

--- a/apps/desktop/src/lib/ai/macros.svelte.ts
+++ b/apps/desktop/src/lib/ai/macros.svelte.ts
@@ -14,6 +14,7 @@ type GenerateCommitMessageParams = {
 
 export default class AIMacros {
 	private _canUseAI: boolean = $state<boolean>(false);
+	private configurationValidationId = 0;
 
 	constructor(
 		private readonly projectId: string,
@@ -22,10 +23,18 @@ export default class AIMacros {
 		private readonly diffInputContext: DiffInputContext,
 	) {}
 
-	async setGenAIEnabled(enabled: boolean) {
-		// TODO: Should this be called here, or evertime that we check the canUseAI?
-		const aiConfigurartionValid = await this.aiService.validateConfiguration();
-		this._canUseAI = enabled && aiConfigurartionValid;
+	async setGenAIEnabled(enabled: boolean, userToken?: string) {
+		const validationId = ++this.configurationValidationId;
+
+		if (!enabled) {
+			this._canUseAI = false;
+			return;
+		}
+
+		const aiConfigurationValid = await this.aiService.validateConfiguration(userToken);
+		if (validationId !== this.configurationValidationId) return;
+
+		this._canUseAI = aiConfigurationValid;
 	}
 
 	get canUseAI() {

--- a/apps/desktop/src/lib/ai/service.test.ts
+++ b/apps/desktop/src/lib/ai/service.test.ts
@@ -341,6 +341,14 @@ describe("AIService", () => {
 		});
 	});
 
+	describe("#validateConfiguration", () => {
+		test("With GitButler API, When a user token is provided directly, It returns true", async () => {
+			const { aiService } = buildDefaultServices();
+
+			expect(await aiService.validateConfiguration("test-token")).toBe(true);
+		});
+	});
+
 	describe.concurrent("#summarizeCommit", async () => {
 		test("When buildModel returns undefined, it returns undefined", async () => {
 			const { aiService } = buildDefaultServices();

--- a/apps/desktop/src/lib/ai/service.ts
+++ b/apps/desktop/src/lib/ai/service.ts
@@ -265,14 +265,14 @@ export class AIService {
 		return openAIActiveAndUsingButlerAPI || anthropicActiveAndUsingButlerAPI;
 	}
 
-	async validateConfiguration(): Promise<boolean> {
+	async validateConfiguration(userToken?: string): Promise<boolean> {
 		const modelKind = await this.getModelKind();
 		const ollamaEndpoint = await this.getOllamaEndpoint();
 		const ollamaModelName = await this.getOllamaModelName();
 		const lmStudioEndpoint = await this.getLMStudioEndpoint();
 		const lmStudioModelName = await this.getLMStudioModelName();
 
-		if (await this.usingGitButlerAPI()) return !!get(this.tokenMemoryService.token);
+		if (await this.usingGitButlerAPI()) return !!(userToken ?? get(this.tokenMemoryService.token));
 
 		const openAIActiveAndKeyProvided =
 			modelKind === ModelKind.OpenAI && !!(await this.getOpenAIKey());


### PR DESCRIPTION
## Tasks

- [ ] get user feedback with [custom Nightly build](https://github.com/Byron/byron/releases/tag/tmp).
- [ ] refackiew

----
Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

Fixes #13734.

The Generate message button could stay disabled even when project AI generation was enabled and global AI settings were configured. The commit editor cached AI availability from async validation, which made it vulnerable to startup token-loading timing and stale validation responses.

This PR makes commit-message AI validation use the currently loaded GitButler API user token directly, so it refreshes when the user finishes loading. It also makes `AIMacros` ignore stale validation responses so an older false result cannot overwrite a newer valid result.

## Validation

- `pnpm --dir apps/desktop test src/lib/ai/macros.svelte.test.ts src/lib/ai/service.test.ts`
- `pnpm --dir apps/desktop check`
- `pnpm exec eslint apps/desktop/src/lib/ai/macros.svelte.test.ts`
- `codex review --uncommitted`
- `codex review --commit 6676d3cc4a6c3bb07a616430f638d99fb3b647bc`
