### PR TITLE
Factor out usages of `BaseBranch` for obtaining push URLs

### DIFF
--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -1,13 +1,27 @@
 //! In place of commands.rs
 use anyhow::{Context as _, Result};
 use but_api_macros::but_api;
-use but_core::RepositoryExt;
+use but_core::{RefMetadata, RepositoryExt, WORKSPACE_REF_NAME};
 use but_ctx::{Context, ThreadSafeContext};
 use but_forge::{
     ForgeName, ReviewTemplateFunctions, available_review_templates, get_review_template_functions,
 };
 use gitbutler_repo::RepoCommands;
 use tracing::instrument;
+
+pub fn remote_url(meta: &impl RefMetadata, repo: &gix::Repository) -> Result<String> {
+    // We're assuming WORKSPACE_REF_NAME here because it's modelling the
+    // previous behaviour of calling `get_base_branch_data`.
+    let ws = meta.workspace(WORKSPACE_REF_NAME.try_into()?)?;
+    ws.remote_url_with_fallback(repo)
+}
+
+pub fn push_remote_url(meta: &impl RefMetadata, repo: &gix::Repository) -> Result<String> {
+    // We're assuming WORKSPACE_REF_NAME here because it's modelling the
+    // previous behaviour of calling `get_base_branch_data`.
+    let ws = meta.workspace(WORKSPACE_REF_NAME.try_into()?)?;
+    ws.push_remote_url(repo)
+}
 
 /// (Deprecated) Get the list of PR template paths for the given project and forge.
 /// This function is deprecated in favor of `list_available_review_templates`.
@@ -23,8 +37,9 @@ pub fn pr_templates(ctx: &but_ctx::Context, forge: ForgeName) -> Result<Vec<Stri
 #[but_api(napi)]
 #[instrument(err(Debug))]
 pub fn forge_provider(ctx: &Context) -> Result<Option<ForgeName>> {
-    let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx)?;
-    let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+    let meta = ctx.meta()?;
+    let repo = ctx.repo.get()?;
+    let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&meta, &repo)?);
     Ok(forge_repo_info.map(|info| info.forge))
 }
 
@@ -32,8 +47,9 @@ pub fn forge_provider(ctx: &Context) -> Result<Option<ForgeName>> {
 #[but_api(napi)]
 #[instrument(err(Debug))]
 pub fn list_available_review_templates(ctx: &Context) -> Result<Vec<String>> {
-    let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx)?;
-    let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+    let meta = ctx.meta()?;
+    let repo = ctx.repo.get()?;
+    let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&meta, &repo)?);
     let forge = &forge_repo_info
         .as_ref()
         .context("No forge could be determined for this repository branch")?
@@ -89,8 +105,9 @@ but_schemars::register_sdk_type!(ReviewTemplateInfo);
 #[but_api(napi)]
 #[instrument(err(Debug))]
 pub fn review_template(ctx: &Context) -> Result<Option<ReviewTemplateInfo>> {
-    let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx)?;
-    let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+    let meta = ctx.meta()?;
+    let repo = ctx.repo.get()?;
+    let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&meta, &repo)?);
     let forge = &forge_repo_info
         .as_ref()
         .context("No forge could be determined for this repository branch")?
@@ -134,8 +151,8 @@ pub fn set_review_template(ctx: &but_ctx::Context, template_path: Option<String>
     let repo = ctx.open_isolated_repo()?;
     let mut git_config = repo.git_settings()?;
 
-    let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx)?;
-    let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+    let meta = ctx.meta()?;
+    let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&meta, &repo)?);
     let forge = &forge_repo_info
         .as_ref()
         .context("No forge could be determined for this repository branch")?
@@ -165,8 +182,9 @@ pub fn list_reviews(
     cache_config: Option<but_forge::CacheConfig>,
 ) -> Result<Vec<but_forge::ForgeReview>> {
     let (storage, forge_repo_info, preferred_forge_user) = {
-        let remote_url = gitbutler_branch_actions::base::get_base_branch_remote_url(ctx)?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url);
+        let meta = ctx.meta()?;
+        let repo = ctx.repo.get()?;
+        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&meta, &repo)?);
 
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
@@ -190,8 +208,9 @@ pub fn list_reviews(
 #[instrument(err(Debug))]
 pub fn get_review(ctx: &Context, review_id: usize) -> Result<but_forge::ForgeReview> {
     let (storage, forge_repo_info, preferred_forge_user) = {
-        let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx)?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url)
+        let meta = ctx.meta()?;
+        let repo = ctx.repo.get()?;
+        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&meta, &repo)?)
             .context("No forge could be determined for this repository.")?;
 
         (
@@ -219,8 +238,9 @@ pub fn list_ci_checks_and_update_cache(
     cache_config: Option<but_forge::CacheConfig>,
 ) -> Result<Vec<but_forge::CiCheck>> {
     let (storage, forge_repo_info, preferred_forge_user) = {
-        let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx)?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+        let meta = ctx.meta()?;
+        let repo = ctx.repo.get()?;
+        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&meta, &repo)?);
 
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
@@ -248,11 +268,14 @@ pub async fn publish_review(
 ) -> Result<but_forge::ForgeReview> {
     let (storage, forge_repo_info, forge_push_repo_info, preferred_forge_user) = {
         let ctx = ctx.into_thread_local();
-        let base_branch = gitbutler_branch_actions::base::get_base_branch_data(&ctx)?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url)
+        let meta = ctx.meta()?;
+        let repo = ctx.repo.get()?;
+        let base_remote_url = remote_url(&meta, &repo)?;
+        let push_remote_url = push_remote_url(&meta, &repo)?;
+        let forge_repo_info = but_forge::derive_forge_repo_info(&base_remote_url)
             .context("No forge could be determined for this repository branch")?;
-        let forge_push_repo_info = if base_branch.remote_url != base_branch.push_remote_url {
-            let info = but_forge::derive_forge_repo_info(&base_branch.push_remote_url).context(
+        let forge_push_repo_info = if base_remote_url != push_remote_url {
+            let info = but_forge::derive_forge_repo_info(&push_remote_url).context(
                 "Failed to derive forge repository information from the push remote URL.",
             )?;
             Some(info)
@@ -284,8 +307,9 @@ pub async fn publish_review(
 pub async fn merge_review(ctx: ThreadSafeContext, review_id: usize) -> Result<()> {
     let (storage, forge_repo_info, preferred_forge_user) = {
         let ctx = ctx.into_thread_local();
-        let base_branch = gitbutler_branch_actions::base::get_base_branch_data(&ctx)?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+        let meta = ctx.meta()?;
+        let repo = ctx.repo.get()?;
+        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&meta, &repo)?);
 
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
@@ -313,8 +337,9 @@ pub async fn set_review_auto_merge(
 ) -> Result<()> {
     let (storage, forge_repo_info, preferred_forge_user) = {
         let ctx = ctx.into_thread_local();
-        let base_branch = gitbutler_branch_actions::base::get_base_branch_data(&ctx)?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+        let meta = ctx.meta()?;
+        let repo = ctx.repo.get()?;
+        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&meta, &repo)?);
 
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
@@ -343,8 +368,9 @@ pub async fn set_review_draftiness(
 ) -> Result<()> {
     let (storage, forge_repo_info, preferred_forge_user) = {
         let ctx = ctx.into_thread_local();
-        let base_branch = gitbutler_branch_actions::base::get_base_branch_data(&ctx)?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+        let meta = ctx.meta()?;
+        let repo = ctx.repo.get()?;
+        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&meta, &repo)?);
 
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
@@ -372,8 +398,9 @@ pub async fn update_review_footers(
 ) -> Result<()> {
     let (storage, forge_repo_info, preferred_forge_user) = {
         let ctx = ctx.into_thread_local();
-        let base_branch = gitbutler_branch_actions::base::get_base_branch_data(&ctx)?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+        let meta = ctx.meta()?;
+        let repo = ctx.repo.get()?;
+        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&meta, &repo)?);
 
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
@@ -400,8 +427,9 @@ pub async fn list_reviews_for_branch(
 ) -> Result<Vec<but_forge::ForgeReview>> {
     let (storage, forge_repo_info, project) = {
         let ctx = ctx.into_thread_local();
-        let base_branch = gitbutler_branch_actions::base::get_base_branch_data(&ctx)?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+        let meta = ctx.meta()?;
+        let repo = ctx.repo.get()?;
+        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&meta, &repo)?);
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
             forge_repo_info,

--- a/crates/but-core/src/ref_metadata.rs
+++ b/crates/but-core/src/ref_metadata.rs
@@ -1,3 +1,4 @@
+use anyhow::{Context as _, Result, bail};
 use gix::refs::FullNameRef;
 use uuid::Uuid;
 
@@ -34,6 +35,12 @@ pub struct Workspace {
     /// Note that even though this is per workspace, the implementation can fill in global information at will.
     pub target_ref: Option<gix::refs::FullName>,
 
+    /// The remote that we used to push to. Now primarily used to determine what
+    /// forge we're using.
+    ///
+    /// You probably want to use [`Self::push_remote_url`] instead in most
+    /// cases. Ideally we should wean this property out of the codebase.
+    pub remote_url: String,
     /// The commit id of a commit that was reachable by [`Self::target_ref`] and that should be included in the workspace.
     /// This is useful to make workspaces appear stable in relationship to the target reference, which may be updated each
     /// time a `git fetch` is performed.
@@ -53,6 +60,7 @@ impl std::fmt::Debug for Workspace {
             ref_info,
             stacks,
             target_ref,
+            remote_url,
             push_remote,
             target_commit_id,
         } = self;
@@ -63,6 +71,7 @@ impl std::fmt::Debug for Workspace {
                 "target_ref",
                 &MaybeDebug(&target_ref.as_ref().map(|rn| rn.as_bstr())),
             )
+            .field("remote_url", remote_url)
             .field("target_commit_id", &MaybeDebug(target_commit_id))
             .field("push_remote", &MaybeDebug(push_remote))
             .finish()
@@ -157,6 +166,51 @@ impl Workspace {
             },
         );
         Some(true)
+    }
+
+    /// Get the remote URL, falling back to the remote URL from the target_ref's
+    /// branch.
+    ///
+    /// You probably want to use [`Self::push_remote_url`] instead.
+    pub fn remote_url_with_fallback(&self, repo: &gix::Repository) -> Result<String> {
+        let remote_url = if self.remote_url.is_empty() {
+            let Some(target_ref) = self.target_ref.as_ref() else {
+                bail!("Target ref required for remote url fallback")
+            };
+            let remote = repo
+                .find_reference(target_ref)?
+                .remote(gix::remote::Direction::Fetch)
+                .transpose()?
+                .context(format!("failed to find remote for branch {target_ref}"))?;
+            remote
+                .url(gix::remote::Direction::Fetch)
+                .map(|url| url.to_bstring().to_string())
+                .context(format!("failed to get remote url for {target_ref}"))?
+        } else {
+            self.remote_url.clone()
+        };
+        Ok(remote_url)
+    }
+
+    /// The URL to push to, inferred by the [`Self::push_remote`] property.
+    ///
+    /// Falls back to [`Self::remote_url`] if the push remote is not set.
+    pub fn push_remote_url(&self, repo: &gix::Repository) -> Result<String> {
+        let push_remote_url = match self.push_remote {
+            Some(ref name) => repo
+                .find_remote(name.as_str())
+                .ok()
+                .and_then(|remote| {
+                    remote
+                        .url(gix::remote::Direction::Push)
+                        .or_else(|| remote.url(gix::remote::Direction::Fetch))
+                        .map(|url| url.to_bstring().to_string())
+                })
+                .unwrap_or_else(|| self.remote_url.clone()),
+            None => self.remote_url.clone(),
+        };
+
+        Ok(push_remote_url)
     }
 }
 

--- a/crates/but-core/tests/core/ref_metadata.rs
+++ b/crates/but-core/tests/core/ref_metadata.rs
@@ -46,15 +46,16 @@ mod workspace {
         assert!(!ws.remove_segment(c_ref));
 
         // Everything should be removed.
-        insta::assert_debug_snapshot!(ws, @r"
+        insta::assert_debug_snapshot!(ws, @r#"
         Workspace {
             ref_info: RefInfo { created_at: None, updated_at: None },
             stacks: [],
             target_ref: None,
+            remote_url: "",
             target_commit_id: None,
             push_remote: None,
         }
-        ");
+        "#);
     }
 
     #[test]
@@ -120,6 +121,7 @@ mod workspace {
                 },
             ],
             target_ref: None,
+            remote_url: "",
             target_commit_id: None,
             push_remote: None,
         }
@@ -130,15 +132,16 @@ mod workspace {
         assert!(ws.remove_segment(c_ref));
 
         // Everything should be removed.
-        insta::assert_debug_snapshot!(ws, @r"
+        insta::assert_debug_snapshot!(ws, @r#"
         Workspace {
             ref_info: RefInfo { created_at: None, updated_at: None },
             stacks: [],
             target_ref: None,
+            remote_url: "",
             target_commit_id: None,
             push_remote: None,
         }
-        ");
+        "#);
     }
 
     fn r(name: &str) -> &gix::refs::FullNameRef {

--- a/crates/but-graph/tests/graph/vis.rs
+++ b/crates/but-graph/tests/graph/vis.rs
@@ -29,6 +29,7 @@ fn post_graph_traversal() -> anyhow::Result<()> {
             target_ref: None,
             target_commit_id: None,
             push_remote: None,
+            remote_url: "".into(),
         })),
         ..Default::default()
     };

--- a/crates/but-meta/src/legacy/mod.rs
+++ b/crates/but-meta/src/legacy/mod.rs
@@ -968,7 +968,7 @@ fn branch_from_ref_name(ref_name: &FullNameRef) -> anyhow::Result<RemoteRefname>
 
 impl VirtualBranchesTomlMetadata {
     fn workspace_from_data(data: &VirtualBranches) -> Workspace {
-        let (target_branch, target_commit_id, push_remote) = data
+        let (target_branch, target_commit_id, push_remote, remote_url) = data
             .default_target
             .as_ref()
             .map(|target| {
@@ -976,6 +976,7 @@ impl VirtualBranchesTomlMetadata {
                     gix::refs::FullName::try_from(target.branch.to_string()).ok(),
                     (!target.sha.is_null()).then_some(target.sha),
                     target.push_remote_name.clone(),
+                    target.remote_url.clone(),
                 )
             })
             .unwrap_or_default();
@@ -1017,6 +1018,7 @@ impl VirtualBranchesTomlMetadata {
                 })
                 .collect(),
             target_ref: target_branch,
+            remote_url,
             target_commit_id,
             push_remote,
         }

--- a/crates/but-meta/tests/meta/ref_metadata_legacy.rs
+++ b/crates/but-meta/tests/meta/ref_metadata_legacy.rs
@@ -348,6 +348,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch_with_workspace_and_una
         ref_info: RefInfo { created_at: "2023-01-31 14:55:57 +0000", updated_at: None },
         stacks: [],
         target_ref: None,
+        remote_url: "",
         target_commit_id: None,
         push_remote: None,
     }
@@ -402,6 +403,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch_with_workspace_and_una
             },
         ],
         target_ref: None,
+        remote_url: "",
         target_commit_id: None,
         push_remote: None,
     }
@@ -438,6 +440,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch_with_workspace_and_una
             },
         ],
         target_ref: None,
+        remote_url: "",
         target_commit_id: None,
         push_remote: None,
     }
@@ -475,6 +478,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch_with_workspace_and_una
             },
         ],
         target_ref: None,
+        remote_url: "",
         target_commit_id: None,
         push_remote: None,
     }
@@ -526,6 +530,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch_with_workspace_and_una
             },
         ],
         target_ref: None,
+        remote_url: "",
         target_commit_id: None,
         push_remote: None,
     }
@@ -903,6 +908,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch() -> anyhow::Result<()
         ref_info: RefInfo { created_at: "2023-01-31 14:55:57 +0000", updated_at: None },
         stacks: [],
         target_ref: None,
+        remote_url: "",
         target_commit_id: None,
         push_remote: None,
     }
@@ -1150,6 +1156,7 @@ fn create_workspace_from_scratch_workspace_first() -> anyhow::Result<()> {
             },
         ],
         target_ref: "refs/remotes/origin/sub-name/main",
+        remote_url: "https://example.com/example-org/example-repo",
         target_commit_id: None,
         push_remote: None,
     }
@@ -1188,6 +1195,7 @@ fn create_workspace_from_scratch_workspace_first() -> anyhow::Result<()> {
             },
         ],
         target_ref: "refs/remotes/origin/sub-name/main",
+        remote_url: "https://example.com/example-org/example-repo",
         target_commit_id: None,
         push_remote: None,
     }

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
@@ -861,6 +861,7 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
                 },
             ],
             target_ref: "refs/remotes/origin/main",
+            remote_url: "should not be needed and when it is extract it from `repo`",
             target_commit_id: Sha1(3183e43ff482a2c4c8ff531d595453b64f58d90b),
             push_remote: None,
         },
@@ -1487,6 +1488,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
             },
         ],
         target_ref: "refs/remotes/origin/main",
+        remote_url: "should not be needed and when it is extract it from `repo`",
         target_commit_id: Sha1(85efbe4d5a663bff0ed8fb5fbc38a72be0592f55),
         push_remote: None,
     }

--- a/crates/but-workspace/tests/workspace/branch_details.rs
+++ b/crates/but-workspace/tests/workspace/branch_details.rs
@@ -278,6 +278,7 @@ mod with_workspace {
                 target_ref: Some(refname(short_name)),
                 target_commit_id: None,
                 push_remote: None,
+                remote_url: "".into(),
             };
             self
         }

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/legacy.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/legacy.rs
@@ -599,6 +599,7 @@ mod stack_details {
                         },
                     ],
                     target_ref: "refs/remotes/origin/main",
+                    remote_url: "should not be needed and when it is extract it from `repo`",
                     target_commit_id: Sha1(85efbe4d5a663bff0ed8fb5fbc38a72be0592f55),
                     push_remote: None,
                 },

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -83,17 +83,10 @@ impl BaseBranch {
 
 #[instrument(skip(ctx), err(Debug))]
 pub fn get_base_branch_data(ctx: &Context) -> Result<BaseBranch> {
-    let target = default_target(ctx)?;
     let repo = ctx.repo.get()?;
-    let base = target_to_base_branch(&repo, &ctx.legacy_project, &target)?;
+    let meta = ctx.meta()?;
+    let base = target_to_base_branch(&repo, &ctx.legacy_project, &meta)?;
     Ok(base)
-}
-
-#[instrument(skip(ctx), err(Debug))]
-pub fn get_base_branch_remote_url(ctx: &Context) -> Result<String> {
-    let target = default_target(ctx)?;
-    let repo = ctx.repo.get()?;
-    remote_url_of_target_to_base_branch(&repo, &target)
 }
 
 /// Restore the default target metadata if it is missing in the currently configured storage
@@ -184,7 +177,8 @@ fn go_back_to_integration(ctx: &Context, default_target: &Target) -> Result<Base
             .context("failed to checkout tree")?;
     }
 
-    let base = target_to_base_branch(&repo, &ctx.legacy_project, default_target)?;
+    let meta = ctx.meta()?;
+    let base = target_to_base_branch(&repo, &ctx.legacy_project, &meta)?;
     update_workspace_commit(ctx, false)?;
     Ok(base)
 }
@@ -309,7 +303,8 @@ pub(crate) fn set_base_branch(
 
     crate::integration::update_workspace_commit_with_vb_state(&vb_state, ctx, true)?;
 
-    let base = target_to_base_branch(&repo, &ctx.legacy_project, &target)?;
+    let new_meta = ctx.meta()?;
+    let base = target_to_base_branch(&repo, &ctx.legacy_project, &new_meta)?;
     Ok(base)
 }
 
@@ -347,18 +342,26 @@ fn set_exclude_decoration(ctx: &Context) -> Result<()> {
 pub(crate) fn target_to_base_branch(
     repo: &gix::Repository,
     project: &Project,
-    target: &Target,
+    meta: &impl RefMetadata,
 ) -> Result<BaseBranch> {
-    let target_ref_commit = repo
-        .find_reference(&target.branch.to_string())?
-        .peel_to_commit()?
-        .id;
+    // This function is presuming a workspace ref name.
+    let ws_meta = meta.workspace(WORKSPACE_REF_NAME.try_into()?)?;
+    let target_ref = ws_meta
+        .target_ref
+        .as_ref()
+        .context("target_to_base_branch require a defined target_ref")
+        .context(Code::DefaultTargetNotFound)?;
+    let target_sha = ws_meta
+        .target_commit_id
+        .context("target_to_base_branch require a defined target_commit_id")?;
+
+    let target_ref_commit = repo.find_reference(target_ref)?.peel_to_commit()?.id;
 
     // The old integrate_upstream function cares about whether the target sha
     // is ahead of the target ref.
     //
     // The old function provided some options for how to resolve this.
-    let target_sha_not_ref = first_parent_commit_ids_until(repo, target.sha, target_ref_commit)
+    let target_sha_not_ref = first_parent_commit_ids_until(repo, target_sha, target_ref_commit)
         .context("failed to get fork point")?;
     let target_sha_ahead_of_ref = !target_sha_not_ref.is_empty();
 
@@ -374,7 +377,7 @@ pub(crate) fn target_to_base_branch(
             .collect();
         if heads.is_empty() {
             // No workspace commit parents — fall back to stored target SHA.
-            Some(target.sha)
+            Some(target_sha)
         } else {
             let base = repo
                 .merge_base_octopus([heads.as_slice(), &[target_ref_commit]].concat())
@@ -401,7 +404,7 @@ pub(crate) fn target_to_base_branch(
     let behind = upstream_commits.len();
 
     // get some recent commits
-    let recent_commits = first_parent_commit_ids_with_limit(repo, target.sha, 20)
+    let recent_commits = first_parent_commit_ids_with_limit(repo, target_sha, 20)
         .context("failed to get recent commits")?
         .iter()
         .map(|id| {
@@ -413,27 +416,19 @@ pub(crate) fn target_to_base_branch(
     // we assume that only local commits can be conflicted
     let conflicted = recent_commits.iter().any(|commit| commit.conflicted);
 
-    // there has got to be a better way to do this.
-    let push_remote_url = match target.push_remote_name {
-        Some(ref name) => repo
-            .find_remote(name.as_str())
-            .ok()
-            .and_then(|remote| {
-                remote
-                    .url(gix::remote::Direction::Push)
-                    .or_else(|| remote.url(gix::remote::Direction::Fetch))
-                    .map(|url| url.to_bstring().to_string())
-            })
-            .unwrap_or_else(|| target.remote_url.clone()),
-        None => target.remote_url.clone(),
-    };
+    let push_remote_url = ws_meta.push_remote_url(repo)?;
+    let remote_url = ws_meta.remote_url_with_fallback(repo)?;
 
-    let remote_url = remote_url_of_target_to_base_branch(repo, target)?;
-
-    let branch_name = target.branch.fullname();
-    let remote_name = target.branch.remote().to_string();
-    let push_remote_name = target
-        .push_remote_name
+    let branch_name = target_ref.shorten().to_string();
+    let remote_name = repo
+        .find_reference(target_ref)?
+        .remote_name(gix::remote::Direction::Push)
+        .context("Failed to get current remote name")?
+        .to_owned()
+        .as_bstr()
+        .to_string();
+    let push_remote_name = ws_meta
+        .push_remote
         .clone()
         .unwrap_or_else(|| remote_name.clone());
     let short_name = BaseBranch::compute_short_name(&branch_name, &remote_name);
@@ -443,7 +438,7 @@ pub(crate) fn target_to_base_branch(
         remote_url,
         push_remote_name,
         push_remote_url,
-        base_sha: target.sha,
+        base_sha: target_sha,
         current_sha: target_ref_commit,
         behind,
         upstream_commits,
@@ -458,27 +453,6 @@ pub(crate) fn target_to_base_branch(
         short_name,
     };
     Ok(base)
-}
-
-fn remote_url_of_target_to_base_branch(repo: &gix::Repository, target: &Target) -> Result<String> {
-    // Fallback to the remote URL of the branch if the target remote URL is empty
-    let remote_url = if target.remote_url.is_empty() {
-        let remote = repo.find_remote(target.branch.remote()).context(format!(
-            "failed to find remote for branch {}",
-            target.branch.fullname()
-        ))?;
-        remote
-            .url(gix::remote::Direction::Fetch)
-            .map(|url| url.to_bstring().to_string())
-            .context(format!(
-                "failed to get remote url for {}",
-                target.branch.fullname()
-            ))?
-    } else {
-        target.remote_url.clone()
-    };
-
-    Ok(remote_url)
 }
 
 fn default_target(ctx: &Context) -> Result<Target> {


### PR DESCRIPTION
The goal here was not to change any behaviour or the relationship between `remote_url` and `push_remote_url`.

My primary goal was to simply remove some reliance on the `BaseBranch` datastructure and get the ws_meta passed into `target_to_base_branch`