### PR TITLE
Restore old metadata reading method while new handle seems unreliable

### DIFF
--- a/crates/but-graph/src/projection/workspace/api/legacy.rs
+++ b/crates/but-graph/src/projection/workspace/api/legacy.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 
 use crate::{FirstParent, Workspace};
 
@@ -45,39 +45,34 @@ impl Workspace {
     ///
     /// If only the commits that aren't in the workspace were needed (i.e. not per stack),
     /// then one can do a mere pruned traversal from `target_tip ^InWorkspace`.
-    pub fn upstream_commits(&self, first_parent: FirstParent) -> Result<Vec<HeadStatus>> {
-        let graph = &self.graph;
-        let target_segment_id = self
-            .target_ref
-            .as_ref()
-            .context("Upstream commits can only be calculated on a workspace with a target ref")?
-            .segment_index;
+    pub fn upstream_commits(
+        &self,
+        repo: &gix::Repository,
+        target_ref: &gix::refs::FullNameRef,
+        first_parent: FirstParent,
+    ) -> Result<Vec<HeadStatus>> {
         let mut heads = self
             .stacks
             .iter()
             .filter_map(|stack| stack.tip_skip_empty())
             .collect::<Vec<_>>();
         if heads.is_empty()
-            && let Some(entrypoint) = graph.entrypoint_commit()
+            && let Some(entrypoint) = self.graph.entrypoint_commit()
         {
             heads.push(entrypoint.id);
         }
+        let target_ref_id = repo.find_reference(target_ref)?.id();
 
         let mut out = vec![];
 
         for head in heads {
-            let head_segment_id = graph.commit_id_to_segment_id(head)?;
+            let mut walk = repo.rev_walk([target_ref_id]).with_hidden([head]);
+            if first_parent == FirstParent::Yes {
+                walk = walk.first_parent_only();
+            }
             out.push(HeadStatus {
                 head,
-                upstream_commits: graph
-                    .find_segments_reachable_from_a_not_b(
-                        target_segment_id,
-                        head_segment_id,
-                        first_parent,
-                    )
-                    .into_iter()
-                    .map(|commit| commit.id)
-                    .collect(),
+                upstream_commits: walk.all()?.map(|i| Ok(i?.id)).collect::<Result<_>>()?,
             })
         }
 

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -85,9 +85,10 @@ impl BaseBranch {
 
 #[instrument(skip(ctx, perm), err(Debug))]
 pub fn get_base_branch_data(ctx: &Context, perm: &RepoShared) -> Result<BaseBranch> {
+    let target = default_target(ctx)?;
     let meta = ctx.meta()?;
     let (repo, ws, _) = ctx.workspace_and_db_with_perm(perm)?;
-    let base = target_to_base_branch(&repo, &ctx.legacy_project, &ws, &meta)?;
+    let base = target_to_base_branch(&repo, &ctx.legacy_project, &ws, &meta, &target)?;
     Ok(base)
 }
 
@@ -352,32 +353,25 @@ pub(crate) fn target_to_base_branch(
     project: &Project,
     ws: &but_graph::Workspace,
     meta: &impl RefMetadata,
+    target: &Target,
 ) -> Result<BaseBranch> {
     // This function is presuming a workspace ref name.
     let ws_meta = meta.workspace(WORKSPACE_REF_NAME.try_into()?)?;
-    let target_ref = ws
-        .target_ref
-        .as_ref()
-        .context("target_to_base_branch require a defined target_ref")
+    let target_ref_name: gix::refs::FullName = target.branch.clone().try_into()?;
+    let target_ref = repo
+        .find_reference(&target_ref_name)
         .context(Code::DefaultTargetNotFound)?;
-    let target_ref_name = target_ref.ref_name.as_ref();
-    let target_sha = ws
-        .target_commit_id()
-        .context("target_to_base_branch require a defined target_commit_id")?;
-
-    let target_ref_commit_id = ws
-        .target_ref_tip_commit_id()
-        .context("target_to_base_branch requires the target ref tip to be in the graph")?;
+    let target_ref_commit_id = target_ref.id().detach();
 
     // The old integrate_upstream function cares about whether the target sha
     // is ahead of the target ref.
     //
     // The old function provided some options for how to resolve this.
-    let target_sha_not_ref = first_parent_commit_ids_until(repo, target_sha, target_ref_commit_id)
+    let target_sha_not_ref = first_parent_commit_ids_until(repo, target.sha, target_ref_commit_id)
         .context("failed to get fork point")?;
     let target_sha_ahead_of_ref = !target_sha_not_ref.is_empty();
 
-    // The longest list of updstream commit ids.
+    // The longest list of upstream commit ids.
     let upstream_commit_ids = ws
         .upstream_commits(FirstParent::Yes)?
         .into_iter()
@@ -396,7 +390,7 @@ pub(crate) fn target_to_base_branch(
     let behind = upstream_commits.len();
 
     // get some recent commits
-    let recent_commits = first_parent_commit_ids_with_limit(repo, target_sha, 20)
+    let recent_commits = first_parent_commit_ids_with_limit(repo, target.sha, 20)
         .context("failed to get recent commits")?
         .iter()
         .map(|id| {
@@ -412,8 +406,7 @@ pub(crate) fn target_to_base_branch(
     let remote_url = ws_meta.remote_url_with_fallback(repo)?;
 
     let branch_name = target_ref_name.shorten().to_string();
-    let remote_name = repo
-        .find_reference(target_ref_name)?
+    let remote_name = target_ref
         .remote_name(gix::remote::Direction::Push)
         .context("Failed to get current remote name")?
         .to_owned()
@@ -430,7 +423,7 @@ pub(crate) fn target_to_base_branch(
         remote_url,
         push_remote_name,
         push_remote_url,
-        base_sha: target_sha,
+        base_sha: target.sha,
         current_sha: target_ref_commit_id,
         behind,
         upstream_commits,

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -373,7 +373,7 @@ pub(crate) fn target_to_base_branch(
 
     // The longest list of upstream commit ids.
     let upstream_commit_ids = ws
-        .upstream_commits(FirstParent::Yes)?
+        .upstream_commits(repo, target_ref_name.as_ref(), FirstParent::Yes)?
         .into_iter()
         .map(|h| h.upstream_commits)
         .max_by_key(|us| us.len())

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -237,14 +237,14 @@ impl<'a> UpstreamIntegrationContext<'a> {
         }
 
         let (target_ref_name, old_target_id, upstream_commits) = {
-            let (_repo, ws, _db) = ctx.workspace_and_db_with_perm(permission.read_permission())?;
+            let (repo, ws, _db) = ctx.workspace_and_db_with_perm(permission.read_permission())?;
             let target_ref_name = ws
                 .target_ref_name()
                 .context("failed to get target reference name")?
                 .to_owned();
 
             let upstream_commits = ws
-                .upstream_commits(FirstParent::Yes)?
+                .upstream_commits(&repo, target_ref_name.as_ref(), FirstParent::Yes)?
                 .into_iter()
                 .map(|h| h.upstream_commits)
                 .max_by_key(|us| us.len())


### PR DESCRIPTION
Users have been encountering an issue where we fail to read the workspace metadata in this critical function. Until we’ve figgured out why it was failing, I’ve restored the old functionality