### PR TITLE
Use standard upstream commits metric

### DIFF
--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -270,8 +270,9 @@ pub fn switch_back_to_workspace_with_perm(
     ctx: &mut but_ctx::Context,
     perm: &mut RepoExclusive,
 ) -> Result<BaseBranch> {
-    let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx)
-        .context("Failed to get base branch data")?;
+    let base_branch =
+        gitbutler_branch_actions::base::get_base_branch_data(ctx, perm.read_permission())
+            .context("Failed to get base branch data")?;
 
     let branch_name = format!("refs/remotes/{}", base_branch.branch_name)
         .parse()
@@ -284,9 +285,14 @@ pub fn switch_back_to_workspace_with_perm(
 }
 
 #[but_api]
-#[instrument(err(Debug))]
-pub fn get_base_branch_data(ctx: &but_ctx::Context) -> Result<Option<BaseBranch>> {
-    if let Ok(base_branch) = gitbutler_branch_actions::base::get_base_branch_data(ctx) {
+#[instrument(skip(perm), err(Debug))]
+pub fn get_base_branch_data(
+    ctx: &but_ctx::Context,
+    perm: &mut RepoExclusive,
+) -> Result<Option<BaseBranch>> {
+    if let Ok(base_branch) =
+        gitbutler_branch_actions::base::get_base_branch_data(ctx, perm.read_permission())
+    {
         Ok(Some(base_branch))
     } else {
         Ok(None)
@@ -656,7 +662,9 @@ pub fn fetch_from_remotes(ctx: &Context, action: Option<String>) -> Result<BaseB
         return Err(anyhow!(error));
     }
 
-    let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx)?;
+    let guard = ctx.shared_worktree_access();
+    let base_branch =
+        gitbutler_branch_actions::base::get_base_branch_data(ctx, guard.read_permission())?;
     Ok(base_branch)
 }
 
@@ -669,10 +677,11 @@ pub async fn upstream_integration_statuses(
 ) -> Result<StackStatuses> {
     let (base_branch, commit_id, ctx) = {
         let ctx = ctx.into_thread_local();
+        let guard = ctx.shared_worktree_access();
 
         // Get all the actively applied reviews
         (
-            gitbutler_branch_actions::base::get_base_branch_data(&ctx)?,
+            gitbutler_branch_actions::base::get_base_branch_data(&ctx, guard.read_permission())?,
             target_commit_id,
             ctx.into_sync(),
         )
@@ -692,7 +701,9 @@ pub async fn integrate_upstream(
 ) -> Result<IntegrationOutcome> {
     let (base_branch, ctx) = {
         let ctx = ctx.into_thread_local();
-        let base_branch = gitbutler_branch_actions::base::get_base_branch_data(&ctx)?;
+        let guard = ctx.shared_worktree_access();
+        let base_branch =
+            gitbutler_branch_actions::base::get_base_branch_data(&ctx, guard.read_permission())?;
         (base_branch, ctx.to_sync())
     };
     let resolved_reviews = resolve_review_map(ctx.clone(), &base_branch).await?;
@@ -703,6 +714,7 @@ pub async fn integrate_upstream(
         base_branch_resolution,
         &resolved_reviews,
     )?;
+    ctx.invalidate_workspace_cache()?;
 
     Ok(outcome)
 }
@@ -715,7 +727,9 @@ pub async fn resolve_upstream_integration(
 ) -> Result<String> {
     let (base_branch, sync_ctx) = {
         let ctx = ctx.into_thread_local();
-        let base_branch = gitbutler_branch_actions::base::get_base_branch_data(&ctx)?;
+        let guard = ctx.shared_worktree_access();
+        let base_branch =
+            gitbutler_branch_actions::base::get_base_branch_data(&ctx, guard.read_permission())?;
         (base_branch, ctx.into_sync())
     };
     let resolved_reviews = resolve_review_map(sync_ctx.clone(), &base_branch).await?;

--- a/crates/but-graph/Cargo.toml
+++ b/crates/but-graph/Cargo.toml
@@ -28,7 +28,7 @@ tracing.workspace = true
 itertools.workspace = true
 
 [dev-dependencies]
-but-graph = { path = "." , features = ["legacy"] }
+but-graph = { path = ".", features = ["legacy"] }
 but-meta = { workspace = true, features = ["legacy"] }
 but-testsupport.workspace = true
 

--- a/crates/but-graph/src/lib.rs
+++ b/crates/but-graph/src/lib.rs
@@ -210,6 +210,7 @@ pub use api::FirstParent;
 /// Produce a graph from a Git repository.
 pub mod init;
 pub mod projection;
+pub mod target_ref_relations;
 mod utils;
 
 mod statistics;

--- a/crates/but-graph/src/target_ref_relations.rs
+++ b/crates/but-graph/src/target_ref_relations.rs
@@ -1,0 +1,138 @@
+//! Describing relationships to the target ref
+//!
+//! The contents of the workspace is defined as `HEAD ^target.sha`.
+//!
+//! When it comes to calling `integrate_upstream`, what we really want to do, is
+//! take the commits in `HEAD ^target.sha` and make sure they in some way
+//! include the `target_ref`.
+//!
+//! What that practically means, is that if there are commits in the set
+//! `target_ref ^[branch in workspace]`, we want to update that branch such
+//! that it includes the changes in `target_ref`.
+//!
+//! Whether or not we update a branch has no relevance to the `target.sha`. The
+//! `target.sha` is simply defining what we consider in the workspace.
+
+use std::{backtrace::Backtrace, collections::HashSet};
+
+use anyhow::{Context, Result, bail};
+use petgraph::Direction;
+
+use crate::{Graph, projection::commit::is_managed_workspace_by_message};
+
+/// A head with the commits that are considered upstream of it.
+pub struct HeadStatus {
+    /// The particular head we're looking at
+    pub head: gix::ObjectId,
+    /// The commits that are considered upstream of it.
+    pub upstream_commits: Vec<gix::ObjectId>,
+}
+
+impl Graph {
+    /// Lists the commits in the set `target_ref ^[branch in workspace]`.
+    ///
+    /// If `entrypoint_commit` is `is_managed_workspace_by_message`, then we
+    /// return an entry for each parent of `entrypoint_commit`, otherwise we
+    /// return one entry for `target_ref ^entrypoint_commit`.
+    ///
+    /// Could return zero head statuses if the workspace commit has no parents.
+    ///
+    /// If a stack head or the HEAD itself in the PGM scenario has no common
+    /// history with the `target_ref`, as a logical extension of the specified
+    /// revspec, all the commits reachable from the `target_ref` will be
+    /// returned.
+    ///
+    /// When looking at the new understanding of stacks used in the new
+    /// `integrate_upstream` function, if you have a stack with N >1 heads,
+    /// there will be a N entries in here which coorespond with each of the
+    /// stack heads. The results for each of head in the smae stack should be
+    /// the same.
+    pub fn upstream_commits(
+        &self,
+        repo: &gix::Repository,
+        target_ref: &gix::refs::FullNameRef,
+    ) -> Result<Vec<HeadStatus>> {
+        let entrypoint = self.entrypoint_commit().context(
+            "Upstream commits can only be calculated on a graph that has some entrypoint commit",
+        )?;
+        let entrypoint = repo.find_commit(entrypoint.id)?;
+        let heads = if is_managed_workspace_by_message(entrypoint.message_raw()?) {
+            entrypoint.parent_ids().collect::<Vec<_>>()
+        } else {
+            vec![entrypoint.id()]
+        };
+
+        let target_ref_id = repo.find_reference(target_ref)?.peel_to_commit()?.id;
+
+        let mut out = vec![];
+
+        for head in heads {
+            // There are more efficient ways of computing a `A ^B` revset, but
+            // with the workspace being reasonably bounded to about 1000 commits
+            // of history, I'm not too concerend about performance here.
+            let mut negative_commits = HashSet::new();
+            self.traverse_commit_and_parents(head.detach(), |id| {
+                negative_commits.insert(id);
+                false
+            })?;
+
+            let mut positive_commits = vec![];
+            self.traverse_commit_and_parents(target_ref_id, |id| {
+                if negative_commits.contains(&id) {
+                    true
+                } else {
+                    positive_commits.push(id);
+                    false
+                }
+            })?;
+
+            out.push(HeadStatus {
+                head: head.detach(),
+                upstream_commits: positive_commits,
+            })
+        }
+
+        Ok(out)
+    }
+}
+
+impl Graph {
+    fn traverse_commit_and_parents(
+        &self,
+        start: gix::ObjectId,
+        mut cb: impl FnMut(gix::ObjectId) -> bool,
+    ) -> Result<()> {
+        let mut sidx = None;
+        for id in self.inner.node_indices() {
+            let mut found = false;
+            for commit in &self[id].commits {
+                if commit.id == start {
+                    found = true;
+                    sidx = Some(id);
+                }
+
+                if found && cb(commit.id) {
+                    return Ok(());
+                }
+            }
+            if found {
+                break;
+            }
+        }
+
+        let Some(sidx) = sidx else {
+            bail!("Failed to find a segment containing commit {start}");
+        };
+        self.visit_all_segments_excluding_start_until(sidx, Direction::Outgoing, |segment| {
+            for commit in &segment.commits {
+                if cb(commit.id) {
+                    return true;
+                }
+            }
+
+            false
+        });
+
+        Ok(())
+    }
+}

--- a/crates/but-graph/src/target_ref_relations.rs
+++ b/crates/but-graph/src/target_ref_relations.rs
@@ -13,10 +13,7 @@
 //! Whether or not we update a branch has no relevance to the `target.sha`. The
 //! `target.sha` is simply defining what we consider in the workspace.
 
-use std::{backtrace::Backtrace, collections::HashSet};
-
-use anyhow::{Context, Result, bail};
-use petgraph::Direction;
+use anyhow::{Context, Result};
 
 use crate::{Graph, projection::commit::is_managed_workspace_by_message};
 
@@ -27,6 +24,8 @@ pub struct HeadStatus {
     /// The commits that are considered upstream of it.
     pub upstream_commits: Vec<gix::ObjectId>,
 }
+
+boolean_enums::gen_boolean_enum!(pub FirstParentTraversal);
 
 impl Graph {
     /// Lists the commits in the set `target_ref ^[branch in workspace]`.
@@ -51,6 +50,7 @@ impl Graph {
         &self,
         repo: &gix::Repository,
         target_ref: &gix::refs::FullNameRef,
+        first_parent: FirstParentTraversal,
     ) -> Result<Vec<HeadStatus>> {
         let entrypoint = self.entrypoint_commit().context(
             "Upstream commits can only be calculated on a graph that has some entrypoint commit",
@@ -67,72 +67,17 @@ impl Graph {
         let mut out = vec![];
 
         for head in heads {
-            // There are more efficient ways of computing a `A ^B` revset, but
-            // with the workspace being reasonably bounded to about 1000 commits
-            // of history, I'm not too concerend about performance here.
-            let mut negative_commits = HashSet::new();
-            self.traverse_commit_and_parents(head.detach(), |id| {
-                negative_commits.insert(id);
-                false
-            })?;
-
-            let mut positive_commits = vec![];
-            self.traverse_commit_and_parents(target_ref_id, |id| {
-                if negative_commits.contains(&id) {
-                    true
-                } else {
-                    positive_commits.push(id);
-                    false
-                }
-            })?;
+            let mut walk = repo.rev_walk([target_ref_id]).with_hidden([head]);
+            if first_parent == FirstParentTraversal::Yes {
+                walk = walk.first_parent_only();
+            };
 
             out.push(HeadStatus {
                 head: head.detach(),
-                upstream_commits: positive_commits,
+                upstream_commits: walk.all()?.map(|c| Ok(c?.id)).collect::<Result<_>>()?,
             })
         }
 
         Ok(out)
-    }
-}
-
-impl Graph {
-    fn traverse_commit_and_parents(
-        &self,
-        start: gix::ObjectId,
-        mut cb: impl FnMut(gix::ObjectId) -> bool,
-    ) -> Result<()> {
-        let mut sidx = None;
-        for id in self.inner.node_indices() {
-            let mut found = false;
-            for commit in &self[id].commits {
-                if commit.id == start {
-                    found = true;
-                    sidx = Some(id);
-                }
-
-                if found && cb(commit.id) {
-                    return Ok(());
-                }
-            }
-            if found {
-                break;
-            }
-        }
-
-        let Some(sidx) = sidx else {
-            bail!("Failed to find a segment containing commit {start}");
-        };
-        self.visit_all_segments_excluding_start_until(sidx, Direction::Outgoing, |segment| {
-            for commit in &segment.commits {
-                if cb(commit.id) {
-                    return true;
-                }
-            }
-
-            false
-        });
-
-        Ok(())
     }
 }

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -143,7 +143,8 @@ async fn show_overview(ctx: &mut Context, out: &mut OutputChannel) -> Result<()>
     // Get target branch
     cfg_if! {
         if #[cfg(feature = "legacy")] {
-            let target_branch = but_api::legacy::virtual_branches::get_base_branch_data(ctx)?
+            let mut guard = ctx.exclusive_worktree_access();
+            let target_branch = but_api::legacy::virtual_branches::get_base_branch_data(ctx, guard.write_permission())?
                                     .map(|b| b.branch_name);
         } else {
             let target_branch = None::<String>;
@@ -1633,7 +1634,13 @@ async fn target_config(
         None => {
             #[cfg(feature = "legacy")]
             {
-                let target = but_api::legacy::virtual_branches::get_base_branch_data(ctx)?;
+                let target = {
+                    let mut guard = ctx.exclusive_worktree_access();
+                    but_api::legacy::virtual_branches::get_base_branch_data(
+                        ctx,
+                        guard.write_permission(),
+                    )?
+                };
 
                 if let Some(target_branch) = target {
                     if let Some(out) = out.for_human() {

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -351,7 +351,10 @@ pub async fn create_review(
 /// Make sure that the account that is about to be used in this repository's forge is correctly authenticated.
 async fn ensure_forge_authentication(ctx: &mut Context) -> Result<(), anyhow::Error> {
     let (storage, forge_repo_info, preferred_forge_user) = {
-        let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx)?;
+        let base_branch = gitbutler_branch_actions::base::get_base_branch_data(
+            ctx,
+            ctx.shared_worktree_access().read_permission(),
+        )?;
         let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
@@ -527,7 +530,10 @@ fn prompt_for_branch_selection(
     applied_stacks: &[but_workspace::legacy::ui::StackEntry],
     out: &mut OutputChannel,
 ) -> anyhow::Result<Vec<String>> {
-    let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx)?;
+    let base_branch = gitbutler_branch_actions::base::get_base_branch_data(
+        ctx,
+        ctx.shared_worktree_access().read_permission(),
+    )?;
     let base_branch_id = base_branch.current_sha;
     let repo = &*ctx.repo.get()?;
 
@@ -627,7 +633,10 @@ async fn publish_reviews_for_branch_and_dependents(
     out: &mut OutputChannel,
 ) -> Result<PublishReviewsOutcome, anyhow::Error> {
     let t = theme::get();
-    let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx)?;
+    let base_branch = {
+        let guard = ctx.shared_worktree_access();
+        gitbutler_branch_actions::base::get_base_branch_data(ctx, guard.read_permission())?
+    };
     let all_branches_up_to_subject = stack_entry
         .heads
         .iter()

--- a/crates/but/src/command/legacy/merge.rs
+++ b/crates/but/src/command/legacy/merge.rs
@@ -15,7 +15,7 @@ pub async fn handle(
 ) -> anyhow::Result<()> {
     let mut progress = out.progress_channel();
     let t = theme::get();
-    let guard = ctx.exclusive_worktree_access();
+    let mut guard = ctx.exclusive_worktree_access();
 
     let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
 
@@ -35,8 +35,10 @@ pub async fn handle(
     };
 
     // Get the base branch data to find the target
-    let base_branch = but_api::legacy::virtual_branches::get_base_branch_data(ctx)?
-        .ok_or_else(|| anyhow::anyhow!("No base branch configured"))?;
+    let base_branch = {
+        but_api::legacy::virtual_branches::get_base_branch_data(ctx, guard.write_permission())?
+            .ok_or_else(|| anyhow::anyhow!("No base branch configured"))?
+    };
 
     let target_remote = base_branch.remote_name;
 
@@ -129,6 +131,10 @@ pub async fn handle(
 
         // TODO: Drop the guard as we can't keep it across await, and `handle` will obtain its own as well.
         drop(guard);
+
+        // After we've updated the target_ref, we should invalidate the workspace.
+        ctx.invalidate_workspace_cache()?;
+
         crate::command::legacy::pull::handle(ctx, out, false).await?;
 
         writeln!(

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -1139,7 +1139,10 @@ fn find_stack_id_by_branch_name(ctx: &Context, branch_name: &str) -> anyhow::Res
 
 /// Update PR/MR target branches to match the current stack structure.
 async fn update_review_targets_for_stacks(ctx: &Context) -> anyhow::Result<()> {
-    let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx)?;
+    let base_branch = {
+        let guard = ctx.shared_worktree_access();
+        gitbutler_branch_actions::base::get_base_branch_data(ctx, guard.read_permission())?
+    };
     let stacks = but_api::legacy::workspace::stacks(
         ctx,
         Some(but_workspace::legacy::StacksFilter::InWorkspace),

--- a/crates/but/src/command/legacy/setup.rs
+++ b/crates/but/src/command/legacy/setup.rs
@@ -260,7 +260,7 @@ pub(crate) fn repo(
     }?;
 
     // Check if target branch is set
-    let target = but_api::legacy::virtual_branches::get_base_branch_data(ctx)?;
+    let target = but_api::legacy::virtual_branches::get_base_branch_data(ctx, perm)?;
 
     // If new or already exists but target is not set, set the target to be the remote's HEAD
     if (matches!(outcome, gitbutler_project::AddProjectOutcome::Added(_))

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -333,9 +333,12 @@ async fn build_status_context<'a>(
     // Calculate common_merge_base data and upstream state in a scope
     // to ensure repo reference is dropped before any async operations
     let (common_merge_base_data, upstream_state, last_fetched_ms, base_branch) = {
-        let base_branch = but_api::legacy::virtual_branches::get_base_branch_data(ctx)
-            .ok()
-            .flatten();
+        let base_branch = {
+            let mut guard = ctx.exclusive_worktree_access();
+            but_api::legacy::virtual_branches::get_base_branch_data(ctx, guard.write_permission())
+                .ok()
+                .flatten()
+        };
         let status_target = resolved_target.for_status(base_branch.as_ref());
         let repo = ctx.repo.get()?;
         let target_commit_id = status_target.commit_id;

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -51,7 +51,7 @@ pub fn set_base_branch(
     perm: &mut RepoExclusive,
 ) -> Result<BaseBranch> {
     let _ = ctx.create_snapshot(SnapshotDetails::new(OperationKind::SetBaseBranch), perm);
-    base::set_base_branch(ctx, target_branch)
+    base::set_base_branch(ctx, perm.read_permission(), target_branch)
 }
 
 pub fn set_target_push_remote(ctx: &Context, push_remote: &str) -> Result<()> {

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -4,6 +4,7 @@ use anyhow::{Context as _, Result, anyhow};
 use but_core::{
     RefMetadata, WORKSPACE_REF_NAME,
     git_config::{edit_repo_config, ensure_config_value},
+    sync::RepoShared,
     worktree::checkout::UncommitedWorktreeChanges,
 };
 use but_ctx::Context;
@@ -81,11 +82,11 @@ impl BaseBranch {
     }
 }
 
-#[instrument(skip(ctx), err(Debug))]
-pub fn get_base_branch_data(ctx: &Context) -> Result<BaseBranch> {
-    let repo = ctx.repo.get()?;
+#[instrument(skip(ctx, perm), err(Debug))]
+pub fn get_base_branch_data(ctx: &Context, perm: &RepoShared) -> Result<BaseBranch> {
     let meta = ctx.meta()?;
-    let base = target_to_base_branch(&repo, &ctx.legacy_project, &meta)?;
+    let (repo, ws, _) = ctx.workspace_and_db_with_perm(perm)?;
+    let base = target_to_base_branch(&repo, &ctx.legacy_project, &ws.graph, &meta)?;
     Ok(base)
 }
 
@@ -137,34 +138,43 @@ pub fn bootstrap_default_target_if_missing(ctx: &Context) -> Result<bool> {
     Ok(true)
 }
 
-#[instrument(skip(ctx), err(Debug))]
-fn go_back_to_integration(ctx: &Context, default_target: &Target) -> Result<BaseBranch> {
-    let repo = ctx.repo.get()?;
+#[instrument(skip(ctx, perm), err(Debug))]
+fn go_back_to_integration(
+    ctx: &Context,
+    perm: &RepoShared,
+    default_target: &Target,
+) -> Result<BaseBranch> {
     if ctx.settings.feature_flags.cv3 {
-        let workspace_commit_to_checkout =
-            but_workspace::legacy::remerged_workspace_commit_v2(ctx)?;
-        let tree_to_checkout_to_avoid_ref_update =
-            repo.find_commit(workspace_commit_to_checkout)?.tree_id()?;
-        but_core::worktree::safe_checkout(
-            repo.head_id()?.detach(),
-            tree_to_checkout_to_avoid_ref_update.detach(),
-            &repo,
-            but_core::worktree::checkout::Options {
-                uncommitted_changes: UncommitedWorktreeChanges::KeepAndAbortOnConflict,
-                skip_head_update: false,
-                ..Default::default()
-            },
-        )?;
-    } else {
-        let (mut outcome, conflict_kind) =
-            but_workspace::legacy::merge_worktree_with_workspace(ctx, &repo)?;
-
-        if outcome.has_unresolved_conflicts(conflict_kind) {
-            return Err(anyhow!("Conflicts while going back to gitbutler/workspace"))
-                .context(Marker::ProjectConflict);
+        {
+            let repo = ctx.repo.get()?;
+            let workspace_commit_to_checkout =
+                but_workspace::legacy::remerged_workspace_commit_v2(ctx)?;
+            let tree_to_checkout_to_avoid_ref_update =
+                repo.find_commit(workspace_commit_to_checkout)?.tree_id()?;
+            but_core::worktree::safe_checkout(
+                repo.head_id()?.detach(),
+                tree_to_checkout_to_avoid_ref_update.detach(),
+                &repo,
+                but_core::worktree::checkout::Options {
+                    uncommitted_changes: UncommitedWorktreeChanges::KeepAndAbortOnConflict,
+                    skip_head_update: false,
+                    ..Default::default()
+                },
+            )?;
         }
+    } else {
+        let final_tree_id = {
+            let repo = ctx.repo.get()?;
+            let (mut outcome, conflict_kind) =
+                but_workspace::legacy::merge_worktree_with_workspace(ctx, &repo)?;
 
-        let final_tree_id = outcome.tree.write()?.detach();
+            if outcome.has_unresolved_conflicts(conflict_kind) {
+                return Err(anyhow!("Conflicts while going back to gitbutler/workspace"))
+                    .context(Marker::ProjectConflict);
+            }
+
+            outcome.tree.write()?.detach()
+        };
 
         #[expect(deprecated, reason = "checkout/materialization boundary")]
         let git2_repo = &*ctx.git2_repo.get()?;
@@ -177,14 +187,13 @@ fn go_back_to_integration(ctx: &Context, default_target: &Target) -> Result<Base
             .context("failed to checkout tree")?;
     }
 
-    let meta = ctx.meta()?;
-    let base = target_to_base_branch(&repo, &ctx.legacy_project, &meta)?;
     update_workspace_commit(ctx, false)?;
-    Ok(base)
+    get_base_branch_data(ctx, perm)
 }
 
 pub(crate) fn set_base_branch(
     ctx: &Context,
+    perm: &RepoShared,
     target_branch_ref: &RemoteRefname,
 ) -> Result<BaseBranch> {
     let repo = ctx.repo.get()?;
@@ -193,7 +202,7 @@ pub(crate) fn set_base_branch(
     if let Ok(target) = default_target(ctx)
         && target.branch.eq(target_branch_ref)
     {
-        return go_back_to_integration(ctx, &target);
+        return go_back_to_integration(ctx, perm, &target);
     }
 
     // lookup a branch by name
@@ -303,9 +312,7 @@ pub(crate) fn set_base_branch(
 
     crate::integration::update_workspace_commit_with_vb_state(&vb_state, ctx, true)?;
 
-    let new_meta = ctx.meta()?;
-    let base = target_to_base_branch(&repo, &ctx.legacy_project, &new_meta)?;
-    Ok(base)
+    get_base_branch_data(ctx, perm)
 }
 
 pub(crate) fn set_target_push_remote(ctx: &Context, push_remote_name: &str) -> Result<()> {
@@ -342,6 +349,7 @@ fn set_exclude_decoration(ctx: &Context) -> Result<()> {
 pub(crate) fn target_to_base_branch(
     repo: &gix::Repository,
     project: &Project,
+    graph: &but_graph::Graph,
     meta: &impl RefMetadata,
 ) -> Result<BaseBranch> {
     // This function is presuming a workspace ref name.
@@ -365,32 +373,12 @@ pub(crate) fn target_to_base_branch(
         .context("failed to get fork point")?;
     let target_sha_ahead_of_ref = !target_sha_not_ref.is_empty();
 
-    // Compute the lowest merge base across all workspace stacks and the target.
-    // Read the workspace ref directly rather than HEAD, since HEAD may not point
-    // at the workspace commit in all code paths.
-    let lowest_merge_base = {
-        let heads: Vec<_> = repo
-            .find_reference(WORKSPACE_REF_NAME)?
-            .peel_to_commit()?
-            .parent_ids()
-            .map(|id| id.detach())
-            .collect();
-        if heads.is_empty() {
-            // No workspace commit parents — fall back to stored target SHA.
-            Some(target_sha)
-        } else {
-            let base = repo
-                .merge_base_octopus([heads.as_slice(), &[target_ref_commit]].concat())
-                .context("failed to compute octopus merge-base for workspace stacks")?;
-            Some(base.object()?.id().detach())
-        }
-    };
-
-    // Commits on the target branch between its tip and the lowest merge base.
-    let upstream_commit_ids = lowest_merge_base
-        .map(|lb| first_parent_commit_ids_until(repo, target_ref_commit, lb))
-        .transpose()
-        .context("failed to get upstream commits")?
+    // The longest list of updstream commit ids.
+    let upstream_commit_ids = graph
+        .upstream_commits(repo, target_ref.as_ref())?
+        .into_iter()
+        .map(|h| h.upstream_commits)
+        .max_by_key(|us| us.len())
         .unwrap_or_default();
 
     let upstream_commits = upstream_commit_ids

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -9,6 +9,7 @@ use but_core::{
 };
 use but_ctx::Context;
 use but_error::{Code, Marker};
+use but_graph::target_ref_relations::FirstParentTraversal;
 use but_oxidize::ObjectIdExt;
 use gitbutler_git::GitContextExt as _;
 use gitbutler_project::{FetchResult, Project};
@@ -375,7 +376,7 @@ pub(crate) fn target_to_base_branch(
 
     // The longest list of updstream commit ids.
     let upstream_commit_ids = graph
-        .upstream_commits(repo, target_ref.as_ref())?
+        .upstream_commits(repo, target_ref.as_ref(), FirstParentTraversal::Yes)?
         .into_iter()
         .map(|h| h.upstream_commits)
         .max_by_key(|us| us.len())

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -211,6 +211,7 @@ pub struct UpstreamIntegrationContext<'a> {
     old_target_id: gix::ObjectId,
     gix_repo: &'a gix::Repository,
     review_map: &'a HashMap<String, but_forge::ForgeReview>,
+    upstream_commits: Vec<gix::ObjectId>,
 }
 
 impl<'a> UpstreamIntegrationContext<'a> {
@@ -234,14 +235,25 @@ impl<'a> UpstreamIntegrationContext<'a> {
             )?;
         }
 
-        let (target_ref_name, old_target_id) = {
-            let (_repo, ws, _db) = ctx.workspace_and_db_with_perm(permission.read_permission())?;
+        let (target_ref_name, old_target_id, upstream_commits) = {
+            let (repo, ws, _db) = ctx.workspace_and_db_with_perm(permission.read_permission())?;
+            let target_ref = ws
+                .target_ref_name()
+                .context("failed to get target reference name")?
+                .to_owned();
+
+            let upstream_commits = ws
+                .graph
+                .upstream_commits(&repo, target_ref.as_ref())?
+                .into_iter()
+                .map(|h| h.upstream_commits)
+                .max_by_key(|us| us.len())
+                .unwrap_or_default();
             (
-                ws.target_ref_name()
-                    .context("failed to get target reference name")?
-                    .to_owned(),
+                target_ref,
                 ws.target_base_commit_id()
                     .context("failed to get target base oid")?,
+                upstream_commits,
             )
         };
         let new_target = match target_commit_oid {
@@ -265,6 +277,7 @@ impl<'a> UpstreamIntegrationContext<'a> {
             ctx,
             gix_repo,
             review_map,
+            upstream_commits,
         })
     }
 }
@@ -450,17 +463,17 @@ pub fn upstream_integration_statuses(
 ) -> Result<StackStatuses> {
     let UpstreamIntegrationContext {
         new_target,
-        old_target_id,
         stacks_in_workspace,
         review_map,
         ctx,
+        upstream_commits,
         ..
     } = context;
 
     let repo = ctx.clone_repo_for_merging()?;
     let repo_in_memory = repo.clone().with_object_memory();
 
-    if *new_target == *old_target_id {
+    if upstream_commits.is_empty() {
         return Ok(StackStatuses::UpToDate);
     };
 

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -4,6 +4,7 @@ use anyhow::{Context as _, Result, bail};
 use bstr::ByteSlice;
 use but_core::{RefMetadata, Reference, RepositoryExt, WORKSPACE_REF_NAME, ref_metadata::StackId};
 use but_ctx::{Context, access::RepoExclusive};
+use but_graph::target_ref_relations::FirstParentTraversal;
 use but_rebase::{RebaseOutput, RebaseStep};
 use but_serde::BStringForFrontend;
 use but_workspace::{legacy::stack_ext::StackDetailsExt, ref_info::Options};
@@ -244,7 +245,7 @@ impl<'a> UpstreamIntegrationContext<'a> {
 
             let upstream_commits = ws
                 .graph
-                .upstream_commits(&repo, target_ref.as_ref())?
+                .upstream_commits(&repo, target_ref.as_ref(), FirstParentTraversal::Yes)?
                 .into_iter()
                 .map(|h| h.upstream_commits)
                 .max_by_key(|us| us.len())

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/set_base_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/set_base_branch.rs
@@ -275,7 +275,11 @@ mod behind_count {
 
         // Stack A is farthest behind (3 commits behind origin/master).
         // Stack C is 1 commit behind. The behind count should reflect the max.
-        let base = gitbutler_branch_actions::base::get_base_branch_data(ctx).unwrap();
+        let guard = ctx.shared_worktree_access();
+        let base =
+            gitbutler_branch_actions::base::get_base_branch_data(ctx, guard.read_permission())
+                .unwrap();
+        drop(guard);
         assert_eq!(
             base.behind, 3,
             "behind count should match the farthest-behind stack (A, which is 3 commits behind)"


### PR DESCRIPTION
The reason why we were seeing the “Branches are all up to date” error was because the metric that was being used by `get_base_branch_data` and `integrate_upstream` where different.

This PR both corrects the list of upstream commits to correctly account for merge commits, and updates both suspect functions to use the same metric