### PR TITLE
Lite: remove effects + on mutation success, update query data and rewrite branch/commit references

### DIFF
--- a/apps/lite/ui/src/api/ref-info.ts
+++ b/apps/lite/ui/src/api/ref-info.ts
@@ -54,6 +54,42 @@ export const findSegmentByBranchRef = ({
 	return null;
 };
 
+export const renameBranchInHeadInfo = ({
+	headInfo,
+	stackId,
+	branchRef,
+	newName,
+	newBranchRef,
+}: {
+	headInfo: RefInfo;
+	stackId: string;
+	branchRef: Array<number>;
+	newName: string;
+	newBranchRef: Array<number>;
+}): RefInfo => ({
+	...headInfo,
+	stacks: headInfo.stacks.map((stack) => {
+		if (stack.id !== stackId) return stack;
+
+		return {
+			...stack,
+			segments: stack.segments.map((segment) => {
+				if (!segment.refName || !refNamesEqual(segment.refName.fullNameBytes, branchRef))
+					return segment;
+
+				return {
+					...segment,
+					refName: {
+						...segment.refName,
+						displayName: newName,
+						fullNameBytes: newBranchRef,
+					},
+				};
+			}),
+		};
+	}),
+});
+
 export const resolveRelativeTo = ({
 	headInfo,
 	relativeTo,

--- a/apps/lite/ui/src/api/ref-info.ts
+++ b/apps/lite/ui/src/api/ref-info.ts
@@ -1,4 +1,4 @@
-import { encodeRefName } from "#ui/api/ref-name.ts";
+import { encodeRefName, refNamesEqual } from "#ui/api/ref-name.ts";
 import { type Commit, type RefInfo, type RelativeTo, type Segment } from "@gitbutler/but-sdk";
 
 export const getCommonBaseCommitId = (headInfo: RefInfo): string | undefined => {
@@ -40,13 +40,6 @@ export const findCommit = ({
 	return null;
 };
 
-const branchRefsEqual = (left: Array<number> | null, right: Array<number> | null): boolean =>
-	left === right ||
-	(left !== null &&
-		right !== null &&
-		left.length === right.length &&
-		left.every((value, index) => value === right[index]));
-
 export const findSegmentByBranchRef = ({
 	headInfo,
 	branchRef,
@@ -56,7 +49,7 @@ export const findSegmentByBranchRef = ({
 }): Segment | null => {
 	for (const stack of headInfo.stacks)
 		for (const segment of stack.segments)
-			if (branchRefsEqual(segment.refName?.fullNameBytes ?? null, branchRef)) return segment;
+			if (refNamesEqual(segment.refName?.fullNameBytes ?? null, branchRef)) return segment;
 
 	return null;
 };

--- a/apps/lite/ui/src/api/ref-info.ts
+++ b/apps/lite/ui/src/api/ref-info.ts
@@ -40,6 +40,17 @@ export const findCommit = ({
 	return null;
 };
 
+export const findCommitStackId = (headInfo: RefInfo, commitId: string): string | null => {
+	for (const stack of headInfo.stacks) {
+		if (stack.id === null) continue;
+
+		for (const segment of stack.segments)
+			if (segment.commits.some((commit) => commit.id === commitId)) return stack.id;
+	}
+
+	return null;
+};
+
 export const findSegmentByBranchRef = ({
 	headInfo,
 	branchRef,

--- a/apps/lite/ui/src/api/ref-name.ts
+++ b/apps/lite/ui/src/api/ref-name.ts
@@ -4,3 +4,10 @@ export const decodeRefName = (fullNameBytes: Array<number>): string =>
 
 export const encodeRefName = (fullName: string): Array<number> =>
 	Array.from(new TextEncoder().encode(fullName));
+
+export const refNamesEqual = (left: Array<number> | null, right: Array<number> | null): boolean =>
+	left === right ||
+	(left !== null &&
+		right !== null &&
+		left.length === right.length &&
+		left.every((value, index) => value === right[index]));

--- a/apps/lite/ui/src/operations/operation.ts
+++ b/apps/lite/ui/src/operations/operation.ts
@@ -13,13 +13,15 @@ import {
 	CommitSquashParams,
 	CommitUncommitParams,
 } from "#electron/ipc.ts";
+import { headInfoQueryOptions } from "#ui/api/queries.ts";
+import { findCommitStackId } from "#ui/api/ref-info.ts";
 import { rejectedChangesToastOptions } from "#ui/operations/rejectedChangesToastOptions.tsx";
-import { DiffSpec, InsertSide, RelativeTo } from "@gitbutler/but-sdk";
-import { Operand, operandEquals, operandFileParent } from "#ui/operands.ts";
+import { DiffSpec, InsertSide, RelativeTo, type WorkspaceState } from "@gitbutler/but-sdk";
+import { commitOperand, Operand, operandEquals, operandFileParent } from "#ui/operands.ts";
 import { resolveDiffSpecs, useResolveDiffSpecs } from "#ui/operations/diff-specs.ts";
 import { decodeRefName } from "#ui/api/ref-name.ts";
-import { projectActions } from "#ui/projects/state.ts";
-import { useAppDispatch } from "#ui/store.ts";
+import { projectActions, selectProjectSelectionOutline } from "#ui/projects/state.ts";
+import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { useParams } from "@tanstack/react-router";
 import { errorMessageForToast } from "#ui/errors.ts";
 
@@ -78,6 +80,25 @@ export type Operation =
 	| ({ _tag: "CommitUncommitChanges" } & CommitUncommitChangesOperation)
 	| ({ _tag: "MoveBranch" } & MoveBranchOperation)
 	| ({ _tag: "TearOffBranch" } & TearOffBranchOperation);
+
+// TODO: move
+export const rewrittenCommitSelection = ({
+	selection,
+	workspace,
+}: {
+	selection: Operand;
+	workspace: WorkspaceState;
+}): Operand | null => {
+	if (selection._tag !== "Commit") return null;
+
+	const commitId = workspace.replacedCommits[selection.commitId];
+	if (commitId === undefined) return null;
+
+	const stackId = findCommitStackId(workspace.headInfo, commitId);
+	if (stackId === null) return null;
+
+	return commitOperand({ stackId, commitId });
+};
 
 /** @public */
 export const commitAmendOperation = (operation: CommitAmendOperation): Operation => ({
@@ -326,6 +347,7 @@ export const useDryRunOperation = ({
 export const useRunOperation = () => {
 	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
 	const dispatch = useAppDispatch();
+	const selection = useAppSelector((state) => selectProjectSelectionOutline(state, projectId));
 	const queryClient = useQueryClient();
 	const toastManager = Toast.useToastManager();
 
@@ -337,14 +359,15 @@ export const useRunOperation = () => {
 				resolveChanges: (source) => resolveDiffSpecs({ projectId, queryClient, source }),
 				dryRun: false,
 			}),
-		onSuccess: async (response, input, _ctx, { client }) => {
+		onSuccess: async (response, _input, _ctx, { client }) => {
 			if (response) {
-				dispatch(
-					projectActions.addReplacedCommits({
-						projectId,
-						replacedCommits: response.workspace.replacedCommits,
-					}),
-				);
+				client.setQueryData(headInfoQueryOptions(projectId).queryKey, response.workspace.headInfo);
+				const rewrittenSelection = rewrittenCommitSelection({
+					selection,
+					workspace: response.workspace,
+				});
+				if (rewrittenSelection)
+					dispatch(projectActions.selectOutline({ projectId, selection: rewrittenSelection }));
 
 				if ("rejectedChanges" in response && response.rejectedChanges.length > 0)
 					toastManager.add(

--- a/apps/lite/ui/src/operations/operation.ts
+++ b/apps/lite/ui/src/operations/operation.ts
@@ -14,14 +14,13 @@ import {
 	CommitUncommitParams,
 } from "#electron/ipc.ts";
 import { headInfoQueryOptions } from "#ui/api/queries.ts";
-import { findCommitStackId } from "#ui/api/ref-info.ts";
 import { rejectedChangesToastOptions } from "#ui/operations/rejectedChangesToastOptions.tsx";
-import { DiffSpec, InsertSide, RelativeTo, type WorkspaceState } from "@gitbutler/but-sdk";
-import { commitOperand, Operand, operandEquals, operandFileParent } from "#ui/operands.ts";
+import { DiffSpec, InsertSide, RelativeTo } from "@gitbutler/but-sdk";
+import { Operand, operandEquals, operandFileParent } from "#ui/operands.ts";
 import { resolveDiffSpecs, useResolveDiffSpecs } from "#ui/operations/diff-specs.ts";
 import { decodeRefName } from "#ui/api/ref-name.ts";
-import { projectActions, selectProjectSelectionOutline } from "#ui/projects/state.ts";
-import { useAppDispatch, useAppSelector } from "#ui/store.ts";
+import { projectActions } from "#ui/projects/state.ts";
+import { useAppDispatch } from "#ui/store.ts";
 import { useParams } from "@tanstack/react-router";
 import { errorMessageForToast } from "#ui/errors.ts";
 
@@ -80,25 +79,6 @@ export type Operation =
 	| ({ _tag: "CommitUncommitChanges" } & CommitUncommitChangesOperation)
 	| ({ _tag: "MoveBranch" } & MoveBranchOperation)
 	| ({ _tag: "TearOffBranch" } & TearOffBranchOperation);
-
-// TODO: move
-export const rewrittenCommitSelection = ({
-	selection,
-	workspace,
-}: {
-	selection: Operand;
-	workspace: WorkspaceState;
-}): Operand | null => {
-	if (selection._tag !== "Commit") return null;
-
-	const commitId = workspace.replacedCommits[selection.commitId];
-	if (commitId === undefined) return null;
-
-	const stackId = findCommitStackId(workspace.headInfo, commitId);
-	if (stackId === null) return null;
-
-	return commitOperand({ stackId, commitId });
-};
 
 /** @public */
 export const commitAmendOperation = (operation: CommitAmendOperation): Operation => ({
@@ -347,7 +327,6 @@ export const useDryRunOperation = ({
 export const useRunOperation = () => {
 	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
 	const dispatch = useAppDispatch();
-	const selection = useAppSelector((state) => selectProjectSelectionOutline(state, projectId));
 	const queryClient = useQueryClient();
 	const toastManager = Toast.useToastManager();
 
@@ -362,12 +341,13 @@ export const useRunOperation = () => {
 		onSuccess: async (response, _input, _ctx, { client }) => {
 			if (response) {
 				client.setQueryData(headInfoQueryOptions(projectId).queryKey, response.workspace.headInfo);
-				const rewrittenSelection = rewrittenCommitSelection({
-					selection,
-					workspace: response.workspace,
-				});
-				if (rewrittenSelection)
-					dispatch(projectActions.selectOutline({ projectId, selection: rewrittenSelection }));
+				dispatch(
+					projectActions.updateRewrittenCommitReferences({
+						projectId,
+						replacedCommits: response.workspace.replacedCommits,
+						headInfo: response.workspace.headInfo,
+					}),
+				);
 
 				if ("rejectedChanges" in response && response.rejectedChanges.length > 0)
 					toastManager.add(

--- a/apps/lite/ui/src/projects/state.ts
+++ b/apps/lite/ui/src/projects/state.ts
@@ -1,6 +1,6 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import type { RootState } from "#ui/store.ts";
-import { type AbsorptionTarget, type RelativeTo } from "@gitbutler/but-sdk";
+import { type AbsorptionTarget, type RefInfo, type RelativeTo } from "@gitbutler/but-sdk";
 import { type BranchOperand, type CommitOperand, type Operand } from "#ui/operands.ts";
 import { type Panel } from "#ui/panels.ts";
 import * as panels from "#ui/panels/state.ts";
@@ -153,6 +153,21 @@ const projectSlice = createSlice({
 		) => {
 			const { projectId, commitTarget } = action.payload;
 			workspace.setCommitTarget(ensureProjectState(state, projectId).workspace, commitTarget);
+		},
+		updateRewrittenCommitReferences: (
+			state,
+			action: PayloadAction<{
+				projectId: string;
+				replacedCommits: Record<string, string>;
+				headInfo: RefInfo;
+			}>,
+		) => {
+			const { projectId, replacedCommits, headInfo } = action.payload;
+			workspace.updateRewrittenCommitReferences(
+				ensureProjectState(state, projectId).workspace,
+				replacedCommits,
+				headInfo,
+			);
 		},
 		showPanel: (state, action: PayloadAction<{ projectId: string; panel: Panel }>) => {
 			panels.showPanel(

--- a/apps/lite/ui/src/projects/state.ts
+++ b/apps/lite/ui/src/projects/state.ts
@@ -79,6 +79,18 @@ const projectSlice = createSlice({
 			const projectState = ensureProjectState(state, projectId);
 			workspace.startRenameBranch(projectState.workspace, branch);
 		},
+		updateRewrittenBranchReferences: (
+			state,
+			action: PayloadAction<{
+				projectId: string;
+				oldBranch: BranchOperand;
+				newBranch: BranchOperand;
+			}>,
+		) => {
+			const { projectId, oldBranch, newBranch } = action.payload;
+			const projectState = ensureProjectState(state, projectId);
+			workspace.updateRewrittenBranchReferences(projectState.workspace, oldBranch, newBranch);
+		},
 		enterTransferMode: (
 			state,
 			action: PayloadAction<{ projectId: string; mode: TransferOperationMode }>,

--- a/apps/lite/ui/src/projects/state.ts
+++ b/apps/lite/ui/src/projects/state.ts
@@ -186,13 +186,6 @@ const projectSlice = createSlice({
 		closeDialog: (state, action: PayloadAction<{ projectId: string }>) => {
 			ensureProjectState(state, action.payload.projectId).dialog = { _tag: "None" };
 		},
-		addReplacedCommits: (
-			state,
-			action: PayloadAction<{ projectId: string; replacedCommits: Record<string, string> }>,
-		) => {
-			const { projectId, replacedCommits } = action.payload;
-			workspace.addReplacedCommits(ensureProjectState(state, projectId).workspace, replacedCommits);
-		},
 	},
 });
 
@@ -225,6 +218,3 @@ export const selectProjectHighlightedCommitIds = (state: RootState, projectId: s
 
 export const selectProjectCommitTarget = (state: RootState, projectId: string) =>
 	workspace.selectCommitTarget(selectProjectWorkspaceState(state, projectId));
-
-export const selectProjectReplacedCommits = (state: RootState, projectId: string) =>
-	workspace.selectReplacedCommits(selectProjectWorkspaceState(state, projectId));

--- a/apps/lite/ui/src/projects/workspace/state.ts
+++ b/apps/lite/ui/src/projects/workspace/state.ts
@@ -1,4 +1,5 @@
 import { type OperationType } from "#ui/operations/operation.ts";
+import { refNamesEqual } from "#ui/api/ref-name.ts";
 import { AbsorptionTarget, type RelativeTo } from "@gitbutler/but-sdk";
 import { Match } from "effect";
 import {
@@ -154,6 +155,33 @@ export const setCommitTarget = (state: WorkspaceState, commitTarget: RelativeTo 
 export const startRenameBranch = (state: WorkspaceState, branch: BranchOperand) => {
 	selectOutline(state, branchOperand(branch));
 	state.mode = renameBranchOutlineMode({ operand: branch });
+};
+
+export const updateRewrittenBranchReferences = (
+	state: WorkspaceState,
+	oldBranch: BranchOperand,
+	newBranch: BranchOperand,
+) => {
+	const oldBranchOperand = branchOperand(oldBranch);
+	const newBranchOperand = branchOperand(newBranch);
+
+	if (
+		state.selection.outline._tag === "Branch" &&
+		operandEquals(state.selection.outline, oldBranchOperand)
+	)
+		state.selection.outline = newBranchOperand;
+
+	if (
+		state.selection.files._tag === "Branch" &&
+		operandEquals(state.selection.files, oldBranchOperand)
+	)
+		state.selection.files = newBranchOperand;
+
+	if (
+		state.commitTarget?.type === "referenceBytes" &&
+		refNamesEqual(state.commitTarget.subject, oldBranch.branchRef)
+	)
+		state.commitTarget = { type: "referenceBytes", subject: newBranch.branchRef };
 };
 
 export const startRewordCommit = (state: WorkspaceState, commit: CommitOperand) => {

--- a/apps/lite/ui/src/projects/workspace/state.ts
+++ b/apps/lite/ui/src/projects/workspace/state.ts
@@ -39,7 +39,6 @@ export type WorkspaceState = {
 	commitTarget: RelativeTo | null;
 	highlightedCommitIds: Array<string>;
 	mode: OutlineMode;
-	replacedCommits: Record<string, string>;
 	selection: SelectionState;
 };
 
@@ -47,7 +46,6 @@ export const createInitialState = (): WorkspaceState => ({
 	commitTarget: null,
 	highlightedCommitIds: [],
 	mode: defaultOutlineMode,
-	replacedCommits: {},
 	selection: createInitialSelectionState(),
 });
 
@@ -153,13 +151,6 @@ export const setCommitTarget = (state: WorkspaceState, commitTarget: RelativeTo 
 	state.commitTarget = commitTarget;
 };
 
-export const addReplacedCommits = (
-	state: WorkspaceState,
-	replacedCommits: Record<string, string>,
-) => {
-	state.replacedCommits = { ...state.replacedCommits, ...replacedCommits };
-};
-
 export const startRenameBranch = (state: WorkspaceState, branch: BranchOperand) => {
 	selectOutline(state, branchOperand(branch));
 	state.mode = renameBranchOutlineMode({ operand: branch });
@@ -181,6 +172,3 @@ export const selectHighlightedCommitIds = (state: WorkspaceState): Array<string>
 	state.highlightedCommitIds;
 
 export const selectCommitTarget = (state: WorkspaceState): RelativeTo | null => state.commitTarget;
-
-export const selectReplacedCommits = (state: WorkspaceState): Record<string, string> =>
-	state.replacedCommits;

--- a/apps/lite/ui/src/projects/workspace/state.ts
+++ b/apps/lite/ui/src/projects/workspace/state.ts
@@ -1,6 +1,6 @@
 import { type OperationType } from "#ui/operations/operation.ts";
 import { refNamesEqual } from "#ui/api/ref-name.ts";
-import { AbsorptionTarget, type RelativeTo } from "@gitbutler/but-sdk";
+import { AbsorptionTarget, type RefInfo, type RelativeTo } from "@gitbutler/but-sdk";
 import { Match } from "effect";
 import {
 	branchOperand,
@@ -23,6 +23,7 @@ import {
 	type OutlineMode,
 	type TransferOperationMode,
 } from "#ui/outline/mode.ts";
+import { findCommitStackId } from "#ui/api/ref-info.ts";
 
 type SelectionState = {
 	outline: Operand;
@@ -150,6 +151,53 @@ export const setHighlightedCommitIds = (state: WorkspaceState, commitIds: Array<
 
 export const setCommitTarget = (state: WorkspaceState, commitTarget: RelativeTo | null) => {
 	state.commitTarget = commitTarget;
+};
+
+const rewrittenCommitOperand = ({
+	commit,
+	headInfo,
+	replacedCommits,
+}: {
+	commit: CommitOperand;
+	headInfo: RefInfo;
+	replacedCommits: Record<string, string>;
+}): CommitOperand | null => {
+	const commitId = replacedCommits[commit.commitId];
+	if (commitId === undefined) return null;
+
+	const stackId = findCommitStackId(headInfo, commitId);
+	if (stackId === null) return null;
+
+	return { stackId, commitId };
+};
+
+export const updateRewrittenCommitReferences = (
+	state: WorkspaceState,
+	replacedCommits: Record<string, string>,
+	headInfo: RefInfo,
+) => {
+	if (state.selection.outline._tag === "Commit") {
+		const commit = rewrittenCommitOperand({
+			commit: state.selection.outline,
+			replacedCommits,
+			headInfo,
+		});
+		if (commit) state.selection.outline = commitOperand(commit);
+	}
+
+	if (state.selection.files._tag === "Commit") {
+		const commit = rewrittenCommitOperand({
+			commit: state.selection.files,
+			replacedCommits,
+			headInfo,
+		});
+		if (commit) state.selection.files = commitOperand(commit);
+	}
+
+	if (state.commitTarget?.type === "commit") {
+		const commitId = replacedCommits[state.commitTarget.subject];
+		if (commitId !== undefined) state.commitTarget = { type: "commit", subject: commitId };
+	}
 };
 
 export const startRenameBranch = (state: WorkspaceState, branch: BranchOperand) => {

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.tsx
@@ -101,7 +101,7 @@ import { Panel, PanelProps } from "react-resizable-panels";
 import styles from "./OutlinePanel.module.css";
 import workspaceItemRowStyles from "./WorkspaceItemRow.module.css";
 import { WorkspaceItemRow, WorkspaceItemRowToolbar } from "./WorkspaceItemRow.tsx";
-import { rewrittenCommitSelection, useDryRunOperation } from "#ui/operations/operation.ts";
+import { useDryRunOperation } from "#ui/operations/operation.ts";
 import { isNonEmptyArray, NonEmptyArray } from "effect/Array";
 import { defaultOutlineSelection } from "#ui/projects/workspace/state.ts";
 import { ShortcutButton } from "#ui/components/ShortcutButton.tsx";
@@ -250,17 +250,13 @@ const useOutlineTreeHotkeys = ({
 				headInfoQueryOptions(input.projectId).queryKey,
 				response.workspace.headInfo,
 			);
-			const rewrittenSelection = rewrittenCommitSelection({
-				selection,
-				workspace: response.workspace,
-			});
-			if (rewrittenSelection)
-				dispatch(
-					projectActions.selectOutline({
-						projectId: input.projectId,
-						selection: rewrittenSelection,
-					}),
-				);
+			dispatch(
+				projectActions.updateRewrittenCommitReferences({
+					projectId: input.projectId,
+					replacedCommits: response.workspace.replacedCommits,
+					headInfo: response.workspace.headInfo,
+				}),
+			);
 
 			await mutation.client.invalidateQueries();
 		},
@@ -759,7 +755,6 @@ const CommitRow: FC<
 	);
 	const dryRunCommit = useDryRunCommit(commit.id);
 	const outlineMode = useAppSelector((state) => selectProjectOutlineModeState(state, projectId));
-	const selection = useAppSelector((state) => selectProjectSelectionOutline(state, projectId));
 
 	const dispatch = useAppDispatch();
 	const commitOperandV: CommitOperand = {
@@ -791,17 +786,13 @@ const CommitRow: FC<
 				headInfoQueryOptions(input.projectId).queryKey,
 				response.workspace.headInfo,
 			);
-			const rewrittenSelection = rewrittenCommitSelection({
-				selection,
-				workspace: response.workspace,
-			});
-			if (rewrittenSelection)
-				dispatch(
-					projectActions.selectOutline({
-						projectId: input.projectId,
-						selection: rewrittenSelection,
-					}),
-				);
+			dispatch(
+				projectActions.updateRewrittenCommitReferences({
+					projectId: input.projectId,
+					replacedCommits: response.workspace.replacedCommits,
+					headInfo: response.workspace.headInfo,
+				}),
+			);
 
 			await mutation.client.invalidateQueries();
 		},
@@ -824,17 +815,13 @@ const CommitRow: FC<
 				headInfoQueryOptions(input.projectId).queryKey,
 				response.workspace.headInfo,
 			);
-			const rewrittenSelection = rewrittenCommitSelection({
-				selection,
-				workspace: response.workspace,
-			});
-			if (rewrittenSelection)
-				dispatch(
-					projectActions.selectOutline({
-						projectId: input.projectId,
-						selection: rewrittenSelection,
-					}),
-				);
+			dispatch(
+				projectActions.updateRewrittenCommitReferences({
+					projectId: input.projectId,
+					replacedCommits: response.workspace.replacedCommits,
+					headInfo: response.workspace.headInfo,
+				}),
+			);
 
 			await mutation.client.invalidateQueries();
 		},
@@ -857,17 +844,13 @@ const CommitRow: FC<
 				headInfoQueryOptions(input.projectId).queryKey,
 				response.workspace.headInfo,
 			);
-			const rewrittenSelection = rewrittenCommitSelection({
-				selection,
-				workspace: response.workspace,
-			});
-			if (rewrittenSelection)
-				dispatch(
-					projectActions.selectOutline({
-						projectId: input.projectId,
-						selection: rewrittenSelection,
-					}),
-				);
+			dispatch(
+				projectActions.updateRewrittenCommitReferences({
+					projectId: input.projectId,
+					replacedCommits: response.workspace.replacedCommits,
+					headInfo: response.workspace.headInfo,
+				}),
+			);
 
 			await mutation.client.invalidateQueries();
 		},
@@ -1321,7 +1304,6 @@ const Changes: FC<{
 	const toastManager = Toast.useToastManager();
 	const queryClient = useQueryClient();
 	const dispatch = useAppDispatch();
-	const selection = useAppSelector((state) => selectProjectSelectionOutline(state, projectId));
 
 	const commitCreate = useMutation({
 		mutationFn: async () => {
@@ -1407,12 +1389,13 @@ const Changes: FC<{
 		},
 		onSuccess: async (response, _input, _ctx, { client }) => {
 			client.setQueryData(headInfoQueryOptions(projectId).queryKey, response.workspace.headInfo);
-			const rewrittenSelection = rewrittenCommitSelection({
-				selection,
-				workspace: response.workspace,
-			});
-			if (rewrittenSelection)
-				dispatch(projectActions.selectOutline({ projectId, selection: rewrittenSelection }));
+			dispatch(
+				projectActions.updateRewrittenCommitReferences({
+					projectId,
+					replacedCommits: response.workspace.replacedCommits,
+					headInfo: response.workspace.headInfo,
+				}),
+			);
 
 			if (commitTarget?.relativeTo.type === "commit" && response.newCommit !== null)
 				dispatch(
@@ -1697,7 +1680,6 @@ const BranchRow: FC<
 	...restProps
 }) => {
 	const outlineMode = useAppSelector((state) => selectProjectOutlineModeState(state, projectId));
-	const selection = useAppSelector((state) => selectProjectSelectionOutline(state, projectId));
 	const dispatch = useAppDispatch();
 	const branchOperandV: BranchOperand = {
 		stackId,
@@ -1779,12 +1761,13 @@ const BranchRow: FC<
 				headInfoQueryOptions(projectId).queryKey,
 				response.workspace.headInfo,
 			);
-			const rewrittenSelection = rewrittenCommitSelection({
-				selection,
-				workspace: response.workspace,
-			});
-			if (rewrittenSelection)
-				dispatch(projectActions.selectOutline({ projectId, selection: rewrittenSelection }));
+			dispatch(
+				projectActions.updateRewrittenCommitReferences({
+					projectId,
+					replacedCommits: response.workspace.replacedCommits,
+					headInfo: response.workspace.headInfo,
+				}),
+			);
 
 			await mutation.client.invalidateQueries();
 		},

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.tsx
@@ -1717,11 +1717,11 @@ const BranchRow: FC<
 		mutationFn: window.lite.updateBranchName,
 		onSuccess: async (_response, input, _context, mutation) => {
 			const newBranchRef = encodeRefName(`refs/heads/${input.newName}`);
-			const newSelection = branchOperand({
+			const newBranch: BranchOperand = {
 				stackId,
 				// TODO: ideally the API would return the new ref?
 				branchRef: newBranchRef,
-			});
+			};
 
 			mutation.client.setQueryData(headInfoQueryOptions(projectId).queryKey, (headInfo) => {
 				if (!headInfo) return headInfo;
@@ -1735,7 +1735,13 @@ const BranchRow: FC<
 				});
 			});
 
-			dispatch(projectActions.selectOutline({ projectId, selection: newSelection }));
+			dispatch(
+				projectActions.updateRewrittenBranchReferences({
+					projectId,
+					oldBranch: branchOperandV,
+					newBranch,
+				}),
+			);
 			dispatch(projectActions.exitMode({ projectId }));
 
 			await mutation.client.invalidateQueries();

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.tsx
@@ -4,7 +4,12 @@ import {
 	changesInWorktreeQueryOptions,
 	headInfoQueryOptions,
 } from "#ui/api/queries.ts";
-import { findCommit, getCommonBaseCommitId, resolveRelativeTo } from "#ui/api/ref-info.ts";
+import {
+	findCommit,
+	getCommonBaseCommitId,
+	renameBranchInHeadInfo,
+	resolveRelativeTo,
+} from "#ui/api/ref-info.ts";
 import { decodeRefName, encodeRefName } from "#ui/api/ref-name.ts";
 import { commitTitle, shortCommitId } from "#ui/commit.ts";
 import {
@@ -1699,15 +1704,29 @@ const BranchRow: FC<
 	const updateBranchName = useMutation({
 		mutationFn: window.lite.updateBranchName,
 		onSuccess: async (_response, input, _context, mutation) => {
-			await mutation.client.invalidateQueries();
-
+			const newBranchRef = encodeRefName(`refs/heads/${input.newName}`);
 			const newSelection = branchOperand({
 				stackId,
 				// TODO: ideally the API would return the new ref?
-				branchRef: encodeRefName(`refs/heads/${input.newName}`),
+				branchRef: newBranchRef,
 			});
+
+			mutation.client.setQueryData(headInfoQueryOptions(projectId).queryKey, (headInfo) => {
+				if (!headInfo) return headInfo;
+
+				return renameBranchInHeadInfo({
+					headInfo,
+					stackId,
+					branchRef,
+					newName: input.newName,
+					newBranchRef,
+				});
+			});
+
 			dispatch(projectActions.selectOutline({ projectId, selection: newSelection }));
 			dispatch(projectActions.exitMode({ projectId }));
+
+			await mutation.client.invalidateQueries();
 		},
 		onError: (error) => {
 			// oxlint-disable-next-line no-console

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.tsx
@@ -43,7 +43,6 @@ import {
 	selectProjectCommitTarget,
 	selectProjectHighlightedCommitIds,
 	selectProjectOutlineModeState,
-	selectProjectReplacedCommits,
 	selectProjectSelectionOutline,
 } from "#ui/projects/state.ts";
 import { OperationSourceC } from "#ui/routes/project/$id/workspace/OperationSourceC.tsx";
@@ -102,7 +101,7 @@ import { Panel, PanelProps } from "react-resizable-panels";
 import styles from "./OutlinePanel.module.css";
 import workspaceItemRowStyles from "./WorkspaceItemRow.module.css";
 import { WorkspaceItemRow, WorkspaceItemRowToolbar } from "./WorkspaceItemRow.tsx";
-import { useDryRunOperation } from "#ui/operations/operation.ts";
+import { rewrittenCommitSelection, useDryRunOperation } from "#ui/operations/operation.ts";
 import { isNonEmptyArray, NonEmptyArray } from "effect/Array";
 import { defaultOutlineSelection } from "#ui/projects/workspace/state.ts";
 import { ShortcutButton } from "#ui/components/ShortcutButton.tsx";
@@ -189,37 +188,10 @@ const useNavigationIndex = ({
 	const navigationIndexUnfiltered = buildNavigationIndex(sections(headInfo));
 
 	const selection = useAppSelector((state) => selectProjectSelectionOutline(state, projectId));
-	const replacedCommits = useAppSelector((state) => selectProjectReplacedCommits(state, projectId));
 
 	// React allows state updates on render, but not for external stores.
 	// https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
 	useEffect(() => {
-		//
-		// Update selection when the commit was replaced.
-		//
-		const updatedSelection = Match.value(selection).pipe(
-			Match.withReturnType<Operand | null>(),
-			Match.tags({
-				Commit: (selection) => {
-					const newCommitId = replacedCommits[selection.commitId];
-					if (newCommitId === undefined || newCommitId === selection.commitId) return null;
-
-					return commitOperand({ ...selection, commitId: newCommitId });
-				},
-			}),
-			Match.orElse(() => null),
-		);
-
-		if (updatedSelection && navigationIndexIncludes(navigationIndexUnfiltered, updatedSelection)) {
-			dispatch(
-				projectActions.selectOutline({
-					projectId,
-					selection: updatedSelection,
-				}),
-			);
-			return;
-		}
-
 		//
 		// Reset selection when it's no longer part of the workspace.
 		//
@@ -230,7 +202,7 @@ const useNavigationIndex = ({
 					selection: defaultOutlineSelection,
 				}),
 			);
-	}, [navigationIndexUnfiltered, selection, projectId, dispatch, replacedCommits]);
+	}, [navigationIndexUnfiltered, selection, projectId, dispatch]);
 
 	const outlineMode = useAppSelector((state) => selectProjectOutlineModeState(state, projectId));
 
@@ -274,12 +246,21 @@ const useOutlineTreeHotkeys = ({
 	const commitMoveMutation = useMutation({
 		mutationFn: window.lite.commitMove,
 		onSuccess: async (response, input, _context, mutation) => {
-			dispatch(
-				projectActions.addReplacedCommits({
-					projectId: input.projectId,
-					replacedCommits: response.workspace.replacedCommits,
-				}),
+			mutation.client.setQueryData(
+				headInfoQueryOptions(input.projectId).queryKey,
+				response.workspace.headInfo,
 			);
+			const rewrittenSelection = rewrittenCommitSelection({
+				selection,
+				workspace: response.workspace,
+			});
+			if (rewrittenSelection)
+				dispatch(
+					projectActions.selectOutline({
+						projectId: input.projectId,
+						selection: rewrittenSelection,
+					}),
+				);
 
 			await mutation.client.invalidateQueries();
 		},
@@ -778,6 +759,7 @@ const CommitRow: FC<
 	);
 	const dryRunCommit = useDryRunCommit(commit.id);
 	const outlineMode = useAppSelector((state) => selectProjectOutlineModeState(state, projectId));
+	const selection = useAppSelector((state) => selectProjectSelectionOutline(state, projectId));
 
 	const dispatch = useAppDispatch();
 	const commitOperandV: CommitOperand = {
@@ -805,12 +787,21 @@ const CommitRow: FC<
 	const commitInsertBlank = useMutation({
 		mutationFn: window.lite.commitInsertBlank,
 		onSuccess: async (response, input, _context, mutation) => {
-			dispatch(
-				projectActions.addReplacedCommits({
-					projectId: input.projectId,
-					replacedCommits: response.workspace.replacedCommits,
-				}),
+			mutation.client.setQueryData(
+				headInfoQueryOptions(input.projectId).queryKey,
+				response.workspace.headInfo,
 			);
+			const rewrittenSelection = rewrittenCommitSelection({
+				selection,
+				workspace: response.workspace,
+			});
+			if (rewrittenSelection)
+				dispatch(
+					projectActions.selectOutline({
+						projectId: input.projectId,
+						selection: rewrittenSelection,
+					}),
+				);
 
 			await mutation.client.invalidateQueries();
 		},
@@ -829,12 +820,21 @@ const CommitRow: FC<
 	const commitDiscard = useMutation({
 		mutationFn: window.lite.commitDiscard,
 		onSuccess: async (response, input, _context, mutation) => {
-			dispatch(
-				projectActions.addReplacedCommits({
-					projectId: input.projectId,
-					replacedCommits: response.workspace.replacedCommits,
-				}),
+			mutation.client.setQueryData(
+				headInfoQueryOptions(input.projectId).queryKey,
+				response.workspace.headInfo,
 			);
+			const rewrittenSelection = rewrittenCommitSelection({
+				selection,
+				workspace: response.workspace,
+			});
+			if (rewrittenSelection)
+				dispatch(
+					projectActions.selectOutline({
+						projectId: input.projectId,
+						selection: rewrittenSelection,
+					}),
+				);
 
 			await mutation.client.invalidateQueries();
 		},
@@ -853,12 +853,21 @@ const CommitRow: FC<
 	const commitReword = useMutation({
 		mutationFn: window.lite.commitReword,
 		onSuccess: async (response, input, _context, mutation) => {
-			dispatch(
-				projectActions.addReplacedCommits({
-					projectId: input.projectId,
-					replacedCommits: response.workspace.replacedCommits,
-				}),
+			mutation.client.setQueryData(
+				headInfoQueryOptions(input.projectId).queryKey,
+				response.workspace.headInfo,
 			);
+			const rewrittenSelection = rewrittenCommitSelection({
+				selection,
+				workspace: response.workspace,
+			});
+			if (rewrittenSelection)
+				dispatch(
+					projectActions.selectOutline({
+						projectId: input.projectId,
+						selection: rewrittenSelection,
+					}),
+				);
 
 			await mutation.client.invalidateQueries();
 		},
@@ -1312,6 +1321,7 @@ const Changes: FC<{
 	const toastManager = Toast.useToastManager();
 	const queryClient = useQueryClient();
 	const dispatch = useAppDispatch();
+	const selection = useAppSelector((state) => selectProjectSelectionOutline(state, projectId));
 
 	const commitCreate = useMutation({
 		mutationFn: async () => {
@@ -1396,12 +1406,13 @@ const Changes: FC<{
 			});
 		},
 		onSuccess: async (response, _input, _ctx, { client }) => {
-			dispatch(
-				projectActions.addReplacedCommits({
-					projectId,
-					replacedCommits: response.workspace.replacedCommits,
-				}),
-			);
+			client.setQueryData(headInfoQueryOptions(projectId).queryKey, response.workspace.headInfo);
+			const rewrittenSelection = rewrittenCommitSelection({
+				selection,
+				workspace: response.workspace,
+			});
+			if (rewrittenSelection)
+				dispatch(projectActions.selectOutline({ projectId, selection: rewrittenSelection }));
 
 			if (commitTarget?.relativeTo.type === "commit" && response.newCommit !== null)
 				dispatch(
@@ -1686,6 +1697,7 @@ const BranchRow: FC<
 	...restProps
 }) => {
 	const outlineMode = useAppSelector((state) => selectProjectOutlineModeState(state, projectId));
+	const selection = useAppSelector((state) => selectProjectSelectionOutline(state, projectId));
 	const dispatch = useAppDispatch();
 	const branchOperandV: BranchOperand = {
 		stackId,
@@ -1757,12 +1769,16 @@ const BranchRow: FC<
 	const tearOffBranchMutation = useMutation({
 		mutationFn: window.lite.tearOffBranch,
 		onSuccess: async (response, _input, _context, mutation) => {
-			dispatch(
-				projectActions.addReplacedCommits({
-					projectId,
-					replacedCommits: response.workspace.replacedCommits,
-				}),
+			mutation.client.setQueryData(
+				headInfoQueryOptions(projectId).queryKey,
+				response.workspace.headInfo,
 			);
+			const rewrittenSelection = rewrittenCommitSelection({
+				selection,
+				workspace: response.workspace,
+			});
+			if (rewrittenSelection)
+				dispatch(projectActions.selectOutline({ projectId, selection: rewrittenSelection }));
 
 			await mutation.client.invalidateQueries();
 		},

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.tsx
@@ -1709,6 +1709,17 @@ const BranchRow: FC<
 			dispatch(projectActions.selectOutline({ projectId, selection: newSelection }));
 			dispatch(projectActions.exitMode({ projectId }));
 		},
+		onError: (error) => {
+			// oxlint-disable-next-line no-console
+			console.error(error);
+
+			toastManager.add({
+				type: "error",
+				title: "Failed to rename branch",
+				description: errorMessageForToast(error),
+				priority: "high",
+			});
+		},
 	});
 
 	const startEditing = () => {

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.tsx
@@ -91,7 +91,6 @@ import {
 	SubmitEventHandler,
 	Suspense,
 	use,
-	useEffect,
 	useOptimistic,
 	useRef,
 	useState,
@@ -113,6 +112,8 @@ import { Spinner } from "#ui/components/Spinner.tsx";
 import { errorMessageForToast } from "#ui/errors.ts";
 
 const NavigationIndexContext = createContext<NavigationIndex | null>(null);
+
+const OutlineSelectionContext = createContext<Operand | null>(null);
 
 const DryRunWorkspaceContext = createContext<WorkspaceState | null>(null);
 
@@ -183,34 +184,23 @@ const useNavigationIndex = ({
 }) => {
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
 
-	const dispatch = useAppDispatch();
-
 	const navigationIndexUnfiltered = buildNavigationIndex(sections(headInfo));
 
 	const selection = useAppSelector((state) => selectProjectSelectionOutline(state, projectId));
-
-	// React allows state updates on render, but not for external stores.
-	// https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
-	useEffect(() => {
-		//
-		// Reset selection when it's no longer part of the workspace.
-		//
-		if (!navigationIndexIncludes(navigationIndexUnfiltered, selection))
-			dispatch(
-				projectActions.selectOutline({
-					projectId,
-					selection: defaultOutlineSelection,
-				}),
-			);
-	}, [navigationIndexUnfiltered, selection, projectId, dispatch]);
+	const derivedSelection = navigationIndexIncludes(navigationIndexUnfiltered, selection)
+		? selection
+		: defaultOutlineSelection;
 
 	const outlineMode = useAppSelector((state) => selectProjectOutlineModeState(state, projectId));
 
-	return filterNavigationIndexForOutlineMode({
-		navigationIndex: navigationIndexUnfiltered,
-		outlineMode,
-		absorptionTargetKeys,
-	});
+	return {
+		navigationIndex: filterNavigationIndexForOutlineMode({
+			navigationIndex: navigationIndexUnfiltered,
+			outlineMode,
+			absorptionTargetKeys,
+		}),
+		selection: derivedSelection,
+	};
 };
 
 export const OutlinePanel: FC<PanelProps> = ({ ...panelProps }) => (
@@ -228,11 +218,12 @@ export const OutlinePanel: FC<PanelProps> = ({ ...panelProps }) => (
 const useOutlineTreeHotkeys = ({
 	navigationIndex,
 	projectId,
+	selection,
 }: {
 	navigationIndex: NavigationIndex;
 	projectId: string;
+	selection: Operand;
 }) => {
-	const selection = useAppSelector((state) => selectProjectSelectionOutline(state, projectId));
 	const outlineMode = useAppSelector((state) => selectProjectOutlineModeState(state, projectId));
 	const focusedPanel = useFocusedProjectPanel(projectId);
 	const { data: worktreeChanges } = useQuery(changesInWorktreeQueryOptions(projectId));
@@ -488,8 +479,6 @@ const useOutlineTreeHotkeys = ({
 const OutlineTreePanel: FC<PanelProps> = ({ ...panelProps }) => {
 	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
 
-	const selection = useAppSelector((state) => selectProjectSelectionOutline(state, projectId));
-
 	const outlineMode = useAppSelector((state) => selectProjectOutlineModeState(state, projectId));
 
 	const absorptionPlanTarget = Match.value(outlineMode).pipe(
@@ -507,7 +496,7 @@ const OutlineTreePanel: FC<PanelProps> = ({ ...panelProps }) => {
 		),
 	);
 
-	const navigationIndex = useNavigationIndex({
+	const { navigationIndex, selection } = useNavigationIndex({
 		projectId,
 		absorptionTargetKeys,
 	});
@@ -529,6 +518,7 @@ const OutlineTreePanel: FC<PanelProps> = ({ ...panelProps }) => {
 	useOutlineTreeHotkeys({
 		navigationIndex,
 		projectId,
+		selection,
 	});
 
 	const operationSource = getOperationSource(outlineMode);
@@ -542,60 +532,58 @@ const OutlineTreePanel: FC<PanelProps> = ({ ...panelProps }) => {
 
 	return (
 		<NavigationIndexContext value={navigationIndex}>
-			<AbsorptionTargetKeysContext value={absorptionTargetKeys}>
-				<DryRunWorkspaceContext value={dryRunWorkspace}>
-					<Panel
-						{...panelProps}
-						tabIndex={0}
-						role="tree"
-						aria-activedescendant={treeItemId(selection)}
-						className={classes(panelProps.className, styles.panel)}
-					>
-						<div className={styles.panelPadding}>
-							<Changes
-								projectId={projectId}
-								commitTarget={commitTarget}
-								targetComboboxItems={targetComboboxItems}
-							/>
-						</div>
-
-						<div className={styles.headInfo}>
-							{headInfo?.stacks.map((stack) => (
-								<StackC
-									key={stack.id}
+			<OutlineSelectionContext value={selection}>
+				<AbsorptionTargetKeysContext value={absorptionTargetKeys}>
+					<DryRunWorkspaceContext value={dryRunWorkspace}>
+						<Panel
+							{...panelProps}
+							tabIndex={0}
+							role="tree"
+							aria-activedescendant={treeItemId(selection)}
+							className={classes(panelProps.className, styles.panel)}
+						>
+							<div className={styles.panelPadding}>
+								<Changes
 									projectId={projectId}
-									stack={stack}
-									commitTarget={commitTarget?.relativeTo ?? null}
+									commitTarget={commitTarget}
+									targetComboboxItems={targetComboboxItems}
 								/>
-							))}
-
-							<BaseCommit
-								projectId={projectId}
-								commitId={headInfo ? getCommonBaseCommitId(headInfo) : undefined}
-							/>
-						</div>
-
-						{operationSource && headInfo && (
-							<div className={styles.operationSourcePreview}>
-								<OperationSourceLabel headInfo={headInfo} source={operationSource} />
-								{outlineMode._tag === "Absorb" && absorptionPlanQuery?.isPending && (
-									<Spinner aria-label="Loading absorb plan" />
-								)}
 							</div>
-						)}
-					</Panel>
-				</DryRunWorkspaceContext>
-			</AbsorptionTargetKeysContext>
+
+							<div className={styles.headInfo}>
+								{headInfo?.stacks.map((stack) => (
+									<StackC
+										key={stack.id}
+										projectId={projectId}
+										stack={stack}
+										commitTarget={commitTarget?.relativeTo ?? null}
+									/>
+								))}
+
+								<BaseCommit
+									projectId={projectId}
+									commitId={headInfo ? getCommonBaseCommitId(headInfo) : undefined}
+								/>
+							</div>
+
+							{operationSource && headInfo && (
+								<div className={styles.operationSourcePreview}>
+									<OperationSourceLabel headInfo={headInfo} source={operationSource} />
+									{outlineMode._tag === "Absorb" && absorptionPlanQuery?.isPending && (
+										<Spinner aria-label="Loading absorb plan" />
+									)}
+								</div>
+							)}
+						</Panel>
+					</DryRunWorkspaceContext>
+				</AbsorptionTargetKeysContext>
+			</OutlineSelectionContext>
 		</NavigationIndexContext>
 	);
 };
 
-const useIsSelected = ({ projectId, operand }: { projectId: string; operand: Operand }): boolean =>
-	useAppSelector((state) => {
-		const selection = selectProjectSelectionOutline(state, projectId);
-
-		return operandEquals(selection, operand);
-	});
+const useIsSelected = (operand: Operand): boolean =>
+	operandEquals(assert(use(OutlineSelectionContext)), operand);
 
 const treeItemId = (operand: Operand): string =>
 	`outline-treeitem-${encodeURIComponent(operandIdentityKey(operand))}`;
@@ -608,7 +596,7 @@ const ItemRow: FC<
 > = ({ projectId, operand, ...props }) => {
 	const dispatch = useAppDispatch();
 	const navigationIndex = assert(use(NavigationIndexContext));
-	const isSelected = useIsSelected({ projectId, operand });
+	const isSelected = useIsSelected(operand);
 	const selectItem = () => {
 		dispatch(projectActions.selectOutline({ projectId, selection: operand }));
 	};
@@ -625,12 +613,11 @@ const ItemRow: FC<
 
 const TreeItem: FC<
 	{
-		projectId: string;
 		operand: Operand;
 		expanded?: boolean;
 	} & useRender.ComponentProps<"div">
-> = ({ projectId, operand, expanded, render, ...props }) => {
-	const isSelected = useIsSelected({ projectId, operand });
+> = ({ operand, expanded, render, ...props }) => {
+	const isSelected = useIsSelected(operand);
 
 	return useRender({
 		render,
@@ -649,7 +636,7 @@ const OperandC: FC<
 		operand: Operand;
 	} & useRender.ComponentProps<"div">
 > = ({ projectId, operand, render, ...props }) => {
-	const isSelected = useIsSelected({ projectId, operand });
+	const isSelected = useIsSelected(operand);
 	const absorptionTargetKeys = assert(use(AbsorptionTargetKeysContext));
 	const isAbsorptionTarget = absorptionTargetKeys.has(operandIdentityKey(operand));
 	const navigationIndex = assert(use(NavigationIndexContext));
@@ -762,7 +749,7 @@ const CommitRow: FC<
 		commitId: commit.id,
 	};
 	const operand = commitOperand(commitOperandV);
-	const isSelected = useIsSelected({ projectId, operand });
+	const isSelected = useIsSelected(operand);
 	const isRewording =
 		isSelected &&
 		outlineMode._tag === "RewordCommit" &&
@@ -1089,7 +1076,6 @@ const CommitC: FC<{
 
 	return (
 		<TreeItem
-			projectId={projectId}
 			operand={operand}
 			aria-label={commitTitle(commit.message)}
 			render={<OperandC projectId={projectId} operand={operand} />}
@@ -1170,7 +1156,6 @@ const BaseCommit: FC<{
 	return (
 		<div className={workspaceItemRowStyles.section}>
 			<TreeItem
-				projectId={projectId}
 				operand={operand}
 				aria-label="Base commit"
 				render={
@@ -1523,7 +1508,6 @@ const Changes: FC<{
 
 	return (
 		<TreeItem
-			projectId={projectId}
 			operand={operand}
 			aria-label={`Changes (${worktreeChanges?.changes.length ?? 0})`}
 			className={classes(workspaceItemRowStyles.section, styles.changesSection)}
@@ -2005,7 +1989,6 @@ const BranchSegment: FC<{
 
 	return (
 		<TreeItem
-			projectId={projectId}
 			operand={operand}
 			aria-label={refName.displayName}
 			expanded
@@ -2098,7 +2081,6 @@ const StackC: FC<{
 
 	return (
 		<TreeItem
-			projectId={projectId}
 			operand={operand}
 			aria-label="Stack"
 			expanded


### PR DESCRIPTION
See commits.

We still have a `useEffect` for repairing files selection. That one needs more thought.