### PR TITLE
Add `peel_restore_snapshot` to but-api

### DIFF
--- a/crates/but-api/src/legacy/oplog.rs
+++ b/crates/but-api/src/legacy/oplog.rs
@@ -261,3 +261,26 @@ pub fn snapshot_diff(
     let diff: Vec<but_core::ui::TreeChange> = diff.into_iter().map(Into::into).collect();
     Ok(diff)
 }
+
+/// Find the final snapshot that a restore snapshot will restore from.
+///
+/// For example if you do a reword and then a series of undos and redos the oplog would look like this:
+///
+/// 9ea77ad REDO
+/// 71c6be6 UNDO
+/// c33acf3 REDO
+/// 3a0c4d1 UNDO
+/// bd1724b REWORD
+///
+/// and `peel_restore_snapshot` will return the snapshot for `bd1724b`.
+///
+/// If the given snapshot is not a restore snapshot then the same snapshot will be returned.
+#[but_api]
+#[instrument(err(Debug))]
+pub fn peel_restore_snapshot(
+    ctx: &but_ctx::Context,
+    sha: gix::ObjectId,
+) -> Result<Option<Snapshot>> {
+    let snapshot = get_snapshot(ctx, sha)?;
+    gitbutler_oplog::peel_restore_snapshot(ctx, &snapshot)
+}

--- a/crates/but/src/command/legacy/oplog.rs
+++ b/crates/but/src/command/legacy/oplog.rs
@@ -112,7 +112,7 @@ pub(crate) fn show_oplog(
                     | OperationKind::RestoreFromSnapshotViaRedo
                     | OperationKind::RestoreFromSnapshot => {
                         if let Ok(Some(restore_target)) =
-                            gitbutler_oplog::peel_restore_snapshot(ctx, &snapshot)
+                            but_api::legacy::oplog::peel_restore_snapshot(ctx, snapshot.commit_id)
                             && restore_target.commit_id != snapshot.commit_id
                             && let Some(restore_target_details) = &restore_target.details
                         {

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -2622,7 +2622,7 @@ impl App {
 
         let text = {
             let restore_from = if let Ok(Some(snapshot)) =
-                gitbutler_oplog::peel_restore_snapshot(ctx, &target_snapshot)
+                but_api::legacy::oplog::peel_restore_snapshot(ctx, target_snapshot.commit_id)
                 && snapshot.commit_id != target_snapshot.commit_id
                 && snapshot.details.is_some()
             {


### PR DESCRIPTION
The TUI uses this for undo/redo do we'll likely have to add it to the SDK for lite.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #13796
- <kbd>&nbsp;1&nbsp;</kbd> #13795 👈 
<!-- GitButler Footer Boundary Bottom -->