### PR TITLE
fly-by fixes

### DIFF
--- a/crates/but-core/src/ref_metadata.rs
+++ b/crates/but-core/src/ref_metadata.rs
@@ -2,7 +2,7 @@ use anyhow::{Context as _, Result, bail};
 use gix::refs::FullNameRef;
 use uuid::Uuid;
 
-use crate::Id;
+use crate::{Id, extract_remote_name_and_short_name};
 
 /// Metadata about workspaces, associated with references that are designated to a workspace,
 /// i.e. `refs/heads/gitbutler/workspaces/<name>`.
@@ -35,12 +35,6 @@ pub struct Workspace {
     /// Note that even though this is per workspace, the implementation can fill in global information at will.
     pub target_ref: Option<gix::refs::FullName>,
 
-    /// The remote that we used to push to. Now primarily used to determine what
-    /// forge we're using.
-    ///
-    /// You probably want to use [`Self::push_remote_url`] instead in most
-    /// cases. Ideally we should wean this property out of the codebase.
-    pub remote_url: String,
     /// The commit id of a commit that was reachable by [`Self::target_ref`] and that should be included in the workspace.
     /// This is useful to make workspaces appear stable in relationship to the target reference, which may be updated each
     /// time a `git fetch` is performed.
@@ -60,7 +54,6 @@ impl std::fmt::Debug for Workspace {
             ref_info,
             stacks,
             target_ref,
-            remote_url,
             push_remote,
             target_commit_id,
         } = self;
@@ -71,7 +64,6 @@ impl std::fmt::Debug for Workspace {
                 "target_ref",
                 &MaybeDebug(&target_ref.as_ref().map(|rn| rn.as_bstr())),
             )
-            .field("remote_url", remote_url)
             .field("target_commit_id", &MaybeDebug(target_commit_id))
             .field("push_remote", &MaybeDebug(push_remote))
             .finish()
@@ -168,49 +160,43 @@ impl Workspace {
         Some(true)
     }
 
-    /// Get the remote URL, falling back to the remote URL from the target_ref's
-    /// branch.
-    ///
-    /// You probably want to use [`Self::push_remote_url`] instead.
+    /// Get the fetch URL of the remote behind [`Self::target_ref`].
     pub fn remote_url_with_fallback(&self, repo: &gix::Repository) -> Result<String> {
-        let remote_url = if self.remote_url.is_empty() {
-            let Some(target_ref) = self.target_ref.as_ref() else {
-                bail!("Target ref required for remote url fallback")
-            };
-            let remote = repo
-                .find_reference(target_ref)?
-                .remote(gix::remote::Direction::Fetch)
-                .transpose()?
-                .context(format!("failed to find remote for branch {target_ref}"))?;
-            remote
-                .url(gix::remote::Direction::Fetch)
-                .map(|url| url.to_bstring().to_string())
-                .context(format!("failed to get remote url for {target_ref}"))?
-        } else {
-            self.remote_url.clone()
+        let Some(target_ref) = self.target_ref.as_ref() else {
+            bail!("Target ref required for remote url")
         };
-        Ok(remote_url)
+        let remote_names = repo.remote_names();
+        let (remote_name, _short_name) =
+            extract_remote_name_and_short_name(target_ref.as_ref(), &remote_names).context(
+                format!("failed to determine remote for branch {target_ref}"),
+            )?;
+        let remote = repo.find_remote(remote_name.as_str()).context(format!(
+            "failed to find remote {remote_name} for branch {target_ref}"
+        ))?;
+        remote
+            .url(gix::remote::Direction::Fetch)
+            .map(|url| url.to_bstring().to_string())
+            .context(format!("failed to get fetch url for remote {remote_name}"))
     }
 
     /// The URL to push to, inferred by the [`Self::push_remote`] property.
     ///
-    /// Falls back to [`Self::remote_url`] if the push remote is not set.
+    /// Falls back to the fetch URL of the remote behind [`Self::target_ref`] if
+    /// the push remote is not set.
     pub fn push_remote_url(&self, repo: &gix::Repository) -> Result<String> {
         let push_remote_url = match self.push_remote {
-            Some(ref name) => repo
-                .find_remote(name.as_str())
-                .ok()
-                .and_then(|remote| {
-                    remote
-                        .url(gix::remote::Direction::Push)
-                        .or_else(|| remote.url(gix::remote::Direction::Fetch))
-                        .map(|url| url.to_bstring().to_string())
-                })
-                .unwrap_or_else(|| self.remote_url.clone()),
-            None => self.remote_url.clone(),
+            Some(ref name) => repo.find_remote(name.as_str()).ok().and_then(|remote| {
+                remote
+                    .url(gix::remote::Direction::Push)
+                    .or_else(|| remote.url(gix::remote::Direction::Fetch))
+                    .map(|url| url.to_bstring().to_string())
+            }),
+            None => None,
         };
 
-        Ok(push_remote_url)
+        push_remote_url
+            .map(Ok)
+            .unwrap_or_else(|| self.remote_url_with_fallback(repo))
     }
 }
 

--- a/crates/but-core/tests/core/ref_metadata.rs
+++ b/crates/but-core/tests/core/ref_metadata.rs
@@ -51,7 +51,6 @@ mod workspace {
             ref_info: RefInfo { created_at: None, updated_at: None },
             stacks: [],
             target_ref: None,
-            remote_url: "",
             target_commit_id: None,
             push_remote: None,
         }
@@ -121,7 +120,6 @@ mod workspace {
                 },
             ],
             target_ref: None,
-            remote_url: "",
             target_commit_id: None,
             push_remote: None,
         }
@@ -137,7 +135,6 @@ mod workspace {
             ref_info: RefInfo { created_at: None, updated_at: None },
             stacks: [],
             target_ref: None,
-            remote_url: "",
             target_commit_id: None,
             push_remote: None,
         }

--- a/crates/but-debug/src/command/revision.rs
+++ b/crates/but-debug/src/command/revision.rs
@@ -3,11 +3,9 @@
 use std::io::{self, Write as _};
 
 use anyhow::{Context as _, Result, bail, ensure};
-use but_core::ref_metadata::{
-    StackId, Workspace, WorkspaceCommitRelation, WorkspaceStack, WorkspaceStackBranch,
-};
 use but_graph::FirstParent;
-use gix::{odb::store::RefreshMode, reference::Category, refs::Target, revision::plumbing::Spec};
+use but_graph::init::Tip;
+use gix::{odb::store::RefreshMode, reference::Category, revision::plumbing::Spec};
 
 use crate::{
     args::{Args, LogArgs, MergeBaseArgs, RevisionArgs, RevisionGraphArgs, RevisionSubcommands},
@@ -52,11 +50,11 @@ fn log(
     let mut graph_commits = vec![included];
     graph_commits.extend(excluded);
 
-    let graph_args = resolve_graph_args(repo, &log_args.graph)?;
+    let graph_tips = args_to_tips(repo, &log_args.graph)?;
     let graph = {
         let _span =
             tracing::info_span!("build graph", commit_count = graph_commits.len()).entered();
-        graph_for_revisions(repo, meta, &graph_commits, graph_args)?
+        graph_for_revisions(repo, meta, &graph_commits, graph_tips)?
     };
 
     let _span = tracing::info_span!("traverse graph").entered();
@@ -101,10 +99,10 @@ fn merge_base(
             .collect::<Result<Vec<_>>>()?
     };
 
-    let graph_args = resolve_graph_args(repo, &merge_base_args.graph)?;
+    let graph_tips = args_to_tips(repo, &merge_base_args.graph)?;
     let graph = {
         let _span = tracing::info_span!("build graph", commit_count = commits.len()).entered();
-        graph_for_revisions(repo, meta, &commits, graph_args)?
+        graph_for_revisions(repo, meta, &commits, graph_tips)?
     };
 
     let segments = {
@@ -148,17 +146,14 @@ fn merge_base(
     Ok(())
 }
 
-struct GraphArgs {
-    target_ref: Option<gix::refs::FullName>,
-    extra_target: Option<gix::ObjectId>,
-}
+fn args_to_tips(repo: &gix::Repository, graph_args: &RevisionGraphArgs) -> Result<Vec<Tip>> {
+    let mut tips = Vec::new();
 
-fn resolve_graph_args(repo: &gix::Repository, graph_args: &RevisionGraphArgs) -> Result<GraphArgs> {
-    let target_ref = graph_args
+    if let Some(tip) = graph_args
         .target_ref
         .as_deref()
         .map(|target_ref| {
-            let reference = repo
+            let mut reference = repo
                 .find_reference(target_ref)
                 .with_context(|| format!("Failed to find target ref '{target_ref}'"))?;
             let name = reference.name().to_owned();
@@ -166,31 +161,35 @@ fn resolve_graph_args(repo: &gix::Repository, graph_args: &RevisionGraphArgs) ->
                 name.category() == Some(Category::RemoteBranch),
                 "Target ref '{name}' resolved from '{target_ref}' is not a remote-tracking branch; use --extra-target for arbitrary revisions"
             );
-            Ok(name)
+            let id = reference.peel_to_id()?.detach();
+            Ok(Tip::integrated(id, Some(name)))
         })
-        .transpose()?;
+        .transpose()?
+    {
+        tips.push(tip);
+    }
 
-    let extra_target = graph_args
+    if let Some(tip) = graph_args
         .extra_target
         .as_deref()
         .map(|rev| {
             repo.rev_parse_single(rev)
-                .map(|id| id.detach())
+                .map(|id| Tip::integrated(id.detach(), None))
                 .with_context(|| format!("Failed to resolve extra target '{rev}'"))
         })
-        .transpose()?;
+        .transpose()?
+    {
+        tips.push(tip);
+    }
 
-    Ok(GraphArgs {
-        target_ref,
-        extra_target,
-    })
+    Ok(tips)
 }
 
 fn graph_for_revisions(
     repo: &gix::Repository,
     meta: &EmptyRefMetadata,
     commits: &[gix::ObjectId],
-    graph_args: GraphArgs,
+    graph_tips: Vec<Tip>,
 ) -> Result<but_graph::Graph> {
     let first = *commits
         .first()
@@ -198,59 +197,17 @@ fn graph_for_revisions(
     let options = but_graph::init::Options {
         collect_tags: false,
         commits_limit_hint: None,
-        extra_target_commit_id: graph_args.extra_target,
         ..Default::default()
     };
-    let mut graph = but_graph::Graph::default();
-    graph.options = options;
+    let tips = std::iter::once(Tip::entrypoint(first, None))
+        .chain(
+            commits
+                .iter()
+                .copied()
+                .skip(1)
+                .map(|id| Tip::reachable(id, None)),
+        )
+        .chain(graph_tips);
 
-    let workspace_ref_name = synthetic_ref_name("workspace")?;
-    let input_ref_names = (0..commits.len())
-        .map(|idx| synthetic_ref_name(&format!("input-{idx}")))
-        .collect::<Result<Vec<_>>>()?;
-
-    let refs = std::iter::once(gix::refs::Reference {
-        name: workspace_ref_name.clone(),
-        target: Target::Object(first),
-        peeled: Some(first),
-    })
-    .chain(
-        input_ref_names
-            .iter()
-            .cloned()
-            .zip(commits.iter().copied())
-            .map(|(name, id)| gix::refs::Reference {
-                name,
-                target: Target::Object(id),
-                peeled: Some(id),
-            }),
-    );
-    let workspace = Workspace {
-        stacks: input_ref_names
-            .iter()
-            .enumerate()
-            .map(|(idx, ref_name)| WorkspaceStack {
-                id: StackId::from_number_for_testing(1000 + idx as u128),
-                branches: vec![WorkspaceStackBranch {
-                    ref_name: ref_name.clone(),
-                    archived: false,
-                }],
-                workspacecommit_relation: WorkspaceCommitRelation::Merged,
-            })
-            .collect(),
-        target_ref: graph_args.target_ref,
-        ..Default::default()
-    };
-    let overlay = but_graph::init::Overlay::default()
-        .with_entrypoint(first, Some(workspace_ref_name.clone()))
-        .with_references(refs)
-        .with_workspace_metadata_override(Some((workspace_ref_name, workspace)));
-
-    graph.redo_traversal_with_overlay(repo, meta, overlay)
-}
-
-fn synthetic_ref_name(suffix: &str) -> Result<gix::refs::FullName> {
-    format!("refs/heads/but-debug/revision/{suffix}")
-        .try_into()
-        .with_context(|| format!("BUG: invalid synthetic ref suffix '{suffix}'"))
+    but_graph::Graph::from_commit_traversal_tips(repo, tips, meta, options)
 }

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -30,6 +30,133 @@ mod post;
 
 pub(crate) type Entrypoint = Option<(gix::ObjectId, Option<gix::refs::FullName>)>;
 
+/// A resolved commit tip to seed graph traversal without requiring it to be
+/// discoverable through repository refs or workspace metadata.
+#[derive(Debug, Clone)]
+pub struct Tip {
+    /// The commit id to start walking from.
+    pub id: gix::ObjectId,
+    /// The ref name to assign to the tip segment, if it should be named.
+    pub ref_name: Option<gix::refs::FullName>,
+    /// How this tip participates in traversal.
+    pub role: TipRole,
+}
+
+/// Lifecycle
+impl Tip {
+    /// A normal named or unnamed traversal entrypoint.
+    ///
+    /// `id` is the commit where graph traversal starts.
+    /// `ref_name` names the entrypoint segment when the caller has a stable ref
+    /// for it.
+    pub fn entrypoint(id: gix::ObjectId, ref_name: Option<gix::refs::FullName>) -> Self {
+        Tip {
+            id,
+            ref_name,
+            role: TipRole::EntryPoint,
+        }
+    }
+
+    /// An entrypoint whose segment should remain detached even if refs point to
+    /// its commit.
+    ///
+    /// `id` is the commit where graph traversal starts.
+    pub fn detached_entrypoint(id: gix::ObjectId) -> Self {
+        Tip {
+            id,
+            ref_name: None,
+            role: TipRole::DetachedEntryPoint,
+        }
+    }
+
+    /// A non-remote tip that should be included in the traversal.
+    ///
+    /// `id` is the commit to include as another non-remote traversal root.
+    /// `ref_name` names the tip segment when the caller has a stable ref for it.
+    pub fn reachable(id: gix::ObjectId, ref_name: Option<gix::refs::FullName>) -> Self {
+        Tip {
+            id,
+            ref_name,
+            role: TipRole::Reachable,
+        }
+    }
+
+    /// A target/integration tip that bounds or extends traversal context.
+    /// It represents part of the graph that [`Self::reachable()`] parts want to integrate with.
+    ///
+    /// `id` is the commit to treat as integrated history.
+    /// `ref_name` names the target segment when the caller has a stable ref for
+    /// it.
+    pub fn integrated(id: gix::ObjectId, ref_name: Option<gix::refs::FullName>) -> Self {
+        Tip {
+            id,
+            ref_name,
+            role: TipRole::Integrated,
+        }
+    }
+}
+
+/// The role a resolved traversal tip plays when constructing a graph.
+///
+/// Roles decide the initial [`CommitFlags`] and `Limit` goals used by the
+/// walk. The explicit entrypoint is the shared goal: reachable and integrated
+/// tips seek connection to it by walking history until they encounter the entrypoint's
+/// propagated goal flag.
+///
+/// Remote-tracking tips are not modeled as explicit [`TipRole`] values. They
+/// are discovered during traversal from refs found at visited commits and their
+/// configured or deduced remote-tracking branches. When such a remote tip is
+/// queued, it receives an indirect goal for the local commit where it was
+/// discovered, while that local side receives a goal for the remote tip. This
+/// reciprocal goal setup lets remote and local tracking histories converge until
+/// the graph can connect them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TipRole {
+    /// The normal traversal entrypoint, typically used to represent `HEAD`.
+    ///
+    /// This is the single anchor tip for explicit traversal. It receives
+    /// [`CommitFlags::NotInRemote`] plus a generated goal flag for its own
+    /// commit, and that goal flag propagates down its ancestry so other tips can
+    /// connect to it.
+    ///
+    /// It does not seek another tip. [`TipRole::Reachable`] and
+    /// [`TipRole::Integrated`] tips seek connection to this role.
+    EntryPoint,
+    /// The traversal entrypoint, but with detached-HEAD presentation semantics.
+    ///
+    /// This behaves like [`TipRole::EntryPoint`] for traversal and is also the
+    /// single anchor that reachable and integrated tips seek. Its segment is
+    /// kept anonymous even if repository refs point to the same commit; those
+    /// refs remain attached to the commit instead of naming the segment.
+    DetachedEntryPoint,
+    /// A non-remote tip that should be traversed and related to the entrypoint.
+    ///
+    /// This tip receives [`CommitFlags::NotInRemote`] and, unless it is the same
+    /// commit as the entrypoint, an indirect goal for the entrypoint commit. It
+    /// seeks connection to [`TipRole::EntryPoint`] or [`TipRole::DetachedEntryPoint`] by
+    /// walking history until it reaches commits carrying the entrypoint's
+    /// propagated goal flag.
+    Reachable,
+    /// A target/integration tip whose reachable history is considered integrated,
+    /// and that reachable/unintegrated tips want to connect with.
+    ///
+    /// This tip receives [`CommitFlags::Integrated`] and an indirect goal for
+    /// the entrypoint commit with no extra allowance once that goal is found. It
+    /// seeks connection to [`TipRole::EntryPoint`] or
+    /// [`TipRole::DetachedEntryPoint`] just far enough to connect target history
+    /// to the entrypoint's ancestry.
+    Integrated,
+}
+
+/// Selects how traversal tips are discovered before they are queued.
+enum TipSource {
+    /// Discover tips from workspace metadata and repository refs.
+    FromMetadata,
+    /// Use caller-provided tips directly, bypassing workspace metadata tip
+    /// discovery.
+    Explicit(Vec<Tip>),
+}
+
 /// A way to define information to be served from memory, instead of from the underlying data source, when
 /// [initializing](Graph::from_commit_traversal()) the graph.
 #[derive(Debug, Default, Clone)]
@@ -191,22 +318,11 @@ impl Graph {
                 (tip, Some(existing_reference.inner.name))
             }
         };
+
         let mut graph = Self::from_commit_traversal(tip, maybe_name, meta, options)?;
         if is_detached {
-            // graph is eagerly naming segments, which we undo to show it's detached.
-            let sidx = graph
-                .entrypoint
-                .context("BUG: entrypoint is set after first traversal")?
-                .0;
-            let s = &mut graph[sidx];
-            if let Some((rn, first_commit)) = s
-                .commits
-                .first_mut()
-                .and_then(|first_commit| s.ref_info.take().map(|rn| (rn, first_commit)))
-            {
-                first_commit.refs.push(rn);
-            }
-        };
+            graph.detach_entrypoint_segment()?;
+        }
         Ok(graph)
     }
     /// Produce a minimal but usable representation of the commit-graph reachable from the commit at `tip` such the returned instance
@@ -261,7 +377,59 @@ impl Graph {
         options: Options,
     ) -> anyhow::Result<Self> {
         let (repo, meta, _entrypoint) = Overlay::default().into_parts(tip.repo, meta);
-        Graph::from_commit_traversal_inner(tip.detach(), &repo, ref_name.into(), &meta, options)
+        Graph::from_commit_traversal_inner(
+            tip.detach(),
+            &repo,
+            ref_name.into(),
+            &meta,
+            options,
+            TipSource::FromMetadata,
+        )
+    }
+
+    /// Produce a graph from already resolved tips and their traversal roles.
+    ///
+    /// This is useful for callers that already know the commits they want to
+    /// relate, or whose tips are not represented by durable repository refs or
+    /// workspace metadata.
+    ///
+    /// `repo` provides commit objects, refs, remotes, worktrees, and optional
+    /// commit-graph acceleration for traversal.
+    /// `tips` provides the resolved commits and their traversal roles. It must
+    /// contain exactly one [`TipRole::EntryPoint`] or
+    /// [`TipRole::DetachedEntryPoint`].
+    /// `meta` provides branch metadata for any refs encountered while walking.
+    /// `options` controls tag collection, traversal limits, extra target
+    /// commits, and post-processing behavior.
+    pub fn from_commit_traversal_tips(
+        repo: &gix::Repository,
+        tips: impl IntoIterator<Item = Tip>,
+        meta: &impl RefMetadata,
+        options: Options,
+    ) -> anyhow::Result<Self> {
+        let tips: Vec<_> = tips.into_iter().collect();
+        let entrypoint = validate_explicit_tips(repo, &tips)?;
+        let tip = entrypoint.id;
+        let ref_name = match entrypoint.role {
+            TipRole::EntryPoint => entrypoint.ref_name.clone(),
+            TipRole::DetachedEntryPoint => None,
+            TipRole::Reachable | TipRole::Integrated => unreachable!("filtered above"),
+        };
+        let is_detached = entrypoint.role == TipRole::DetachedEntryPoint;
+
+        let (repo, meta, _entrypoint) = Overlay::default().into_parts(repo, meta);
+        let mut graph = Graph::from_commit_traversal_inner(
+            tip,
+            &repo,
+            ref_name,
+            &meta,
+            options,
+            TipSource::Explicit(tips),
+        )?;
+        if is_detached {
+            graph.detach_entrypoint_segment()?;
+        }
+        Ok(graph)
     }
 
     fn from_commit_traversal_inner<T: RefMetadata>(
@@ -270,6 +438,7 @@ impl Graph {
         ref_name: Option<gix::refs::FullName>,
         meta: &OverlayMetadata<'_, T>,
         options: Options,
+        tip_source: TipSource,
     ) -> anyhow::Result<Self> {
         {
             if let Some(name) = &ref_name {
@@ -307,8 +476,23 @@ impl Graph {
 
         let configured_remote_tracking_branches =
             remotes::configured_remote_tracking_branches(repo)?;
-        let (workspaces, target_refs) =
-            obtain_workspace_infos(repo, ref_name.as_ref().map(|rn| rn.as_ref()), meta)?;
+        let explicit_tips = match tip_source {
+            TipSource::FromMetadata => None,
+            TipSource::Explicit(tips) => Some(tips),
+        };
+        let (workspaces, target_refs) = if explicit_tips.is_some() {
+            (
+                Vec::new(),
+                explicit_tips
+                    .iter()
+                    .flatten()
+                    .filter(|tip| tip.role == TipRole::Integrated)
+                    .filter_map(|tip| tip.ref_name.clone())
+                    .collect(),
+            )
+        } else {
+            obtain_workspace_infos(repo, ref_name.as_ref().map(|rn| rn.as_ref()), meta)?
+        };
         let refs_by_id = repo.collect_ref_mapping_by_prefix(
             [
                 "refs/heads/",
@@ -360,6 +544,12 @@ impl Graph {
                         })
                     })
                 }))
+                .chain(explicit_tips.iter().flatten().filter_map(|tip| {
+                    tip.ref_name.as_ref().and_then(|ref_name| {
+                        extract_remote_name_and_short_name(ref_name.as_ref(), &remote_names)
+                            .map(|(remote, _short_name)| (1, remote))
+                    })
+                }))
                 .collect();
             v.sort();
             v.dedup();
@@ -383,119 +573,140 @@ impl Graph {
             dangerously_skip_postprocessing_for_debugging,
             worktree_by_branch,
         };
-        match tip_ref_matches_ws_ref {
-            None => {
-                let current =
-                    graph.insert_segment_set_entrypoint(branch_segment_from_name_and_meta(
-                        None,
-                        meta,
-                        Some((&ctx.refs_by_id, tip)),
-                        &ctx.worktree_by_branch,
-                    )?);
-                let tip_info = find(commit_graph.as_ref(), repo.for_find_only(), tip, &mut buf)?;
-                _ = next.push_back_exhausted((
-                    tip_info,
-                    tip_flags,
-                    Instruction::CollectCommit { into: current },
-                    max_limit,
-                ));
-            }
-            Some(ws_tip) => {
-                ensure!(
-                    *ws_tip == tip,
-                    format!(
-                        "BUG:: {ref_name:?} points to {ws_tip}, but the caller claimed it points to {tip}"
-                    )
-                );
-            }
-        }
 
         let target_limit = max_limit
             .with_indirect_goal(tip, &mut goals)
             .without_allowance();
         let (mut ws_tips, mut ws_metas) = (Vec::new(), Vec::new());
         let mut additional_target_commits = Vec::new();
-        for (ws_tip, ws_ref, ws_meta) in workspaces {
-            ws_tips.push(ws_tip);
-            ws_metas.push(ws_meta.clone());
-            let target = ws_meta.target_ref.as_ref().and_then(|trn| {
-                let tid = try_refname_to_id(repo, trn.as_ref())
-                    .map_err(|err| {
-                        tracing::warn!("Ignoring non-existing target branch {trn}: {err}");
-                        err
-                    })
-                    .ok()??;
-                let local_info = repo
-                    .upstream_branch_and_remote_for_tracking_branch(trn.as_ref())
-                    .ok()
-                    .flatten()
-                    .and_then(|(local_tracking_name, _remote_name)| {
-                        let ltid = try_refname_to_id(repo, local_tracking_name.as_ref()).ok()??;
-                        if next.is_queued(ltid) {
-                            return None;
-                        }
-                        Some((local_tracking_name, ltid))
-                    });
-                Some((trn.clone(), tid, local_info))
-            });
-
-            let (ws_extra_flags, ws_limit) = if Some(&ws_ref) == ref_name.as_ref() {
-                (tip_flags, max_limit)
-            } else {
-                (
-                    CommitFlags::empty(),
-                    max_limit.with_indirect_goal(tip, &mut goals),
-                )
-            };
-            let mut ws_segment = branch_segment_from_name_and_meta(
-                Some((ws_ref, None)),
-                meta,
-                None,
-                &ctx.worktree_by_branch,
-            )?;
-
-            additional_target_commits.extend(ws_meta.target_commit_id);
-            // The limits for the target ref and the worktree ref are synced so they can always find each other,
-            // while being able to stop when the entrypoint is included.
-            ws_segment.metadata = Some(SegmentMetadata::Workspace(ws_meta));
-            let ws_segment = graph.insert_segment(ws_segment);
-            if graph.entrypoint.is_none()
-                && graph
-                    .entrypoint_ref
-                    .as_ref()
-                    .zip(ref_name.as_ref())
-                    .is_some_and(|(a, b)| a == b)
-            {
-                graph.entrypoint = Some((ws_segment, EntryPointCommit::AtCommit(tip)));
-            }
-            // As workspaces typically have integration branches which can help us to stop the traversal,
-            // pick these up first.
-            let ws_tip_info = find(
+        if let Some(explicit_tips) = explicit_tips.as_ref() {
+            queue_explicit_tips(
+                &mut graph,
+                &mut next,
+                explicit_tips,
+                tip,
+                tip_flags,
+                max_limit,
+                target_limit,
+                &mut goals,
                 commit_graph.as_ref(),
-                repo.for_find_only(),
-                ws_tip,
+                repo,
+                meta,
+                &ctx,
                 &mut buf,
             )?;
-            _ = next.push_front_exhausted((
-                ws_tip_info,
-                CommitFlags::InWorkspace |
-                    // We only allow workspaces that are not remote, and that are not target refs.
-                    // Theoretically they can still cross-reference each other, but then we'd simply ignore
-                    // their status for now.
-                    CommitFlags::NotInRemote| ws_extra_flags,
-                Instruction::CollectCommit { into: ws_segment },
-                ws_limit,
-            ));
+        } else {
+            match tip_ref_matches_ws_ref {
+                None => {
+                    let current =
+                        graph.insert_segment_set_entrypoint(branch_segment_from_name_and_meta(
+                            None,
+                            meta,
+                            Some((&ctx.refs_by_id, tip)),
+                            &ctx.worktree_by_branch,
+                        )?);
+                    let tip_info =
+                        find(commit_graph.as_ref(), repo.for_find_only(), tip, &mut buf)?;
+                    _ = next.push_back_exhausted((
+                        tip_info,
+                        tip_flags,
+                        Instruction::CollectCommit { into: current },
+                        max_limit,
+                    ));
+                }
+                Some(ws_tip) => {
+                    ensure!(
+                        *ws_tip == tip,
+                        format!(
+                            "BUG:: {ref_name:?} points to {ws_tip}, but the caller claimed it points to {tip}"
+                        )
+                    );
+                }
+            }
 
-            if let Some((target_ref, target_ref_id, local_tip_info)) = target {
-                let target_segment = graph.insert_segment(branch_segment_from_name_and_meta(
-                    Some((target_ref, None)),
+            for (ws_tip, ws_ref, ws_meta) in workspaces {
+                ws_tips.push(ws_tip);
+                ws_metas.push(ws_meta.clone());
+                let target = ws_meta.target_ref.as_ref().and_then(|trn| {
+                    let tid = try_refname_to_id(repo, trn.as_ref())
+                        .map_err(|err| {
+                            tracing::warn!("Ignoring non-existing target branch {trn}: {err}");
+                            err
+                        })
+                        .ok()??;
+                    let local_info = repo
+                        .upstream_branch_and_remote_for_tracking_branch(trn.as_ref())
+                        .ok()
+                        .flatten()
+                        .and_then(|(local_tracking_name, _remote_name)| {
+                            let ltid =
+                                try_refname_to_id(repo, local_tracking_name.as_ref()).ok()??;
+                            if next.is_queued(ltid) {
+                                return None;
+                            }
+                            Some((local_tracking_name, ltid))
+                        });
+                    Some((trn.clone(), tid, local_info))
+                });
+
+                let (ws_extra_flags, ws_limit) = if Some(&ws_ref) == ref_name.as_ref() {
+                    (tip_flags, max_limit)
+                } else {
+                    (
+                        CommitFlags::empty(),
+                        max_limit.with_indirect_goal(tip, &mut goals),
+                    )
+                };
+                let mut ws_segment = branch_segment_from_name_and_meta(
+                    Some((ws_ref, None)),
                     meta,
                     None,
                     &ctx.worktree_by_branch,
-                )?);
-                let (local_sidx, local_goal) =
-                    if let Some((local_ref_name, target_local_tip)) = local_tip_info {
+                )?;
+
+                additional_target_commits.extend(ws_meta.target_commit_id);
+                // The limits for the target ref and the worktree ref are synced so they can always find each other,
+                // while being able to stop when the entrypoint is included.
+                ws_segment.metadata = Some(SegmentMetadata::Workspace(ws_meta));
+                let ws_segment = graph.insert_segment(ws_segment);
+                if graph.entrypoint.is_none()
+                    && graph
+                        .entrypoint_ref
+                        .as_ref()
+                        .zip(ref_name.as_ref())
+                        .is_some_and(|(a, b)| a == b)
+                {
+                    graph.entrypoint = Some((ws_segment, EntryPointCommit::AtCommit(tip)));
+                }
+                // As workspaces typically have integration branches which can help us to stop the traversal,
+                // pick these up first.
+                let ws_tip_info = find(
+                    commit_graph.as_ref(),
+                    repo.for_find_only(),
+                    ws_tip,
+                    &mut buf,
+                )?;
+                _ = next.push_front_exhausted((
+                    ws_tip_info,
+                    CommitFlags::InWorkspace |
+                        // We only allow workspaces that are not remote, and that are not target refs.
+                        // Theoretically they can still cross-reference each other, but then we'd simply ignore
+                        // their status for now.
+                        CommitFlags::NotInRemote| ws_extra_flags,
+                    Instruction::CollectCommit { into: ws_segment },
+                    ws_limit,
+                ));
+
+                if let Some((target_ref, target_ref_id, local_tip_info)) = target {
+                    let target_segment = graph.insert_segment(branch_segment_from_name_and_meta(
+                        Some((target_ref, None)),
+                        meta,
+                        None,
+                        &ctx.worktree_by_branch,
+                    )?);
+                    let (local_sidx, local_goal) = if let Some((local_ref_name, target_local_tip)) =
+                        local_tip_info
+                    {
                         let local_sidx = graph.insert_segment(branch_segment_from_name_and_meta(
                             None,
                             meta,
@@ -531,23 +742,24 @@ impl Graph {
                     } else {
                         (None, CommitFlags::empty())
                     };
-                let target_ref_info = find(
-                    commit_graph.as_ref(),
-                    repo.for_find_only(),
-                    target_ref_id,
-                    &mut buf,
-                )?;
-                _ = next.push_front_exhausted((
-                    target_ref_info,
-                    CommitFlags::Integrated,
-                    Instruction::CollectCommit {
-                        into: target_segment,
-                    },
-                    // Once the goal was found, be done immediately,
-                    // we are not interested in these.
-                    target_limit.additional_goal(local_goal),
-                ));
-                graph[target_segment].sibling_segment_id = local_sidx;
+                    let target_ref_info = find(
+                        commit_graph.as_ref(),
+                        repo.for_find_only(),
+                        target_ref_id,
+                        &mut buf,
+                    )?;
+                    _ = next.push_front_exhausted((
+                        target_ref_info,
+                        CommitFlags::Integrated,
+                        Instruction::CollectCommit {
+                            into: target_segment,
+                        },
+                        // Once the goal was found, be done immediately,
+                        // we are not interested in these.
+                        target_limit.additional_goal(local_goal),
+                    ));
+                    graph[target_segment].sibling_segment_id = local_sidx;
+                }
             }
         }
 
@@ -830,6 +1042,28 @@ impl Graph {
         graph.post_processed(meta, tip, ctx)
     }
 
+    /// Take the ref-info from a named segment and put it back onto the first commit
+    /// where it pointed to before it was lifted up.
+    ///
+    /// Graph traversal eagerly names segments from refs pointing at their
+    /// first commit. Detached entrypoints keep those refs on the commit, but
+    /// the entrypoint segment itself must stay anonymous.
+    fn detach_entrypoint_segment(&mut self) -> anyhow::Result<()> {
+        let sidx = self
+            .entrypoint
+            .context("BUG: entrypoint is set after first traversal")?
+            .0;
+        let s = &mut self[sidx];
+        if let Some((rn, first_commit)) = s
+            .commits
+            .first_mut()
+            .and_then(|first_commit| s.ref_info.take().map(|rn| (rn, first_commit)))
+        {
+            first_commit.refs.push(rn);
+        }
+        Ok(())
+    }
+
     /// Repeat the traversal that generated this graph using `repo` and `meta`, but allow to set an in-memory
     /// `overlay` to amend the data available from `repo` and `meta`.
     /// This way, one can see this graph as it will be in the future once the changes to `repo` and `meta` are actually made.
@@ -870,7 +1104,14 @@ impl Graph {
                 (tip, ref_name)
             }
         };
-        Graph::from_commit_traversal_inner(tip, &repo, ref_name, &meta, self.options.clone())
+        Graph::from_commit_traversal_inner(
+            tip,
+            &repo,
+            ref_name,
+            &meta,
+            self.options.clone(),
+            TipSource::FromMetadata,
+        )
     }
 
     /// Like [`Self::redo_traversal_with_overlay()`], but replaces this instance, without overlay, and returns
@@ -884,6 +1125,129 @@ impl Graph {
         self = new;
         self.into_workspace()
     }
+}
+
+/// Validate caller-provided traversal tips before they seed graph traversal.
+///
+/// Explicit tips must name exactly one entrypoint, must not reuse commit ids or
+/// ref names, must keep detached entrypoints unnamed, and any supplied ref name
+/// must resolve to the same commit id as its tip.
+fn validate_explicit_tips<'a>(repo: &gix::Repository, tips: &'a [Tip]) -> anyhow::Result<&'a Tip> {
+    let mut entrypoints = tips
+        .iter()
+        .filter(|tip| matches!(tip.role, TipRole::EntryPoint | TipRole::DetachedEntryPoint));
+    let entrypoint = entrypoints
+        .next()
+        .context("explicit traversal tips require exactly one entrypoint")?;
+    ensure!(
+        entrypoints.next().is_none(),
+        "explicit traversal tips require exactly one entrypoint"
+    );
+
+    for (idx, tip) in tips.iter().enumerate() {
+        ensure!(
+            tip.role != TipRole::DetachedEntryPoint || tip.ref_name.is_none(),
+            "explicit detached entrypoint tip cannot have a ref name"
+        );
+
+        for previous in &tips[..idx] {
+            ensure!(
+                tip.id != previous.id,
+                "explicit traversal tips contain duplicate commit id {id}",
+                id = tip.id
+            );
+            if let Some(ref_name) = tip
+                .ref_name
+                .as_ref()
+                .filter(|ref_name| previous.ref_name.as_ref() == Some(*ref_name))
+            {
+                bail!("explicit traversal tips contain duplicate ref name {ref_name}");
+            }
+        }
+
+        if let Some(ref_name) = tip.ref_name.as_ref() {
+            let resolved_id = repo
+                .try_find_reference(ref_name.as_ref())?
+                .with_context(|| format!("explicit traversal tip ref {ref_name} does not exist"))?
+                .peel_to_id()?
+                .detach();
+            ensure!(
+                resolved_id == tip.id,
+                "explicit traversal tip ref {ref_name} points to {resolved_id}, not {tip_id}",
+                tip_id = tip.id
+            );
+        }
+    }
+
+    Ok(entrypoint)
+}
+
+/// Queue explicit caller-provided tips into the normal traversal queue.
+///
+/// `graph` receives one initial segment per explicit tip.
+/// `next` receives the queue entries that drive commit traversal.
+/// `tips` are the resolved commits and roles supplied by the caller.
+/// `entrypoint` is the entrypoint commit id used as the shared traversal goal.
+/// `entrypoint_flags` are the initial flags applied to the entrypoint tip.
+/// `max_limit` is the traversal limit for non-target tips.
+/// `target_limit` is the traversal limit for integrated target tips.
+/// `goals` allocates and records additional reachability goals.
+/// `commit_graph` accelerates commit lookups when available.
+/// `repo` provides commit lookup and ref/worktree context through the overlay.
+/// `meta` provides branch metadata for named explicit tips.
+/// `ctx` provides ref and worktree mappings gathered for this traversal.
+/// `buf` is scratch storage reused for commit object reads.
+#[expect(clippy::too_many_arguments)]
+fn queue_explicit_tips<T: RefMetadata>(
+    graph: &mut Graph,
+    next: &mut Queue,
+    tips: &[Tip],
+    entrypoint: gix::ObjectId,
+    entrypoint_flags: CommitFlags,
+    max_limit: Limit,
+    target_limit: Limit,
+    goals: &mut Goals,
+    commit_graph: Option<&gix::commitgraph::Graph>,
+    repo: &OverlayRepo<'_>,
+    meta: &OverlayMetadata<'_, T>,
+    ctx: &post::Context<'_>,
+    buf: &mut Vec<u8>,
+) -> anyhow::Result<()> {
+    for tip in tips {
+        let named_ref = (!matches!(tip.role, TipRole::DetachedEntryPoint))
+            .then(|| tip.ref_name.clone())
+            .flatten();
+        let segment = branch_segment_from_name_and_meta(
+            named_ref.map(|ref_name| (ref_name, None)),
+            meta,
+            Some((&ctx.refs_by_id, tip.id)),
+            &ctx.worktree_by_branch,
+        )?;
+        let segment = graph.insert_segment(segment);
+        let (flags, limit) = match tip.role {
+            TipRole::EntryPoint | TipRole::DetachedEntryPoint => {
+                graph.entrypoint = Some((segment, EntryPointCommit::AtCommit(tip.id)));
+                (entrypoint_flags, max_limit)
+            }
+            TipRole::Reachable => {
+                let limit = if tip.id == entrypoint {
+                    max_limit
+                } else {
+                    max_limit.with_indirect_goal(entrypoint, goals)
+                };
+                (CommitFlags::NotInRemote, limit)
+            }
+            TipRole::Integrated => (CommitFlags::Integrated, target_limit),
+        };
+        let tip_info = find(commit_graph, repo.for_find_only(), tip.id, buf)?;
+        _ = next.push_back_exhausted((
+            tip_info,
+            flags,
+            Instruction::CollectCommit { into: segment },
+            limit,
+        ));
+    }
+    Ok(())
 }
 
 #[expect(clippy::too_many_arguments)]

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -1,4 +1,7 @@
-use but_graph::{CommitFlags, Graph, StopCondition};
+use but_graph::{
+    CommitFlags, Graph, StopCondition,
+    init::{Tip, TipRole},
+};
 use but_testsupport::{
     gix_testtools::{self, Creation, rust_fixture_writable},
     graph_tree, graph_workspace, visualize_commit_graph_all,
@@ -551,6 +554,104 @@ fn four_diamond() -> anyhow::Result<()> {
 }
 
 #[test]
+fn explicit_traversal_tips_reject_duplicate_commit_ids() -> anyhow::Result<()> {
+    let (repo, meta) = read_only_in_memory_scenario("four-diamond")?;
+    let merged_id = id_by_rev(&repo, "merged").detach();
+    let a_ref = ref_name("refs/heads/A");
+
+    for inputs in [
+        [
+            Tip::entrypoint(merged_id, None),
+            Tip::reachable(merged_id, None),
+        ],
+        [
+            Tip::entrypoint(merged_id, None),
+            Tip::reachable(merged_id, Some(a_ref)),
+        ],
+    ] {
+        let err = Graph::from_commit_traversal_tips(&repo, inputs, &*meta, standard_options())
+            .expect_err("duplicate tips must be rejected");
+
+        assert_eq!(
+            err.to_string(),
+            format!("explicit traversal tips contain duplicate commit id {merged_id}")
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn explicit_traversal_tips_reject_duplicate_ref_names() -> anyhow::Result<()> {
+    let (repo, meta) = read_only_in_memory_scenario("four-diamond")?;
+    let a_id = id_by_rev(&repo, "A").detach();
+    let c_id = id_by_rev(&repo, "C").detach();
+    let a_ref = ref_name("refs/heads/A");
+
+    let err = Graph::from_commit_traversal_tips(
+        &repo,
+        [
+            Tip::entrypoint(a_id, Some(a_ref.clone())),
+            Tip::reachable(c_id, Some(a_ref.clone())),
+        ],
+        &*meta,
+        standard_options(),
+    )
+    .expect_err("duplicate ref names must be rejected");
+
+    assert_eq!(
+        err.to_string(),
+        format!("explicit traversal tips contain duplicate ref name {a_ref}")
+    );
+    Ok(())
+}
+
+#[test]
+fn explicit_traversal_tips_reject_detached_entrypoint_with_ref_name() -> anyhow::Result<()> {
+    let (repo, meta) = read_only_in_memory_scenario("four-diamond")?;
+    let merged_id = id_by_rev(&repo, "merged").detach();
+
+    let err = Graph::from_commit_traversal_tips(
+        &repo,
+        [Tip {
+            id: merged_id,
+            ref_name: Some(ref_name("refs/heads/merged")),
+            role: TipRole::DetachedEntryPoint,
+        }],
+        &*meta,
+        standard_options(),
+    )
+    .expect_err("detached entrypoints must not be named");
+
+    assert_eq!(
+        err.to_string(),
+        "explicit detached entrypoint tip cannot have a ref name"
+    );
+    Ok(())
+}
+
+#[test]
+fn explicit_traversal_tips_reject_ref_names_that_point_elsewhere() -> anyhow::Result<()> {
+    let (repo, meta) = read_only_in_memory_scenario("four-diamond")?;
+    let merged_id = id_by_rev(&repo, "merged").detach();
+    let a_id = id_by_rev(&repo, "A").detach();
+    let a_ref = ref_name("refs/heads/A");
+
+    let err = Graph::from_commit_traversal_tips(
+        &repo,
+        [Tip::entrypoint(merged_id, Some(a_ref.clone()))],
+        &*meta,
+        standard_options(),
+    )
+    .expect_err("ref names must resolve to their tip id");
+
+    assert_eq!(
+        err.to_string(),
+        format!("explicit traversal tip ref {a_ref} points to {a_id}, not {merged_id}")
+    );
+    Ok(())
+}
+
+#[test]
 fn stacked_rebased_remotes() -> anyhow::Result<()> {
     let (repo, meta) = read_only_in_memory_scenario("remote-includes-another-remote")?;
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
@@ -1075,3 +1176,7 @@ pub use utils::{
 };
 
 use crate::init::utils::{in_memory_meta, standard_options_with_extra_target};
+
+fn ref_name(name: &str) -> gix::refs::FullName {
+    name.try_into().expect("valid full ref name")
+}

--- a/crates/but-graph/tests/graph/merge_base.rs
+++ b/crates/but-graph/tests/graph/merge_base.rs
@@ -1,4 +1,4 @@
-use but_graph::{FirstParent, Graph, Segment, SegmentIndex, SegmentRelation};
+use but_graph::{FirstParent, Graph, Segment, SegmentIndex, SegmentRelation, init::Tip};
 use but_testsupport::{graph_tree, visualize_commit_graph_all};
 
 use crate::init::{read_only_in_memory_scenario, standard_options};
@@ -144,6 +144,61 @@ fn reachable_difference_returns_commits_in_traversal_order() -> anyhow::Result<(
             .find_commit_ids_reachable_from_a_not_b(a_id, a_id, FirstParent::No)?
             .is_empty(),
         "self-exclusion means nothing is returned"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn explicit_traversal_tips_include_unnamed_revisions() -> anyhow::Result<()> {
+    let (repo, meta) = read_only_in_memory_scenario("four-diamond")?;
+    let merged_id = repo.rev_parse_single("merged")?.detach();
+    let a_id = repo.rev_parse_single("A")?.detach();
+    let c_id = repo.rev_parse_single("C")?.detach();
+    let main_id = repo.rev_parse_single("main")?.detach();
+
+    let graph = Graph::from_commit_traversal_tips(
+        &repo,
+        [
+            Tip::entrypoint(merged_id, None),
+            Tip::reachable(a_id, None),
+            Tip::reachable(c_id, None),
+        ],
+        &*meta,
+        standard_options(),
+    )?
+    .validated()?;
+
+    insta::assert_snapshot!(graph_tree(&graph), @"
+
+    └── 👉►:0[0]:merged[🌳]
+        └── ·8a6c109 (⌂|1)
+            ├── ►:1[1]:A
+            │   └── ·62b409a (⌂|1)
+            │       ├── ►:3[2]:anon:
+            │       │   └── ·592abec (⌂|1)
+            │       │       └── ►:7[3]:main
+            │       │           └── 🏁·965998b (⌂|1)
+            │       └── ►:4[2]:B
+            │           └── ·f16dddf (⌂|1)
+            │               └── →:7: (main)
+            └── ►:2[1]:C
+                └── ·7ed512a (⌂|1)
+                    ├── ►:5[2]:anon:
+                    │   └── ·35ee481 (⌂|1)
+                    │       └── →:7: (main)
+                    └── ►:6[2]:D
+                        └── ·ecb1877 (⌂|1)
+                            └── →:7: (main)
+    ");
+
+    assert_eq!(
+        graph.find_commit_ids_reachable_from_a_not_b(merged_id, a_id, FirstParent::No)?,
+        ids_by_revs(&repo, &["merged", "C", "C^1", "C^2"])?
+    );
+    assert_eq!(
+        graph.find_merge_base_octopus_by_commit_id([a_id, c_id, merged_id])?,
+        Some(main_id)
     );
 
     Ok(())

--- a/crates/but-graph/tests/graph/vis.rs
+++ b/crates/but-graph/tests/graph/vis.rs
@@ -29,7 +29,6 @@ fn post_graph_traversal() -> anyhow::Result<()> {
             target_ref: None,
             target_commit_id: None,
             push_remote: None,
-            remote_url: "".into(),
         })),
         ..Default::default()
     };

--- a/crates/but-meta/src/legacy/mod.rs
+++ b/crates/but-meta/src/legacy/mod.rs
@@ -968,7 +968,7 @@ fn branch_from_ref_name(ref_name: &FullNameRef) -> anyhow::Result<RemoteRefname>
 
 impl VirtualBranchesTomlMetadata {
     fn workspace_from_data(data: &VirtualBranches) -> Workspace {
-        let (target_branch, target_commit_id, push_remote, remote_url) = data
+        let (target_branch, target_commit_id, push_remote) = data
             .default_target
             .as_ref()
             .map(|target| {
@@ -976,7 +976,6 @@ impl VirtualBranchesTomlMetadata {
                     gix::refs::FullName::try_from(target.branch.to_string()).ok(),
                     (!target.sha.is_null()).then_some(target.sha),
                     target.push_remote_name.clone(),
-                    target.remote_url.clone(),
                 )
             })
             .unwrap_or_default();
@@ -1018,7 +1017,6 @@ impl VirtualBranchesTomlMetadata {
                 })
                 .collect(),
             target_ref: target_branch,
-            remote_url,
             target_commit_id,
             push_remote,
         }

--- a/crates/but-meta/tests/meta/ref_metadata_legacy.rs
+++ b/crates/but-meta/tests/meta/ref_metadata_legacy.rs
@@ -348,7 +348,6 @@ fn create_workspace_and_stacks_with_branches_from_scratch_with_workspace_and_una
         ref_info: RefInfo { created_at: "2023-01-31 14:55:57 +0000", updated_at: None },
         stacks: [],
         target_ref: None,
-        remote_url: "",
         target_commit_id: None,
         push_remote: None,
     }
@@ -403,7 +402,6 @@ fn create_workspace_and_stacks_with_branches_from_scratch_with_workspace_and_una
             },
         ],
         target_ref: None,
-        remote_url: "",
         target_commit_id: None,
         push_remote: None,
     }
@@ -440,7 +438,6 @@ fn create_workspace_and_stacks_with_branches_from_scratch_with_workspace_and_una
             },
         ],
         target_ref: None,
-        remote_url: "",
         target_commit_id: None,
         push_remote: None,
     }
@@ -478,7 +475,6 @@ fn create_workspace_and_stacks_with_branches_from_scratch_with_workspace_and_una
             },
         ],
         target_ref: None,
-        remote_url: "",
         target_commit_id: None,
         push_remote: None,
     }
@@ -530,7 +526,6 @@ fn create_workspace_and_stacks_with_branches_from_scratch_with_workspace_and_una
             },
         ],
         target_ref: None,
-        remote_url: "",
         target_commit_id: None,
         push_remote: None,
     }
@@ -908,7 +903,6 @@ fn create_workspace_and_stacks_with_branches_from_scratch() -> anyhow::Result<()
         ref_info: RefInfo { created_at: "2023-01-31 14:55:57 +0000", updated_at: None },
         stacks: [],
         target_ref: None,
-        remote_url: "",
         target_commit_id: None,
         push_remote: None,
     }
@@ -1156,7 +1150,6 @@ fn create_workspace_from_scratch_workspace_first() -> anyhow::Result<()> {
             },
         ],
         target_ref: "refs/remotes/origin/sub-name/main",
-        remote_url: "https://example.com/example-org/example-repo",
         target_commit_id: None,
         push_remote: None,
     }
@@ -1195,7 +1188,6 @@ fn create_workspace_from_scratch_workspace_first() -> anyhow::Result<()> {
             },
         ],
         target_ref: "refs/remotes/origin/sub-name/main",
-        remote_url: "https://example.com/example-org/example-repo",
         target_commit_id: None,
         push_remote: None,
     }

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
@@ -861,7 +861,6 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
                 },
             ],
             target_ref: "refs/remotes/origin/main",
-            remote_url: "should not be needed and when it is extract it from `repo`",
             target_commit_id: Sha1(3183e43ff482a2c4c8ff531d595453b64f58d90b),
             push_remote: None,
         },
@@ -1488,7 +1487,6 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
             },
         ],
         target_ref: "refs/remotes/origin/main",
-        remote_url: "should not be needed and when it is extract it from `repo`",
         target_commit_id: Sha1(85efbe4d5a663bff0ed8fb5fbc38a72be0592f55),
         push_remote: None,
     }

--- a/crates/but-workspace/tests/workspace/branch_details.rs
+++ b/crates/but-workspace/tests/workspace/branch_details.rs
@@ -278,7 +278,6 @@ mod with_workspace {
                 target_ref: Some(refname(short_name)),
                 target_commit_id: None,
                 push_remote: None,
-                remote_url: "".into(),
             };
             self
         }

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/legacy.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/legacy.rs
@@ -599,7 +599,6 @@ mod stack_details {
                         },
                     ],
                     target_ref: "refs/remotes/origin/main",
-                    remote_url: "should not be needed and when it is extract it from `repo`",
                     target_commit_id: Sha1(85efbe4d5a663bff0ed8fb5fbc38a72be0592f55),
                     push_remote: None,
                 },

--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -653,6 +653,15 @@ but_schemars::register_sdk_type!(StackReference);
 
 /// Takes a list of `branch_names` (the given name, as returned by `BranchListing`) and returns
 /// a list of enriched branch data.
+// TODO(performance): this needs a redesign, around what takes the most time.
+//                    - listing all branches + heads: fast, do it in one call. reftables only helps later.
+//                    - how many commits ahead/behind? Query for a set of branches and use a Graph to accelerate the queries
+//                          - this needs better support for 'free' graph creation, not bound to a workspace.
+//                    - fill in line-changes on a per-branch basis, passing the tip and merge-base to a specialised function
+//                      that just churns out tree-diffs and blob-diffs for the line changes. It itself may spawn a thread like now,
+//                      so a multi-branch version of this might be helpful, depending on what the UI needs. It seems reasonable for it
+//                      to chunk up what's in view and, request ahead/behind information, then pass this to the long-running (but soon cached)
+//                      function compute line diffs.
 pub fn get_branch_listing_details(
     ctx: &Context,
     branch_names: impl IntoIterator<Item = impl TryInto<BranchIdentity>>,
@@ -742,6 +751,7 @@ pub fn get_branch_listing_details(
             })
             .collect();
         let (merge_tx, merge_rx) = std::sync::mpsc::channel();
+        let parent_span = tracing::Span::current();
         let merge_bases = std::thread::Builder::new()
             .name("gitbutler-mergebases".into())
             .spawn({
@@ -750,6 +760,12 @@ pub fn get_branch_listing_details(
                     let repo = repo.to_thread_local().for_tree_diffing()?;
                     let cache = repo.commit_graph_if_enabled()?;
                     let mut graph = repo.revision_graph(cache.as_ref());
+                    let _span = tracing::debug_span!(
+                        parent: &parent_span,
+                        "branch merge-bases and commits",
+                        num_branches = all_other_branch_commit_ids.len(),
+                    )
+                    .entered();
                     for (other_branch_commit_id, branch_head) in all_other_branch_commit_ids {
                         let base = repo
                             .merge_base_with_graph(other_branch_commit_id, branch_head, &mut graph)
@@ -759,23 +775,15 @@ pub fn get_branch_listing_details(
                             Some(base) => {
                                 let mut num_commits = 0;
                                 let mut authors = HashSet::new();
-                                for attempt in 1..=2 {
-                                    let mut revwalk =
-                                        repo.rev_walk(Some(branch_head)).with_boundary(Some(base));
-                                    if attempt == 2 {
-                                        revwalk = revwalk
-                                            .sorting(gix::revision::walk::Sorting::BreadthFirst);
-                                    }
-                                    let revwalk = revwalk.all()?;
-                                    for commit_info in revwalk {
-                                        let commit_info = commit_info?;
-                                        let commit = repo.find_commit(commit_info.id)?;
-                                        authors.insert(commit.author()?.into());
-                                        num_commits += 1;
-                                    }
-                                    if num_commits > 0 {
-                                        break;
-                                    }
+                                let revwalk = repo
+                                    .rev_walk(Some(branch_head))
+                                    .with_hidden(Some(base))
+                                    .all()?;
+                                for commit_info in revwalk {
+                                    let commit_info = commit_info?;
+                                    let commit = repo.find_commit(commit_info.id)?;
+                                    authors.insert(commit.author()?.into());
+                                    num_commits += 1;
                                 }
                                 merge_tx.send(Some((base, authors, num_commits)))
                             }


### PR DESCRIPTION
Various fixes and improvements while looking at existing and new PRs.

### Tasks

* [x] more correct commit count for branch-listing (it's fast enough as well on git-lab
* [x] but-graph with clear non-workspace dependent initialisation. This makes it easy to create it outside of the scope of the workspace, with only the notion of tips and their role. This will be relevant later when obtaining branch listing information.
* [x] see if the new [`remote_url`](https://github.com/gitbutlerapp/gitbutler/pull/13791/changes#diff-1f9434e30c2fec15d619d354921de3702f7b4dd923a255d8021985ab370a4563R43) can be removed.
