### PR TITLE
but-rebase: Immutable extra refs

### DIFF
--- a/crates/but-rebase/src/graph_rebase/creation.rs
+++ b/crates/but-rebase/src/graph_rebase/creation.rs
@@ -6,8 +6,8 @@ use but_graph::{Commit, SegmentIndex};
 use petgraph::{Direction, visit::EdgeRef as _};
 
 use crate::graph_rebase::{
-    Checkout, Edge, Editor, Pick, RevisionHistory, Selector, Step, StepGraph, StepGraphIndex,
-    SuccessfulRebase, util,
+    Checkout, Edge, Editor, ExtraRef, ExtraRefMutability, Pick, RevisionHistory, Selector, Step,
+    StepGraph, StepGraphIndex, SuccessfulRebase, util,
 };
 
 #[derive(Clone)]
@@ -18,8 +18,9 @@ pub struct GraphEditorOptions<'a> {
     /// Extra references that should be included in the editor.
     ///
     /// If the parentage of a commit in the extra references list gets modified,
-    /// the extra reference will be updated.
-    pub extra_refs: Vec<&'a gix::refs::FullNameRef>,
+    /// mutable extra references will be updated while immutable ones remain
+    /// traversal-only.
+    pub extra_refs: Vec<ExtraRef<'a>>,
 }
 
 impl Default for GraphEditorOptions<'_> {
@@ -63,10 +64,22 @@ impl<'ws, 'meta, M: RefMetadata> Editor<'ws, 'meta, M> {
 
         let mut entrypoints = vec![entrypoint.segment_index];
 
+        let immutable_references = options
+            .extra_refs
+            .iter()
+            .filter(|extra_ref| extra_ref.mutability == ExtraRefMutability::Immutable)
+            .map(|extra_ref| extra_ref.ref_name.to_owned())
+            .collect::<HashSet<_>>();
+
         for extra_ref in &options.extra_refs {
-            let Some((segment, _)) = workspace.graph.segment_and_commit_by_ref_name(extra_ref)
+            let Some((segment, _)) = workspace
+                .graph
+                .segment_and_commit_by_ref_name(extra_ref.ref_name)
             else {
-                bail!("Failed to find corresponding segment for {extra_ref}");
+                bail!(
+                    "Failed to find corresponding segment for {}",
+                    extra_ref.ref_name
+                );
             };
             entrypoints.push(segment.id);
         }
@@ -306,6 +319,7 @@ impl<'ws, 'meta, M: RefMetadata> Editor<'ws, 'meta, M> {
                 .collect(),
             repo: repo.clone().with_object_memory(),
             history: RevisionHistory::new(),
+            immutable_references,
             workspace,
             meta,
         })
@@ -321,6 +335,7 @@ impl<'ws, 'meta, M: RefMetadata> SuccessfulRebase<'ws, 'meta, M> {
             checkouts: self.checkouts,
             repo: self.repo,
             history: self.history,
+            immutable_references: self.immutable_references,
             workspace: self.workspace,
             meta: self.meta,
         }

--- a/crates/but-rebase/src/graph_rebase/mod.rs
+++ b/crates/but-rebase/src/graph_rebase/mod.rs
@@ -24,6 +24,42 @@ pub mod mutate;
 pub mod ordering;
 pub(crate) mod util;
 
+/// Additional reference to include in an editor, with persistence behavior.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExtraRef<'a> {
+    /// The reference name to include in the editor graph.
+    pub ref_name: &'a gix::refs::FullNameRef,
+    /// Whether rebases/materialization may update this ref.
+    pub mutability: ExtraRefMutability,
+}
+
+impl<'a> ExtraRef<'a> {
+    /// Track an extra ref and allow the editor to update it.
+    pub fn mutable(ref_name: &'a gix::refs::FullNameRef) -> Self {
+        Self {
+            ref_name,
+            mutability: ExtraRefMutability::Mutable,
+        }
+    }
+
+    /// Track an extra ref for traversal only, without persisting updates.
+    pub fn immutable(ref_name: &'a gix::refs::FullNameRef) -> Self {
+        Self {
+            ref_name,
+            mutability: ExtraRefMutability::Immutable,
+        }
+    }
+}
+
+/// Controls whether an extra ref may be updated by editor materialization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExtraRefMutability {
+    /// The ref may be rewritten and deleted as needed by the edited graph.
+    Mutable,
+    /// The ref is available for graph traversal but must not be persisted.
+    Immutable,
+}
+
 /// Utilities for testing
 pub mod testing;
 
@@ -239,6 +275,9 @@ pub struct Editor<'ws, 'meta, M: RefMetadata> {
     repo: gix::Repository,
     /// Provides data about how the editor instance was transformed.
     history: RevisionHistory,
+    /// References that should remain selectable in the graph but must never be
+    /// updated or deleted during materialization.
+    immutable_references: std::collections::HashSet<gix::refs::FullName>,
     /// A reference to the workspace that the editor was created for.
     workspace: &'ws mut but_graph::Workspace,
     /// A reference to the metadata that the editor was created for.
@@ -258,6 +297,7 @@ pub struct SuccessfulRebase<'ws, 'meta, M: RefMetadata> {
     pub(crate) checkouts: Vec<Checkout>,
     /// Provides data about how the editor instance was transformed.
     pub history: RevisionHistory,
+    pub(crate) immutable_references: std::collections::HashSet<gix::refs::FullName>,
     /// A reference to the workspace that the editor was created for.
     workspace: &'ws mut but_graph::Workspace,
     /// A reference to the metadata that the editor was created for.

--- a/crates/but-rebase/src/graph_rebase/rebase.rs
+++ b/crates/but-rebase/src/graph_rebase/rebase.rs
@@ -29,13 +29,17 @@ impl<'ws, 'graph, M: RefMetadata> Editor<'ws, 'graph, M> {
         // multiple.
 
         let mut ref_edits = vec![];
-        let steps_to_pick = order_steps_picking(
-            &self.graph,
-            &self
-                .graph
-                .externals(Direction::Incoming)
-                .collect::<Vec<_>>(),
-        );
+        let rebase_heads = self
+            .graph
+            .externals(Direction::Incoming)
+            .filter(|idx| {
+                !matches!(
+                    &self.graph[*idx],
+                    Step::Reference { refname } if self.immutable_references.contains(refname)
+                )
+            })
+            .collect::<Vec<_>>();
+        let steps_to_pick = order_steps_picking(&self.graph, &rebase_heads);
 
         // A 1 to 1 mapping between the incoming graph and the output graph
         let mut graph_mapping: HashMap<StepGraphIndex, StepGraphIndex> = HashMap::new();
@@ -118,6 +122,7 @@ impl<'ws, 'graph, M: RefMetadata> Editor<'ws, 'graph, M> {
                     }
                 }
                 Step::Reference { refname } => {
+                    let is_immutable = self.immutable_references.contains(&refname);
                     let graph_parents = collect_ordered_parents(&self.graph, step_idx);
                     let first_parent_idx = graph_parents
                         .first()
@@ -139,7 +144,7 @@ impl<'ws, 'graph, M: RefMetadata> Editor<'ws, 'graph, M> {
                             gix::refs::TargetRef::Object(id) => {
                                 if id == to_reference {
                                     unchanged_references.push(refname.clone());
-                                } else {
+                                } else if !is_immutable {
                                     ref_edits.push(RefEdit {
                                         name: refname.clone(),
                                         change: Change::Update {
@@ -151,13 +156,15 @@ impl<'ws, 'graph, M: RefMetadata> Editor<'ws, 'graph, M> {
                                         },
                                         deref: false,
                                     });
+                                } else {
+                                    unchanged_references.push(refname.clone());
                                 }
                             }
                             gix::refs::TargetRef::Symbolic(name) => {
                                 bail!("Attempted to update the symbolic reference {name}");
                             }
                         }
-                    } else {
+                    } else if !is_immutable {
                         ref_edits.push(RefEdit {
                             name: refname.clone(),
                             change: Change::Update {
@@ -167,7 +174,7 @@ impl<'ws, 'graph, M: RefMetadata> Editor<'ws, 'graph, M> {
                             },
                             deref: false,
                         });
-                    };
+                    }
 
                     output_graph.add_node(Step::Reference { refname })
                 }
@@ -194,6 +201,9 @@ impl<'ws, 'graph, M: RefMetadata> Editor<'ws, 'graph, M> {
 
         // Find deleted references
         for reference in self.initial_references.iter() {
+            if self.immutable_references.contains(reference) {
+                continue;
+            }
             if !ref_edits
                 .iter()
                 .any(|e| e.name.as_ref() == reference.as_ref())
@@ -221,6 +231,7 @@ impl<'ws, 'graph, M: RefMetadata> Editor<'ws, 'graph, M> {
             graph: output_graph,
             checkouts: self.checkouts.to_owned(),
             history,
+            immutable_references: self.immutable_references,
             workspace: self.workspace,
             meta: self.meta,
         })

--- a/crates/but-rebase/tests/rebase/graph_rebase/editor_creation.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/editor_creation.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use but_graph::Graph;
-use but_rebase::graph_rebase::{Editor, GraphEditorOptions, testing::Testing as _};
+use but_rebase::graph_rebase::{Editor, ExtraRef, GraphEditorOptions, testing::Testing as _};
 use but_testsupport::{StackState, graph_tree, visualize_commit_graph_all};
 
 use crate::{
@@ -467,7 +467,7 @@ fn includes_extra_refs_in_editor_creation() -> Result<()> {
             &mut *meta,
             &repo,
             &GraphEditorOptions {
-                extra_refs: vec![main_ref.as_ref()],
+                extra_refs: vec![ExtraRef::mutable(main_ref.as_ref())],
                 ..<_>::default()
             },
         )?;

--- a/crates/but-rebase/tests/rebase/graph_rebase/materialize.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/materialize.rs
@@ -1,10 +1,15 @@
 //! Tests for `materialize` vs `materialize_without_checkout` behavior differences
 use anyhow::Result;
 use but_graph::Graph;
-use but_rebase::graph_rebase::{Editor, Step};
-use but_testsupport::{graph_tree, visualize_commit_graph_all, visualize_disk_tree_skip_dot_git};
+use but_rebase::graph_rebase::{Editor, ExtraRef, GraphEditorOptions, Step};
+use but_testsupport::{
+    StackState, graph_tree, visualize_commit_graph_all, visualize_disk_tree_skip_dot_git,
+};
 
-use crate::utils::{fixture_writable, standard_options};
+use crate::{
+    graph_rebase::add_stack_with_segments,
+    utils::{fixture_writable, standard_options},
+};
 
 #[test]
 fn materialize_removes_dropped_commit_changes_from_worktree() -> Result<()> {
@@ -192,6 +197,108 @@ fn both_methods_update_references_identically() -> Result<()> {
     );
 
     insta::assert_snapshot!(ref_after_materialize, @"a96434e2505c2ea0896cf4f58fec0778e074d3da");
+
+    Ok(())
+}
+
+#[test]
+fn materialize_keeps_immutable_extra_refs_unchanged_while_updating_local_refs() -> Result<()> {
+    let (repo, _tmpdir, mut meta) = fixture_writable("workspace-with-empty-stack")?;
+    add_stack_with_segments(&mut meta, 1, "stack-1", StackState::InWorkspace, &[]);
+    add_stack_with_segments(&mut meta, 2, "stack-2", StackState::InWorkspace, &[]);
+    let main_ref = gix::refs::FullName::try_from("refs/heads/main")?;
+    let main_before = repo.rev_parse_single("main")?.detach();
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   74bcc92 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    * | 2169646 (stack-1) Commit D
+    * | 46ef828 Commit C
+    |/  
+    | * a0f2ac5 (origin/main, main) Commit X
+    |/  
+    * f555940 (stack-2) Commit A
+    * d664be0 Commit B
+    * fafd9d0 init
+    ");
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create_with_opts(
+        &mut ws,
+        &mut *meta,
+        &repo,
+        &GraphEditorOptions {
+            extra_refs: vec![ExtraRef::immutable(main_ref.as_ref())],
+            ..<_>::default()
+        },
+    )?;
+
+    let stack_tip = repo.rev_parse_single("stack-2")?.detach();
+    let stack_tip_sel = editor.select_commit(stack_tip)?;
+    editor.replace(stack_tip_sel, Step::None)?;
+
+    let outcome = editor.rebase()?;
+    outcome.materialize()?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   3cc8b6f (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    * | c869f24 (stack-1) Commit D
+    * | 07a9b49 Commit C
+    |/  
+    | * a0f2ac5 (origin/main, main) Commit X
+    | * f555940 Commit A
+    |/  
+    * d664be0 (stack-2) Commit B
+    * fafd9d0 init
+    ");
+
+    assert_eq!(repo.rev_parse_single("main")?.detach(), main_before);
+
+    Ok(())
+}
+
+#[test]
+fn materialize_does_not_delete_immutable_extra_refs_removed_from_graph() -> Result<()> {
+    let (repo, _tmpdir, mut meta) = fixture_writable("workspace-with-empty-stack")?;
+    add_stack_with_segments(&mut meta, 1, "stack-1", StackState::InWorkspace, &[]);
+    add_stack_with_segments(&mut meta, 2, "stack-2", StackState::InWorkspace, &[]);
+    let main_ref = gix::refs::FullName::try_from("refs/heads/main")?;
+    let main_before = repo.rev_parse_single("main")?.detach();
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create_with_opts(
+        &mut ws,
+        &mut *meta,
+        &repo,
+        &GraphEditorOptions {
+            extra_refs: vec![ExtraRef::immutable(main_ref.as_ref())],
+            ..<_>::default()
+        },
+    )?;
+
+    let main_sel = editor.select_reference(main_ref.as_ref())?;
+    editor.replace(main_sel, Step::None)?;
+
+    let outcome = editor.rebase()?;
+    outcome.materialize()?;
+
+    assert_eq!(repo.rev_parse_single("main")?.detach(), main_before);
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   74bcc92 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    * | 2169646 (stack-1) Commit D
+    * | 46ef828 Commit C
+    |/  
+    | * a0f2ac5 (origin/main, main) Commit X
+    |/  
+    * f555940 (stack-2) Commit A
+    * d664be0 Commit B
+    * fafd9d0 init
+    ");
 
     Ok(())
 }

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -9,7 +9,8 @@ use but_graph::workspace::commit::is_managed_workspace_by_message;
 use but_rebase::{
     commit::DateMode,
     graph_rebase::{
-        Editor, GraphEditorOptions, LookupStep, Pick, Selector, Step, SuccessfulRebase, ToSelector,
+        Editor, ExtraRef, GraphEditorOptions, LookupStep, Pick, Selector, Step, SuccessfulRebase,
+        ToSelector,
         mutate::{InsertSide, RelativeTo},
     },
 };
@@ -144,7 +145,7 @@ pub fn integrate_upstream<'ws, 'meta, M: RefMetadata>(
     let head_is_workspace_commit = is_managed_workspace_by_message(head_commit.message_raw()?);
 
     let editor_options = GraphEditorOptions {
-        extra_refs: vec![target_ref.ref_name.as_ref()],
+        extra_refs: vec![ExtraRef::immutable(target_ref.ref_name.as_ref())],
         ..GraphEditorOptions::default()
     };
     let mut editor = Editor::create_with_opts(workspace, meta, repo, &editor_options)?;

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -51,6 +51,7 @@ fn diamond_partially_historically_integrated_rebase() -> Result<()> {
     ");
 
     let mut workspace = graph.into_workspace()?;
+    let remote_tip_before = repo.rev_parse_single("origin/master")?.detach();
     let but_workspace::IntegrateUpstreamOutcome { rebase, .. } = integrate_upstream(
         &mut workspace,
         &mut meta,
@@ -79,6 +80,11 @@ fn diamond_partially_historically_integrated_rebase() -> Result<()> {
     |/  
     * 85aa44b (o1) o1
     ");
+
+    assert_eq!(
+        repo.rev_parse_single("origin/master")?.detach(),
+        remote_tip_before
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Add the ability to include refs to traverse in the editor graph,
without mutating them. This is required to be able to pick commits in
refs that we don’t want to change.

---

### Why do we need this?

In the case of e.g. integration upstream changes from the remote into the local branch, we want to be able to pick, or merge in commits from the remote, without modifying it. This ensures that we are able to do that safely.