### PR TITLE
Read through graph post-traversal functions

### DIFF
--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -330,7 +330,7 @@ impl Graph {
         Ok(())
     }
 
-    /// Assure that workspace segments with managed commits only have that commit, and move all others
+    /// Ensure that workspace segments with managed commits only have that commit, and move all others
     /// into a new segment.
     fn fixup_workspace_segments<T: RefMetadata>(
         &mut self,

--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -157,7 +157,7 @@ impl Graph {
         }
     }
 
-    /// After everything, assure the entrypoint still points to a segment with the correct ref-name,
+    /// After everything, ensure the entrypoint still points to a segment with the correct ref-name,
     /// if one was given when starting the traversal.
     /// If not, try to find a segment with the right ref-name.
     ///

--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -275,10 +275,17 @@ impl Graph {
         Ok(())
     }
 
-    /// This is a post-process as only in the end we are sure what is a remote commit.
-    /// On remote commits, we want to further segment remote tracking segments to avoid picking
+    /// This is a post-process as only in the end we are sure what is a remote
+    /// commit.
+    ///
+    /// We want to further segment remote tracking segments to avoid picking
     /// up too many remote commits later.
-    /// For everything else, we want to just remove the extra ref-names that we aren't interested in.
+    ///
+    /// We drop all remote-tracking branch references from each commit's `refs`
+    /// list. In the case of a commit being considered remote, if it's
+    /// containing segment is splittable, we preserve the remote reference by
+    /// splitting the containing segment, with the new segment being named with
+    /// the remote reference.
     fn fixup_remote_tracking_refs_and_maybe_split_segments<T: RefMetadata>(
         &mut self,
         meta: &OverlayMetadata<'_, T>,

--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -294,28 +294,43 @@ impl Graph {
     ///
     /// We want to further segment remote tracking segments to avoid picking
     /// up too many remote commits later.
-    /// 
+    ///
     /// The purpose here is to *restore* named segments for remote tracking branches
     /// as during traversal, such segments are only created if their local tracking branches
     /// were reachable through the entrypoint. This is done so that remote tracking branches
-    /// will not make segnemt naming ambiguous unnecessarily, i.e. we prefer segments named
+    /// will not make segment naming ambiguous unnecessarily, i.e. we prefer segments named
     /// by local branches right now.
-    /// 
+    ///
     /// Having additional segmentation caused by remote tracking branches is valuable
     /// as it can reduce the amount of remote-commits that are attributed to the remote
     /// tracking branch of a workspace commit, which is relevant for stacks in particular.
-    /// 
+    ///
     /// We drop all remote-tracking branch references from each commit's `refs`
-    /// list. For remote commits that are not the first commit in a multi-commit
-    /// segment, we preserve the first remote-tracking reference by splitting the
-    /// containing segment there, with the new segment being named with that
-    /// reference.
+    /// list. For remote commits that are not the first commit in a
+    /// multi-commit segment, we preserve the first remote-tracking reference by
+    /// splitting the containing segment there, with the new segment being named
+    /// with that reference. Additional remote-tracking references at the same
+    /// commit become named empty virtual segments pointing to the owning remote
+    /// segment. They are not 'inline', and merely there as visual evidence of what
+    /// happened here during debugging. For now, no algorithm discovers references
+    /// by checking incoming connections, instead they are expected to be either
+    /// inline, i.e. virutal branch segments in a workspace, or they are
+    /// named segments.
     fn fixup_remote_tracking_refs_and_maybe_split_segments<T: RefMetadata>(
         &mut self,
         meta: &OverlayMetadata<'_, T>,
         worktree_by_branch: &WorktreeByBranch,
     ) -> anyhow::Result<()> {
-        let mut split_info = Vec::new();
+        struct SplitInfo {
+            segment: SegmentIndex,
+            commit: CommitIndex,
+            owner_ref: gix::refs::FullName,
+            /// Additional remote-tracking refs at `commit` that should become
+            /// named empty virtual segments pointing to `owner_ref`.
+            virtual_refs: Vec<gix::refs::FullName>,
+        }
+
+        let mut split_info = Vec::<SplitInfo>::new();
         for node in self.node_weights_mut() {
             let node_has_commits = node.commits.len() > 1;
             for (cidx, commit_with_refs) in node
@@ -331,12 +346,18 @@ impl Graph {
                         if matches!(c, Category::RemoteBranch) {
                             // Always remove the ref, but keep info to create a split if possible.
                             if is_splittable {
-                                let info = (node.id, cidx, ri.ref_name.clone());
-                                // This means we are more interested in the split than in representing every reference for now.
-                                if split_info.iter().any(|(a_sidx, a_cidx, _)| *a_sidx == node.id && *a_cidx == cidx) {
-                                    tracing::debug!(?node.id, ?commit_with_refs.id, ?ri, "Ignoring remote reference which *should* have no effect");
+                                if let Some(info) = split_info
+                                    .iter_mut()
+                                    .find(|info| info.segment == node.id && info.commit == cidx)
+                                {
+                                    info.virtual_refs.push(ri.ref_name.clone());
                                 } else {
-                                    split_info.push(info);
+                                    split_info.push(SplitInfo {
+                                        segment: node.id,
+                                        commit: cidx,
+                                        owner_ref: ri.ref_name.clone(),
+                                        virtual_refs: Vec::new(),
+                                    });
                                 }
                             }
                             false
@@ -348,15 +369,41 @@ impl Graph {
             }
         }
 
-        for (sidx, new_segment_start_idx, segment_name) in split_info.into_iter().rev() {
-            self.split_segment(
-                sidx,
-                new_segment_start_idx,
-                Some(segment_name),
+        for info in split_info.into_iter().rev() {
+            let owner_sidx = self.split_segment(
+                info.segment,
+                info.commit,
+                Some(info.owner_ref),
                 None,
                 meta,
                 worktree_by_branch,
             )?;
+            let owner_tip = self[owner_sidx]
+                .commits
+                .first()
+                .context("BUG: remote split segment should own at least one commit")?
+                .id;
+
+            for virtual_segment_name in info.virtual_refs {
+                let virtual_segment = crate::Segment {
+                    ref_info: Some(crate::RefInfo::from_ref(
+                        virtual_segment_name,
+                        owner_tip,
+                        worktree_by_branch,
+                    )),
+                    ..Default::default()
+                };
+                let virtual_sidx = self.insert_segment(virtual_segment);
+                self.connect_segments_with_ids(
+                    virtual_sidx,
+                    None,
+                    None,
+                    owner_sidx,
+                    0,
+                    Some(owner_tip),
+                    0,
+                );
+            }
         }
         Ok(())
     }

--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -564,7 +564,7 @@ impl Graph {
                         if target_ref.is_some() {
                             return None;
                         }
-                        // It's a very specialised filter… will that lead to strange behaviour later?
+                        // It's a very specialized filter… will that lead to strange behavior later?
                         let segment = &self[s];
                         if segment.ref_info.is_some() {
                             return None;
@@ -640,7 +640,7 @@ impl Graph {
     /// * workspace segments are either empty, or have just one managed commit.
     /// * insert empty segments as defined by the workspace that affects its downstream.
     /// * put workspace connection into the order defined in the workspace metadata.
-    /// * set sibling segment IDs for unnamed segments that are descendents of an out-of-workspace but known segment.
+    /// * set sibling segment IDs for unnamed segments that are descendants of an out-of-workspace but known segment.
     fn workspace_upgrades<T: RefMetadata>(
         &mut self,
         meta: &OverlayMetadata<'_, T>,

--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -159,6 +159,7 @@ impl Graph {
 
     /// After everything, ensure the entrypoint still points to a segment with
     /// the correct ref-name if one was given when starting the traversal.
+    /// This is only relevant if a ref-name is given at all.
     ///
     /// If the the entrypoint ref doesn't match the ref specified at the start
     /// we:
@@ -170,6 +171,8 @@ impl Graph {
     ///     entrypoint.
     ///   - Otherwise we split it out into a new segment and set that new
     ///     entrypoint.
+    /// - Otherwise, it's an error if no segment is named after the entrypoint-ref,
+    ///   or has a commit that holds it.
     ///
     /// *This is the brute-force way of doing it, instead of ensuring that the
     /// workspace upgrade functions that create independent and dependent
@@ -279,8 +282,8 @@ impl Graph {
                 s.ref_info = Some(desired_ref_name);
             }
         } else {
-            tracing::warn!(
-                "Couldn't find any segment that was named after the entrypoint ref name or contained its name '{desired_ref_name}'",
+            bail!(
+                "BUG: Couldn't find any segment that was named after the entrypoint ref name or contained its name '{desired_ref_name}'",
             );
         };
         Ok(())

--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -157,12 +157,23 @@ impl Graph {
         }
     }
 
-    /// After everything, ensure the entrypoint still points to a segment with the correct ref-name,
-    /// if one was given when starting the traversal.
-    /// If not, try to find a segment with the right ref-name.
+    /// After everything, ensure the entrypoint still points to a segment with
+    /// the correct ref-name if one was given when starting the traversal.
     ///
-    /// *This is the brute-force way of doing it, instead of ensuring that the workspace upgrade functions
-    /// that create independent and dependent branches keep everything up-to-date at all times.
+    /// If the the entrypoint ref doesn't match the ref specified at the start
+    /// we:
+    /// - If a segment named with the desired ref is found, we update the
+    ///   entrypoint to match that
+    /// - If any segment whose first commit owns a ref with the desired name
+    ///   - If the segment has no ref_info, we remove the ref from the commit
+    ///     and set the ref_info on the segment, before setting the segment as the
+    ///     entrypoint.
+    ///   - Otherwise we split it out into a new segment and set that new
+    ///     entrypoint.
+    ///
+    /// *This is the brute-force way of doing it, instead of ensuring that the
+    /// workspace upgrade functions that create independent and dependent
+    /// branches keep everything up-to-date at all times.
     fn set_entrypoint_to_ref_name<T: RefMetadata>(
         &mut self,
         meta: &OverlayMetadata<'_, T>,

--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -1199,7 +1199,7 @@ impl Graph {
             // If both remote and local point to the same commit, make sure that the remote points to the local segment.
             if let Some((
                 (_remote_commit, _owner_of_commit_same_as_local),
-                (_local_commmit, owner_of_commit_same_as_remote),
+                (_local_commit, owner_of_commit_same_as_remote),
             )) = self
                 .resolve_to_unambiguously_pointed_to_commit(remote_sidx)
                 .zip(self.resolve_to_unambiguously_pointed_to_commit(local_sidx))

--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -294,12 +294,22 @@ impl Graph {
     ///
     /// We want to further segment remote tracking segments to avoid picking
     /// up too many remote commits later.
-    ///
+    /// 
+    /// The purpose here is to *restore* named segments for remote tracking branches
+    /// as during traversal, such segments are only created if their local tracking branches
+    /// were reachable through the entrypoint. This is done so that remote tracking branches
+    /// will not make segnemt naming ambiguous unnecessarily, i.e. we prefer segments named
+    /// by local branches right now.
+    /// 
+    /// Having additional segmentation caused by remote tracking branches is valuable
+    /// as it can reduce the amount of remote-commits that are attributed to the remote
+    /// tracking branch of a workspace commit, which is relevant for stacks in particular.
+    /// 
     /// We drop all remote-tracking branch references from each commit's `refs`
-    /// list. In the case of a commit being considered remote, if it's
-    /// containing segment is splittable, we preserve the remote reference by
-    /// splitting the containing segment, with the new segment being named with
-    /// the remote reference.
+    /// list. For remote commits that are not the first commit in a multi-commit
+    /// segment, we preserve the first remote-tracking reference by splitting the
+    /// containing segment there, with the new segment being named with that
+    /// reference.
     fn fixup_remote_tracking_refs_and_maybe_split_segments<T: RefMetadata>(
         &mut self,
         meta: &OverlayMetadata<'_, T>,

--- a/crates/but-graph/src/lib.rs
+++ b/crates/but-graph/src/lib.rs
@@ -32,7 +32,7 @@
 //! Besides that, operating on a graph, despite its own complexities, is finally aligning the mental model of the programmer
 //! with what's actually there, for algorithms suitable to perform the job correctly.
 //!
-//! All this makes the Graph the **new core data-structure** that is the world of GitButler and upon which visualisations and
+//! All this makes the Graph the **new core data-structure** that is the world of GitButler and upon which visualizations and
 //! mutation operations are based.
 //!
 //! ### New Workspace Concepts
@@ -154,7 +154,7 @@
 //! first commit in `gitbutler/workspace` effectively. The other references aren't participating in the traversal.
 //!
 //! The tip that finds the commit first is dependent on various factors, and it could also happen that `origin/main` finds
-//! it first. In any case, this needs to be adjusted after traversal in the process called *reconiliation*, so the graph
+//! it first. In any case, this needs to be adjusted after traversal in the process called *reconciliation*, so the graph
 //! matches what our [workspace metadata](but_core::ref_metadata::Workspace::stacks) says it should be.
 //!
 //! After reconciling, the graph would become this:

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -4369,17 +4369,35 @@ fn two_dependent_branches_rebased_with_remotes_squash_merge_remote_ambiguous() -
     │                           └── 🏁·281456a (⌂|🏘|✓|1111)
     ├── ►:1[0]:origin/main →:2:
     │   └── →:2: (main →:1:)
-    └── ►:4[0]:origin/D →:3:
-        └── 🟣3045ea6 (0x0|1000)
-            └── ►:6[1]:origin/A
-                └── 🟣1818c17 (0x0|1000)
-                    └── →:5:
+    ├── ►:4[0]:origin/D →:3:
+    │   └── 🟣3045ea6 (0x0|1000)
+    │       └── ►:6[1]:origin/A
+    │           └── 🟣1818c17 (0x0|1000)
+    │               └── →:5:
+    ├── ►:7[0]:origin/B
+    │   └── →:6: (origin/A)
+    └── ►:8[0]:origin/C
+        └── →:6: (origin/A)
     ");
 
-    // We want to let each remote on the path down own a commit, even if ownership would be ambiguous
-    // as we are in this situation because these ambiguous remotes don't actually matter as their
-    // local tracking branches aren't present anymore.
-    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @r"
+    let ambiguous_remote_tip = repo.rev_parse_single("origin/A")?.detach();
+    for remote_ref in [
+        "refs/remotes/origin/A",
+        "refs/remotes/origin/B",
+        "refs/remotes/origin/C",
+    ] {
+        let remote_ref = super::ref_name(remote_ref);
+        let remote_segment = graph
+            .segment_by_ref_name(remote_ref.as_ref())
+            .expect("remote tracking segment should be present");
+        assert_eq!(
+            graph.tip_skip_empty(remote_segment.id).map(|c| c.id),
+            Some(ambiguous_remote_tip),
+            "{remote_ref} should resolve to the commit its Git ref points to, showing that something special happened here"
+        );
+    }
+
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), "only one remote commit as unrelated remotes split a linear segment", @r"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 0b6b861
     └── ≡📙:3:D <> origin/D →:4:⇡1⇣1 on 0b6b861 {0}
         └── 📙:3:D <> origin/D →:4:⇡1⇣1


### PR DESCRIPTION
I read through the comments and most of the code for the post traversal portion of post-traversal work we do for creating the Graph.

Notes that I didn't address while reading through:

## fn workspace_upgrades<T: RefMetadata>(
>     /// * workspace segments are either empty, or have just one managed commit.
Why can we have empty workspace segments?

Does the `to_workspace_state` call end up reading a bunch of commit messages? I'm a little surprised by this. Perhaps some explanation of _why_ this makes sense would be nice.

I guess this is doing something to disambiguate between two stacked references and what should be two independent. It seems to rely on a primitive version of constructing the workspace projection which seems a little circular logic-wise.

I would love to know more about what this is trying to achieve and the algorithm it uses to achieve it.

### fn candidates_for_independent_branches_in_workspace(
It's not clear to me what makes something a candidate.