### PR TITLE
Extend new stack dropzone to accept commits

### DIFF
--- a/apps/desktop/src/lib/dragging/dropHandlers/stackDropHandler.ts
+++ b/apps/desktop/src/lib/dragging/dropHandlers/stackDropHandler.ts
@@ -6,10 +6,15 @@ import {
 	type ChangeDropData,
 } from "$lib/dragging/draggables";
 import { BranchDropData } from "$lib/dragging/dropHandlers/branchDropHandler";
+import { CommitDropData } from "$lib/dragging/dropHandlers/commitDropHandler";
+import { parseError } from "$lib/error/parser";
 import { unstackPRs, updateStackPrs } from "$lib/forge/shared/prFooter";
+import { toCommitMovePlacement } from "$lib/stacks/commitMovePlacement";
 import StackMacros from "$lib/stacks/macros";
-import { toMoveBranchWarning } from "$lib/stacks/stack";
+import { getStackName, toMoveBranchWarning } from "$lib/stacks/stack";
+import { withStackBusy } from "$lib/state/uiState.svelte";
 import { ensureValue } from "$lib/utils/validation";
+import { untrack } from "svelte";
 import type { DropResult } from "$lib/dragging/dropResult";
 import type { DropzoneHandler } from "$lib/dragging/handler";
 import type { ForgePrService } from "$lib/forge/interface/forgePrService";
@@ -61,11 +66,18 @@ export class OutsideLaneDzHandler implements DropzoneHandler {
 		return true;
 	}
 
+	private acceptsCommitDropData(data: unknown): data is CommitDropData {
+		if (!(data instanceof CommitDropData)) return false;
+		if (data.allCommits.some((c) => c.hasConflicts)) return false;
+		return true;
+	}
+
 	accepts(data: unknown) {
 		return (
 			this.acceptsChangeDropData(data) ||
 			this.acceptsBranchDropData(data) ||
-			this.acceptsHunkDropData(data)
+			this.acceptsHunkDropData(data) ||
+			this.acceptsCommitDropData(data)
 		);
 	}
 
@@ -192,6 +204,57 @@ export class OutsideLaneDzHandler implements DropzoneHandler {
 		}
 	}
 
+	async ondropCommitData(data: CommitDropData): Promise<DropResult | void> {
+		// Clear the selection from the source lane if any dragged commit was selected.
+		const sourceSelection = untrack(() => this.uiState.lane(data.stackId).selection.current);
+		if (
+			sourceSelection?.commitId &&
+			data.allCommits.some((c) => c.id === sourceSelection.commitId)
+		) {
+			this.uiState.lane(data.stackId).selection.set(undefined);
+		}
+
+		const stack = await this.stackService.newStackMutation({
+			projectId: this.projectId,
+			branch: { name: undefined },
+		});
+
+		const stackId = ensureValue(stack.id);
+		const branchName = getStackName(stack);
+
+		const { relativeTo, side } = toCommitMovePlacement({
+			targetBranchName: branchName,
+			targetCommitId: "top",
+		});
+
+		const commitIds = data.allCommits.map((c) => c.id);
+		let result: DropResult | undefined;
+		await withStackBusy(
+			this.uiState,
+			this.projectId,
+			{ stackIds: [data.stackId, stackId] },
+			async () => {
+				try {
+					await this.stackService.commitMove({
+						projectId: this.projectId,
+						subjectCommitIds: commitIds,
+						relativeTo,
+						side,
+						dryRun: false,
+					});
+				} catch (error) {
+					const { description, message } = parseError(error);
+					result = {
+						type: "warning",
+						title: "Cannot move commits",
+						message: description ?? message,
+					};
+				}
+			},
+		);
+		return result;
+	}
+
 	async ondropBranchData(data: BranchDropData): Promise<DropResult | void> {
 		const beforeAppliedStackCount = (await this.stackService.fetchStacks(this.projectId)).length;
 		const result = await this.stackService.tearOffBranch({
@@ -230,6 +293,10 @@ export class OutsideLaneDzHandler implements DropzoneHandler {
 		if (this.acceptsHunkDropData(data)) {
 			await this.ondropHunkData(data);
 			return;
+		}
+
+		if (this.acceptsCommitDropData(data)) {
+			return await this.ondropCommitData(data);
 		}
 
 		if (this.acceptsBranchDropData(data)) {

--- a/apps/desktop/src/lib/stacks/stackEndpoints.test.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.test.ts
@@ -95,6 +95,8 @@ describe("buildStackEndpoints", () => {
 			invalidatesList(ReduxTag.HeadSha),
 			invalidatesList(ReduxTag.WorktreeChanges),
 			invalidatesList(ReduxTag.BranchChanges),
+			invalidatesList(ReduxTag.Stacks),
+			invalidatesList(ReduxTag.StackDetails),
 		]);
 	});
 

--- a/apps/desktop/src/lib/stacks/stackEndpoints.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.ts
@@ -723,6 +723,8 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 				invalidatesList(ReduxTag.HeadSha),
 				invalidatesList(ReduxTag.WorktreeChanges), // Moving commits can cause conflicts
 				invalidatesList(ReduxTag.BranchChanges),
+				invalidatesList(ReduxTag.Stacks),
+				invalidatesList(ReduxTag.StackDetails),
 			],
 		}),
 		moveBranch: build.mutation<

--- a/e2e/playwright/tests/moveCommitToNewStack.spec.ts
+++ b/e2e/playwright/tests/moveCommitToNewStack.spec.ts
@@ -1,0 +1,123 @@
+import { getBaseURL, type GitButler, startGitButler } from "../src/setup.ts";
+import { test } from "../src/test.ts";
+import { dragAndDropByLocator, waitForTestId } from "../src/util.ts";
+import { expect, type Page } from "@playwright/test";
+
+let gitbutler: GitButler;
+
+test.use({
+	baseURL: getBaseURL(),
+});
+
+test.afterEach(async () => {
+	await gitbutler?.destroy();
+});
+
+/**
+ * Set up a workspace with branch2 (2 commits, modifies b_file) and
+ * branch3 (2 commits, modifies c_file) applied.
+ * These branches are independent of each other and of master's a_file,
+ * so moving commits between stacks won't cause merge conflicts.
+ */
+async function setupWorkspace(page: Page, context: any, testInfo: any) {
+	const workdir = testInfo.outputPath("workdir");
+	const configdir = testInfo.outputPath("config");
+	gitbutler = await startGitButler(workdir, configdir, context);
+
+	await gitbutler.runScript("project-with-stacks.sh");
+	await gitbutler.runScript("apply-upstream-branch.sh", ["branch2", "local-clone"]);
+	await gitbutler.runScript("apply-upstream-branch.sh", ["branch3", "local-clone"]);
+
+	await page.goto("/");
+	await waitForTestId(page, "workspace-view");
+
+	const stacks = page.getByTestId("stack");
+	await expect(stacks).toHaveCount(2);
+}
+
+test("move a commit to the new stack dropzone to create a new stack", async ({
+	page,
+	context,
+}, testInfo) => {
+	test.setTimeout(120_000);
+	await setupWorkspace(page, context, testInfo);
+
+	const stack2 = page
+		.getByTestId("stack")
+		.filter({ has: page.getByTestId("branch-header").filter({ hasText: "branch2" }) });
+
+	// branch2 should have 2 commits
+	const commits = stack2.getByTestId("commit-row");
+	await expect(commits).toHaveCount(2);
+
+	// Pick a commit to drag
+	const commitToDrag = commits.filter({ hasText: "branch2: first commit" });
+	await expect(commitToDrag).toBeVisible();
+
+	// Drag the commit onto the new stack dropzone
+	const stackDropzone = await waitForTestId(page, "stack-offlane-dropzone");
+	await dragAndDropByLocator(page, commitToDrag, stackDropzone, {
+		force: true,
+		position: {
+			x: 10,
+			y: 10,
+		},
+	});
+
+	// Should now have three stacks (branch2, branch3, and the new one)
+	const stacks = page.getByTestId("stack");
+	await expect(stacks).toHaveCount(3, { timeout: 15_000 });
+
+	// The original stack should have 1 commit (one was moved)
+	await expect(stack2.getByTestId("commit-row")).toHaveCount(1, { timeout: 15_000 });
+
+	// The moved commit should no longer be in the original stack
+	await expect(
+		stack2.getByTestId("commit-row").filter({ hasText: "branch2: first commit" }),
+	).toHaveCount(0);
+});
+
+test("move multiple selected commits to the new stack dropzone", async ({
+	page,
+	context,
+}, testInfo) => {
+	test.setTimeout(120_000);
+	await setupWorkspace(page, context, testInfo);
+
+	const stack3 = page
+		.getByTestId("stack")
+		.filter({ has: page.getByTestId("branch-header").filter({ hasText: "branch3" }) });
+
+	const commits = stack3.getByTestId("commit-row");
+	await expect(commits).toHaveCount(2);
+
+	// Multi-select both commits
+	const firstCommit = commits.filter({ hasText: "branch3: first commit" });
+	const secondCommit = commits.filter({ hasText: "branch3: second commit" });
+
+	await firstCommit.click();
+	const modKey = process.platform === "darwin" ? "Meta" : "Control";
+	await secondCommit.click({ modifiers: [modKey] });
+
+	// Both should be selected
+	await expect(firstCommit).toHaveClass(/\bselected\b/);
+	await expect(secondCommit).toHaveClass(/\bselected\b/);
+
+	// Drag onto the new stack dropzone
+	const stackDropzone = await waitForTestId(page, "stack-offlane-dropzone");
+	await dragAndDropByLocator(page, firstCommit, stackDropzone, {
+		force: true,
+		position: {
+			x: 10,
+			y: 10,
+		},
+	});
+
+	// Should now have three stacks
+	const stacks = page.getByTestId("stack");
+	await expect(stacks).toHaveCount(3, { timeout: 15_000 });
+
+	// The original branch3 stack should be empty (both commits were moved).
+	// An empty branch shows no commit rows.
+	await expect(stack3.getByTestId("commit-row")).toHaveCount(0, { timeout: 15_000 });
+});


### PR DESCRIPTION
Allow dragging commits onto the new stack dropzone to create a new
stack and move the commits there. Uses commitMove with withStackBusy
for proper UI state management. Also adds Stacks/StackDetails cache
invalidation to the commitMove endpoint.