### PR TITLE
cli+tui: make oplog descriptions more useful

### DIFF
--- a/crates/but/src/command/legacy/oplog.rs
+++ b/crates/but/src/command/legacy/oplog.rs
@@ -108,6 +108,28 @@ pub(crate) fn show_oplog(
                             details.operation.title().to_owned()
                         }
                     }
+                    OperationKind::RestoreFromSnapshotViaUndo
+                    | OperationKind::RestoreFromSnapshotViaRedo
+                    | OperationKind::RestoreFromSnapshot => {
+                        if let Ok(Some(restore_target)) =
+                            gitbutler_oplog::peel_restore_snapshot(ctx, &snapshot)
+                            && restore_target.commit_id != snapshot.commit_id
+                            && let Some(restore_target_details) = &restore_target.details
+                        {
+                            format!(
+                                "Restored from snapshot: {} ({})",
+                                restore_target_details.operation.title(),
+                                t.cli_id.paint(
+                                    restore_target
+                                        .commit_id
+                                        .to_hex_with_len(longest_short_id_len)
+                                        .to_string()
+                                ),
+                            )
+                        } else {
+                            details.operation.title().to_owned()
+                        }
+                    }
                     OperationKind::CreateCommit
                     | OperationKind::CreateBranch
                     | OperationKind::StashIntoBranch
@@ -138,9 +160,6 @@ pub(crate) fn show_oplog(
                     | OperationKind::MoveCommit
                     | OperationKind::MoveBranch
                     | OperationKind::TearOffBranch
-                    | OperationKind::RestoreFromSnapshotViaUndo
-                    | OperationKind::RestoreFromSnapshotViaRedo
-                    | OperationKind::RestoreFromSnapshot
                     | OperationKind::ReorderCommit
                     | OperationKind::InsertBlankCommit
                     | OperationKind::MoveCommitFile

--- a/crates/but/src/command/legacy/status/tui/confirm.rs
+++ b/crates/but/src/command/legacy/status/tui/confirm.rs
@@ -1,4 +1,5 @@
 use but_ctx::Context;
+use nonempty::NonEmpty;
 use ratatui::{
     Frame,
     layout::{Constraint, Flex, Layout, Rect},
@@ -10,19 +11,19 @@ use crate::{command::legacy::status::tui::Message, theme::Theme, utils::DebugAsT
 
 #[derive(Debug)]
 pub(super) struct Confirm {
-    text: Line<'static>,
+    lines: NonEmpty<Line<'static>>,
     yes_selected: bool,
     on_yes: DebugAsType<Box<dyn FnOnce(&mut Context, &mut Vec<Message>) -> anyhow::Result<()>>>,
     theme: &'static Theme,
 }
 
 impl Confirm {
-    pub(super) fn new<F>(text: Line<'static>, theme: &'static Theme, on_yes: F) -> Self
+    pub(super) fn new<F>(lines: NonEmpty<Line<'static>>, theme: &'static Theme, on_yes: F) -> Self
     where
         F: FnOnce(&mut Context, &mut Vec<Message>) -> anyhow::Result<()> + 'static,
     {
         Self {
-            text,
+            lines,
             yes_selected: true,
             on_yes: DebugAsType(Box::new(on_yes)),
             theme,
@@ -36,27 +37,37 @@ impl Confirm {
 
         let space_taken_up_by_border: u16 = 2;
 
-        let items = Vec::from([
-            ListItem::new(self.text.clone()),
-            ListItem::new(""),
-            ListItem::new(Line::from_iter([
-                style_button(
-                    Span::raw("  Yes  "),
-                    self.yes_selected,
-                    has_focus,
-                    self.theme,
-                ),
-                style_button(
-                    Span::raw("  No  "),
-                    !self.yes_selected,
-                    has_focus,
-                    self.theme,
-                ),
-            ])),
-        ]);
+        let items = self
+            .lines
+            .iter()
+            .map(|line| ListItem::new(line.clone()))
+            .chain([
+                ListItem::new(""),
+                ListItem::new(Line::from_iter([
+                    style_button(
+                        Span::raw("  Yes  "),
+                        self.yes_selected,
+                        has_focus,
+                        self.theme,
+                    ),
+                    style_button(
+                        Span::raw("  No  "),
+                        !self.yes_selected,
+                        has_focus,
+                        self.theme,
+                    ),
+                ])),
+            ])
+            .collect::<Vec<_>>();
 
+        let line_width = self
+            .lines
+            .iter()
+            .map(|line| line.width())
+            .max()
+            .unwrap_or(0) as u16;
         let horizontal_layout = Layout::horizontal([Constraint::Length(
-            (self.text.width() as u16) + space_taken_up_by_border + horizontal_padding,
+            line_width + space_taken_up_by_border + horizontal_padding,
         )])
         .flex(Flex::Center)
         .split(area);

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -1403,7 +1403,7 @@ impl App {
                 let drop_to_be_discarded =
                     message_on_drop::message_on_drop(Message::DropToBeDiscarded, messages);
                 Confirm::new(
-                    "Discard unassigned changes?".into(),
+                    NonEmpty::new("Discard unassigned changes?".into()),
                     self.theme,
                     move |ctx, messages| {
                         operations::discard_unassigned_legacy(ctx)?;
@@ -1441,7 +1441,7 @@ impl App {
                 let drop_to_be_discarded =
                     message_on_drop::message_on_drop(Message::DropToBeDiscarded, messages);
                 Confirm::new(
-                    format!("Discard {}?", uncommitted.describe()).into(),
+                    NonEmpty::new(format!("Discard {}?", uncommitted.describe()).into()),
                     self.theme,
                     move |ctx, messages| {
                         let hunk_assignments = uncommitted
@@ -1468,7 +1468,7 @@ impl App {
                 let drop_to_be_discarded =
                     message_on_drop::message_on_drop(Message::DropToBeDiscarded, messages);
                 Confirm::new(
-                    "Discard staged changes in this stack?".into(),
+                    NonEmpty::new("Discard staged changes in this stack?".into()),
                     self.theme,
                     move |ctx, messages| {
                         operations::discard_stack(ctx, stack_id)?;
@@ -1490,7 +1490,9 @@ impl App {
                 let drop_to_be_discarded =
                     message_on_drop::message_on_drop(Message::DropToBeDiscarded, messages);
                 Confirm::new(
-                    format!("Discard commit {}?", commit_id.to_hex_with_len(7)).into(),
+                    NonEmpty::new(
+                        format!("Discard commit {}?", commit_id.to_hex_with_len(7)).into(),
+                    ),
                     self.theme,
                     move |ctx, messages| {
                         let discard_result = operations::commit_discard(ctx, commit_id)?;
@@ -1526,7 +1528,7 @@ impl App {
                 let drop_to_be_discarded =
                     message_on_drop::message_on_drop(Message::DropToBeDiscarded, messages);
                 Confirm::new(
-                    format!("Discard branch {name}?").into(),
+                    NonEmpty::new(format!("Discard branch {name}?").into()),
                     self.theme,
                     move |ctx, messages| {
                         operations::remove_branch_legacy(ctx, stack_id, name)?;
@@ -2619,11 +2621,21 @@ impl App {
         };
 
         let text = {
-            let time = target_snapshot
+            let restore_from = if let Ok(Some(snapshot)) =
+                gitbutler_oplog::peel_restore_snapshot(ctx, &target_snapshot)
+                && snapshot.commit_id != target_snapshot.commit_id
+                && snapshot.details.is_some()
+            {
+                Cow::Owned(snapshot)
+            } else {
+                Cow::Borrowed(&target_snapshot)
+            };
+
+            let time = restore_from
                 .created_at
                 .format_or_unix(gix::date::time::format::DEFAULT);
 
-            let commit = target_snapshot.commit_id.to_hex_with_len(7);
+            let commit = restore_from.commit_id.to_hex_with_len(7);
 
             Line::from_iter(
                 [
@@ -2635,7 +2647,7 @@ impl App {
                 ]
                 .into_iter()
                 .chain([Span::raw(" "), Span::raw(time).style(self.theme.time)])
-                .chain(target_snapshot.details.iter().flat_map(|details| {
+                .chain(restore_from.details.iter().flat_map(|details| {
                     [
                         Span::raw(" "),
                         Span::raw(details.operation.title()).style(self.theme.attention),
@@ -2646,18 +2658,22 @@ impl App {
         };
 
         let commit = target_snapshot.commit_id;
-        self.confirm = Some(Confirm::new(text, self.theme, move |ctx, messages| {
-            but_api::legacy::oplog::restore_snapshot_with_kind(
-                ctx,
-                match kind {
-                    UndoOrRedo::Undo => RestoreKind::RestoreFromSnapshotViaUndo,
-                    UndoOrRedo::Redo => RestoreKind::RestoreFromSnapshotViaRedo,
-                },
-                commit,
-            )?;
-            messages.push(Message::Reload(None, ReloadCause::Mutation));
-            Ok(())
-        }));
+        self.confirm = Some(Confirm::new(
+            NonEmpty::new(text),
+            self.theme,
+            move |ctx, messages| {
+                but_api::legacy::oplog::restore_snapshot_with_kind(
+                    ctx,
+                    match kind {
+                        UndoOrRedo::Undo => RestoreKind::RestoreFromSnapshotViaUndo,
+                        UndoOrRedo::Redo => RestoreKind::RestoreFromSnapshotViaRedo,
+                    },
+                    commit,
+                )?;
+                messages.push(Message::Reload(None, ReloadCause::Mutation));
+                Ok(())
+            },
+        ));
 
         Ok(())
     }

--- a/crates/but/tests/but/command/undo.rs
+++ b/crates/but/tests/but/command/undo.rs
@@ -277,15 +277,15 @@ fn can_undo_repeatedly() -> anyhow::Result<()> {
         .args(["list"])
         .assert()
         .success()
-        .stdout_eq(
-            r#"Operations History
+        .stdout_eq(snapbox::str![[r#"
+Operations History
 ──────────────────────────────────────────────────
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
-"#,
-        );
+
+"#]]);
 
     undo(
         &env,
@@ -298,16 +298,16 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .args(["list"])
         .assert()
         .success()
-        .stdout_eq(
-            r#"Operations History
+        .stdout_eq(snapbox::str![[r#"
+Operations History
 ──────────────────────────────────────────────────
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
-"#,
-        );
+
+"#]]);
 
     undo(
         &env,
@@ -320,17 +320,17 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .args(["list"])
         .assert()
         .success()
-        .stdout_eq(
-            r#"Operations History
+        .stdout_eq(snapbox::str![[r#"
+Operations History
 ──────────────────────────────────────────────────
-8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
-"#,
-        );
+
+"#]]);
 
     undo(
         &env,
@@ -343,18 +343,18 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .args(["list"])
         .assert()
         .success()
-        .stdout_eq(
-            r#"Operations History
+        .stdout_eq(snapbox::str![[r#"
+Operations History
 ──────────────────────────────────────────────────
-800274e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+800274e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (90c8e9b)
+8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
-"#,
-        );
+
+"#]]);
 
     Ok(())
 }
@@ -373,15 +373,15 @@ fn can_undo_explicit_restore() -> anyhow::Result<()> {
         .args(["list"])
         .assert()
         .success()
-        .stdout_eq(
-            r#"Operations History
+        .stdout_eq(snapbox::str![[r#"
+Operations History
 ──────────────────────────────────────────────────
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
-"#,
-        );
+
+"#]]);
 
     restore(&env, "e637109", &status_two);
 
@@ -389,16 +389,16 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .args(["list"])
         .assert()
         .success()
-        .stdout_eq(
-            r#"Operations History
+        .stdout_eq(snapbox::str![[r#"
+Operations History
 ──────────────────────────────────────────────────
-10e3b45 2000-01-02 00:00:00 [RESTORE] Restored from snapshot
+10e3b45 2000-01-02 00:00:00 [RESTORE] Restored from snapshot: Updated commit message (e637109)
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
-"#,
-        );
+
+"#]]);
 
     undo(
         &env,
@@ -411,17 +411,17 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .args(["list"])
         .assert()
         .success()
-        .stdout_eq(
-            r#"Operations History
+        .stdout_eq(snapbox::str![[r#"
+Operations History
 ──────────────────────────────────────────────────
-a875d2c 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-10e3b45 2000-01-02 00:00:00 [RESTORE] Restored from snapshot
+a875d2c 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
+10e3b45 2000-01-02 00:00:00 [RESTORE] Restored from snapshot: Updated commit message (e637109)
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
-"#,
-        );
+
+"#]]);
 
     Ok(())
 }
@@ -440,15 +440,15 @@ fn can_undo_perform_operation_then_undo_again() -> anyhow::Result<()> {
         .args(["list"])
         .assert()
         .success()
-        .stdout_eq(
-            r#"Operations History
+        .stdout_eq(snapbox::str![[r#"
+Operations History
 ──────────────────────────────────────────────────
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
-"#,
-        );
+
+"#]]);
 
     undo(
         &env,
@@ -463,17 +463,17 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .args(["list"])
         .assert()
         .success()
-        .stdout_eq(
-            r#"Operations History
+        .stdout_eq(snapbox::str![[r#"
+Operations History
 ──────────────────────────────────────────────────
 3b50353 2000-01-02 00:00:00 [REWORD] Updated commit message
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
-"#,
-        );
+
+"#]]);
 
     undo(
         &env,
@@ -486,18 +486,18 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .args(["list"])
         .assert()
         .success()
-        .stdout_eq(
-            r#"Operations History
+        .stdout_eq(snapbox::str![[r#"
+Operations History
 ──────────────────────────────────────────────────
-c00e67a 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+c00e67a 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (3b50353)
 3b50353 2000-01-02 00:00:00 [REWORD] Updated commit message
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
-"#,
-        );
+
+"#]]);
 
     undo(
         &env,
@@ -522,13 +522,13 @@ fn undoing_past_end_of_oplog() -> anyhow::Result<()> {
         .args(["list"])
         .assert()
         .success()
-        .stdout_eq(
-            r#"Operations History
+        .stdout_eq(snapbox::str![[r#"
+Operations History
 ──────────────────────────────────────────────────
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
-"#,
-        );
+
+"#]]);
 
     undo(
         &env,
@@ -541,14 +541,14 @@ fn undoing_past_end_of_oplog() -> anyhow::Result<()> {
         .args(["list"])
         .assert()
         .success()
-        .stdout_eq(
-            r#"Operations History
+        .stdout_eq(snapbox::str![[r#"
+Operations History
 ──────────────────────────────────────────────────
-1c40c14 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+1c40c14 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (90c8e9b)
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
-"#,
-        );
+
+"#]]);
 
     undo(
         &env,
@@ -561,15 +561,15 @@ fn undoing_past_end_of_oplog() -> anyhow::Result<()> {
         .args(["list"])
         .assert()
         .success()
-        .stdout_eq(
-            r#"Operations History
+        .stdout_eq(snapbox::str![[r#"
+Operations History
 ──────────────────────────────────────────────────
-092cc32 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-1c40c14 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+092cc32 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (7665ea7)
+1c40c14 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (90c8e9b)
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
-"#,
-        );
+
+"#]]);
 
     env.but("undo").assert().success().stdout_eq(
         r#"No previous operations to undo.
@@ -593,15 +593,15 @@ fn can_redo() -> anyhow::Result<()> {
         .args(["list"])
         .assert()
         .success()
-        .stdout_eq(
-            r#"Operations History
+        .stdout_eq(snapbox::str![[r#"
+Operations History
 ──────────────────────────────────────────────────
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
-"#,
-        );
+
+"#]]);
 
     undo(
         &env,
@@ -614,16 +614,16 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .args(["list"])
         .assert()
         .success()
-        .stdout_eq(
-            r#"Operations History
+        .stdout_eq(snapbox::str![[r#"
+Operations History
 ──────────────────────────────────────────────────
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
-"#,
-        );
+
+"#]]);
 
     redo(
         &env,
@@ -636,17 +636,17 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .args(["list"])
         .assert()
         .success()
-        .stdout_eq(
-            r#"Operations History
+        .stdout_eq(snapbox::str![[r#"
+Operations History
 ──────────────────────────────────────────────────
-b57a0e1 2000-01-02 00:00:00 [REDO] Restored from snapshot
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+b57a0e1 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (f4e985f)
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
-"#,
-        );
+
+"#]]);
 
     env.but("redo").assert().success().stdout_eq(
         r#"No previous undo to redo.
@@ -670,15 +670,15 @@ fn can_mix_undo_and_redo() -> anyhow::Result<()> {
         .args(["list"])
         .assert()
         .success()
-        .stdout_eq(
-            r#"Operations History
+        .stdout_eq(snapbox::str![[r#"
+Operations History
 ──────────────────────────────────────────────────
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
-"#,
-        );
+
+"#]]);
 
     undo(
         &env,
@@ -697,17 +697,17 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .args(["list"])
         .assert()
         .success()
-        .stdout_eq(
-            r#"Operations History
+        .stdout_eq(snapbox::str![[r#"
+Operations History
 ──────────────────────────────────────────────────
-8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
-"#,
-        );
+
+"#]]);
 
     redo(
         &env,
@@ -720,18 +720,18 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .args(["list"])
         .assert()
         .success()
-        .stdout_eq(
-            r#"Operations History
+        .stdout_eq(snapbox::str![[r#"
+Operations History
 ──────────────────────────────────────────────────
-d07be52 2000-01-02 00:00:00 [REDO] Restored from snapshot
-8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+d07be52 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (e637109)
+8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
-"#,
-        );
+
+"#]]);
 
     undo(
         &env,
@@ -744,19 +744,19 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .args(["list"])
         .assert()
         .success()
-        .stdout_eq(
-            r#"Operations History
+        .stdout_eq(snapbox::str![[r#"
+Operations History
 ──────────────────────────────────────────────────
-4769e9f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-d07be52 2000-01-02 00:00:00 [REDO] Restored from snapshot
-8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+4769e9f 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
+d07be52 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (e637109)
+8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
-"#,
-        );
+
+"#]]);
 
     undo(
         &env,
@@ -769,20 +769,20 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .args(["list"])
         .assert()
         .success()
-        .stdout_eq(
-            r#"Operations History
+        .stdout_eq(snapbox::str![[r#"
+Operations History
 ──────────────────────────────────────────────────
-5ffc4e1 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-4769e9f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-d07be52 2000-01-02 00:00:00 [REDO] Restored from snapshot
-8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+5ffc4e1 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (90c8e9b)
+4769e9f 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
+d07be52 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (e637109)
+8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
-"#,
-        );
+
+"#]]);
 
     redo(
         &env,
@@ -795,21 +795,21 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .args(["list"])
         .assert()
         .success()
-        .stdout_eq(
-            r#"Operations History
+        .stdout_eq(snapbox::str![[r#"
+Operations History
 ──────────────────────────────────────────────────
-6ba0709 2000-01-02 00:00:00 [REDO] Restored from snapshot
-5ffc4e1 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-4769e9f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-d07be52 2000-01-02 00:00:00 [REDO] Restored from snapshot
-8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+6ba0709 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (90c8e9b)
+5ffc4e1 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (90c8e9b)
+4769e9f 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
+d07be52 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (e637109)
+8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
-"#,
-        );
+
+"#]]);
 
     redo(
         &env,
@@ -822,22 +822,22 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .args(["list"])
         .assert()
         .success()
-        .stdout_eq(
-            r#"Operations History
+        .stdout_eq(snapbox::str![[r#"
+Operations History
 ──────────────────────────────────────────────────
-62ccc54 2000-01-02 00:00:00 [REDO] Restored from snapshot
-6ba0709 2000-01-02 00:00:00 [REDO] Restored from snapshot
-5ffc4e1 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-4769e9f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-d07be52 2000-01-02 00:00:00 [REDO] Restored from snapshot
-8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+62ccc54 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (e637109)
+6ba0709 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (90c8e9b)
+5ffc4e1 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (90c8e9b)
+4769e9f 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
+d07be52 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (e637109)
+8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
-"#,
-        );
+
+"#]]);
 
     redo(
         &env,
@@ -850,23 +850,23 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
         .args(["list"])
         .assert()
         .success()
-        .stdout_eq(
-            r#"Operations History
+        .stdout_eq(snapbox::str![[r#"
+Operations History
 ──────────────────────────────────────────────────
-9306108 2000-01-02 00:00:00 [REDO] Restored from snapshot
-62ccc54 2000-01-02 00:00:00 [REDO] Restored from snapshot
-6ba0709 2000-01-02 00:00:00 [REDO] Restored from snapshot
-5ffc4e1 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-4769e9f 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-d07be52 2000-01-02 00:00:00 [REDO] Restored from snapshot
-8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot
-0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot
+9306108 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (f4e985f)
+62ccc54 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (e637109)
+6ba0709 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (90c8e9b)
+5ffc4e1 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (90c8e9b)
+4769e9f 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
+d07be52 2000-01-02 00:00:00 [REDO] Restored from snapshot: Updated commit message (e637109)
+8b8b27a 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (e637109)
+0a0795e 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Updated commit message (f4e985f)
 f4e985f 2000-01-02 00:00:00 [REWORD] Updated commit message
 e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 90c8e9b 2000-01-02 00:00:00 [REWORD] Updated commit message
 7665ea7 2000-01-02 00:00:00 [REWORD] Updated commit message
-"#,
-        );
+
+"#]]);
 
     Ok(())
 }

--- a/crates/gitbutler-oplog/src/lib.rs
+++ b/crates/gitbutler-oplog/src/lib.rs
@@ -2,6 +2,7 @@ pub mod entry;
 mod oplog;
 pub use oplog::OplogExt;
 pub use oplog::RestoreKind;
+pub use oplog::peel_restore_snapshot;
 mod reflog;
 mod snapshot;
 pub use snapshot::SnapshotExt;

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -1103,3 +1103,45 @@ impl Iterator for SnapshotIter {
         }
     }
 }
+
+/// Find the final snapshot that a restore snapshot will restore from.
+///
+/// For example if you do a reword and then a series of undos and redos the oplog would look like this:
+///
+/// 9ea77ad REDO
+/// 71c6be6 UNDO
+/// c33acf3 REDO
+/// 3a0c4d1 UNDO
+/// bd1724b REWORD
+///
+/// and `peel_restore_snapshot` will return the snapshot for `bd1724b`.
+///
+/// If the given snapshot is not a restore snapshot then the same snapshot will be returned.
+pub fn peel_restore_snapshot(ctx: &Context, snapshot: &Snapshot) -> Result<Option<Snapshot>> {
+    let mut current = snapshot.clone();
+
+    loop {
+        let Some(details) = &current.details else {
+            return Ok(None);
+        };
+
+        match details.operation {
+            OperationKind::RestoreFromSnapshotViaUndo
+            | OperationKind::RestoreFromSnapshotViaRedo
+            | OperationKind::RestoreFromSnapshot => {}
+            _ => return Ok(Some(current)),
+        }
+
+        let Some(restored_from) = details.trailers.iter().find_map(|trailer| {
+            if let Trailer::RestoredFrom(commit) = trailer {
+                Some(*commit)
+            } else {
+                None
+            }
+        }) else {
+            return Ok(None);
+        };
+
+        current = ctx.get_snapshot(restored_from)?;
+    }
+}


### PR DESCRIPTION
Instead of

```
❯ but oplog list
Operations History
──────────────────────────────────────────────────
d064bca 2026-05-13 09:42:48 [UNDO] Restored from snapshot
6dc2099 2026-05-13 09:42:45 [RESTORE] Restored from snapshot
62e1d1b 2026-05-13 09:19:05 [UNDO] Restored from snapshot
1d0d989 2026-05-13 09:18:13 [UNDO] Restored from snapshot
f25d266 2026-05-13 09:17:27 [REWORD] Updated commit message
52c0dc1 2026-05-13 09:17:21 [INSERT_COMMIT] Inserted blank commit
bf46936 2026-05-13 09:17:21 [INSERT_COMMIT] Inserted blank commit
5fdcf68 2026-05-13 09:17:21 [INSERT_COMMIT] Inserted blank commit
31655dd 2026-05-13 09:17:21 [INSERT_COMMIT] Inserted blank commit
3036037 2026-05-13 09:17:19 [DISCARD_COMMIT] Discarded commit
b6044d2 2026-05-13 09:16:29 [RESTORE] Restored from snapshot
ecee205 2026-05-13 09:16:14 [DISCARD_COMMIT] Discarded commit
7438a6a 2026-05-12 22:29:55 [UNDO] Restored from snapshot
145d24f 2026-05-12 22:29:54 [DISCARD_COMMIT] Discarded commit
d0fa044 2026-05-12 22:28:41 [UNDO] Restored from snapshot
1cfe606 2026-05-12 22:28:40 [MOVE] Moved commit
53688a3 2026-05-12 22:28:37 [INSERT_COMMIT] Inserted blank commit
2c93ead 2026-05-12 22:27:53 [UNDO] Restored from snapshot
91812ea 2026-05-12 22:27:53 [MOVE] Moved commit
156554b 2026-05-12 22:27:51 [MOVE] Moved commit
```

It now shows the snapshot that a restore targets:

```

❯ but oplog list
Operations History
──────────────────────────────────────────────────
ce777be 2026-05-13 10:32:25 [UNDO] Restored from snapshot: Updated commit message (aef4277)
aef4277 2026-05-13 10:31:42 [REWORD] Updated commit message
37a46e5 2026-05-13 10:31:39 [REDO] Restored from snapshot: Inserted blank commit (bf46936)
f72b25b 2026-05-13 10:31:00 [UNDO] Restored from snapshot: Inserted blank commit (bf46936)
2f8bc78 2026-05-13 10:18:25 [REDO] Restored from snapshot: Inserted blank commit (bf46936)
96630f9 2026-05-13 10:16:13 [UNDO] Restored from snapshot: Inserted blank commit (bf46936)
d064bca 2026-05-13 09:42:48 [UNDO] Restored from snapshot: Moved commit (1cfe606)
6dc2099 2026-05-13 09:42:45 [RESTORE] Restored from snapshot: Moved commit (1cfe606)
62e1d1b 2026-05-13 09:19:05 [UNDO] Restored from snapshot: Inserted blank commit (52c0dc1)
1d0d989 2026-05-13 09:18:13 [UNDO] Restored from snapshot: Updated commit message (f25d266)
f25d266 2026-05-13 09:17:27 [REWORD] Updated commit message
52c0dc1 2026-05-13 09:17:21 [INSERT_COMMIT] Inserted blank commit
bf46936 2026-05-13 09:17:21 [INSERT_COMMIT] Inserted blank commit
5fdcf68 2026-05-13 09:17:21 [INSERT_COMMIT] Inserted blank commit
31655dd 2026-05-13 09:17:21 [INSERT_COMMIT] Inserted blank commit
3036037 2026-05-13 09:17:19 [DISCARD_COMMIT] Discarded commit
b6044d2 2026-05-13 09:16:29 [RESTORE] Restored from snapshot: Discarded commit (ecee205)
ecee205 2026-05-13 09:16:14 [DISCARD_COMMIT] Discarded commit
7438a6a 2026-05-12 22:29:55 [UNDO] Restored from snapshot: Discarded commit (145d24f)
145d24f 2026-05-12 22:29:54 [DISCARD_COMMIT] Discarded commit
```

Same for the TUI. It now shows the actual snapshot we'll undo/redo:

<img width="547" height="154" alt="image" src="https://github.com/user-attachments/assets/920cbe36-268e-4ce7-9dd1-87ace263ed63" />

whereas before it would show

<img width="578" height="143" alt="image" src="https://github.com/user-attachments/assets/303beaaf-19f2-425e-8a26-2e03724b83b2" />
