### PR TITLE
fix(but): prevent stale cache from causing `<NEW> -> <OLD>` update hint

### DIFF
--- a/crates/but-db/src/cache/table/update.rs
+++ b/crates/but-db/src/cache/table/update.rs
@@ -2,10 +2,11 @@ use chrono::{DateTime, Utc};
 
 use crate::{AppCacheHandle, M, SchemaVersion, Transaction};
 
-pub(crate) const M: &[M<'static>] = &[M::up(
-    2026_01_19__15_00_00,
-    SchemaVersion::Zero,
-    "CREATE TABLE `update-check`(
+pub(crate) const M: &[M<'static>] = &[
+    M::up(
+        2026_01_19__15_00_00,
+        SchemaVersion::Zero,
+        "CREATE TABLE `update-check`(
     `id` INTEGER NOT NULL PRIMARY KEY CHECK (id = 1),
     `checked_at` TIMESTAMP NOT NULL,
     `up_to_date` BOOLEAN NOT NULL,
@@ -16,7 +17,13 @@ pub(crate) const M: &[M<'static>] = &[M::up(
     `suppressed_at` TIMESTAMP,
     `suppress_duration_hours` INTEGER
 );",
-)];
+    ),
+    M::up(
+        2026_05_18__08_00_00,
+        SchemaVersion::Zero,
+        "ALTER TABLE `update-check` ADD COLUMN `valid_for_version` TEXT NULL;",
+    ),
+];
 
 // This table currently only has a single row representing the latest update check.
 const SINGLETON_RECORD_ID: u8 = 1;
@@ -80,6 +87,18 @@ pub struct CachedCheckResult {
 /// Information about the latest available version and whether an update is needed.
 #[derive(Debug, Clone, PartialEq)]
 pub struct CheckUpdateStatus {
+    /// The version of the app for which this update check is valid.
+    ///
+    /// This is used to check for cache staleness. As the version comparison is done server side,
+    /// the value of [`Self::up_to_date`] is only valid if the current version of the app matches
+    /// the version running at the time of the update check.
+    ///
+    /// # Compatibility
+    /// This is nullable only for forward compatibility reasons, as this column hasn't always
+    /// existed. Removing nullability requires bumping the schema version as old clients will no
+    /// longer be able to write to the table.
+    pub valid_for_version: Option<String>,
+
     /// `true` if the current version matches the latest available version, `false` otherwise.
     ///
     /// When this is `false`, you should prompt the user to update or automatically download
@@ -125,7 +144,7 @@ impl UpdateCheckHandle<'_> {
     /// Like [`Self::get`], but fallible.
     pub fn try_get(&self) -> rusqlite::Result<Option<CachedCheckResult>> {
         let mut stmt = self.conn.prepare(
-            "SELECT checked_at, up_to_date, latest_version, release_notes, url, signature,
+            "SELECT checked_at, up_to_date, latest_version, release_notes, url, signature, valid_for_version,
                     suppressed_at, suppress_duration_hours
              FROM `update-check` WHERE id = 1",
         )?;
@@ -137,7 +156,7 @@ impl UpdateCheckHandle<'_> {
                 let checked_at_naive: chrono::NaiveDateTime = row.get(0)?;
                 let checked_at = DateTime::from_naive_utc_and_offset(checked_at_naive, Utc);
 
-                let suppressed_at_naive: Option<chrono::NaiveDateTime> = row.get(6)?;
+                let suppressed_at_naive: Option<chrono::NaiveDateTime> = row.get(7)?;
                 let suppressed_at = suppressed_at_naive
                     .map(|naive| DateTime::from_naive_utc_and_offset(naive, Utc));
 
@@ -149,9 +168,10 @@ impl UpdateCheckHandle<'_> {
                         release_notes: row.get(3)?,
                         url: row.get(4)?,
                         signature: row.get(5)?,
+                        valid_for_version: row.get(6)?,
                     },
                     suppressed_at,
-                    suppress_duration_hours: row.get(7)?,
+                    suppress_duration_hours: row.get(8)?,
                 }))
             }
             None => Ok(None),
@@ -179,9 +199,9 @@ impl UpdateCheckHandleMut<'_> {
 
         sp.execute(
             "INSERT OR REPLACE INTO `update-check`
-             (id, checked_at, up_to_date, latest_version, release_notes, url, signature,
+             (id, checked_at, up_to_date, latest_version, release_notes, url, signature, valid_for_version,
               suppressed_at, suppress_duration_hours)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
             rusqlite::params![
                 SINGLETON_RECORD_ID,
                 result.checked_at.naive_utc(),
@@ -190,6 +210,7 @@ impl UpdateCheckHandleMut<'_> {
                 result.status.release_notes,
                 result.status.url,
                 result.status.signature,
+                result.status.valid_for_version,
                 result.suppressed_at.map(|dt| dt.naive_utc()),
                 result.suppress_duration_hours,
             ],

--- a/crates/but-db/tests/db/cache/table/update.rs
+++ b/crates/but-db/tests/db/cache/table/update.rs
@@ -184,6 +184,7 @@ fn all_fields_persisted() -> anyhow::Result<()> {
     let result = CachedCheckResult {
         checked_at: DateTime::from_timestamp(1000000, 0).unwrap(),
         status: CheckUpdateStatus {
+            valid_for_version: Some("1.2.3".to_string()),
             up_to_date: false,
             latest_version: "2.0.0".to_string(),
             release_notes: Some("Major release".to_string()),
@@ -209,6 +210,7 @@ fn optional_fields_can_be_none() -> anyhow::Result<()> {
     let result = CachedCheckResult {
         checked_at: DateTime::from_timestamp(1000000, 0).unwrap(),
         status: CheckUpdateStatus {
+            valid_for_version: None,
             up_to_date: true,
             latest_version: "1.0.0".to_string(),
             release_notes: None,
@@ -264,6 +266,7 @@ fn delete_removes_existing() -> anyhow::Result<()> {
 
 fn sample_status(up_to_date: bool) -> CheckUpdateStatus {
     CheckUpdateStatus {
+        valid_for_version: Some("0.0.0".to_string()),
         up_to_date,
         latest_version: "1.2.3".to_string(),
         release_notes: Some("Bug fixes and improvements".to_string()),

--- a/crates/but-update/src/cache.rs
+++ b/crates/but-update/src/cache.rs
@@ -38,30 +38,19 @@ pub struct AvailableUpdate {
     pub url: Option<String>,
 }
 
-impl AvailableUpdate {
-    /// Checks if the available update is a no-op (i.e., the available version is the same as the current version).
-    /// This can happen if the update check cache is stale.
-    pub fn is_noop(&self) -> bool {
-        self.available_version == self.current_version
-    }
-}
-
 /// Returns information about an available application update, if one exists and is not suppressed.
 ///
 /// This function checks the cache for a previously performed update check and returns
 /// update information if:
 /// - A cached update check exists
 /// - The cached status indicates an update is available (`up_to_date == false`)
+/// - The cached check is valid for the current version of the app
 /// - The update is not currently suppressed
-/// - The available version differs from the current version (not a no-op)
-///
-/// No-op updates (where the available version matches the current version) can occur when
-/// the cache becomes stale. This function automatically filters them out.
 ///
 /// # Returns
 ///
 /// * `Ok(Some(AvailableUpdate))` - An update is available and not suppressed
-/// * `Ok(None)` - No update is available, no cache exists, cache is invalid, update is suppressed, or update is a no-op
+/// * `Ok(None)` - No update is available, no cache exists, cache is invalid, cache is stale or update is suppressed
 /// * `Err(_)` - Failed to access the cache
 pub fn available_update(cache: &but_db::AppCacheHandle) -> anyhow::Result<Option<AvailableUpdate>> {
     let cached = match cache.update_check().get() {
@@ -69,8 +58,13 @@ pub fn available_update(cache: &but_db::AppCacheHandle) -> anyhow::Result<Option
         None => return Ok(None),
     };
 
-    // If already up to date, no update available
-    if cached.status.up_to_date {
+    let current_version = option_env!("VERSION").unwrap_or("0.0.0").to_string();
+    let valid_for_version = cached
+        .status
+        .valid_for_version
+        .unwrap_or_else(|| current_version.clone());
+
+    if cached.status.up_to_date || current_version != valid_for_version {
         return Ok(None);
     }
 
@@ -88,19 +82,12 @@ pub fn available_update(cache: &but_db::AppCacheHandle) -> anyhow::Result<Option
     }
 
     // Update is available and not suppressed
-    let current_version = option_env!("VERSION").unwrap_or("0.0.0").to_string();
-
     let update = AvailableUpdate {
         current_version,
         available_version: cached.status.latest_version,
         release_notes: cached.status.release_notes,
         url: cached.status.url,
     };
-
-    // Filter out no-op updates (stale cache entries where versions are identical)
-    if update.is_noop() {
-        return Ok(None);
-    }
 
     Ok(Some(update))
 }

--- a/crates/but-update/src/check.rs
+++ b/crates/but-update/src/check.rs
@@ -163,6 +163,7 @@ pub fn check_status_with_url(
                 release_notes: status.release_notes.clone(),
                 url: status.url.clone(),
                 signature: status.signature.clone(),
+                valid_for_version: Some(option_env!("VERSION").unwrap_or("0.0.0").to_string()),
             },
             suppressed_at,
             suppress_duration_hours,

--- a/crates/but-update/tests/update/available_update.rs
+++ b/crates/but-update/tests/update/available_update.rs
@@ -5,17 +5,50 @@ use but_db::{
 use chrono::DateTime;
 
 #[test]
-fn no_op_update_when_versions_match() -> anyhow::Result<()> {
+fn returns_none_when_update_status_is_stale() -> anyhow::Result<()> {
     let mut cache = in_memory_cache();
 
-    // Seed the cache with up_to_date=false but latest_version="0.0.0"
-    // which matches the VERSION fallback in available_update()
     let cached_result = CachedCheckResult {
         checked_at: DateTime::from_timestamp(1000000, 0).unwrap(),
         status: CheckUpdateStatus {
+            // Note: The default for VERSION in `available_update` is 0.0.0. The test relies on this
+            // for correctness. This is fragile but not easily circumvented at this time.
+            valid_for_version: Some("0.0.1".to_string()),
             up_to_date: false,
-            latest_version: "0.0.0".to_string(),
-            release_notes: Some("Test release notes".to_string()),
+            latest_version: "1.2.3".to_string(),
+            release_notes: None,
+            url: None,
+            signature: None,
+        },
+        suppressed_at: None,
+        suppress_duration_hours: None,
+    };
+
+    cache.update_check_mut()?.save(&cached_result)?;
+
+    let result = but_update::available_update(&cache)?;
+    assert!(
+        result.is_none(),
+        "Expected stale update status to be filtered out"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn returns_update_when_versions_differ_and_valid_for_version_matches() -> anyhow::Result<()> {
+    let mut cache = in_memory_cache();
+
+    // Seed the cache with up_to_date=false and a different version
+    let cached_result = CachedCheckResult {
+        checked_at: DateTime::from_timestamp(1000000, 0).unwrap(),
+        status: CheckUpdateStatus {
+            // Note: The default for VERSION in `available_update` is 0.0.0. The test relies on this
+            // for correctness. This is fragile but not easily circumvented at this time.
+            valid_for_version: Some("0.0.0".to_string()),
+            up_to_date: false,
+            latest_version: "1.2.3".to_string(),
+            release_notes: Some("Bug fixes and improvements".to_string()),
             url: Some("https://example.com/download".to_string()),
             signature: Some("signature123".to_string()),
         },
@@ -25,24 +58,36 @@ fn no_op_update_when_versions_match() -> anyhow::Result<()> {
 
     cache.update_check_mut()?.save(&cached_result)?;
 
-    // available_update should return None because the versions match (no-op)
+    // available_update should return Some because versions differ
     let result = but_update::available_update(&cache)?;
     assert!(
-        result.is_none(),
-        "Expected None for no-op update where latest_version matches current_version"
+        result.is_some(),
+        "Expected Some(AvailableUpdate) when versions differ"
     );
+
+    let update = result.unwrap();
+    assert_eq!(update.current_version, "0.0.0");
+    assert_eq!(update.available_version, "1.2.3");
+    assert_eq!(
+        update.release_notes,
+        Some("Bug fixes and improvements".to_string())
+    );
+    assert_eq!(update.url, Some("https://example.com/download".to_string()));
 
     Ok(())
 }
 
 #[test]
-fn returns_update_when_versions_differ() -> anyhow::Result<()> {
+/// This is a forward compatibility test. Old data that lacks valid_for_version column should
+/// operate under the assumption that the check is valid for whatever version is currently running.
+fn returns_update_when_versions_differ_and_valid_for_version_is_none() -> anyhow::Result<()> {
     let mut cache = in_memory_cache();
 
     // Seed the cache with up_to_date=false and a different version
     let cached_result = CachedCheckResult {
         checked_at: DateTime::from_timestamp(1000000, 0).unwrap(),
         status: CheckUpdateStatus {
+            valid_for_version: None,
             up_to_date: false,
             latest_version: "1.2.3".to_string(),
             release_notes: Some("Bug fixes and improvements".to_string()),

--- a/crates/but-update/tests/update/suppress_update.rs
+++ b/crates/but-update/tests/update/suppress_update.rs
@@ -47,6 +47,9 @@ fn in_memory_cache() -> AppCacheHandle {
 
 fn sample_status(up_to_date: bool) -> CheckUpdateStatus {
     CheckUpdateStatus {
+        // Note: The default for VERSION in `available_update` is 0.0.0. The test relies on this
+        // for correctness. This is fragile but not easily circumvented at this time.
+        valid_for_version: Some("0.0.0".to_string()),
         up_to_date,
         latest_version: "1.2.3".to_string(),
         release_notes: Some("Bug fixes and improvements".to_string()),


### PR DESCRIPTION
Adds in a forward and backward compatible fix for a stale cache causing confusing update hints. Note that the backward compatible layer will still cause the bug to appear, it's only when the cache has been refreshed that the fix actually takes effect as it relies on a new column.