### PR TITLE
Fix Gerrit push destination output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,6 +901,7 @@ dependencies = [
  "but-ctx",
  "but-db",
  "but-error",
+ "but-graph",
  "but-hunk-assignment",
  "but-llm",
  "but-meta",
@@ -908,7 +909,6 @@ dependencies = [
  "but-serde",
  "but-workspace",
  "chrono",
- "gitbutler-branch",
  "gitbutler-branch-actions",
  "gitbutler-operating-modes",
  "gitbutler-oplog",
@@ -1179,9 +1179,11 @@ name = "but-feedback"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "but-core",
  "but-ctx",
  "but-graph",
  "chrono",
+ "gix",
  "tempfile",
  "walkdir",
  "zip",

--- a/crates/but-action/Cargo.toml
+++ b/crates/but-action/Cargo.toml
@@ -18,6 +18,7 @@ builtin-but = []
 but-serde.workspace = true
 but-db.workspace = true
 but-core.workspace = true
+but-graph.workspace = true
 but-error.workspace = true
 but-workspace = { workspace = true, features = ["legacy"] }
 but-rebase.workspace = true
@@ -28,9 +29,8 @@ but-meta = { workspace = true, features = ["legacy"] }
 
 gitbutler-operating-modes.workspace = true
 gitbutler-branch-actions.workspace = true
-gitbutler-branch.workspace = true
-gitbutler-oplog.workspace = true
 gitbutler-reference.workspace = true
+gitbutler-oplog.workspace = true
 
 serde.workspace = true
 serde-error = "0.1.3"

--- a/crates/but-action/src/action.rs
+++ b/crates/but-action/src/action.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, str::FromStr};
 
-use but_ctx::Context;
+use but_db::DbHandle;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -146,19 +146,50 @@ impl ButlerAction {
     }
 }
 
-pub(crate) fn persist_action(ctx: &Context, action: ButlerAction) -> anyhow::Result<()> {
-    ctx.db
-        .get_cache_mut()?
-        .butler_actions_mut()
+fn persist_action(db: &mut DbHandle, action: ButlerAction) -> anyhow::Result<()> {
+    db.butler_actions_mut()
         .insert(action.try_into()?)
         .map_err(|e| anyhow::anyhow!("Failed to persist action: {e}"))?;
     Ok(())
 }
 
-pub fn list_actions(ctx: &Context, offset: i64, limit: i64) -> anyhow::Result<ActionListing> {
-    let (total, actions) = ctx
-        .db
-        .get_cache()?
+/// Persist a completed handle-changes action record and return its generated ID.
+///
+/// `db` is the already-open project database handle to write into. `change_summary`,
+/// `external_prompt`, `handler`, and `source` describe the request that produced the action.
+/// `snapshot_before` and `snapshot_after` link the action to the surrounding oplog snapshots.
+/// `response` is stored as either the successful action outcome or the error text.
+#[expect(clippy::too_many_arguments)]
+pub(crate) fn record_handle_changes_action(
+    db: &mut DbHandle,
+    change_summary: &str,
+    external_prompt: Option<String>,
+    handler: crate::ActionHandler,
+    source: Source,
+    snapshot_before: gix::ObjectId,
+    snapshot_after: gix::ObjectId,
+    response: &anyhow::Result<Outcome>,
+) -> anyhow::Result<Uuid> {
+    let action = ButlerAction::new(
+        handler,
+        external_prompt,
+        change_summary.to_owned(),
+        snapshot_before,
+        snapshot_after,
+        response,
+        source,
+    );
+    let id = action.id;
+    persist_action(db, action)?;
+    Ok(id)
+}
+
+/// List persisted Butler actions from `db` using `offset` and `limit` pagination.
+///
+/// Invalid database rows are skipped to preserve the historical best-effort behavior of the
+/// action list endpoint.
+pub fn list_actions(db: &DbHandle, offset: i64, limit: i64) -> anyhow::Result<ActionListing> {
+    let (total, actions) = db
         .butler_actions()
         .list(offset, limit)
         .map_err(|e| anyhow::anyhow!("Failed to list actions: {e}"))?;

--- a/crates/but-action/src/lib.rs
+++ b/crates/but-action/src/lib.rs
@@ -9,8 +9,13 @@ use but_core::{RefMetadata, WORKSPACE_REF_NAME, sync::RepoExclusive};
 use but_ctx::Context;
 use but_meta::virtual_branches_legacy_types::Target;
 use but_workspace::legacy::ui::StackEntry;
-use gitbutler_branch::BranchCreateRequest;
+use gitbutler_operating_modes::OperatingMode;
+use gitbutler_oplog::{
+    OplogExt,
+    entry::{OperationKind, SnapshotDetails},
+};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 mod action;
 pub mod cli;
@@ -23,25 +28,116 @@ mod workflow;
 pub use action::{ActionListing, Source, list_actions};
 use but_core::ref_metadata::StackId;
 use strum::EnumString;
-use uuid::Uuid;
 pub use workflow::{WorkflowList, list_workflows};
 
-pub fn handle_changes(
+/// React to detected worktree changes by creating commits on the appropriate workspace stacks.
+///
+/// This is the action-side callback for watcher or external tool flows that have noticed
+/// uncommitted changes and want GitButler to absorb them. It first prepares the repository state,
+/// then collects hunk assignments, creates a stack if none exists, groups changes by target stack,
+/// and creates commits with the requested message.
+///
+/// `ctx` provides the repository, workspace, database, metadata, settings, default-target setup,
+/// and operating-mode state. `change_summary` is the generated or user-provided summary used in the
+/// commit message. `external_prompt` is optional additional prompt text to prepend to the commit
+/// message. `handler` selects the concrete handle-changes implementation. `exclusive_stack` limits
+/// commits to one stack when set. `perm` is the caller-held exclusive worktree permission used for
+/// every repository and workspace access in this function.
+pub fn on_uncommitted_changes(
+    ctx: &mut Context,
+    change_summary: &str,
+    external_prompt: Option<String>,
+    handler: ActionHandler,
+    exclusive_stack: Option<StackId>,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<Outcome> {
+    prepare_handle_changes(ctx, perm)?;
+    let context_lines = ctx.settings.context_lines;
+    let mut meta = ctx.meta()?;
+    let (repo, mut ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
+    match handler {
+        ActionHandler::HandleChangesSimple => simple::handle_changes(
+            change_summary,
+            external_prompt,
+            exclusive_stack,
+            perm,
+            &repo,
+            &mut ws,
+            &mut db,
+            &mut meta,
+            context_lines,
+        ),
+    }
+}
+
+/// Record and run an uncommitted-changes reaction while reusing the caller's worktree permission.
+///
+/// `ctx` provides the repository, workspace, database, metadata, settings, snapshots, and
+/// operating-mode state. `change_summary` is the generated or user-provided summary used in the
+/// commit message and action record. `external_prompt` is optional additional prompt text to
+/// prepend to the commit message and persist with the action. `handler` selects the concrete
+/// handle-changes implementation. `source` records where the action originated. `exclusive_stack`
+/// limits commits to one stack when set. `perm` is the caller-held exclusive worktree permission
+/// used for snapshots, repository access, workspace access, and rule preparation.
+pub fn record_uncommitted_changes_with_perm(
     ctx: &mut Context,
     change_summary: &str,
     external_prompt: Option<String>,
     handler: ActionHandler,
     source: Source,
     exclusive_stack: Option<StackId>,
+    perm: &mut RepoExclusive,
 ) -> anyhow::Result<(Uuid, Outcome)> {
-    match handler {
-        ActionHandler::HandleChangesSimple => simple::handle_changes(
-            ctx,
+    let snapshot_before = ctx.create_snapshot(
+        SnapshotDetails::new(OperationKind::AutoHandleChangesBefore),
+        perm,
+    )?;
+    let response = on_uncommitted_changes(
+        ctx,
+        change_summary,
+        external_prompt.clone(),
+        handler,
+        exclusive_stack,
+        perm,
+    );
+    let snapshot_after = ctx.create_snapshot(
+        SnapshotDetails::new(OperationKind::AutoHandleChangesAfter),
+        perm,
+    )?;
+    let id = {
+        let mut db = ctx.db.get_cache_mut()?;
+        action::record_handle_changes_action(
+            &mut db,
             change_summary,
             external_prompt,
+            handler,
             source,
-            exclusive_stack,
-        ),
+            snapshot_before,
+            snapshot_after,
+            &response,
+        )?
+    };
+    response.map(|outcome| (id, outcome))
+}
+
+/// Prepare repository state for handle-changes.
+///
+/// This preserves the legacy preconditions from the old context-owning action flow:
+/// ensure a default target exists, reject edit mode, and switch back to the workspace
+/// branch when the repository is currently outside the workspace. Callers must hold
+/// exclusive worktree access and pass its permission through so no nested guard is
+/// acquired here.
+fn prepare_handle_changes(ctx: &mut Context, perm: &mut RepoExclusive) -> anyhow::Result<()> {
+    default_target_setting_if_none(ctx)?;
+    match gitbutler_operating_modes::operating_mode(ctx, perm.read_permission())? {
+        OperatingMode::OpenWorkspace => Ok(()),
+        OperatingMode::Edit(_) => Err(anyhow::anyhow!(
+            "Cannot handle changes while in edit mode. Please exit edit mode first."
+        )),
+        OperatingMode::OutsideWorkspace(_) => {
+            let default_target = ctx.persisted_default_target()?;
+            gitbutler_branch_actions::set_base_branch(ctx, &default_target.branch, perm).map(|_| ())
+        }
     }
 }
 
@@ -95,27 +191,6 @@ fn stacks(ctx: &Context, repo: &gix::Repository) -> anyhow::Result<Vec<StackEntr
         but_workspace::legacy::StacksFilter::InWorkspace,
         None,
     )
-}
-
-/// Returns the currently applied stacks, creating one if none exists.
-fn stacks_creating_if_none(
-    ctx: &Context,
-    perm: &mut RepoExclusive,
-) -> anyhow::Result<Vec<StackEntry>> {
-    let repo = &*ctx.repo.get()?;
-    let stacks = stacks(ctx, repo)?;
-    if stacks.is_empty() {
-        let template = but_core::branch::canned_refname(repo)?;
-        let branch_name = but_core::branch::find_unique_refname(repo, template.as_ref())?;
-        let create_req = BranchCreateRequest {
-            name: Some(branch_name.shorten().to_string()),
-            order: None,
-        };
-        let stack = gitbutler_branch_actions::create_virtual_branch(ctx, &create_req, perm)?;
-        Ok(vec![stack.into()])
-    } else {
-        Ok(stacks)
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, EnumString, Default)]

--- a/crates/but-action/src/reword.rs
+++ b/crates/but-action/src/reword.rs
@@ -1,8 +1,8 @@
 use anyhow::bail;
 use bstr::ByteSlice as _;
-use but_ctx::{Context, ThreadSafeContext};
+use but_core::RefMetadata;
+use but_ctx::ThreadSafeContext;
 use but_rebase::graph_rebase::{Editor, LookupStep as _};
-use but_workspace::legacy::{StacksFilter, ui::StackEntry};
 use uuid::Uuid;
 
 use crate::workflow::{self, Workflow};
@@ -17,24 +17,24 @@ pub struct CommitEvent {
     pub trigger: Uuid,
 }
 
+/// Generate and apply an AI commit-message reword for `event.commit_id`.
+///
+/// `llm` produces the replacement message from the event summaries and the commit diff.
+/// `event` carries the commit, stack branch name, workflow trigger, and thread-safe context used
+/// only for workflow persistence after the reword attempt. `repo`, `ws`, and `meta` are supplied by
+/// the caller so this action does not acquire repository guards or rebuild workspace state itself.
+/// `context_lines` controls the amount of diff context shown to the message generator.
 pub fn commit(
     llm: &but_llm::LLMProvider,
     event: CommitEvent,
+    repo: &gix::Repository,
+    ws: &mut but_graph::Workspace,
+    meta: &mut impl RefMetadata,
+    context_lines: u32,
 ) -> anyhow::Result<Option<(gix::ObjectId, String)>> {
-    let (diff, sync_ctx) = {
-        let ctx = event.ctx.into_thread_local();
-        let repo = &ctx.clone_repo_for_merging_non_persisting()?;
-        let changes = but_core::diff::ui::commit_changes_with_line_stats_by_worktree_dir(
-            repo,
-            event.commit_id,
-        )?;
-        (
-            changes
-                .try_to_unidiff(repo, ctx.settings.context_lines)?
-                .to_string(),
-            ctx.into_sync(),
-        )
-    };
+    let changes =
+        but_core::diff::ui::commit_changes_with_line_stats_by_worktree_dir(repo, event.commit_id)?;
+    let diff = changes.try_to_unidiff(repo, context_lines)?.to_string();
     let message = crate::generate::commit_message(
         llm,
         &event.external_summary,
@@ -45,22 +45,22 @@ pub fn commit(
     // Format the commit message to follow email RFC format (80 char line wrapping)
     let message = crate::commit_format::format_commit_message(&message);
 
-    let mut ctx = sync_ctx.into_thread_local();
-    let stacks = stacks(&ctx)?;
-    let stack_id = stacks
+    let stack_id = ws
+        .stacks
         .iter()
-        .find(|s| s.heads.iter().any(|h| h.name == event.branch_name))
-        .and_then(|s| s.id)
+        .find(|stack| {
+            stack
+                .ref_name()
+                .is_some_and(|name| name.shorten() == event.branch_name)
+        })
+        .and_then(|stack| stack.id)
         .ok_or_else(|| anyhow::anyhow!("Stack with name '{}' not found", event.branch_name))?;
     let result = (|| -> anyhow::Result<gix::ObjectId> {
         if message.is_empty() {
             bail!("commit message can not be empty");
         }
 
-        let mut guard = ctx.exclusive_worktree_access();
-        let mut meta = ctx.meta()?;
-        let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(guard.write_permission())?;
-        let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+        let editor = Editor::create(ws, meta, repo)?;
         let (rebase, edited_commit_selector) =
             but_workspace::commit::reword(editor, event.commit_id, message.as_bytes().as_bstr())?;
         let new_commit_id = rebase.lookup_pick(edited_commit_selector)?;
@@ -92,15 +92,8 @@ pub fn commit(
         output_commits,
         None,
     )
-    .persist(&ctx)
+    .persist(&event.ctx.into_thread_local())
     .ok();
 
     Ok(new_commit_id.map(|id| (id, message)))
-}
-
-#[expect(deprecated, reason = "calls but_workspace::legacy::stacks_v3")]
-fn stacks(ctx: &Context) -> anyhow::Result<Vec<StackEntry>> {
-    let repo = ctx.clone_repo_for_merging_non_persisting()?;
-    let meta = ctx.legacy_meta()?;
-    but_workspace::legacy::stacks_v3(&repo, &meta, StacksFilter::default(), None)
 }

--- a/crates/but-action/src/simple.rs
+++ b/crates/but-action/src/simple.rs
@@ -1,103 +1,53 @@
 use std::collections::HashMap;
 
-use anyhow::anyhow;
-use but_core::{DiffSpec, ref_metadata::StackId};
-use but_ctx::{Context, access::RepoExclusive};
+use anyhow::{Context as _, anyhow};
+use but_core::{DiffSpec, RefMetadata, ref_metadata::StackId, sync::RepoExclusive};
+use but_db::DbHandle;
 use but_rebase::graph_rebase::{
     Editor, LookupStep as _,
     mutate::{InsertSide, RelativeToRef},
 };
-use gitbutler_operating_modes::OperatingMode;
-use gitbutler_oplog::{
-    OplogExt,
-    entry::{OperationKind, SnapshotDetails},
-};
-use uuid::Uuid;
 
-use crate::{Outcome, Source, default_target_setting_if_none};
+use crate::Outcome;
 
-/// This is a GitButler automation which allows easy handling of uncommitted changes in a repository.
-/// At a high level, it will:
-///   - Checkout GitButler's workspace branch if not already checked out
-///   - Create a new branch if necessary (using a generic canned branch name)
-///   - Create a new commit with all uncommitted changes found in the worktree (the request context is used as the commit message)
-///
-/// Avery time this automation is ran, GitButler will also:
-///   - Create an oplog snaposhot entry _before_ the automation is executed
-///   - Create an oplog snapshot entry _after_ the automation is executed
-///   - Create a separate persisted entry recording the request context and IDs for the two oplog snapshots
-pub(crate) fn handle_changes(
-    ctx: &mut Context,
-    change_summary: &str,
-    external_prompt: Option<String>,
-    source: Source,
-    exclusive_stack: Option<StackId>,
-) -> anyhow::Result<(Uuid, Outcome)> {
-    let mut guard = ctx.exclusive_worktree_access();
-    let perm = guard.write_permission();
-
-    default_target_setting_if_none(ctx)?; // Create a default target if none exists.
-
-    let snapshot_before = ctx.create_snapshot(
-        SnapshotDetails::new(OperationKind::AutoHandleChangesBefore),
-        perm,
-    )?;
-
-    let response = handle_changes_simple_inner(
-        ctx,
-        change_summary,
-        external_prompt.clone(),
-        perm,
-        exclusive_stack,
-    );
-
-    let snapshot_after = ctx.create_snapshot(
-        SnapshotDetails::new(OperationKind::AutoHandleChangesAfter),
-        perm,
-    )?;
-
-    let action = crate::action::ButlerAction::new(
-        crate::ActionHandler::HandleChangesSimple,
-        external_prompt,
-        change_summary.to_owned(),
-        snapshot_before,
-        snapshot_after,
-        &response,
-        source,
-    );
-    let response = response.map(|outcome| (action.id, outcome));
-    crate::action::persist_action(ctx, action)?;
-    response
+struct StackForAction {
+    id: StackId,
+    branch_name: String,
 }
 
-fn handle_changes_simple_inner(
-    ctx: &mut Context,
+/// Create commits for currently uncommitted changes and report the updated stacks.
+///
+/// The simple handler:
+/// - loads hunk assignments for the current worktree changes;
+/// - returns without changes if there is nothing to commit;
+/// - creates a new workspace stack when no stack exists yet;
+/// - groups assigned changes by their target stack and unassigned changes by the default stack;
+/// - skips unassigned changes when `exclusive_stack` is set;
+/// - creates one commit per stack with pending changes via flattened diff-specs;
+/// - materializes successful rebases and reports the branches that received new commits.
+///
+/// `change_summary` forms the commit message, optionally prefixed by `external_prompt`.
+/// `exclusive_stack` limits commits to one stack and leaves unassigned changes untouched when set.
+/// `perm` proves that the caller holds exclusive worktree access for the commit and reference
+/// mutations. `repo`, `ws`, `db`, and `meta` are supplied by the caller, so this function does not
+/// acquire repository guards. `context_lines` controls hunk assignment fallback and commit creation
+/// context.
+#[expect(clippy::too_many_arguments)]
+pub(crate) fn handle_changes(
     change_summary: &str,
     external_prompt: Option<String>,
-    perm: &mut RepoExclusive,
     exclusive_stack: Option<StackId>,
+    perm: &mut RepoExclusive,
+    repo: &gix::Repository,
+    ws: &mut but_graph::Workspace,
+    db: &mut DbHandle,
+    meta: &mut impl RefMetadata,
+    context_lines: u32,
 ) -> anyhow::Result<Outcome> {
-    match gitbutler_operating_modes::operating_mode(ctx, perm.read_permission())? {
-        OperatingMode::OpenWorkspace => {
-            // No action needed, we're already in the workspace
-        }
-        OperatingMode::Edit(_) => {
-            return Err(anyhow::anyhow!(
-                "Cannot handle changes while in edit mode. Please exit edit mode first."
-            ));
-        }
-        OperatingMode::OutsideWorkspace(_) => {
-            let default_target = ctx.persisted_default_target()?;
-            gitbutler_branch_actions::set_base_branch(ctx, &default_target.branch, perm)?;
-        }
-    }
-
-    let context_lines = ctx.settings.context_lines;
-    let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(perm.read_permission())?;
     let (assignments, _) = but_hunk_assignment::assignments_with_fallback(
         db.hunk_assignments_mut()?,
-        &repo,
-        &ws,
+        repo,
+        ws,
         None::<Vec<but_core::TreeChange>>,
         context_lines,
     )
@@ -109,17 +59,14 @@ fn handle_changes_simple_inner(
     }
 
     // Get the current stacks in the workspace, creating one if none exists.
-    drop((repo, ws, db));
-    let stacks = crate::stacks_creating_if_none(ctx, perm)?;
+    let stacks = stacks_creating_if_none(repo, ws, meta, perm)?;
 
     // Put the assignments into buckets by stack ID.
-    let mut stack_assignments: HashMap<StackId, Vec<DiffSpec>> = stacks
-        .iter()
-        .filter_map(|s| Some((s.id?, vec![])))
-        .collect();
+    let mut stack_assignments: HashMap<StackId, Vec<DiffSpec>> =
+        stacks.iter().map(|s| (s.id, vec![])).collect();
     let default_stack_id = stacks
         .first()
-        .and_then(|s| s.id)
+        .map(|s| s.id)
         .ok_or_else(|| anyhow::anyhow!("No stacks found in the workspace"))?;
     for assignment in assignments {
         if let Some(stack_id) = assignment.stack_id {
@@ -161,22 +108,20 @@ fn handle_changes_simple_inner(
 
         let stack_branch_name = stacks
             .iter()
-            .find(|s| s.id == Some(stack_id))
-            .and_then(|s| s.heads.first().map(|h| h.name.to_string()))
+            .find(|s| s.id == stack_id)
+            .map(|s| s.branch_name.clone())
             .ok_or(anyhow!("Could not find associated reference name"))?;
         let full_ref_name: gix::refs::FullName =
             format!("refs/heads/{stack_branch_name}").try_into()?;
 
-        let mut meta = ctx.meta()?;
-        let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
-        let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+        let editor = Editor::create(ws, meta, repo)?;
         let outcome = but_workspace::commit::commit_create(
             editor,
             diff_specs,
             RelativeToRef::Reference(full_ref_name.as_ref()),
             InsertSide::Below,
             &commit_message,
-            ctx.settings.context_lines,
+            context_lines,
         )?;
 
         if !outcome.rejected_specs.is_empty() {
@@ -201,4 +146,61 @@ fn handle_changes_simple_inner(
     }
 
     Ok(Outcome { updated_branches })
+}
+
+/// Return the applied stacks that can receive action commits, creating one if none exists.
+///
+/// `repo` is used to generate the canned branch name and create the underlying reference. `ws` is
+/// updated when the first stack has to be created. `meta` records the stack metadata written by the
+/// reference creation operation. `_perm` proves that the caller holds exclusive worktree access for
+/// the reference creation path.
+fn stacks_creating_if_none(
+    repo: &gix::Repository,
+    ws: &mut but_graph::Workspace,
+    meta: &mut impl RefMetadata,
+    _perm: &mut RepoExclusive,
+) -> anyhow::Result<Vec<StackForAction>> {
+    let stacks = stack_info(ws);
+    if !stacks.is_empty() {
+        return Ok(stacks);
+    }
+
+    let branch_name = but_core::branch::unique_canned_refname(repo)?;
+    let new_ws = but_workspace::branch::create_reference(
+        branch_name.as_ref(),
+        None,
+        repo,
+        ws,
+        meta,
+        |_| StackId::generate(),
+        None,
+    )?;
+    *ws = new_ws.into_owned();
+    let stack = ws
+        .stacks
+        .iter()
+        .find(|stack| stack.ref_name() == Some(branch_name.as_ref()))
+        .context("BUG: need to find stack that was just created")?;
+    let id = stack
+        .id
+        .context("BUG: newly created stacks always have an ID")?;
+    Ok(vec![StackForAction {
+        id,
+        branch_name: branch_name.shorten().to_string(),
+    }])
+}
+
+/// Extract stack IDs and shortened branch names from `ws` for action commit targeting.
+///
+/// Stacks without an ID or reference name are skipped because the action needs both values to map
+/// assignments to a branch and report the resulting update.
+fn stack_info(ws: &but_graph::Workspace) -> Vec<StackForAction> {
+    ws.stacks
+        .iter()
+        .filter_map(|stack| {
+            let id = stack.id?;
+            let branch_name = stack.ref_name()?.shorten().to_string();
+            Some(StackForAction { id, branch_name })
+        })
+        .collect()
 }

--- a/crates/but-api/src/diff.rs
+++ b/crates/but-api/src/diff.rs
@@ -1,5 +1,8 @@
 use but_api_macros::but_api;
-use but_core::{sync::RepoExclusive, ui::TreeChange};
+use but_core::{
+    sync::{RepoExclusive, RepoShared},
+    ui::TreeChange,
+};
 use but_ctx::Context;
 use but_hunk_assignment::{HunkAssignmentRequest, WorktreeChanges};
 use but_hunk_dependency::ui::hunk_dependencies_for_workspace_changes_by_worktree_dir;
@@ -103,9 +106,9 @@ pub fn tree_change_diffs(
 /// See [`changes_in_worktree_with_perm()`].
 #[but_api(napi)]
 #[instrument(err(Debug))]
-pub fn changes_in_worktree(ctx: &mut Context) -> anyhow::Result<WorktreeChanges> {
-    let mut guard = ctx.exclusive_worktree_access();
-    changes_in_worktree_with_perm(ctx, guard.write_permission())
+pub fn changes_in_worktree(ctx: &Context) -> anyhow::Result<WorktreeChanges> {
+    let guard = ctx.shared_worktree_access();
+    changes_in_worktree_with_perm(ctx, guard.read_permission())
 }
 
 /// This UI-version of [`but_core::diff::worktree_changes()`] simplifies the `git status` information for display in
@@ -125,12 +128,12 @@ pub fn changes_in_worktree(ctx: &mut Context) -> anyhow::Result<WorktreeChanges>
 #[but_api(napi)]
 #[instrument(skip_all, err(Debug))]
 pub fn changes_in_worktree_with_perm(
-    ctx: &mut Context,
-    perm: &mut RepoExclusive,
+    ctx: &Context,
+    perm: &RepoShared,
 ) -> anyhow::Result<WorktreeChanges> {
     let context_lines = ctx.settings.context_lines;
 
-    let (repo, ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
+    let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(perm)?;
 
     let changes = but_core::diff::worktree_changes(&repo)?;
 
@@ -153,8 +156,6 @@ pub fn changes_in_worktree_with_perm(
 
     trans.commit()?;
     drop((repo, ws, db));
-    #[cfg(feature = "legacy")]
-    but_rules::handler::process_workspace_rules(ctx, &assignments, perm).ok();
 
     Ok(WorktreeChanges {
         worktree_changes: changes.into(),

--- a/crates/but-api/src/legacy/absorb.rs
+++ b/crates/but-api/src/legacy/absorb.rs
@@ -123,7 +123,8 @@ pub fn absorption_plan_with_perm(
             // Get all worktree changes, assignments, and dependencies
             // TODO: Ideally, there's a simpler way of getting the worktree changes without passing the context to it.
             // At this time, the context is passed pretty deep into the function.
-            let worktree_changes = crate::diff::changes_in_worktree_with_perm(ctx, perm)?;
+            let worktree_changes =
+                crate::diff::changes_in_worktree_with_perm(ctx, perm.read_permission())?;
             let all_assignments = worktree_changes.assignments;
             let dependencies = worktree_changes.dependencies;
 
@@ -160,7 +161,8 @@ pub fn absorption_plan_with_perm(
             assigned_stack_id,
         } => {
             // Get all worktree changes, assignments, and dependencies
-            let worktree_changes = crate::diff::changes_in_worktree_with_perm(ctx, perm)?;
+            let worktree_changes =
+                crate::diff::changes_in_worktree_with_perm(ctx, perm.read_permission())?;
             let all_assignments = worktree_changes.assignments;
             let dependencies = worktree_changes.dependencies;
 
@@ -193,7 +195,8 @@ pub fn absorption_plan_with_perm(
             // Get all worktree changes, assignments, and dependencies
             // TODO: Ideally, there's a simpler way of getting the worktree changes without passing the context to it.
             // At this time, the context is passed pretty deep into the function.
-            let worktree_changes = crate::diff::changes_in_worktree_with_perm(ctx, perm)?;
+            let worktree_changes =
+                crate::diff::changes_in_worktree_with_perm(ctx, perm.read_permission())?;
             (worktree_changes.assignments, worktree_changes.dependencies)
         }
     };
@@ -229,7 +232,7 @@ fn group_changes_by_target_commit(
             .as_ref()
             .map(|idx| locks_for_assignment(idx, assignment))
             .filter(|l| !l.is_empty());
-        let (stack_id, commit_id, reason) = determine_target_commit(
+        let (stack_id, commit_id, reason) = ensure_target_commit(
             ctx,
             assignment,
             locks.as_deref(),
@@ -370,7 +373,8 @@ fn find_target_branch<'a>(
 }
 
 /// Determine the target commit for an assignment based on dependencies and assignments
-fn determine_target_commit(
+/// Create a blank one if needed.
+fn ensure_target_commit(
     ctx: &mut Context,
     assignment: &HunkAssignment,
     locks: Option<&[HunkLock]>,

--- a/crates/but-api/src/legacy/cherry_apply.rs
+++ b/crates/but-api/src/legacy/cherry_apply.rs
@@ -12,7 +12,7 @@ use tracing::instrument;
 #[but_api]
 #[instrument(err(Debug))]
 pub fn cherry_apply_status(
-    ctx: &mut but_ctx::Context,
+    ctx: &but_ctx::Context,
     subject: gix::ObjectId,
 ) -> Result<CherryApplyStatus> {
     let guard = ctx.shared_worktree_access();
@@ -25,7 +25,7 @@ pub fn cherry_apply_status(
 /// This reports whether `subject` can be applied in the current workspace state using
 /// [`but_cherry_apply::cherry_apply_status()`].
 pub fn cherry_apply_status_with_perm(
-    ctx: &mut but_ctx::Context,
+    ctx: &but_ctx::Context,
     subject: gix::ObjectId,
     perm: &but_core::sync::RepoShared,
 ) -> Result<CherryApplyStatus> {

--- a/crates/but-api/src/legacy/modes.rs
+++ b/crates/but-api/src/legacy/modes.rs
@@ -63,13 +63,24 @@ pub fn enter_edit_mode(
     commit_id: gix::ObjectId,
     stack_id: StackId,
 ) -> Result<EditModeMetadata> {
-    gitbutler_edit_mode::commands::enter_edit_mode(ctx, commit_id, stack_id)
+    let mut guard = ctx.exclusive_worktree_access();
+    gitbutler_edit_mode::commands::enter_edit_mode(
+        ctx,
+        commit_id,
+        stack_id,
+        guard.write_permission(),
+    )
 }
 
 #[but_api]
 #[instrument(err(Debug))]
 pub fn abort_edit_and_return_to_workspace(ctx: &mut but_ctx::Context, force: bool) -> Result<()> {
-    gitbutler_edit_mode::commands::abort_and_return_to_workspace(ctx, force)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    gitbutler_edit_mode::commands::abort_and_return_to_workspace(
+        ctx,
+        force,
+        guard.write_permission(),
+    )?;
 
     Ok(())
 }
@@ -78,7 +89,8 @@ pub fn abort_edit_and_return_to_workspace(ctx: &mut but_ctx::Context, force: boo
 #[but_api]
 #[instrument(err(Debug))]
 pub fn save_edit_and_return_to_workspace(ctx: &mut but_ctx::Context) -> Result<()> {
-    gitbutler_edit_mode::commands::save_and_return_to_workspace(ctx)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    gitbutler_edit_mode::commands::save_and_return_to_workspace(ctx, guard.write_permission())?;
 
     Ok(())
 }
@@ -86,20 +98,23 @@ pub fn save_edit_and_return_to_workspace(ctx: &mut but_ctx::Context) -> Result<(
 #[but_api]
 #[instrument(err(Debug))]
 pub fn save_edit_and_return_to_workspace_with_output(ctx: &mut but_ctx::Context) -> Result<()> {
-    gitbutler_edit_mode::commands::save_and_return_to_workspace(ctx)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    gitbutler_edit_mode::commands::save_and_return_to_workspace(ctx, guard.write_permission())?;
     Ok(())
 }
 
 #[but_api]
 #[instrument(err(Debug))]
 pub fn edit_initial_index_state(
-    ctx: &mut but_ctx::Context,
+    ctx: &but_ctx::Context,
 ) -> Result<Vec<(TreeChange, Option<ConflictEntryPresence>)>> {
-    gitbutler_edit_mode::commands::starting_index_state(ctx)
+    let guard = ctx.shared_worktree_access();
+    gitbutler_edit_mode::commands::starting_index_state(ctx, guard.read_permission())
 }
 
 #[but_api]
 #[instrument(err(Debug))]
-pub fn edit_changes_from_initial(ctx: &mut but_ctx::Context) -> Result<Vec<TreeChange>> {
-    gitbutler_edit_mode::commands::changes_from_initial(ctx)
+pub fn edit_changes_from_initial(ctx: &but_ctx::Context) -> Result<Vec<TreeChange>> {
+    let guard = ctx.shared_worktree_access();
+    gitbutler_edit_mode::commands::changes_from_initial(ctx, guard.read_permission())
 }

--- a/crates/but-api/src/legacy/rules.rs
+++ b/crates/but-api/src/legacy/rules.rs
@@ -24,7 +24,8 @@ pub fn create_workspace_rule(
 #[but_api]
 #[instrument(err(Debug))]
 pub fn delete_workspace_rule(ctx: &Context, rule_id: String) -> Result<()> {
-    delete_rule(ctx, &rule_id)
+    let mut db = ctx.db.get_cache_mut()?;
+    delete_rule(&mut db, &rule_id)
 }
 
 #[but_api]
@@ -49,7 +50,8 @@ pub fn list_workspace_rules(ctx: &Context) -> Result<Vec<WorkspaceRule>> {
     .collect::<Vec<StackId>>();
 
     // Filter out specifically Codegen related rules that are refering to a stack that is not in the workspace.
-    let rules = list_rules(ctx)?
+    let db = ctx.db.get_cache()?;
+    let rules = list_rules(&db)?
         .into_iter()
         .filter(|rule| {
             if let (Some(_), Some(stack_id)) = (

--- a/crates/but-api/src/legacy/stack.rs
+++ b/crates/but-api/src/legacy/stack.rs
@@ -2,7 +2,11 @@ use std::borrow::Cow;
 
 use anyhow::{Context as _, Result, anyhow};
 use but_api_macros::but_api;
-use but_core::{DryRun, branch, ref_metadata::StackId, sync::RepoExclusive};
+use but_core::{
+    DryRun, branch,
+    ref_metadata::StackId,
+    sync::{RepoExclusive, RepoShared},
+};
 use but_ctx::Context;
 use but_oplog::legacy::{OperationKind, SnapshotDetails, Trailer};
 use gitbutler_branch_actions::stack::CreateSeriesRequest;
@@ -382,6 +386,29 @@ pub fn push_stack(
         branch,
         run_hooks,
         push_opts,
+    )
+}
+
+#[expect(clippy::too_many_arguments)]
+pub fn push_stack_with_perm(
+    ctx: &mut Context,
+    stack_id: StackId,
+    with_force: bool,
+    skip_force_push_protection: bool,
+    branch: String,
+    run_hooks: bool,
+    push_opts: Vec<but_gerrit::PushFlag>,
+    perm: &RepoShared,
+) -> Result<PushResult> {
+    gitbutler_branch_actions::stack::push_stack_with_perm(
+        ctx,
+        stack_id,
+        with_force,
+        skip_force_push_protection,
+        branch,
+        run_hooks,
+        push_opts,
+        perm,
     )
 }
 

--- a/crates/but-api/src/legacy/worktree.rs
+++ b/crates/but-api/src/legacy/worktree.rs
@@ -14,7 +14,7 @@ pub fn worktree_new(
     ctx: &mut but_ctx::Context,
     reference: gix::refs::FullName,
 ) -> Result<NewWorktreeOutcome> {
-    let guard = ctx.exclusive_worktree_access();
+    let guard = ctx.shared_worktree_access();
 
     but_worktrees::new::worktree_new(ctx, guard.read_permission(), reference.as_ref())
 }
@@ -22,7 +22,7 @@ pub fn worktree_new(
 #[but_api]
 #[instrument(err(Debug))]
 pub fn worktree_list(ctx: &mut but_ctx::Context) -> Result<ListWorktreeOutcome> {
-    let guard = ctx.exclusive_worktree_access();
+    let guard = ctx.shared_worktree_access();
 
     but_worktrees::list::worktree_list(ctx, guard.read_permission())
 }

--- a/crates/but-core/src/sync.rs
+++ b/crates/but-core/src/sync.rs
@@ -91,11 +91,12 @@ pub fn exclusive_repo_access(
     git_dir: impl Into<PathBuf>,
     project_data_dir: Option<&Path>,
 ) -> RepoExclusiveGuard {
+    let git_dir = git_dir.into();
     let lock = {
-        let git_dir = git_dir.into();
         let mut map = WORKTREE_LOCKS.lock();
-        Arc::clone(map.entry(git_dir).or_default())
+        Arc::clone(map.entry(git_dir.clone()).or_default())
     };
+    panic_if_locked_in_debug(&lock, &git_dir, "exclusive");
     // The global `WORKTREE_LOCKS` mutex is released before blocking on the per-repo RwLock,
     // so contention on one repo cannot block access to unrelated repos.
     let in_process_lock = lock.write_arc();
@@ -119,14 +120,48 @@ pub fn exclusive_repo_access(
 /// alive in the caller that owns the lock, and pass [`RepoShared`] further down instead via
 /// [`RepoSharedGuard::read_permission()`].
 pub fn shared_repo_access(git_dir: impl Into<PathBuf>) -> RepoSharedGuard {
+    let git_dir = git_dir.into();
     let lock = {
         let mut map = WORKTREE_LOCKS.lock();
-        let git_dir = git_dir.into();
-        Arc::clone(map.entry(git_dir).or_default())
+        Arc::clone(map.entry(git_dir.clone()).or_default())
     };
+    panic_if_locked_in_debug(&lock, &git_dir, "shared");
     // The global `WORKTREE_LOCKS` mutex is released before blocking on the per-repo RwLock,
     // so contention on one repo cannot block access to unrelated repos.
     RepoSharedGuard(Some(lock.read_arc()))
+}
+
+/// Turn lock re-entry deadlocks into immediate panics while debugging.
+///
+/// This helper is active only in debug builds and only when `BUT_WS_LOCK_DEBUG` is present in the
+/// environment. In all other cases it is a no-op and normal lock acquisition keeps its blocking
+/// semantics.
+///
+/// The probe uses `try_write_arc()` for *both* shared and exclusive acquisition attempts. That is
+/// intentional: the goal is not to check whether this particular `mode` could proceed, but whether
+/// any repository lock is already held in this process for `git_dir`. This catches nested shared
+/// acquisitions too, as they are often harmless by themselves but still indicate code that would
+/// deadlock once the outer operation changes to hold an exclusive lock, or once a nested exclusive
+/// acquisition appears later in the same call path.
+fn panic_if_locked_in_debug(lock: &Arc<parking_lot::RwLock<()>>, git_dir: &Path, mode: &str) {
+    #[cfg(debug_assertions)]
+    {
+        if std::env::var_os("BUT_WS_LOCK_DEBUG").is_none() {
+            return;
+        }
+
+        if lock.try_write_arc().is_none() {
+            panic!(
+                "BUT_WS_LOCK_DEBUG: refusing to acquire {mode} worktree lock for '{}' because it is already held",
+                git_dir.display()
+            );
+        }
+    }
+
+    #[cfg(not(debug_assertions))]
+    {
+        let _ = (lock, git_dir, mode);
+    }
 }
 
 /// Owns the *exclusive* in-process repository lock and the optional best-effort inter-process file

--- a/crates/but-feedback/Cargo.toml
+++ b/crates/but-feedback/Cargo.toml
@@ -11,10 +11,12 @@ test = false
 doctest = false
 
 [dependencies]
+but-core.workspace = true
 but-graph.workspace = true
 but-ctx = { workspace = true, features = ["legacy"] }
 
 anyhow.workspace = true
+gix.workspace = true
 zip.workspace = true
 walkdir = "2.5.0"
 chrono.workspace = true

--- a/crates/but-feedback/src/lib.rs
+++ b/crates/but-feedback/src/lib.rs
@@ -3,6 +3,7 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
+use but_core::RefMetadata;
 use but_ctx::{Context, ProjectHandleOrLegacyProjectId};
 
 /// A utility to keep important paths to make archival/zip-file creation easier later.
@@ -31,20 +32,17 @@ impl Archival {
         create_zip_file_from_dir(ctx.workdir_or_gitdir()?, output_file)
     }
 
-    /// Create an archive commit graph behind `project_id` such that it doesn't reveal PII.
+    /// Create an anonymous archive commit graph for `repo` and `meta`, such that it doesn't reveal PII.
     pub fn zip_anonymous_graph(
         &self,
-        project_id: ProjectHandleOrLegacyProjectId,
+        repo: &gix::Repository,
+        meta: &impl RefMetadata,
     ) -> Result<PathBuf> {
-        let ctx: Context = project_id.try_into()?;
-        let _guard = ctx.shared_worktree_access();
-        let repo = ctx.repo.get()?;
-        let meta = ctx.meta()?;
         let mut graph =
-            but_graph::Graph::from_head(&repo, &meta, Default::default()).or_else(|_| {
+            but_graph::Graph::from_head(repo, meta, Default::default()).or_else(|_| {
                 but_graph::Graph::from_head(
-                    &repo,
-                    &meta,
+                    repo,
+                    meta,
                     but_graph::init::Options {
                         // Assume it fails because of post-processing, try again without.
                         dangerously_skip_postprocessing_for_debugging: true,

--- a/crates/but-rules/src/handler.rs
+++ b/crates/but-rules/src/handler.rs
@@ -1,26 +1,42 @@
 use std::str::FromStr;
 
 use anyhow::ensure;
-use but_core::{ChangeId, DiffSpec, ref_metadata::StackId, sync::RepoExclusive};
-use but_ctx::Context;
-use but_db::HunkAssignmentsHandleMut;
+use but_core::{ChangeId, DiffSpec, RefMetadata, ref_metadata::StackId, sync::RepoExclusive};
+use but_db::{DbHandle, HunkAssignmentsHandleMut};
 use but_hunk_assignment::HunkAssignment;
 use but_rebase::graph_rebase::Editor;
 use itertools::Itertools;
 
-use crate::{Filter, StackTarget};
+use crate::{Filter, StackTarget, WorkspaceRule};
 
+/// Apply matching workspace `rules` to the current worktree `assignments`.
+///
+/// `rules` provides the enabled filesystem-change rules to evaluate. `assignments`
+/// is the current hunk-assignment view used for matching filters and deciding
+/// whether an update is necessary. `repo` is used for diff and commit lookups.
+/// `ws` is the mutable workspace graph that may be updated when a rule creates a
+/// new stack or amends a commit. `db` provides mutable access to persisted hunk
+/// assignments. `meta` is updated by workspace graph editing operations. `perm`
+/// proves the caller holds exclusive access because rule processing may create a
+/// stack and update the workspace graph.
+/// `context_lines` controls diff context when assigning or amending hunks.
+#[expect(clippy::too_many_arguments)]
 pub fn process_workspace_rules(
-    ctx: &mut Context,
+    rules: Vec<WorkspaceRule>,
     assignments: &[HunkAssignment],
+    repo: &gix::Repository,
+    ws: &mut but_graph::Workspace,
+    db: &mut DbHandle,
+    meta: &mut impl RefMetadata,
     perm: &mut RepoExclusive,
+    context_lines: u32,
 ) -> anyhow::Result<usize> {
     let mut updates = 0;
     if assignments.is_empty() {
         // Don't create stacks if there are no changes to assign anywhere
         return Ok(updates);
     }
-    let rules = super::list_rules(ctx)?
+    let rules = rules
         .into_iter()
         .filter(|r| r.enabled)
         .filter(|r| matches!(r.trigger, super::Trigger::FileSytemChange))
@@ -39,10 +55,6 @@ pub fn process_workspace_rules(
         return Ok(updates);
     }
 
-    let context_lines = ctx.settings.context_lines;
-    let mut meta = ctx.meta()?;
-    let (repo, mut ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
-
     let stack_ids: Vec<_> = ws.stacks.iter().filter_map(|s| s.id).collect();
     let mut new_ws = None;
 
@@ -50,7 +62,7 @@ pub fn process_workspace_rules(
         match rule.action {
             super::Action::Explicit(super::Operation::Assign { target }) => {
                 if let Some((stack_id, maybe_new_ws)) =
-                    get_or_create_stack_id(&repo, &ws, &mut meta, target, &stack_ids, perm)
+                    get_or_create_stack_id(repo, ws, meta, perm, target, &stack_ids)
                 {
                     if let Some(ws) = maybe_new_ws {
                         ensure!(
@@ -70,8 +82,8 @@ pub fn process_workspace_rules(
                         .collect_vec();
                     updates += handle_assign(
                         db.hunk_assignments_mut()?,
-                        &repo,
-                        new_ws.as_ref().unwrap_or(&ws),
+                        repo,
+                        new_ws.as_ref().unwrap_or(&*ws),
                         assignments,
                         context_lines,
                     )
@@ -83,9 +95,9 @@ pub fn process_workspace_rules(
                 let ws = if let Some(new_ws) = new_ws.as_mut() {
                     new_ws
                 } else {
-                    &mut ws
+                    &mut *ws
                 };
-                handle_amend(&repo, ws, &mut meta, assignments, &change_id, context_lines)
+                handle_amend(repo, ws, meta, assignments, &change_id, context_lines)
                     .unwrap_or_default();
             }
             _ => continue,
@@ -99,6 +111,14 @@ pub fn process_workspace_rules(
     Ok(updates)
 }
 
+/// Amend the commit identified by `change_id` with the provided `assignments`.
+///
+/// `repo` is used to inspect commits and materialize the resulting rebase. `ws`
+/// is the mutable workspace graph edited by the amend operation. `meta` stores
+/// graph metadata updates produced by the editor. `assignments` are flattened
+/// into diff specs to apply to the matched commit. `change_id` selects the
+/// destination commit by its Gerrit Change-Id header. `context_lines` controls
+/// diff context for the amend operation.
 fn handle_amend(
     repo: &gix::Repository,
     ws: &mut but_graph::Workspace,
@@ -134,13 +154,21 @@ fn handle_amend(
     Ok(())
 }
 
+/// Resolve a rule `target` into a stack ID, creating a stack if necessary.
+///
+/// `repo` is used when a new branch name must be generated. `ws` is inspected
+/// to find existing stacks or used as the base for a newly-created workspace
+/// graph. `meta` receives metadata updates if a new stack is created. `target`
+/// describes the requested stack selection. `perm` proves that stack creation is
+/// allowed if the target requires a new stack. `stack_ids_in_ws` is the
+/// precomputed list of stack IDs currently present in the workspace.
 fn get_or_create_stack_id(
     repo: &gix::Repository,
     ws: &but_graph::Workspace,
     meta: &mut impl but_core::RefMetadata,
+    perm: &mut RepoExclusive,
     target: StackTarget,
     stack_ids_in_ws: &[StackId],
-    perm: &mut RepoExclusive,
 ) -> Option<(StackId, Option<but_graph::Workspace>)> {
     match target {
         StackTarget::StackId(stack_id) => {
@@ -175,6 +203,12 @@ fn get_or_create_stack_id(
     }
 }
 
+/// Create a new stack in `ws` and return its generated ID and updated workspace.
+///
+/// `repo` is used to generate a unique canned branch name. `ws` is the workspace
+/// graph used as the base for the new reference. `meta` receives metadata updates
+/// from reference creation. `_perm` proves the caller holds exclusive access for
+/// the workspace change.
 fn create_stack(
     repo: &gix::Repository,
     ws: &but_graph::Workspace,
@@ -201,6 +235,12 @@ fn create_stack(
         .map(|id| (id, new_ws.into_owned()))
 }
 
+/// Persist assignment updates and return how many were attempted.
+///
+/// `db` is the mutable hunk-assignment table handle to update. `repo` and
+/// `workspace` provide the repository/workspace context required by assignment
+/// validation. `assignments` are converted into assignment requests before
+/// writing. `context_lines` controls diff context during assignment.
 fn handle_assign(
     db: HunkAssignmentsHandleMut,
     repo: &gix::Repository,
@@ -220,6 +260,10 @@ fn handle_assign(
     .or_else(|_| Ok(0))
 }
 
+/// Return worktree assignments matching any of the provided `filters`.
+///
+/// `wt_assignments` is the source list to filter. `filters` contains the rule
+/// filter predicates to evaluate; an empty list matches all assignments.
 fn matching(wt_assignments: &[HunkAssignment], filters: Vec<Filter>) -> Vec<HunkAssignment> {
     if filters.is_empty() {
         return wt_assignments.to_vec();

--- a/crates/but-rules/src/lib.rs
+++ b/crates/but-rules/src/lib.rs
@@ -1,5 +1,6 @@
-use but_core::{ChangeId, sync::RepoExclusive};
+use but_core::{ChangeId, RefMetadata, sync::RepoExclusive};
 use but_ctx::Context;
+use but_db::DbHandle;
 use serde::{Deserialize, Serialize};
 
 pub mod db;
@@ -46,6 +47,7 @@ impl WorkspaceRule {
         }
     }
 
+    /// Return the target change ID if its action is an explicit amend operation.
     pub fn target_change_id(&self) -> Option<ChangeId> {
         if let Action::Explicit(Operation::Amend { change_id }) = &self.action {
             Some(change_id.clone())
@@ -54,6 +56,7 @@ impl WorkspaceRule {
         }
     }
 
+    /// Return the persistent rule ID.
     pub fn id(&self) -> String {
         self.id.clone()
     }
@@ -62,6 +65,7 @@ impl WorkspaceRule {
         self.enabled
     }
 
+    /// Return the creation timestamp.
     pub fn created_at(&self) -> chrono::NaiveDateTime {
         self.created_at
     }
@@ -185,12 +189,26 @@ pub struct CreateRuleRequest {
     pub action: Action,
 }
 
-/// Creates a new workspace rule
+/// Create a new workspace rule and attempt to reevaluate all workspace rules.
+///
+/// `ctx` provides database access for insertion and repository/workspace state for reevaluation.
+/// `req` contains the trigger, filters, and action to persist. `perm` is the caller-held exclusive
+/// worktree permission used while reevaluating rules after the insert.
 pub fn create_rule(
     ctx: &mut Context,
     req: CreateRuleRequest,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<WorkspaceRule> {
+    let rule = {
+        let mut db = ctx.db.get_cache_mut()?;
+        insert_rule(&mut db, req)?
+    };
+    process_rules_from_context(ctx, perm).ok(); // Reevaluate rules after creating
+    Ok(rule)
+}
+
+/// Insert a new workspace rule record into `db` from `req`.
+fn insert_rule(db: &mut DbHandle, req: CreateRuleRequest) -> anyhow::Result<WorkspaceRule> {
     let rule = WorkspaceRule {
         id: uuid::Uuid::new_v4().to_string(),
         created_at: chrono::Local::now().naive_local(),
@@ -200,16 +218,13 @@ pub fn create_rule(
         action: req.action,
     };
 
-    ctx.db
-        .get_cache_mut()?
-        .workspace_rules_mut()
-        .insert(rule.clone().try_into()?)?;
-    process_rules(ctx, perm).ok(); // Reevaluate rules after creating
+    db.workspace_rules_mut().insert(rule.clone().try_into()?)?;
     Ok(rule)
 }
 
-pub fn delete_rule(ctx: &Context, id: &str) -> anyhow::Result<()> {
-    ctx.db.get_cache_mut()?.workspace_rules_mut().delete(id)?;
+/// Delete the workspace rule with `id` from `db`.
+pub fn delete_rule(db: &mut DbHandle, id: &str) -> anyhow::Result<()> {
+    db.workspace_rules_mut().delete(id)?;
     Ok(())
 }
 
@@ -241,14 +256,29 @@ impl From<WorkspaceRule> for UpdateRuleRequest {
     }
 }
 
-/// Updates an existing workspace rule with the provided request data.
+/// Update an existing workspace rule and attempt to reevaluate all workspace rules.
+///
+/// `ctx` provides database access for the update and repository/workspace state for reevaluation.
+/// `req` contains the rule ID and optional replacement fields. `perm` is the caller-held exclusive
+/// worktree permission used while reevaluating rules after the update.
 pub fn update_rule(
     ctx: &mut Context,
     req: UpdateRuleRequest,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<WorkspaceRule> {
+    let rule = {
+        let mut db = ctx.db.get_cache_mut()?;
+        update_rule_record(&mut db, req)?
+    };
+    process_rules_from_context(ctx, perm).ok(); // Reevaluate rules after updating
+    Ok(rule)
+}
+
+/// Apply `req` to an existing workspace rule record in `db`.
+///
+/// Fields omitted from `req` retain their current values.
+fn update_rule_record(db: &mut DbHandle, req: UpdateRuleRequest) -> anyhow::Result<WorkspaceRule> {
     let mut rule: WorkspaceRule = {
-        let db = ctx.db.get_cache_mut()?;
         db.workspace_rules()
             .get(&req.id)?
             .ok_or_else(|| anyhow::anyhow!("Rule with ID {} not found", req.id))?
@@ -268,19 +298,14 @@ pub fn update_rule(
         rule.action = action;
     }
 
-    ctx.db
-        .get_cache_mut()?
-        .workspace_rules_mut()
+    db.workspace_rules_mut()
         .update(&req.id, rule.clone().try_into()?)?;
-    process_rules(ctx, perm).ok(); // Reevaluate rules after updating
     Ok(rule)
 }
 
-/// Retrieves a workspace rule by its ID.
-pub fn get_rule(ctx: &Context, id: &str) -> anyhow::Result<WorkspaceRule> {
-    let rule = ctx
-        .db
-        .get_cache()?
+/// Retrieve the workspace rule with `id` from `db`.
+pub fn get_rule(db: &DbHandle, id: &str) -> anyhow::Result<WorkspaceRule> {
+    let rule = db
         .workspace_rules()
         .get(id)?
         .ok_or_else(|| anyhow::anyhow!("Rule with ID {id} not found"))?
@@ -288,11 +313,9 @@ pub fn get_rule(ctx: &Context, id: &str) -> anyhow::Result<WorkspaceRule> {
     Ok(rule)
 }
 
-/// Lists all workspace rules in the database.
-pub fn list_rules(ctx: &Context) -> anyhow::Result<Vec<WorkspaceRule>> {
-    let rules = ctx
-        .db
-        .get_cache()?
+/// List all workspace rules stored in `db`.
+pub fn list_rules(db: &DbHandle) -> anyhow::Result<Vec<WorkspaceRule>> {
+    let rules = db
         .workspace_rules()
         .list()?
         .into_iter()
@@ -301,17 +324,55 @@ pub fn list_rules(ctx: &Context) -> anyhow::Result<Vec<WorkspaceRule>> {
     Ok(rules)
 }
 
+/// Reevaluate workspace rules using state extracted from `ctx`.
+///
+/// `ctx` provides rules from the database, settings, metadata, repository, workspace, and hunk
+/// assignment storage. `perm` is the caller-held exclusive worktree permission used for workspace
+/// access and any rule action that mutates workspace state.
+///
 /// NOTE: may create an empty branch!
-pub fn process_rules(ctx: &mut Context, perm: &mut RepoExclusive) -> anyhow::Result<()> {
+fn process_rules_from_context(ctx: &mut Context, perm: &mut RepoExclusive) -> anyhow::Result<()> {
+    let context_lines = ctx.settings.context_lines;
+    let mut meta = ctx.meta()?;
+    let (repo, mut ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
+    let rules = list_rules(&db)?;
+    process_rules(
+        rules,
+        &repo,
+        &mut ws,
+        &mut db,
+        &mut meta,
+        perm,
+        context_lines,
+    )
+}
+
+/// Reevaluate `rules` against current worktree changes and apply matching actions.
+///
+/// `rules` are the workspace rules to evaluate. `repo` is used to read worktree changes and create
+/// or amend commits. `ws` is the mutable workspace view that rule actions inspect and update. `db`
+/// provides hunk assignment storage. `meta` provides mutable ref metadata for stack creation and
+/// rebase operations. `perm` is the caller-held exclusive worktree permission for workspace
+/// mutations. `context_lines` controls the diff context used while deriving hunk assignments and
+/// applying rule actions.
+///
+/// NOTE: may create an empty branch!
+pub fn process_rules(
+    rules: Vec<WorkspaceRule>,
+    repo: &gix::Repository,
+    ws: &mut but_graph::Workspace,
+    db: &mut DbHandle,
+    meta: &mut impl RefMetadata,
+    perm: &mut RepoExclusive,
+    context_lines: u32,
+) -> anyhow::Result<()> {
     let assignments = {
-        let context_lines = ctx.settings.context_lines;
-        let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(perm.read_permission())?;
-        let wt_changes = but_core::diff::worktree_changes(&repo)?;
+        let wt_changes = but_core::diff::worktree_changes(repo)?;
 
         let (assignments, _) = but_hunk_assignment::assignments_with_fallback(
             db.hunk_assignments_mut()?,
-            &repo,
-            &ws,
+            repo,
+            ws,
             Some(wt_changes.changes),
             context_lines,
         )
@@ -319,6 +380,6 @@ pub fn process_rules(ctx: &mut Context, perm: &mut RepoExclusive) -> anyhow::Res
         assignments
     };
 
-    handler::process_workspace_rules(ctx, &assignments, perm)?;
+    handler::process_workspace_rules(rules, &assignments, repo, ws, db, meta, perm, context_lines)?;
     Ok(())
 }

--- a/crates/but/AGENTS.md
+++ b/crates/but/AGENTS.md
@@ -17,6 +17,27 @@ changes, also read `crates/WORKSPACE_MODEL.md`.
   `read: impl std::io::Read` so tests can inject data. Keep `stdin().lock()` at
   top-level CLI wiring.
 
+## Worktree Guards And Deadlocks
+
+Command handlers should acquire the required worktree guard at the top of the
+operation and pass the derived permission down the call chain. Prefer
+permission-taking helpers such as `*_with_perm(...)` when a guard is already
+held. Do not call helpers that acquire another shared or exclusive worktree
+guard while the command is still holding one.
+
+When debugging a suspected worktree-lock deadlock, use a debug build with
+`BUT_WS_LOCK_DEBUG=1`. In debug builds, this makes worktree guard acquisition
+panic when the lock is already held instead of blocking indefinitely. Run the
+failing command with a backtrace, for example:
+
+```sh
+BUT_WS_LOCK_DEBUG=1 RUST_BACKTRACE=1 cargo run -p but -- -C <repo> <command>
+```
+
+Use the panic backtrace to find the nested guard acquisition, then thread the
+existing permission to that call site or switch it to an existing
+permission-taking helper.
+
 ## CLI Tests
 
 - In `crates/but/tests/`, prefer `env.but(...).assert().success()/failure()`

--- a/crates/but/src/command/legacy/actions.rs
+++ b/crates/but/src/command/legacy/actions.rs
@@ -10,13 +10,17 @@ pub(crate) fn handle_changes(
     handler: impl Into<but_action::ActionHandler>,
     change_description: &str,
 ) -> anyhow::Result<()> {
-    let response = but_action::handle_changes(
+    let mut guard = ctx.exclusive_worktree_access();
+    let perm = guard.write_permission();
+    let handler = handler.into();
+    let response = but_action::record_uncommitted_changes_with_perm(
         ctx,
         change_description,
         None,
-        handler.into(),
+        handler,
         Source::ButCli,
         None,
+        perm,
     )?;
     print_json_or_human(&response, out)
 }
@@ -35,7 +39,8 @@ pub(crate) fn list_actions(
     offset: i64,
     limit: i64,
 ) -> anyhow::Result<()> {
-    let response = but_action::list_actions(ctx, offset, limit)?;
+    let db = ctx.db.get_cache()?;
+    let response = but_action::list_actions(&db, offset, limit)?;
     print_json_or_human(&response, out)
 }
 

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -353,7 +353,7 @@ pub(crate) fn commit(
     )?;
 
     // Get changes and assignments using but-api
-    let worktree_changes = diff::changes_in_worktree_with_perm(ctx, guard.write_permission())?;
+    let worktree_changes = diff::changes_in_worktree_with_perm(ctx, guard.read_permission())?;
     let changes = worktree_changes.worktree_changes.changes;
 
     // Get files to commit - either specific files by ID or all eligible files

--- a/crates/but/src/command/legacy/discard.rs
+++ b/crates/but/src/command/legacy/discard.rs
@@ -34,7 +34,7 @@ pub fn handle(ctx: &mut Context, out: &mut OutputChannel, id: &str) -> Result<()
 
     // Get worktree changes once for the Unassigned case
     // Also used to determine file status for additions/deletions
-    let worktree_changes = diff::changes_in_worktree_with_perm(ctx, guard.write_permission())?;
+    let worktree_changes = diff::changes_in_worktree_with_perm(ctx, guard.read_permission())?;
     let path_status: std::collections::HashMap<_, _> = worktree_changes
         .worktree_changes
         .changes

--- a/crates/but/src/command/legacy/mark.rs
+++ b/crates/but/src/command/legacy/mark.rs
@@ -23,8 +23,12 @@ pub(crate) fn handle(
         ));
     }
     // Hack - delete all other rules
-    for rule in but_rules::list_rules(ctx)? {
-        but_rules::delete_rule(ctx, &rule.id())?;
+    {
+        let mut db = ctx.db.get_cache_mut()?;
+        let rules = but_rules::list_rules(&db)?;
+        for rule in rules {
+            but_rules::delete_rule(&mut db, &rule.id())?;
+        }
     }
     match target_result[0].clone() {
         CliId::Branch { name, .. } => mark_branch(ctx, name, delete, out, guard.write_permission()),
@@ -45,10 +49,11 @@ fn mark_commit(
     if delete {
         let repo = ctx.repo.get()?.clone();
         let commit = repo.find_commit(oid)?;
-        let rules = but_rules::list_rules(ctx)?;
+        let mut db = ctx.db.get_cache_mut()?;
+        let rules = but_rules::list_rules(&db)?;
         for rule in rules {
             if rule.target_change_id() == commit.change_id() {
-                but_rules::delete_rule(ctx, &rule.id())?;
+                but_rules::delete_rule(&mut db, &rule.id())?;
             }
         }
         if let Some(out) = out.for_human() {
@@ -92,10 +97,11 @@ fn mark_branch(
 ) -> anyhow::Result<()> {
     let stack_id = branch_name_to_stack_id(ctx, Some(&branch_name))?;
     if delete {
-        let rules = but_rules::list_rules(ctx)?;
+        let mut db = ctx.db.get_cache_mut()?;
+        let rules = but_rules::list_rules(&db)?;
         for rule in rules {
             if rule.target_stack_id() == stack_id.map(|s| s.to_string()) {
-                but_rules::delete_rule(ctx, &rule.id())?;
+                but_rules::delete_rule(&mut db, &rule.id())?;
             }
         }
         if let Some(out) = out.for_human() {
@@ -124,7 +130,8 @@ fn mark_branch(
 }
 
 pub(crate) fn stack_marked(ctx: &Context, stack_id: StackId) -> anyhow::Result<bool> {
-    let rules = but_rules::list_rules(ctx)?
+    let db = ctx.db.get_cache()?;
+    let rules = but_rules::list_rules(&db)?
         .iter()
         .any(|r| r.target_stack_id() == Some(stack_id.to_string()) && r.session_id().is_none());
     Ok(rules)
@@ -138,17 +145,16 @@ pub(crate) fn commit_marked(ctx: &Context, commit_id: String) -> anyhow::Result<
             anyhow::anyhow!("Commit {commit_id} does not have a Change-Id, cannot mark it")
         })?
     };
-    let rules = but_rules::list_rules(ctx)?
+    let db = ctx.db.get_cache()?;
+    let rules = but_rules::list_rules(&db)?
         .iter()
         .any(|r| r.target_change_id() == Some(change_id.clone()));
     Ok(rules)
 }
 
-pub(crate) fn unmark(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
-    // TODO: do we need an exclusive lock here? This only affects metadata. This is very safe for now,
-    // and `create_rule()` already needs a write guard, so this is just symmetric.
-    let _guard = ctx.exclusive_worktree_access();
-    let rules = but_rules::list_rules(ctx)?;
+pub(crate) fn unmark(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<()> {
+    let mut db = ctx.db.get_cache_mut()?;
+    let rules = but_rules::list_rules(&db)?;
     let rule_count = rules.len();
 
     if rule_count == 0 {
@@ -159,7 +165,7 @@ pub(crate) fn unmark(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Resu
     }
 
     for rule in rules {
-        but_rules::delete_rule(ctx, &rule.id())?;
+        but_rules::delete_rule(&mut db, &rule.id())?;
     }
 
     if let Some(out) = out.for_human() {

--- a/crates/but/src/command/legacy/mcp/event.rs
+++ b/crates/but/src/command/legacy/mcp/event.rs
@@ -20,7 +20,21 @@ impl Handler {
                     while let Some(event) = receiver.recv().await {
                         match event {
                             Event::Commit(c) => {
-                                let _ = but_action::reword::commit(&llm, c);
+                                let mut ctx = c.ctx.clone().into_thread_local();
+                                let context_lines = ctx.settings.context_lines;
+                                let _res = (|| -> anyhow::Result<_> {
+                                    let mut meta = ctx.meta()?;
+                                    let (_guard, repo, mut ws, _db) =
+                                        ctx.workspace_mut_and_db_mut()?;
+                                    but_action::reword::commit(
+                                        &llm,
+                                        c,
+                                        &repo,
+                                        &mut ws,
+                                        &mut meta,
+                                        context_lines,
+                                    )
+                                })();
                             }
                         }
                     }

--- a/crates/but/src/command/legacy/mcp/mod.rs
+++ b/crates/but/src/command/legacy/mcp/mod.rs
@@ -129,14 +129,17 @@ impl Mcp {
             .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
         let mut ctx = Context::new_from_legacy_project_and_settings(&project, settings)
             .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
+        let mut guard = ctx.exclusive_worktree_access();
+        let perm = guard.write_permission();
 
-        let (id, outcome) = but_action::handle_changes(
+        let (id, outcome) = but_action::record_uncommitted_changes_with_perm(
             &mut ctx,
             &request.changes_summary,
             Some(request.full_prompt.clone()),
             ActionHandler::HandleChangesSimple,
             Source::Mcp(client_info.clone().map(Into::into)),
             None,
+            perm,
         )
         .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
         // Trigger commit message generation for newly created commits

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -613,9 +613,11 @@ fn push_single_branch(
     writeln!(progress, "{} Push completed successfully", t.sym().success)?;
     writeln!(progress)?;
     if !result.branch_sha_updates.is_empty() {
-        let repo = ctx.repo.get()?;
-        let repo_for_commit_shortening = repo.clone().for_commit_shortening();
+        let repo = ctx.repo.get()?.clone().for_commit_shortening();
         let gerrit_review_ref = if gerrit_mode {
+            // This should be a top-level guard, but called code further down also acquires their own, so it will deadlock.
+            // Generally, we have a lot of problems with plumbing code that accepts `ctx` and then can (and often will)
+            // acquire a workspace which right now also requires a guard.
             let guard = ctx.shared_worktree_access();
             Some(gerrit_review_ref(ctx, guard.read_permission(), &repo)?)
         } else {
@@ -625,9 +627,9 @@ fn push_single_branch(
             let before_str = if before_sha == "0000000000000000000000000000000000000000" {
                 "(new branch)".to_string()
             } else {
-                shorten_hex_object_id(&repo_for_commit_shortening, before_sha)
+                shorten_hex_object_id(&repo, before_sha)
             };
-            let after_str = shorten_hex_object_id(&repo_for_commit_shortening, after_sha);
+            let after_str = shorten_hex_object_id(&repo, after_sha);
             let remote_ref =
                 branch_remote_ref_for_display(&result, branch, gerrit_review_ref.as_deref());
 
@@ -780,8 +782,7 @@ fn push_all_branches(
         writeln!(progress)?;
 
         // Print combined branch, remote, and SHA information for all pushed branches
-        let repo = ctx.repo.get()?;
-        let repo_for_commit_shortening = repo.clone().for_commit_shortening();
+        let repo = ctx.repo.get()?.clone().for_commit_shortening();
         let gerrit_review_ref = if gerrit_mode {
             let guard = ctx.shared_worktree_access();
             Some(gerrit_review_ref(ctx, guard.read_permission(), &repo)?)
@@ -793,9 +794,9 @@ fn push_all_branches(
                 let before_str = if before_sha == "0000000000000000000000000000000000000000" {
                     "(new branch)".to_string()
                 } else {
-                    shorten_hex_object_id(&repo_for_commit_shortening, before_sha)
+                    shorten_hex_object_id(&repo, before_sha)
                 };
-                let after_str = shorten_hex_object_id(&repo_for_commit_shortening, after_sha);
+                let after_str = shorten_hex_object_id(&repo, after_sha);
                 let remote_ref =
                     branch_remote_ref_for_display(result, branch, gerrit_review_ref.as_deref());
 
@@ -1226,8 +1227,8 @@ fn check_for_conflicted_commits(ctx: &Context, branch_name: &str) -> anyhow::Res
         ctx,
         Some(but_workspace::legacy::StacksFilter::InWorkspace),
     )?;
-    let repo = ctx.repo.get()?.clone().for_commit_shortening();
 
+    let repo = ctx.repo.get()?.clone().for_commit_shortening();
     // Find the stack containing this branch and get its details
     for stack in &stacks {
         if let Some(stack_id) = stack.id {

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -46,8 +46,6 @@ pub async fn handle(
     ctx: &mut Context,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
-    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
-
     // Check gerrit mode early
     let gerrit_mode = {
         let repo = ctx.repo.get()?;
@@ -58,6 +56,10 @@ pub async fn handle(
     if args.dry_run {
         return handle_dry_run(ctx, &args.branch_id, out);
     }
+
+    let guard = ctx.shared_worktree_access();
+    let perm = guard.read_permission();
+    let id_map = IdMap::new_from_context(ctx, None, perm)?;
 
     // If no branch_id is provided, show all branches and prompt or push all
     let branch_selection = if let Some(ref branch_id) = args.branch_id {
@@ -70,16 +72,16 @@ pub async fn handle(
 
     // Handle branch selection
     let had_successful_push = match branch_selection {
-        BranchSelection::All => push_all_branches(ctx, &args, gerrit_mode, out)?,
+        BranchSelection::All => push_all_branches(ctx, perm, &args, gerrit_mode, out)?,
         BranchSelection::Single(branch_name) => {
-            push_single_branch(ctx, &branch_name, &args, gerrit_mode, out)?;
+            push_single_branch(ctx, perm, &branch_name, &args, gerrit_mode, out)?;
             true
         }
         BranchSelection::None => return Ok(()),
     };
 
     // Best-effort: update PR/MR target branches to match the current stack structure.
-    if had_successful_push && let Err(err) = update_review_targets_for_stacks(ctx).await {
+    if had_successful_push && let Err(err) = update_review_targets_for_stacks(ctx, perm).await {
         tracing::warn!(?err, "Failed to update review target branches after push");
     }
 
@@ -596,13 +598,14 @@ fn dry_run_push_details(
 
 fn push_single_branch(
     ctx: &mut Context,
+    perm: &RepoShared,
     branch_name: &str,
     args: &Command,
     gerrit_mode: bool,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
     let t = theme::get();
-    let result = push_single_branch_impl(ctx, branch_name, args, gerrit_mode)?;
+    let result = push_single_branch_impl(ctx, perm, branch_name, args, gerrit_mode)?;
     let mut progress = out.progress_channel();
 
     if let Some(out) = out.for_json() {
@@ -615,11 +618,7 @@ fn push_single_branch(
     if !result.branch_sha_updates.is_empty() {
         let repo = ctx.repo.get()?.clone().for_commit_shortening();
         let gerrit_review_ref = if gerrit_mode {
-            // This should be a top-level guard, but called code further down also acquires their own, so it will deadlock.
-            // Generally, we have a lot of problems with plumbing code that accepts `ctx` and then can (and often will)
-            // acquire a workspace which right now also requires a guard.
-            let guard = ctx.shared_worktree_access();
-            Some(gerrit_review_ref(ctx, guard.read_permission(), &repo)?)
+            Some(gerrit_review_ref(ctx, perm, &repo)?)
         } else {
             None
         };
@@ -650,6 +649,7 @@ fn push_single_branch(
 // Shared implementation for pushing a single branch
 fn push_single_branch_impl(
     ctx: &mut Context,
+    perm: &RepoShared,
     branch_name: &str,
     args: &Command,
     gerrit_mode: bool,
@@ -664,7 +664,7 @@ fn push_single_branch_impl(
     let gerrit_flags = get_gerrit_flags(args, branch_name, gerrit_mode)?;
 
     // Call push_stack
-    let result: PushResult = but_api::legacy::stack::push_stack(
+    let result: PushResult = but_api::legacy::stack::push_stack_with_perm(
         ctx,
         stack_id,
         args.with_force,
@@ -672,6 +672,7 @@ fn push_single_branch_impl(
         branch_name.to_string(),
         !args.no_hooks,
         gerrit_flags,
+        perm,
     )?;
 
     Ok(result)
@@ -680,6 +681,7 @@ fn push_single_branch_impl(
 /// Returns `true` if at least one branch was pushed successfully.
 fn push_all_branches(
     ctx: &mut Context,
+    perm: &RepoShared,
     args: &Command,
     gerrit_mode: bool,
     out: &mut OutputChannel,
@@ -728,7 +730,7 @@ fn push_all_branches(
             t.important.paint(&branch_name)
         )?;
 
-        match push_single_branch_impl(ctx, &branch_name, args, gerrit_mode) {
+        match push_single_branch_impl(ctx, perm, &branch_name, args, gerrit_mode) {
             Ok(result) => {
                 total_commits_pushed += unpushed_count;
                 writeln!(
@@ -784,8 +786,7 @@ fn push_all_branches(
         // Print combined branch, remote, and SHA information for all pushed branches
         let repo = ctx.repo.get()?.clone().for_commit_shortening();
         let gerrit_review_ref = if gerrit_mode {
-            let guard = ctx.shared_worktree_access();
-            Some(gerrit_review_ref(ctx, guard.read_permission(), &repo)?)
+            Some(gerrit_review_ref(ctx, perm, &repo)?)
         } else {
             None
         };
@@ -1186,11 +1187,8 @@ fn find_stack_id_by_branch_name(ctx: &Context, branch_name: &str) -> anyhow::Res
 }
 
 /// Update PR/MR target branches to match the current stack structure.
-async fn update_review_targets_for_stacks(ctx: &Context) -> anyhow::Result<()> {
-    let base_branch = {
-        let guard = ctx.shared_worktree_access();
-        gitbutler_branch_actions::base::get_base_branch_data(ctx, guard.read_permission())?
-    };
+async fn update_review_targets_for_stacks(ctx: &Context, perm: &RepoShared) -> anyhow::Result<()> {
+    let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx, perm)?;
     let stacks = but_api::legacy::workspace::stacks(
         ctx,
         Some(but_workspace::legacy::StacksFilter::InWorkspace),

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write;
 
-use but_core::{RepositoryExt, ref_metadata::StackId};
+use but_core::{RepositoryExt, ref_metadata::StackId, sync::RepoShared};
 use but_ctx::Context;
 use cli_prompts::DisplayPrompt;
 use gitbutler_git::PushResult;
@@ -613,17 +613,23 @@ fn push_single_branch(
     writeln!(progress, "{} Push completed successfully", t.sym().success)?;
     writeln!(progress)?;
     if !result.branch_sha_updates.is_empty() {
-        let repo = ctx.repo.get()?.clone().for_commit_shortening();
+        let repo = ctx.repo.get()?;
+        let repo_for_commit_shortening = repo.clone().for_commit_shortening();
+        let gerrit_review_ref = if gerrit_mode {
+            let guard = ctx.shared_worktree_access();
+            Some(gerrit_review_ref(ctx, guard.read_permission(), &repo)?)
+        } else {
+            None
+        };
         for (branch, before_sha, after_sha) in &result.branch_sha_updates {
             let before_str = if before_sha == "0000000000000000000000000000000000000000" {
                 "(new branch)".to_string()
             } else {
-                shorten_hex_object_id(&repo, before_sha)
+                shorten_hex_object_id(&repo_for_commit_shortening, before_sha)
             };
-            let after_str = shorten_hex_object_id(&repo, after_sha);
-
-            // Construct simple remote ref format: remote/branch
-            let remote_ref = format!("{}/{}", result.remote, branch);
+            let after_str = shorten_hex_object_id(&repo_for_commit_shortening, after_sha);
+            let remote_ref =
+                branch_remote_ref_for_display(&result, branch, gerrit_review_ref.as_deref());
 
             writeln!(
                 progress,
@@ -774,18 +780,24 @@ fn push_all_branches(
         writeln!(progress)?;
 
         // Print combined branch, remote, and SHA information for all pushed branches
-        let repo = ctx.repo.get()?.clone().for_commit_shortening();
+        let repo = ctx.repo.get()?;
+        let repo_for_commit_shortening = repo.clone().for_commit_shortening();
+        let gerrit_review_ref = if gerrit_mode {
+            let guard = ctx.shared_worktree_access();
+            Some(gerrit_review_ref(ctx, guard.read_permission(), &repo)?)
+        } else {
+            None
+        };
         for result in &pushed_results {
             for (branch, before_sha, after_sha) in &result.branch_sha_updates {
                 let before_str = if before_sha == "0000000000000000000000000000000000000000" {
                     "(new branch)".to_string()
                 } else {
-                    shorten_hex_object_id(&repo, before_sha)
+                    shorten_hex_object_id(&repo_for_commit_shortening, before_sha)
                 };
-                let after_str = shorten_hex_object_id(&repo, after_sha);
-
-                // Construct simple remote ref format: remote/branch
-                let remote_ref = format!("{}/{}", result.remote, branch);
+                let after_str = shorten_hex_object_id(&repo_for_commit_shortening, after_sha);
+                let remote_ref =
+                    branch_remote_ref_for_display(result, branch, gerrit_review_ref.as_deref());
 
                 writeln!(
                     progress,
@@ -1108,6 +1120,41 @@ fn format_branch_suggestions(branches: &[String]) -> String {
         .join("\n")
 }
 
+fn branch_remote_ref_for_display(
+    result: &PushResult,
+    branch: &str,
+    gerrit_review_ref: Option<&str>,
+) -> String {
+    if let Some(review_ref) = gerrit_review_ref {
+        return review_ref.to_string();
+    }
+
+    result
+        .branch_to_remote
+        .iter()
+        .find(|(pushed_branch, _)| pushed_branch == branch)
+        .map(|(_, remote_ref)| remote_ref.shorten().to_string())
+        .unwrap_or_else(|| format!("{}/{}", result.remote, branch))
+}
+
+fn gerrit_review_ref(
+    ctx: &Context,
+    perm: &RepoShared,
+    repo: &gix::Repository,
+) -> anyhow::Result<String> {
+    let target_ref_name = workspace_target::ResolvedTarget::resolve_with_perm(ctx, perm)?
+        .ref_name()
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| anyhow::anyhow!("Failed to determine Gerrit target branch"))?;
+    let remote_names = repo.remote_names();
+    let target_branch =
+        but_core::extract_remote_name_and_short_name(target_ref_name.as_ref(), &remote_names)
+            .map(|(_, short_name)| short_name.to_string())
+            .unwrap_or_else(|| target_ref_name.shorten().to_string());
+
+    Ok(format!("refs/for/{target_branch}"))
+}
+
 fn find_stack_id_by_branch_name(ctx: &Context, branch_name: &str) -> anyhow::Result<StackId> {
     let stacks = but_api::legacy::workspace::stacks(
         ctx,
@@ -1228,4 +1275,42 @@ fn check_for_conflicted_commits(ctx: &Context, branch_name: &str) -> anyhow::Res
     Err(anyhow::anyhow!(
         "Branch '{branch_name}' not found when checking for conflicts"
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::branch_remote_ref_for_display;
+    use gitbutler_git::PushResult;
+
+    #[test]
+    fn branch_remote_ref_display_uses_recorded_remote_ref() -> anyhow::Result<()> {
+        let result = PushResult {
+            remote: "origin".to_string(),
+            branch_to_remote: vec![(
+                "feature".to_string(),
+                "refs/remotes/upstream/feature".try_into()?,
+            )],
+            branch_sha_updates: vec![],
+        };
+
+        assert_eq!(
+            branch_remote_ref_for_display(&result, "feature", None),
+            "upstream/feature"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn branch_remote_ref_display_uses_gerrit_review_ref() {
+        let result = PushResult {
+            remote: "origin".to_string(),
+            branch_to_remote: vec![],
+            branch_sha_updates: vec![],
+        };
+
+        assert_eq!(
+            branch_remote_ref_for_display(&result, "feature", Some("refs/for/main")),
+            "refs/for/main"
+        );
+    }
 }

--- a/crates/but/src/command/legacy/resolve.rs
+++ b/crates/but/src/command/legacy/resolve.rs
@@ -369,7 +369,10 @@ fn cancel_resolution(ctx: &mut Context, out: &mut OutputChannel, force: bool) ->
         return show_workflow_help(out);
     }
 
-    if !force && !changes_from_initial(ctx)?.is_empty() {
+    if !force && {
+        let guard = ctx.shared_worktree_access();
+        !changes_from_initial(ctx, guard.read_permission())?.is_empty()
+    } {
         bail!(
             "There are changes that differ from the original commit you were editing. Canceling will drop those changes.\n\nIf you want to go through with this, please re-run with `--force`.\n\nIf you want to keep the changes you have made, consider finishing the resolution and then moving the changes with the rub command."
         )

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -254,8 +254,25 @@ async fn build_status_context<'a>(
         stacks,
         resolved_target,
     ) = {
-        let mut guard = ctx.exclusive_worktree_access();
-        but_rules::process_rules(ctx, guard.write_permission()).ok(); // TODO: this is doing double work (hunk-dependencies can be reused)
+        let context_lines = ctx.settings.context_lines;
+        let mut meta = ctx.meta()?;
+        let mut guard;
+        {
+            let (new_guard, repo, mut ws, mut db) = ctx.workspace_mut_and_db_mut()?;
+            guard = new_guard;
+            if let Ok(rules) = but_rules::list_rules(&db) {
+                but_rules::process_rules(
+                    rules,
+                    &repo,
+                    &mut ws,
+                    &mut db,
+                    &mut meta,
+                    guard.write_permission(),
+                    context_lines,
+                )
+                .ok(); // TODO: this is doing double work (hunk-dependencies can be reused)
+            }
+        }
 
         let (repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
         let head_info = but_workspace::graph_to_ref_info(

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -2861,7 +2861,7 @@ fn handle_mark_commit(commit: &CliId, mode: &mut Mode) -> bool {
 
 fn handle_mark_branch(
     marks: &mut Marks,
-    ctx: &mut Context,
+    ctx: &Context,
     stack_id: StackId,
     name: &str,
 ) -> anyhow::Result<()> {

--- a/crates/but/src/command/legacy/workspace_target.rs
+++ b/crates/but/src/command/legacy/workspace_target.rs
@@ -41,8 +41,8 @@ impl ResolvedTarget {
 
     /// Resolve the effective workspace target while reusing an existing repository permission.
     pub(crate) fn resolve_with_perm(ctx: &Context, perm: &RepoShared) -> Result<Self> {
-        let (_, workspace, _) = ctx.workspace_and_db_with_perm(perm)?;
-        Self::from_workspace(&workspace)
+        let (_, ws, _) = ctx.workspace_and_db_with_perm(perm)?;
+        Self::from_workspace(&ws)
     }
 
     /// Return the effective target commit ID.

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -731,7 +731,7 @@ async fn match_subcommand(
         }
         #[cfg(feature = "legacy")]
         Subcommands::Unmark => {
-            let mut ctx = setup::init_ctx(
+            let ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
                     background_sync: BackgroundSync::Enabled { silent: false },
@@ -739,7 +739,7 @@ async fn match_subcommand(
                 },
                 out,
             )?;
-            command::legacy::mark::unmark(&mut ctx, out)
+            command::legacy::mark::unmark(&ctx, out)
                 .context("Can't unmark this. Taaaa-na-na-na. Can't unmark this.")
                 .emit_metrics(metrics_ctx)
                 .show_root_cause_error_then_exit_without_destructors(output)

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context as _, Result};
 use but_core::{RepositoryExt, extract_remote_name_and_short_name, ref_metadata::StackId};
-use but_ctx::Context;
+use but_ctx::{Context, access::RepoShared};
 use gitbutler_git::{GitContextExt as _, PushResult};
 use gitbutler_operating_modes::ensure_open_workspace_mode;
 use gitbutler_oplog::{
@@ -152,12 +152,36 @@ pub fn push_stack(
 ) -> Result<PushResult> {
     let mut guard = ctx.exclusive_worktree_access();
     ctx.verify(guard.write_permission())?;
-    ensure_open_workspace_mode(ctx, guard.read_permission())
-        .context("Requires an open workspace mode")?;
+    push_stack_with_perm(
+        ctx,
+        stack_id,
+        with_force,
+        skip_force_push_protection,
+        branch_limit,
+        run_hooks,
+        push_opts,
+        guard.read_permission(),
+    )
+}
+
+/// Pushes all series in the stack to the remote using an existing shared repository permission.
+/// This operation will error out if the target has no push remote configured.
+#[expect(clippy::too_many_arguments)]
+pub fn push_stack_with_perm(
+    ctx: &mut Context,
+    stack_id: StackId,
+    with_force: bool,
+    skip_force_push_protection: bool,
+    branch_limit: String,
+    run_hooks: bool,
+    push_opts: Vec<but_gerrit::PushFlag>,
+    perm: &RepoShared,
+) -> Result<PushResult> {
+    ensure_open_workspace_mode(ctx, perm).context("Requires an open workspace mode")?;
     let virtual_branches = ctx.virtual_branches();
     let stack = virtual_branches.get_stack(stack_id)?;
     let (target_ref_name, target_base_oid, target_push_remote_name, target_branch_name) = {
-        let (repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
+        let (repo, ws, _db) = ctx.workspace_and_db_with_perm(perm)?;
         let target_ref_name = ws
             .target_ref_name()
             .context("failed to get target reference name")?

--- a/crates/gitbutler-edit-mode/src/commands.rs
+++ b/crates/gitbutler-edit-mode/src/commands.rs
@@ -1,6 +1,9 @@
 use anyhow::{Context as _, Result};
 use but_core::{ref_metadata::StackId, ui::TreeChange};
-use but_ctx::Context;
+use but_ctx::{
+    Context,
+    access::{RepoExclusive, RepoShared},
+};
 use gitbutler_operating_modes::{
     EditModeMetadata, ensure_edit_mode, ensure_open_workspace_mode, in_edit_mode,
 };
@@ -15,68 +18,63 @@ pub fn enter_edit_mode(
     ctx: &mut Context,
     commit_oid: gix::ObjectId,
     stack_id: StackId,
+    perm: &mut RepoExclusive,
 ) -> Result<EditModeMetadata> {
-    let mut guard = ctx.exclusive_worktree_access();
-
-    ensure_open_workspace_mode(ctx, guard.read_permission())
+    ensure_open_workspace_mode(ctx, perm.read_permission())
         .context("Entering edit mode may only be done when the workspace is open")?;
 
     let snapshot = ctx
-        .prepare_snapshot(guard.read_permission())
+        .prepare_snapshot(perm.read_permission())
         .context("Failed to prepare snapshot")?;
 
-    let edit_mode_metadata =
-        crate::enter_edit_mode(ctx, commit_oid, stack_id, guard.write_permission())?;
+    let edit_mode_metadata = crate::enter_edit_mode(ctx, commit_oid, stack_id, perm)?;
 
     let _ = ctx.commit_snapshot(
         snapshot,
         SnapshotDetails::new(OperationKind::EnterEditMode),
-        guard.write_permission(),
+        perm,
     );
 
     Ok(edit_mode_metadata)
 }
 
-pub fn save_and_return_to_workspace(ctx: &mut Context) -> Result<()> {
-    let mut guard = ctx.exclusive_worktree_access();
-
-    ensure_edit_mode(ctx, guard.read_permission())
+pub fn save_and_return_to_workspace(ctx: &mut Context, perm: &mut RepoExclusive) -> Result<()> {
+    ensure_edit_mode(ctx, perm.read_permission())
         .context("Edit mode may only be left while in edit mode")?;
 
-    crate::save_and_return_to_workspace(ctx, guard.write_permission())
+    crate::save_and_return_to_workspace(ctx, perm)
 }
 
-pub fn abort_and_return_to_workspace(ctx: &mut Context, force: bool) -> Result<()> {
-    let mut guard = ctx.exclusive_worktree_access();
-
-    ensure_edit_mode(ctx, guard.read_permission())
+pub fn abort_and_return_to_workspace(
+    ctx: &mut Context,
+    force: bool,
+    perm: &mut RepoExclusive,
+) -> Result<()> {
+    ensure_edit_mode(ctx, perm.read_permission())
         .context("Edit mode may only be left while in edit mode")?;
 
-    crate::abort_and_return_to_workspace(ctx, force, guard.write_permission())
+    crate::abort_and_return_to_workspace(ctx, force, perm)
 }
 
 pub fn starting_index_state(
-    ctx: &mut Context,
+    ctx: &Context,
+    perm: &RepoShared,
 ) -> Result<Vec<(TreeChange, Option<ConflictEntryPresence>)>> {
-    let guard = ctx.exclusive_worktree_access();
+    ensure_edit_mode(ctx, perm)?;
 
-    ensure_edit_mode(ctx, guard.read_permission())?;
-
-    let state = crate::starting_index_state(ctx, guard.read_permission())?;
+    let state = crate::starting_index_state(ctx, perm)?;
     Ok(state.into_iter().map(|(a, b)| (a.into(), b)).collect())
 }
 
-pub fn changes_from_initial(ctx: &mut Context) -> Result<Vec<TreeChange>> {
-    let guard = ctx.exclusive_worktree_access();
-
+pub fn changes_from_initial(ctx: &Context, perm: &RepoShared) -> Result<Vec<TreeChange>> {
     // The frontend's `worktree_changes` listener may fire one last event
     // after the workspace has already left edit mode. Treat that as "no
     // changes" instead of an error so the listener can stay simple and
     // PostHog/Sentry don't see a noisy benign error.
-    if !in_edit_mode(ctx, guard.read_permission())? {
+    if !in_edit_mode(ctx, perm)? {
         return Ok(Vec::new());
     }
 
-    let state = crate::changes_from_initial(ctx, guard.read_permission())?;
+    let state = crate::changes_from_initial(ctx, perm)?;
     Ok(state.into_iter().map(|a| a.into()).collect())
 }

--- a/crates/gitbutler-edit-mode/tests/edit_mode.rs
+++ b/crates/gitbutler-edit-mode/tests/edit_mode.rs
@@ -64,9 +64,7 @@ fn seed_metadata(repo: &gix::Repository) -> Result<()> {
     Ok(())
 }
 
-fn stack_id(ctx: &Context) -> Result<StackId> {
-    let guard = ctx.shared_worktree_access();
-    let (_repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
+fn stack_id(ws: &but_graph::Workspace) -> Result<StackId> {
     ws.stacks
         .first()
         .context("expected workspace stack")?
@@ -104,13 +102,17 @@ fn basic_leaving_edit_mode() -> Result<()> {
 
     let worktree_dir = repo.workdir().unwrap().to_owned();
     drop(repo);
-    let stack_id = stack_id(&ctx)?;
-    enter_edit_mode(&mut ctx, foobar, stack_id)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    let stack_id = {
+        let (_repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
+        stack_id(&ws)?
+    };
+    enter_edit_mode(&mut ctx, foobar, stack_id, guard.write_permission())?;
 
     std::fs::write(worktree_dir.join("file"), "edited during edit mode\n")?;
     std::fs::write(worktree_dir.join("newfile"), "created during edit mode\n")?;
 
-    save_and_return_to_workspace(&mut ctx)?;
+    save_and_return_to_workspace(&mut ctx, guard.write_permission())?;
 
     let repo = ctx.repo.get()?;
     let blob = repo.rev_parse_single(b"HEAD^{/foobar}:file")?.object()?;
@@ -130,12 +132,16 @@ fn evolution_parents_written() -> Result<()> {
 
     let worktree_dir = repo.workdir().unwrap().to_owned();
     drop(repo);
-    let stack_id = stack_id(&ctx)?;
-    enter_edit_mode(&mut ctx, foobar, stack_id)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    let stack_id = {
+        let (_repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
+        stack_id(&ws)?
+    };
+    enter_edit_mode(&mut ctx, foobar, stack_id, guard.write_permission())?;
 
     std::fs::write(worktree_dir.join("file"), "edited during edit mode\n")?;
 
-    save_and_return_to_workspace(&mut ctx)?;
+    save_and_return_to_workspace(&mut ctx, guard.write_permission())?;
 
     let repo = ctx.repo.get()?;
     let session = git_meta_lib::Session::open(repo.path())?;
@@ -169,8 +175,12 @@ fn multiple_commits_created_during_edit_mode() -> Result<()> {
 
     let worktree_dir = repo.workdir().unwrap().to_owned();
     drop(repo);
-    let stack_id = stack_id(&ctx)?;
-    enter_edit_mode(&mut ctx, foobar, stack_id)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    let stack_id = {
+        let (_repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
+        stack_id(&ws)?
+    };
+    enter_edit_mode(&mut ctx, foobar, stack_id, guard.write_permission())?;
 
     let repo = ctx.repo.get()?;
     let commit = gix::objs::Commit::try_from(repo.find_commit(foobar)?.decode()?)?;
@@ -201,7 +211,7 @@ fn multiple_commits_created_during_edit_mode() -> Result<()> {
 
     std::fs::write(worktree_dir.join("file"), "edited during edit mode\n")?;
 
-    save_and_return_to_workspace(&mut ctx)?;
+    save_and_return_to_workspace(&mut ctx, guard.write_permission())?;
 
     let repo = &*ctx.repo.get()?;
     insta::assert_snapshot!(visualize_commit_graph(repo, "refs/heads/gitbutler/workspace")?, @"
@@ -230,8 +240,12 @@ fn apply_commit_on_itself() -> Result<()> {
     let foobar = repo.head_commit()?.decode()?.parents().next().unwrap();
 
     drop(repo);
-    let stack_id = stack_id(&ctx)?;
-    enter_edit_mode(&mut ctx, foobar, stack_id)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    let stack_id = {
+        let (_repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
+        stack_id(&ws)?
+    };
+    enter_edit_mode(&mut ctx, foobar, stack_id, guard.write_permission())?;
 
     let repo = ctx.repo.get()?;
     // Set HEAD to gitbutler/workspace, detached, to see what happens when we
@@ -255,7 +269,7 @@ fn apply_commit_on_itself() -> Result<()> {
     })?;
     drop(repo);
 
-    save_and_return_to_workspace(&mut ctx)?;
+    save_and_return_to_workspace(&mut ctx, guard.write_permission())?;
 
     let repo = &*ctx.repo.get()?;
     // It works.
@@ -283,7 +297,8 @@ fn conficted_entries_get_written_when_leaving_edit_mode() -> Result<()> {
     let (mut ctx, _tempdir) =
         command_ctx("conficted_entries_get_written_when_leaving_edit_mode_in_edit_mode")?;
     seed_edit_mode_metadata(&ctx, "refs/heads/branchy")?;
-    save_and_return_to_workspace(&mut ctx)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    save_and_return_to_workspace(&mut ctx, guard.write_permission())?;
 
     let repo = ctx.repo.get()?;
     insta::assert_snapshot!(
@@ -308,8 +323,12 @@ fn abort_requires_force_when_changes_were_made() -> Result<()> {
     let foobar = repo.head_commit()?.decode()?.parents().next().unwrap();
     drop(repo);
 
-    let stack_id = stack_id(&ctx)?;
-    enter_edit_mode(&mut ctx, foobar, stack_id)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    let stack_id = {
+        let (_repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
+        stack_id(&ws)?
+    };
+    enter_edit_mode(&mut ctx, foobar, stack_id, guard.write_permission())?;
 
     let repo = ctx.repo.get()?;
     insta::assert_debug_snapshot!(
@@ -327,7 +346,7 @@ fn abort_requires_force_when_changes_were_made() -> Result<()> {
 
     std::fs::write(worktree_dir.join("file"), "edited during edit mode\n")?;
 
-    let result = abort_and_return_to_workspace(&mut ctx, false);
+    let result = abort_and_return_to_workspace(&mut ctx, false, guard.write_permission());
     insta::assert_debug_snapshot!(result.as_ref().map(|_| ()).is_err(), @"true");
     let err = result
         .err()
@@ -350,7 +369,7 @@ fn abort_requires_force_when_changes_were_made() -> Result<()> {
     "#
     );
 
-    abort_and_return_to_workspace(&mut ctx, true)?;
+    abort_and_return_to_workspace(&mut ctx, true, guard.write_permission())?;
     insta::assert_debug_snapshot!(
         ctx.repo.get()?.head_name()?,
         @r#"
@@ -377,8 +396,17 @@ fn enter_edit_mode_checks_out_conflicted_commit() -> Result<()> {
 
     drop(repo);
 
-    let stack_id = stack_id(&ctx)?;
-    enter_edit_mode(&mut ctx, conflicted_commit, stack_id)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    let stack_id = {
+        let (_repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
+        stack_id(&ws)?
+    };
+    enter_edit_mode(
+        &mut ctx,
+        conflicted_commit,
+        stack_id,
+        guard.write_permission(),
+    )?;
 
     let repo = ctx.repo.get()?;
     insta::assert_debug_snapshot!(
@@ -425,7 +453,7 @@ fn enter_edit_mode_checks_out_conflicted_commit() -> Result<()> {
     );
     drop(repo);
 
-    abort_and_return_to_workspace(&mut ctx, true)?;
+    abort_and_return_to_workspace(&mut ctx, true, guard.write_permission())?;
     insta::assert_debug_snapshot!(
         ctx.repo.get()?.head_name()?,
         @r#"
@@ -472,8 +500,12 @@ fn enter_edit_mode_works_with_only_integration_ref_present() -> Result<()> {
         foobar
     };
 
-    let stack_id = stack_id(&ctx)?;
-    enter_edit_mode(&mut ctx, foobar, stack_id)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    let stack_id = {
+        let (_repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
+        stack_id(&ws)?
+    };
+    enter_edit_mode(&mut ctx, foobar, stack_id, guard.write_permission())?;
 
     insta::assert_debug_snapshot!(
         ctx.repo.get()?.head_name()?,

--- a/crates/gitbutler-tauri/src/action.rs
+++ b/crates/gitbutler-tauri/src/action.rs
@@ -10,7 +10,8 @@ pub fn list_actions(
     limit: i64,
 ) -> anyhow::Result<but_action::ActionListing, Error> {
     let ctx: Context = project_id.try_into()?;
-    but_action::list_actions(&ctx, offset, limit).map_err(|e| Error::from(anyhow::anyhow!(e)))
+    let db = ctx.db.get_cache()?;
+    but_action::list_actions(&db, offset, limit).map_err(|e| Error::from(anyhow::anyhow!(e)))
 }
 
 #[tauri::command(async)]
@@ -21,16 +22,18 @@ pub fn handle_changes(
     handler: but_action::ActionHandler,
 ) -> anyhow::Result<but_action::Outcome, Error> {
     let mut ctx: Context = project_id.try_into()?;
-    but_action::handle_changes(
+    let mut guard = ctx.exclusive_worktree_access();
+    let perm = guard.write_permission();
+    let (_, outcome) = but_action::record_uncommitted_changes_with_perm(
         &mut ctx,
         &change_summary,
         None,
         handler,
         but_action::Source::GitButler,
         None,
-    )
-    .map(|(_id, outcome)| outcome)
-    .map_err(|e| Error::from(anyhow::anyhow!(e)))
+        perm,
+    )?;
+    Ok(outcome)
 }
 
 #[tauri::command(async)]

--- a/crates/gitbutler-tauri/src/zip.rs
+++ b/crates/gitbutler-tauri/src/zip.rs
@@ -2,7 +2,7 @@
 use std::path::PathBuf;
 
 use but_api::json::Error;
-use but_ctx::ProjectHandleOrLegacyProjectId;
+use but_ctx::{Context, ProjectHandleOrLegacyProjectId};
 use tauri::State;
 use tracing::instrument;
 
@@ -23,7 +23,13 @@ pub fn get_anonymous_graph_path(
     archival: State<'_, but_feedback::Archival>,
     project_id: ProjectHandleOrLegacyProjectId,
 ) -> Result<PathBuf, Error> {
-    archival.zip_anonymous_graph(project_id).map_err(Into::into)
+    let ctx: Context = project_id.try_into()?;
+    let _guard = ctx.shared_worktree_access();
+    let repo = ctx.repo.get()?;
+    let meta = ctx.meta()?;
+    archival
+        .zip_anonymous_graph(&repo, &meta)
+        .map_err(Into::into)
 }
 
 #[tauri::command(async)]

--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -96,7 +96,9 @@ impl Handler {
         perm: &mut RepoExclusive,
     ) -> Result<()> {
         let context_lines = ctx.settings.context_lines;
-        let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(perm.read_permission())?;
+        let mut meta = ctx.meta()?;
+        let (repo, mut ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
+        let rules = but_rules::list_rules(&db)?;
 
         let wt_changes = but_core::diff::worktree_changes(&repo)?;
 
@@ -124,12 +126,17 @@ impl Handler {
                 .err()
                 .map(|err| serde_error::Error::new(&**err)),
         };
-        drop((repo, ws, db));
-        if let Ok(update_count) =
-            but_rules::handler::process_workspace_rules(ctx, &assignments, perm)
-            && update_count > 0
+        if let Ok(update_count) = but_rules::handler::process_workspace_rules(
+            rules,
+            &assignments,
+            &repo,
+            &mut ws,
+            &mut db,
+            &mut meta,
+            perm,
+            context_lines,
+        ) && update_count > 0
         {
-            let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(perm.read_permission())?;
             // Getting these again since they were updated
             let (assignments, assignments_error) = assignments_and_errors(
                 db.hunk_assignments_mut()?,


### PR DESCRIPTION
## Summary
- show the Gerrit review ref (`refs/for/<target>`) in successful push output when Gerrit mode is enabled
- reuse the recorded remote ref from the push result for non-Gerrit output
- add focused coverage for both display paths

Fixes #13487

## Testing
- cargo fmt --check
- git diff --check
- cargo test -p but branch_remote_ref_display --lib -j1