### PR TITLE
Immutable parent refs

### DIFF
--- a/crates/but-rebase/src/graph_rebase/creation.rs
+++ b/crates/but-rebase/src/graph_rebase/creation.rs
@@ -62,14 +62,8 @@ impl<'ws, 'meta, M: RefMetadata> Editor<'ws, 'meta, M> {
         // common base
         let entrypoint = workspace.graph.lookup_entrypoint()?;
 
-        let mut entrypoints = vec![entrypoint.segment_index];
-
-        let immutable_references = options
-            .extra_refs
-            .iter()
-            .filter(|extra_ref| extra_ref.mutability == ExtraRefMutability::Immutable)
-            .map(|extra_ref| extra_ref.ref_name.to_owned())
-            .collect::<HashSet<_>>();
+        let mut mutable_entrypoints = vec![entrypoint.segment_index];
+        let mut immutable_entrypoints = vec![];
 
         for extra_ref in &options.extra_refs {
             let Some((segment, _)) = workspace
@@ -81,18 +75,46 @@ impl<'ws, 'meta, M: RefMetadata> Editor<'ws, 'meta, M> {
                     extra_ref.ref_name
                 );
             };
-            entrypoints.push(segment.id);
+            if extra_ref.mutability == ExtraRefMutability::Mutable {
+                mutable_entrypoints.push(segment.id);
+            } else {
+                immutable_entrypoints.push(segment.id);
+            }
         }
 
         let mut segments_to_add = vec![];
         let mut seen_segments = HashSet::new();
 
-        for entrypoint in entrypoints {
+        for entrypoint in mutable_entrypoints {
             workspace.graph.visit_all_segments_including_start_until(
                 entrypoint,
                 Direction::Outgoing,
                 |segment| {
                     if seen_segments.insert(segment.id) {
+                        segments_to_add.push(segment.id);
+                        false
+                    } else {
+                        true
+                    }
+                },
+            );
+        }
+        let mut immutable_references = HashSet::new();
+        for entrypoint in immutable_entrypoints {
+            workspace.graph.visit_all_segments_including_start_until(
+                entrypoint,
+                Direction::Outgoing,
+                |segment| {
+                    if seen_segments.insert(segment.id) {
+                        immutable_references.extend(segment.ref_name().map(|r| r.to_owned()));
+                        immutable_references.extend(
+                            segment
+                                .commits
+                                .iter()
+                                .flat_map(|c| c.ref_iter())
+                                .map(|r| r.to_owned()),
+                        );
+
                         segments_to_add.push(segment.id);
                         false
                     } else {

--- a/crates/but-rebase/src/graph_rebase/rebase.rs
+++ b/crates/but-rebase/src/graph_rebase/rebase.rs
@@ -341,7 +341,7 @@ fn format_base_merge_error(
 #[cfg(test)]
 mod test {
     mod order_steps_picking {
-        use std::str::FromStr;
+        use std::{collections::HashSet, str::FromStr};
 
         use anyhow::Result;
 
@@ -365,7 +365,7 @@ mod test {
             graph.add_edge(a, b, Edge { order: 0 });
             graph.add_edge(b, c, Edge { order: 0 });
 
-            insta::assert_snapshot!(render_ascii_graph(&graph, |_| None), @"
+            insta::assert_snapshot!(render_ascii_graph(&graph, &HashSet::new(), |_| None), @"
             ● 1000000
             ● 2000000
             ● 3000000
@@ -428,7 +428,7 @@ mod test {
 
             graph.add_edge(i, j, Edge { order: 0 });
 
-            insta::assert_snapshot!(render_ascii_graph(&graph, |_| None), @"
+            insta::assert_snapshot!(render_ascii_graph(&graph, &HashSet::new(), |_| None), @"
             ● 1000000
             ● 2000000
             │ ● 6000000
@@ -477,7 +477,7 @@ mod test {
             graph.add_edge(d, e, Edge { order: 0 });
             graph.add_edge(e, b, Edge { order: 0 });
 
-            insta::assert_snapshot!(render_ascii_graph(&graph, |_| None), @"
+            insta::assert_snapshot!(render_ascii_graph(&graph, &HashSet::new(), |_| None), @"
             ● 1000000
             ├─╮
             │ ● 4000000
@@ -520,7 +520,7 @@ mod test {
 
             graph.add_edge(a, b, Edge { order: 1 });
 
-            insta::assert_snapshot!(render_ascii_graph(&graph, |_| None), @"
+            insta::assert_snapshot!(render_ascii_graph(&graph, &HashSet::new(), |_| None), @"
             ● 1000000
             ├─╮
             ● │ 4000000

--- a/crates/but-rebase/src/graph_rebase/testing.rs
+++ b/crates/but-rebase/src/graph_rebase/testing.rs
@@ -21,13 +21,17 @@ pub trait Testing {
 
 impl<M: RefMetadata> Testing for Editor<'_, '_, M> {
     fn steps_ascii(&self) -> String {
-        render_ascii_graph(&self.graph, |id| lookup_commit_title(&self.repo, id))
+        render_ascii_graph(&self.graph, &self.immutable_references, |id| {
+            lookup_commit_title(&self.repo, id)
+        })
     }
 }
 
 impl<M: RefMetadata> Testing for SuccessfulRebase<'_, '_, M> {
     fn steps_ascii(&self) -> String {
-        render_ascii_graph(&self.graph, |id| lookup_commit_title(&self.repo, id))
+        render_ascii_graph(&self.graph, &self.immutable_references, |id| {
+            lookup_commit_title(&self.repo, id)
+        })
     }
 }
 /// An extension trait that adds debugging output for graphs
@@ -201,7 +205,11 @@ impl LayoutState {
 }
 
 /// Format a step for display, optionally with a commit title
-fn format_step(step: &Step, title: Option<String>) -> String {
+fn format_step(
+    immutable_references: &HashSet<gix::refs::FullName>,
+    step: &Step,
+    title: Option<String>,
+) -> String {
     match step {
         Step::Pick(Pick { id, .. }) => {
             let mut sha = id.to_string();
@@ -211,7 +219,14 @@ fn format_step(step: &Step, title: Option<String>) -> String {
                 None => sha,
             }
         }
-        Step::Reference { refname } => refname.as_bstr().to_string(),
+        Step::Reference { refname } => {
+            let name = refname.as_bstr().to_string();
+            if immutable_references.contains(refname) {
+                format!("{name} (immutable)")
+            } else {
+                name
+            }
+        }
         Step::None => "no-op".to_string(),
     }
 }
@@ -369,7 +384,12 @@ fn compute_layout(graph: &StepGraph, order: &[StepGraphIndex]) -> Vec<LayoutEven
 }
 
 /// Phase 2: Render events to ASCII
-fn render_events<F>(graph: &StepGraph, events: &[LayoutEvent], mut get_title: F) -> String
+fn render_events<F>(
+    graph: &StepGraph,
+    immutable_references: &HashSet<gix::refs::FullName>,
+    events: &[LayoutEvent],
+    mut get_title: F,
+) -> String
 where
     F: FnMut(gix::ObjectId) -> Option<String>,
 {
@@ -383,7 +403,13 @@ where
                     Step::Pick(Pick { id, .. }) => get_title(*id),
                     _ => None,
                 };
-                lines.push(render_node_line(*col, step, active.as_slice(), title));
+                lines.push(render_node_line(
+                    immutable_references,
+                    *col,
+                    step,
+                    active.as_slice(),
+                    title,
+                ));
             }
             LayoutEvent::Fork {
                 from_col,
@@ -405,7 +431,13 @@ where
 }
 
 /// Render a node line
-fn render_node_line(col: usize, step: &Step, active: &[bool], title: Option<String>) -> String {
+fn render_node_line(
+    immutable_references: &HashSet<gix::refs::FullName>,
+    col: usize,
+    step: &Step,
+    active: &[bool],
+    title: Option<String>,
+) -> String {
     let width = active.len().max(col + 1);
     let mut cells: Vec<[char; 2]> = vec![[' ', ' ']; width];
 
@@ -418,7 +450,11 @@ fn render_node_line(col: usize, step: &Step, active: &[bool], title: Option<Stri
     }
 
     let grid: String = cells.iter().flat_map(|c| c.iter()).collect();
-    format!("{} {}", grid.trim_end(), format_step(step, title))
+    format!(
+        "{} {}",
+        grid.trim_end(),
+        format_step(immutable_references, step, title)
+    )
 }
 
 /// Render a fork line
@@ -511,7 +547,11 @@ fn render_terminate_line(col: usize, active: &[bool]) -> String {
 }
 
 /// Main entry point: render graph as ASCII
-pub(crate) fn render_ascii_graph<F>(graph: &StepGraph, get_title: F) -> String
+pub(crate) fn render_ascii_graph<F>(
+    graph: &StepGraph,
+    immutable_references: &HashSet<gix::refs::FullName>,
+    get_title: F,
+) -> String
 where
     F: FnMut(gix::ObjectId) -> Option<String>,
 {
@@ -534,7 +574,7 @@ where
     }
 
     let events = compute_layout(graph, &order);
-    render_events(graph, &events, get_title)
+    render_events(graph, immutable_references, &events, get_title)
 }
 
 #[cfg(test)]
@@ -573,7 +613,7 @@ mod tests {
         add_edge(&mut graph, c, d, 0);
         add_edge(&mut graph, d, none, 0);
 
-        let output = render_ascii_graph(&graph, |_| None);
+        let output = render_ascii_graph(&graph, &HashSet::new(), |_| None);
         insta::assert_snapshot!(output, @"
         ◎ refs/heads/main
         ● 1111111
@@ -605,7 +645,7 @@ mod tests {
         add_edge(&mut graph, a, c, 0);
         add_edge(&mut graph, b, c, 0);
 
-        let output = render_ascii_graph(&graph, |_| None);
+        let output = render_ascii_graph(&graph, &HashSet::new(), |_| None);
         insta::assert_snapshot!(output, @"
         ◎ refs/heads/main
         ├─╮
@@ -641,7 +681,7 @@ mod tests {
         add_edge(&mut graph, b, d, 0);
         add_edge(&mut graph, c, d, 0);
 
-        let output = render_ascii_graph(&graph, |_| None);
+        let output = render_ascii_graph(&graph, &HashSet::new(), |_| None);
         insta::assert_snapshot!(output, @"
         ◎ refs/heads/main
         ├─┬─╮
@@ -690,7 +730,7 @@ mod tests {
         // B also goes to C
         add_edge(&mut graph, b, c, 0);
 
-        let output = render_ascii_graph(&graph, |_| None);
+        let output = render_ascii_graph(&graph, &HashSet::new(), |_| None);
         insta::assert_snapshot!(output, @"
         ◎ refs/heads/main
         ├─╮
@@ -727,7 +767,7 @@ mod tests {
         add_edge(&mut graph, c, base, 0);
         add_edge(&mut graph, d, base, 0);
 
-        let output = render_ascii_graph(&graph, |_| None);
+        let output = render_ascii_graph(&graph, &HashSet::new(), |_| None);
         insta::assert_snapshot!(output, @"
         ◎ refs/heads/main
         ├─┬─┬─╮
@@ -768,7 +808,7 @@ mod tests {
         add_edge(&mut graph, a3, c, 0);
         add_edge(&mut graph, b, c, 0);
 
-        let output = render_ascii_graph(&graph, |_| None);
+        let output = render_ascii_graph(&graph, &HashSet::new(), |_| None);
         insta::assert_snapshot!(output, @"
         ◎ refs/heads/main
         ├─╮
@@ -813,7 +853,7 @@ mod tests {
         add_edge(&mut graph, e, f, 0);
         add_edge(&mut graph, c, f, 0);
 
-        let output = render_ascii_graph(&graph, |_| None);
+        let output = render_ascii_graph(&graph, &HashSet::new(), |_| None);
         insta::assert_snapshot!(output, @"
         ◎ refs/heads/main
         ├─╮
@@ -866,7 +906,7 @@ mod tests {
         add_edge(&mut graph, b, d, 0);
         add_edge(&mut graph, c, d, 0);
 
-        let output = render_ascii_graph(&graph, |_| None);
+        let output = render_ascii_graph(&graph, &HashSet::new(), |_| None);
         insta::assert_snapshot!(output, @"
         ◎ refs/heads/main
         ├─┬─╮
@@ -927,7 +967,7 @@ mod tests {
         add_edge(&mut graph, e, base, 0);
         add_edge(&mut graph, f, base, 0);
 
-        let output = render_ascii_graph(&graph, |_| None);
+        let output = render_ascii_graph(&graph, &HashSet::new(), |_| None);
         insta::assert_snapshot!(output, @"
         ◎ refs/heads/main
         ├─┬─╮
@@ -992,7 +1032,7 @@ mod tests {
         add_edge(&mut graph, e, f, 0);
         add_edge(&mut graph, g, f, 0);
 
-        let output = render_ascii_graph(&graph, |_| None);
+        let output = render_ascii_graph(&graph, &HashSet::new(), |_| None);
         insta::assert_snapshot!(output, @"
         ◎ refs/heads/main
         ├─┬─╮
@@ -1057,7 +1097,7 @@ mod tests {
         add_edge(&mut graph, f, base, 0);
         add_edge(&mut graph, shared, base, 0);
 
-        let output = render_ascii_graph(&graph, |_| None);
+        let output = render_ascii_graph(&graph, &HashSet::new(), |_| None);
         insta::assert_snapshot!(output, @"
         ◎ refs/heads/main
         ├─┬─╮

--- a/crates/but-rebase/tests/fixtures/scenario/extra-refs-to-include.sh
+++ b/crates/but-rebase/tests/fixtures/scenario/extra-refs-to-include.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+git init
+
+echo "base" >base && git add . && git commit -m "base"
+# common ancestor
+echo "a" >a && git add . && git commit -m "a"
+git update-ref refs/heads/foo HEAD
+# extra mutable ref
+echo "b" >b && git add . && git commit -m "b"
+git update-ref refs/heads/explicit-mut HEAD
+# included implicitly as immutable
+echo "c" >c && git add . && git commit -m "c"
+git update-ref refs/heads/implicit-const HEAD
+# extra immutable ref
+echo "d" >d && git add . && git commit -m "d"
+git update-ref refs/heads/explicit-const HEAD
+git checkout --detach refs/heads/foo
+# head ref
+echo "e" >e && git add . && git commit -m "e"
+git update-ref refs/heads/implicit-mut HEAD
+# included implicitly as immutable
+echo "f" >f && git add . && git commit -m "f"
+git update-ref refs/heads/implicit-const-2 HEAD
+# extra immutable ref
+echo "g" >g && git add . && git commit -m "g"
+git update-ref refs/heads/explicit-const-2 HEAD
+git checkout refs/heads/implicit-mut

--- a/crates/but-rebase/tests/rebase/graph_rebase/editor_creation.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/editor_creation.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use but_graph::Graph;
+use but_graph::{Graph, init::Tip};
 use but_rebase::graph_rebase::{Editor, ExtraRef, GraphEditorOptions, testing::Testing as _};
 use but_testsupport::{StackState, graph_tree, visualize_commit_graph_all};
 
@@ -549,6 +549,99 @@ fn merge_first_parent_older_than_second() -> Result<()> {
     ◎ refs/heads/main
     ◎ refs/tags/base
     ● 793a434 base
+    ╵
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn immutable_entrypoints_propogate_until_mutable_entrypoints() -> Result<()> {
+    let (repo, mut meta) = fixture("extra-refs-to-include")?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * be4ae80 (main, explicit-const) d
+    * 120e3a9 (implicit-const) c
+    * a96434e (explicit-mut) b
+    | * d9fa122 (explicit-const-2) g
+    | * 85bccf0 (implicit-const-2) f
+    | * c8dd361 (HEAD, implicit-mut) e
+    |/  
+    * d591dfe (foo) a
+    * 35b8235 base
+    ");
+
+    let graph = Graph::from_commit_traversal_tips(
+        &repo,
+        [
+            Tip::entrypoint(
+                repo.rev_parse_single("refs/heads/implicit-mut")?.detach(),
+                Some("refs/heads/implicit-mut".try_into()?),
+            ),
+            Tip::reachable(
+                repo.rev_parse_single("refs/heads/explicit-const")?.detach(),
+                Some("refs/heads/explicit-const".try_into()?),
+            ),
+            Tip::reachable(
+                repo.rev_parse_single("refs/heads/explicit-const-2")?
+                    .detach(),
+                Some("refs/heads/explicit-const-2".try_into()?),
+            ),
+        ],
+        &*meta,
+        standard_options(),
+    )?
+    .validated()?;
+
+    insta::assert_snapshot!(graph_tree(&graph), @"
+
+    ├── ►:0[0]:explicit-const
+    │   └── ·be4ae80 (⌂) ►main
+    │       └── ►:3[1]:implicit-const
+    │           └── ·120e3a9 (⌂)
+    │               └── ►:6[2]:explicit-mut
+    │                   └── ·a96434e (⌂)
+    │                       └── ►:5[3]:foo
+    │                           ├── ·d591dfe (⌂|1)
+    │                           └── 🏁·35b8235 (⌂|1)
+    └── ►:1[0]:explicit-const-2
+        └── ·d9fa122 (⌂)
+            └── ►:4[1]:implicit-const-2
+                └── ·85bccf0 (⌂)
+                    └── 👉►:2[2]:implicit-mut
+                        └── ·c8dd361 (⌂|1)
+                            └── →:5: (foo)
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    let opts = GraphEditorOptions {
+        extra_refs: vec![
+            ExtraRef::mutable("refs/heads/explicit-mut".try_into()?),
+            ExtraRef::immutable("refs/heads/explicit-const".try_into()?),
+            ExtraRef::immutable("refs/heads/explicit-const-2".try_into()?),
+        ],
+        ..Default::default()
+    };
+    let editor = Editor::create_with_opts(&mut ws, &mut *meta, &repo, &opts)?;
+
+    insta::assert_snapshot!(editor.steps_ascii(), @"
+    ◎ refs/heads/explicit-const (immutable)
+    ◎ refs/heads/main (immutable)
+    ● be4ae80 d
+    ◎ refs/heads/implicit-const (immutable)
+    ● 120e3a9 c
+    ◎ refs/heads/explicit-mut
+    ● a96434e b
+    │ ◎ refs/heads/explicit-const-2 (immutable)
+    │ ● d9fa122 g
+    │ ◎ refs/heads/implicit-const-2 (immutable)
+    │ ● 85bccf0 f
+    │ ◎ refs/heads/implicit-mut
+    │ ● c8dd361 e
+    ├─╯
+    ◎ refs/heads/foo
+    ● d591dfe a
+    ● 35b8235 base
     ╵
     ");
 


### PR DESCRIPTION
When working with the editor, we want to be really careful to only edit references that are displayed in the GitButler workspace.

If we were to modify references the user can’t see, this is almost certainly unexpected “bad gitizen” behaviour.

This PR refines the newly introduced “immutable” reference behaviour to consider any reference in the revset `(immutable entrypoints) ^(mutable entrypoints)` also as an immutable reference.