### PR TITLE
Lite: use branch operand as source/target for whole branch rather than just branch reference

### DIFF
--- a/apps/lite/ui/src/operations/operation.ts
+++ b/apps/lite/ui/src/operations/operation.ts
@@ -477,14 +477,22 @@ export const moveOperation = ({
 
 	if (branchMoveOperation) return branchMoveOperation;
 
-	const relativeTo: RelativeTo | null = Match.value(target).pipe(
-		Match.tags({
-			Commit: ({ commitId }): RelativeTo | null => ({ type: "commit", subject: commitId }),
-			Branch: ({ branchRef }): RelativeTo | null => ({
-				type: "referenceBytes",
-				subject: branchRef,
-			}),
-		}),
+	const relativeTo: RelativeTo | null = Match.value({ target, side }).pipe(
+		Match.when({ target: { _tag: "Commit" } }, ({ target }): RelativeTo | null => ({
+			type: "commit",
+			subject: target.commitId,
+		})),
+		Match.when(
+			{
+				target: { _tag: "Branch" },
+				// We use the branch operand as the source/target for the branch
+				// contents. However, `RelativeTo` is interpreted to mean just the
+				// branch reference rather than the whole branch (reference + contents),
+				// meaning `side: "below"` won't work as expected.
+				side: "above",
+			},
+			({ target }): RelativeTo | null => ({ type: "referenceBytes", subject: target.branchRef }),
+		),
 		Match.orElse((): RelativeTo | null => null),
 	);
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.tsx
@@ -1498,18 +1498,13 @@ const BranchSegment: FC<{
 			aria-label={refName.displayName}
 			expanded
 			className={classes(workspaceItemRowStyles.section, styles.segment)}
+			render={<OperandC projectId={projectId} operand={operand} />}
 		>
-			<OperandC
+			<BranchRow
 				projectId={projectId}
-				operand={operand}
-				render={
-					<BranchRow
-						projectId={projectId}
-						branchName={refName.displayName}
-						branchRef={refName.fullNameBytes}
-						stackId={stackId}
-					/>
-				}
+				branchName={refName.displayName}
+				branchRef={refName.fullNameBytes}
+				stackId={stackId}
 			/>
 
 			{segment.commits.length === 0 ? (


### PR DESCRIPTION
Table of all permutations for future reference. In Jujutsu I believe all of these operations can be expressed as follows, using `-r` for commit sources and `-b` for branch sources:

- above (after): `jj rebase <source> -A <target>`
- onto: `jj rebase <source> -o <target>`
- below (before): `jj rebase <source> -B <target>`

| Source | Target | Side | Function |
|---|---|---|---|
| Whole branch | Whole branch | above | `moveBranch` |
| Whole branch | Whole branch | onto | missing |
| Whole branch | Whole branch | below | missing |
| Whole branch | Branch reference | above | `moveBranch` |
| Whole branch | Branch reference | onto | missing |
| Whole branch | Branch reference | below | missing |
| Whole branch | Commit | above | missing |
| Whole branch | Commit | onto | missing |
| Whole branch | Commit | below | missing |
| Commit | Whole branch | above | `commitMove` with `relativeTo: { type: "referenceBytes" }` |
| Commit | Whole branch | onto | missing |
| Commit | Whole branch | below | missing |
| Commit | Branch reference | above | `commitMove` with `relativeTo: { type: "referenceBytes" }` |
| Commit | Branch reference | onto | missing |
| Commit | Branch reference | below | `commitMove` with `relativeTo: { type: "referenceBytes" }` |
| Commit | Commit | above | `commitMove` with `relativeTo: { type: "commit" }` |
| Commit | Commit | onto | missing |
| Commit | Commit | below | `commitMove` with `relativeTo: { type: "commit" }` |