### PR TITLE
Improve code quality of Playwright e2e tests

### DIFF
--- a/e2e/playwright/src/serverLog.ts
+++ b/e2e/playwright/src/serverLog.ts
@@ -1,0 +1,6 @@
+/**
+ * Module-level log sink for but-server output.
+ * Safe because tests run sequentially within each worker process.
+ * Cleared at the start of each test by the _autoArtifacts fixture.
+ */
+export const serverLogSink: string[] = [];

--- a/e2e/playwright/src/setup.ts
+++ b/e2e/playwright/src/setup.ts
@@ -1,11 +1,37 @@
 import { setConfig } from "./config.ts";
 import { BUT, BUT_SERVER, BUT_SERVER_PORT, DESKTOP_PORT, GIT_CONFIG_GLOBAL } from "./env.ts";
-import { serverLogSink } from "./test.ts";
-import { type BrowserContext } from "@playwright/test";
+import { serverLogSink } from "./serverLog.ts";
+import { waitForTestId } from "./util.ts";
+import { type BrowserContext, type Page } from "@playwright/test";
 import { ChildProcess, spawn } from "node:child_process";
 import { existsSync, mkdirSync } from "node:fs";
 import { Socket } from "node:net";
 import path from "node:path";
+
+/**
+ * Apply one or more upstream branches from `local-clone` (the default project workdir).
+ */
+export async function applyUpstream(gitbutler: GitButler, ...branches: string[]): Promise<void> {
+	for (const branch of branches) {
+		await gitbutler.runScript("apply-upstream-branch.sh", [branch, "local-clone"]);
+	}
+}
+
+/**
+ * Navigate to the workspace and wait for it to load.
+ */
+export async function openWorkspace(page: Page): Promise<void> {
+	await page.goto("/");
+	await waitForTestId(page, "workspace-view");
+}
+
+/**
+ * Navigate to the onboarding page and wait for it to load.
+ */
+export async function gotoOnboarding(page: Page): Promise<void> {
+	await page.goto("/");
+	await waitForTestId(page, "onboarding-page");
+}
 
 export function getBaseURL() {
 	const port = parseInt(DESKTOP_PORT, 10);

--- a/e2e/playwright/src/test.ts
+++ b/e2e/playwright/src/test.ts
@@ -1,15 +1,15 @@
+import { serverLogSink } from "./serverLog.ts";
+import { startGitButler, type GitButler } from "./setup.ts";
 import { test as base } from "@playwright/test";
 import fs from "node:fs";
 import path from "node:path";
 
-const FLAT_RESULTS_DIR = path.resolve(import.meta.dirname, "../test-results-flat");
+export type GitButlerOptions = {
+	env?: Record<string, string>;
+	config?: Record<string, unknown>;
+};
 
-/**
- * Module-level log sink for but-server output.
- * Safe because tests run sequentially within each worker process.
- * Cleared at the start of each test by the _autoArtifacts fixture.
- */
-export const serverLogSink: string[] = [];
+const FLAT_RESULTS_DIR = path.resolve(import.meta.dirname, "../test-results-flat");
 
 /**
  * Sanitize a string for use as a filename.
@@ -31,7 +31,25 @@ function sanitizeFilename(name: string): string {
  *   <suite>--<test-name>.webm         (video)
  *   <suite>--<test-name>-trace.zip    (trace)
  */
-export const test = base.extend<{ _autoArtifacts: void }>({
+export const test = base.extend<{
+	_autoArtifacts: void;
+	gitbutlerOptions: GitButlerOptions;
+	gitbutler: GitButler;
+}>({
+	gitbutlerOptions: [{ config: { onboardingComplete: true } }, { option: true }],
+	gitbutler: async ({ context, gitbutlerOptions }, use, testInfo) => {
+		const workdir = testInfo.outputPath("workdir");
+		const configdir = testInfo.outputPath("config");
+		const instance = await startGitButler(
+			workdir,
+			configdir,
+			context,
+			gitbutlerOptions.env,
+			gitbutlerOptions.config,
+		);
+		await use(instance);
+		await instance.destroy();
+	},
 	_autoArtifacts: [
 		async ({ page }, use, testInfo) => {
 			const logs: string[] = [];

--- a/e2e/playwright/src/util.ts
+++ b/e2e/playwright/src/util.ts
@@ -4,12 +4,39 @@ import { expect, type Locator, type Page } from "@playwright/test";
 type TestIdValues = `${TestId}`;
 
 /**
+ * Platform modifier key for multi-select (Cmd on macOS, Ctrl elsewhere).
+ */
+export const MOD_KEY: "Meta" | "Control" = process.platform === "darwin" ? "Meta" : "Control";
+
+/**
  * Get by test ID from the page.
  *
  * This is only here in order to have nice autocompletion in the IDE.
  */
 export function getByTestId(page: Page, testId: TestIdValues) {
 	return page.getByTestId(testId);
+}
+
+/**
+ * Locator for a commit row, optionally filtered by its visible text.
+ */
+export function commitRow(page: Page, hasText?: string): Locator {
+	const base = page.getByTestId("commit-row");
+	return hasText ? base.filter({ hasText }) : base;
+}
+
+/**
+ * Locator for a stack. When `branchName` is provided, finds the stack
+ * that contains a branch header matching that name. This is more reliable
+ * than `.filter({ hasText })` because commit messages can also mention
+ * branch names.
+ */
+export function stack(page: Page, branchName?: string): Locator {
+	const base = page.getByTestId("stack");
+	if (!branchName) return base;
+	return base.filter({
+		has: page.getByTestId("branch-header").filter({ hasText: branchName }),
+	});
 }
 
 export async function waitForTestId(page: Page, testId: TestIdValues): Promise<Locator> {

--- a/e2e/playwright/tests/absorb.spec.ts
+++ b/e2e/playwright/tests/absorb.spec.ts
@@ -1,61 +1,32 @@
 import { assertFileContent, writeToFile } from "../src/file.ts";
-import { getBaseURL, startGitButler, type GitButler } from "../src/setup.ts";
+import { applyUpstream, openWorkspace } from "../src/setup.ts";
 import { test } from "../src/test.ts";
 import { clickByTestId, waitForTestId } from "../src/util.ts";
 import { expect } from "@playwright/test";
 
-let gitbutler: GitButler;
-
-test.use({
-	baseURL: getBaseURL(),
-});
-
-test.afterEach(async () => {
-	await gitbutler?.destroy();
-});
-
-test("should be able to absorb a file to a commit - simple", async ({
-	page,
-	context,
-}, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+test("should be able to absorb a file to a commit - simple", async ({ page, gitbutler }) => {
 	const filePath = gitbutler.pathInWorkdir("local-clone/a_file");
 
 	await gitbutler.runScript("project-with-remote-branches.sh");
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
-
-	await page.goto("/");
-
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
+	await applyUpstream(gitbutler, "branch1");
+	await openWorkspace(page);
 
 	const newFileContent = `This is the NEW content of the file.\n`;
 	// Create a locked change by replacing the file content completely
 	writeToFile(filePath, newFileContent);
 
-	// Right-click the file to open the context menu
 	const fileRow = (await waitForTestId(page, "file-list-item")).filter({ hasText: "a_file" });
 	await fileRow.click({ button: "right" });
-
-	// Click "Absorb changes" in the context menu
 	await clickByTestId(page, "file-list-item-context-menu__absorb");
 
-	// Wait for the absorb modal to appear
 	await waitForTestId(page, "absorb-modal");
-
 	const commitAbsorptionItems = await waitForTestId(page, "absorb-modal-commit-absorption");
 	await expect(commitAbsorptionItems).toHaveCount(1);
 
-	// Click the "Absorb changes" button in the modal
 	await clickByTestId(page, "absorb-modal-action-button");
 
-	// Verify that the file content has been absorbed
 	await assertFileContent(filePath, newFileContent);
 
-	// No more uncommitted changes should be present
 	const files = await waitForTestId(page, "file-list-item");
 	await expect(files).toHaveCount(0);
 });

--- a/e2e/playwright/tests/addingAProject.spec.ts
+++ b/e2e/playwright/tests/addingAProject.spec.ts
@@ -1,89 +1,47 @@
-import { getBaseURL, startGitButler, type GitButler } from "../src/setup.ts";
+import { gotoOnboarding, openWorkspace } from "../src/setup.ts";
 import { test } from "../src/test.ts";
-import { clickByTestId, getByTestId, mockPickDirectory, waitForTestId } from "../src/util.ts";
+import {
+	clickByTestId,
+	getByTestId,
+	mockPickDirectory,
+	stack,
+	waitForTestId,
+} from "../src/util.ts";
 import { expect } from "@playwright/test";
 
-let gitbutler: GitButler;
-
-test.use({
-	baseURL: getBaseURL(),
-});
-
-test.afterEach(async () => {
-	await gitbutler?.destroy();
-});
-
-test("should handle gracefully adding an existing project", async ({ page, context }, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+test("should handle gracefully adding an existing project", async ({ page, gitbutler }) => {
 	const projectPath = gitbutler.pathInWorkdir("local-clone-2/");
-
 	await gitbutler.runScript("two-projects-with-remote-branches.sh");
+	await openWorkspace(page);
 
-	await page.goto("/");
-
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// Open the project selector
 	await clickByTestId(page, "chrome-header-project-selector");
-	// Click the add local project button
 	await mockPickDirectory(page, projectPath);
 	await clickByTestId(page, "chrome-header-project-selector-add-local-project");
 
-	// Should display the "project already exists" modal
 	await waitForTestId(page, "add-project-already-exists-modal");
-	// Click it in order to close the select dropdown behind
+	// Click the modal first to dismiss the select dropdown behind it.
 	await clickByTestId(page, "add-project-already-exists-modal", true);
-
-	// Click to open the existing project
 	await clickByTestId(page, "add-project-already-exists-modal-open-project-button");
 
-	// Should navigate to the existing project
-	const projectSelector = getByTestId(page, "chrome-header-project-selector");
-	await expect(projectSelector).toContainText("local-clone-2");
+	await expect(getByTestId(page, "chrome-header-project-selector")).toContainText("local-clone-2");
 });
 
-test("should handle gracefully adding bare repo", async ({ page, context }, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+test("should handle gracefully adding bare repo", async ({ page, gitbutler }) => {
 	const projectPath = gitbutler.pathInWorkdir("local-clone/");
-
 	await gitbutler.runScript("setup-empty-project-bare.sh");
+	await gotoOnboarding(page);
 
-	await page.goto("/");
-	const onboardingPage = getByTestId(page, "onboarding-page");
-	await onboardingPage.waitFor();
-
-	clickByTestId(page, "analytics-continue");
-
-	// Add a local project
 	await mockPickDirectory(page, projectPath);
 	await clickByTestId(page, "add-local-project");
 
 	await waitForTestId(page, "add-project-bare-repo-modal");
 });
 
-test("should handle gracefully adding a non-git directory", async ({ page, context }, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+test("should handle gracefully adding a non-git directory", async ({ page, gitbutler }) => {
 	const projectPath = gitbutler.pathInWorkdir("not-a-git-repo/");
-
 	await gitbutler.runScript("setup-empty-project.sh");
+	await gotoOnboarding(page);
 
-	await page.goto("/");
-	const onboardingPage = getByTestId(page, "onboarding-page");
-	await onboardingPage.waitFor();
-
-	clickByTestId(page, "analytics-continue");
-
-	// Add a local project
 	await mockPickDirectory(page, projectPath);
 	await clickByTestId(page, "add-local-project");
 
@@ -92,38 +50,19 @@ test("should handle gracefully adding a non-git directory", async ({ page, conte
 
 test("should handle adding a project with extra commit and uncommitted changes on main branch", async ({
 	page,
-	context,
-}, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+	gitbutler,
+}) => {
 	const projectPath = gitbutler.pathInWorkdir("local-with-changes/");
-
-	// Set up repository with extra commit and uncommitted changes
 	await gitbutler.runScript("project-with-commit-and-uncommitted-changes.sh");
+	await gotoOnboarding(page);
 
-	await page.goto("/");
-
-	const onboardingPage = getByTestId(page, "onboarding-page");
-	await onboardingPage.waitFor();
-
-	clickByTestId(page, "analytics-continue");
-
-	// Click the add local project button
 	await mockPickDirectory(page, projectPath);
 	await clickByTestId(page, "add-local-project");
 
 	clickByTestId(page, "set-base-branch");
-
-	// Should load the workspace directly after setting base branch
 	await waitForTestId(page, "workspace-view");
 
-	// There should be only one stack
-	const stacks = getByTestId(page, "stack");
+	const stacks = stack(page);
 	await expect(stacks).toHaveCount(1);
-	const stack = stacks.first();
-
-	// The stack should not have the branch called "master"
-	await expect(stack).not.toContainText("master");
+	await expect(stacks.first()).not.toContainText("master");
 });

--- a/e2e/playwright/tests/branches.spec.ts
+++ b/e2e/playwright/tests/branches.spec.ts
@@ -1,271 +1,155 @@
 import { createNewBranch, deleteBranch, unapplyStack } from "../src/branch.ts";
-import { getBaseURL, type GitButler, startGitButler } from "../src/setup.ts";
+import { applyUpstream, openWorkspace } from "../src/setup.ts";
 import { test } from "../src/test.ts";
 import {
 	clickByTestId,
+	commitRow,
 	fillByTestId,
 	getByTestId,
+	stack,
 	textEditorFillByTestId,
 	waitForTestId,
 	waitForTestIdToNotExist,
 } from "../src/util.ts";
-import { expect } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 
-let gitbutler: GitButler;
-
-test.use({
-	baseURL: getBaseURL(),
-});
-
-test.afterEach(async () => {
-	await gitbutler?.destroy();
-});
-
-test("should be able to apply a remote branch", async ({ page, context }, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
-	// const projectPath = gitbutler.pathInWorkdir('local-clone/');
-
-	await gitbutler.runScript("project-with-remote-branches.sh");
-
-	await page.goto("/");
-
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// Should navigate to the branches page when clicking the branches button
+/**
+ * Navigate to the branches page and assert the standard 3-card layout from
+ * `project-with-remote-branches.sh`. Filters on the `origin/master` header
+ * because workspace stack headers also use the `branch-header` test id.
+ */
+async function gotoBranchesView(page: Page) {
 	await clickByTestId(page, "navigation-branches-button");
-	const header = await waitForTestId(page, "branch-header");
+	const originHeader = getByTestId(page, "branch-header").filter({ hasText: "origin/master" });
+	await expect(originHeader).toBeVisible();
 
-	await expect(header).toContainText("origin/master");
+	const cards = getByTestId(page, "branch-list-card");
+	await expect(cards).toHaveCount(3);
+}
 
-	const branchListCards = getByTestId(page, "branch-list-card");
-	await expect(branchListCards).toHaveCount(3);
+/**
+ * Navigate to the branches page and apply a branch from its card.
+ */
+async function applyBranchFromBranchesView(page: Page, branchName: string) {
+	await gotoBranchesView(page);
 
-	const firstBranchCard = branchListCards.filter({ hasText: "branch1" });
-	await expect(firstBranchCard).toBeVisible();
-	await firstBranchCard.click();
-
-	// The delete branch should be visible
+	await getByTestId(page, "branch-list-card").filter({ hasText: branchName }).click();
 	await waitForTestId(page, "branches-view-delete-local-branch-button");
 
-	// Apply the branch
 	await clickByTestId(page, "branches-view-apply-branch-button");
-	// Should be redirected to the workspace
 	await waitForTestId(page, "workspace-view");
+}
 
-	// There should be only one stack
-	const stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(1);
-	const stack = stacks.first();
-	await expect(stack).toContainText("branch1");
+async function syncAndIntegrate(page: Page) {
+	await clickByTestId(page, "sync-button");
+	await clickByTestId(page, "upstream-commits-integrate-button");
+	await waitForTestIdToNotExist(page, "upstream-commits-integrate-button");
+	await waitForTestIdToNotExist(page, "upstream-commits-commit-action");
+}
 
-	// The stack should have two commits
-	const commits = getByTestId(page, "commit-row");
-	await expect(commits).toHaveCount(2);
+test("should be able to apply a remote branch", async ({ page, gitbutler }) => {
+	await gitbutler.runScript("project-with-remote-branches.sh");
+	await openWorkspace(page);
+
+	await applyBranchFromBranchesView(page, "branch1");
+
+	await expect(stack(page, "branch1")).toHaveCount(1);
+	await expect(commitRow(page)).toHaveCount(2);
 });
 
 test("should be able to apply a remote branch and integrate the remote changes - simple", async ({
 	page,
-	context,
-}, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+	gitbutler,
+}) => {
 	await gitbutler.runScript("project-with-remote-branches.sh");
+	await openWorkspace(page);
 
-	await page.goto("/");
-
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// Should navigate to the branches page when clicking the branches button
-	await clickByTestId(page, "navigation-branches-button");
-	const header = await waitForTestId(page, "branch-header");
-
-	await expect(header).toContainText("origin/master");
-
-	const branchListCards = getByTestId(page, "branch-list-card");
-	await expect(branchListCards).toHaveCount(3);
-
-	const firstBranchCard = branchListCards.filter({ hasText: "branch1" });
-	await expect(firstBranchCard).toBeVisible();
-	await firstBranchCard.click();
-
-	// The delete branch should be visible
-	await waitForTestId(page, "branches-view-delete-local-branch-button");
-
-	// Apply the branch
-	await clickByTestId(page, "branches-view-apply-branch-button");
-	// Should be redirected to the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// There should be only one stack
-	const stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(1);
-	const stack = stacks.first();
-	await expect(stack).toContainText("branch1");
-
-	// The stack should have two commits
-	const commits = getByTestId(page, "commit-row");
-	await expect(commits).toHaveCount(2);
+	await applyBranchFromBranchesView(page, "branch1");
+	await expect(commitRow(page)).toHaveCount(2);
 
 	await gitbutler.runScript("project-with-remote-branches__add-commit-to-remote-branch.sh");
+	await syncAndIntegrate(page);
 
-	// Click the sync button
-	await clickByTestId(page, "sync-button");
-
-	// Integrate upstream commits
-	await clickByTestId(page, "upstream-commits-integrate-button");
-	await waitForTestIdToNotExist(page, "upstream-commits-integrate-button");
-	await waitForTestIdToNotExist(page, "upstream-commits-commit-action");
-
-	const commitsAfterIntegration = getByTestId(page, "commit-row");
-	await expect(commitsAfterIntegration).toHaveCount(3);
+	await expect(commitRow(page)).toHaveCount(3);
 });
 
 test("should be able to apply a remote branch and integrate the remote changes - create commit", async ({
 	page,
-	context,
-}, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+	gitbutler,
+}) => {
 	const fileCPath = gitbutler.pathInWorkdir("local-clone/c_file");
 
 	await gitbutler.runScript("project-with-remote-branches.sh");
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
+	await applyUpstream(gitbutler, "branch1");
+	await openWorkspace(page);
 
-	await page.goto("/");
-
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// There should be only one stack
-	const stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(1);
-	const stack = stacks.first();
-	await expect(stack).toContainText("branch1");
-
-	// The stack should have two commits
-	const commits = getByTestId(page, "commit-row");
-	await expect(commits).toHaveCount(2);
+	await expect(stack(page, "branch1")).toHaveCount(1);
+	await expect(commitRow(page)).toHaveCount(2);
 
 	await gitbutler.runScript("project-with-remote-branches__add-commit-to-remote-branch.sh");
-
-	// Click the sync button
 	await clickByTestId(page, "sync-button");
 
-	// Create a new commit
+	// New local commit
 	writeFileSync(fileCPath, "This is file C\n", { flag: "w" });
 	await clickByTestId(page, "start-commit-button");
-
-	// Should see the commit drawer
 	await waitForTestId(page, "new-commit-view");
 
 	const newCommitMessage = "New local commit: adding file C";
-	const newCommitMessageBody = "CCCCCCC";
-	// Write a commit message
 	await fillByTestId(page, "commit-drawer-title-input", newCommitMessage);
-	await textEditorFillByTestId(page, "commit-drawer-description-input", newCommitMessageBody);
-
-	// Click the commit button
+	await textEditorFillByTestId(page, "commit-drawer-description-input", "CCCCCCC");
 	await clickByTestId(page, "commit-drawer-action-button");
 
-	// Integrate upstream commits
+	// Integrate upstream commits on top
 	await clickByTestId(page, "upstream-commits-integrate-button");
 	await waitForTestIdToNotExist(page, "upstream-commits-integrate-button");
 	await waitForTestIdToNotExist(page, "upstream-commits-commit-action");
 
-	const commitsAfterIntegration = getByTestId(page, "commit-row");
-	await expect(commitsAfterIntegration).toHaveCount(4);
-	const firstCommit = commitsAfterIntegration.nth(0);
-	await expect(firstCommit).toContainText(newCommitMessage);
+	const commits = commitRow(page);
+	await expect(commits).toHaveCount(4);
+	await expect(commits.nth(0)).toContainText(newCommitMessage);
 });
 
 test("should be able to apply a remote branch and integrate the remote changes - conflict", async ({
 	page,
-	context,
-}, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+	gitbutler,
+}) => {
 	const filePath = gitbutler.pathInWorkdir("local-clone/a_file");
 
 	await gitbutler.runScript("project-with-remote-branches.sh");
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
+	await applyUpstream(gitbutler, "branch1");
+	await openWorkspace(page);
 
-	await page.goto("/");
+	await expect(commitRow(page)).toHaveCount(2);
 
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-	// There should be only one stack
-	const stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(1);
-	const stack = stacks.first();
-	await expect(stack).toContainText("branch1");
-
-	// The stack should have two commits
-	const commits = getByTestId(page, "commit-row");
-	await expect(commits).toHaveCount(2);
-
-	// Make a conflicting change
 	writeFileSync(filePath, "conflicting change\n", { flag: "a" });
 
-	// Commit the change
 	await clickByTestId(page, "start-commit-button");
-
-	// Should see the commit drawer
 	await waitForTestId(page, "new-commit-view");
 
 	const newCommitMessage = "Conflicting change commit";
-	const newCommitMessageBody = "This should be oh-so-bad 🤭";
-	// Write a commit message
 	await fillByTestId(page, "commit-drawer-title-input", newCommitMessage);
-	await textEditorFillByTestId(page, "commit-drawer-description-input", newCommitMessageBody);
-
-	// Click the commit button
+	await textEditorFillByTestId(
+		page,
+		"commit-drawer-description-input",
+		"This should be oh-so-bad 🤭",
+	);
 	await clickByTestId(page, "commit-drawer-action-button");
 
-	// This should create a new commit
-	const commitsAfterChange = getByTestId(page, "commit-row");
-	await expect(commitsAfterChange).toHaveCount(3);
+	await expect(commitRow(page)).toHaveCount(3);
 
 	await gitbutler.runScript("project-with-remote-branches__add-commit-to-remote-branch.sh");
+	await syncAndIntegrate(page);
 
-	// Click the sync button
-	await clickByTestId(page, "sync-button");
+	const commits = commitRow(page);
+	await expect(commits).toHaveCount(4);
 
-	// Integrate upstream commits
-	await clickByTestId(page, "upstream-commits-integrate-button");
-	await waitForTestIdToNotExist(page, "upstream-commits-integrate-button");
-	await waitForTestIdToNotExist(page, "upstream-commits-commit-action");
-
-	const commitsAfterIntegration = getByTestId(page, "commit-row");
-	await expect(commitsAfterIntegration).toHaveCount(4);
-
-	const conflictedCommit = commitsAfterIntegration.filter({
-		hasText: "Conflicting change commit",
-	});
-	await expect(conflictedCommit).toBeVisible();
-
-	// Click on the conflicted commit to open the commit drawer
+	const conflictedCommit = commitRow(page, newCommitMessage);
 	await conflictedCommit.click();
-
-	// Click the resolve conflicts button (now in the file list area)
 	await clickByTestId(page, "commit-drawer-resolve-conflicts-button");
-
-	// Should open the edit mode
 	await waitForTestId(page, "edit-mode");
 
-	const conflictedFileContent = readFileSync(filePath, "utf-8");
-	expect(conflictedFileContent).toEqual(
+	expect(readFileSync(filePath, "utf-8")).toEqual(
 		`foo
 bar
 baz
@@ -281,156 +165,63 @@ conflicting change
 `,
 	);
 
-	// Resolve the conflict by keeping both changes
-	writeFileSync(
-		filePath,
-		`foo
+	const resolved = `foo
 bar
 baz
 branch1 commit 1
 branch1 commit 2
 branch1 commit 3
 conflicting change
-`,
-		{ flag: "w" },
-	);
+`;
+	writeFileSync(filePath, resolved, { flag: "w" });
 
-	// Click the save and exit button
 	await clickByTestId(page, "edit-mode-save-and-exit-button");
-
-	// Should be back in the workspace
 	await waitForTestId(page, "workspace-view");
 
-	const commitsAfterResolving = getByTestId(page, "commit-row");
-	await expect(commitsAfterResolving).toHaveCount(4);
-
-	const resolvedFileContent = readFileSync(filePath, "utf-8");
-	expect(resolvedFileContent).toEqual(
-		`foo
-bar
-baz
-branch1 commit 1
-branch1 commit 2
-branch1 commit 3
-conflicting change
-`,
-	);
+	await expect(commitRow(page)).toHaveCount(4);
+	expect(readFileSync(filePath, "utf-8")).toEqual(resolved);
 });
 
 test("should be able gracefully handle adding a branch that is ahead of our target commit", async ({
 	page,
-	context,
-}, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+	gitbutler,
+}) => {
 	const fileBPath = gitbutler.pathInWorkdir("local-clone/b_file");
 
 	await gitbutler.runScript("project-with-remote-branches.sh");
+	await openWorkspace(page);
 
-	await page.goto("/");
-
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// There are remote changes in the base branch
 	await gitbutler.runScript("project-with-remote-branches__add-commit-to-base-and-branch.sh");
-
-	// Click the sync button
 	await clickByTestId(page, "sync-button");
 
-	// Should navigate to the branches page when clicking the branches button
-	await clickByTestId(page, "navigation-branches-button");
-	const header = await waitForTestId(page, "branch-header");
+	await applyBranchFromBranchesView(page, "branch1");
 
-	await expect(header).toContainText("origin/master");
-
-	const branchListCards = getByTestId(page, "branch-list-card");
-	await expect(branchListCards).toHaveCount(3);
-
-	const firstBranchCard = branchListCards.filter({ hasText: "branch1" });
-	await expect(firstBranchCard).toBeVisible();
-	await firstBranchCard.click();
-
-	// The delete branch should be visible
-	await waitForTestId(page, "branches-view-delete-local-branch-button");
-
-	// Apply the branch
-	await clickByTestId(page, "branches-view-apply-branch-button");
-	// Should be redirected to the workspace
-	await waitForTestId(page, "workspace-view");
-
-	const commits = getByTestId(page, "commit-row");
-	// Should have 4 commits.
-	// Three commits from branch 1, and the new commit from the base branch
-	await expect(commits).toHaveCount(4);
-
+	// 3 commits from branch1 + 1 base commit
+	await expect(commitRow(page)).toHaveCount(4);
 	expect(existsSync(fileBPath)).toBe(true);
 });
 
 // TODO: The integrate-upstream-commits-button assertion fails because target.sha
 // is now set correctly after upstream integration, so no further integration is detected.
-// This will be resolved once the upstream integration flow is updated.
 test.skip("should be able gracefully handle adding a branch that is behind of our target commit", async ({
 	page,
-	context,
-}, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+	gitbutler,
+}) => {
 	const filePath = gitbutler.pathInWorkdir("local-clone/a_file");
 	await gitbutler.runScript("project-with-remote-branches.sh");
+	await openWorkspace(page);
 
-	await page.goto("/");
-
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// There are remote changes in the base branch
 	await gitbutler.runScript("project-with-remote-branches__add-commit-to-base.sh");
-
-	// Click the sync button
 	await clickByTestId(page, "sync-button");
-	// Update the workspace
 	await clickByTestId(page, "integrate-upstream-commits-button");
 	await clickByTestId(page, "integrate-upstream-action-button");
 	await waitForTestIdToNotExist(page, "integrate-upstream-commits-button");
 
-	// Should navigate to the branches page when clicking the branches button
-	await clickByTestId(page, "navigation-branches-button");
-	const header = await waitForTestId(page, "branch-header");
-
-	await expect(header).toContainText("origin/master");
-
-	const branchListCards = getByTestId(page, "branch-list-card");
-	await expect(branchListCards).toHaveCount(3);
-
-	const firstBranchCard = branchListCards.filter({ hasText: "branch1" });
-	await expect(firstBranchCard).toBeVisible();
-	await firstBranchCard.click();
-
-	// The delete branch should be visible
-	await waitForTestId(page, "branches-view-delete-local-branch-button");
-
-	// Apply the branch
-	await clickByTestId(page, "branches-view-apply-branch-button");
-	// Should be redirected to the workspace
-	await waitForTestId(page, "workspace-view");
+	await applyBranchFromBranchesView(page, "branch1");
 	await expect(getByTestId(page, "integrate-upstream-commits-button")).toBeVisible();
 
-	const commits = getByTestId(page, "commit-row");
-	await expect(commits).toHaveCount(2);
-
-	const conflictedCommit = commits.filter({
-		hasText: "branch1: first commit",
-	});
-	await expect(conflictedCommit).toBeVisible();
-
-	// New apply does not rebase the branch onto the updated target. The branch stays
-	// based on the older target, so applying it should not create the old per-commit
-	// conflict resolution flow.
+	await expect(commitRow(page)).toHaveCount(2);
+	const conflictedCommit = commitRow(page, "branch1: first commit");
 	await conflictedCommit.click();
 	await expect(getByTestId(page, "commit-drawer-resolve-conflicts-button")).toHaveCount(0);
 	expect(readFileSync(filePath, "utf-8")).toEqual(
@@ -443,247 +234,113 @@ branch1 commit 2
 	);
 });
 
-test("should handle gracefully applying two conflicting branches", async ({
-	page,
-	context,
-}, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+test("should handle gracefully applying two conflicting branches", async ({ page, gitbutler }) => {
 	await gitbutler.runScript("project-with-remote-branches.sh");
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
+	await applyUpstream(gitbutler, "branch1");
+	await openWorkspace(page);
 
-	await page.goto("/");
+	await expect(commitRow(page)).toHaveCount(2);
 
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	const commits = getByTestId(page, "commit-row");
-	await expect(commits).toHaveCount(2);
-
-	// Should navigate to the branches page when clicking the branches button
-	await clickByTestId(page, "navigation-branches-button");
-
-	const branchCard2 = getByTestId(page, "branch-list-card").filter({ hasText: "branch2" });
-	await expect(branchCard2).toBeVisible();
-	await branchCard2.click();
-
-	// Apply the second branch
+	await gotoBranchesView(page);
+	await getByTestId(page, "branch-list-card").filter({ hasText: "branch2" }).click();
 	await clickByTestId(page, "branches-view-apply-branch-button");
-	// Should be redirected to the workspace
 	await waitForTestId(page, "workspace-view");
 
-	// The modal explaining this should be visible
 	await waitForTestId(page, "stacks-unapplied-toast");
 });
 
-test("should update the stale selection of an unexisting branch", async ({
-	page,
-	context,
-}, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+test("should update the stale selection of an unexisting branch", async ({ page, gitbutler }) => {
 	await gitbutler.runScript("project-with-remote-branches.sh");
-	// Apply branch1
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
+	await applyUpstream(gitbutler, "branch1");
+	await openWorkspace(page);
 
-	await page.goto("/");
+	await gotoBranchesView(page);
+	await getByTestId(page, "branch-list-card").filter({ hasText: "branch1" }).click();
 
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// Navigate to branches page
-	await clickByTestId(page, "navigation-branches-button");
-	let header = await waitForTestId(page, "branch-header");
-
-	await expect(header).toContainText("origin/master");
-
-	let branchListCards = getByTestId(page, "branch-list-card");
-	await expect(branchListCards).toHaveCount(3);
-
-	// Select the branch1
-	let firstBranchCard = branchListCards.filter({ hasText: "branch1" });
-	await expect(firstBranchCard).toBeVisible();
-	await firstBranchCard.click();
-
-	// Go back to the workspace
 	await clickByTestId(page, "navigation-workspace-button");
 	await waitForTestId(page, "workspace-view");
+	await expect(stack(page)).toHaveCount(1);
 
-	// There should be one stack applied
-	const stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(1);
-
-	// Branch one was merged in the forge
+	// branch1 was merged in the forge — sync and integrate it away.
 	await gitbutler.runScript("merge-upstream-branch-to-base.sh", ["branch1"]);
-
-	// Click the sync button
 	await clickByTestId(page, "sync-button");
-
-	// Update the workspace
 	await clickByTestId(page, "integrate-upstream-commits-button");
 	await clickByTestId(page, "integrate-upstream-action-button");
 	await waitForTestIdToNotExist(page, "integrate-upstream-action-button");
 
-	// There should be no stacks
 	await waitForTestIdToNotExist(page, "stack");
 
-	// Navigate to branches page
-	await clickByTestId(page, "navigation-branches-button");
-	await waitForTestId(page, "branches-view");
+	await gotoBranchesView(page);
 
-	header = await waitForTestId(page, "branch-header");
-
-	await expect(header).toContainText("origin/master");
-	// The previously selected branch1 should not be selected anymore
-	branchListCards = getByTestId(page, "branch-list-card");
-	// We don't prune anymore, hence 3 branches are still present.
-	await expect(branchListCards).toHaveCount(3);
-	firstBranchCard = branchListCards.filter({ hasText: "branch1" });
-	await expect(firstBranchCard).toBeVisible();
-	await expect(firstBranchCard).not.toHaveClass(/\bselected\b/);
+	// We don't prune, so 3 branches remain, but branch1 is not selected anymore.
+	const cardsAfter = getByTestId(page, "branch-list-card");
+	await expect(cardsAfter.filter({ hasText: "branch1" })).not.toHaveClass(/\bselected\b/);
 	await expect(getByTestId(page, "current-origin-list-card")).toHaveClass(/\bselected\b/);
 });
 
-test("should be able to delete a local branch", async ({ page, context }, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+test("should be able to delete a local branch", async ({ page, gitbutler }) => {
 	await gitbutler.runScript("project-with-remote-branches.sh");
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch3", "local-clone"]);
+	await applyUpstream(gitbutler, "branch1", "branch3");
 	await gitbutler.runScript("move-branch.sh", ["branch3", "branch1", "local-clone"]);
+	await openWorkspace(page);
 
-	await page.goto("/");
+	await expect(stack(page)).toHaveCount(1);
+	await expect(getByTestId(page, "branch-header")).toHaveCount(2);
 
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// There should be one stack with two branches applied
-	let stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(1);
-	let branchHeaders = getByTestId(page, "branch-header");
-	await expect(branchHeaders).toHaveCount(2);
-
-	// Right click on the branch header to open the branch menu
 	await deleteBranch(page, "branch1");
-
-	// Should be back in the workspace
 	await waitForTestId(page, "workspace-view");
 
-	// There should be one stack with only one branch
-	stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(1);
-
-	branchHeaders = getByTestId(page, "branch-header");
-	await expect(branchHeaders).toHaveCount(1);
-	await expect(branchHeaders.first()).toContainText("branch3");
+	await expect(stack(page)).toHaveCount(1);
+	const headers = getByTestId(page, "branch-header");
+	await expect(headers).toHaveCount(1);
+	await expect(headers.first()).toContainText("branch3");
 });
 
-test("should be able to delete an empty local branch", async ({ page, context }, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+test("should be able to delete an empty local branch", async ({ page, gitbutler }) => {
 	await gitbutler.runScript("project-with-remote-branches.sh");
+	await openWorkspace(page);
 
-	await page.goto("/");
-
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// Create a new branch
 	await createNewBranch(page, "new-branch");
+	await expect(stack(page)).toHaveCount(1);
 
-	// There should be one stack applied
-	let stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(1);
-
-	// Right click on the branch header to open the branch menu
 	await deleteBranch(page, "new-branch");
-
-	// Should be back in the workspace
 	await waitForTestId(page, "workspace-view");
 
-	// There should be no stacks
-	stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(0);
-
-	const branchHeaders = getByTestId(page, "branch-header");
-	await expect(branchHeaders).toHaveCount(0);
+	await expect(stack(page)).toHaveCount(0);
+	await expect(getByTestId(page, "branch-header")).toHaveCount(0);
 });
 
-test("should be able to unapply a stack", async ({ page, context }, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+test("should be able to unapply a stack", async ({ page, gitbutler }) => {
 	await gitbutler.runScript("project-with-remote-branches.sh");
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
+	await applyUpstream(gitbutler, "branch1");
+	await openWorkspace(page);
 
-	await page.goto("/");
+	await expect(stack(page)).toHaveCount(1);
+	await expect(getByTestId(page, "branch-header").filter({ hasText: "branch1" })).toBeVisible();
 
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// There should be one stack applied
-	let stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(1);
-	let branchHeaders = getByTestId(page, "branch-header").filter({ hasText: "branch1" });
-	await expect(branchHeaders).toBeVisible();
-
-	// Unapply the stack
 	await unapplyStack(page, "branch1");
-
-	// Should be back in the workspace
 	await waitForTestId(page, "workspace-view");
 
-	// There should be no stacks
-	stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(0);
-
-	branchHeaders = getByTestId(page, "branch-header").filter({ hasText: "branch1" });
-	await expect(branchHeaders).toHaveCount(0);
+	await expect(stack(page)).toHaveCount(0);
+	await expect(getByTestId(page, "branch-header").filter({ hasText: "branch1" })).toHaveCount(0);
 });
 
 test("should be able to move a branch when origin/master has advanced past the fork point", async ({
 	page,
-	context,
-}, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
-	// Set up project with branches (branch1 and branch3 fork from initial master).
+	gitbutler,
+}) => {
 	await gitbutler.runScript("project-with-remote-branches.sh");
-	// Apply branch1 and branch3 as two separate stacks.
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch3", "local-clone"]);
+	await applyUpstream(gitbutler, "branch1", "branch3");
 
-	// Advance remote master past the fork point. This creates a commit on
-	// origin/master that is ahead of where branch1 and branch3 diverge.
+	// Advance origin/master past the fork point of branch1/branch3 so the old
+	// fork point becomes an unnamed segment in the graph.
 	await gitbutler.runScript("project-with-remote-branches__add-commit-to-base.sh");
-	// Fetch so that origin/master advances in the local clone, making the
-	// old fork point an unnamed segment in the graph.
 	await gitbutler.runScript("fetch-in-clone.sh", ["local-clone"]);
-
-	// Move branch3 on top of branch1. This should succeed even though the
-	// base segment at the old fork point has no ref name.
+	// Move branch3 on top of branch1 — must succeed even with a nameless base segment.
 	await gitbutler.runScript("move-branch.sh", ["branch3", "branch1", "local-clone"]);
 
-	await page.goto("/");
+	await openWorkspace(page);
 
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// There should be one stack with both branches
-	const stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(1);
-
-	const branchHeaders = getByTestId(page, "branch-header");
-	await expect(branchHeaders).toHaveCount(2);
+	await expect(stack(page)).toHaveCount(1);
+	await expect(getByTestId(page, "branch-header")).toHaveCount(2);
 });

--- a/e2e/playwright/tests/commitActions.spec.ts
+++ b/e2e/playwright/tests/commitActions.spec.ts
@@ -7,107 +7,61 @@ import {
 	verifyCommitPlaceholderPosition,
 } from "../src/commit.ts";
 import { stageFirstFile, unstageAllFiles, writeFiles } from "../src/file.ts";
-import { getBaseURL, type GitButler, startGitButler } from "../src/setup.ts";
+import { applyUpstream, openWorkspace } from "../src/setup.ts";
 import { test } from "../src/test.ts";
 import {
 	clickByTestId,
+	commitRow,
 	dragAndDropByLocator,
 	getByTestId,
-	waitForTestId,
+	stack,
 	waitForTestIdToNotExist,
 } from "../src/util.ts";
 import { expect, type Page } from "@playwright/test";
 import { copyFileSync, writeFileSync } from "fs";
 import { join } from "path";
 
-let gitbutler: GitButler;
-
-test.use({
-	baseURL: getBaseURL(),
-});
-
-test.afterEach(async () => {
-	await gitbutler.destroy();
-});
-
 const FIXTURE_IMAGE_PATH = join(import.meta.dirname, "../fixtures/lesh0.jpg");
 
-test("should be able to amend a file to a commit", async ({ page, context }, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+test("should be able to amend a file to a commit", async ({ page, gitbutler }) => {
 	const filePath = gitbutler.pathInWorkdir("local-clone/b_file");
 
 	await gitbutler.runScript("project-with-remote-branches.sh");
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
+	await applyUpstream(gitbutler, "branch1");
+	await openWorkspace(page);
 
-	await page.goto("/");
+	// Imported remote branches start out already synced.
+	await expect(getByTestId(page, "stack-push-button")).toBeDisabled();
 
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// There should be only one stack
-	const stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(1);
-	const stack = stacks.first();
-	await expect(stack).toContainText("branch1");
-
-	// The stack should have two commits
-	const commits = getByTestId(page, "commit-row");
-	await expect(commits).toHaveCount(2);
-
-	// Imported remote branches start out already synced when added via `but apply`.
-	const initialPushButton = getByTestId(page, "stack-push-button");
-	await expect(initialPushButton).toBeDisabled();
-
-	// Add a new file
 	writeFileSync(filePath, "Hello! this is file b\n", { flag: "w" });
 
 	const fileLocator = getByTestId(page, "file-list-item").filter({ hasText: "b_file" });
-	const topCommitLocator = getByTestId(page, "commit-row").filter({
-		hasText: "branch1:  second commit",
-	});
+	const topCommit = commitRow(page, "branch1:  second commit");
 
-	// Drag the new file onto the top commit, to amend it
-	await dragAndDropByLocator(page, fileLocator, topCommitLocator);
-
-	// Push the changes to the remote branch
+	await dragAndDropByLocator(page, fileLocator, topCommit);
 	await clickByTestId(page, "stack-push-button");
 
-	// The stack should have two commits
-	const commitsAfterAmend = getByTestId(page, "commit-row");
-	await expect(commitsAfterAmend).toHaveCount(2);
-
-	const pushButton = getByTestId(page, "stack-push-button");
-	await expect(pushButton).toBeDisabled();
+	await expect(commitRow(page)).toHaveCount(2);
+	await expect(getByTestId(page, "stack-push-button")).toBeDisabled();
 });
 
 test("should be able to commit a bunch of times in a row and edit their message", async ({
 	page,
-	context,
-}, testInfo) => {
+	gitbutler,
+}) => {
 	test.setTimeout(120_000);
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
 
 	await gitbutler.runScript("project-with-remote-branches.sh");
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
+	await applyUpstream(gitbutler, "branch1");
 
-	// Create a couple of uncommitted files.
 	const fileNames = ["file1.txt", "file2.txt", "file3.txt", "file4.txt", "file5.txt", "file6.txt"];
 	const filesContent: Record<string, string> = {};
 	for (const fileName of fileNames) {
-		const filePath = gitbutler.pathInWorkdir(`local-clone/${fileName}`);
-		filesContent[filePath] = `This is ${fileName}\n`;
+		filesContent[gitbutler.pathInWorkdir(`local-clone/${fileName}`)] = `This is ${fileName}\n`;
 	}
 	writeFiles(filesContent);
 
-	await page.goto("/");
-
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
+	await openWorkspace(page);
 
 	const TIMES = 3;
 	await commitMultipleTimes(TIMES, page);
@@ -116,255 +70,157 @@ test("should be able to commit a bunch of times in a row and edit their message"
 	await startCommittingAndCancel(page, TIMES);
 });
 
-test("should be able to commit a binary file", async ({ page, context }, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+test("should be able to commit a binary file", async ({ page, gitbutler }) => {
 	await gitbutler.runScript("project-with-remote-branches.sh");
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
+	await applyUpstream(gitbutler, "branch1");
 
-	// Copy the binary image file from fixtures to the working directory
 	const targetImagePath = gitbutler.pathInWorkdir("local-clone/lesh0.jpg");
 	copyFileSync(FIXTURE_IMAGE_PATH, targetImagePath);
 
-	await page.goto("/");
+	await openWorkspace(page);
 
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// There should be only one stack
-	const stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(1);
-
-	// The binary file should appear in the uncommitted changes
 	const fileLocator = getByTestId(page, "file-list-item").filter({ hasText: "lesh0.jpg" });
 	await expect(fileLocator).toBeVisible();
 
-	// Start committing the binary file
 	await clickByTestId(page, "start-commit-button");
-
 	await verifyCommitPlaceholderPosition(page);
 	await unstageAllFiles(page);
 
-	// Stage the binary file
-	const imageFileCheckbox = fileLocator.locator('input[type="checkbox"]');
-	await expect(imageFileCheckbox).toBeVisible();
-	await imageFileCheckbox.click();
+	await fileLocator.locator('input[type="checkbox"]').click();
 
 	const commitTitle = "Add binary image file";
 	const commitMessage = "Adding lesh0.jpg to the repository";
-
-	// Fill the commit message
 	await verifyCommitMessageEditor(page, "", "");
 	await updateCommitMessage(page, commitTitle, commitMessage);
-
-	// Submit the commit
 	await clickByTestId(page, "commit-drawer-action-button");
 
-	// Commit with title should be visible in the commit list
-	const commitRow = getByTestId(page, "commit-row").filter({ hasText: commitTitle });
-	await expect(commitRow).toBeVisible();
+	await expect(commitRow(page, commitTitle)).toBeVisible();
+	const drawer = await openCommitDrawer(page, commitTitle);
+	await verifyCommitDrawerContent(drawer, commitTitle, commitMessage);
 
-	// Open the commit drawer to verify the binary file was committed
-	const commitDrawer = await openCommitDrawer(page, commitTitle);
-	await verifyCommitDrawerContent(commitDrawer, commitTitle, commitMessage);
-
-	const stackPreview = getByTestId(page, "stack");
-	// Verify the binary file is listed in the commit
-	const committedFile = stackPreview.getByTestId("file-list-item").filter({ hasText: "lesh0.jpg" });
-	await expect(committedFile).toBeVisible();
+	await expect(
+		stack(page).getByTestId("file-list-item").filter({ hasText: "lesh0.jpg" }),
+	).toBeVisible();
 });
 
-test("should be able to commit a git submodule", async ({ page, context }, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+test("should be able to commit a git submodule", async ({ page, gitbutler }) => {
 	await gitbutler.runScript("project-with-remote-branches.sh");
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
+	await applyUpstream(gitbutler, "branch1");
+	await openWorkspace(page);
 
-	await page.goto("/");
-
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// There should be only one stack
-	const stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(1);
-
-	// Add a git submodule to the working directory
 	await gitbutler.runScript("project-with-remote-branches__add-submodule.sh");
 
-	// The submodule files should appear in the uncommitted changes
 	const gitmodulesFile = getByTestId(page, "file-list-item").filter({ hasText: ".gitmodules" });
 	const submoduleDir = getByTestId(page, "file-list-item").filter({ hasText: "my-submodule" });
 	await expect(gitmodulesFile).toBeVisible();
 	await expect(submoduleDir).toBeVisible();
 
-	// Start committing the submodule
 	await clickByTestId(page, "start-commit-button");
-
 	await verifyCommitPlaceholderPosition(page);
 	await unstageAllFiles(page);
 
-	// Stage the .gitmodules file and submodule directory
-	const gitmodulesCheckbox = gitmodulesFile.locator('input[type="checkbox"]');
-	await expect(gitmodulesCheckbox).toBeVisible();
-	await gitmodulesCheckbox.click();
-
-	const submoduleCheckbox = submoduleDir.locator('input[type="checkbox"]');
-	await expect(submoduleCheckbox).toBeVisible();
-	await submoduleCheckbox.click();
+	await gitmodulesFile.locator('input[type="checkbox"]').click();
+	await submoduleDir.locator('input[type="checkbox"]').click();
 
 	const commitTitle = "Add git submodule";
 	const commitMessage = "Adding my-submodule to the repository";
-
-	// Fill the commit message
 	await verifyCommitMessageEditor(page, "", "");
 	await updateCommitMessage(page, commitTitle, commitMessage);
-
-	// Submit the commit
 	await clickByTestId(page, "commit-drawer-action-button");
 
-	// Commit with title should be visible in the commit list
-	const commitRow = getByTestId(page, "commit-row").filter({ hasText: commitTitle });
-	await expect(commitRow).toBeVisible();
+	await expect(commitRow(page, commitTitle)).toBeVisible();
+	const drawer = await openCommitDrawer(page, commitTitle);
+	await verifyCommitDrawerContent(drawer, commitTitle, commitMessage);
 
-	// Open the commit drawer to verify the submodule was committed
-	const commitDrawer = await openCommitDrawer(page, commitTitle);
-	await verifyCommitDrawerContent(commitDrawer, commitTitle, commitMessage);
-
-	const stackPreview = getByTestId(page, "stack");
-	// Verify the .gitmodules file is listed in the commit
-	const committedGitmodules = stackPreview
-		.getByTestId("file-list-item")
-		.filter({ hasText: ".gitmodules" });
-	await expect(committedGitmodules).toBeVisible();
-
-	// Verify the submodule directory is listed in the commit
-	const committedSubmodule = stackPreview
-		.getByTestId("file-list-item")
-		.filter({ hasText: "my-submodule" });
-	await expect(committedSubmodule).toBeVisible();
+	const stackFiles = stack(page).getByTestId("file-list-item");
+	await expect(stackFiles.filter({ hasText: ".gitmodules" })).toBeVisible();
+	await expect(stackFiles.filter({ hasText: "my-submodule" })).toBeVisible();
 });
 
 /**
- * Commit multiple times in a row.
- *
- * Each time, only the first file will be staged and committed.
+ * Commit multiple times in a row, staging only the first file each time.
  */
 async function commitMultipleTimes(TIMES: number, page: Page) {
 	for (let i = 0; i < TIMES; i++) {
-		// Start committing the files one by one
 		await clickByTestId(page, "start-commit-button");
-
 		await verifyCommitPlaceholderPosition(page);
 		await unstageAllFiles(page);
 		await stageFirstFile(page);
 
-		const commitTitle = getCommitTitle(i);
-		const commitMessage = getCommitDescription(i);
-
-		// Fill the commit message
+		const title = commitTitleFor(i);
+		const body = commitDescriptionFor(i);
 		await verifyCommitMessageEditor(page, "", "");
-		await updateCommitMessage(page, commitTitle, commitMessage);
-
-		// Submit the commit
+		await updateCommitMessage(page, title, body);
 		await clickByTestId(page, "commit-drawer-action-button");
 
-		// Commit with title should be visible in the commit list
-		const commitRow = getByTestId(page, "commit-row").filter({ hasText: commitTitle });
-		await expect(commitRow).toBeVisible();
+		await expect(commitRow(page, title)).toBeVisible();
 	}
 }
 
 async function startCommittingAndCancel(page: Page, index: number) {
-	// Start committing the files one by one
 	await clickByTestId(page, "start-commit-button");
-
 	await verifyCommitPlaceholderPosition(page);
 	await unstageAllFiles(page);
 	await stageFirstFile(page);
 
-	const commitTitle = getCommitTitle(index);
-	const commitMessage = getCommitDescription(index);
-
-	// Fill the commit message
+	const title = commitTitleFor(index);
 	await verifyCommitMessageEditor(page, "", "");
-	await updateCommitMessage(page, commitTitle, commitMessage);
-
-	// Cancel the commit
+	await updateCommitMessage(page, title, commitDescriptionFor(index));
 	await clickByTestId(page, "commit-drawer-cancel-button");
 
-	// Commit with title should be visible in the commit list
-	const commitRow = getByTestId(page, "commit-row").filter({ hasText: commitTitle });
-	await expect(commitRow).toHaveCount(0);
+	await expect(commitRow(page, title)).toHaveCount(0);
 }
 
-/**
- * Amend the commit message of multiple commits in a row.
- */
 async function amendCommitMessageMultipleTimes(TIMES: number, page: Page) {
 	for (let i = 0; i < TIMES; i++) {
-		const commitTitle = getCommitTitle(i);
-		const commitMessage = getCommitDescription(i);
-		const newCommitTitle = getAmendedCommitTitle(i);
-		const newCommitMessage = getAmendedCommitDescription(i);
+		const title = commitTitleFor(i);
+		const body = commitDescriptionFor(i);
+		const newTitle = amendedTitleFor(i);
+		const newBody = amendedDescriptionFor(i);
 
-		// Open the commit drawer and verify initial content
-		const commitDrawer = await openCommitDrawer(page, commitTitle);
-		await verifyCommitDrawerContent(commitDrawer, commitTitle, commitMessage);
+		const drawer = await openCommitDrawer(page, title);
+		await verifyCommitDrawerContent(drawer, title, body);
 
-		// Start editing the commit message
-		await startEditingCommitMessage(page, commitDrawer);
-		await verifyCommitMessageEditor(page, commitTitle, commitMessage);
+		await startEditingCommitMessage(page, drawer);
+		await verifyCommitMessageEditor(page, title, body);
 
-		// Update and submit the changes
-		await updateCommitMessage(page, newCommitTitle, newCommitMessage);
+		await updateCommitMessage(page, newTitle, newBody);
 		await clickByTestId(page, "commit-drawer-action-button");
 
-		// Verify the changes were applied
 		await waitForTestIdToNotExist(page, "edit-commit-message-box");
-		await verifyCommitDrawerContent(commitDrawer, newCommitTitle, newCommitMessage);
+		await verifyCommitDrawerContent(drawer, newTitle, newBody);
 	}
 }
 
-async function startAmendingACommitMessageAndCancel(page: Page, commitIndex: number) {
-	const commitTitle = getCommitTitle(commitIndex);
-	const commitMessage = getCommitDescription(commitIndex);
-	const newCommitTitle = getAmendedCommitTitle(commitIndex);
-	const newCommitMessage = getAmendedCommitDescription(commitIndex);
+async function startAmendingACommitMessageAndCancel(page: Page, index: number) {
+	const title = commitTitleFor(index);
+	const body = commitDescriptionFor(index);
 
-	// Open the commit drawer and verify initial content
-	const commitDrawer = await openCommitDrawer(page, commitTitle);
-	await verifyCommitDrawerContent(commitDrawer, commitTitle, commitMessage);
+	const drawer = await openCommitDrawer(page, title);
+	await verifyCommitDrawerContent(drawer, title, body);
 
-	// Start editing the commit message
-	await startEditingCommitMessage(page, commitDrawer);
-	await verifyCommitMessageEditor(page, commitTitle, commitMessage);
+	await startEditingCommitMessage(page, drawer);
+	await verifyCommitMessageEditor(page, title, body);
 
-	// Update and cancel the changes
-	await updateCommitMessage(page, newCommitTitle, newCommitMessage);
+	await updateCommitMessage(page, amendedTitleFor(index), amendedDescriptionFor(index));
 	await clickByTestId(page, "commit-drawer-cancel-button");
 
-	// Verify the changes were NOT applied (original values remain)
 	await waitForTestIdToNotExist(page, "edit-commit-message-box");
-	await verifyCommitDrawerContent(commitDrawer, commitTitle, commitMessage);
+	await verifyCommitDrawerContent(drawer, title, body);
 }
 
-function getCommitTitle(i: number): string {
+function commitTitleFor(i: number): string {
 	return `Commit number ${i + 1}`;
 }
 
-function getAmendedCommitTitle(i: number): string {
+function amendedTitleFor(i: number): string {
 	return `Amended Commit number ${i + 1}`;
 }
 
-function getCommitDescription(i: number): string {
+function commitDescriptionFor(i: number): string {
 	return `Desc ${i + 1}`;
 }
 
-function getAmendedCommitDescription(i: number): string {
+function amendedDescriptionFor(i: number): string {
 	return `Amended ${i + 1}`;
 }

--- a/e2e/playwright/tests/commitHooks.spec.ts
+++ b/e2e/playwright/tests/commitHooks.spec.ts
@@ -1,352 +1,137 @@
-import { getBaseURL, getButlerPort, type GitButler, startGitButler } from "../src/setup.ts";
+import { getButlerPort, type GitButler } from "../src/setup.ts";
 import { test } from "../src/test.ts";
-import { clickByTestId, fillByTestId, getByTestId, waitForTestId } from "../src/util.ts";
+import { clickByTestId, commitRow, fillByTestId, getByTestId, waitForTestId } from "../src/util.ts";
 import { expect, type Page } from "@playwright/test";
-
-let gitbutler: GitButler;
 
 test.describe.configure({ mode: "serial" });
 
-test.use({
-	baseURL: getBaseURL(),
-});
+/**
+ * Bring up the hook-equipped project, enable hooks for the project, and reload
+ * so the settings take effect. Returns once the workspace is visible.
+ */
+async function setupWithHooks(page: Page, gitbutler: GitButler) {
+	await gitbutler.runScript("project-with-commit-hooks.sh");
+	await page.goto("/");
+	await waitForTestId(page, "workspace-view");
 
-test.afterEach(async () => {
-	await gitbutler?.destroy();
-});
-
-function getProjectIdFromWorkspaceUrl(page: Page): string {
-	const url = page.url();
-	return url.split("/")[3];
-}
-
-async function enableProjectHooks(page: Page, projectId: string) {
+	const projectId = page.url().split("/")[3];
 	await page.evaluate((id) => {
 		localStorage.setItem(`projectRunCommitHooks_${id}`, "true");
 	}, projectId);
 
 	const response = await page.request.post(`http://localhost:${getButlerPort()}/update_project`, {
-		data: {
-			project: {
-				id: projectId,
-				husky_hooks_enabled: true,
-			},
-		},
+		data: { project: { id: projectId, husky_hooks_enabled: true } },
 	});
-	const payload = await response.json();
 	expect(response.ok()).toBeTruthy();
-	expect(payload.type).toBe("success");
+	expect((await response.json()).type).toBe("success");
+
+	await page.reload();
+	await waitForTestId(page, "workspace-view");
 }
 
-test("should show commit-msg hook rejection error", async ({ page, context }, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context, { RUST_LOG: "debug" });
-
-	await gitbutler.runScript("project-with-commit-hooks.sh");
-
-	await page.goto("/");
-
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// Get the project ID from the URL and enable commit hooks
-	const projectId = getProjectIdFromWorkspaceUrl(page);
-	await enableProjectHooks(page, projectId);
-
-	// Reload to apply the settings
-	await page.reload();
-	await waitForTestId(page, "workspace-view");
-
-	// There should be a file with uncommitted changes
-	const fileList = getByTestId(page, "file-list-item");
-	await expect(fileList).toHaveCount(1);
-	await expect(fileList).toContainText("uncommitted.txt");
-
-	// Open the commit view
+async function tryCommit(page: Page, title: string) {
 	await clickByTestId(page, "start-commit-button");
-
-	// The commit view should be visible
-	const commitView = getByTestId(page, "new-commit-view");
-	await expect(commitView).toBeVisible();
-
-	// Type a commit message that should be rejected by the hook
-	await fillByTestId(page, "commit-drawer-title-input", "This message should REJECT");
-
-	// Try to create the commit
+	await expect(getByTestId(page, "new-commit-view")).toBeVisible();
+	await fillByTestId(page, "commit-drawer-title-input", title);
 	await clickByTestId(page, "commit-drawer-action-button");
+}
 
-	// Should show an error toast about the hook rejection
-	const toastMessage = getByTestId(page, "toast-info-message");
-	await expect(toastMessage).toBeVisible();
-	await expect(toastMessage).toContainText("REJECT");
+test.describe("commit-msg hook", () => {
+	test.use({ gitbutlerOptions: { env: { RUST_LOG: "debug" } } });
+
+	test("rejection shows error toast", async ({ page, gitbutler }) => {
+		await setupWithHooks(page, gitbutler);
+
+		const fileList = getByTestId(page, "file-list-item");
+		await expect(fileList).toHaveCount(1);
+		await expect(fileList).toContainText("uncommitted.txt");
+
+		await tryCommit(page, "This message should REJECT");
+
+		const toast = getByTestId(page, "toast-info-message");
+		await expect(toast).toBeVisible();
+		await expect(toast).toContainText("REJECT");
+	});
 });
 
-test("should show modified commit message from commit-msg hook", async ({
-	page,
-	context,
-}, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
+test("shows modified commit message from commit-msg hook", async ({ page, gitbutler }) => {
+	await setupWithHooks(page, gitbutler);
 
-	await gitbutler.runScript("project-with-commit-hooks.sh");
+	await expect(getByTestId(page, "file-list-item")).toHaveCount(1);
+	await tryCommit(page, "This message should MODIFY");
 
-	await page.goto("/");
-
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// Get the project ID from the URL and enable commit hooks
-	const projectId = getProjectIdFromWorkspaceUrl(page);
-	await enableProjectHooks(page, projectId);
-
-	// Reload to apply the settings
-	await page.reload();
-	await waitForTestId(page, "workspace-view");
-
-	// There should be a file with uncommitted changes
-	const fileList = getByTestId(page, "file-list-item");
-	await expect(fileList).toHaveCount(1);
-
-	// Open the commit view
-	await clickByTestId(page, "start-commit-button");
-
-	// The commit view should be visible
-	const commitView = getByTestId(page, "new-commit-view");
-	await expect(commitView).toBeVisible();
-
-	// Type a commit message that should be modified by the hook
-	await fillByTestId(page, "commit-drawer-title-input", "This message should MODIFY");
-
-	// Try to create the commit
-	await clickByTestId(page, "commit-drawer-action-button");
-
-	// The commit should be created successfully
-	// Wait for the commit to appear in the commit list
-	const commitRow = getByTestId(page, "commit-row").first();
-	await expect(commitRow).toBeVisible();
-
-	// The commit title should include the [MODIFIED] prefix added by the hook
-	await expect(commitRow).toContainText("[MODIFIED]");
+	const row = commitRow(page).first();
+	await expect(row).toBeVisible();
+	await expect(row).toContainText("[MODIFIED]");
 });
 
-test("should allow commits when commit-msg hook passes", async ({ page, context }, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
+test("allows commits when commit-msg hook passes", async ({ page, gitbutler }) => {
+	await setupWithHooks(page, gitbutler);
 
-	await gitbutler.runScript("project-with-commit-hooks.sh");
+	await expect(getByTestId(page, "file-list-item")).toHaveCount(1);
+	await tryCommit(page, "A normal commit message");
 
-	await page.goto("/");
-
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// Get the project ID from the URL and enable commit hooks
-	const projectId = getProjectIdFromWorkspaceUrl(page);
-	await enableProjectHooks(page, projectId);
-
-	// Reload to apply the settings
-	await page.reload();
-	await waitForTestId(page, "workspace-view");
-
-	// There should be a file with uncommitted changes
-	const fileList = getByTestId(page, "file-list-item");
-	await expect(fileList).toHaveCount(1);
-
-	// Open the commit view
-	await clickByTestId(page, "start-commit-button");
-
-	// Type a normal commit message that should pass
-	await fillByTestId(page, "commit-drawer-title-input", "A normal commit message");
-
-	// Try to create the commit
-	await clickByTestId(page, "commit-drawer-action-button");
-
-	// The commit should be created successfully
-	const commitRow = getByTestId(page, "commit-row").first();
-	await expect(commitRow).toBeVisible();
-	await expect(commitRow).toContainText("A normal commit message");
+	const row = commitRow(page).first();
+	await expect(row).toBeVisible();
+	await expect(row).toContainText("A normal commit message");
 });
 
-test("should reject commit when pre-commit hook fails", async ({ page, context }, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
+test("rejects commit when pre-commit hook fails", async ({ page, gitbutler }) => {
+	await setupWithHooks(page, gitbutler);
 
-	await gitbutler.runScript("project-with-commit-hooks.sh");
-
-	await page.goto("/");
-
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// Get the project ID from the URL and enable commit hooks
-	const projectId = getProjectIdFromWorkspaceUrl(page);
-	await enableProjectHooks(page, projectId);
-
-	// Reload to apply the settings
-	await page.reload();
-	await waitForTestId(page, "workspace-view");
-
-	// Create a file with forbidden content
 	await gitbutler.runScript("create-forbidden-file.sh");
-
-	// Wait for the file to appear in the UI
-	await page.waitForTimeout(500);
 	await page.reload();
 	await waitForTestId(page, "workspace-view");
 
-	// There should be files with uncommitted changes
-	const fileList = getByTestId(page, "file-list-item");
-	await expect(fileList).toHaveCount(2); // uncommitted.txt and forbidden.txt
+	await expect(getByTestId(page, "file-list-item")).toHaveCount(2);
 
-	// Open the commit view
-	await clickByTestId(page, "start-commit-button");
+	await tryCommit(page, "Adding forbidden file");
 
-	// Type a commit message
-	await fillByTestId(page, "commit-drawer-title-input", "Adding forbidden file");
-
-	// Try to create the commit
-	await clickByTestId(page, "commit-drawer-action-button");
-
-	// Should show an error toast about the pre-commit hook rejection
-	const toastMessage = getByTestId(page, "toast-info-message");
-	await expect(toastMessage).toBeVisible();
-	await expect(toastMessage).toContainText("FORBIDDEN");
+	const toast = getByTestId(page, "toast-info-message");
+	await expect(toast).toBeVisible();
+	await expect(toast).toContainText("FORBIDDEN");
 });
 
-test("should allow commit when pre-commit hook passes", async ({ page, context }, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
+test("allows commit when pre-commit hook passes", async ({ page, gitbutler }) => {
+	await setupWithHooks(page, gitbutler);
 
-	await gitbutler.runScript("project-with-commit-hooks.sh");
-
-	await page.goto("/");
-
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// Get the project ID from the URL and enable commit hooks
-	const projectId = getProjectIdFromWorkspaceUrl(page);
-	await enableProjectHooks(page, projectId);
-
-	// Reload to apply the settings
-	await page.reload();
-	await waitForTestId(page, "workspace-view");
-
-	// Create a file with allowed content
 	await gitbutler.runScript("create-allowed-file.sh");
-
-	// Wait for the file to appear in the UI
-	await page.waitForTimeout(500);
 	await page.reload();
 	await waitForTestId(page, "workspace-view");
 
-	// Open the commit view
-	await clickByTestId(page, "start-commit-button");
+	await tryCommit(page, "Adding allowed file");
 
-	// Type a commit message
-	await fillByTestId(page, "commit-drawer-title-input", "Adding allowed file");
-
-	// Try to create the commit
-	await clickByTestId(page, "commit-drawer-action-button");
-
-	// The commit should be created successfully (pre-commit hook passed)
-	const commitRow = getByTestId(page, "commit-row").first();
-	await expect(commitRow).toBeVisible();
-	await expect(commitRow).toContainText("Adding allowed file");
+	const row = commitRow(page).first();
+	await expect(row).toBeVisible();
+	await expect(row).toContainText("Adding allowed file");
 });
 
-test("should show post-commit hook success", async ({ page, context }, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
+test("post-commit hook success", async ({ page, gitbutler }) => {
+	await setupWithHooks(page, gitbutler);
 
-	await gitbutler.runScript("project-with-commit-hooks.sh");
+	await expect(getByTestId(page, "file-list-item").first()).toBeVisible();
+	await tryCommit(page, "Testing post-commit hook");
 
-	await page.goto("/");
+	const row = commitRow(page).first();
+	await expect(row).toBeVisible();
+	await expect(row).toContainText("Testing post-commit hook");
 
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// Get the project ID from the URL and enable commit hooks
-	const projectId = getProjectIdFromWorkspaceUrl(page);
-	await enableProjectHooks(page, projectId);
-
-	// Reload to apply the settings
-	await page.reload();
-	await waitForTestId(page, "workspace-view");
-
-	// There should be a file with uncommitted changes
-	const fileList = getByTestId(page, "file-list-item");
-	await expect(fileList.first()).toBeVisible();
-
-	// Open the commit view
-	await clickByTestId(page, "start-commit-button");
-
-	// Type a commit message
-	await fillByTestId(page, "commit-drawer-title-input", "Testing post-commit hook");
-
-	// Try to create the commit
-	await clickByTestId(page, "commit-drawer-action-button");
-
-	// The commit should be created successfully
-	const commitRow = getByTestId(page, "commit-row").first();
-	await expect(commitRow).toBeVisible();
-	await expect(commitRow).toContainText("Testing post-commit hook");
-
-	// Wait for post-commit hook to execute (it runs in background)
+	// Post-commit hook runs in the background.
 	await page.waitForTimeout(1500);
 });
 
-test("should show post-commit hook failure but commit still created", async ({
-	page,
-	context,
-}, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
+test("post-commit hook failure does not block commit", async ({ page, gitbutler }) => {
+	await setupWithHooks(page, gitbutler);
 
-	await gitbutler.runScript("project-with-commit-hooks.sh");
-
-	await page.goto("/");
-
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// Get the project ID from the URL and enable commit hooks
-	const projectId = getProjectIdFromWorkspaceUrl(page);
-	await enableProjectHooks(page, projectId);
-
-	// Reload to apply the settings
-	await page.reload();
-	await waitForTestId(page, "workspace-view");
-
-	// Create a marker file that will trigger post-commit failure
 	await gitbutler.runScript("create-postcommit-fail-marker.sh");
-
-	// Wait for the file to appear in the UI
-	await page.waitForTimeout(500);
 	await page.reload();
 	await waitForTestId(page, "workspace-view");
 
-	// Open the commit view
-	await clickByTestId(page, "start-commit-button");
+	await tryCommit(page, "Trigger post-commit failure");
 
-	// Type a commit message
-	await fillByTestId(page, "commit-drawer-title-input", "Trigger post-commit failure");
+	const row = commitRow(page).first();
+	await expect(row).toBeVisible();
+	await expect(row).toContainText("Trigger post-commit failure");
 
-	// Try to create the commit
-	await clickByTestId(page, "commit-drawer-action-button");
-
-	// The commit should be created (pre-commit passed)
-	const commitRow = getByTestId(page, "commit-row").first();
-	await expect(commitRow).toBeVisible();
-	await expect(commitRow).toContainText("Trigger post-commit failure");
-
-	// Wait for post-commit hook to run and fail (it runs in background)
 	await page.waitForTimeout(1500);
 });

--- a/e2e/playwright/tests/dragToCommit.spec.ts
+++ b/e2e/playwright/tests/dragToCommit.spec.ts
@@ -5,27 +5,13 @@ import {
 	assertFileIsUncommitted,
 	assertFileIsUnstaged,
 } from "../src/file.ts";
-import { getBaseURL, type GitButler, startGitButler } from "../src/setup.ts";
+import { applyUpstream, openWorkspace } from "../src/setup.ts";
 import { test } from "../src/test.ts";
-import { clickByTestId, dragAndDropByLocator, getByTestId, waitForTestId } from "../src/util.ts";
+import { clickByTestId, commitRow, dragAndDropByLocator, waitForTestId } from "../src/util.ts";
 import { expect } from "@playwright/test";
 import { writeFileSync } from "fs";
 
-let gitbutler: GitButler;
-
-test.use({
-	baseURL: getBaseURL(),
-});
-
-test.afterEach(async () => {
-	await gitbutler.destroy();
-});
-
-test("should be able to start a commit by dragging a file", async ({ page, context }, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+test("should be able to start a commit by dragging a file", async ({ page, gitbutler }) => {
 	const fileName = "b_file";
 	const filePath = gitbutler.pathInWorkdir("local-clone/" + fileName);
 	const fileContent = "Hello! this is file b\n";
@@ -34,68 +20,32 @@ test("should be able to start a commit by dragging a file", async ({ page, conte
 	const anotherFileContent = "Hello! this is file c\n";
 
 	await gitbutler.runScript("project-with-remote-branches.sh");
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
+	await applyUpstream(gitbutler, "branch1");
+	await openWorkspace(page);
 
-	await page.goto("/");
-
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// There should be only one stack
-	const stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(1);
-	const stack = stacks.first();
-	await expect(stack).toContainText("branch1");
-
-	// The stack should have two commits
-	const commits = getByTestId(page, "commit-row");
-	await expect(commits).toHaveCount(2);
-
-	// Imported remote branches start out already synced when added via `but apply`.
-	const initialPushButton = getByTestId(page, "stack-push-button");
-	await expect(initialPushButton).toBeDisabled();
-
-	// Add a two new files to the workdir
 	writeFileSync(filePath, fileContent, { flag: "w" });
 	writeFileSync(anotherFilePath, anotherFileContent, { flag: "w" });
 
 	const fileLocator = page
 		.getByTestId("uncommitted-changes-file-list")
 		.getByTestId("file-list-item")
-		.filter({
-			hasText: fileName,
-		});
-	await expect(fileLocator).toHaveCount(1);
+		.filter({ hasText: fileName });
 	await expect(fileLocator).toBeVisible();
 
-	const branchCardLocators = await waitForTestId(page, "branch-card");
-	const branchCardLocator = branchCardLocators.filter({
-		hasText: "branch1",
-	});
+	const branchCard = (await waitForTestId(page, "branch-card")).filter({ hasText: "branch1" });
+	await dragAndDropByLocator(page, fileLocator, branchCard);
 
-	// Drag the new file onto the top commit, to amend it
-	await dragAndDropByLocator(page, fileLocator, branchCardLocator);
-
-	// Verify that the only the dragged file is now staged
 	await assertFileIsStaged(page, fileName);
 	await assertFileIsUnstaged(page, anotherFileName);
 
 	const commitTitle = "New file added";
 	const commitMessage = `Added ${fileName} to the project`;
-
-	// Fill the commit message
 	await verifyCommitMessageEditor(page, "", "");
 	await updateCommitMessage(page, commitTitle, commitMessage);
-
-	// Submit the commit
 	await clickByTestId(page, "commit-drawer-action-button");
-	const commitRow = getByTestId(page, "commit-row").filter({ hasText: commitTitle });
-	await expect(commitRow).toHaveCount(1);
 
-	// Verify that the other file is still uncommitted
+	await expect(commitRow(page, commitTitle)).toHaveCount(1);
 	await assertFileIsUncommitted(page, anotherFileName);
-
-	// Verify the file contents are correct
 	await assertFileContent(filePath, fileContent);
 	await assertFileContent(anotherFilePath, anotherFileContent);
 });

--- a/e2e/playwright/tests/dropResult.spec.ts
+++ b/e2e/playwright/tests/dropResult.spec.ts
@@ -1,49 +1,26 @@
-import { getBaseURL, type GitButler, startGitButler } from "../src/setup.ts";
+import { applyUpstream, openWorkspace } from "../src/setup.ts";
 import { test } from "../src/test.ts";
-import { clickByTestId, dragAndDropByLocator, getByTestId, waitForTestId } from "../src/util.ts";
+import { clickByTestId, commitRow, dragAndDropByLocator, getByTestId } from "../src/util.ts";
 import { expect } from "@playwright/test";
 import { writeFileSync } from "fs";
 
-let gitbutler: GitButler;
-
-test.use({
-	baseURL: getBaseURL(),
-});
-
-test.afterEach(async () => {
-	await gitbutler?.destroy();
-});
-
 test("should show commit-failed modal when amending causes a conflict", async ({
 	page,
-	context,
-}, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+	gitbutler,
+}) => {
 	// Set up a project with a branch that has two commits modifying the same
 	// line of a 20-line file. Amending the first commit with a conflicting
 	// worktree change will cause a cherry-pick merge conflict when rebasing
 	// the second commit on top.
 	await gitbutler.runScript("project-with-conflicting-commits.sh");
-	await gitbutler.runScript("apply-upstream-branch.sh", ["conflicting-branch", "local-clone"]);
+	await applyUpstream(gitbutler, "conflicting-branch");
+	await openWorkspace(page);
 
-	await page.goto("/");
-	await waitForTestId(page, "workspace-view");
+	await expect(commitRow(page)).toHaveCount(2);
 
-	// Should have one stack with two commits
-	const stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(1);
-
-	const commits = getByTestId(page, "commit-row");
-	await expect(commits).toHaveCount(2);
-
-	// Write a conflicting worktree change to a_file.
 	// HEAD has "JULIET-SECOND" on line 10 (from commit 2).
-	// We change it to "JULIET-WORKTREE". When this is amended into the first
-	// commit, rebasing the second commit will fail because it expects
-	// "JULIET-FIRST" but finds "JULIET-WORKTREE".
+	// Changing it to "JULIET-WORKTREE" will, when amended into commit 1, make
+	// the rebase of commit 2 fail because it expects "JULIET-FIRST".
 	const filePath = gitbutler.pathInWorkdir("local-clone/a_file");
 	const newContent =
 		[
@@ -70,79 +47,36 @@ test("should show commit-failed modal when amending causes a conflict", async ({
 		].join("\n") + "\n";
 	writeFileSync(filePath, newContent);
 
-	// Wait for the uncommitted change to appear
 	const fileLocator = page
 		.getByTestId("uncommitted-changes-file-list")
 		.getByTestId("file-list-item")
 		.filter({ hasText: "a_file" });
 	await expect(fileLocator).toBeVisible();
 
-	// Drag the uncommitted file onto the FIRST commit (bottom one).
-	// "Change juliet to JULIET-FIRST" is the first commit.
-	const firstCommit = getByTestId(page, "commit-row").filter({
-		hasText: "Change juliet to JULIET-FIRST",
-	});
-	await expect(firstCommit).toBeVisible();
-
+	const firstCommit = commitRow(page, "Change juliet to JULIET-FIRST");
 	await dragAndDropByLocator(page, fileLocator, firstCommit);
 
-	// The commit-failed modal should appear because rebasing the second commit
-	// on top of the amended first commit causes a cherry-pick merge conflict.
 	const modal = getByTestId(page, "global-modal-commit-failed");
 	await expect(modal).toBeVisible();
-
-	// The modal should indicate that some changes were not committed
 	await expect(modal).toContainText(/changes were not committed|Failed to create commit/);
 
-	// Close the modal
 	await clickByTestId(page, "global-modal-action-button");
 	await expect(modal).not.toBeVisible();
 });
 
-test("should squash commits via drag-and-drop without errors", async ({
-	page,
-	context,
-}, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
-	// project-with-stacks creates branch1 with 4 commits
+test("should squash commits via drag-and-drop without errors", async ({ page, gitbutler }) => {
 	await gitbutler.runScript("project-with-stacks.sh");
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
+	await applyUpstream(gitbutler, "branch1");
+	await openWorkspace(page);
 
-	await page.goto("/");
-	await waitForTestId(page, "workspace-view");
+	await expect(commitRow(page)).toHaveCount(4);
 
-	// Should have 4 commits in one stack
-	const commits = getByTestId(page, "commit-row");
-	await expect(commits).toHaveCount(4);
-
-	// Drag the top commit onto the second commit to squash them
-	const topCommit = getByTestId(page, "commit-row").filter({
-		hasText: "branch1: fourth commit",
-	});
-	const secondCommit = getByTestId(page, "commit-row").filter({
-		hasText: "branch1: third commit",
-	});
-	await expect(topCommit).toBeVisible();
-	await expect(secondCommit).toBeVisible();
-
+	const topCommit = commitRow(page, "branch1: fourth commit");
+	const secondCommit = commitRow(page, "branch1: third commit");
 	await dragAndDropByLocator(page, topCommit, secondCommit);
 
-	// After squashing, the branch should show an upstream divergence section
-	// because local history changed. The upstream action row confirms
-	// the squash was successful.
-	const upstreamSection = getByTestId(page, "upstream-commits-commit-action");
-	await expect(upstreamSection).toBeVisible();
-
-	// The first commit should still be present (it was not part of the squash)
-	const remainingFirst = getByTestId(page, "commit-row").filter({
-		hasText: "branch1: first commit",
-	});
-	await expect(remainingFirst).toBeVisible();
-
-	// No error modal should appear
-	const modal = getByTestId(page, "global-modal-commit-failed");
-	await expect(modal).not.toBeVisible();
+	// After squashing, the branch shows upstream divergence — the squash worked.
+	await expect(getByTestId(page, "upstream-commits-commit-action")).toBeVisible();
+	await expect(commitRow(page, "branch1: first commit")).toBeVisible();
+	await expect(getByTestId(page, "global-modal-commit-failed")).not.toBeVisible();
 });

--- a/e2e/playwright/tests/editMode.spec.ts
+++ b/e2e/playwright/tests/editMode.spec.ts
@@ -1,56 +1,25 @@
-import { getBaseURL, startGitButler, type GitButler } from "../src/setup.ts";
+import { applyUpstream, openWorkspace } from "../src/setup.ts";
 import { test } from "../src/test.ts";
-import { clickByTestId, waitForTestId } from "../src/util.ts";
+import { clickByTestId, commitRow, waitForTestId } from "../src/util.ts";
 import { expect } from "@playwright/test";
 import { readFileSync, writeFileSync } from "fs";
 
-let gitbutler: GitButler;
-
-test.use({
-	baseURL: getBaseURL(),
-});
-
-test.afterEach(async () => {
-	await gitbutler?.destroy();
-});
-
-test("should be able to edit a commit through the edit mode", async ({
-	page,
-	context,
-}, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+test("should be able to edit a commit through the edit mode", async ({ page, gitbutler }) => {
 	const fileBPath = gitbutler.pathInWorkdir("file-b.txt");
 
 	await gitbutler.runScript("project-with-remote-branches.sh");
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
+	await applyUpstream(gitbutler, "branch1");
+	await openWorkspace(page);
 
-	await page.goto("/");
-
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	const commitRows = page.getByTestId("commit-row");
-	await expect(commitRows).toHaveCount(2);
-	const bottomCommit = commitRows.filter({ hasText: "branch1: first commit" });
-
-	bottomCommit.click({ button: "right" });
+	const bottomCommit = commitRow(page, "branch1: first commit");
+	await bottomCommit.click({ button: "right" });
 	await clickByTestId(page, "commit-row-context-menu-edit-commit");
-	// Should open the edit mode
 	await waitForTestId(page, "edit-mode");
 
-	// Create another file to commit
 	writeFileSync(fileBPath, "This is file B\n", { encoding: "utf-8" });
 
-	// Click the save and exit button
 	await clickByTestId(page, "edit-mode-save-and-exit-button");
-
-	// Should be back in the workspace
 	await waitForTestId(page, "workspace-view");
 
-	const fileBContent = readFileSync(fileBPath, { encoding: "utf-8" });
-
-	expect(fileBContent).toEqual("This is file B\n");
+	expect(readFileSync(fileBPath, { encoding: "utf-8" })).toEqual("This is file B\n");
 });

--- a/e2e/playwright/tests/moveBranch.spec.ts
+++ b/e2e/playwright/tests/moveBranch.spec.ts
@@ -1,139 +1,63 @@
-import { getBaseURL, type GitButler, startGitButler } from "../src/setup.ts";
+import { applyUpstream, openWorkspace } from "../src/setup.ts";
 import { test } from "../src/test.ts";
-import { dragAndDropByLocator, waitForTestId } from "../src/util.ts";
+import { dragAndDropByLocator, stack, waitForTestId } from "../src/util.ts";
 import { expect } from "@playwright/test";
 
-let gitbutler: GitButler;
-
-test.use({
-	baseURL: getBaseURL(),
-});
-
-test.afterEach(async () => {
-	await gitbutler?.destroy();
-});
-
-test("move branch to top of other stack and tear it off", async ({ page, context }, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+test("move branch to top of other stack and tear it off", async ({ page, gitbutler }) => {
 	await gitbutler.runScript("project-with-stacks.sh");
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch2", "local-clone"]);
+	await applyUpstream(gitbutler, "branch1", "branch2");
+	await openWorkspace(page);
 
-	await page.goto("/");
+	const branchHeaders = page.getByTestId("branch-header");
+	await expect(stack(page)).toHaveCount(2);
 
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
+	// Drag branch1 to the top of branch2's stack. The dropzone above branch2
+	// (isFirst=true) activates on hover during drag — we hit it via position offset.
+	await dragAndDropByLocator(
+		page,
+		branchHeaders.filter({ hasText: "branch1" }),
+		branchHeaders.filter({ hasText: "branch2" }),
+		{ force: true, position: { x: 120, y: -10 } },
+	);
 
-	let stacks = page.getByTestId("stack");
-	await expect(stacks).toHaveCount(2);
-	const stack1 = stacks.filter({ hasText: "branch1" });
-	await stack1.isVisible();
-	const stack2 = stacks.filter({ hasText: "branch2" });
-	await stack2.isVisible();
-
-	let branchHeaders = page.getByTestId("branch-header");
-	await expect(branchHeaders).toHaveCount(2);
-	const branch1Locator = branchHeaders.filter({ hasText: "branch1" });
-	const branch2Locator = branchHeaders.filter({ hasText: "branch2" });
-
-	// Drag branch1 to the top of branch2's stack
-	// The dropzone above branch2 (isFirst=true) activates on hover during drag
-	// We drag to branch2 with a position offset to hit the dropzone area above it
-	await dragAndDropByLocator(page, branch1Locator, branch2Locator, {
-		force: true,
-		position: {
-			x: 120,
-			y: -10,
-		},
-	});
-
-	// Should have moved branch1 to the top of stack2
-	stacks = page.getByTestId("stack");
-	await expect(stacks).toHaveCount(1);
-	branchHeaders = page.getByTestId("branch-header");
+	await expect(stack(page)).toHaveCount(1);
 	await expect(branchHeaders).toHaveCount(2);
 
-	// Now tear off branch2
-	const updatedBranch1Locator = branchHeaders.filter({ hasText: "branch2" });
+	// Now tear off branch2 onto the new stack dropzone.
 	const stackDropzone = await waitForTestId(page, "stack-offlane-dropzone");
-	await dragAndDropByLocator(page, updatedBranch1Locator, stackDropzone, {
+	await dragAndDropByLocator(page, branchHeaders.filter({ hasText: "branch2" }), stackDropzone, {
 		force: true,
-		position: {
-			x: 10,
-			y: 10,
-		},
+		position: { x: 10, y: 10 },
 	});
 
-	// Should have two stacks again
-	stacks = page.getByTestId("stack");
-	await expect(stacks).toHaveCount(2);
-	branchHeaders = page.getByTestId("branch-header");
+	await expect(stack(page)).toHaveCount(2);
 	await expect(branchHeaders).toHaveCount(2);
 });
 
-test("move branch to the middle of other stack", async ({ page, context }, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+test("move branch to the middle of other stack", async ({ page, gitbutler }) => {
 	await gitbutler.runScript("project-with-stacks.sh");
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch2", "local-clone"]);
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch3", "local-clone"]);
+	await applyUpstream(gitbutler, "branch1", "branch2", "branch3");
+	await openWorkspace(page);
 
-	await page.goto("/");
+	const branchHeaders = page.getByTestId("branch-header");
+	await expect(stack(page)).toHaveCount(3);
 
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
+	// Move branch2 on top of branch1.
+	await dragAndDropByLocator(
+		page,
+		branchHeaders.filter({ hasText: "branch2" }),
+		branchHeaders.filter({ hasText: "branch1" }),
+		{ force: true, position: { x: 120, y: -10 } },
+	);
+	await expect(stack(page)).toHaveCount(2);
 
-	let stacks = page.getByTestId("stack");
-	await expect(stacks).toHaveCount(3);
-	const stack1 = stacks.filter({ hasText: "branch1" });
-	await stack1.isVisible();
-	const stack2 = stacks.filter({ hasText: "branch2" });
-	await stack2.isVisible();
-	const stack3 = stacks.filter({ hasText: "branch3" });
-	await stack3.isVisible();
-
-	let branchHeaders = page.getByTestId("branch-header");
-	await expect(branchHeaders).toHaveCount(3);
-	let branch1Locator = branchHeaders.filter({ hasText: "branch1" });
-	const branch2Locator = branchHeaders.filter({ hasText: "branch2" });
-
-	// Move branch 2 on top of branch 1
-	// Drag to branch1 with position offset to hit the dropzone above it
-	await dragAndDropByLocator(page, branch2Locator, branch1Locator, {
-		force: true,
-		position: {
-			x: 120,
-			y: -10,
-		},
-	});
-	stacks = page.getByTestId("stack");
-	await expect(stacks).toHaveCount(2);
-
-	branchHeaders = page.getByTestId("branch-header");
-	await expect(branchHeaders).toHaveCount(3);
-	// Move branch3 on top of branch 1 (which is now in the middle of stack)
-	const branch3Locator = branchHeaders.filter({ hasText: "branch3" });
-	branch1Locator = branchHeaders.filter({ hasText: "branch1" });
-
-	// After merge, there's one stack with branch2 on top and branch1 below.
-	// Drag to the top of branch1's header to hit the between-branch dropzone.
-	await dragAndDropByLocator(page, branch3Locator, branch1Locator, {
-		force: true,
-		position: {
-			x: 120,
-			y: 0,
-		},
-	});
-
-	// Should have moved branch3 into the same stack
-	stacks = page.getByTestId("stack");
-	await expect(stacks).toHaveCount(1);
-	branchHeaders = page.getByTestId("branch-header");
+	// Move branch3 on top of branch1 (now in the middle of the merged stack).
+	await dragAndDropByLocator(
+		page,
+		branchHeaders.filter({ hasText: "branch3" }),
+		branchHeaders.filter({ hasText: "branch1" }),
+		{ force: true, position: { x: 120, y: 0 } },
+	);
+	await expect(stack(page)).toHaveCount(1);
 	await expect(branchHeaders).toHaveCount(3);
 });

--- a/e2e/playwright/tests/moveCommitToNewStack.spec.ts
+++ b/e2e/playwright/tests/moveCommitToNewStack.spec.ts
@@ -1,123 +1,68 @@
-import { getBaseURL, type GitButler, startGitButler } from "../src/setup.ts";
+import { applyUpstream, openWorkspace, type GitButler } from "../src/setup.ts";
 import { test } from "../src/test.ts";
-import { dragAndDropByLocator, waitForTestId } from "../src/util.ts";
+import { dragAndDropByLocator, MOD_KEY, stack, waitForTestId } from "../src/util.ts";
 import { expect, type Page } from "@playwright/test";
 
-let gitbutler: GitButler;
-
-test.use({
-	baseURL: getBaseURL(),
-});
-
-test.afterEach(async () => {
-	await gitbutler?.destroy();
-});
-
 /**
- * Set up a workspace with branch2 (2 commits, modifies b_file) and
- * branch3 (2 commits, modifies c_file) applied.
- * These branches are independent of each other and of master's a_file,
- * so moving commits between stacks won't cause merge conflicts.
+ * Apply branch2 (modifies b_file) and branch3 (modifies c_file) — two
+ * stacks independent of master's a_file, so moves don't conflict.
  */
-async function setupWorkspace(page: Page, context: any, testInfo: any) {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+async function applyTwoIndependentStacks(gitbutler: GitButler, page: Page) {
 	await gitbutler.runScript("project-with-stacks.sh");
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch2", "local-clone"]);
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch3", "local-clone"]);
-
-	await page.goto("/");
-	await waitForTestId(page, "workspace-view");
-
-	const stacks = page.getByTestId("stack");
-	await expect(stacks).toHaveCount(2);
+	await applyUpstream(gitbutler, "branch2", "branch3");
+	await openWorkspace(page);
+	await expect(stack(page)).toHaveCount(2);
 }
 
 test("move a commit to the new stack dropzone to create a new stack", async ({
 	page,
-	context,
-}, testInfo) => {
+	gitbutler,
+}) => {
 	test.setTimeout(120_000);
-	await setupWorkspace(page, context, testInfo);
+	await applyTwoIndependentStacks(gitbutler, page);
 
-	const stack2 = page
-		.getByTestId("stack")
-		.filter({ has: page.getByTestId("branch-header").filter({ hasText: "branch2" }) });
+	const stack2 = stack(page, "branch2");
+	await expect(stack2.getByTestId("commit-row")).toHaveCount(2);
 
-	// branch2 should have 2 commits
-	const commits = stack2.getByTestId("commit-row");
-	await expect(commits).toHaveCount(2);
-
-	// Pick a commit to drag
-	const commitToDrag = commits.filter({ hasText: "branch2: first commit" });
-	await expect(commitToDrag).toBeVisible();
-
-	// Drag the commit onto the new stack dropzone
+	const commitToDrag = stack2.getByTestId("commit-row").filter({
+		hasText: "branch2: first commit",
+	});
 	const stackDropzone = await waitForTestId(page, "stack-offlane-dropzone");
 	await dragAndDropByLocator(page, commitToDrag, stackDropzone, {
 		force: true,
-		position: {
-			x: 10,
-			y: 10,
-		},
+		position: { x: 10, y: 10 },
 	});
 
-	// Should now have three stacks (branch2, branch3, and the new one)
-	const stacks = page.getByTestId("stack");
-	await expect(stacks).toHaveCount(3, { timeout: 15_000 });
-
-	// The original stack should have 1 commit (one was moved)
+	await expect(stack(page)).toHaveCount(3, { timeout: 15_000 });
 	await expect(stack2.getByTestId("commit-row")).toHaveCount(1, { timeout: 15_000 });
-
-	// The moved commit should no longer be in the original stack
 	await expect(
 		stack2.getByTestId("commit-row").filter({ hasText: "branch2: first commit" }),
 	).toHaveCount(0);
 });
 
-test("move multiple selected commits to the new stack dropzone", async ({
-	page,
-	context,
-}, testInfo) => {
+test("move multiple selected commits to the new stack dropzone", async ({ page, gitbutler }) => {
 	test.setTimeout(120_000);
-	await setupWorkspace(page, context, testInfo);
+	await applyTwoIndependentStacks(gitbutler, page);
 
-	const stack3 = page
-		.getByTestId("stack")
-		.filter({ has: page.getByTestId("branch-header").filter({ hasText: "branch3" }) });
-
+	const stack3 = stack(page, "branch3");
 	const commits = stack3.getByTestId("commit-row");
 	await expect(commits).toHaveCount(2);
 
-	// Multi-select both commits
 	const firstCommit = commits.filter({ hasText: "branch3: first commit" });
 	const secondCommit = commits.filter({ hasText: "branch3: second commit" });
 
 	await firstCommit.click();
-	const modKey = process.platform === "darwin" ? "Meta" : "Control";
-	await secondCommit.click({ modifiers: [modKey] });
-
-	// Both should be selected
+	await secondCommit.click({ modifiers: [MOD_KEY] });
 	await expect(firstCommit).toHaveClass(/\bselected\b/);
 	await expect(secondCommit).toHaveClass(/\bselected\b/);
 
-	// Drag onto the new stack dropzone
 	const stackDropzone = await waitForTestId(page, "stack-offlane-dropzone");
 	await dragAndDropByLocator(page, firstCommit, stackDropzone, {
 		force: true,
-		position: {
-			x: 10,
-			y: 10,
-		},
+		position: { x: 10, y: 10 },
 	});
 
-	// Should now have three stacks
-	const stacks = page.getByTestId("stack");
-	await expect(stacks).toHaveCount(3, { timeout: 15_000 });
-
-	// The original branch3 stack should be empty (both commits were moved).
-	// An empty branch shows no commit rows.
+	await expect(stack(page)).toHaveCount(3, { timeout: 15_000 });
+	// Original branch3 stack should be empty (both commits moved out).
 	await expect(stack3.getByTestId("commit-row")).toHaveCount(0, { timeout: 15_000 });
 });

--- a/e2e/playwright/tests/moveMultipleCommits.spec.ts
+++ b/e2e/playwright/tests/moveMultipleCommits.spec.ts
@@ -1,92 +1,41 @@
-import { getBaseURL, type GitButler, startGitButler } from "../src/setup.ts";
+import { applyUpstream, openWorkspace } from "../src/setup.ts";
 import { test } from "../src/test.ts";
-import { dragAndDropByLocator, waitForTestId } from "../src/util.ts";
-import { expect, type Page } from "@playwright/test";
-
-let gitbutler: GitButler;
-
-test.use({
-	baseURL: getBaseURL(),
-});
-
-test.afterEach(async () => {
-	await gitbutler?.destroy();
-});
-
-/**
- * Set up a workspace with branch1 (4 commits) and branch2 (2 commits) applied.
- * branch1 modifies a_file, branch2 modifies b_file — they are independent.
- */
-async function setupWorkspaceWithTwoBranches(page: Page, context: any, testInfo: any) {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
-	await gitbutler.runScript("project-with-stacks.sh");
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch2", "local-clone"]);
-
-	await page.goto("/");
-	await waitForTestId(page, "workspace-view");
-
-	// Verify we have two stacks
-	const stacks = page.getByTestId("stack");
-	await expect(stacks).toHaveCount(2);
-}
-
-/**
- * Get the modifier key for multi-select (Meta on macOS, Control elsewhere).
- */
-function getModifierKey(): "Meta" | "Control" {
-	return process.platform === "darwin" ? "Meta" : "Control";
-}
+import { dragAndDropByLocator, MOD_KEY, stack } from "../src/util.ts";
+import { expect } from "@playwright/test";
 
 test("should move multiple selected commits to a different branch via drag and drop", async ({
 	page,
-	context,
-}, testInfo) => {
+	gitbutler,
+}) => {
 	test.setTimeout(120_000);
-	await setupWorkspaceWithTwoBranches(page, context, testInfo);
 
-	// Identify the two stacks by their branch header (not hasText, since commit
-	// messages contain "branch2" and would match both stacks after the move).
-	const stack1 = page
-		.getByTestId("stack")
-		.filter({ has: page.getByTestId("branch-header").filter({ hasText: "branch1" }) });
-	const stack2 = page
-		.getByTestId("stack")
-		.filter({ has: page.getByTestId("branch-header").filter({ hasText: "branch2" }) });
-	await expect(stack1).toBeVisible();
-	await expect(stack2).toBeVisible();
+	// branch1 (4 commits, modifies a_file) and branch2 (2 commits, modifies b_file) — independent.
+	await gitbutler.runScript("project-with-stacks.sh");
+	await applyUpstream(gitbutler, "branch1", "branch2");
+	await openWorkspace(page);
 
-	// branch1 should have 4 commits, branch2 should have 2
-	const branch1Commits = stack1.getByTestId("commit-row");
-	await expect(branch1Commits).toHaveCount(4);
-	const branch2Commits = stack2.getByTestId("commit-row");
-	await expect(branch2Commits).toHaveCount(2);
+	const stack1 = stack(page, "branch1");
+	const stack2 = stack(page, "branch2");
+	await expect(stack1.getByTestId("commit-row")).toHaveCount(4);
+	await expect(stack2.getByTestId("commit-row")).toHaveCount(2);
 
-	// Move branch2 commits to branch1 (branch2 modifies b_file, so no conflict).
-	// Select both branch2 commits.
-	const b2Second = branch2Commits.filter({ hasText: "branch2: second commit" });
-	const b2First = branch2Commits.filter({ hasText: "branch2: first commit" });
+	const b2Second = stack2.getByTestId("commit-row").filter({ hasText: "branch2: second commit" });
+	const b2First = stack2.getByTestId("commit-row").filter({ hasText: "branch2: first commit" });
 
 	await b2Second.click();
-	const modKey = getModifierKey();
-	await b2First.click({ modifiers: [modKey] });
-
-	// Both should be selected
+	await b2First.click({ modifiers: [MOD_KEY] });
 	await expect(b2Second).toHaveClass(/\bselected\b/);
 	await expect(b2First).toHaveClass(/\bselected\b/);
 
-	// Drag the selected commits onto branch1's branch header
+	// Drag the selected commits onto branch1's header.
 	const branch1Header = stack1.getByTestId("branch-header").first();
 	await dragAndDropByLocator(page, b2Second, branch1Header, { force: true });
 
-	// After the move, branch1 should have 6 commits (original 4 + moved 2)
 	await expect(stack1.getByTestId("commit-row")).toHaveCount(6, { timeout: 15_000 });
-
-	// Verify the moved commits appear in branch1
-	const branch1CommitsAfter = stack1.getByTestId("commit-row");
-	await expect(branch1CommitsAfter.filter({ hasText: "branch2: first commit" })).toHaveCount(1);
-	await expect(branch1CommitsAfter.filter({ hasText: "branch2: second commit" })).toHaveCount(1);
+	await expect(
+		stack1.getByTestId("commit-row").filter({ hasText: "branch2: first commit" }),
+	).toHaveCount(1);
+	await expect(
+		stack1.getByTestId("commit-row").filter({ hasText: "branch2: second commit" }),
+	).toHaveCount(1);
 });

--- a/e2e/playwright/tests/multiCommitSelection.spec.ts
+++ b/e2e/playwright/tests/multiCommitSelection.spec.ts
@@ -1,309 +1,167 @@
-import { getBaseURL, type GitButler, startGitButler } from "../src/setup.ts";
+import { applyUpstream, openWorkspace, type GitButler } from "../src/setup.ts";
 import { test } from "../src/test.ts";
-import { getByTestId, waitForElementToStabilize, waitForTestId } from "../src/util.ts";
+import {
+	commitRow,
+	getByTestId,
+	MOD_KEY,
+	waitForElementToStabilize,
+	waitForTestId,
+} from "../src/util.ts";
 import { expect, type Page } from "@playwright/test";
 
-let gitbutler: GitButler;
-
-test.use({
-	baseURL: getBaseURL(),
-});
-
-test.afterEach(async () => {
-	await gitbutler?.destroy();
-});
-
 /**
- * Set up a workspace with branch1 applied (4 commits from project-with-stacks).
+ * Apply branch1 (4 commits) and open the workspace.
  */
-async function setupWorkspaceWithCommits(page: Page, context: any, testInfo: any) {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+async function applyBranch1(gitbutler: GitButler, page: Page) {
 	await gitbutler.runScript("project-with-stacks.sh");
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
-
-	await page.goto("/");
-	await waitForTestId(page, "workspace-view");
-
-	// Verify we have our expected commits
-	const commits = getByTestId(page, "commit-row");
-	await expect(commits).toHaveCount(4);
+	await applyUpstream(gitbutler, "branch1");
+	await openWorkspace(page);
+	await expect(commitRow(page)).toHaveCount(4);
 }
 
-/**
- * Get the modifier key for multi-select (Meta on macOS, Control elsewhere).
- */
-function getModifierKey(): "Meta" | "Control" {
-	return process.platform === "darwin" ? "Meta" : "Control";
-}
+test("should select multiple commits with Cmd/Ctrl+Click", async ({ page, gitbutler }) => {
+	await applyBranch1(gitbutler, page);
 
-test("should select multiple commits with Cmd/Ctrl+Click", async ({ page, context }, testInfo) => {
-	await setupWorkspaceWithCommits(page, context, testInfo);
+	const first = commitRow(page, "branch1: first commit");
+	const second = commitRow(page, "branch1: second commit");
+	const third = commitRow(page, "branch1: third commit");
 
-	const firstCommit = getByTestId(page, "commit-row").filter({
-		hasText: "branch1: first commit",
-	});
-	const thirdCommit = getByTestId(page, "commit-row").filter({
-		hasText: "branch1: third commit",
-	});
+	await first.click();
+	await expect(getByTestId(page, "commit-drawer")).toBeVisible();
 
-	// Click the first commit to select it
-	await firstCommit.click();
+	await third.click({ modifiers: [MOD_KEY] });
 
-	// Verify the commit drawer opens for the first commit
-	const drawer = getByTestId(page, "commit-drawer");
-	await expect(drawer).toBeVisible();
-
-	// Cmd/Ctrl+Click the third commit to add it to selection
-	const modKey = getModifierKey();
-	await thirdCommit.click({ modifiers: [modKey] });
-
-	// Both commits should have the selected visual state
-	await expect(firstCommit).toHaveClass(/\bselected\b/);
-	await expect(thirdCommit).toHaveClass(/\bselected\b/);
-
-	// The second commit should NOT be selected
-	const secondCommit = getByTestId(page, "commit-row").filter({
-		hasText: "branch1: second commit",
-	});
-	await expect(secondCommit).not.toHaveClass(/\bselected\b/);
+	await expect(first).toHaveClass(/\bselected\b/);
+	await expect(third).toHaveClass(/\bselected\b/);
+	await expect(second).not.toHaveClass(/\bselected\b/);
 });
 
-test("should select a range of commits with Shift+Click", async ({ page, context }, testInfo) => {
-	await setupWorkspaceWithCommits(page, context, testInfo);
+test("should select a range of commits with Shift+Click", async ({ page, gitbutler }) => {
+	await applyBranch1(gitbutler, page);
 
-	const firstCommit = getByTestId(page, "commit-row").filter({
-		hasText: "branch1: first commit",
-	});
-	const fourthCommit = getByTestId(page, "commit-row").filter({
-		hasText: "branch1: fourth commit",
-	});
+	await commitRow(page, "branch1: fourth commit").click();
+	await commitRow(page, "branch1: first commit").click({ modifiers: ["Shift"] });
 
-	// Click the fourth commit (top of list) to select it
-	await fourthCommit.click();
-
-	// Shift+Click the first commit to select the range
-	await firstCommit.click({ modifiers: ["Shift"] });
-
-	// All four commits should be selected
-	const allCommits = getByTestId(page, "commit-row");
+	const allCommits = commitRow(page);
 	const count = await allCommits.count();
 	for (let i = 0; i < count; i++) {
 		await expect(allCommits.nth(i)).toHaveClass(/\bselected\b/);
 	}
 });
 
-test("should toggle individual commits with Cmd/Ctrl+Click", async ({
-	page,
-	context,
-}, testInfo) => {
-	await setupWorkspaceWithCommits(page, context, testInfo);
+test("should toggle individual commits with Cmd/Ctrl+Click", async ({ page, gitbutler }) => {
+	await applyBranch1(gitbutler, page);
 
-	const firstCommit = getByTestId(page, "commit-row").filter({
-		hasText: "branch1: first commit",
-	});
-	const secondCommit = getByTestId(page, "commit-row").filter({
-		hasText: "branch1: second commit",
-	});
+	const first = commitRow(page, "branch1: first commit");
+	const second = commitRow(page, "branch1: second commit");
 
-	const modKey = getModifierKey();
+	await first.click();
+	await expect(first).toHaveClass(/\bselected\b/);
 
-	// Click to select first commit
-	await firstCommit.click();
-	await expect(firstCommit).toHaveClass(/\bselected\b/);
+	await second.click({ modifiers: [MOD_KEY] });
+	await expect(first).toHaveClass(/\bselected\b/);
+	await expect(second).toHaveClass(/\bselected\b/);
 
-	// Cmd/Ctrl+Click to add second commit
-	await secondCommit.click({ modifiers: [modKey] });
-	await expect(firstCommit).toHaveClass(/\bselected\b/);
-	await expect(secondCommit).toHaveClass(/\bselected\b/);
-
-	// Cmd/Ctrl+Click first commit again to deselect it
-	await firstCommit.click({ modifiers: [modKey] });
-	await expect(firstCommit).not.toHaveClass(/\bselected\b/);
-	await expect(secondCommit).toHaveClass(/\bselected\b/);
+	// Toggle first off
+	await first.click({ modifiers: [MOD_KEY] });
+	await expect(first).not.toHaveClass(/\bselected\b/);
+	await expect(second).toHaveClass(/\bselected\b/);
 });
 
 test("should show multi-select context menu with squash and uncommit", async ({
 	page,
-	context,
-}, testInfo) => {
-	await setupWorkspaceWithCommits(page, context, testInfo);
+	gitbutler,
+}) => {
+	await applyBranch1(gitbutler, page);
 
-	const firstCommit = getByTestId(page, "commit-row").filter({
-		hasText: "branch1: first commit",
-	});
-	const secondCommit = getByTestId(page, "commit-row").filter({
-		hasText: "branch1: second commit",
-	});
+	const first = commitRow(page, "branch1: first commit");
+	const second = commitRow(page, "branch1: second commit");
 
-	const modKey = getModifierKey();
+	await first.click();
+	await second.click({ modifiers: [MOD_KEY] });
+	await first.click({ button: "right" });
 
-	// Select two commits
-	await firstCommit.click();
-	await secondCommit.click({ modifiers: [modKey] });
-
-	// Right-click a selected commit row to open the multi-select context menu
-	await firstCommit.click({ button: "right" });
-
-	// Wait for context menu to stabilize
 	const squashItem = await waitForTestId(page, "commit-row-context-menu-squash-selected");
 	await waitForElementToStabilize(page, squashItem);
-
-	// Verify multi-select menu items are visible
-	await expect(squashItem).toBeVisible();
 	await expect(squashItem).toContainText("Squash 2 commits");
 
 	const uncommitItem = getByTestId(page, "commit-row-context-menu-uncommit-selected");
-	await expect(uncommitItem).toBeVisible();
 	await expect(uncommitItem).toContainText("Uncommit 2 commits");
 
 	// Single-commit items should NOT be visible
-	const editMessageBtn = page.getByTestId("commit-row-context-menu-edit-message-menu-btn");
-	await expect(editMessageBtn).toHaveCount(0);
-
-	const editCommitBtn = page.getByTestId("commit-row-context-menu-edit-commit");
-	await expect(editCommitBtn).toHaveCount(0);
+	await expect(page.getByTestId("commit-row-context-menu-edit-message-menu-btn")).toHaveCount(0);
+	await expect(page.getByTestId("commit-row-context-menu-edit-commit")).toHaveCount(0);
 });
 
 test("should collapse changed files when multiple commits are selected", async ({
 	page,
-	context,
-}, testInfo) => {
-	await setupWorkspaceWithCommits(page, context, testInfo);
+	gitbutler,
+}) => {
+	await applyBranch1(gitbutler, page);
 
-	const firstCommit = getByTestId(page, "commit-row").filter({
-		hasText: "branch1: first commit",
-	});
-	const secondCommit = getByTestId(page, "commit-row").filter({
-		hasText: "branch1: second commit",
-	});
-
-	// Click first commit — changed files should be visible
-	await firstCommit.click();
-
-	// Verify changed files are shown for the selected commit
+	await commitRow(page, "branch1: first commit").click();
 	const changedFilesContainer = page.locator(".changed-files-container");
 	await expect(changedFilesContainer).toBeVisible();
 
-	// Now Cmd/Ctrl+Click to add second commit
-	const modKey = getModifierKey();
-	await secondCommit.click({ modifiers: [modKey] });
-
-	// Changed files container should no longer be visible
+	await commitRow(page, "branch1: second commit").click({ modifiers: [MOD_KEY] });
 	await expect(changedFilesContainer).not.toBeVisible();
 });
 
-test("should squash 3 selected commits via context menu", async ({ page, context }, testInfo) => {
+test("should squash 3 selected commits via context menu", async ({ page, gitbutler }) => {
 	test.setTimeout(120_000);
-	await setupWorkspaceWithCommits(page, context, testInfo);
+	await applyBranch1(gitbutler, page);
 
-	const secondCommit = getByTestId(page, "commit-row").filter({
-		hasText: "branch1: second commit",
-	});
-	const thirdCommit = getByTestId(page, "commit-row").filter({
-		hasText: "branch1: third commit",
-	});
-	const fourthCommit = getByTestId(page, "commit-row").filter({
-		hasText: "branch1: fourth commit",
-	});
+	const second = commitRow(page, "branch1: second commit");
+	await second.click();
+	await commitRow(page, "branch1: third commit").click({ modifiers: [MOD_KEY] });
+	await commitRow(page, "branch1: fourth commit").click({ modifiers: [MOD_KEY] });
 
-	const modKey = getModifierKey();
-
-	// Select three commits
-	await secondCommit.click();
-	await thirdCommit.click({ modifiers: [modKey] });
-	await fourthCommit.click({ modifiers: [modKey] });
-
-	// Right-click a selected commit row to open the multi-select context menu
-	await secondCommit.click({ button: "right" });
+	await second.click({ button: "right" });
 
 	const squashItem = await waitForTestId(page, "commit-row-context-menu-squash-selected");
 	await waitForElementToStabilize(page, squashItem);
 	await expect(squashItem).toContainText("Squash 3 commits");
 	await squashItem.click();
 
-	// After squashing, the branch should show an upstream divergence section
-	// because local history changed. The "Upstream has new commits" indicator confirms
-	// the squash was successful.
-	const upstreamSection = page.locator("text=Upstream has new commits");
-	await expect(upstreamSection).toBeVisible();
-
-	// The first commit should still be present (it was not part of the squash)
-	const remainingFirst = getByTestId(page, "commit-row").filter({
-		hasText: "branch1: first commit",
-	});
-	await expect(remainingFirst).toBeVisible();
+	// Local history changed → upstream divergence indicator appears.
+	await expect(page.locator("text=Upstream has new commits")).toBeVisible();
+	await expect(commitRow(page, "branch1: first commit")).toBeVisible();
 });
 
-test("should uncommit 3 selected commits via context menu", async ({ page, context }, testInfo) => {
+test("should uncommit 3 selected commits via context menu", async ({ page, gitbutler }) => {
 	test.setTimeout(120_000);
-	await setupWorkspaceWithCommits(page, context, testInfo);
+	await applyBranch1(gitbutler, page);
 
-	const secondCommit = getByTestId(page, "commit-row").filter({
-		hasText: "branch1: second commit",
-	});
-	const thirdCommit = getByTestId(page, "commit-row").filter({
-		hasText: "branch1: third commit",
-	});
-	const fourthCommit = getByTestId(page, "commit-row").filter({
-		hasText: "branch1: fourth commit",
-	});
+	const fourth = commitRow(page, "branch1: fourth commit");
+	await fourth.click();
+	await commitRow(page, "branch1: third commit").click({ modifiers: [MOD_KEY] });
+	await commitRow(page, "branch1: second commit").click({ modifiers: [MOD_KEY] });
 
-	const modKey = getModifierKey();
-
-	// Select the top three commits
-	await fourthCommit.click();
-	await thirdCommit.click({ modifiers: [modKey] });
-	await secondCommit.click({ modifiers: [modKey] });
-
-	// Right-click a selected commit row to open the multi-select context menu
-	await fourthCommit.click({ button: "right" });
+	await fourth.click({ button: "right" });
 
 	const uncommitItem = await waitForTestId(page, "commit-row-context-menu-uncommit-selected");
 	await waitForElementToStabilize(page, uncommitItem);
 	await expect(uncommitItem).toContainText("Uncommit 3 commits");
 	await uncommitItem.click();
 
-	// After uncommitting, the uncommitted changes should contain the files
-	const uncommittedHeader = getByTestId(page, "uncommitted-changes-header");
-	await expect(uncommittedHeader).toBeVisible();
-
-	// The first commit should still exist (it was not selected)
-	const remainingFirst = getByTestId(page, "commit-row").filter({
-		hasText: "branch1: first commit",
-	});
-	await expect(remainingFirst).toBeVisible();
+	await expect(getByTestId(page, "uncommitted-changes-header")).toBeVisible();
+	await expect(commitRow(page, "branch1: first commit")).toBeVisible();
 });
 
-test("should deselect all when clicking a commit without modifier", async ({
-	page,
-	context,
-}, testInfo) => {
-	await setupWorkspaceWithCommits(page, context, testInfo);
+test("should deselect all when clicking a commit without modifier", async ({ page, gitbutler }) => {
+	await applyBranch1(gitbutler, page);
 
-	const firstCommit = getByTestId(page, "commit-row").filter({
-		hasText: "branch1: first commit",
-	});
-	const secondCommit = getByTestId(page, "commit-row").filter({
-		hasText: "branch1: second commit",
-	});
-	const thirdCommit = getByTestId(page, "commit-row").filter({
-		hasText: "branch1: third commit",
-	});
+	const first = commitRow(page, "branch1: first commit");
+	const second = commitRow(page, "branch1: second commit");
+	const third = commitRow(page, "branch1: third commit");
 
-	const modKey = getModifierKey();
+	await first.click();
+	await second.click({ modifiers: [MOD_KEY] });
+	await expect(first).toHaveClass(/\bselected\b/);
+	await expect(second).toHaveClass(/\bselected\b/);
 
-	// Select multiple commits
-	await firstCommit.click();
-	await secondCommit.click({ modifiers: [modKey] });
-	await expect(firstCommit).toHaveClass(/\bselected\b/);
-	await expect(secondCommit).toHaveClass(/\bselected\b/);
-
-	// Plain click on third commit should deselect everything and select only third
-	await thirdCommit.click();
-	await expect(thirdCommit).toHaveClass(/\bselected\b/);
-	await expect(firstCommit).not.toHaveClass(/\bselected\b/);
-	await expect(secondCommit).not.toHaveClass(/\bselected\b/);
+	await third.click();
+	await expect(third).toHaveClass(/\bselected\b/);
+	await expect(first).not.toHaveClass(/\bselected\b/);
+	await expect(second).not.toHaveClass(/\bselected\b/);
 });

--- a/e2e/playwright/tests/projectOffboarding.spec.ts
+++ b/e2e/playwright/tests/projectOffboarding.spec.ts
@@ -1,84 +1,31 @@
-import { getBaseURL, type GitButler, startGitButler } from "../src/setup.ts";
+import { openWorkspace } from "../src/setup.ts";
 import { test } from "../src/test.ts";
 import { clickByTestId, waitForTestId, waitForTestIdToNotExist } from "../src/util.ts";
 
-let gitbutler: GitButler;
-
-test.use({
-	baseURL: getBaseURL(),
-});
-
-test.afterEach(async () => {
-	await gitbutler?.destroy();
-});
-
-test("should be able to delete the last project gracefully", async ({
-	page,
-	context,
-}, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context, undefined, {
-		onboardingComplete: true,
-	});
-
-	await gitbutler.runScript("project-with-remote-branches.sh");
-
-	await page.goto("/");
-
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// Open project settings
+async function openProjectSettingsAndDelete(page: import("@playwright/test").Page) {
 	await clickByTestId(page, "chrome-sidebar-project-settings-button");
-
 	await waitForTestId(page, "project-settings-modal");
 
-	const deleteProjectButton = await waitForTestId(page, "project-delete-button");
-	await deleteProjectButton.scrollIntoViewIfNeeded();
-	await deleteProjectButton.click();
-
+	const deleteButton = await waitForTestId(page, "project-delete-button");
+	await deleteButton.scrollIntoViewIfNeeded();
+	await deleteButton.click();
 	await clickByTestId(page, "project-delete-modal-confirm");
 
 	await waitForTestIdToNotExist(page, "project-delete-modal-confirm");
 	await waitForTestIdToNotExist(page, "project-delete-button");
 	await waitForTestIdToNotExist(page, "project-settings-modal");
+}
 
+test("should be able to delete the last project gracefully", async ({ page, gitbutler }) => {
+	await gitbutler.runScript("project-with-remote-branches.sh");
+	await openWorkspace(page);
+	await openProjectSettingsAndDelete(page);
 	await waitForTestId(page, "welcome-page");
 });
 
-test("should be able to delete a project when multiple exist", async ({
-	page,
-	context,
-}, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context, undefined, {
-		onboardingComplete: true,
-	});
-
+test("should be able to delete a project when multiple exist", async ({ page, gitbutler }) => {
 	await gitbutler.runScript("two-projects-with-remote-branches.sh");
-
-	await page.goto("/");
-
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// Open project settings
-	await clickByTestId(page, "chrome-sidebar-project-settings-button");
-
-	await waitForTestId(page, "project-settings-modal");
-
-	const deleteProjectButton = await waitForTestId(page, "project-delete-button");
-	await deleteProjectButton.scrollIntoViewIfNeeded();
-	await deleteProjectButton.click();
-
-	await clickByTestId(page, "project-delete-modal-confirm");
-
-	await waitForTestIdToNotExist(page, "project-delete-modal-confirm");
-	await waitForTestIdToNotExist(page, "project-delete-button");
-	await waitForTestIdToNotExist(page, "project-settings-modal");
-
-	// Should still be in the workspace
+	await openWorkspace(page);
+	await openProjectSettingsAndDelete(page);
 	await waitForTestId(page, "workspace-view");
 });

--- a/e2e/playwright/tests/startTheApp.spec.ts
+++ b/e2e/playwright/tests/startTheApp.spec.ts
@@ -1,85 +1,60 @@
 import { GIT_CONFIG_GLOBAL } from "../src/env.ts";
 import { writeToFile } from "../src/file.ts";
-import { getBaseURL, type GitButler, startGitButler } from "../src/setup.ts";
+import { gotoOnboarding, startGitButler } from "../src/setup.ts";
 import { test } from "../src/test.ts";
 import {
 	clickByTestId,
+	commitRow,
 	fillByTestId,
 	getByTestId,
 	mockPickDirectory,
 	textEditorFillByTestId,
 	waitForTestId,
 } from "../src/util.ts";
-import { expect } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 
-let gitbutler: GitButler;
+async function addProjectAndOpenWorkspace(page: Page, projectPath: string) {
+	await gotoOnboarding(page);
 
-test.use({
-	baseURL: getBaseURL(),
-});
-
-test.afterEach(async () => {
-	await gitbutler?.destroy();
-});
-
-test("should start the application and be able to commit", async ({ page, context }, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
-	const projectPath = gitbutler.pathInWorkdir("local-clone/");
-
-	await gitbutler.runScript("setup-empty-project.sh");
-
-	await page.goto("/");
-	const onboardingPage = getByTestId(page, "onboarding-page");
-	await onboardingPage.waitFor();
-
-	clickByTestId(page, "analytics-continue");
-
-	// Add a local project
 	await mockPickDirectory(page, projectPath);
 	await clickByTestId(page, "add-local-project");
 
-	// Should see the set target page
 	await waitForTestId(page, "project-setup-page");
-
 	clickByTestId(page, "set-base-branch");
-
-	// Should load the workspace directly after setting base branch
 	await waitForTestId(page, "workspace-view");
+}
 
-	// Let's write some files
-	const filePath = gitbutler.pathInWorkdir("local-clone/test-file.txt");
+async function writeCommitAndAssert(page: Page, filePath: string) {
 	writeToFile(filePath, "This is supper important content");
 
-	// Should see the uncommitted changes list
-	await waitForTestId(page, "uncommitted-changes-file-list");
 	const files = getByTestId(page, "file-list-item");
-
 	await expect(files).toHaveCount(1);
 	await expect(files.first()).toHaveText("test-file.txt");
 
-	// Click the commit button
 	await clickByTestId(page, "commit-to-new-branch-button");
-
-	// Should see the commit drawer
 	await waitForTestId(page, "new-commit-view");
 
-	const newCommitMessage = "New commit message";
-	const newCommitMessageBody = "This is the body of the commit message.";
-	// Write a commit message
-	await fillByTestId(page, "commit-drawer-title-input", newCommitMessage);
-	await textEditorFillByTestId(page, "commit-drawer-description-input", newCommitMessageBody);
-
-	// Click the commit button
+	const title = "New commit message";
+	const body = "This is the body of the commit message.";
+	await fillByTestId(page, "commit-drawer-title-input", title);
+	await textEditorFillByTestId(page, "commit-drawer-description-input", body);
 	await clickByTestId(page, "commit-drawer-action-button");
 
-	const commitRows = getByTestId(page, "commit-row");
-	await expect(commitRows).toHaveCount(1);
-	await expect(commitRows.first()).toHaveText(newCommitMessage);
+	const rows = commitRow(page);
+	await expect(rows).toHaveCount(1);
+	await expect(rows.first()).toHaveText(title);
+}
+
+test("should start the application and be able to commit", async ({ page, gitbutler }) => {
+	await gitbutler.runScript("setup-empty-project.sh");
+
+	const projectPath = gitbutler.pathInWorkdir("local-clone/");
+	await addProjectAndOpenWorkspace(page, projectPath);
+	await writeCommitAndAssert(page, gitbutler.pathInWorkdir("local-clone/test-file.txt"));
 });
 
+// This test needs a per-test git config path derived from testInfo, so it
+// bypasses the gitbutler fixture and manages the lifecycle directly.
 test("no author setup - should start the application and be able to commit", async ({
 	page,
 	context,
@@ -88,72 +63,33 @@ test("no author setup - should start the application and be able to commit", asy
 	const configdir = testInfo.outputPath("config");
 	const otherGitConfig = testInfo.outputPath("config/gitconfig");
 
-	gitbutler = await startGitButler(workdir, configdir, context, {
-		GIT_CONFIG_GLOBAL: otherGitConfig,
-	});
+	const gitbutler = await startGitButler(
+		workdir,
+		configdir,
+		context,
+		{
+			GIT_CONFIG_GLOBAL: otherGitConfig,
+		},
+		{ onboardingComplete: true },
+	);
 
-	const projectPath = gitbutler.pathInWorkdir("local-clone/");
+	try {
+		// Setup uses the normal git config so the repo has an author —
+		// only the running server lacks one.
+		await gitbutler.runScript("setup-empty-project.sh", undefined, {
+			GIT_CONFIG_GLOBAL,
+		});
 
-	await gitbutler.runScript("setup-empty-project.sh", undefined, {
-		// Use the right config to create the setup
-		GIT_CONFIG_GLOBAL,
-	});
+		await addProjectAndOpenWorkspace(page, gitbutler.pathInWorkdir("local-clone/"));
 
-	await page.goto("/");
-	const onboardingPage = getByTestId(page, "onboarding-page");
-	await onboardingPage.waitFor();
+		await waitForTestId(page, "global-modal-author-missing");
+		await fillByTestId(page, "global-modal-author-missing-name-input", "Test User");
+		await fillByTestId(page, "global-modal-author-missing-email-input", "test@example.com");
+		await clickByTestId(page, "global-modal-author-missing-action-button");
+		await expect(getByTestId(page, "global-modal-author-missing")).toBeHidden();
 
-	clickByTestId(page, "analytics-continue");
-
-	// Add a local project
-	await mockPickDirectory(page, projectPath);
-	await clickByTestId(page, "add-local-project");
-
-	// Should see the set target page
-	await waitForTestId(page, "project-setup-page");
-
-	clickByTestId(page, "set-base-branch");
-
-	// Should load the workspace directly after setting base branch
-	await waitForTestId(page, "workspace-view");
-
-	// Should see the author missing modal
-	await waitForTestId(page, "global-modal-author-missing");
-
-	await fillByTestId(page, "global-modal-author-missing-name-input", "Test User");
-	await fillByTestId(page, "global-modal-author-missing-email-input", "test@example.com");
-	await clickByTestId(page, "global-modal-author-missing-action-button");
-
-	// Wait for the author-missing modal to close before interacting with the page
-	await expect(getByTestId(page, "global-modal-author-missing")).toBeHidden();
-
-	// Let's write some files
-	const filePath = gitbutler.pathInWorkdir("local-clone/test-file.txt");
-	writeToFile(filePath, "This is supper important content");
-
-	// Should see the uncommitted changes list
-	await waitForTestId(page, "uncommitted-changes-file-list");
-	const files = getByTestId(page, "file-list-item");
-
-	await expect(files).toHaveCount(1);
-	await expect(files.first()).toHaveText("test-file.txt");
-
-	// Click the commit button
-	await clickByTestId(page, "commit-to-new-branch-button");
-
-	// Should see the commit drawer
-	await waitForTestId(page, "new-commit-view");
-
-	const newCommitMessage = "New commit message";
-	const newCommitMessageBody = "This is the body of the commit message.";
-	// Write a commit message
-	await fillByTestId(page, "commit-drawer-title-input", newCommitMessage);
-	await textEditorFillByTestId(page, "commit-drawer-description-input", newCommitMessageBody);
-
-	// Click the commit button
-	await clickByTestId(page, "commit-drawer-action-button");
-
-	const commitRows = getByTestId(page, "commit-row");
-	await expect(commitRows).toHaveCount(1);
-	await expect(commitRows.first()).toHaveText(newCommitMessage);
+		await writeCommitAndAssert(page, gitbutler.pathInWorkdir("local-clone/test-file.txt"));
+	} finally {
+		await gitbutler.destroy();
+	}
 });

--- a/e2e/playwright/tests/unifiedDiffView.spec.ts
+++ b/e2e/playwright/tests/unifiedDiffView.spec.ts
@@ -1,27 +1,18 @@
 import { discardFile } from "../src/file.ts";
 import { getHunkHeaderSelector, getHunkLineSelector } from "../src/hunk.ts";
-import { getBaseURL, startGitButler, type GitButler } from "../src/setup.ts";
+import { openWorkspace, type GitButler } from "../src/setup.ts";
 import { test } from "../src/test.ts";
 import {
 	clickByTestId,
+	commitRow,
 	fillByTestId,
 	getByTestId,
 	waitForTestId,
 	waitForTestIdToNotExist,
 } from "../src/util.ts";
-import { expect, type Locator } from "@playwright/test";
+import { expect, type Locator, type Page } from "@playwright/test";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import { join, resolve } from "path";
-
-let gitbutler: GitButler;
-
-test.use({
-	baseURL: getBaseURL(),
-});
-
-test.afterEach(async () => {
-	await gitbutler?.destroy();
-});
 
 const BIG_FILE_PATH_BEFORE = resolve(import.meta.dirname, "../fixtures/big-file_before.md");
 const BIG_FILE_PATH_AFTER = resolve(import.meta.dirname, "../fixtures/big-file_after.md");
@@ -30,196 +21,141 @@ const BIG_FILE_PATH_AFTER_SMALL_CHANGES = resolve(
 	"../fixtures/big-file_after-small-changes.md",
 );
 
-test("should be able to select the hunks correctly in a complex file", async ({
-	page,
-	context,
-}, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
-	const projectName = "my-new-project";
-	const fileName = "big-file.md";
-
-	const projectPath = gitbutler.pathInWorkdir(projectName + "/");
-	const bigFilePath = join(projectPath, fileName);
-	const contentBefore = readFileSync(BIG_FILE_PATH_BEFORE, "utf-8");
-	const contentAfter = readFileSync(BIG_FILE_PATH_AFTER, "utf-8");
-
+/**
+ * Seed a remote-base commit with the given file content, clone it into a fresh
+ * local project, and delete the original local-clone so the test sees only the
+ * new project. Returns the local path of the seeded file.
+ */
+async function seedRemoteFileAndCloneFresh(
+	gitbutler: GitButler,
+	projectName: string,
+	fileName: string,
+	contentBefore: string,
+	commitMessage: string,
+): Promise<string> {
 	await gitbutler.runScript("project-with-remote-branches.sh");
-	// Add the big file on the remote base
 	await gitbutler.runScript("project-with-remote-branches__commit-file-into-remote-base.sh", [
-		"Create big file with complex changes",
+		commitMessage,
 		fileName,
 		contentBefore,
 	]);
-	// Clone into a new project
 	await gitbutler.runScript("project-with-remote-branches__clone-into-new-project.sh", [
 		projectName,
 	]);
-	// Delete the other project to avoid having to switch between them
 	await gitbutler.runScript("project-with-remote-branches__delete-project.sh", ["local-clone"]);
+	return join(gitbutler.pathInWorkdir(projectName + "/"), fileName);
+}
 
-	await page.goto("/");
-
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// Make the changes to the big file in the local project
-	writeFileSync(bigFilePath, contentAfter, "utf-8");
-
-	// Start the commit process
-	await clickByTestId(page, "commit-to-new-branch-button");
-
-	// The file should appear on the uncommitted changes area
-	const uncommittedChangesList = getByTestId(page, "uncommitted-changes-file-list");
-	let fileItem = uncommittedChangesList.getByTestId("file-list-item").filter({ hasText: fileName });
+async function startCommitWith(page: Page, fileName: string, title: string) {
+	await clickByTestId(page, "start-commit-button");
+	const fileItem = getByTestId(page, "uncommitted-changes-file-list")
+		.getByTestId("file-list-item")
+		.filter({ hasText: fileName });
 	await expect(fileItem).toBeVisible();
 	await fileItem.click();
+	await expect(getByTestId(page, "unified-diff-view")).toBeVisible();
+	await fillByTestId(page, "commit-drawer-title-input", title);
+}
 
-	// The unified diff view should be visible
+test("should be able to select the hunks correctly in a complex file", async ({
+	page,
+	gitbutler,
+}) => {
+	const fileName = "big-file.md";
+	const bigFilePath = await seedRemoteFileAndCloneFresh(
+		gitbutler,
+		"my-new-project",
+		fileName,
+		readFileSync(BIG_FILE_PATH_BEFORE, "utf-8"),
+		"Create big file with complex changes",
+	);
+
+	await openWorkspace(page);
+
+	writeFileSync(bigFilePath, readFileSync(BIG_FILE_PATH_AFTER, "utf-8"), "utf-8");
+
+	await clickByTestId(page, "commit-to-new-branch-button");
+
+	const uncommittedFile = getByTestId(page, "uncommitted-changes-file-list")
+		.getByTestId("file-list-item")
+		.filter({ hasText: fileName });
+	await uncommittedFile.click();
+
 	const unifiedDiffView = getByTestId(page, "unified-diff-view");
 	await expect(unifiedDiffView).toBeVisible();
 
-	let leftLines = [1, 5, 9, 11, 13, 19, 23];
-	let rightLines = [1, 5, 9, 11, 13, 19, 23];
-
-	// Unselect a couple of lines
-	await unselectHunkLines(fileName, unifiedDiffView, leftLines, rightLines);
-
-	// Commit the changes
+	// Part 1 — partial commit with some lines unselected
+	await unselectHunkLines(fileName, unifiedDiffView, [1, 5, 9, 11, 13, 19, 23]);
 	await fillByTestId(page, "commit-drawer-title-input", "Partial commit: Part 1");
 	await clickByTestId(page, "commit-drawer-action-button");
-
-	// Wait for the commit view to close before proceeding
 	await waitForTestIdToNotExist(page, "new-commit-view");
 
-	// Start the commit process
-	await clickByTestId(page, "start-commit-button");
-
-	fileItem = uncommittedChangesList.getByTestId("file-list-item").filter({ hasText: fileName });
-	await expect(fileItem).toBeVisible();
-	await fileItem.click();
-
-	leftLines = [1, 5, 9, 11];
-	rightLines = [1, 5, 9, 11];
-
-	// Unselect a couple of lines
-	await unselectHunkLines(fileName, unifiedDiffView, leftLines, rightLines);
-
-	// Commit the changes
-	await fillByTestId(page, "commit-drawer-title-input", "Partial commit: Part 2");
+	// Part 2 — another partial commit
+	await startCommitWith(page, fileName, "Partial commit: Part 2");
+	await unselectHunkLines(fileName, unifiedDiffView, [1, 5, 9, 11]);
 	await clickByTestId(page, "commit-drawer-action-button");
-
-	// Wait for the commit view to close before proceeding
 	await waitForTestIdToNotExist(page, "new-commit-view");
 
-	// Start the commit process
+	// Part 3 — full remainder
 	await clickByTestId(page, "start-commit-button");
-
-	// Commit the changes
 	await fillByTestId(page, "commit-drawer-title-input", "Full commit: Part 3");
 	await clickByTestId(page, "commit-drawer-action-button");
 
-	// Verify the commits
-	const commits = getByTestId(page, "commit-row");
-	await expect(commits).toHaveCount(3);
+	await expect(commitRow(page)).toHaveCount(3);
 });
 
-test("should unselect a complete hunk", async ({ page, context }, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
-	const projectName = "hunk-unselect-project";
+test("should unselect a complete hunk", async ({ page, gitbutler }) => {
 	const fileName = "hunk-file.md";
-
-	const projectPath = gitbutler.pathInWorkdir(projectName + "/");
-	const filePath = join(projectPath, fileName);
-
-	const contentBefore = readFileSync(BIG_FILE_PATH_BEFORE, "utf-8");
-	const contentAfter = readFileSync(BIG_FILE_PATH_AFTER_SMALL_CHANGES, "utf-8");
-
-	await gitbutler.runScript("project-with-remote-branches.sh");
-	await gitbutler.runScript("project-with-remote-branches__commit-file-into-remote-base.sh", [
-		"Initial file for hunk unselect",
+	const filePath = await seedRemoteFileAndCloneFresh(
+		gitbutler,
+		"hunk-unselect-project",
 		fileName,
-		contentBefore,
-	]);
-	await gitbutler.runScript("project-with-remote-branches__clone-into-new-project.sh", [
-		projectName,
-	]);
-	await gitbutler.runScript("project-with-remote-branches__delete-project.sh", ["local-clone"]);
+		readFileSync(BIG_FILE_PATH_BEFORE, "utf-8"),
+		"Initial file for hunk unselect",
+	);
 
-	await page.goto("/");
+	await openWorkspace(page);
 
-	await waitForTestId(page, "workspace-view");
-
-	writeFileSync(filePath, contentAfter, "utf-8");
+	writeFileSync(filePath, readFileSync(BIG_FILE_PATH_AFTER_SMALL_CHANGES, "utf-8"), "utf-8");
 
 	await clickByTestId(page, "commit-to-new-branch-button");
 
-	const uncommittedChangesList = getByTestId(page, "uncommitted-changes-file-list");
-	const fileItem = uncommittedChangesList
+	const fileItem = getByTestId(page, "uncommitted-changes-file-list")
 		.getByTestId("file-list-item")
 		.filter({ hasText: fileName });
-	await expect(fileItem).toBeVisible();
 	await fileItem.click();
 
 	const unifiedDiffView = getByTestId(page, "unified-diff-view");
 	await expect(unifiedDiffView).toBeVisible();
 
-	// Unselect the first hunk (hunkIndex = 0)
 	await unselectHunk(fileName, unifiedDiffView, 0);
 
-	// Commit the changes
 	await fillByTestId(page, "commit-drawer-title-input", "Partial commit: Part 1");
 	await clickByTestId(page, "commit-drawer-action-button");
 
-	// Discard the remaining changes
 	await discardFile(fileName, page);
 
-	// Verify the file has the expected content
-	const finalContent = readFileSync(filePath, "utf-8");
-	expect(finalContent).toMatchSnapshot();
+	expect(readFileSync(filePath, "utf-8")).toMatchSnapshot();
 });
 
-test("should discard an untracked added file via context menu", async ({
-	page,
-	context,
-}, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+test("should discard an untracked added file via context menu", async ({ page, gitbutler }) => {
 	const fileName = "demo.txt";
-	const projectPath = gitbutler.pathInWorkdir("local-clone/");
-	const filePath = join(projectPath, fileName);
+	const filePath = join(gitbutler.pathInWorkdir("local-clone/"), fileName);
 
 	await gitbutler.runScript("project-with-remote-branches.sh");
+	await openWorkspace(page);
 
-	await page.goto("/");
-
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// Create an untracked file.
 	writeFileSync(filePath, "Hello world\nSecond line\n", "utf-8");
 	expect(existsSync(filePath)).toBe(true);
 
-	// The file should appear on the uncommitted changes area
-	const uncommittedChangesList = getByTestId(page, "uncommitted-changes-file-list");
-	const fileItem = uncommittedChangesList
+	const fileItem = getByTestId(page, "uncommitted-changes-file-list")
 		.getByTestId("file-list-item")
 		.filter({ hasText: fileName });
-	await expect(fileItem).toBeVisible();
 	await fileItem.click();
 
-	// The unified diff view should be visible
 	const unifiedDiffView = getByTestId(page, "unified-diff-view");
 	await expect(unifiedDiffView).toBeVisible();
 
-	// Open the hunk context menu for the added file and discard it.
 	await unifiedDiffView
 		.locator('[data-testid="hunk-count-column"]')
 		.first()
@@ -229,33 +165,20 @@ test("should discard an untracked added file via context menu", async ({
 
 	await expect.poll(() => existsSync(filePath)).toBe(false);
 	await expect(fileItem).toHaveCount(0);
-	await expect(getByTestId(page, "workspace-view")).toBeVisible();
 });
 
 async function unselectHunk(fileName: string, unifiedDiffView: Locator, hunkIndex: number) {
-	const headerSelector = getHunkHeaderSelector(fileName, hunkIndex);
-	const header = unifiedDiffView.locator(headerSelector).first();
+	const header = unifiedDiffView.locator(getHunkHeaderSelector(fileName, hunkIndex)).first();
 	await expect(header).toBeVisible();
 	await header.click();
 }
 
-async function unselectHunkLines(
-	fileName: string,
-	unifiedDiffView: Locator,
-	leftLines: number[],
-	rightLines: number[],
-) {
-	for (const line of leftLines) {
-		const leftSelector = getHunkLineSelector(fileName, line, "left");
-		const leftLine = unifiedDiffView.locator(leftSelector).first();
-		await expect(leftLine).toBeVisible();
-		await leftLine.click();
-	}
-
-	for (const line of rightLines) {
-		const rightSelector = getHunkLineSelector(fileName, line, "right");
-		const rightLine = unifiedDiffView.locator(rightSelector).first();
-		await expect(rightLine).toBeVisible();
-		await rightLine.click();
+async function unselectHunkLines(fileName: string, unifiedDiffView: Locator, lines: number[]) {
+	for (const side of ["left", "right"] as const) {
+		for (const line of lines) {
+			const locator = unifiedDiffView.locator(getHunkLineSelector(fileName, line, side)).first();
+			await expect(locator).toBeVisible();
+			await locator.click();
+		}
 	}
 }

--- a/e2e/playwright/tests/upstreamIntegration.spec.ts
+++ b/e2e/playwright/tests/upstreamIntegration.spec.ts
@@ -1,274 +1,132 @@
 import { createNewBranch } from "../src/branch.ts";
-import { getBaseURL, type GitButler, startGitButler } from "../src/setup.ts";
+import { applyUpstream, openWorkspace } from "../src/setup.ts";
 import { test } from "../src/test.ts";
-import { clickByTestId, getByTestId, waitForTestId, waitForTestIdToNotExist } from "../src/util.ts";
-import { expect } from "@playwright/test";
+import {
+	clickByTestId,
+	commitRow,
+	getByTestId,
+	stack,
+	waitForTestId,
+	waitForTestIdToNotExist,
+} from "../src/util.ts";
+import { expect, type Page } from "@playwright/test";
 
-let gitbutler: GitButler;
-
-test.use({
-	baseURL: getBaseURL(),
-});
-
-test.afterEach(async () => {
-	await gitbutler?.destroy();
-});
+async function syncAndIntegrate(page: Page) {
+	await clickByTestId(page, "sync-button");
+	await clickByTestId(page, "integrate-upstream-commits-button");
+	await clickByTestId(page, "integrate-upstream-action-button");
+}
 
 test("should handle the update of workspace with one conflicting branch gracefully", async ({
 	page,
-	context,
-}, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+	gitbutler,
+}) => {
 	await gitbutler.runScript("project-with-remote-branches.sh");
-	// Apply branch1
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
+	await applyUpstream(gitbutler, "branch1");
+	await openWorkspace(page);
 
-	await page.goto("/");
-
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// There are remote changes in the base branch
 	await gitbutler.runScript("project-with-remote-branches__add-commit-to-base.sh");
+	await syncAndIntegrate(page);
 
-	// Click the sync button
-	await clickByTestId(page, "sync-button");
-
-	// Update the workspace
-	await clickByTestId(page, "integrate-upstream-commits-button");
-	await clickByTestId(page, "integrate-upstream-action-button");
-
-	// There should be one stack
-	const stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(1);
+	await expect(stack(page)).toHaveCount(1);
 });
 
 test("should handle the update of workspace with integrated branch gracefully", async ({
 	page,
-	context,
-}, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+	gitbutler,
+}) => {
 	await gitbutler.runScript("project-with-remote-branches.sh");
-	// Apply branch1
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
+	await applyUpstream(gitbutler, "branch1");
+	await openWorkspace(page);
 
-	await page.goto("/");
+	await expect(stack(page)).toHaveCount(1);
 
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// There should be one stack applied
-	const stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(1);
-
-	// Branch one was merged in the forge
 	await gitbutler.runScript("merge-upstream-branch-to-base.sh", ["branch1"]);
+	await syncAndIntegrate(page);
 
-	// Click the sync button
-	await clickByTestId(page, "sync-button");
-
-	// Update the workspace
-	await clickByTestId(page, "integrate-upstream-commits-button");
-	await clickByTestId(page, "integrate-upstream-action-button");
-
-	// There should be no stacks
 	await waitForTestIdToNotExist(page, "stack");
 });
 
 test("should handle the update of workspace with integrated parent branch in stack gracefully", async ({
 	page,
-	context,
-}, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+	gitbutler,
+}) => {
 	await gitbutler.runScript("project-with-remote-branches.sh");
-	// Apply branch1
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch3", "local-clone"]);
+	await applyUpstream(gitbutler, "branch1", "branch3");
 	await gitbutler.runScript("move-branch.sh", ["branch3", "branch1", "local-clone"]);
+	await openWorkspace(page);
 
-	await page.goto("/");
+	await expect(stack(page)).toHaveCount(1);
+	await expect(getByTestId(page, "branch-card")).toHaveCount(2);
 
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// There should be one stack applied
-	let stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(1);
-	let branchCards = getByTestId(page, "branch-card");
-	await expect(branchCards).toHaveCount(2);
-
-	// Branch one was merged in the forge
 	await gitbutler.runScript("merge-upstream-branch-to-base.sh", ["branch1"]);
-
-	// Click the sync button
 	await clickByTestId(page, "sync-button");
-
-	// Update the workspace
 	await clickByTestId(page, "integrate-upstream-commits-button");
 
-	// The status of the branch1 should be "Integrated"
-	const branch1Status = page.locator('[data-integration-row-branch-name="branch1"]').first();
-	await branch1Status.waitFor();
-	const statusBadge = branch1Status.getByTestId("integrate-upstream-series-row-status-badge");
-	await statusBadge.waitFor();
+	const branch1Row = page.locator('[data-integration-row-branch-name="branch1"]').first();
+	const statusBadge = branch1Row.getByTestId("integrate-upstream-series-row-status-badge");
 	await expect(statusBadge).toHaveText("Integrated");
 
 	await clickByTestId(page, "integrate-upstream-action-button");
 
-	// There should be one stack left with one branch
-	stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(1);
-	branchCards = getByTestId(page, "branch-card");
-	await expect(branchCards).toHaveCount(1);
+	await expect(stack(page)).toHaveCount(1);
+	await expect(getByTestId(page, "branch-card")).toHaveCount(1);
 });
 
 test("should handle the update of the workspace with multiple stacks gracefully", async ({
 	page,
-	context,
-}, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+	gitbutler,
+}) => {
 	await gitbutler.runScript("project-with-stacks.sh");
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
-	await gitbutler.runScript("apply-upstream-branch.sh", ["branch2", "local-clone"]);
+	await applyUpstream(gitbutler, "branch1", "branch2");
+	await openWorkspace(page);
 
-	await page.goto("/");
+	await expect(stack(page)).toHaveCount(2);
 
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// There should be one stack applied
-	let stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(2);
-
-	// Branch one was merged in the forge
 	await gitbutler.runScript("merge-upstream-branch-to-base.sh", ["branch1"]);
+	await syncAndIntegrate(page);
 
-	// Click the sync button
-	await clickByTestId(page, "sync-button");
-
-	// Update the workspace
-	await clickByTestId(page, "integrate-upstream-commits-button");
-	await clickByTestId(page, "integrate-upstream-action-button");
-
-	// There should be one stack left
-	stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(1);
+	await expect(stack(page)).toHaveCount(1);
 });
 
-test("should handle the update of an empty branch gracefully", async ({
-	page,
-	context,
-}, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+test("should handle the update of an empty branch gracefully", async ({ page, gitbutler }) => {
 	await gitbutler.runScript("project-with-stacks.sh");
+	await openWorkspace(page);
 
-	await page.goto("/");
-
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// There should be no stacks
-	let stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(0);
-
-	// Create a new branch
+	await expect(stack(page)).toHaveCount(0);
 	await createNewBranch(page, "new-branch");
+	await expect(stack(page)).toHaveCount(1);
 
-	// There should be no stacks
-	stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(1);
-
-	// Branch one was merged in the forge
 	await gitbutler.runScript("merge-upstream-branch-to-base.sh", ["branch1"]);
+	await syncAndIntegrate(page);
 
-	// Click the sync button
-	await clickByTestId(page, "sync-button");
-
-	// Update the workspace
-	await clickByTestId(page, "integrate-upstream-commits-button");
-	await clickByTestId(page, "integrate-upstream-action-button");
-
-	// There should be one stack left
-	stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(1);
+	await expect(stack(page)).toHaveCount(1);
 });
 
-test("should handle the update of a branch with an empty commit", async ({
-	page,
-	context,
-}, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+test("should handle the update of a branch with an empty commit", async ({ page, gitbutler }) => {
 	await gitbutler.runScript("project-with-stacks.sh");
+	await openWorkspace(page);
 
-	await page.goto("/");
-
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	// There should be no stacks
-	let stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(0);
+	await expect(stack(page)).toHaveCount(0);
 
 	// Create a new branch
 	await clickByTestId(page, "chrome-header-create-branch-button");
 	const modal = await waitForTestId(page, "create-new-branch-modal");
-
-	const input = modal.locator("#new-branch-name-input");
-	await input.fill("new-branch");
+	await modal.locator("#new-branch-name-input").fill("new-branch");
 	await clickByTestId(page, "confirm-submit");
+	await expect(stack(page)).toHaveCount(1);
 
-	// There should be one stack
-	stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(1);
-
+	// Add an empty commit via the branch context menu.
 	const branchCard = getByTestId(page, "branch-card");
-	await branchCard.isVisible();
-	await branchCard.click({
-		button: "right",
-	});
-
-	// Add an empty commit
+	await branchCard.click({ button: "right" });
 	await waitForTestId(page, "branch-header-context-menu");
 	await clickByTestId(page, "branch-header-context-menu-add-empty-commit");
+	await expect(commitRow(page)).toHaveCount(1);
 
-	// There should be one commit
-	let commits = getByTestId(page, "commit-row");
-	await expect(commits).toHaveCount(1);
-
-	// Branch one was merged in the forge
 	await gitbutler.runScript("merge-upstream-branch-to-base.sh", ["branch1"]);
-
-	// Click the sync button
-	await clickByTestId(page, "sync-button");
-
-	// Update the workspace
-	await clickByTestId(page, "integrate-upstream-commits-button");
-	await clickByTestId(page, "integrate-upstream-action-button");
-
+	await syncAndIntegrate(page);
 	await waitForTestIdToNotExist(page, "integrate-upstream-action-button");
 
-	// There should be one stack left
-	stacks = getByTestId(page, "stack");
-	await expect(stacks).toHaveCount(1);
-	// There should be one commit
-	commits = getByTestId(page, "commit-row");
-	await expect(commits).toHaveCount(1);
+	await expect(stack(page)).toHaveCount(1);
+	await expect(commitRow(page)).toHaveCount(1);
 });

--- a/e2e/playwright/tests/workspace.spec.ts
+++ b/e2e/playwright/tests/workspace.spec.ts
@@ -1,44 +1,21 @@
 import { assertBranch } from "../src/branch.ts";
-import { getBaseURL, type GitButler, startGitButler } from "../src/setup.ts";
+import { openWorkspace } from "../src/setup.ts";
 import { test } from "../src/test.ts";
 import { waitForTestId, waitForTestIdToNotExist } from "../src/util.ts";
 
-let gitbutler: GitButler;
-
-test.use({
-	baseURL: getBaseURL(),
-});
-
-test.afterEach(async () => {
-	await gitbutler?.destroy();
-});
-
-test("can switch back to workspace", async ({ page, context }, testInfo) => {
-	const workdir = testInfo.outputPath("workdir");
-	const configdir = testInfo.outputPath("config");
-	gitbutler = await startGitButler(workdir, configdir, context);
-
+test("can switch back to workspace", async ({ page, gitbutler }) => {
 	await gitbutler.runScript("project-with-remote-branches.sh");
+	await openWorkspace(page);
 
-	await page.goto("/");
+	const localClone = gitbutler.pathInWorkdir("local-clone");
+	await assertBranch("gitbutler/workspace", localClone);
 
-	// Should load the workspace
-	await waitForTestId(page, "workspace-view");
-
-	await assertBranch("gitbutler/workspace", workdir + "/local-clone");
-
-	// Switch to master branch
 	await gitbutler.runScript("project-with-remote-branches__checkout-master.sh", ["local-clone"]);
+	assertBranch("master", localClone);
 
-	assertBranch("master", workdir + "/local-clone");
-
-	// Button to switch back to workspace should be visible
 	const switchButton = await waitForTestId(page, "chrome-header-switch-back-to-workspace-button");
 	await switchButton.click();
 
-	// Should be back on workspace
-	await assertBranch("gitbutler/workspace", workdir + "/local-clone");
-
-	// Button should no longer be visible
+	await assertBranch("gitbutler/workspace", localClone);
 	await waitForTestIdToNotExist(page, "chrome-header-switch-back-to-workspace-button");
 });


### PR DESCRIPTION
Each spec carried its own startup/teardown plumbing and repeated the same
workspace-bringup, locator, and assertion patterns. The tests were harder
to read than the behavior they describe.

Broad strategies:

- Lifecycle as a fixture. A 'gitbutler' Playwright fixture handles
  startGitButler + afterEach destroy, with an options slot for tests
  that need a custom env or config. Specs drop the let-gitbutler,
  test.use({ baseURL }), and test.afterEach trio entirely.

- Shared setup helpers. applyUpstream() and openWorkspace() collapse
  the most common bringup pattern into one line each.

- Shared locators. commitRow() and stack() encapsulate the repeated
  getByTestId(...).filter({ hasText }) patterns. A MOD_KEY constant
  replaces three copies of the same platform check.

- Trim narration. Generic 'should load workspace / one stack / N
  commits' assertions are removed when they aren't what the test is
  actually verifying — each test should read as its essential idea.

- One real bug fix surfaced along the way: navigating to the branches
  view sometimes raced against the workspace's stack header, since
  both use the same branch-header test id. Pinned the assertion to the
  origin/master header to make navigation deterministic.

Written by claude.