### PR TITLE
Feature/comment char

### DIFF
--- a/crates/but/src/args/config.rs
+++ b/crates/but/src/args/config.rs
@@ -342,6 +342,9 @@ pub enum UserConfigKey {
     Email,
     /// Git editor (core.editor)
     Editor,
+    /// Git comment character (core.commentChar)
+    #[clap(name = "commentChar")]
+    CommentChar,
 }
 
 /// Subcommands for `but config ui`
@@ -417,6 +420,7 @@ impl UserConfigKey {
             UserConfigKey::Name => "user.name",
             UserConfigKey::Email => "user.email",
             UserConfigKey::Editor => "core.editor",
+            UserConfigKey::CommentChar => "core.commentChar",
         }
     }
 }

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -357,18 +357,37 @@ pub(crate) fn load_app_settings_sync() -> Result<AppSettingsWithDiskSync> {
     AppSettingsWithDiskSync::new_with_customization(config_dir, None)
 }
 
+/// Get the comment character from git config. Defaults to '#' if not set or set to "auto".
+pub(crate) fn get_comment_char(config: &gix::config::Snapshot<'_>) -> char {
+    if let Some(s) = config.string("core.commentChar") {
+        let s_str = s.to_str_lossy();
+        if s_str == "auto" {
+            '#'
+        } else if let Some(c) = s_str.chars().next() {
+            c
+        } else {
+            '#'
+        }
+    } else {
+        '#'
+    }
+}
+
 /// User configuration information
 #[derive(serde::Serialize)]
 struct UserConfigInfo {
     name: Option<String>,
     email: Option<String>,
     editor: Option<String>,
+    comment_char: Option<String>,
     #[serde(serialize_with = "serialize_config_source")]
     name_scope: Option<gix::config::Source>,
     #[serde(serialize_with = "serialize_config_source")]
     email_scope: Option<gix::config::Source>,
     #[serde(serialize_with = "serialize_config_source")]
     editor_scope: Option<gix::config::Source>,
+    #[serde(serialize_with = "serialize_config_source")]
+    comment_char_scope: Option<gix::config::Source>,
 }
 
 /// Get user configuration info from git config
@@ -376,15 +395,18 @@ fn get_user_config_info(config: &gix::config::Snapshot<'_>) -> UserConfigInfo {
     let (name, name_scope) = get_config_string_and_scope(config, "user.name");
     let (email, email_scope) = get_config_string_and_scope(config, "user.email");
     let (_editor, editor_scope) = get_config_string_and_scope(config, "core.editor");
+    let (comment_char, comment_char_scope) = get_config_string_and_scope(config, "core.commentChar");
     let editor = tui::get_text::get_editor_command();
 
     UserConfigInfo {
         name,
         email,
         editor,
+        comment_char,
         name_scope,
         email_scope,
         editor_scope,
+        comment_char_scope,
     }
 }
 
@@ -418,6 +440,16 @@ fn write_user_config_human(out: &mut dyn std::fmt::Write, info: &UserConfigInfo)
         t.config_value
             .paint(info.editor.as_deref().unwrap_or("(built-in)")),
         format_scope(info.editor_scope)
+    )?;
+    writeln!(
+        out,
+        "  {}: {} {}",
+        t.hint.paint("Comment char"),
+        info.comment_char
+            .as_deref()
+            .map(|c| t.config_value.paint(c))
+            .unwrap_or_else(|| t.config_value.paint("# (default)")),
+        format_scope(info.comment_char_scope)
     )?;
     writeln!(out)?;
     Ok(())

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -357,19 +357,17 @@ pub(crate) fn load_app_settings_sync() -> Result<AppSettingsWithDiskSync> {
     AppSettingsWithDiskSync::new_with_customization(config_dir, None)
 }
 
-/// Get the comment character from git config. Defaults to '#' if not set or set to "auto".
-pub(crate) fn get_comment_char(config: &gix::config::Snapshot<'_>) -> char {
+/// Get the comment character(s) from git config. Defaults to "#" if not set or set to "auto".
+pub(crate) fn get_comment_char(config: &gix::config::Snapshot<'_>) -> String {
     if let Some(s) = config.string("core.commentChar") {
         let s_str = s.to_str_lossy();
-        if s_str == "auto" {
-            '#'
-        } else if let Some(c) = s_str.chars().next() {
-            c
+        if s_str == "auto" || s_str.is_empty() {
+            "#".to_string()
         } else {
-            '#'
+            s_str.to_string()
         }
     } else {
-        '#'
+        "#".to_string()
     }
 }
 

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -430,7 +430,7 @@ pub(crate) fn commit(
             let config = repo.config_snapshot();
             crate::command::config::get_comment_char(&config)
         };
-        get_commit_message_from_editor(ctx, &files_to_commit, &changes, show_diff_in_editor, comment_char)?
+        get_commit_message_from_editor(ctx, &files_to_commit, &changes, show_diff_in_editor, &comment_char)?
     };
 
     if commit_message.trim().is_empty() {
@@ -734,7 +734,7 @@ fn get_commit_message_from_editor(
     files_to_commit: &[FileAssignment],
     changes: &[TreeChange],
     show_diff_in_editor: ShowDiffInEditor,
-    comment_char: char,
+    comment_char: &str,
 ) -> anyhow::Result<String> {
     // Generate commit message template
     let mut template = String::new();

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -425,7 +425,12 @@ pub(crate) fn commit(
                 "In JSON mode, a commit message must be provided via --message (-m), --message-file, or --ai (-i)"
             );
         }
-        get_commit_message_from_editor(ctx, &files_to_commit, &changes, show_diff_in_editor)?
+        let comment_char = {
+            let repo = ctx.repo.get()?;
+            let config = repo.config_snapshot();
+            crate::command::config::get_comment_char(&config)
+        };
+        get_commit_message_from_editor(ctx, &files_to_commit, &changes, show_diff_in_editor, comment_char)?
     };
 
     if commit_message.trim().is_empty() {
@@ -729,19 +734,20 @@ fn get_commit_message_from_editor(
     files_to_commit: &[FileAssignment],
     changes: &[TreeChange],
     show_diff_in_editor: ShowDiffInEditor,
+    comment_char: char,
 ) -> anyhow::Result<String> {
     // Generate commit message template
     let mut template = String::new();
-    template.push_str("\n# Please enter the commit message for your changes. Lines starting\n");
-    template.push_str("# with '#' will be ignored, and an empty message aborts the commit.\n");
-    template.push_str("#\n");
-    template.push_str("# Changes to be committed:\n");
+    template.push_str(&format!("\n{comment_char} Please enter the commit message for your changes. Lines starting\n"));
+    template.push_str(&format!("{comment_char} with '{comment_char}' will be ignored, and an empty message aborts the commit.\n"));
+    template.push_str(&format!("{comment_char}\n"));
+    template.push_str(&format!("{comment_char} Changes to be committed:\n"));
 
     for fa in files_to_commit {
         let status_char = get_status_char(&fa.path, changes);
-        template.push_str(&format!("#\t{}  {}\n", status_char, fa.path.to_str_lossy()));
+        template.push_str(&format!("{comment_char}\t{}  {}\n", status_char, fa.path.to_str_lossy()));
     }
-    template.push_str("#\n");
+    template.push_str(&format!("{comment_char}\n"));
 
     // Compute diff for the editor if requested
     let should_show_diff = show_diff_in_editor.should_show_diff(|| {
@@ -767,6 +773,7 @@ fn get_commit_message_from_editor(
         "commit_msg",
         &template,
         diff_text.as_deref(),
+        comment_char,
     )?
     .to_string();
     Ok(lossy_message)

--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -93,8 +93,13 @@ fn edit_branch_name(
         }
 
         if let Some(sid) = stack_entry.id {
+            let comment_char = {
+                let repo = ctx.repo.get()?;
+                let config = repo.config_snapshot();
+                crate::command::config::get_comment_char(&config)
+            };
             let new_name = prepare_provided_message(message, "branch name")
-                .unwrap_or_else(|| get_branch_name_from_editor(branch_name))?;
+                .unwrap_or_else(|| get_branch_name_from_editor(branch_name, comment_char))?;
             but_api::legacy::stack::update_branch_name_with_perm(
                 ctx,
                 sid,
@@ -145,10 +150,17 @@ pub(crate) fn get_commit_message_from_editor(
         })
         .transpose()?;
 
+    let comment_char = {
+        let repo = ctx.repo.get()?;
+        let config = repo.config_snapshot();
+        crate::command::config::get_comment_char(&config)
+    };
+
     let new_message = actually_get_commit_message_from_editor(
         &editor_initial_message,
         &changed_files,
         diff.as_deref(),
+        comment_char,
     )?;
 
     if should_update_commit_message(current_message_for_comparison, &new_message) {
@@ -250,6 +262,7 @@ fn actually_get_commit_message_from_editor(
     current_message: &str,
     changed_files: &[String],
     diff: Option<&[BString]>,
+    comment_char: char,
 ) -> Result<String> {
     // Generate commit message template with current message
     let mut template = String::new();
@@ -257,15 +270,15 @@ fn actually_get_commit_message_from_editor(
     if !current_message.is_empty() && !current_message.ends_with('\n') {
         template.push('\n');
     }
-    template.push_str("\n# Please enter the commit message for your changes. Lines starting\n");
-    template.push_str("# with '#' will be ignored, and an empty message aborts the commit.\n");
-    template.push_str("#\n");
-    template.push_str("# Changes in this commit:\n");
+    template.push_str(&format!("\n{comment_char} Please enter the commit message for your changes. Lines starting\n"));
+    template.push_str(&format!("{comment_char} with '{comment_char}' will be ignored, and an empty message aborts the commit.\n"));
+    template.push_str(&format!("{comment_char}\n"));
+    template.push_str(&format!("{comment_char} Changes in this commit:\n"));
 
     for file in changed_files {
-        template.push_str(&format!("#\t{file}\n"));
+        template.push_str(&format!("{comment_char}\t{file}\n"));
     }
-    template.push_str("#\n");
+    template.push_str(&format!("{comment_char}\n"));
 
     let mut template_rest = String::new();
     if let Some(diff) = diff
@@ -281,6 +294,7 @@ fn actually_get_commit_message_from_editor(
         "commit_msg",
         &template,
         Some(template_rest.as_str()).filter(|s| !s.is_empty()),
+        comment_char,
     )?
     .to_string();
 
@@ -291,18 +305,18 @@ fn actually_get_commit_message_from_editor(
     Ok(lossy_message)
 }
 
-pub(crate) fn get_branch_name_from_editor(current_name: &str) -> Result<String> {
+pub(crate) fn get_branch_name_from_editor(current_name: &str, comment_char: char) -> Result<String> {
     let mut template = String::new();
     template.push_str(current_name);
     if !current_name.is_empty() && !current_name.ends_with('\n') {
         template.push('\n');
     }
-    template.push_str("\n# Please enter the new branch name. Lines starting\n");
-    template.push_str("# with '#' will be ignored, and an empty name aborts the operation.\n");
-    template.push_str("#\n");
+    template.push_str(&format!("\n{comment_char} Please enter the new branch name. Lines starting\n"));
+    template.push_str(&format!("{comment_char} with '{comment_char}' will be ignored, and an empty name aborts the operation.\n"));
+    template.push_str(&format!("{comment_char}\n"));
 
     let branch_name_lossy =
-        tui::get_text::from_editor_no_comments("branch_name", &template)?.to_string();
+        tui::get_text::from_editor_no_comments("branch_name", &template, comment_char)?.to_string();
     let branch_name = branch_name_lossy.trim();
 
     if branch_name.is_empty() {

--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -99,7 +99,7 @@ fn edit_branch_name(
                 crate::command::config::get_comment_char(&config)
             };
             let new_name = prepare_provided_message(message, "branch name")
-                .unwrap_or_else(|| get_branch_name_from_editor(branch_name, comment_char))?;
+                .unwrap_or_else(|| get_branch_name_from_editor(branch_name, &comment_char))?;
             but_api::legacy::stack::update_branch_name_with_perm(
                 ctx,
                 sid,
@@ -160,7 +160,7 @@ pub(crate) fn get_commit_message_from_editor(
         &editor_initial_message,
         &changed_files,
         diff.as_deref(),
-        comment_char,
+        &comment_char,
     )?;
 
     if should_update_commit_message(current_message_for_comparison, &new_message) {
@@ -262,7 +262,7 @@ fn actually_get_commit_message_from_editor(
     current_message: &str,
     changed_files: &[String],
     diff: Option<&[BString]>,
-    comment_char: char,
+    comment_char: &str,
 ) -> Result<String> {
     // Generate commit message template with current message
     let mut template = String::new();
@@ -305,7 +305,7 @@ fn actually_get_commit_message_from_editor(
     Ok(lossy_message)
 }
 
-pub(crate) fn get_branch_name_from_editor(current_name: &str, comment_char: char) -> Result<String> {
+pub(crate) fn get_branch_name_from_editor(current_name: &str, comment_char: &str) -> Result<String> {
     let mut template = String::new();
     template.push_str(current_name);
     if !current_name.is_empty() && !current_name.ends_with('\n') {

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -2333,7 +2333,7 @@ impl App {
                     let config = repo.config_snapshot();
                     crate::command::config::get_comment_char(&config)
                 };
-                let new_name = get_branch_name_from_editor(line, comment_char)?;
+                let new_name = get_branch_name_from_editor(line, &comment_char)?;
                 let normalized_name =
                     operations::reword_branch_legacy(ctx, *stack_id, name.clone(), new_name)?;
                 SelectAfterReload::Branch(normalized_name)

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -2328,7 +2328,12 @@ impl App {
                 }
             }
             InlineRewordMode::Branch { name, stack_id, .. } => {
-                let new_name = get_branch_name_from_editor(line)?;
+                let comment_char = {
+                    let repo = ctx.repo.get()?;
+                    let config = repo.config_snapshot();
+                    crate::command::config::get_comment_char(&config)
+                };
+                let new_name = get_branch_name_from_editor(line, comment_char)?;
                 let normalized_name =
                     operations::reword_branch_legacy(ctx, *stack_id, name.clone(), new_name)?;
                 SelectAfterReload::Branch(normalized_name)

--- a/crates/but/src/tui/get_text.rs
+++ b/crates/but/src/tui/get_text.rs
@@ -13,7 +13,7 @@ const REST_TEXT_MARKER: &str = "# --- ignore-rest ---";
 /// Note that this string must be valid in filenames.
 ///
 /// Returns the edited text (*without known encoding*), with comment lines (starting with `comment_char`) removed.
-pub fn from_editor_no_comments(filename_safe_intent: &str, initial_text: &str, comment_char: char) -> Result<BString> {
+pub fn from_editor_no_comments(filename_safe_intent: &str, initial_text: &str, comment_char: &str) -> Result<BString> {
     let content = from_editor_impl(filename_safe_intent, initial_text, None, ".txt", Some(comment_char))?;
     let filtered_lines = filter_content_from_editor(content.as_bstr(), comment_char);
     Ok(filtered_lines.into_iter().collect())
@@ -30,7 +30,7 @@ pub fn from_editor_no_comments_as_patch(
     filename_safe_intent: &str,
     initial_text: &str,
     diff_text: Option<&str>,
-    comment_char: char,
+    comment_char: &str,
 ) -> Result<BString> {
     let content = from_editor_impl(filename_safe_intent, initial_text, diff_text, ".patch", Some(comment_char))?;
     let filtered_lines = filter_content_from_editor(content.as_bstr(), comment_char);
@@ -38,13 +38,12 @@ pub fn from_editor_no_comments_as_patch(
 }
 
 /// Strip comment lines (starting with `comment_char`) and everything below `REST_TEXT_MARKER`.
-fn filter_content_from_editor(content: &BStr, comment_char: char) -> Vec<&BStr> {
-    let comment_prefix = comment_char.to_string();
+fn filter_content_from_editor<'a>(content: &'a BStr, comment_char: &str) -> Vec<&'a BStr> {
     let rest_marker = format!("{comment_char} --- ignore-rest ---");
     content
         .lines_with_terminator()
         .take_while(|line| !line.trim_start().starts_with_str(&rest_marker))
-        .filter(|line| !line.trim_start().starts_with_str(&comment_prefix))
+        .filter(|line| !line.trim_start().starts_with_str(comment_char))
         .map(|line| line.as_bstr())
         .collect()
 }
@@ -71,7 +70,7 @@ fn from_editor_impl(
     initial_text: &str,
     rest_text: Option<&str>,
     file_suffix: &str,
-    comment_char: Option<char>,
+    comment_char: Option<&str>,
 ) -> Result<BString> {
     const ALLOWED_SUFFIXES: &[&str] = &[".txt", ".md", ".patch"]; // feel free to add more allowed suffixes
     if !ALLOWED_SUFFIXES.contains(&file_suffix) {
@@ -102,7 +101,7 @@ fn from_external_editor(
     initial_text: &str,
     rest_text: Option<&str>,
     file_suffix: &str,
-    comment_char: Option<char>,
+    comment_char: Option<&str>,
 ) -> Result<BString> {
     // Create a temporary file with the initial text
     let mut tempfile = tempfile::Builder::new()
@@ -147,7 +146,7 @@ fn from_builtin_editor(
     filename_safe_intent: &str,
     initial_text: &str,
     rest_text: Option<&str>,
-    comment_char: Option<char>,
+    comment_char: Option<&str>,
 ) -> Result<BString> {
     // Determine editor mode based on the intent
     let mode = if filename_safe_intent.contains("commit") {
@@ -426,7 +425,7 @@ will
 be
 ignored"#
         ));
-        let filtered_content = filter_content_from_editor(raw_content.as_bstr(), '#');
+        let filtered_content = filter_content_from_editor(raw_content.as_bstr(), "#");
 
         assert_eq!(
             filtered_content,
@@ -461,7 +460,42 @@ will
 be
 ignored"#
         ));
-        let filtered_content = filter_content_from_editor(raw_content.as_bstr(), ';');
+        let filtered_content = filter_content_from_editor(raw_content.as_bstr(), ";");
+
+        assert_eq!(
+            filtered_content,
+            Vec::from([
+                "commit message\n",
+                "\n",
+                "here is a longer description about the commit\n",
+                "\n",
+                "1. It does the thing\n",
+                "2. It does the other thing\n",
+                "\n",
+            ])
+        );
+    }
+
+    #[test]
+    fn test_filter_content_from_editor_multichar_comment_string() {
+        let raw_content = BString::from(format!(
+            r#"commit message
+
+here is a longer description about the commit
+
+1. It does the thing
+2. It does the other thing
+
+// this line will be ignored
+// as will this
+// --- ignore-rest ---
+all
+this
+will
+be
+ignored"#
+        ));
+        let filtered_content = filter_content_from_editor(raw_content.as_bstr(), "//");
 
         assert_eq!(
             filtered_content,

--- a/crates/but/src/tui/get_text.rs
+++ b/crates/but/src/tui/get_text.rs
@@ -12,10 +12,10 @@ const REST_TEXT_MARKER: &str = "# --- ignore-rest ---";
 /// identified by a `filename_safe_intent` to help the user understand what's wanted of them.
 /// Note that this string must be valid in filenames.
 ///
-/// Returns the edited text (*without known encoding*), with comment lines (starting with `#`) removed.
-pub fn from_editor_no_comments(filename_safe_intent: &str, initial_text: &str) -> Result<BString> {
-    let content = from_editor(filename_safe_intent, initial_text, None, ".txt")?;
-    let filtered_lines = filter_content_from_editor(content.as_bstr());
+/// Returns the edited text (*without known encoding*), with comment lines (starting with `comment_char`) removed.
+pub fn from_editor_no_comments(filename_safe_intent: &str, initial_text: &str, comment_char: char) -> Result<BString> {
+    let content = from_editor_impl(filename_safe_intent, initial_text, None, ".txt", Some(comment_char))?;
+    let filtered_lines = filter_content_from_editor(content.as_bstr(), comment_char);
     Ok(filtered_lines.into_iter().collect())
 }
 
@@ -25,23 +25,26 @@ pub fn from_editor_no_comments(filename_safe_intent: &str, initial_text: &str) -
 /// If `diff_text` is `Some`, appends it after a `REST_TEXT_MARKER` separator line in the editor.
 /// The marker and everything below it is automatically stripped from the returned text.
 ///
-/// Returns the edited text (*without known encoding*), with comment lines (starting with `#`) removed.
+/// Returns the edited text (*without known encoding*), with comment lines (starting with `comment_char`) removed.
 pub fn from_editor_no_comments_as_patch(
     filename_safe_intent: &str,
     initial_text: &str,
     diff_text: Option<&str>,
+    comment_char: char,
 ) -> Result<BString> {
-    let content = from_editor(filename_safe_intent, initial_text, diff_text, ".patch")?;
-    let filtered_lines = filter_content_from_editor(content.as_bstr());
+    let content = from_editor_impl(filename_safe_intent, initial_text, diff_text, ".patch", Some(comment_char))?;
+    let filtered_lines = filter_content_from_editor(content.as_bstr(), comment_char);
     Ok(filtered_lines.into_iter().collect())
 }
 
-/// Strip comment lines (starting with '#') and everything below `REST_TEXT_MARKER`.
-fn filter_content_from_editor(content: &BStr) -> Vec<&BStr> {
+/// Strip comment lines (starting with `comment_char`) and everything below `REST_TEXT_MARKER`.
+fn filter_content_from_editor(content: &BStr, comment_char: char) -> Vec<&BStr> {
+    let comment_prefix = comment_char.to_string();
+    let rest_marker = format!("{comment_char} --- ignore-rest ---");
     content
         .lines_with_terminator()
-        .take_while(|line| !line.trim_start().starts_with_str(REST_TEXT_MARKER))
-        .filter(|line| !line.trim_start().starts_with_str("#"))
+        .take_while(|line| !line.trim_start().starts_with_str(&rest_marker))
+        .filter(|line| !line.trim_start().starts_with_str(&comment_prefix))
         .map(|line| line.as_bstr())
         .collect()
 }
@@ -60,6 +63,16 @@ pub fn from_editor(
     rest_text: Option<&str>,
     file_suffix: &str,
 ) -> Result<BString> {
+    from_editor_impl(filename_safe_intent, initial_text, rest_text, file_suffix, None)
+}
+
+fn from_editor_impl(
+    filename_safe_intent: &str,
+    initial_text: &str,
+    rest_text: Option<&str>,
+    file_suffix: &str,
+    comment_char: Option<char>,
+) -> Result<BString> {
     const ALLOWED_SUFFIXES: &[&str] = &[".txt", ".md", ".patch"]; // feel free to add more allowed suffixes
     if !ALLOWED_SUFFIXES.contains(&file_suffix) {
         bail!(
@@ -76,8 +89,9 @@ pub fn from_editor(
             initial_text,
             rest_text,
             file_suffix,
+            comment_char,
         ),
-        None => from_builtin_editor(filename_safe_intent, initial_text, rest_text),
+        None => from_builtin_editor(filename_safe_intent, initial_text, rest_text, comment_char),
     }
 }
 
@@ -88,6 +102,7 @@ fn from_external_editor(
     initial_text: &str,
     rest_text: Option<&str>,
     file_suffix: &str,
+    comment_char: Option<char>,
 ) -> Result<BString> {
     // Create a temporary file with the initial text
     let mut tempfile = tempfile::Builder::new()
@@ -101,7 +116,10 @@ fn from_external_editor(
         if !initial_text.ends_with('\n') {
             writeln!(&mut tempfile)?;
         }
-        writeln!(&mut tempfile, "{REST_TEXT_MARKER}")?;
+        let marker = comment_char
+            .map(|c| format!("{c} --- ignore-rest ---"))
+            .unwrap_or_else(|| REST_TEXT_MARKER.to_string());
+        writeln!(&mut tempfile, "{marker}")?;
         writeln!(&mut tempfile, "{rest_text}")?;
     }
 
@@ -129,6 +147,7 @@ fn from_builtin_editor(
     filename_safe_intent: &str,
     initial_text: &str,
     rest_text: Option<&str>,
+    comment_char: Option<char>,
 ) -> Result<BString> {
     // Determine editor mode based on the intent
     let mode = if filename_safe_intent.contains("commit") {
@@ -144,7 +163,10 @@ fn from_builtin_editor(
         if !initial_text.ends_with('\n') {
             initial_text.push('\n');
         }
-        initial_text.push_str(REST_TEXT_MARKER);
+        let marker = comment_char
+            .map(|c| format!("{c} --- ignore-rest ---"))
+            .unwrap_or_else(|| REST_TEXT_MARKER.to_string());
+        initial_text.push_str(&marker);
         initial_text.push('\n');
         initial_text.push_str(rest_text);
         super::editor::run_builtin_editor(filename_safe_intent, &initial_text, mode)?
@@ -404,7 +426,42 @@ will
 be
 ignored"#
         ));
-        let filtered_content = filter_content_from_editor(raw_content.as_bstr());
+        let filtered_content = filter_content_from_editor(raw_content.as_bstr(), '#');
+
+        assert_eq!(
+            filtered_content,
+            Vec::from([
+                "commit message\n",
+                "\n",
+                "here is a longer description about the commit\n",
+                "\n",
+                "1. It does the thing\n",
+                "2. It does the other thing\n",
+                "\n",
+            ])
+        );
+    }
+
+    #[test]
+    fn test_filter_content_from_editor_custom_comment_char() {
+        let raw_content = BString::from(format!(
+            r#"commit message
+
+here is a longer description about the commit
+
+1. It does the thing
+2. It does the other thing
+
+; this line will be ignored
+; as will this
+; --- ignore-rest ---
+all
+this
+will
+be
+ignored"#
+        ));
+        let filtered_content = filter_content_from_editor(raw_content.as_bstr(), ';');
 
         assert_eq!(
             filtered_content,


### PR DESCRIPTION
## 🧢 Changes

Adds full support for Git's `core.commentChar` configuration across the CLI, TUI, and editor workflows, including dynamic comment stripping and custom ignore markers.

## ☕️ Reasoning

Ensures GitButler correctly respects custom commit comment characters (such as `;`) during commit, reword, and branch renaming operations instead of hardcoding `#`.

## 🎫 Affected issues

Fixes: #13845 