### PR TITLE
Add `but-debug dump` to create a lightweight archive of a project.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,11 +1224,19 @@ dependencies = [
  "anyhow",
  "but-core",
  "but-graph",
+ "but-testsupport",
  "clap",
  "gix 0.83.0 (git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd)",
+ "insta",
+ "open",
+ "prodash",
+ "signal-hook 0.4.3",
+ "tempfile",
+ "termtree",
  "tracing",
  "tracing-forest",
  "tracing-subscriber",
+ "zip",
 ]
 
 [[package]]
@@ -1878,6 +1886,12 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bytesize"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 
 [[package]]
 name = "bzip2"
@@ -2556,6 +2570,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crosstermion"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6ae462f0b868614980d59df41e217a77648de7ad7cf8b2a407155659896d889"
+dependencies = [
+ "crossterm 0.29.0",
+ "nu-ansi-term",
 ]
 
 [[package]]
@@ -9046,7 +9070,12 @@ version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
 dependencies = [
+ "bytesize",
+ "crosstermion",
+ "is-terminal",
+ "jiff",
  "parking_lot",
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,6 +1223,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "but-core",
+ "but-ctx",
  "but-graph",
  "but-testsupport",
  "clap",
@@ -1230,7 +1231,6 @@ dependencies = [
  "insta",
  "open",
  "prodash",
- "signal-hook 0.4.3",
  "tempfile",
  "termtree",
  "tracing",
@@ -4539,7 +4539,9 @@ dependencies = [
  "gix-worktree-state 0.30.0 (git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd)",
  "gix-worktree-stream 0.32.0 (git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd)",
  "nonempty",
+ "parking_lot",
  "serde",
+ "signal-hook 0.4.3",
  "smallvec",
  "thiserror 2.0.18",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,6 +213,8 @@ gitbutler-workspace = { path = "crates/gitbutler-workspace" }
 rusqlite = { version = "0.39.0", features = ["bundled"] }
 backoff = "0.4.0"
 bstr = "1.12.1"
+# Version must match the one in `tauri plugin updater` to avoid duplication.
+zip = { version = "4", default-features = false, features = ["bzip2"] }
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
 # When adjusting this, update `gix-testtools` as well!
 gix = { version = "0.83.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "575113dfb10b3ba12eb57f57a81b241e773968bd", default-features = false, features = [

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -111,3 +111,10 @@ vendored, or fixture data unless the task is specifically about that code.
   `packages/but-sdk/src/generated`.
 - Use workspace-wide checks only when the change affects shared contracts or
   multiple crates.
+
+## Assertions
+
+- Explain why a standard Rust assertion holds concisely using the last-argument message, like `assert!(1!=2, "arithmetic unit on CPU works")`
+- Explain why an `insta` assertion holds concisely using the second argument as message, like `insta::assert_debug_snapshot(debug, "needs to be this because...", @r"")`.
+- Use `insta` redactions to remove unstable output from the snapshot. Avoid *creating* additional macros, as it's possible to change its settings
+  directly. It's fine to use its own utility macros to configure redactions, where applicable.

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -89,7 +89,7 @@ pub(crate) fn stacks_v3_from_ctx(
 pub fn show_graph_svg(ctx: &Context) -> Result<()> {
     let repo = ctx.open_isolated_repo()?;
     let meta = ctx.meta()?;
-    let mut graph = but_graph::Graph::from_head(
+    let graph = but_graph::Graph::from_head(
         &repo,
         &meta,
         but_graph::init::Options {
@@ -97,78 +97,8 @@ pub fn show_graph_svg(ctx: &Context) -> Result<()> {
             ..but_graph::init::Options::limited()
         },
     )?;
-    let lower_bound_segment_id = graph.clone().into_workspace()?.lower_bound_segment_id;
-    if let Some(lower_bound_segment_id) = lower_bound_segment_id {
-        remove_in_workspace_flag_below_lower_bound(&mut graph, lower_bound_segment_id);
-    }
-    // It's OK if it takes a while, prefer complete graphs.
-    const LIMIT: usize = 5000;
-    let mut to_remove = graph.num_segments().saturating_sub(LIMIT);
-    if to_remove > 0 {
-        tracing::warn!(
-            "Pruning at most {to_remove} nodes from the bottom to assure 'dot' won't hang",
-        );
-        let mut next = std::collections::VecDeque::new();
-        next.extend(graph.base_segments());
-        let mut seen = std::collections::BTreeSet::new();
-        while let Some(sidx) = next.pop_front() {
-            if to_remove == 0 {
-                break;
-            }
-            if let Some(s) = graph.node_weight(sidx) {
-                if lower_bound_segment_id.is_some()
-                    && s.non_empty_flags_of_first_commit()
-                        .is_some_and(|flags| flags.contains(but_graph::CommitFlags::InWorkspace))
-                {
-                    continue;
-                }
-                if s.metadata.is_some()
-                    || s.sibling_segment_id.is_some()
-                    || s.remote_tracking_branch_segment_id.is_some()
-                {
-                    continue;
-                }
-            }
-            next.extend(
-                graph
-                    .neighbors_directed(sidx, but_graph::petgraph::Direction::Incoming)
-                    .filter(|n| seen.insert(*n)),
-            );
-            graph.remove_node(sidx);
-            to_remove -= 1;
-        }
-        if to_remove != 0 {
-            tracing::warn!("{to_remove} extra nodes were kept to keep vital portions of the graph");
-        }
-        graph.set_hard_limit_hit();
-    }
     graph.open_as_svg();
     Ok(())
-}
-
-#[cfg(unix)]
-fn remove_in_workspace_flag_below_lower_bound(
-    graph: &mut but_graph::Graph,
-    lower_bound_segment_id: but_graph::SegmentIndex,
-) {
-    let mut seen = std::collections::BTreeSet::from([lower_bound_segment_id]);
-    let mut queue = std::collections::VecDeque::from([lower_bound_segment_id]);
-    while let Some(sidx) = queue.pop_front() {
-        let below_segments: Vec<_> = graph
-            .neighbors_directed(sidx, but_graph::petgraph::Direction::Outgoing)
-            .filter(|n| seen.insert(*n))
-            .collect();
-        for below_sidx in below_segments {
-            if let Some(segment) = graph.node_weight_mut(below_sidx)
-                && let Some(first_commit) = segment.commits.first_mut()
-            {
-                first_commit
-                    .flags
-                    .remove(but_graph::CommitFlags::InWorkspace);
-            }
-            queue.push_back(below_sidx);
-        }
-    }
 }
 
 #[but_api]

--- a/crates/but-debug/Cargo.toml
+++ b/crates/but-debug/Cargo.toml
@@ -16,6 +16,7 @@ doctest = false
 
 [dependencies]
 but-core.workspace = true
+but-ctx.workspace = true
 but-graph.workspace = true
 anyhow.workspace = true
 clap = { workspace = true, features = [
@@ -26,7 +27,7 @@ clap = { workspace = true, features = [
     "usage",
     "suggestions",
 ] }
-gix = { workspace = true, features = ["excludes"] }
+gix = { workspace = true, features = ["excludes", "interrupt"] }
 open.workspace = true
 prodash = { version = "31.0.0", default-features = false, features = [
     "progress-tree",
@@ -35,7 +36,6 @@ prodash = { version = "31.0.0", default-features = false, features = [
     "render-line-crossterm",
     "unit-bytes",
 ] }
-signal-hook = { version = "0.4.3", default-features = false }
 tracing.workspace = true
 tracing-forest.workspace = true
 tracing-subscriber = { workspace = true, features = ["std", "fmt"] }

--- a/crates/but-debug/Cargo.toml
+++ b/crates/but-debug/Cargo.toml
@@ -26,10 +26,26 @@ clap = { workspace = true, features = [
     "usage",
     "suggestions",
 ] }
-gix.workspace = true
+gix = { workspace = true, features = ["excludes"] }
+open.workspace = true
+prodash = { version = "31.0.0", default-features = false, features = [
+    "progress-tree",
+    "render-line",
+    "render-line-autoconfigure",
+    "render-line-crossterm",
+    "unit-bytes",
+] }
+signal-hook = { version = "0.4.3", default-features = false }
 tracing.workspace = true
 tracing-forest.workspace = true
 tracing-subscriber = { workspace = true, features = ["std", "fmt"] }
+zip.workspace = true
+
+[dev-dependencies]
+but-testsupport.workspace = true
+insta.workspace = true
+termtree = "0.5.1"
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/but-debug/src/args.rs
+++ b/crates/but-debug/src/args.rs
@@ -14,7 +14,13 @@ pub struct Args {
     #[arg(short = 't', long, action = clap::ArgAction::Count)]
     pub trace: u8,
     /// Run as if `but-debug` was started in `PATH` instead of the current working directory.
-    #[arg(short = 'C', long, default_value = ".", value_name = "PATH")]
+    #[arg(
+        short = 'C',
+        long,
+        default_value = ".",
+        value_name = "PATH",
+        global = true
+    )]
     pub current_dir: PathBuf,
     /// The debugging command to run.
     #[command(subcommand)]
@@ -24,11 +30,27 @@ pub struct Args {
 /// The debugging subcommands supported by `but-debug`.
 #[derive(Debug, clap::Subcommand)]
 pub enum Subcommands {
+    /// Archive a repository for debugging.
+    Dump(DumpArgs),
     /// Return a segmented graph starting from `HEAD`.
     Graph(GraphArgs),
     /// Debug revision graph operations.
     #[clap(visible_alias = "rev")]
     Revision(RevisionArgs),
+}
+
+/// Arguments for the `dump` debugging subcommand.
+#[derive(Debug, clap::Args)]
+pub struct DumpArgs {
+    /// Where to write the zip archive.
+    #[arg(long, value_name = "PATH")]
+    pub output: Option<PathBuf>,
+    /// Open the directory containing the archive after it is created.
+    #[arg(long, short = 'o')]
+    pub open_archive_dir: bool,
+    /// Include only Git directory state and skip worktree files.
+    #[arg(long)]
+    pub git_only: bool,
 }
 
 /// Arguments for the `graph` debugging subcommand.

--- a/crates/but-debug/src/args.rs
+++ b/crates/but-debug/src/args.rs
@@ -100,7 +100,7 @@ pub struct DiagnosticsDumpArgs {
 #[derive(Debug, clap::Args)]
 pub struct DiagnosticsCaptureArgs {
     /// Maximum seconds to wait for `dot -Tsvg`; 0 disables the timeout.
-    #[arg(long = "dot-timeout", value_name = "SECONDS", default_value_t = 10)]
+    #[arg(long = "dot-timeout", value_name = "SECONDS", default_value_t = 30)]
     pub dot_timeout_seconds: u32,
 }
 

--- a/crates/but-debug/src/args.rs
+++ b/crates/but-debug/src/args.rs
@@ -42,15 +42,66 @@ pub enum Subcommands {
 /// Arguments for the `dump` debugging subcommand.
 #[derive(Debug, clap::Args)]
 pub struct DumpArgs {
-    /// Where to write the zip archive.
-    #[arg(long, value_name = "PATH")]
-    pub output: Option<PathBuf>,
-    /// Open the directory containing the archive after it is created.
-    #[arg(long, short = 'o')]
-    pub open_archive_dir: bool,
+    /// The kind of dump archive to create.
+    #[command(subcommand)]
+    pub cmd: DumpSubcommands,
+}
+
+/// The archive kinds supported by `but-debug dump`.
+#[derive(Debug, clap::Subcommand)]
+pub enum DumpSubcommands {
+    /// Archive a repository for debugging.
+    Repo(RepoDumpArgs),
+    /// Archive graph and workspace diagnostics.
+    #[clap(visible_alias = "diag")]
+    Diagnostics(DiagnosticsDumpArgs),
+}
+
+/// Arguments for the `dump repo` debugging subcommand.
+#[derive(Debug, clap::Args)]
+pub struct RepoDumpArgs {
+    /// Shared archive output options.
+    #[command(flatten)]
+    pub archive: ArchiveOutputArgs,
+    /// Diagnostics capture options.
+    #[command(flatten)]
+    pub diagnostics: DiagnosticsCaptureArgs,
     /// Include only Git directory state and skip worktree files.
     #[arg(long)]
     pub git_only: bool,
+    /// Do not include graph and workspace diagnostics in the archive root.
+    #[arg(long)]
+    pub no_diagnostics: bool,
+}
+
+/// Archive output options shared by dump subcommands.
+#[derive(Debug, clap::Args)]
+pub struct ArchiveOutputArgs {
+    /// Where to write the zip archive.
+    #[arg(long, value_name = "PATH")]
+    pub output: Option<PathBuf>,
+    /// Do not open the directory containing the archive after it is created.
+    #[arg(long = "no-open-archive-directory", visible_alias = "no-open")]
+    pub no_open_archive_directory: bool,
+}
+
+/// Arguments for the `dump diagnostics` debugging subcommand.
+#[derive(Debug, clap::Args)]
+pub struct DiagnosticsDumpArgs {
+    /// Shared archive output options.
+    #[command(flatten)]
+    pub archive: ArchiveOutputArgs,
+    /// Diagnostics capture options.
+    #[command(flatten)]
+    pub diagnostics: DiagnosticsCaptureArgs,
+}
+
+/// Options for graph and workspace diagnostics capture.
+#[derive(Debug, clap::Args)]
+pub struct DiagnosticsCaptureArgs {
+    /// Maximum seconds to wait for `dot -Tsvg`; 0 disables the timeout.
+    #[arg(long = "dot-timeout", value_name = "SECONDS", default_value_t = 10)]
+    pub dot_timeout_seconds: u32,
 }
 
 /// Arguments for the `graph` debugging subcommand.

--- a/crates/but-debug/src/command/dump/diagnostics.rs
+++ b/crates/but-debug/src/command/dump/diagnostics.rs
@@ -1,0 +1,277 @@
+//! Diagnostics archive support for `but-debug dump`.
+
+use std::{
+    fs,
+    io::{self, Write as _},
+    path::Path,
+    process::{Command, Stdio},
+    sync::atomic::{AtomicUsize, Ordering},
+    time::{Duration, Instant},
+};
+
+use anyhow::{Context as _, Result};
+use zip::{CompressionMethod, ZipWriter, write::SimpleFileOptions};
+
+use crate::{
+    args::{Args, DiagnosticsDumpArgs},
+    command::dump::default_output_path,
+};
+
+/// Capture diagnostics by discovering a GitButler context at `current_dir`.
+pub(super) fn capture_from_current_dir(
+    current_dir: &Path,
+    dot_timeout: Option<Duration>,
+    out: &mut dyn io::Write,
+    err: &mut dyn io::Write,
+) -> Result<Diagnostics> {
+    let ctx = but_ctx::Context::discover(current_dir).with_context(|| {
+        format!(
+            "Could not open GitButler context at '{}'",
+            current_dir.display()
+        )
+    })?;
+    Diagnostics::capture(&ctx, dot_timeout, out, err)
+}
+
+/// Execute the `dump diagnostics` subcommand.
+pub(super) fn run(
+    args: &Args,
+    diagnostics_args: &DiagnosticsDumpArgs,
+    out: &mut dyn io::Write,
+    err: &mut dyn io::Write,
+) -> Result<()> {
+    let current_dir = super::effective_current_dir(args)?;
+    let ctx = but_ctx::Context::discover(&current_dir).with_context(|| {
+        format!(
+            "Could not open GitButler context at '{}'",
+            current_dir.display()
+        )
+    })?;
+    let repo = ctx.repo.get()?;
+    let output_path = match &diagnostics_args.archive.output {
+        Some(path) => current_dir.join(path),
+        None => default_output_path(&repo, "diagnostics")?,
+    };
+    let diagnostics = Diagnostics::capture(
+        &ctx,
+        dot_timeout(diagnostics_args.diagnostics.dot_timeout_seconds),
+        out,
+        err,
+    )?;
+    let archive_root = format!("{}-diagnostics", super::archive_base_name(&repo)?);
+    let lock = super::acquire_archive_lock(&output_path, repo.workdir().map(Path::to_owned))?;
+    let mut archive = ZipWriter::new(lock);
+    diagnostics.write_to_archive(&mut archive, &archive_root)?;
+    let lock = archive.finish()?;
+    super::persist_archive(lock)?;
+
+    writeln!(out, "Archive at: {}", output_path.display())?;
+    super::open_archive_dir_unless_requested(
+        &output_path,
+        diagnostics_args.archive.no_open_archive_directory,
+    )?;
+    Ok(())
+}
+
+/// In-memory files produced for a diagnostics archive.
+pub(super) struct Diagnostics {
+    files: Vec<DiagnosticFile>,
+}
+
+impl Diagnostics {
+    /// Capture graph and workspace diagnostics through a GitButler context.
+    pub(super) fn capture(
+        ctx: &but_ctx::Context,
+        dot_timeout: Option<Duration>,
+        out: &mut dyn io::Write,
+        err: &mut dyn io::Write,
+    ) -> Result<Self> {
+        let (_guard, _repo, ws, _db) = ctx.workspace_and_db()?;
+        let dot_graph = ws.graph.dot_graph();
+        let workspace_debug = format!("{ws:#?}\n");
+
+        let mut files = vec![
+            DiagnosticFile::new("graph.dot", dot_graph.as_bytes().to_vec()),
+            DiagnosticFile::new("workspace.ron.txt", workspace_debug.into_bytes()),
+        ];
+        if let Some(svg) = render_svg_with_timeout(&dot_graph, dot_timeout, out, err)? {
+            files.push(DiagnosticFile::new("graph.svg", svg));
+        }
+        Ok(Self { files })
+    }
+
+    /// Write all diagnostics into `archive` below `archive_root`.
+    pub(super) fn write_to_archive<W: io::Write + io::Seek>(
+        &self,
+        archive: &mut ZipWriter<W>,
+        archive_root: &str,
+    ) -> Result<()> {
+        archive.add_directory(archive_root, directory_options())?;
+        for file in &self.files {
+            archive.start_file(
+                format!("{archive_root}/{}", file.relative_path),
+                file_options(),
+            )?;
+            archive.write_all(&file.contents)?;
+        }
+        Ok(())
+    }
+
+    /// Iterate diagnostics as relative archive paths and complete file contents.
+    pub(super) fn entries(&self) -> impl Iterator<Item = (&'static str, &[u8])> + '_ {
+        self.files
+            .iter()
+            .map(|file| (file.relative_path, file.contents.as_slice()))
+    }
+
+    /// Return the number of files that will be emitted.
+    pub(super) fn file_count(&self) -> usize {
+        self.files.len()
+    }
+}
+
+pub(super) fn dot_timeout(seconds: u32) -> Option<Duration> {
+    (seconds != 0).then(|| Duration::from_secs(u64::from(seconds)))
+}
+
+struct DiagnosticFile {
+    /// Path below the diagnostics archive root, using zip `/` separators.
+    relative_path: &'static str,
+    /// Complete bytes written to the archive entry at `relative_path`.
+    contents: Vec<u8>,
+}
+
+impl DiagnosticFile {
+    fn new(relative_path: &'static str, contents: Vec<u8>) -> Self {
+        Self {
+            relative_path,
+            contents,
+        }
+    }
+}
+
+/// Render `dot_graph` with Graphviz and return the generated SVG bytes.
+///
+/// Returns `Ok(Some(svg))` when `dot -Tsvg` exits successfully and the SVG file
+/// can be read. Returns `Ok(None)` when `dot` is not installed, exits with a
+/// non-zero status, or does not finish before `timeout`. A `None` timeout waits
+/// indefinitely. Returns `Err` for
+/// failures managing the temporary files or launching/polling the process.
+fn render_svg_with_timeout(
+    dot_graph: &str,
+    timeout: Option<Duration>,
+    out: &mut dyn io::Write,
+    err: &mut dyn io::Write,
+) -> Result<Option<Vec<u8>>> {
+    static SUFFIX: AtomicUsize = AtomicUsize::new(0);
+
+    let suffix = SUFFIX.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir().join(format!(
+        "but-debug-diagnostics-{}-{suffix}",
+        std::process::id()
+    ));
+    fs::create_dir(&dir)
+        .with_context(|| format!("Could not create temporary directory '{}'", dir.display()))?;
+    let result = render_svg_with_timeout_in(dot_graph, timeout, &dir, out, err);
+    let cleanup = fs::remove_dir_all(&dir);
+    match (result, cleanup) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Err(err), _) => Err(err),
+        (Ok(_), Err(err)) => Err(err)
+            .with_context(|| format!("Could not remove temporary directory '{}'", dir.display())),
+    }
+}
+
+fn render_svg_with_timeout_in(
+    dot_graph: &str,
+    timeout: Option<Duration>,
+    dir: &Path,
+    out: &mut dyn io::Write,
+    err: &mut dyn io::Write,
+) -> Result<Option<Vec<u8>>> {
+    let dot_path = dir.join("graph.dot");
+    let svg_path = dir.join("graph.svg");
+    fs::write(&dot_path, dot_graph).with_context(|| {
+        format!(
+            "Could not write temporary dot file '{}'",
+            dot_path.display()
+        )
+    })?;
+
+    writeln!(
+        out,
+        "Running: dot -Tsvg {} -o {}",
+        dot_path.display(),
+        svg_path.display()
+    )?;
+
+    let mut child = match Command::new("dot")
+        .arg("-Tsvg")
+        .arg(&dot_path)
+        .arg("-o")
+        .arg(&svg_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err).context("Could not start dot to render graph SVG"),
+    };
+
+    let started_at = Instant::now();
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return if status.success() {
+                fs::read(&svg_path)
+                    .with_context(|| {
+                        format!("Could not read generated SVG '{}'", svg_path.display())
+                    })
+                    .map(Some)
+            } else {
+                Ok(None)
+            };
+        }
+        if let Some(timeout) = timeout
+            && started_at.elapsed() >= timeout
+        {
+            writeln!(
+                err,
+                "dot did not finish within {timeout:?}; killing process {}",
+                child.id()
+            )?;
+            child.kill().ok();
+            child.wait().ok();
+            return Ok(None);
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn file_options() -> SimpleFileOptions {
+    SimpleFileOptions::default()
+        .compression_method(CompressionMethod::Bzip2)
+        .unix_permissions(0o644)
+}
+
+fn directory_options() -> SimpleFileOptions {
+    SimpleFileOptions::default()
+        .compression_method(CompressionMethod::Bzip2)
+        .unix_permissions(0o755)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_dot_timeout_disables_timeout() {
+        assert_eq!(dot_timeout(0), None, "zero seconds means no timeout");
+        assert_eq!(
+            dot_timeout(7),
+            Some(Duration::from_secs(7)),
+            "non-zero values are interpreted as seconds"
+        );
+    }
+}

--- a/crates/but-debug/src/command/dump/diagnostics.rs
+++ b/crates/but-debug/src/command/dump/diagnostics.rs
@@ -87,7 +87,7 @@ impl Diagnostics {
         err: &mut dyn io::Write,
     ) -> Result<Self> {
         let (_guard, _repo, ws, _db) = ctx.workspace_and_db()?;
-        let dot_graph = ws.graph.dot_graph();
+        let dot_graph = ws.graph.dot_graph_pruned();
         let workspace_debug = format!("{ws:#?}\n");
 
         let mut files = vec![

--- a/crates/but-debug/src/command/dump/mod.rs
+++ b/crates/but-debug/src/command/dump/mod.rs
@@ -1,0 +1,775 @@
+//! Implementation of the `dump` debug command.
+//!
+//! ## QUALITY NOTICE
+//! NOTE: mostly vibed, what's properly reviewed is the tests. Also tested by hand of course.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs, io,
+    path::{Component, Path, PathBuf},
+};
+
+use anyhow::{Context, Result};
+use gix::{bstr::ByteSlice as _, index};
+use zip::{CompressionMethod, ZipWriter, write::SimpleFileOptions};
+
+use crate::{
+    args::{Args, DumpArgs},
+    setup,
+};
+
+mod progress;
+use progress::{DumpProgress, ProgressReader, ProgressWriter};
+
+/// Execute the `dump` subcommand.
+pub(crate) fn run(
+    args: &Args,
+    dump_args: &DumpArgs,
+    out: &mut dyn io::Write,
+    err: &mut dyn io::Write,
+) -> Result<()> {
+    let current_dir = std::env::current_dir()?.join(&args.current_dir);
+    let repo = setup::repo_from_args(args).with_context(|| {
+        format!(
+            "Could not discover Git repository at '{}'",
+            current_dir.display()
+        )
+    })?;
+
+    let output_path = match &dump_args.output {
+        Some(path) => current_dir.join(path),
+        None => default_output_path(&repo)?,
+    };
+    if let Some(parent) = output_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Could not create output directory '{}'", parent.display()))?;
+    }
+
+    let progress = DumpProgress::new()?;
+    let layout = ArchiveLayout::new(&repo)?;
+    let output_path = OutputPath::new(output_path);
+    std::thread::scope(|scope| -> Result<()> {
+        let counter = scope.spawn({
+            let progress = &progress;
+            let repo = repo.clone().into_sync();
+            let output_path = output_path.clone();
+            move || count_archive_input(repo, &output_path, dump_args.git_only, progress)
+        });
+
+        let file = fs::File::create(&output_path.path)
+            .with_context(|| format!("Could not create '{}'", output_path.path.display()))?;
+        let file = ProgressWriter::new(file, &progress);
+        let mut archive = ArchiveWriter::new(file, &progress);
+        archive.add_repo(&repo, &layout, &output_path, dump_args.git_only)?;
+        archive.finish(err)?;
+
+        let _ = counter
+            .join()
+            .map_err(|_| anyhow::anyhow!("Archive progress counter thread panicked"))?;
+        Ok(())
+    })?;
+
+    writeln!(out, "Archive at: {}", output_path.path.display())?;
+    if dump_args.open_archive_dir {
+        let dir = output_path.path.parent().unwrap_or_else(|| Path::new("."));
+        open::that(dir)
+            .with_context(|| format!("Could not open archive directory '{}'", dir.display()))?;
+    }
+    Ok(())
+}
+
+/// Return the default output archive path for `repo`.
+fn default_output_path(repo: &gix::Repository) -> Result<PathBuf> {
+    let base = archive_base_name(repo)?;
+    let root = if let Some(workdir) = repo.workdir() {
+        workdir
+    } else {
+        repo.git_dir()
+    };
+    let parent = root.parent().unwrap_or_else(|| Path::new("."));
+    Ok(parent.join(format!("{base}-dump.zip")))
+}
+
+/// Keeps worktree files and Git files under the right top-level paths in the zip.
+///
+/// Computes and stores the zip-internal root names for repository content.
+///
+/// These are owned `String` values because they are derived at runtime from the
+/// repository directory name and are reused while writing the archive. They are
+/// not `PathBuf`s because they are zip entry prefixes, not filesystem paths:
+/// zip entries always use `/` separators regardless of the host platform.
+#[derive(Clone)]
+struct ArchiveLayout {
+    /// Root directory for worktree files in the archive.
+    worktree_root: String,
+    /// Root directory for Git repository files in the archive.
+    git_root: String,
+}
+
+impl ArchiveLayout {
+    /// Build archive root names for `repo`, accounting for bare and non-bare layouts.
+    fn new(repo: &gix::Repository) -> Result<Self> {
+        let base = archive_base_name(repo)?;
+        let worktree_root = if repo.workdir().is_some() {
+            format!("{base}-dump")
+        } else {
+            format!("{base}-dump.git")
+        };
+        let git_root = if repo.workdir().is_some() {
+            format!("{worktree_root}/.git")
+        } else {
+            worktree_root.clone()
+        };
+        Ok(Self {
+            worktree_root,
+            git_root,
+        })
+    }
+}
+
+/// Return the sanitized archive base name for `repo`.
+///
+/// For example, a worktree at `/tmp/my repo` becomes `my-repo`, while a bare
+/// repository at `/tmp/project.git` becomes `project`.
+fn archive_base_name(repo: &gix::Repository) -> Result<String> {
+    let root = repo.workdir().unwrap_or_else(|| repo.git_dir());
+    let raw = root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .context("Repository path does not have a usable final component")?;
+    let raw = if repo.workdir().is_none() {
+        raw.strip_suffix(".git").unwrap_or(raw)
+    } else {
+        raw
+    };
+    Ok(root_name_slug(raw))
+}
+
+/// Convert `name` into a safe zip root component.
+///
+/// For example, `my repo/main` becomes `my-repo-main`, `你好` stays `你好`,
+/// and an all-dot name like `...` falls back to `repository`.
+fn root_name_slug(name: &str) -> String {
+    let sanitized: String = name
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || matches!(c, '-' | '_' | '.') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let sanitized = sanitized.trim_matches('.');
+    if sanitized.is_empty() || sanitized == ".." {
+        "repository".to_owned()
+    } else {
+        sanitized.to_owned()
+    }
+}
+
+struct ArchiveWriter<'progress, W: io::Write + io::Seek> {
+    zip: ZipWriter<W>,
+    progress: &'progress DumpProgress,
+    written: BTreeSet<String>,
+    skipped_unarchivable_paths: BTreeSet<PathBuf>,
+}
+
+impl<'progress, W: io::Write + io::Seek> ArchiveWriter<'progress, W> {
+    /// Create an archive writer around `writer`.
+    fn new(writer: W, progress: &'progress DumpProgress) -> Self {
+        Self {
+            zip: ZipWriter::new(writer),
+            progress,
+            written: BTreeSet::new(),
+            skipped_unarchivable_paths: BTreeSet::new(),
+        }
+    }
+
+    /// Add all selected repository entries to `self`.
+    ///
+    /// `repo` supplies the worktree, index, ignore rules, and Git directory
+    /// locations to archive. `layout` defines the zip-internal roots used for
+    /// worktree and Git state entries. `output_path` identifies the archive
+    /// currently being written so it can be skipped if it appears during
+    /// traversal. `git_only` omits worktree files when true and archives only
+    /// Git repository state.
+    fn add_repo(
+        &mut self,
+        repo: &gix::Repository,
+        layout: &ArchiveLayout,
+        output_path: &OutputPath,
+        git_only: bool,
+    ) -> Result<()> {
+        let mut skipped_unarchivable_paths = BTreeSet::new();
+        let result = visit_archive_entries(
+            repo,
+            layout,
+            output_path,
+            git_only,
+            self.progress,
+            |entry| self.add_entry(entry),
+            |path| {
+                skipped_unarchivable_paths.insert(path);
+            },
+        );
+        self.skipped_unarchivable_paths
+            .extend(skipped_unarchivable_paths);
+        result
+    }
+
+    /// Add `entry` to `self`.
+    ///
+    /// The `written` set makes duplicate archive names a no-op. This matters
+    /// for linked worktrees, where common Git state and per-worktree Git state
+    /// are overlaid into one `.git` directory. Symlinks are stored as symlinks
+    /// with their link target, directories are added as directory entries, and
+    /// regular files are streamed into the zip with permissions derived from
+    /// `meta`. Other filesystem node types are ignored.
+    fn add_entry(&mut self, entry: ArchiveEntry) -> Result<()> {
+        self.progress.check_abort()?;
+        if !self.written.insert(entry.entry_name.clone()) {
+            return Ok(());
+        }
+
+        if entry.meta.file_type().is_symlink() {
+            let target = fs::read_link(&entry.path)?;
+            self.zip
+                .add_symlink_from_path(&entry.entry_name, target, symlink_options())?;
+            self.progress.add_file_processed();
+        } else if entry.meta.is_dir() {
+            self.zip
+                .add_directory(&entry.entry_name, directory_options())?;
+        } else if entry.meta.is_file() {
+            let file = fs::File::open(&entry.path)?;
+            let mut file = ProgressReader::new(file, self.progress);
+            self.zip
+                .start_file(&entry.entry_name, file_options(&entry))?;
+            io::copy(&mut file, &mut self.zip)?;
+            self.progress.add_file_processed();
+        }
+        Ok(())
+    }
+
+    /// Finish writing `self` and return the wrapped writer.
+    fn finish(self, err: &mut dyn io::Write) -> Result<W> {
+        self.report_skipped_unarchivable_paths(err)?;
+        Ok(self.zip.finish()?)
+    }
+
+    /// Report paths skipped because they could not be represented safely as zip names.
+    fn report_skipped_unarchivable_paths(&self, err: &mut dyn io::Write) -> Result<()> {
+        if self.skipped_unarchivable_paths.is_empty() {
+            return Ok(());
+        }
+
+        writeln!(
+            err,
+            "Skipped paths that cannot be represented safely in the archive:"
+        )?;
+        for path in &self.skipped_unarchivable_paths {
+            writeln!(err, "  {path:?}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Filesystem entry selected for inclusion in the archive.
+struct ArchiveEntry {
+    /// Source filesystem path to read from.
+    path: PathBuf,
+    /// Zip entry name to write, using `/` separators and rooted in the archive layout.
+    entry_name: String,
+    /// Metadata captured while traversing, reused while writing to preserve type and mode.
+    meta: fs::Metadata,
+}
+
+impl ArchiveEntry {
+    /// Return the maximum number of source bytes expected to be read for `self`.
+    ///
+    /// Regular files are streamed into the zip, so their file length contributes
+    /// to the progress upper bound. Directories and symlinks do not read file
+    /// contents from `path`, so they contribute zero bytes.
+    fn bytes_read_upper_bound(&self) -> usize {
+        if self.meta.is_file() {
+            usize::try_from(self.meta.len()).unwrap_or(usize::MAX)
+        } else {
+            0
+        }
+    }
+
+    /// Return `true` if `self` advances the processed-file progress counter.
+    ///
+    /// Regular files and symlinks are counted because they produce concrete
+    /// archive payload entries. Directories are written too, but are structural
+    /// entries and are intentionally left out of the file count.
+    fn is_archivable(&self) -> bool {
+        self.meta.is_file() || self.meta.file_type().is_symlink()
+    }
+
+    /// Return the zip compression method to use for `self`.
+    fn compression_method(&self) -> CompressionMethod {
+        if is_git_object_entry(&self.entry_name) {
+            CompressionMethod::Stored
+        } else {
+            CompressionMethod::Bzip2
+        }
+    }
+}
+
+/// Progress upper bounds collected before archive writing completes.
+#[derive(Default)]
+struct ArchiveTotals {
+    /// Total regular-file bytes expected to be read.
+    bytes_read: usize,
+    /// Total regular files and symlinks expected to be processed.
+    files_processed: usize,
+}
+
+impl ArchiveTotals {
+    fn add(&mut self, entry: &ArchiveEntry) {
+        self.bytes_read = self
+            .bytes_read
+            .saturating_add(entry.bytes_read_upper_bound());
+        if entry.is_archivable() {
+            self.files_processed = self.files_processed.saturating_add(1);
+        }
+    }
+}
+
+struct SourceEntry {
+    path: PathBuf,
+    meta: fs::Metadata,
+}
+
+#[derive(Clone, Copy)]
+struct GitEntryFilter {
+    skip_link_layout_files: bool,
+    skip_worktree_registry: bool,
+}
+
+/// Count archive input for progress upper bounds without writing entries.
+/// The latter is written once everything is countered.
+///
+/// `repo` is the thread-safe repository clone used by the scoped counter
+/// thread. `output_path` is skipped for the same reason as during archive
+/// writing. `git_only` mirrors the user option so the counter and writer count
+/// the same entry set. `progress` receives the computed byte and file-count
+/// upper bounds.
+fn count_archive_input(
+    repo: gix::ThreadSafeRepository,
+    output_path: &OutputPath,
+    git_only: bool,
+    progress: &DumpProgress,
+) -> Result<()> {
+    let repo: gix::Repository = repo.into();
+    let layout = ArchiveLayout::new(&repo)?;
+    let mut totals = ArchiveTotals::default();
+    visit_archive_entries(
+        &repo,
+        &layout,
+        output_path,
+        git_only,
+        progress,
+        |entry| {
+            totals.add(&entry);
+            Ok(())
+        },
+        |_path| {},
+    )?;
+    progress.set_input_upper_bounds(totals.bytes_read, totals.files_processed);
+    Ok(())
+}
+
+/// Visit every repository entry that should be represented in the archive.
+///
+/// The traversal first visits non-ignored worktree contents, when requested and
+/// available, then always visits Git repository state. Linked worktree Git
+/// directories are normalized by the Git-state visitor before entries reach
+/// `visit`.
+///
+/// `repo` supplies the repository layout and ignore/index state. `layout`
+/// provides the archive roots for worktree and Git entries. `output_path` is
+/// skipped if encountered so the dump does not include the archive currently
+/// being written. `git_only` disables the worktree pass when true. `progress`
+/// is checked for interruption during traversal. For each archivable entry,
+/// `visit` receives an [`ArchiveEntry`] to inform about what's traversed.
+/// Paths that cannot be represented as a safe zip entry name are passed
+/// to `skip_unarchivable` instead.
+fn visit_archive_entries(
+    repo: &gix::Repository,
+    layout: &ArchiveLayout,
+    output_path: &OutputPath,
+    git_only: bool,
+    progress: &DumpProgress,
+    mut visit: impl FnMut(ArchiveEntry) -> Result<()>,
+    mut skip_unarchivable: impl FnMut(PathBuf),
+) -> Result<()> {
+    if !git_only && let Some(workdir) = repo.workdir() {
+        visit_worktree_entries(
+            repo,
+            workdir,
+            &layout.worktree_root,
+            output_path,
+            progress,
+            &mut visit,
+            &mut skip_unarchivable,
+        )?;
+    }
+    visit_git_entries(
+        repo,
+        &layout.git_root,
+        output_path,
+        progress,
+        &mut visit,
+        &mut skip_unarchivable,
+    )
+}
+
+/// Visit the non-ignored worktree contents below `workdir`.
+///
+/// Entries are rooted under `archive_root`, use `repo` for index and ignore
+/// state, and skip `output_path` to avoid archiving the file being written.
+/// The worktree `.git` entry is intentionally omitted here; Git repository
+/// state is written separately by [`visit_git_entries()`].
+fn visit_worktree_entries(
+    repo: &gix::Repository,
+    workdir: &Path,
+    archive_root: &str,
+    output_path: &OutputPath,
+    progress: &DumpProgress,
+    visit: &mut impl FnMut(ArchiveEntry) -> Result<()>,
+    skip_unarchivable: &mut impl FnMut(PathBuf),
+) -> Result<()> {
+    let index = repo.index_or_empty()?;
+    let mut excludes = repo.excludes(
+        &index,
+        None,
+        gix::worktree::stack::state::ignore::Source::WorktreeThenIdMappingIfNotSkipped,
+    )?;
+
+    let mut stack = sorted_children(workdir)?;
+    while let Some(path) = stack.pop() {
+        progress.check_abort()?;
+        if output_path.is_same(&path) {
+            continue;
+        }
+        let relative = path.strip_prefix(workdir)?;
+        if is_dot_git(relative) {
+            continue;
+        }
+
+        let meta = path.symlink_metadata()?;
+        let is_dir = meta.is_dir();
+        let is_excluded = excludes
+            .at_path(relative, is_dir.then_some(index::entry::Mode::DIR))
+            .is_ok_and(|platform| platform.is_excluded());
+        if is_excluded && !is_tracked(relative, is_dir, &index) {
+            continue;
+        }
+
+        let Some(entry_name) = entry_name(archive_root, relative) else {
+            skip_unarchivable(relative.to_owned());
+            continue;
+        };
+        visit(ArchiveEntry {
+            path: path.clone(),
+            entry_name,
+            meta,
+        })?;
+        if is_dir {
+            stack.extend(sorted_children(&path)?);
+        }
+    }
+    Ok(())
+}
+
+/// Visit Git repository state from `repo`.
+///
+/// Entries are rooted under `archive_root` and skip `output_path`.
+///
+/// A normal repository has the same `git_dir()` and `common_dir()`, so its
+/// `.git` directory can be copied as-is. A linked worktree has a small
+/// per-worktree Git directory whose `commondir` and `gitdir` files point
+/// back to the main repository. For that case, this first collects the
+/// common Git directory and then overlays the linked worktree's Git
+/// directory by relative path. While doing that, it omits the common
+/// `worktrees/` registry and the linked worktree's `commondir`/`gitdir`
+/// link files, producing a self-contained `.git` directory that can be
+/// unpacked and used as a regular repository.
+fn visit_git_entries(
+    repo: &gix::Repository,
+    archive_root: &str,
+    output_path: &OutputPath,
+    progress: &DumpProgress,
+    visit: &mut impl FnMut(ArchiveEntry) -> Result<()>,
+    skip_unarchivable: &mut impl FnMut(PathBuf),
+) -> Result<()> {
+    let mut entries = BTreeMap::new();
+    let is_linked_worktree = repo.git_dir() != repo.common_dir();
+    collect_git_entries(
+        repo.common_dir(),
+        repo.common_dir(),
+        &mut entries,
+        output_path,
+        progress,
+        GitEntryFilter {
+            skip_link_layout_files: false,
+            skip_worktree_registry: is_linked_worktree,
+        },
+    )?;
+    if is_linked_worktree {
+        collect_git_entries(
+            repo.git_dir(),
+            repo.git_dir(),
+            &mut entries,
+            output_path,
+            progress,
+            GitEntryFilter {
+                skip_link_layout_files: true,
+                skip_worktree_registry: false,
+            },
+        )?;
+    }
+
+    for (relative, source) in entries {
+        progress.check_abort()?;
+        let Some(entry_name) = entry_name(archive_root, &relative) else {
+            skip_unarchivable(relative);
+            continue;
+        };
+        visit(ArchiveEntry {
+            path: source.path,
+            entry_name,
+            meta: source.meta,
+        })?;
+    }
+    Ok(())
+}
+
+/// Collect Git directory entries below `dir` into `entries`.
+///
+/// Paths are stored relative to `root`, skip `output_path`, and apply `filter`
+/// to omit linked-worktree bookkeeping that should not be archived.
+fn collect_git_entries(
+    root: &Path,
+    dir: &Path,
+    entries: &mut BTreeMap<PathBuf, SourceEntry>,
+    output_path: &OutputPath,
+    progress: &DumpProgress,
+    filter: GitEntryFilter,
+) -> Result<()> {
+    let mut children = sorted_children(dir)?;
+    while let Some(path) = children.pop() {
+        progress.check_abort()?;
+        if output_path.is_same(&path) {
+            continue;
+        }
+        let relative = path.strip_prefix(root)?.to_owned();
+        if filter.skip_link_layout_files && is_link_layout_file(&relative) {
+            continue;
+        }
+        if filter.skip_worktree_registry && is_worktree_registry(&relative) {
+            continue;
+        }
+        let meta = path.symlink_metadata()?;
+        if meta.is_dir() {
+            children.extend(sorted_children(&path)?);
+        }
+        entries.insert(relative, SourceEntry { path, meta });
+    }
+    Ok(())
+}
+
+/// Return children of `dir` in deterministic pop order.
+fn sorted_children(dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut children = fs::read_dir(dir)?
+        .map(|entry| entry.map(|entry| entry.path()))
+        .collect::<io::Result<Vec<_>>>()?;
+    children.sort();
+    children.reverse();
+    Ok(children)
+}
+
+/// Return true if `relative` starts with a worktree `.git` component.
+fn is_dot_git(relative: &Path) -> bool {
+    relative
+        .components()
+        .next()
+        .is_some_and(|component| matches!(component, Component::Normal(name) if name == ".git"))
+}
+
+/// Return true if `relative` is a linked-worktree layout file.
+fn is_link_layout_file(relative: &Path) -> bool {
+    matches!(
+        relative.components().next(),
+        Some(Component::Normal(name)) if name == "commondir" || name == "gitdir"
+    )
+}
+
+/// Return true if `relative` points into the common Git worktree registry.
+fn is_worktree_registry(relative: &Path) -> bool {
+    matches!(
+        relative.components().next(),
+        Some(Component::Normal(name)) if name == "worktrees"
+    )
+}
+
+/// Return true if `relative` is tracked in `index`.
+///
+/// Directories use `is_dir` to switch to prefix matching so ignored directories
+/// containing tracked files are still archived.
+fn is_tracked(relative: &Path, is_dir: bool, index: &gix::index::State) -> bool {
+    let relative = gix::path::to_unix_separators_on_windows(gix::path::into_bstr(relative));
+    if !is_dir {
+        return index.entry_by_path(relative.as_ref()).is_some();
+    }
+
+    let mut prefix = relative.into_owned();
+    if !prefix.ends_with(b"/") {
+        prefix.push(b'/');
+    }
+    index
+        .entries()
+        .iter()
+        .any(|entry| entry.path(index).as_bytes().starts_with(prefix.as_slice()))
+}
+
+/// Build a safe zip entry name from archive `root` and filesystem `relative` path.
+///
+/// Returns `None` when `relative` cannot be represented as Unicode without
+/// losing information, or when the resulting zip entry would be unsafe.
+fn entry_name(root: &str, relative: &Path) -> Option<String> {
+    let mut name = String::with_capacity(root.len() + relative.as_os_str().len() + 2);
+    name.push_str(root);
+    if !relative.as_os_str().is_empty() {
+        let relative = relative.to_str()?;
+        name.push('/');
+        #[cfg(windows)]
+        {
+            name.push_str(&relative.replace('\\', "/"));
+        }
+        #[cfg(not(windows))]
+        {
+            name.push_str(relative);
+        }
+    }
+    if name.contains('\0') || name.split('/').any(|component| component == "..") {
+        return None;
+    }
+    Some(name)
+}
+
+/// Stores the output archive path and its canonical form.
+#[derive(Clone)]
+struct OutputPath {
+    /// The path requested by the caller.
+    path: PathBuf,
+    /// Canonical form of `path`, when it can be resolved.
+    canonical: Option<PathBuf>,
+}
+
+impl OutputPath {
+    /// Create an output path handle for `path`.
+    fn new(path: PathBuf) -> Self {
+        let canonical = fs::canonicalize(&path).ok();
+        Self { path, canonical }
+    }
+
+    /// Return true if `path` identifies the output archive path.
+    fn is_same(&self, path: &Path) -> bool {
+        path == self.path
+            || self.canonical.as_deref().is_some_and(|output_path| {
+                fs::canonicalize(path).ok().as_deref() == Some(output_path)
+            })
+    }
+}
+
+/// Return zip file options for a regular archive entry.
+fn file_options(entry: &ArchiveEntry) -> SimpleFileOptions {
+    SimpleFileOptions::default()
+        .compression_method(entry.compression_method())
+        .unix_permissions(file_permissions(&entry.meta))
+}
+
+/// Return true if `entry_name` points into a dumped Git object database.
+fn is_git_object_entry(entry_name: &str) -> bool {
+    let mut components = entry_name.split('/');
+    if components.next().is_some_and(|root| root.ends_with(".git")) {
+        return components.next() == Some("objects");
+    }
+
+    while let Some(component) = components.next() {
+        if component == ".git" {
+            return components.next() == Some("objects");
+        }
+    }
+    false
+}
+
+/// Return zip directory options.
+fn directory_options() -> SimpleFileOptions {
+    SimpleFileOptions::default()
+        .compression_method(CompressionMethod::Bzip2)
+        .unix_permissions(0o755)
+}
+
+/// Return zip symlink options.
+fn symlink_options() -> SimpleFileOptions {
+    SimpleFileOptions::default().unix_permissions(0o777)
+}
+
+#[cfg(unix)]
+/// Return normalized Unix file permissions for `meta`.
+fn file_permissions(meta: &fs::Metadata) -> u32 {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    if meta.permissions().mode() & 0o111 != 0 {
+        0o755
+    } else {
+        0o644
+    }
+}
+
+#[cfg(not(unix))]
+/// Return portable non-Unix file permissions; `_meta` is ignored.
+fn file_permissions(_meta: &fs::Metadata) -> u32 {
+    0o644
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn entry_name_skips_non_unicode_relative_paths() -> anyhow::Result<()> {
+        use std::{ffi::OsString, os::unix::ffi::OsStringExt};
+
+        let relative = PathBuf::from(OsString::from_vec(b"non-unicode-\xff.txt".to_vec()));
+
+        assert!(entry_name("root", &relative).is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn entry_name_skips_unsafe_relative_paths() -> anyhow::Result<()> {
+        assert!(entry_name("root", Path::new("../escape")).is_none());
+        assert!(entry_name("root", Path::new("null-\0-byte")).is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn git_object_entries_are_detected_for_stored_compression() {
+        assert!(is_git_object_entry(
+            "project-dump/.git/objects/pack/pack-abc.pack"
+        ));
+        assert!(is_git_object_entry("project-dump/.git/objects/12/34567890"));
+        assert!(is_git_object_entry(
+            "project-dump.git/objects/pack/pack-abc.idx"
+        ));
+
+        assert!(!is_git_object_entry("project-dump/.git/config"));
+        assert!(!is_git_object_entry("project-dump/objects/file"));
+    }
+}

--- a/crates/but-debug/src/command/dump/mod.rs
+++ b/crates/but-debug/src/command/dump/mod.rs
@@ -14,10 +14,11 @@ use gix::{bstr::ByteSlice as _, index};
 use zip::{CompressionMethod, ZipWriter, write::SimpleFileOptions};
 
 use crate::{
-    args::{Args, DumpArgs},
+    args::{Args, DumpArgs, DumpSubcommands, RepoDumpArgs},
     setup,
 };
 
+mod diagnostics;
 mod progress;
 use progress::{DumpProgress, ProgressReader, ProgressWriter};
 
@@ -28,7 +29,22 @@ pub(crate) fn run(
     out: &mut dyn io::Write,
     err: &mut dyn io::Write,
 ) -> Result<()> {
-    let current_dir = std::env::current_dir()?.join(&args.current_dir);
+    match &dump_args.cmd {
+        DumpSubcommands::Repo(repo_args) => run_repo(args, repo_args, out, err),
+        DumpSubcommands::Diagnostics(diagnostics_args) => {
+            diagnostics::run(args, diagnostics_args, out, err)
+        }
+    }
+}
+
+/// Execute the `dump repo` subcommand.
+fn run_repo(
+    args: &Args,
+    repo_args: &RepoDumpArgs,
+    out: &mut dyn io::Write,
+    err: &mut dyn io::Write,
+) -> Result<()> {
+    let current_dir = effective_current_dir(args)?;
     let repo = setup::repo_from_args(args).with_context(|| {
         format!(
             "Could not discover Git repository at '{}'",
@@ -36,58 +52,118 @@ pub(crate) fn run(
         )
     })?;
 
-    let output_path = match &dump_args.output {
+    let output_path = match &repo_args.archive.output {
         Some(path) => current_dir.join(path),
-        None => default_output_path(&repo)?,
+        None => default_output_path(&repo, "dump")?,
     };
-    if let Some(parent) = output_path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("Could not create output directory '{}'", parent.display()))?;
-    }
-
+    let diagnostics = if repo_args.no_diagnostics {
+        None
+    } else {
+        Some(diagnostics::capture_from_current_dir(
+            &current_dir,
+            diagnostics::dot_timeout(repo_args.diagnostics.dot_timeout_seconds),
+            out,
+            err,
+        )?)
+    };
     let progress = DumpProgress::new()?;
     let layout = ArchiveLayout::new(&repo)?;
     let output_path = OutputPath::new(output_path);
+    let lock = acquire_archive_lock(&output_path.path, repo.workdir().map(Path::to_owned))?;
+    let output_path = output_path.with_lock_path(lock.lock_path().to_owned());
     std::thread::scope(|scope| -> Result<()> {
         let counter = scope.spawn({
             let progress = &progress;
             let repo = repo.clone().into_sync();
             let output_path = output_path.clone();
-            move || count_archive_input(repo, &output_path, dump_args.git_only, progress)
+            let diagnostics_files = diagnostics
+                .as_ref()
+                .map_or(0, diagnostics::Diagnostics::file_count);
+            move || {
+                count_archive_input(
+                    repo,
+                    &output_path,
+                    repo_args.git_only,
+                    diagnostics_files,
+                    progress,
+                )
+            }
         });
 
-        let file = fs::File::create(&output_path.path)
-            .with_context(|| format!("Could not create '{}'", output_path.path.display()))?;
-        let file = ProgressWriter::new(file, &progress);
+        let file = ProgressWriter::new(lock, &progress);
         let mut archive = ArchiveWriter::new(file, &progress);
-        archive.add_repo(&repo, &layout, &output_path, dump_args.git_only)?;
-        archive.finish(err)?;
+        if let Some(diagnostics) = &diagnostics {
+            archive.add_diagnostics(diagnostics, &layout.worktree_root)?;
+        }
+        archive.add_repo(&repo, &layout, &output_path, repo_args.git_only)?;
+        let file = archive.finish(err)?;
+        let lock = file.into_inner();
 
         let _ = counter
             .join()
             .map_err(|_| anyhow::anyhow!("Archive progress counter thread panicked"))?;
+        persist_archive(lock)?;
         Ok(())
     })?;
 
     writeln!(out, "Archive at: {}", output_path.path.display())?;
-    if dump_args.open_archive_dir {
-        let dir = output_path.path.parent().unwrap_or_else(|| Path::new("."));
+    open_archive_dir_unless_requested(
+        &output_path.path,
+        repo_args.archive.no_open_archive_directory,
+    )?;
+    Ok(())
+}
+
+/// Return the effective current directory selected by `-C`.
+fn effective_current_dir(args: &Args) -> Result<PathBuf> {
+    Ok(std::env::current_dir()?.join(&args.current_dir))
+}
+
+/// Return the default archive path for `repo`, using `suffix` after the repository name.
+fn default_output_path(repo: &gix::Repository, suffix: &str) -> Result<PathBuf> {
+    let base = archive_base_name(repo)?;
+    let root = repo.workdir().unwrap_or_else(|| repo.git_dir());
+    let parent = root.parent().unwrap_or_else(|| Path::new("."));
+    Ok(parent.join(format!("{base}-{suffix}.zip")))
+}
+
+/// Acquire a lock file for writing an archive atomically.
+///
+/// When `boundary_directory` is provided, missing directories below that
+/// boundary may be created for the archive path and removed again if the lock is
+/// rolled back. When it is `None`, the archive's parent directory must already
+/// exist.
+fn acquire_archive_lock(
+    archive_path: &Path,
+    boundary_directory: Option<PathBuf>,
+) -> Result<gix::lock::File> {
+    gix::lock::File::acquire_to_update_resource(
+        archive_path,
+        gix::lock::acquire::Fail::Immediately,
+        boundary_directory,
+    )
+    .with_context(|| format!("Could not lock archive '{}'", archive_path.display()))
+}
+
+/// Atomically move a fully-written archive lock file into its final path.
+fn persist_archive(mut lock: gix::lock::File) -> Result<PathBuf> {
+    let archive_path = lock.resource_path();
+    io::Write::flush(&mut lock)
+        .with_context(|| format!("Could not flush archive '{}'", archive_path.display()))?;
+    lock.commit()
+        .map(|(path, _file)| path)
+        .map_err(|err| err.error)
+        .with_context(|| format!("Could not persist archive '{}'", archive_path.display()))
+}
+
+/// Open the parent directory of `archive_path` unless disabled by the caller.
+fn open_archive_dir_unless_requested(archive_path: &Path, disabled: bool) -> Result<()> {
+    if !disabled {
+        let dir = archive_path.parent().unwrap_or_else(|| Path::new("."));
         open::that(dir)
             .with_context(|| format!("Could not open archive directory '{}'", dir.display()))?;
     }
     Ok(())
-}
-
-/// Return the default output archive path for `repo`.
-fn default_output_path(repo: &gix::Repository) -> Result<PathBuf> {
-    let base = archive_base_name(repo)?;
-    let root = if let Some(workdir) = repo.workdir() {
-        workdir
-    } else {
-        repo.git_dir()
-    };
-    let parent = root.parent().unwrap_or_else(|| Path::new("."));
-    Ok(parent.join(format!("{base}-dump.zip")))
 }
 
 /// Keeps worktree files and Git files under the right top-level paths in the zip.
@@ -216,6 +292,29 @@ impl<'progress, W: io::Write + io::Seek> ArchiveWriter<'progress, W> {
         self.skipped_unarchivable_paths
             .extend(skipped_unarchivable_paths);
         result
+    }
+
+    /// Add generated diagnostics files directly below `archive_root`.
+    fn add_diagnostics(
+        &mut self,
+        diagnostics: &diagnostics::Diagnostics,
+        archive_root: &str,
+    ) -> Result<()> {
+        for (relative_path, contents) in diagnostics.entries() {
+            self.add_generated_file(format!("{archive_root}/{relative_path}"), contents)?;
+        }
+        Ok(())
+    }
+
+    fn add_generated_file(&mut self, entry_name: String, contents: &[u8]) -> Result<()> {
+        self.progress.check_abort()?;
+        if !self.written.insert(entry_name.clone()) {
+            return Ok(());
+        }
+        self.zip.start_file(entry_name, generated_file_options())?;
+        io::Write::write_all(&mut self.zip, contents)?;
+        self.progress.add_file_processed();
+        Ok(())
     }
 
     /// Add `entry` to `self`.
@@ -360,6 +459,7 @@ fn count_archive_input(
     repo: gix::ThreadSafeRepository,
     output_path: &OutputPath,
     git_only: bool,
+    diagnostics_files: usize,
     progress: &DumpProgress,
 ) -> Result<()> {
     let repo: gix::Repository = repo.into();
@@ -377,6 +477,7 @@ fn count_archive_input(
         },
         |_path| {},
     )?;
+    totals.files_processed = totals.files_processed.saturating_add(diagnostics_files);
     progress.set_input_upper_bounds(totals.bytes_read, totals.files_processed);
     Ok(())
 }
@@ -665,6 +766,8 @@ fn entry_name(root: &str, relative: &Path) -> Option<String> {
 struct OutputPath {
     /// The path requested by the caller.
     path: PathBuf,
+    /// Lock file path used while writing the archive.
+    lock_path: Option<PathBuf>,
     /// Canonical form of `path`, when it can be resolved.
     canonical: Option<PathBuf>,
 }
@@ -673,12 +776,26 @@ impl OutputPath {
     /// Create an output path handle for `path`.
     fn new(path: PathBuf) -> Self {
         let canonical = fs::canonicalize(&path).ok();
-        Self { path, canonical }
+        Self {
+            path,
+            lock_path: None,
+            canonical,
+        }
+    }
+
+    /// Track the in-progress lock file so repository traversal can skip it too.
+    ///
+    /// For example, while writing `repo-dump.zip`, the temporary lock file may
+    /// be `repo-dump.zip.lock`.
+    fn with_lock_path(mut self, lock_path: PathBuf) -> Self {
+        self.lock_path = Some(lock_path);
+        self
     }
 
     /// Return true if `path` identifies the output archive path.
     fn is_same(&self, path: &Path) -> bool {
         path == self.path
+            || self.lock_path.as_deref() == Some(path)
             || self.canonical.as_deref().is_some_and(|output_path| {
                 fs::canonicalize(path).ok().as_deref() == Some(output_path)
             })
@@ -712,6 +829,13 @@ fn directory_options() -> SimpleFileOptions {
     SimpleFileOptions::default()
         .compression_method(CompressionMethod::Bzip2)
         .unix_permissions(0o755)
+}
+
+/// Return zip file options for generated diagnostics entries.
+fn generated_file_options() -> SimpleFileOptions {
+    SimpleFileOptions::default()
+        .compression_method(CompressionMethod::Bzip2)
+        .unix_permissions(0o644)
 }
 
 /// Return zip symlink options.
@@ -771,5 +895,54 @@ mod tests {
 
         assert!(!is_git_object_entry("project-dump/.git/config"));
         assert!(!is_git_object_entry("project-dump/objects/file"));
+    }
+
+    #[test]
+    fn archive_lock_rolls_back_until_persisted_and_prevents_double_writes() -> anyhow::Result<()> {
+        use std::io::Write as _;
+
+        let dir = tempfile::tempdir()?;
+        let archive_path = dir.path().join("out.zip");
+        fs::write(&archive_path, b"previous")?;
+
+        let mut lock = acquire_archive_lock(&archive_path, None)?;
+        lock.write_all(b"partial")?;
+        assert!(
+            acquire_archive_lock(&archive_path, None).is_err(),
+            "archive lock should prevent concurrent writers"
+        );
+        drop(lock);
+        assert_eq!(
+            fs::read(&archive_path)?,
+            b"previous",
+            "dropping the lock should keep the previous archive"
+        );
+
+        let nested_archive_path = dir.path().join("new").join("nested").join("out.zip");
+        assert!(
+            acquire_archive_lock(&nested_archive_path, None).is_err(),
+            "without a boundary, the archive parent directory should have to exist"
+        );
+
+        let mut lock = acquire_archive_lock(&nested_archive_path, Some(dir.path().to_owned()))?;
+        lock.write_all(b"partial")?;
+        drop(lock);
+        assert!(
+            !nested_archive_path
+                .parent()
+                .expect("nested archive has a parent")
+                .exists(),
+            "dropping the lock should remove empty parent directories created for it"
+        );
+
+        let mut lock = acquire_archive_lock(&archive_path, None)?;
+        lock.write_all(b"complete")?;
+        persist_archive(lock)?;
+        assert_eq!(
+            fs::read(&archive_path)?,
+            b"complete",
+            "persisting the lock should replace the archive"
+        );
+        Ok(())
     }
 }

--- a/crates/but-debug/src/command/dump/mod.rs
+++ b/crates/but-debug/src/command/dump/mod.rs
@@ -68,7 +68,7 @@ fn run_repo(
     };
     let progress = DumpProgress::new()?;
     let layout = ArchiveLayout::new(&repo)?;
-    let output_path = OutputPath::new(output_path);
+    let output_path = OutputPath::new(output_path, current_dir.clone());
     let lock = acquire_archive_lock(&output_path.path, repo.workdir().map(Path::to_owned))?;
     let output_path = output_path.with_lock_path(lock.lock_path().to_owned());
     std::thread::scope(|scope| -> Result<()> {
@@ -761,25 +761,31 @@ fn entry_name(root: &str, relative: &Path) -> Option<String> {
     Some(name)
 }
 
-/// Stores the output archive path and its canonical form.
+/// Stores the output archive path and its normalized form.
 #[derive(Clone)]
 struct OutputPath {
     /// The path requested by the caller.
     path: PathBuf,
+    /// The current directory used to resolve relative output paths.
+    current_dir: PathBuf,
     /// Lock file path used while writing the archive.
     lock_path: Option<PathBuf>,
-    /// Canonical form of `path`, when it can be resolved.
-    canonical: Option<PathBuf>,
+    /// Realpath form of `path`, even when only parent directories exist.
+    realpath: Option<PathBuf>,
+    /// Realpath form of the lock file path used while writing.
+    lock_realpath: Option<PathBuf>,
 }
 
 impl OutputPath {
     /// Create an output path handle for `path`.
-    fn new(path: PathBuf) -> Self {
-        let canonical = fs::canonicalize(&path).ok();
+    fn new(path: PathBuf, current_dir: PathBuf) -> Self {
+        let realpath = realpath(&path, &current_dir);
         Self {
             path,
+            current_dir,
             lock_path: None,
-            canonical,
+            realpath,
+            lock_realpath: None,
         }
     }
 
@@ -788,6 +794,7 @@ impl OutputPath {
     /// For example, while writing `repo-dump.zip`, the temporary lock file may
     /// be `repo-dump.zip.lock`.
     fn with_lock_path(mut self, lock_path: PathBuf) -> Self {
+        self.lock_realpath = realpath(&lock_path, &self.current_dir);
         self.lock_path = Some(lock_path);
         self
     }
@@ -796,10 +803,15 @@ impl OutputPath {
     fn is_same(&self, path: &Path) -> bool {
         path == self.path
             || self.lock_path.as_deref() == Some(path)
-            || self.canonical.as_deref().is_some_and(|output_path| {
-                fs::canonicalize(path).ok().as_deref() == Some(output_path)
+            || realpath(path, &self.current_dir).is_some_and(|path| {
+                self.realpath.as_deref() == Some(path.as_path())
+                    || self.lock_realpath.as_deref() == Some(path.as_path())
             })
     }
+}
+
+fn realpath(path: &Path, current_dir: &Path) -> Option<PathBuf> {
+    gix::path::realpath_opts(path, current_dir, gix::path::realpath::MAX_SYMLINKS).ok()
 }
 
 /// Return zip file options for a regular archive entry.

--- a/crates/but-debug/src/command/dump/progress.rs
+++ b/crates/but-debug/src/command/dump/progress.rs
@@ -1,9 +1,6 @@
 use std::{
     io,
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
+    sync::{Arc, atomic::Ordering},
     time::Duration,
 };
 
@@ -24,10 +21,8 @@ pub(super) struct DumpProgress {
     bytes_written: prodash::tree::Item,
     /// Counter for regular files and symlinks added to the archive.
     files_processed: prodash::tree::Item,
-    /// Set by signal handlers to request a cooperative abort.
-    is_interrupted: Arc<AtomicBool>,
-    /// Signal registrations scoped to this dump operation.
-    _signals: SignalHandlers,
+    /// Signal handler registration scoped to this dump operation.
+    interrupt: Option<gix::interrupt::Deregister>,
 }
 
 impl DumpProgress {
@@ -78,8 +73,14 @@ impl DumpProgress {
             )),
         );
 
-        let abort = Arc::new(AtomicBool::new(false));
-        let signals = SignalHandlers::new(Arc::clone(&abort))?;
+        gix::interrupt::reset();
+        #[allow(unsafe_code)]
+        let interrupt = unsafe {
+            // SAFETY: The callback runs from a signal handler, so it must only
+            // perform signal-safe work. It is intentionally empty; gix updates
+            // its global atomic interrupt flag after invoking it.
+            gix::interrupt::init_handler(1, || {})
+        }?;
 
         Ok(Self {
             _root: root,
@@ -88,8 +89,7 @@ impl DumpProgress {
             bytes_read,
             bytes_written,
             files_processed,
-            is_interrupted: abort,
-            _signals: signals,
+            interrupt: Some(interrupt),
         })
     }
 
@@ -111,14 +111,14 @@ impl DumpProgress {
     }
 
     pub(super) fn check_abort(&self) -> Result<()> {
-        if self.is_interrupted.load(Ordering::SeqCst) {
+        if gix::interrupt::IS_INTERRUPTED.load(Ordering::SeqCst) {
             bail!("Interrupted while creating repository dump");
         }
         Ok(())
     }
 
     fn check_abort_io(&self) -> io::Result<()> {
-        if self.is_interrupted.load(Ordering::SeqCst) {
+        if gix::interrupt::IS_INTERRUPTED.load(Ordering::SeqCst) {
             return Err(io::Error::other(
                 "interrupted while creating repository dump",
             ));
@@ -132,33 +132,8 @@ impl Drop for DumpProgress {
         if let Some(renderer) = self.renderer.take() {
             renderer.shutdown_and_wait();
         }
-    }
-}
-
-/// Registers temporary termination signal handlers for one dump operation.
-struct SignalHandlers {
-    ids: Vec<signal_hook::SigId>,
-}
-
-impl SignalHandlers {
-    fn new(abort: Arc<AtomicBool>) -> io::Result<Self> {
-        let mut ids = Vec::new();
-        for signal in signal_hook::consts::TERM_SIGNALS {
-            ids.push(signal_hook::flag::register_conditional_shutdown(
-                *signal,
-                1,
-                Arc::clone(&abort),
-            )?);
-            ids.push(signal_hook::flag::register(*signal, Arc::clone(&abort))?);
-        }
-        Ok(Self { ids })
-    }
-}
-
-impl Drop for SignalHandlers {
-    fn drop(&mut self) {
-        for id in self.ids.drain(..) {
-            signal_hook::low_level::unregister(id);
+        if let Some(interrupt) = self.interrupt.take() {
+            interrupt.with_reset(true).deregister().ok();
         }
     }
 }
@@ -193,6 +168,10 @@ pub(super) struct ProgressWriter<'progress, W> {
 impl<'progress, W> ProgressWriter<'progress, W> {
     pub(super) fn new(inner: W, progress: &'progress DumpProgress) -> Self {
         Self { inner, progress }
+    }
+
+    pub(super) fn into_inner(self) -> W {
+        self.inner
     }
 }
 

--- a/crates/but-debug/src/command/dump/progress.rs
+++ b/crates/but-debug/src/command/dump/progress.rs
@@ -1,0 +1,218 @@
+use std::{
+    io,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+
+use anyhow::{Result, bail};
+
+/// Owns dump progress counters, rendering, and abort state.
+pub(super) struct DumpProgress {
+    /// Keeps the shared progress tree alive for the renderer and task items.
+    _root: Arc<prodash::tree::Root>,
+    /// Background line renderer for terminal progress output.
+    /// It terminates automatically once `_root` is dropped.
+    renderer: Option<prodash::render::line::JoinHandle>,
+    /// Parent task grouping all dump counters as a headline.
+    _task: prodash::tree::Item,
+    /// Counter for bytes read from repository files.
+    bytes_read: prodash::tree::Item,
+    /// Counter for bytes written to the archive file.
+    bytes_written: prodash::tree::Item,
+    /// Counter for regular files and symlinks added to the archive.
+    files_processed: prodash::tree::Item,
+    /// Set by signal handlers to request a cooperative abort.
+    is_interrupted: Arc<AtomicBool>,
+    /// Signal registrations scoped to this dump operation.
+    _signals: SignalHandlers,
+}
+
+impl DumpProgress {
+    pub(super) fn new() -> Result<Self> {
+        let root: Arc<prodash::tree::Root> = prodash::tree::root::Options {
+            message_buffer_capacity: 200,
+            ..Default::default()
+        }
+        .into();
+        let renderer = prodash::render::line(
+            std::io::stderr(),
+            Arc::downgrade(&root),
+            prodash::render::line::Options {
+                level_filter: None,
+                frames_per_second: 6.0,
+                initial_delay: Some(Duration::from_secs(1)),
+                timestamp: true,
+                throughput: true,
+                hide_cursor: true,
+                ..Default::default()
+            }
+            .auto_configure(prodash::render::line::StreamKind::Stderr),
+        );
+
+        let mut task = root.add_child("dump repository");
+        let throughput = prodash::unit::display::Mode::with_throughput();
+        let bytes_read = task.add_child("bytes in");
+        bytes_read.init(
+            None,
+            Some(prodash::unit::dynamic_and_mode(
+                prodash::unit::Bytes,
+                throughput,
+            )),
+        );
+
+        let files_processed = task.add_child("processed");
+        files_processed.init(
+            None,
+            Some(prodash::unit::label_and_mode("files", throughput)),
+        );
+
+        let bytes_written = task.add_child("archive out");
+        bytes_written.init(
+            None,
+            Some(prodash::unit::dynamic_and_mode(
+                prodash::unit::Bytes,
+                throughput,
+            )),
+        );
+
+        let abort = Arc::new(AtomicBool::new(false));
+        let signals = SignalHandlers::new(Arc::clone(&abort))?;
+
+        Ok(Self {
+            _root: root,
+            renderer: Some(renderer),
+            _task: task,
+            bytes_read,
+            bytes_written,
+            files_processed,
+            is_interrupted: abort,
+            _signals: signals,
+        })
+    }
+
+    pub(super) fn set_input_upper_bounds(&self, bytes_read: usize, files_processed: usize) {
+        self.bytes_read.set_max(Some(bytes_read));
+        self.files_processed.set_max(Some(files_processed));
+    }
+
+    fn add_bytes_read(&self, amount: usize) {
+        self.bytes_read.inc_by(amount);
+    }
+
+    fn add_bytes_written(&self, amount: usize) {
+        self.bytes_written.inc_by(amount);
+    }
+
+    pub(super) fn add_file_processed(&self) {
+        self.files_processed.inc();
+    }
+
+    pub(super) fn check_abort(&self) -> Result<()> {
+        if self.is_interrupted.load(Ordering::SeqCst) {
+            bail!("Interrupted while creating repository dump");
+        }
+        Ok(())
+    }
+
+    fn check_abort_io(&self) -> io::Result<()> {
+        if self.is_interrupted.load(Ordering::SeqCst) {
+            return Err(io::Error::other(
+                "interrupted while creating repository dump",
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for DumpProgress {
+    fn drop(&mut self) {
+        if let Some(renderer) = self.renderer.take() {
+            renderer.shutdown_and_wait();
+        }
+    }
+}
+
+/// Registers temporary termination signal handlers for one dump operation.
+struct SignalHandlers {
+    ids: Vec<signal_hook::SigId>,
+}
+
+impl SignalHandlers {
+    fn new(abort: Arc<AtomicBool>) -> io::Result<Self> {
+        let mut ids = Vec::new();
+        for signal in signal_hook::consts::TERM_SIGNALS {
+            ids.push(signal_hook::flag::register_conditional_shutdown(
+                *signal,
+                1,
+                Arc::clone(&abort),
+            )?);
+            ids.push(signal_hook::flag::register(*signal, Arc::clone(&abort))?);
+        }
+        Ok(Self { ids })
+    }
+}
+
+impl Drop for SignalHandlers {
+    fn drop(&mut self) {
+        for id in self.ids.drain(..) {
+            signal_hook::low_level::unregister(id);
+        }
+    }
+}
+
+/// Reader wrapper that counts source bytes and observes abort requests.
+pub(super) struct ProgressReader<'progress, R> {
+    inner: R,
+    progress: &'progress DumpProgress,
+}
+
+impl<'progress, R> ProgressReader<'progress, R> {
+    pub(super) fn new(inner: R, progress: &'progress DumpProgress) -> Self {
+        Self { inner, progress }
+    }
+}
+
+impl<R: io::Read> io::Read for ProgressReader<'_, R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.progress.check_abort_io()?;
+        let amount = self.inner.read(buf)?;
+        self.progress.add_bytes_read(amount);
+        Ok(amount)
+    }
+}
+
+/// Writer wrapper that counts archive bytes and observes abort requests.
+pub(super) struct ProgressWriter<'progress, W> {
+    inner: W,
+    progress: &'progress DumpProgress,
+}
+
+impl<'progress, W> ProgressWriter<'progress, W> {
+    pub(super) fn new(inner: W, progress: &'progress DumpProgress) -> Self {
+        Self { inner, progress }
+    }
+}
+
+impl<W: io::Write> io::Write for ProgressWriter<'_, W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.progress.check_abort_io()?;
+        let amount = self.inner.write(buf)?;
+        self.progress.add_bytes_written(amount);
+        Ok(amount)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.progress.check_abort_io()?;
+        self.inner.flush()
+    }
+}
+
+impl<W: io::Seek> io::Seek for ProgressWriter<'_, W> {
+    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
+        self.progress.check_abort_io()?;
+        self.inner.seek(pos)
+    }
+}

--- a/crates/but-debug/src/command/graph.rs
+++ b/crates/but-debug/src/command/graph.rs
@@ -1,6 +1,6 @@
 //! Implementation of the `graph` debug command.
 
-use std::io::{self, Write as _};
+use std::io;
 
 use anyhow::Result;
 use gix::odb::store::RefreshMode;
@@ -23,7 +23,12 @@ enum DotMode {
 }
 
 /// Execute the `graph` subcommand.
-pub(crate) fn run(args: &Args, graph_args: &GraphArgs) -> Result<()> {
+pub(crate) fn run(
+    args: &Args,
+    graph_args: &GraphArgs,
+    out: &mut dyn io::Write,
+    err: &mut dyn io::Write,
+) -> Result<()> {
     let mut repo = setup::repo_from_args(args)?;
     repo.objects.refresh = RefreshMode::Never;
     let meta = EmptyRefMetadata;
@@ -67,15 +72,16 @@ pub(crate) fn run(args: &Args, graph_args: &GraphArgs) -> Result<()> {
 
     let errors = graph.validation_errors();
     if !errors.is_empty() {
-        eprintln!("VALIDATION FAILED: {errors:?}");
+        writeln!(err, "VALIDATION FAILED: {errors:?}")?;
     }
     if graph_args.stats {
-        eprintln!("{:#?}", graph.statistics());
+        writeln!(err, "{:#?}", graph.statistics())?;
     }
 
     let workspace = graph.into_workspace()?;
     if graph_args.no_debug_workspace {
-        eprintln!(
+        writeln!(
+            err,
             "Workspace with {} stacks and {} segments across all stacks with {} commits total",
             workspace.stacks.len(),
             workspace
@@ -88,21 +94,21 @@ pub(crate) fn run(args: &Args, graph_args: &GraphArgs) -> Result<()> {
                 .iter()
                 .flat_map(|stack| stack.segments.iter().map(|segment| segment.commits.len()))
                 .sum::<usize>(),
-        );
+        )?;
     } else {
-        eprintln!("{workspace:#?}");
+        writeln!(err, "{workspace:#?}")?;
     }
 
     match dot_mode(graph_args) {
         Some(DotMode::Print) => {
-            io::stdout().write_all(workspace.graph.dot_graph().as_bytes())?;
+            out.write_all(workspace.graph.dot_graph().as_bytes())?;
         }
         Some(DotMode::OpenAsSvg) => {
             #[cfg(unix)]
             workspace.graph.open_as_svg();
         }
         Some(DotMode::Debug) => {
-            eprintln!("{graph:#?}", graph = workspace.graph);
+            writeln!(err, "{graph:#?}", graph = workspace.graph)?;
         }
         None => {}
     }

--- a/crates/but-debug/src/command/graph.rs
+++ b/crates/but-debug/src/command/graph.rs
@@ -101,7 +101,7 @@ pub(crate) fn run(
 
     match dot_mode(graph_args) {
         Some(DotMode::Print) => {
-            out.write_all(workspace.graph.dot_graph().as_bytes())?;
+            out.write_all(workspace.graph.dot_graph_pruned().as_bytes())?;
         }
         Some(DotMode::OpenAsSvg) => {
             #[cfg(unix)]

--- a/crates/but-debug/src/command/graph.rs
+++ b/crates/but-debug/src/command/graph.rs
@@ -2,7 +2,7 @@
 
 use std::io;
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use gix::odb::store::RefreshMode;
 
 use crate::{
@@ -29,6 +29,17 @@ pub(crate) fn run(
     out: &mut dyn io::Write,
     err: &mut dyn io::Write,
 ) -> Result<()> {
+    if uses_context_discovery(graph_args) {
+        let ctx = but_ctx::Context::discover(&args.current_dir).with_context(|| {
+            format!(
+                "Could not open GitButler context at '{}'",
+                args.current_dir.display()
+            )
+        })?;
+        let (_guard, _repo, workspace, _db) = ctx.workspace_and_db()?;
+        return emit_workspace(&workspace, graph_args, out, err);
+    }
+
     let mut repo = setup::repo_from_args(args)?;
     repo.objects.refresh = RefreshMode::Never;
     let meta = EmptyRefMetadata;
@@ -70,15 +81,24 @@ pub(crate) fn run(
         }
     }?;
 
-    let errors = graph.validation_errors();
+    let workspace = graph.into_workspace()?;
+    emit_workspace(&workspace, graph_args, out, err)
+}
+
+fn emit_workspace(
+    workspace: &but_graph::projection::Workspace,
+    graph_args: &GraphArgs,
+    out: &mut dyn io::Write,
+    err: &mut dyn io::Write,
+) -> Result<()> {
+    let errors = workspace.graph.validation_errors();
     if !errors.is_empty() {
         writeln!(err, "VALIDATION FAILED: {errors:?}")?;
     }
     if graph_args.stats {
-        writeln!(err, "{:#?}", graph.statistics())?;
+        writeln!(err, "{:#?}", workspace.graph.statistics())?;
     }
 
-    let workspace = graph.into_workspace()?;
     if graph_args.no_debug_workspace {
         writeln!(
             err,
@@ -114,6 +134,22 @@ pub(crate) fn run(
     }
 
     Ok(())
+}
+
+/// Return `true` when the command can use the workspace graph from
+/// `but_ctx::Context` because nothing special is specified.
+///
+/// Context discovery loads the same workspace graph used by the application,
+/// including metadata-backed target handling. The manual repository path below
+/// is still needed when any debug traversal knob is set, because those options
+/// must be passed directly into `but_graph::Graph::from_*`.
+fn uses_context_discovery(graph_args: &GraphArgs) -> bool {
+    graph_args.extra_target.is_none()
+        && !graph_args.no_post
+        && graph_args.hard_limit.is_none()
+        && graph_args.limit == Some(Some(300))
+        && graph_args.limit_extension.is_empty()
+        && graph_args.ref_name.is_none()
 }
 
 /// Determine which graph output mode should be used.

--- a/crates/but-debug/src/command/mod.rs
+++ b/crates/but-debug/src/command/mod.rs
@@ -1,4 +1,5 @@
 //! A place for each `but-debug` command implementation.
 
+pub(crate) mod dump;
 pub(crate) mod graph;
 pub(crate) mod revision;

--- a/crates/but-debug/src/command/revision.rs
+++ b/crates/but-debug/src/command/revision.rs
@@ -1,16 +1,13 @@
 //! Implementation of the `revision` debug commands.
 
-use std::io::Write;
+use std::io::{self, Write as _};
 
 use anyhow::{Context as _, Result, bail, ensure};
 use but_core::ref_metadata::{
     StackId, Workspace, WorkspaceCommitRelation, WorkspaceStack, WorkspaceStackBranch,
 };
 use but_graph::FirstParent;
-use gix::{
-    bstr::ByteVec, odb::store::RefreshMode, reference::Category, refs::Target,
-    revision::plumbing::Spec,
-};
+use gix::{odb::store::RefreshMode, reference::Category, refs::Target, revision::plumbing::Spec};
 
 use crate::{
     args::{Args, LogArgs, MergeBaseArgs, RevisionArgs, RevisionGraphArgs, RevisionSubcommands},
@@ -19,20 +16,29 @@ use crate::{
 };
 
 /// Execute the `revision` subcommand.
-pub(crate) fn run(args: &Args, revision_args: &RevisionArgs) -> Result<()> {
+pub(crate) fn run(
+    args: &Args,
+    revision_args: &RevisionArgs,
+    out: &mut dyn io::Write,
+) -> Result<()> {
     let mut repo = setup::repo_from_args(args)?;
     repo.objects.refresh = RefreshMode::Never;
     let meta = EmptyRefMetadata;
 
     match &revision_args.cmd {
-        RevisionSubcommands::Log(log_args) => log(&repo, &meta, log_args),
+        RevisionSubcommands::Log(log_args) => log(&repo, &meta, log_args, out),
         RevisionSubcommands::MergeBase(merge_base_args) => {
-            merge_base(&repo, &meta, merge_base_args)
+            merge_base(&repo, &meta, merge_base_args, out)
         }
     }
 }
 
-fn log(repo: &gix::Repository, meta: &EmptyRefMetadata, log_args: &LogArgs) -> Result<()> {
+fn log(
+    repo: &gix::Repository,
+    meta: &EmptyRefMetadata,
+    log_args: &LogArgs,
+    out: &mut dyn io::Write,
+) -> Result<()> {
     let parsed = repo
         .rev_parse(log_args.rev_spec.as_str())
         .with_context(|| format!("Failed to parse rev-spec '{}'", log_args.rev_spec))?
@@ -64,13 +70,11 @@ fn log(repo: &gix::Repository, meta: &EmptyRefMetadata, log_args: &LogArgs) -> R
         bail!("Need to specify a rev-spec of form `a..b` to indicate an exclusion for now.")
     };
 
-    let mut out = Vec::with_capacity(512);
+    let mut out = io::BufWriter::new(out);
     for commit_id in commits {
         commit_id.write_hex_to(&mut out)?;
-        out.push_byte(b'\n');
+        writeln!(out)?;
     }
-
-    std::io::stdout().write_all(&out)?;
     Ok(())
 }
 
@@ -78,6 +82,7 @@ fn merge_base(
     repo: &gix::Repository,
     meta: &EmptyRefMetadata,
     merge_base_args: &MergeBaseArgs,
+    out: &mut dyn io::Write,
 ) -> Result<()> {
     let commits = {
         let _span = tracing::info_span!(
@@ -138,7 +143,7 @@ fn merge_base(
             merge_base_args.revisions.join(", ")
         );
     };
-    println!("{merge_base}");
+    writeln!(out, "{merge_base}")?;
 
     Ok(())
 }

--- a/crates/but-debug/src/lib.rs
+++ b/crates/but-debug/src/lib.rs
@@ -1,5 +1,5 @@
 //! Debugging utilities exposed as a dedicated CLI.
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 
 use std::{ffi::OsString, io};
 

--- a/crates/but-debug/src/lib.rs
+++ b/crates/but-debug/src/lib.rs
@@ -1,7 +1,7 @@
 //! Debugging utilities exposed as a dedicated CLI.
 #![forbid(unsafe_code)]
 
-use std::ffi::OsString;
+use std::{ffi::OsString, io};
 
 use anyhow::Result;
 use clap::Parser;
@@ -15,13 +15,18 @@ mod trace;
 use args::{Args, Subcommands};
 
 /// Parse CLI arguments and dispatch the requested subcommand.
-pub fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
+pub fn handle_args(
+    args: impl Iterator<Item = OsString>,
+    out: &mut dyn io::Write,
+    err: &mut dyn io::Write,
+) -> Result<()> {
     let args = Args::parse_from(args);
     trace::init(args.trace)?;
 
     let _span = tracing::info_span!("run").entered();
     match &args.cmd {
-        Subcommands::Graph(graph_args) => command::graph::run(&args, graph_args),
-        Subcommands::Revision(revision_args) => command::revision::run(&args, revision_args),
+        Subcommands::Dump(dump_args) => command::dump::run(&args, dump_args, out, err),
+        Subcommands::Graph(graph_args) => command::graph::run(&args, graph_args, out, err),
+        Subcommands::Revision(revision_args) => command::revision::run(&args, revision_args, out),
     }
 }

--- a/crates/but-debug/src/main.rs
+++ b/crates/but-debug/src/main.rs
@@ -1,4 +1,8 @@
 /// Start the `but-debug` CLI.
 fn main() -> anyhow::Result<()> {
-    but_debug::handle_args(std::env::args_os())
+    but_debug::handle_args(
+        std::env::args_os(),
+        &mut std::io::stdout(),
+        &mut std::io::stderr(),
+    )
 }

--- a/crates/but-debug/tests/debug/dump.rs
+++ b/crates/but-debug/tests/debug/dump.rs
@@ -3,6 +3,7 @@ use std::{
     ffi::OsString,
     fmt,
     fs::File,
+    io::Read as _,
     path::{Path, PathBuf},
 };
 
@@ -89,6 +90,152 @@ fn git_only_skips_worktree_files() -> anyhow::Result<()> {
     │   └── vb.toml:100644
     └── ... 25 files and 15 directories not shown
 ");
+
+    Ok(())
+}
+
+#[test]
+fn diagnostics_archive_contains_graph_and_workspace_projection() -> anyhow::Result<()> {
+    let fixture = writable_fixture("dump-normal-repo-with-worktree-changes.sh")?;
+    let repo = fixture.path().join("你好 repo");
+    let output_dir = TempDir::new()?;
+    let output = output_dir.path().join("diagnostics.zip");
+
+    let dump_output = run_dump_diagnostics(&repo, &output)?;
+    insta::assert_snapshot!(dump_output.display_for_snapshot(&output), @"
+    stdout:
+    Running: dot -Tsvg [dot path] -o [svg path]
+    Archive at: [output path]
+    stderr:
+    ");
+
+    let mut archive = zip::ZipArchive::new(File::open(&output)?)?;
+    let root = "你好-repo-diagnostics";
+    let mut dot = String::new();
+    archive
+        .by_name(&format!("{root}/graph.dot"))?
+        .read_to_string(&mut dot)?;
+    assert!(
+        dot.contains("digraph"),
+        "graph dot diagnostics should contain a dot graph"
+    );
+
+    let mut workspace = String::new();
+    archive
+        .by_name(&format!("{root}/workspace.ron.txt"))?
+        .read_to_string(&mut workspace)?;
+    assert!(
+        workspace.contains("Workspace("),
+        "workspace diagnostics should contain the debug workspace projection"
+    );
+
+    if let Ok(mut svg) = archive.by_name(&format!("{root}/graph.svg")) {
+        let mut header = String::new();
+        svg.read_to_string(&mut header)?;
+        assert!(
+            header.contains("<svg"),
+            "generated graph svg diagnostics should contain an SVG document"
+        );
+    } else {
+        eprintln!(
+            "The graph.svg wasn't generated within 10 seconds, or 'dot' didn't exist here. Should be fine."
+        )
+    }
+
+    Ok(())
+}
+
+#[test]
+fn repo_dump_with_diagnostics_injects_files_at_dump_root() -> anyhow::Result<()> {
+    let fixture = writable_fixture("dump-normal-repo-with-worktree-changes.sh")?;
+    let repo = fixture.path().join("你好 repo");
+    let output_dir = TempDir::new()?;
+    let output = output_dir.path().join("repo-with-diagnostics.zip");
+
+    let dump_output = run_dump_with_options(&repo, &output, false, true)?;
+    insta::assert_snapshot!(dump_output.display_for_snapshot(&output), @"
+    stdout:
+    Running: dot -Tsvg [dot path] -o [svg path]
+    Archive at: [output path]
+    stderr:
+    ");
+
+    insta::assert_snapshot!(archive_tree(&output)?, "diagnostic files are injected right away", @r"
+你好-repo-dump/
+├── .git/
+│   ├── HEAD:100644
+│   ├── config:100644
+│   ├── gitbutler:40755/
+│   │   └── vb.toml:100644
+│   └── ... 27 files and 16 directories not shown
+├── .gitignore:100644
+├── executable.sh:100755
+├── graph.dot:100644
+├── graph.svg:100644
+├── tracked.ignored:100644
+├── visible.txt:100644
+└── workspace.ron.txt:100644
+");
+
+    Ok(())
+}
+
+#[test]
+fn repo_dump_diagnostics_override_worktree_files() -> anyhow::Result<()> {
+    let fixture = writable_fixture("dump-normal-repo-with-worktree-changes.sh")?;
+    let repo = fixture.path().join("你好 repo");
+    std::fs::write(repo.join("graph.dot"), "worktree graph")?;
+
+    let output_dir = TempDir::new()?;
+    let output = output_dir.path().join("repo-with-diagnostics.zip");
+
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(&repo)?, @"
+    .
+    ├── .git:40755
+    ├── .gitignore:100644
+    ├── executable.sh:100755
+    ├── graph.dot:100644
+    ├── ignored-dir:40755
+    │   └── file.txt:100644
+    ├── ignored.ignored:100644
+    ├── tracked.ignored:100644
+    └── visible.txt:100644
+    ");
+
+    let dump_output = run_dump_with_options(&repo, &output, false, true)?;
+    insta::assert_snapshot!(dump_output.display_for_snapshot(&output), @"
+    stdout:
+    Running: dot -Tsvg [dot path] -o [svg path]
+    Archive at: [output path]
+    stderr:
+    ");
+
+    insta::assert_snapshot!(archive_tree(&output)?, @r"
+你好-repo-dump/
+├── .git/
+│   ├── HEAD:100644
+│   ├── config:100644
+│   ├── gitbutler:40755/
+│   │   └── vb.toml:100644
+│   └── ... 27 files and 16 directories not shown
+├── .gitignore:100644
+├── executable.sh:100755
+├── graph.dot:100644
+├── graph.svg:100644
+├── tracked.ignored:100644
+├── visible.txt:100644
+└── workspace.ron.txt:100644
+");
+
+    let mut archive = zip::ZipArchive::new(File::open(&output)?)?;
+    let mut graph = String::new();
+    archive
+        .by_name("你好-repo-dump/graph.dot")?
+        .read_to_string(&mut graph)?;
+    assert!(
+        graph.contains("digraph"),
+        "diagnostic graph.dot should override the colliding worktree file"
+    );
 
     Ok(())
 }
@@ -289,23 +436,68 @@ impl fmt::Display for DumpOutput {
 
 impl DumpOutput {
     fn display_for_snapshot(&self, output: &Path) -> String {
-        self.to_string()
-            .replace(&output.display().to_string(), "[output path]")
+        let output = self
+            .to_string()
+            .replace(&output.display().to_string(), "[output path]");
+        let mut normalized = String::new();
+        for line in output.lines() {
+            if line.starts_with("Running: dot -Tsvg ") {
+                normalized.push_str("Running: dot -Tsvg [dot path] -o [svg path]\n");
+            } else {
+                normalized.push_str(line);
+                normalized.push('\n');
+            }
+        }
+        normalized
     }
 }
 
 fn run_dump(repo: &Path, output: &Path, git_only: bool) -> anyhow::Result<DumpOutput> {
+    run_dump_with_options(repo, output, git_only, false)
+}
+
+fn run_dump_with_options(
+    repo: &Path,
+    output: &Path,
+    git_only: bool,
+    diagnostics: bool,
+) -> anyhow::Result<DumpOutput> {
     let mut args = vec![
         OsString::from("but-debug"),
         OsString::from("dump"),
+        OsString::from("repo"),
         OsString::from("-C"),
         repo.as_os_str().to_owned(),
         OsString::from("--output"),
         output.as_os_str().to_owned(),
+        OsString::from("--no-open-archive-directory"),
     ];
     if git_only {
         args.push(OsString::from("--git-only"));
     }
+    if !diagnostics {
+        args.push(OsString::from("--no-diagnostics"));
+    }
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    but_debug::handle_args(args.into_iter(), &mut stdout, &mut stderr)?;
+    Ok(DumpOutput {
+        stdout: String::from_utf8(stdout)?,
+        stderr: String::from_utf8(stderr)?,
+    })
+}
+
+fn run_dump_diagnostics(repo: &Path, output: &Path) -> anyhow::Result<DumpOutput> {
+    let args = [
+        OsString::from("but-debug"),
+        OsString::from("dump"),
+        OsString::from("diagnostics"),
+        OsString::from("-C"),
+        repo.as_os_str().to_owned(),
+        OsString::from("--output"),
+        output.as_os_str().to_owned(),
+        OsString::from("--no-open-archive-directory"),
+    ];
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
     but_debug::handle_args(args.into_iter(), &mut stdout, &mut stderr)?;

--- a/crates/but-debug/tests/debug/dump.rs
+++ b/crates/but-debug/tests/debug/dump.rs
@@ -5,6 +5,7 @@ use std::{
     fs::File,
     io::Read as _,
     path::{Path, PathBuf},
+    process::{Command, Stdio},
 };
 
 use but_testsupport::gix_testtools::{
@@ -45,7 +46,7 @@ fn normal_repo_includes_git_state_and_unignored_worktree() -> anyhow::Result<()>
 │   ├── config:100644
 │   ├── gitbutler:40755/
 │   │   └── vb.toml:100644
-│   └── ... 25 files and 15 directories not shown
+│   └── ... 25 files not shown
 ├── .gitignore:100644
 ├── executable.sh:100755
 ├── tracked.ignored:100644
@@ -88,7 +89,7 @@ fn git_only_skips_worktree_files() -> anyhow::Result<()> {
     ├── config:100644
     ├── gitbutler:40755/
     │   └── vb.toml:100644
-    └── ... 25 files and 15 directories not shown
+    └── ... 25 files not shown
 ");
 
     Ok(())
@@ -160,14 +161,15 @@ fn repo_dump_with_diagnostics_injects_files_at_dump_root() -> anyhow::Result<()>
     stderr:
     ");
 
-    insta::assert_snapshot!(archive_tree(&output)?, "diagnostic files are injected right away", @r"
+    if dot_is_available() {
+        insta::assert_snapshot!(archive_tree(&output)?, "diagnostic files are injected right away", @r"
 你好-repo-dump/
 ├── .git/
 │   ├── HEAD:100644
 │   ├── config:100644
 │   ├── gitbutler:40755/
 │   │   └── vb.toml:100644
-│   └── ... 27 files and 16 directories not shown
+│   └── ... 27 files not shown
 ├── .gitignore:100644
 ├── executable.sh:100755
 ├── graph.dot:100644
@@ -176,6 +178,7 @@ fn repo_dump_with_diagnostics_injects_files_at_dump_root() -> anyhow::Result<()>
 ├── visible.txt:100644
 └── workspace.ron.txt:100644
 ");
+    }
 
     Ok(())
 }
@@ -210,14 +213,15 @@ fn repo_dump_diagnostics_override_worktree_files() -> anyhow::Result<()> {
     stderr:
     ");
 
-    insta::assert_snapshot!(archive_tree(&output)?, @r"
+    if dot_is_available() {
+        insta::assert_snapshot!(archive_tree(&output)?, @r"
 你好-repo-dump/
 ├── .git/
 │   ├── HEAD:100644
 │   ├── config:100644
 │   ├── gitbutler:40755/
 │   │   └── vb.toml:100644
-│   └── ... 27 files and 16 directories not shown
+│   └── ... 27 files not shown
 ├── .gitignore:100644
 ├── executable.sh:100755
 ├── graph.dot:100644
@@ -226,6 +230,7 @@ fn repo_dump_diagnostics_override_worktree_files() -> anyhow::Result<()> {
 ├── visible.txt:100644
 └── workspace.ron.txt:100644
 ");
+    }
 
     let mut archive = zip::ZipArchive::new(File::open(&output)?)?;
     let mut graph = String::new();
@@ -244,37 +249,6 @@ fn repo_dump_diagnostics_override_worktree_files() -> anyhow::Result<()> {
 fn bare_repo_extracts_as_dump_git_directory() -> anyhow::Result<()> {
     let repo = read_only_repo("dump-bare-repo.sh", "sample.git")?;
     let output_dir = TempDir::new()?;
-    let initial = visualize_disk_tree_skip_dot_git(&repo)?;
-
-    insta::assert_snapshot!(initial, @r"
-.
-├── HEAD:100644
-├── config:100644
-├── description:100644
-├── hooks:40755
-│   ├── applypatch-msg.sample:100755
-│   ├── commit-msg.sample:100755
-│   ├── fsmonitor-watchman.sample:100755
-│   ├── post-update.sample:100755
-│   ├── pre-applypatch.sample:100755
-│   ├── pre-commit.sample:100755
-│   ├── pre-merge-commit.sample:100755
-│   ├── pre-push.sample:100755
-│   ├── pre-rebase.sample:100755
-│   ├── pre-receive.sample:100755
-│   ├── prepare-commit-msg.sample:100755
-│   ├── push-to-checkout.sample:100755
-│   ├── sendemail-validate.sample:100755
-│   └── update.sample:100755
-├── info:40755
-│   └── exclude:100644
-├── objects:40755
-│   ├── info:40755
-│   └── pack:40755
-└── refs:40755
-    ├── heads:40755
-    └── tags:40755
-");
 
     let output = output_dir.path().join("out.zip");
     let dump_output = run_dump(&repo, &output, false)?;
@@ -288,7 +262,7 @@ fn bare_repo_extracts_as_dump_git_directory() -> anyhow::Result<()> {
 sample-dump.git/
 ├── HEAD:100644
 ├── config:100644
-└── ... 16 files and 8 directories not shown
+└── ... 16 files not shown
 ");
 
     Ok(())
@@ -322,7 +296,7 @@ linked-dump/
 ├── .git/
 │   ├── HEAD:100644
 │   ├── config:100644
-│   └── ... 30 files and 17 directories not shown
+│   └── ... 30 files not shown
 ├── .gitignore:100644
 ├── linked-worktree-added-to-index.txt:100644
 ├── linked-worktree-untracked.txt:100644
@@ -376,7 +350,7 @@ fn current_output_inside_worktree_is_not_archived() -> anyhow::Result<()> {
 │   ├── config:100644
 │   ├── gitbutler:40755/
 │   │   └── vb.toml:100644
-│   └── ... 25 files and 15 directories not shown
+│   └── ... 25 files not shown
 ├── .gitignore:100644
 ├── executable.sh:100755
 ├── nested:40755/
@@ -400,7 +374,7 @@ fn current_output_inside_worktree_is_not_archived() -> anyhow::Result<()> {
 │   ├── config:100644
 │   ├── gitbutler:40755/
 │   │   └── vb.toml:100644
-│   └── ... 25 files and 15 directories not shown
+│   └── ... 25 files not shown
 ├── .gitignore:100644
 ├── executable.sh:100755
 ├── nested:40755/
@@ -519,6 +493,16 @@ fn git_status(repo: &Path) -> anyhow::Result<String> {
     Ok(String::from_utf8(output.stdout)?)
 }
 
+fn dot_is_available() -> bool {
+    Command::new("dot")
+        .arg("-V")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
 #[derive(Default)]
 struct Node {
     children: BTreeMap<String, Node>,
@@ -585,8 +569,8 @@ impl Node {
         for (name, child) in self.children {
             tree.push(child.into_tree(name));
         }
-        if self.hidden_files != 0 || self.hidden_dirs != 0 {
-            tree.push(hidden_summary(self.hidden_files, self.hidden_dirs));
+        if self.hidden_files != 0 {
+            tree.push(hidden_summary(self.hidden_files));
         }
         tree
     }
@@ -683,14 +667,9 @@ fn entry_kind(is_dir: bool) -> EntryKind {
     }
 }
 
-fn hidden_summary(files: usize, directories: usize) -> termtree::Tree<String> {
+fn hidden_summary(files: usize) -> termtree::Tree<String> {
     termtree::Tree::new(format!(
-        "... {files} {} and {directories} {} not shown",
+        "... {files} {} not shown",
         if files == 1 { "file" } else { "files" },
-        if directories == 1 {
-            "directory"
-        } else {
-            "directories"
-        },
     ))
 }

--- a/crates/but-debug/tests/debug/dump.rs
+++ b/crates/but-debug/tests/debug/dump.rs
@@ -1,0 +1,504 @@
+use std::{
+    collections::BTreeMap,
+    ffi::OsString,
+    fmt,
+    fs::File,
+    path::{Path, PathBuf},
+};
+
+use but_testsupport::gix_testtools::{
+    scripted_fixture_read_only, scripted_fixture_writable, tempfile::TempDir,
+};
+use but_testsupport::{CommandExt, git_at_dir, visualize_disk_tree_skip_dot_git};
+
+#[test]
+fn normal_repo_includes_git_state_and_unignored_worktree() -> anyhow::Result<()> {
+    let repo = read_only_repo("dump-normal-repo-with-worktree-changes.sh", "你好 repo")?;
+    let output_dir = TempDir::new()?;
+    let initial = visualize_disk_tree_skip_dot_git(&repo)?;
+
+    insta::assert_snapshot!(initial, @r"
+.
+├── .git:40755
+├── .gitignore:100644
+├── executable.sh:100755
+├── ignored-dir:40755
+│   └── file.txt:100644
+├── ignored.ignored:100644
+├── tracked.ignored:100644
+└── visible.txt:100644
+");
+
+    let output = output_dir.path().join("out.zip");
+    let dump_output = run_dump(&repo, &output, false)?;
+    insta::assert_snapshot!(dump_output.display_for_snapshot(&output), @"
+    stdout:
+    Archive at: [output path]
+    stderr:
+    ");
+
+    insta::assert_snapshot!(archive_tree(&output)?, @r"
+你好-repo-dump/
+├── .git/
+│   ├── HEAD:100644
+│   ├── config:100644
+│   ├── gitbutler:40755/
+│   │   └── vb.toml:100644
+│   └── ... 25 files and 15 directories not shown
+├── .gitignore:100644
+├── executable.sh:100755
+├── tracked.ignored:100644
+└── visible.txt:100644
+");
+
+    Ok(())
+}
+
+#[test]
+fn git_only_skips_worktree_files() -> anyhow::Result<()> {
+    let repo = read_only_repo("dump-normal-repo-with-worktree-changes.sh", "你好 repo")?;
+    let output_dir = TempDir::new()?;
+    let initial = visualize_disk_tree_skip_dot_git(&repo)?;
+
+    insta::assert_snapshot!(initial, @r"
+.
+├── .git:40755
+├── .gitignore:100644
+├── executable.sh:100755
+├── ignored-dir:40755
+│   └── file.txt:100644
+├── ignored.ignored:100644
+├── tracked.ignored:100644
+└── visible.txt:100644
+");
+
+    let output = output_dir.path().join("out.zip");
+    let dump_output = run_dump(&repo, &output, true)?;
+    insta::assert_snapshot!(dump_output.display_for_snapshot(&output), @"
+    stdout:
+    Archive at: [output path]
+    stderr:
+    ");
+
+    insta::assert_snapshot!(archive_tree(&output)?, @r"
+你好-repo-dump/
+└── .git/
+    ├── HEAD:100644
+    ├── config:100644
+    ├── gitbutler:40755/
+    │   └── vb.toml:100644
+    └── ... 25 files and 15 directories not shown
+");
+
+    Ok(())
+}
+
+#[test]
+fn bare_repo_extracts_as_dump_git_directory() -> anyhow::Result<()> {
+    let repo = read_only_repo("dump-bare-repo.sh", "sample.git")?;
+    let output_dir = TempDir::new()?;
+    let initial = visualize_disk_tree_skip_dot_git(&repo)?;
+
+    insta::assert_snapshot!(initial, @r"
+.
+├── HEAD:100644
+├── config:100644
+├── description:100644
+├── hooks:40755
+│   ├── applypatch-msg.sample:100755
+│   ├── commit-msg.sample:100755
+│   ├── fsmonitor-watchman.sample:100755
+│   ├── post-update.sample:100755
+│   ├── pre-applypatch.sample:100755
+│   ├── pre-commit.sample:100755
+│   ├── pre-merge-commit.sample:100755
+│   ├── pre-push.sample:100755
+│   ├── pre-rebase.sample:100755
+│   ├── pre-receive.sample:100755
+│   ├── prepare-commit-msg.sample:100755
+│   ├── push-to-checkout.sample:100755
+│   ├── sendemail-validate.sample:100755
+│   └── update.sample:100755
+├── info:40755
+│   └── exclude:100644
+├── objects:40755
+│   ├── info:40755
+│   └── pack:40755
+└── refs:40755
+    ├── heads:40755
+    └── tags:40755
+");
+
+    let output = output_dir.path().join("out.zip");
+    let dump_output = run_dump(&repo, &output, false)?;
+    insta::assert_snapshot!(dump_output.display_for_snapshot(&output), @"
+    stdout:
+    Archive at: [output path]
+    stderr:
+    ");
+
+    insta::assert_snapshot!(archive_tree(&output)?, @r"
+sample-dump.git/
+├── HEAD:100644
+├── config:100644
+└── ... 16 files and 8 directories not shown
+");
+
+    Ok(())
+}
+
+#[test]
+fn linked_worktree_is_unlinked_into_real_git_directory() -> anyhow::Result<()> {
+    let linked = read_only_repo("dump-linked-worktree.sh", "linked")?;
+    let output_dir = TempDir::new()?;
+    let initial = visualize_disk_tree_skip_dot_git(&linked)?;
+
+    insta::assert_snapshot!(initial, @r"
+.
+├── .git:100644
+├── .gitignore:100644
+├── linked-worktree-added-to-index.txt:100644
+├── linked-worktree-untracked.txt:100644
+└── tracked.ignored:100644
+");
+
+    let output = output_dir.path().join("out.zip");
+    let dump_output = run_dump(&linked, &output, false)?;
+    insta::assert_snapshot!(dump_output.display_for_snapshot(&output), @"
+    stdout:
+    Archive at: [output path]
+    stderr:
+    ");
+
+    insta::assert_snapshot!(archive_tree(&output)?, ".git is now a directory", @r"
+linked-dump/
+├── .git/
+│   ├── HEAD:100644
+│   ├── config:100644
+│   └── ... 30 files and 17 directories not shown
+├── .gitignore:100644
+├── linked-worktree-added-to-index.txt:100644
+├── linked-worktree-untracked.txt:100644
+└── tracked.ignored:100644
+");
+
+    let extraction = TempDir::new()?;
+    unzip(&output, extraction.path())?;
+    let unpacked = extraction.path().join("linked-dump");
+    git_at_dir(&unpacked).arg("status").run();
+    insta::assert_snapshot!(git_status(&unpacked)?, "the unpacked repository keeps the linked worktree HEAD and index", @r"
+## linked
+A  linked-worktree-added-to-index.txt
+ M tracked.ignored
+?? linked-worktree-untracked.txt
+");
+
+    Ok(())
+}
+
+#[test]
+fn current_output_inside_worktree_is_not_archived() -> anyhow::Result<()> {
+    let fixture = writable_fixture("dump-normal-repo-with-worktree-changes.sh")?;
+    let repo = fixture.path().join("你好 repo");
+    let initial = visualize_disk_tree_skip_dot_git(&repo)?;
+
+    insta::assert_snapshot!(initial, "before any dump output exists in the worktree", @r"
+.
+├── .git:40755
+├── .gitignore:100644
+├── executable.sh:100755
+├── ignored-dir:40755
+│   └── file.txt:100644
+├── ignored.ignored:100644
+├── tracked.ignored:100644
+└── visible.txt:100644
+");
+
+    let first_output = repo.join("nested/output/sample-dump.zip");
+    let dump_output = run_dump(&repo, &first_output, false)?;
+    insta::assert_snapshot!(dump_output.display_for_snapshot(&first_output), "first dump output", @"
+    stdout:
+    Archive at: [output path]
+    stderr:
+    ");
+
+    insta::assert_snapshot!(archive_tree(&first_output)?, "the archive being written is not included in itself", @r"
+你好-repo-dump/
+├── .git/
+│   ├── HEAD:100644
+│   ├── config:100644
+│   ├── gitbutler:40755/
+│   │   └── vb.toml:100644
+│   └── ... 25 files and 15 directories not shown
+├── .gitignore:100644
+├── executable.sh:100755
+├── nested:40755/
+│   └── output:40755/
+├── tracked.ignored:100644
+└── visible.txt:100644
+");
+
+    let second_output = repo.join("sample-second-dump.zip");
+    let dump_output = run_dump(&repo, &second_output, false)?;
+    insta::assert_snapshot!(dump_output.display_for_snapshot(&second_output), "second dump output", @"
+    stdout:
+    Archive at: [output path]
+    stderr:
+    ");
+
+    insta::assert_snapshot!(archive_tree(&second_output)?, "a previous dump archive in the worktree is included like any other visible file", @r"
+你好-repo-dump/
+├── .git/
+│   ├── HEAD:100644
+│   ├── config:100644
+│   ├── gitbutler:40755/
+│   │   └── vb.toml:100644
+│   └── ... 25 files and 15 directories not shown
+├── .gitignore:100644
+├── executable.sh:100755
+├── nested:40755/
+│   └── output:40755/
+│       └── sample-dump.zip:100644
+├── tracked.ignored:100644
+└── visible.txt:100644
+");
+
+    Ok(())
+}
+
+fn read_only_repo(fixture: &str, repo_name: &str) -> anyhow::Result<PathBuf> {
+    Ok(scripted_fixture_read_only(fixture)
+        .map_err(anyhow::Error::from_boxed)?
+        .join(repo_name))
+}
+
+fn writable_fixture(fixture: &str) -> anyhow::Result<TempDir> {
+    scripted_fixture_writable(fixture).map_err(|err| anyhow::anyhow!("{err}"))
+}
+
+struct DumpOutput {
+    stdout: String,
+    stderr: String,
+}
+
+impl fmt::Display for DumpOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "stdout:\n{}stderr:\n{}", self.stdout, self.stderr)
+    }
+}
+
+impl DumpOutput {
+    fn display_for_snapshot(&self, output: &Path) -> String {
+        self.to_string()
+            .replace(&output.display().to_string(), "[output path]")
+    }
+}
+
+fn run_dump(repo: &Path, output: &Path, git_only: bool) -> anyhow::Result<DumpOutput> {
+    let mut args = vec![
+        OsString::from("but-debug"),
+        OsString::from("dump"),
+        OsString::from("-C"),
+        repo.as_os_str().to_owned(),
+        OsString::from("--output"),
+        output.as_os_str().to_owned(),
+    ];
+    if git_only {
+        args.push(OsString::from("--git-only"));
+    }
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    but_debug::handle_args(args.into_iter(), &mut stdout, &mut stderr)?;
+    Ok(DumpOutput {
+        stdout: String::from_utf8(stdout)?,
+        stderr: String::from_utf8(stderr)?,
+    })
+}
+
+fn git_status(repo: &Path) -> anyhow::Result<String> {
+    let output = git_at_dir(repo)
+        .args(["status", "--short", "--branch"])
+        .output()?;
+    assert!(
+        output.status.success(),
+        "git status failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+#[derive(Default)]
+struct Node {
+    children: BTreeMap<String, Node>,
+    explicit_dir: bool,
+    explicit_file: bool,
+    mode: Option<u32>,
+    hidden_files: usize,
+    hidden_dirs: usize,
+}
+
+fn archive_tree(path: &Path) -> anyhow::Result<termtree::Tree<String>> {
+    let file = File::open(path)?;
+    let mut archive = zip::ZipArchive::new(file)?;
+    let mut root = Node::default();
+    for index in 0..archive.len() {
+        let file = archive.by_index(index)?;
+        let name = file.name();
+        let mode = file.unix_mode();
+        match classify_entry(name, file.is_dir()) {
+            EntryDisplay::Shown => root.insert(name, mode),
+            EntryDisplay::Hidden { parent, entry_kind } => root.insert_hidden(&parent, entry_kind),
+        }
+    }
+    Ok(root.into_single_tree())
+}
+
+fn unzip(archive: &Path, destination: &Path) -> anyhow::Result<()> {
+    let file = File::open(archive)?;
+    zip::ZipArchive::new(file)?.extract(destination)?;
+    Ok(())
+}
+
+impl Node {
+    fn insert(&mut self, name: &str, mode: Option<u32>) {
+        let is_dir = name.ends_with('/');
+        let mut node = self;
+        for component in name.trim_end_matches('/').split('/') {
+            if component.is_empty() {
+                continue;
+            }
+            node = node.children.entry(component.to_owned()).or_default();
+        }
+        if is_dir {
+            node.explicit_dir = true;
+        } else {
+            node.explicit_file = true;
+        }
+        node.mode = mode;
+    }
+
+    fn insert_hidden(&mut self, parent: &[String], entry_kind: EntryKind) {
+        let mut node = self;
+        for component in parent {
+            node = node.children.entry(component.to_owned()).or_default();
+        }
+        match entry_kind {
+            EntryKind::File => node.hidden_files += 1,
+            EntryKind::Directory => node.hidden_dirs += 1,
+        }
+    }
+
+    fn into_tree(self, name: String) -> termtree::Tree<String> {
+        let mut tree = termtree::Tree::new(self.label(name));
+        for (name, child) in self.children {
+            tree.push(child.into_tree(name));
+        }
+        if self.hidden_files != 0 || self.hidden_dirs != 0 {
+            tree.push(hidden_summary(self.hidden_files, self.hidden_dirs));
+        }
+        tree
+    }
+
+    fn into_single_tree(self) -> termtree::Tree<String> {
+        let mut children = self.children;
+        assert_eq!(children.len(), 1, "archive should have exactly one root");
+        let (name, child) = children.pop_first().expect("archive root is present");
+        child.into_tree(name)
+    }
+
+    fn label(&self, name: String) -> String {
+        let mode = self
+            .mode
+            .map(|mode| format!(":{mode:o}"))
+            .unwrap_or_default();
+        match (
+            self.children.is_empty(),
+            self.explicit_dir,
+            self.explicit_file,
+        ) {
+            (false, _, true) => format!("{name}{mode} [file+dir]"),
+            (false, _, false) | (true, true, false) => format!("{name}{mode}/"),
+            _ => format!("{name}{mode}"),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum EntryKind {
+    File,
+    Directory,
+}
+
+enum EntryDisplay {
+    Shown,
+    Hidden {
+        parent: Vec<String>,
+        entry_kind: EntryKind,
+    },
+}
+
+fn classify_entry(name: &str, is_dir: bool) -> EntryDisplay {
+    let components: Vec<_> = name
+        .trim_end_matches('/')
+        .split('/')
+        .filter(|component| !component.is_empty())
+        .collect();
+
+    if components.contains(&"..") {
+        return EntryDisplay::Shown;
+    }
+
+    if let Some(git_position) = components.iter().position(|component| *component == ".git") {
+        let git_path = &components[git_position + 1..];
+        return match git_path {
+            []
+            | ["HEAD" | "config" | "commondir" | "gitdir"]
+            | ["gitbutler"]
+            | ["gitbutler", "vb.toml"] => EntryDisplay::Shown,
+            ["worktrees", ..] => EntryDisplay::Shown,
+            _ => EntryDisplay::Hidden {
+                parent: components[..=git_position]
+                    .iter()
+                    .map(|component| component.to_string())
+                    .collect(),
+                entry_kind: entry_kind(is_dir),
+            },
+        };
+    }
+
+    if let Some((root, git_path)) = components.split_first()
+        && root.ends_with(".git")
+    {
+        return match git_path {
+            [] | ["HEAD" | "config"] | ["gitbutler"] | ["gitbutler", "vb.toml"] => {
+                EntryDisplay::Shown
+            }
+            _ => EntryDisplay::Hidden {
+                parent: vec![root.to_string()],
+                entry_kind: entry_kind(is_dir),
+            },
+        };
+    }
+
+    EntryDisplay::Shown
+}
+
+fn entry_kind(is_dir: bool) -> EntryKind {
+    if is_dir {
+        EntryKind::Directory
+    } else {
+        EntryKind::File
+    }
+}
+
+fn hidden_summary(files: usize, directories: usize) -> termtree::Tree<String> {
+    termtree::Tree::new(format!(
+        "... {files} {} and {directories} {} not shown",
+        if files == 1 { "file" } else { "files" },
+        if directories == 1 {
+            "directory"
+        } else {
+            "directories"
+        },
+    ))
+}

--- a/crates/but-debug/tests/debug/dump.rs
+++ b/crates/but-debug/tests/debug/dump.rs
@@ -384,6 +384,33 @@ fn current_output_inside_worktree_is_not_archived() -> anyhow::Result<()> {
 └── visible.txt:100644
 ");
 
+    std::fs::create_dir_all(repo.join("nested"))?;
+    let denormalized_output = repo.join("nested/../denormalized-dump.zip");
+    let dump_output = run_dump(&repo, &denormalized_output, false)?;
+    insta::assert_snapshot!(dump_output.display_for_snapshot(&denormalized_output), "denormalized dump output", @"
+    stdout:
+    Archive at: [output path]
+    stderr:
+    ");
+
+    insta::assert_snapshot!(archive_tree(&repo.join("denormalized-dump.zip"))?, "the denormalized output path is still skipped", @r"
+你好-repo-dump/
+├── .git/
+│   ├── HEAD:100644
+│   ├── config:100644
+│   ├── gitbutler:40755/
+│   │   └── vb.toml:100644
+│   └── ... 25 files not shown
+├── .gitignore:100644
+├── executable.sh:100755
+├── nested:40755/
+│   └── output:40755/
+│       └── sample-dump.zip:100644
+├── sample-second-dump.zip:100644
+├── tracked.ignored:100644
+└── visible.txt:100644
+");
+
     Ok(())
 }
 

--- a/crates/but-debug/tests/debug/main.rs
+++ b/crates/but-debug/tests/debug/main.rs
@@ -1,0 +1,1 @@
+mod dump;

--- a/crates/but-debug/tests/fixtures/dump-bare-repo.sh
+++ b/crates/but-debug/tests/fixtures/dump-bare-repo.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+# Initial state for verifying that dumping a bare repository preserves the
+# repository directory shape and extracts under a `*-dump.git` root.
+git init --bare sample.git

--- a/crates/but-debug/tests/fixtures/dump-linked-worktree.sh
+++ b/crates/but-debug/tests/fixtures/dump-linked-worktree.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+# Initial state for verifying that dumping a linked worktree follows the
+# `.git` indirection and writes a real `.git/` directory in the archive. The
+# main worktree and linked worktree both have untracked, modified, and staged
+# files so the test can verify the dump contains only the linked worktree's
+# `HEAD`, worktree, and per-worktree index state.
+git init main
+(
+  cd main
+  printf "*.ignored\nignored-dir/\n" >.gitignore
+  printf "tracked ignored" >tracked.ignored
+  git add .gitignore
+  git add -f tracked.ignored
+  git commit -m "initial"
+  git worktree add -b linked ../linked
+
+  printf "main modified" >tracked.ignored
+  printf "main added to index" >main-worktree-added-to-index.txt
+  git add main-worktree-added-to-index.txt
+  printf "main untracked" >main-worktree-untracked.txt
+)
+(
+  cd linked
+  printf "linked modified" >tracked.ignored
+  printf "added to index" >linked-worktree-added-to-index.txt
+  git add linked-worktree-added-to-index.txt
+  printf "untracked" >linked-worktree-untracked.txt
+)

--- a/crates/but-debug/tests/fixtures/dump-normal-repo-with-worktree-changes.sh
+++ b/crates/but-debug/tests/fixtures/dump-normal-repo-with-worktree-changes.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+# Shared normal-repository state used by dump tests that need tracked files,
+# untracked visible files, ignored files/directories, and a Unicode root name.
+git init "你好 repo"
+(
+  cd "你好 repo"
+  printf "*.ignored\nignored-dir/\n" >.gitignore
+  printf "tracked ignored" >tracked.ignored
+  git add .gitignore
+  git add -f tracked.ignored
+  git commit -m "initial"
+  mkdir -p .git/gitbutler
+  printf "project_id = 'fixture'\n" >.git/gitbutler/vb.toml
+
+  printf "visible" >visible.txt
+  printf "#!/usr/bin/env sh\n" >executable.sh
+  chmod +x executable.sh
+  printf "ignored" >ignored.ignored
+  mkdir ignored-dir
+  printf "ignored dir" >ignored-dir/file.txt
+)

--- a/crates/but-feedback/Cargo.toml
+++ b/crates/but-feedback/Cargo.toml
@@ -15,8 +15,7 @@ but-graph.workspace = true
 but-ctx = { workspace = true, features = ["legacy"] }
 
 anyhow.workspace = true
-# Version must match the one in `tauri plugin updater` to avoid duplication.
-zip = { version = "4", default-features = false, features = ["bzip2"] }
+zip.workspace = true
 walkdir = "2.5.0"
 chrono.workspace = true
 

--- a/crates/but-feedback/src/lib.rs
+++ b/crates/but-feedback/src/lib.rs
@@ -52,7 +52,7 @@ impl Archival {
                     },
                 )
             })?;
-        let dot_file_contents = graph.anonymize(&repo.remote_names())?.dot_graph();
+        let dot_file_contents = graph.anonymize(&repo.remote_names())?.dot_graph_pruned();
         let output_file = self.cache_dir.join(format!(
             "commit-graph-anon-{date}.zip",
             date = filesafe_date_time()

--- a/crates/but-graph/src/debug.rs
+++ b/crates/but-graph/src/debug.rs
@@ -1,11 +1,13 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use anyhow::{Context as _, bail};
 use bstr::{BString, ByteSlice, ByteVec};
 use gix::reference::Category;
 use petgraph::{prelude::EdgeRef, stable_graph::EdgeReference};
 
-use crate::{Edge, Graph, Segment, SegmentIndex, SegmentMetadata, StopCondition, init::PetGraph};
+use crate::{
+    CommitFlags, Edge, Graph, Segment, SegmentIndex, SegmentMetadata, StopCondition, init::PetGraph,
+};
 
 /// Debugging
 impl Graph {
@@ -251,7 +253,7 @@ impl Graph {
     /// Note that this may reveal additional debug information when invariants of the graph are violated.
     /// This often is more useful than seeing a hard error, which can be achieved with `Self::validated()`
     pub fn eprint_dot_graph(&self) {
-        let dot = self.dot_graph();
+        let dot = self.dot_graph_pruned();
         eprintln!("{dot}");
     }
 
@@ -279,7 +281,7 @@ impl Graph {
         dot.stdin
             .as_mut()
             .unwrap()
-            .write_all(self.dot_graph().as_bytes())
+            .write_all(self.dot_graph_pruned().as_bytes())
             .ok();
         let mut out = dot.wait_with_output().unwrap();
         out.stdout.extend(out.stderr);
@@ -310,8 +312,23 @@ impl Graph {
             .max()
     }
 
-    /// Produces a dot-version of the graph.
-    pub fn dot_graph(&self) -> String {
+    /// Produces a pruned dot-version of the graph.
+    ///
+    /// This best-effort rendering path prunes very large graphs from the bottom
+    /// before handing them to Graphviz, because complete DOT input can make
+    /// `dot` hang on huge histories. It tries to compute the workspace lower
+    /// bound to preserve workspace-relevant segments and clear stale
+    /// `InWorkspace` flags below that bound, but projection is allowed to fail:
+    /// DOT output is diagnostic-only, so a workspace projection error must not
+    /// prevent rendering the graph.
+    pub fn dot_graph_pruned(&self) -> String {
+        let mut graph = self.clone();
+        graph.prune_for_dot_graph();
+        graph.dot_graph_unpruned()
+    }
+
+    /// Produces a dot-version of the graph without pruning.
+    fn dot_graph_unpruned(&self) -> String {
         const HEX: usize = 7;
         let entrypoint = self.entrypoint_location();
         let max_goals = self.max_goals();
@@ -404,5 +421,78 @@ impl Graph {
         };
         let dot = petgraph::dot::Dot::with_attr_getters(&self.inner, &[], &edge_attrs, &node_attrs);
         format!("{dot:?}")
+    }
+
+    fn prune_for_dot_graph(&mut self) {
+        let lower_bound_segment_id = self
+            .clone()
+            .into_workspace()
+            .ok()
+            .and_then(|workspace| workspace.lower_bound_segment_id);
+        if let Some(lower_bound_segment_id) = lower_bound_segment_id {
+            self.remove_in_workspace_flag_below_lower_bound(lower_bound_segment_id);
+        }
+
+        // It's OK if it takes a while, prefer complete graphs.
+        const LIMIT: usize = 5000;
+        let mut to_remove = self.num_segments().saturating_sub(LIMIT);
+        if to_remove > 0 {
+            tracing::warn!(
+                "Pruning at most {to_remove} nodes from the bottom to assure 'dot' won't hang",
+            );
+            let mut next = VecDeque::new();
+            next.extend(self.base_segments());
+            let mut seen = BTreeSet::new();
+            while let Some(sidx) = next.pop_front() {
+                if to_remove == 0 {
+                    break;
+                }
+                if let Some(s) = self.node_weight(sidx) {
+                    if lower_bound_segment_id.is_some()
+                        && s.non_empty_flags_of_first_commit()
+                            .is_some_and(|flags| flags.contains(CommitFlags::InWorkspace))
+                    {
+                        continue;
+                    }
+                    if s.metadata.is_some()
+                        || s.sibling_segment_id.is_some()
+                        || s.remote_tracking_branch_segment_id.is_some()
+                    {
+                        continue;
+                    }
+                }
+                next.extend(
+                    self.neighbors_directed(sidx, petgraph::Direction::Incoming)
+                        .filter(|n| seen.insert(*n)),
+                );
+                self.remove_node(sidx);
+                to_remove -= 1;
+            }
+            if to_remove != 0 {
+                tracing::warn!(
+                    "{to_remove} extra nodes were kept to keep vital portions of the graph"
+                );
+            }
+            self.set_hard_limit_hit();
+        }
+    }
+
+    fn remove_in_workspace_flag_below_lower_bound(&mut self, lower_bound_segment_id: SegmentIndex) {
+        let mut seen = BTreeSet::from([lower_bound_segment_id]);
+        let mut queue = VecDeque::from([lower_bound_segment_id]);
+        while let Some(sidx) = queue.pop_front() {
+            let below_segments: Vec<_> = self
+                .neighbors_directed(sidx, petgraph::Direction::Outgoing)
+                .filter(|n| seen.insert(*n))
+                .collect();
+            for below_sidx in below_segments {
+                if let Some(segment) = self.node_weight_mut(below_sidx)
+                    && let Some(first_commit) = segment.commits.first_mut()
+                {
+                    first_commit.flags.remove(CommitFlags::InWorkspace);
+                }
+                queue.push_back(below_sidx);
+            }
+        }
     }
 }

--- a/crates/but-graph/src/debug.rs
+++ b/crates/but-graph/src/debug.rs
@@ -322,9 +322,9 @@ impl Graph {
     /// DOT output is diagnostic-only, so a workspace projection error must not
     /// prevent rendering the graph.
     pub fn dot_graph_pruned(&self) -> String {
-        let mut graph = self.clone();
-        graph.prune_for_dot_graph();
-        graph.dot_graph_unpruned()
+        let mut display_graph = self.clone();
+        display_graph.prune_for_dot_graph();
+        display_graph.dot_graph_unpruned()
     }
 
     /// Produces a dot-version of the graph without pruning.
@@ -423,12 +423,12 @@ impl Graph {
         format!("{dot:?}")
     }
 
+    // WARNING: should only be run on a fresh clone as it probably leaves the graph unusable.
     fn prune_for_dot_graph(&mut self) {
         let lower_bound_segment_id = self
-            .clone()
-            .into_workspace()
+            .to_workspace_state(crate::projection::workspace::Downgrade::Allow)
             .ok()
-            .and_then(|workspace| workspace.lower_bound_segment_id);
+            .and_then(|state| state.lower_bound_segment_id);
         if let Some(lower_bound_segment_id) = lower_bound_segment_id {
             self.remove_in_workspace_flag_below_lower_bound(lower_bound_segment_id);
         }

--- a/crates/but-graph/src/projection/workspace/api.rs
+++ b/crates/but-graph/src/projection/workspace/api.rs
@@ -530,6 +530,7 @@ impl std::fmt::Debug for Workspace {
             .field("stacks", &self.stacks)
             .field("metadata", &self.metadata)
             .field("target_ref", &self.target_ref)
+            .field("target_commit", &self.target_commit)
             .field("extra_target", &self.extra_target)
             .finish()
     }

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/legacy.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/legacy.rs
@@ -613,6 +613,12 @@ mod stack_details {
                     commits_ahead: 0,
                 },
             ),
+            target_commit: Some(
+                TargetCommit {
+                    commit_id: Sha1(85efbe4d5a663bff0ed8fb5fbc38a72be0592f55),
+                    segment_index: NodeIndex(2),
+                },
+            ),
             extra_target: None,
         }
         "#);


### PR DESCRIPTION
Let's build out our debugging infrastructure.
Use `but-debug dump repo` to quickly get a snapshot fo the repo that is causing trouble for hand-off to peers.

### Tasks

* [x] `dump repo`
* [x] `dump diagnostics` with `dump diagnostics --open` for easy inspection

~~Note that this is mostly vibed and does not necessarily fulfill the quality standards for production code.~~ Actually that's not how it works and I just reviewed it like anything else.

