### PR TITLE
Extend WSL detection to check kernel version strings

### DIFF
--- a/crates/but-api/src/legacy/open.rs
+++ b/crates/but-api/src/legacy/open.rs
@@ -123,8 +123,13 @@ fn open_editor_url_as_command_invocation_on_wsl(target_url: &Url) -> bool {
 }
 
 fn is_wsl() -> bool {
-    cfg!(target_os = "linux") && env::var_os("WSL_DISTRO_NAME").is_some()
-        || env::var_os("WSL_INTEROP").is_some()
+    cfg!(target_os = "linux")
+        && std::fs::read_to_string("/proc/sys/kernel/osrelease")
+            .map(|release| {
+                let release = release.to_ascii_lowercase();
+                release.contains("microsoft")
+            })
+            .unwrap_or(false)
 }
 
 /// Builds the editor CLI command needed to open a WSL editor URL.


### PR DESCRIPTION
## Summary

Follow-up to #13738.

That PR added a WSL-specific path that opens editor URLs through the editor CLI instead of falling back to the generic URL opener. The code path was merged correctly, but WSL detection still relied on `WSL_DISTRO_NAME` / `WSL_INTEROP`.

Those environment variables are not guaranteed to be present in the GitButler GUI process. When both are missing, GitButler does not detect WSL and falls back to the generic URL opener, which can open the browser again for `vscode://file/...` URLs.

This changes WSL detection to use `/proc/sys/kernel/osrelease` as the single source of truth and check for the `microsoft` marker in the running kernel release.

## Notes

On the affected WSL2 machine:

```text
/proc/sys/kernel/osrelease = 6.6.114.1-microsoft-standard-WSL2
```

`/proc/sys/kernel/osrelease` comes from the running kernel, so it does not depend on which environment variables the GUI process inherited.

## Verification

Built and installed locally with:

```sh
GITBUTLER_SKIP_SKILL_UPDATE=1 ./compile.sh bin
```
