### PR TITLE
feat(but): add `--checkout-to` override for teardown

### DIFF
--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -299,6 +299,7 @@ pub enum Subcommands {
     /// This command:
     /// - Creates an oplog snapshot of the current state
     /// - Finds the first active branch and checks it out
+    ///     - Alternatively, use `--checkout-to <branch>` to override this default
     /// - Cherry-picks any dangling commits from gitbutler/workspace
     /// - Provides instructions on how to return to GitButler mode
     ///
@@ -313,9 +314,17 @@ pub enum Subcommands {
     /// but teardown
     /// ```
     ///
+    /// ```text
+    /// but teardown --checkout-to my-feature-branch
+    /// ```
+    ///
     #[cfg(feature = "legacy")]
     #[clap(verbatim_doc_comment)]
-    Teardown,
+    Teardown {
+        /// Explicit override for which local branch to checkout to.
+        #[clap(long, short = 'c', value_name = "LOCAL_BRANCH")]
+        checkout_to: Option<String>,
+    },
 
     /// Updates all applied branches to be up to date with the target branch.
     ///

--- a/crates/but/src/command/legacy/teardown.rs
+++ b/crates/but/src/command/legacy/teardown.rs
@@ -59,12 +59,10 @@ pub(crate) fn teardown(
         let ref_name: gix::refs::PartialName = checkout_to
             .clone()
             .try_into()
-            .context(format!("Invalid ref name: {checkout_to}"))?;
+            .with_context(|| format!("Invalid ref name: {checkout_to}"))?;
         let resolved_ref = repo.find_reference(ref_name.as_ref())?;
         if !matches!(resolved_ref.name().category(), Some(Category::LocalBranch)) {
-            anyhow::bail!(format!(
-                "Invalid ref for checkout: '{checkout_to}' is not a local branch"
-            ))
+            anyhow::bail!("Invalid ref for checkout: '{checkout_to}' is not a local branch")
         }
         Some(resolved_ref.name().shorten().to_string())
     } else {

--- a/crates/but/src/command/legacy/teardown.rs
+++ b/crates/but/src/command/legacy/teardown.rs
@@ -2,7 +2,7 @@ use anyhow::Context as _;
 use but_core::WORKSPACE_REF_NAME;
 use but_ctx::Context;
 use but_workspace::legacy::StacksFilter;
-use gix::refs::transaction::PreviousValue;
+use gix::refs::{Category, transaction::PreviousValue};
 use serde::Serialize;
 
 use crate::{
@@ -17,8 +17,13 @@ struct TeardownResult {
     checked_out_branch: String,
 }
 
-pub(crate) fn teardown(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
+pub(crate) fn teardown(
+    ctx: &mut Context,
+    checkout_to: Option<String>,
+    out: &mut OutputChannel,
+) -> anyhow::Result<()> {
     let t = theme::get();
+
     // Check that we're on gitbutler/workspace
     let head_name = {
         let repo = ctx.repo.get()?;
@@ -47,6 +52,24 @@ pub(crate) fn teardown(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Re
         }
         anyhow::bail!("Not on gitbutler/workspace branch");
     }
+
+    // Note: Validate checkout_to before snapshot creation to prevent unnecessary snapshot
+    let checkout_to = if let Some(checkout_to) = &checkout_to {
+        let repo = ctx.repo.get()?;
+        let ref_name: gix::refs::PartialName = checkout_to
+            .clone()
+            .try_into()
+            .context(format!("Invalid ref name: {checkout_to}"))?;
+        let resolved_ref = repo.find_reference(ref_name.as_ref())?;
+        if !matches!(resolved_ref.name().category(), Some(Category::LocalBranch)) {
+            anyhow::bail!(format!(
+                "Invalid ref for checkout: '{checkout_to}' is not a local branch"
+            ))
+        }
+        Some(resolved_ref.name().shorten().to_string())
+    } else {
+        None
+    };
 
     if let Some(out) = out.for_human() {
         writeln!(out, "{}", t.progress.paint("Exiting GitButler mode..."))?;
@@ -97,19 +120,27 @@ pub(crate) fn teardown(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Re
         }
     };
 
-    // Sort by order to ensure we get the leftmost (lowest order) stack first
-    stacks.sort_by_key(|s| s.order.unwrap_or(usize::MAX));
+    let target_branch_name = if let Some(checkout_to) = checkout_to {
+        checkout_to
+    } else {
+        // Sort by order to ensure we get the leftmost (lowest order) stack first
+        stacks.sort_by_key(|s| s.order.unwrap_or(usize::MAX));
 
-    let target_stack = stacks
-        .first()
-        .ok_or_else(|| anyhow::anyhow!("No active branches found"))?;
+        if let Some(target_stack) = stacks.first() {
+            target_stack
+                .heads
+                .first()
+                .map(|h| h.name.to_string())
+                .ok_or_else(|| anyhow::anyhow!("Stack has no branches"))?
+        } else {
+            let msg = "Failed to determine checkout target branch. Specify a target branch with `--checkout-to <branch>`.";
+            if let Some(out) = out.for_human() {
+                writeln!(out, "   {}", t.error.paint(msg))?;
+            }
 
-    // Get the name of the top branch in the stack
-    let target_branch_name = target_stack
-        .heads
-        .first()
-        .map(|h| h.name.to_string())
-        .ok_or_else(|| anyhow::anyhow!("Stack has no branches"))?;
+            anyhow::bail!(msg)
+        }
+    };
 
     if let Some(out) = out.for_human() {
         writeln!(
@@ -224,7 +255,7 @@ pub(crate) fn teardown(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Re
 
 // a call to get stacks failed, which could be because someone committed on top
 // of gitbutler/workspace. Try to fix that.
-fn try_stack_fixes(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
+fn try_stack_fixes(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<()> {
     let t = theme::get();
     if let Some(out) = out.for_human() {
         writeln!(

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -1123,7 +1123,7 @@ async fn match_subcommand(
                 .emit_metrics(metrics_ctx)
         }
         #[cfg(feature = "legacy")]
-        Subcommands::Teardown => {
+        Subcommands::Teardown { checkout_to } => {
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
@@ -1132,7 +1132,7 @@ async fn match_subcommand(
                 },
                 out,
             )?;
-            command::legacy::teardown::teardown(&mut ctx, out)
+            command::legacy::teardown::teardown(&mut ctx, checkout_to, out)
                 .context("Failed to teardown GitButler project.")
                 .emit_metrics(metrics_ctx)
         }

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -166,7 +166,7 @@ impl Subcommands {
             Subcommands::Actions(_)
             | Subcommands::Mcp
             | Subcommands::Setup { .. }
-            | Subcommands::Teardown => Unknown,
+            | Subcommands::Teardown { .. } => Unknown,
             Subcommands::Config(config::Platform { cmd }) => match cmd {
                 Some(config::Subcommands::Forge {
                     cmd: Some(config::ForgeSubcommand::Auth),

--- a/crates/but/tests/but/command/teardown.rs
+++ b/crates/but/tests/but/command/teardown.rs
@@ -400,3 +400,178 @@ fn json_output_with_dangling_commits() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn teardown_informs_of_checkout_to_when_there_are_no_stacks() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+    env.but("unapply A").assert().success();
+
+    env.but("teardown")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: Failed to teardown GitButler project.
+
+Caused by:
+    Failed to determine checkout target branch. Specify a target branch with `--checkout-to <branch>`.
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn teardown_checks_out_to_branch_override() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+    env.but("unapply A").assert().success();
+
+    env.but("--json teardown")
+        .arg("--checkout-to")
+        .arg("A")
+        .allow_json()
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+{
+  "snapshotId": "[..]",
+  "checkedOutBranch": "A"
+}
+
+"#]]);
+
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(env.projects_root())
+        .arg("rev-parse")
+        .arg("--abbrev-ref")
+        .arg("HEAD")
+        .output()?;
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "A");
+
+    Ok(())
+}
+
+#[test]
+fn teardown_checks_out_to_branch_override_with_qualified_ref_name() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+    env.but("unapply A").assert().success();
+
+    env.but("--json teardown")
+        .arg("--checkout-to")
+        .arg("refs/heads/A")
+        .allow_json()
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+{
+  "snapshotId": "[..]",
+  "checkedOutBranch": "A"
+}
+
+"#]]);
+
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(env.projects_root())
+        .arg("rev-parse")
+        .arg("--abbrev-ref")
+        .arg("HEAD")
+        .output()?;
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "A");
+
+    Ok(())
+}
+
+#[test]
+fn teardown_checkout_to_handles_missing_branch() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("teardown")
+        .arg("--checkout-to")
+        .arg("no-such-branch")
+        .assert()
+        .failure()
+        .stderr_eq(str![
+            r#"
+Error: Failed to teardown GitButler project.
+
+Caused by:
+    The reference 'no-such-branch' did not exist
+
+"#
+        ]);
+
+    Ok(())
+}
+
+#[test]
+fn teardown_checkout_to_handles_malformed_branch_name() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("teardown")
+        .arg("--checkout-to")
+        .arg("not a branch")
+        .assert()
+        .failure()
+        .stderr_eq(str![
+            r#"
+Error: Failed to teardown GitButler project.
+
+Caused by:
+    0: Invalid ref name: not a branch
+    1: Reference name contains invalid byte: " "
+
+"#
+        ]);
+
+    Ok(())
+}
+
+#[test]
+fn teardown_checkout_to_disallows_non_branch_ref() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("teardown")
+        .arg("--checkout-to")
+        .arg("HEAD")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: Failed to teardown GitButler project.
+
+Caused by:
+    Invalid ref for checkout: 'HEAD' is not a local branch
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn teardown_checkout_to_disallows_non_local_branch_ref() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("teardown")
+        .arg("--checkout-to")
+        .arg("origin/main")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: Failed to teardown GitButler project.
+
+Caused by:
+    Invalid ref for checkout: 'origin/main' is not a local branch
+
+"#]]);
+
+    Ok(())
+}


### PR DESCRIPTION
This is a combined bugfix and feature addition. Or rather, the feature addition obviates the need for a bugfix. There are many ways to fail to resolve the correct local branch automatically, so instead of fixing that I'm just adding in a `--checkout-to` option that allows the user to explicitly say where to checkout to when tearing down.

`but teardown` would fail if there were no active stacks, as it used active stacks to determine the branch to checkout to. With `--checkout-to` you can now decide yourself where to checkout to.

In the event the user encounters the "no active stacks" situation, a message suggesting the use of `--checkout-to` is printed.