### PR TITLE
feat: add COSMIC Terminal support for Linux

### DIFF
--- a/apps/desktop/src/components/settings/GeneralSettings.svelte
+++ b/apps/desktop/src/components/settings/GeneralSettings.svelte
@@ -97,7 +97,7 @@
 		{ identifier: "hyper", displayName: "Hyper", platform: "linux" },
 		{ identifier: "wezterm", displayName: "WezTerm", platform: "linux" },
 		{ identifier: "kitty", displayName: "Kitty", platform: "linux" },
-		{ identifier: "cosmic-term", displayName: "COSMIC Terminal", platform: "linux" }
+		{ identifier: "cosmic-term", displayName: "COSMIC Terminal", platform: "linux" },
 	];
 
 	const terminalOptions = allTerminalOptions.filter((t) => t.platform === platformName);

--- a/apps/desktop/src/components/settings/GeneralSettings.svelte
+++ b/apps/desktop/src/components/settings/GeneralSettings.svelte
@@ -97,6 +97,7 @@
 		{ identifier: "hyper", displayName: "Hyper", platform: "linux" },
 		{ identifier: "wezterm", displayName: "WezTerm", platform: "linux" },
 		{ identifier: "kitty", displayName: "Kitty", platform: "linux" },
+		{ identifier: "cosmic-term", displayName: "COSMIC Terminal", platform: "linux" }
 	];
 
 	const terminalOptions = allTerminalOptions.filter((t) => t.platform === platformName);

--- a/crates/but-api/src/legacy/open.rs
+++ b/crates/but-api/src/legacy/open.rs
@@ -307,6 +307,7 @@ pub fn open_url(url: String) -> Result<()> {
 /// - `hyper` - Hyper
 /// - `wezterm` - WezTerm
 /// - `kitty` - Kitty
+/// - `cosmic-term` - COSMIC Terminal
 ///
 /// # Errors
 /// Returns an error if:
@@ -459,7 +460,7 @@ pub fn open_in_terminal(terminal_id: String, path: String) -> Result<()> {
             // Note: `binary` is used instead of the terminal ID because some terminals
             // have a different binary name (e.g. "warp" launches "warp-terminal").
             "gnome-terminal" | "konsole" | "xfce4-terminal" | "alacritty" | "ghostty" | "warp"
-            | "kitty" => {
+            | "kitty" | "cosmic-term" => {
                 let mut cmd = Command::new(binary);
                 cmd.current_dir(&path);
                 spawn_and_reap(cmd, binary, &path)?;


### PR DESCRIPTION
## 🧢 Changes

- Adds COSMIC Terminal to supported terminals on Linux.

## ☕️ Reasoning

Add support for COSMIC Terminal, the default terminal in distributions using COSMIC DE, which is currently unsupported. This is especially useful on atomic distributions, where avoiding layered third-party terminals helps keep the base image close to the original tree.

COSMIC Terminal is currently available only on Linux systems running COSMIC DE, and does not support Windows or macOS as of the time of writing.

## 🎫 Affected issues

Fixes: #13750 

## 📌 Todos

- [x] Test COSMIC Terminal on Linux

As requested by the maintainer, I attached a video recording of the testing below.

https://github.com/user-attachments/assets/896df3b1-fc6e-4546-ae30-a699397353ef

Testing notes: I’m currently using Fedora COSMIC Atomic and doing development inside Distrobox. To test launching COSMIC Terminal from the host environment, I created a wrapper at `~/.local/bin/cosmic-term` that forwards the call to the host binary:

```bash
#!/usr/bin/env bash
distrobox-host-exec cosmic-term "$@"
```

This allowed testing the terminal detection and launch behavior from inside the Distrobox environment while using the host-installed COSMIC Terminal.