### PR TITLE
commit squash: use merge arithmetic

### DIFF
--- a/crates/but-workspace/src/commit/squash_commits.rs
+++ b/crates/but-workspace/src/commit/squash_commits.rs
@@ -1,11 +1,13 @@
 //! An action to squash multiple commits into a target commit.
 
 use anyhow::{Result, bail};
-use but_core::RefMetadata;
+use but_core::{RefMetadata, RepositoryExt};
 use but_rebase::{
     commit::DateMode,
     graph_rebase::{
-        Editor, Selector, Step, SuccessfulRebase, ToCommitSelector, mutate::InsertSide,
+        Editor, LookupStep as _, Selector, Step, SuccessfulRebase, ToCommitSelector,
+        merge_commit_changes::MergeCommitChangesOutcome,
+        mutate::{SegmentDelimiter, SelectorSet},
     },
 };
 
@@ -43,73 +45,56 @@ fn push_message_with_spacing(combined: &mut Vec<u8>, message: &[u8]) {
     combined.extend_from_slice(message);
 }
 
-/// Reorder commits around `target_commit` so all selected commits become
-/// adjacent around the target in parentage order.
-///
-/// Returns the rewritten editor together with the original below/above anchor
-/// commit IDs used for remapping after the first rebase.
-fn reorder_commits_around_target<'ws, 'meta, M: RefMetadata>(
-    mut editor: Editor<'ws, 'meta, M>,
-    ordered_all_commits: &[Selector],
-    target_commit: Selector,
-) -> Result<(Editor<'ws, 'meta, M>, Selector, Selector)> {
-    let target_pos = ordered_all_commits
-        .iter()
-        .position(|id| *id == target_commit)
-        .expect("target commit must be in ordered commit list");
-
-    let (below_commits, target_and_above_commits) = ordered_all_commits.split_at(target_pos);
-
-    let mut below_anchor = target_commit;
-    for source_id in below_commits.iter().rev().copied() {
-        editor = crate::commit::move_commit_no_rebase(
-            editor,
-            source_id,
-            below_anchor,
-            InsertSide::Below,
-        )?;
-        below_anchor = source_id;
-    }
-
-    let mut above_anchor = target_commit;
-    for source_id in target_and_above_commits.iter().skip(1).copied() {
-        editor = crate::commit::move_commit_no_rebase(
-            editor,
-            source_id,
-            above_anchor,
-            InsertSide::Above,
-        )?;
-        above_anchor = source_id;
-    }
-
-    Ok((editor, below_anchor, above_anchor))
-}
-
-/// Build the squashed commit from the mapped top/bottom commits and replace the
-/// bottom selector with the newly created commit.
+/// Build the squashed commit and replace the target selector with the newly
+/// created commit.
 ///
 /// Returns the updated editor and the selector that now points to the squashed
 /// commit.
 fn construct_new_squashed_commit<'ws, 'meta, M: RefMetadata>(
     mut editor: Editor<'ws, 'meta, M>,
-    top_most_commit_id: Selector,
-    bottom_most_commit_id: Selector,
+    squashed_tree: MergeCommitChangesOutcome,
+    target_commit_id: Selector,
     combined_message: Vec<u8>,
 ) -> Result<(Editor<'ws, 'meta, M>, Selector)> {
-    let (_, top_most_commit) = editor.find_selectable_commit(top_most_commit_id)?;
-    let (bottom_most_selector, bottom_most_commit) =
-        editor.find_selectable_commit(bottom_most_commit_id)?;
+    let (target_selector, target_commit) = editor.find_selectable_commit(target_commit_id)?;
+    let target_parent_ids = parent_commit_ids(&editor, target_selector)?;
 
     let new_commit = {
-        let mut squashed_commit = bottom_most_commit.clone();
-        squashed_commit.tree = top_most_commit.tree;
+        let mut squashed_commit = target_commit.clone();
+        squashed_commit.inner.parents = target_parent_ids.into();
+        squashed_commit.tree = squashed_tree.tree_id;
         squashed_commit.message = combined_message.into();
         editor.new_commit(squashed_commit, DateMode::CommitterUpdateAuthorKeep)?
     };
 
-    editor.replace(bottom_most_selector, Step::new_pick(new_commit))?;
+    editor.replace(target_selector, Step::new_pick(new_commit))?;
 
-    Ok((editor, bottom_most_selector))
+    Ok((editor, target_selector))
+}
+
+fn parent_commit_ids<M: RefMetadata>(
+    editor: &Editor<'_, '_, M>,
+    selector: Selector,
+) -> Result<Vec<gix::ObjectId>> {
+    let mut parents = editor.direct_parents(selector)?;
+    parents.sort_by_key(|(_, order)| *order);
+
+    parents
+        .into_iter()
+        .map(|(parent_selector, _)| match editor.lookup_step(parent_selector)? {
+            Step::Pick(_) => {
+                let (_, commit) = editor.find_selectable_commit(parent_selector)?;
+                Ok(commit.id)
+            }
+            Step::Reference { .. } => {
+                let (_, commit) = editor.find_reference_target(parent_selector)?;
+                Ok(commit.id)
+            }
+            Step::None => bail!(
+                "BUG: expected parent selector {parent_selector:?} to point to a pick or reference"
+            ),
+        })
+        .collect()
 }
 
 /// How to combine messages of commits being squashed.
@@ -133,21 +118,21 @@ but_schemars::register_sdk_type!(MessageCombinationStrategy);
 
 /// Squash `subjects` into `target_commit`.
 ///
-/// `subjects` may be provided in any order. They are ordered by
-/// parentage internally together with `target_commit` before reordering and
-/// squashing.
-///
 /// The `target_commit` must not also appear in `subjects`.
+/// This operation assumes the provided editor is already normalized and up to
+/// date. Callers chaining previous editor mutations should first run
+/// `editor.rebase()?.into_editor()` before squashing.
 ///
-/// After reordering and squashing, the resulting squashed commit has:
-/// - The tree of the commit that is top-most after reordering.
+/// After squashing, the resulting squashed commit has:
+/// - The tree produced from the target commit's full tree plus the subject
+///   commits' own change ranges.
 /// - A message determined by `how_to_combine_messages`:
 ///   - `KeepTarget`: target message only.
 ///   - `KeepSubject`: subject messages only.
 ///   - `KeepBoth`: target message followed by subject messages.
 ///
-/// Subject messages are appended in squash order (top-most first after
-/// reordering), with at least one blank line between non-empty message blocks.
+/// Subject messages are appended in the order they are provided, with at least
+/// one blank line between non-empty message blocks.
 ///
 pub fn squash_commits<'ws, 'meta, M: RefMetadata, S: ToCommitSelector, T: ToCommitSelector>(
     editor: Editor<'ws, 'meta, M>,
@@ -155,6 +140,8 @@ pub fn squash_commits<'ws, 'meta, M: RefMetadata, S: ToCommitSelector, T: ToComm
     target_commit: T,
     how_to_combine_messages: MessageCombinationStrategy,
 ) -> Result<SquashCommitsOutcome<'ws, 'meta, M>> {
+    let mut seen_subjects = std::collections::HashSet::with_capacity(subjects.len());
+
     if subjects.is_empty() {
         bail!("Need at least 2 commits to squash")
     }
@@ -162,43 +149,38 @@ pub fn squash_commits<'ws, 'meta, M: RefMetadata, S: ToCommitSelector, T: ToComm
     let (target_commit_selector, target_commit_obj) =
         editor.find_selectable_commit(target_commit)?;
 
-    let mut all_commits = Vec::with_capacity(subjects.len() + 1);
-    all_commits.push(target_commit_selector);
+    let mut subject_selectors = Vec::with_capacity(subjects.len());
     for subject_commit in subjects {
         let (subject_commit_selector, _) = editor.find_selectable_commit(subject_commit)?;
         if subject_commit_selector == target_commit_selector {
             bail!("Cannot squash a commit into itself")
         }
-        all_commits.push(subject_commit_selector);
+        if !seen_subjects.insert(subject_commit_selector) {
+            continue;
+        }
+        subject_selectors.push(subject_commit_selector);
     }
 
-    let ordered_selectors = editor.order_commit_selectors_by_parentage(all_commits)?;
-
-    let (editor, below_anchor, above_anchor) =
-        reorder_commits_around_target(editor, &ordered_selectors, target_commit_selector)?;
-
-    let rebase = editor.rebase()?;
-    let editor = rebase.into_editor();
-
-    for commit_selector in &ordered_selectors {
-        let (_, commit) = editor.find_selectable_commit(*commit_selector)?;
-        if commit.clone().attach(editor.repo()).is_conflicted() {
-            bail!(
-                "Commit {} became conflicted after reordering. Can't continue with squash.",
-                commit.id
-            );
-        }
+    let subject_commit_ids = subject_selectors
+        .iter()
+        .map(|commit_selector| {
+            let (_, commit) = editor.find_selectable_commit(*commit_selector)?;
+            Ok(commit.id)
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let squashed_tree = editor.merge_commit_changes_to_tree(
+        target_commit_obj.id,
+        subject_commit_ids,
+        editor.repo().merge_options_force_ours()?,
+    )?;
+    if squashed_tree.conflict.is_some() {
+        bail!("Cannot squash commits that would result in merge conflicts");
     }
 
     let mut combined_message = Vec::new();
     match how_to_combine_messages {
         MessageCombinationStrategy::KeepSubject => {
-            for source_id in ordered_selectors
-                .iter()
-                .rev()
-                .copied()
-                .filter(|commit_selector| *commit_selector != target_commit_selector)
-            {
+            for source_id in subject_selectors.iter().copied() {
                 let (_, source_commit) = editor.find_selectable_commit(source_id)?;
                 push_message_with_spacing(&mut combined_message, source_commit.message.as_ref());
             }
@@ -208,37 +190,34 @@ pub fn squash_commits<'ws, 'meta, M: RefMetadata, S: ToCommitSelector, T: ToComm
         }
         MessageCombinationStrategy::KeepBoth => {
             push_message_with_spacing(&mut combined_message, target_commit_obj.message.as_ref());
-            for source_id in ordered_selectors
-                .iter()
-                .rev()
-                .copied()
-                .filter(|commit_selector| *commit_selector != target_commit_selector)
-            {
+            for source_id in subject_selectors.iter().copied() {
                 let (_, source_commit) = editor.find_selectable_commit(source_id)?;
                 push_message_with_spacing(&mut combined_message, source_commit.message.as_ref());
             }
         }
     }
 
-    let (editor, bottom_most_selector) =
-        construct_new_squashed_commit(editor, above_anchor, below_anchor, combined_message)?;
-
-    let rebase = editor.rebase()?;
-    let mut editor = rebase.into_editor();
-
-    for commit_selector in ordered_selectors {
-        if commit_selector == below_anchor {
-            continue;
-        }
-        let Ok((selector, _)) = editor.find_selectable_commit(commit_selector) else {
-            continue;
+    let mut editor = editor;
+    for commit_selector in subject_selectors {
+        let delimiter = SegmentDelimiter {
+            child: commit_selector,
+            parent: commit_selector,
         };
+        editor.disconnect_segment_from(delimiter, SelectorSet::All, SelectorSet::All, false)?;
+        let (selector, _) = editor.find_selectable_commit(commit_selector)?;
         editor.replace(selector, Step::None)?;
     }
 
+    let (editor, new_target_selector) = construct_new_squashed_commit(
+        editor,
+        squashed_tree,
+        target_commit_selector,
+        combined_message,
+    )?;
+
     Ok(SquashCommitsOutcome {
         rebase: editor.rebase()?,
-        commit_selector: bottom_most_selector,
+        commit_selector: new_target_selector,
     })
 }
 

--- a/crates/but-workspace/tests/fixtures/scenario/ws-ref-ws-commit-double-stack-triple-stack-files.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/ws-ref-ws-commit-double-stack-triple-stack-files.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A ws-ref points to a workspace commit, with two deeper stacks inside:
+# - One stack `A -> D` with file-a and file-d changes
+# - Another stack `B -> C -> E` with file-b, file-c, and file-e changes
+git init
+
+echo base >base
+git add base
+git commit -m M
+setup_target_to_match_main
+
+git branch B
+git checkout -b A
+  echo a >file-a
+  git add file-a
+  git commit -m A
+git checkout A -b D
+  echo d >file-d
+  git add file-d
+  git commit -m D
+git checkout B
+  echo b >file-b
+  git add file-b
+  git commit -m B
+git checkout B -b C
+  echo c >file-c
+  git add file-c
+  git commit -m C
+git checkout C -b E
+  echo e >file-e
+  git add file-e
+  git commit -m E
+create_workspace_commit_once D E

--- a/crates/but-workspace/tests/fixtures/scenario/ws-ref-ws-commit-single-stack-double-stack-files.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/ws-ref-ws-commit-single-stack-double-stack-files.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A ws-ref points to a workspace commit, with two stacks inside:
+# - One stack `A` with file-a changes
+# - Another stack with `B` introducing file-b and `C` introducing file-c
+git init
+
+echo base >base
+git add base
+git commit -m M
+setup_target_to_match_main
+
+git branch B
+git checkout -b A
+  echo a >file-a
+  git add file-a
+  git commit -m A
+git checkout B
+  echo b >file-b
+  git add file-b
+  git commit -m B
+git checkout B -b C
+  echo c >file-c
+  git add file-c
+  git commit -m C
+create_workspace_commit_once A C

--- a/crates/but-workspace/tests/workspace/commit/squash_commits.rs
+++ b/crates/but-workspace/tests/workspace/commit/squash_commits.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use bstr::ByteSlice as _;
 use but_rebase::graph_rebase::{Editor, LookupStep};
 use but_testsupport::{graph_workspace, visualize_commit_graph_all};
@@ -192,6 +192,36 @@ fn squash_reorders_when_subject_is_not_on_top() -> Result<()> {
 }
 
 #[test]
+fn squash_deduplicates_duplicate_subjects() -> Result<()> {
+    let (_tmp, graph, repo, mut _meta, _description) =
+        writable_scenario("reword-three-commits", |_| {})?;
+
+    let subject_id = repo.rev_parse_single("three")?.detach();
+    let target_id = repo.rev_parse_single("two")?.detach();
+
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
+    let outcome = squash_commits(
+        editor,
+        vec![subject_id, subject_id],
+        target_id,
+        squash_commits::MessageCombinationStrategy::KeepBoth,
+    )?;
+
+    let materialized = outcome.rebase.materialize()?;
+    let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
+    let squashed_commit = repo.find_commit(squashed_id)?;
+
+    assert_eq!(
+        squashed_commit.message_raw()?,
+        "commit two\n\ncommit three\n",
+        "duplicate subject commits should only be squashed once"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn squash_same_commit_is_rejected() -> Result<()> {
     let (_tmp, graph, repo, mut _meta, _description) =
         writable_scenario("reword-three-commits", |_| {})?;
@@ -339,7 +369,7 @@ fn squash_move_subject_below_target_for_shared_file_lineage() -> Result<()> {
 }
 
 #[test]
-fn squash_move_subject_above_target_out_of_order_for_shared_file_lineage_fails() -> Result<()> {
+fn squash_move_subject_above_target_out_of_order_for_shared_file_lineage() -> Result<()> {
     let (_tmp, graph, repo, mut _meta, _description) =
         writable_scenario("squash-shared-file-three-commits", |_| {})?;
 
@@ -360,12 +390,10 @@ fn squash_move_subject_above_target_out_of_order_for_shared_file_lineage_fails()
         target_id,
         squash_commits::MessageCombinationStrategy::KeepBoth,
     )
-    .expect_err("must fail when reordering produces conflicts");
-
-    assert!(
-        err.to_string()
-            .contains("became conflicted after reordering"),
-        "error should explain that conflicted commits cannot be squashed"
+    .expect_err("squash should fail before rebase materialization when the merge conflicts");
+    assert_eq!(
+        err.to_string(),
+        "Cannot squash commits that would result in merge conflicts"
     );
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
@@ -507,6 +535,258 @@ fn squash_across_stacks_target_into_subject() -> Result<()> {
     └── ≡📙:4:B on 85efbe4 {2}
         └── 📙:4:B
     ");
+
+    Ok(())
+}
+
+#[test]
+fn squash_cross_stack_commit_does_not_pull_in_ancestor_tree_state() -> Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        writable_scenario("ws-ref-ws-commit-single-stack-double-stack-files", |meta| {
+            add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            add_stack_with_segments(meta, 2, "C", StackState::InWorkspace, &["B"]);
+        })?;
+
+    let normalized = visualize_commit_graph_all(&repo)?.replace("  \n", "\n");
+    insta::assert_snapshot!(normalized, @r"
+    *   c47834b (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\
+    | * 26e45af (A) A
+    * | 356de85 (C) C
+    * | f25f65c (B) B
+    |/
+    * 893d602 (origin/main, main) M
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    let subject_id = repo.rev_parse_single("C")?.detach();
+    let target_id = repo.rev_parse_single("A")?.detach();
+
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+    let outcome = squash_commits(
+        editor,
+        vec![subject_id],
+        target_id,
+        squash_commits::MessageCombinationStrategy::KeepBoth,
+    )?;
+
+    let materialized = outcome.rebase.materialize()?;
+    let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
+
+    let file_a = repo
+        .rev_parse_single(format!("{squashed_id}:file-a").as_str())
+        .with_context(|| format!("expected squashed commit {squashed_id} to contain file-a"))?
+        .object()
+        .with_context(|| {
+            format!("expected squashed commit {squashed_id}:file-a to resolve to an object")
+        })?;
+    assert_eq!(file_a.data.as_bstr(), "a\n");
+
+    let file_c = repo
+        .rev_parse_single(format!("{squashed_id}:file-c").as_str())
+        .with_context(|| format!("expected squashed commit {squashed_id} to contain file-c"))?
+        .object()
+        .with_context(|| {
+            format!("expected squashed commit {squashed_id}:file-c to resolve to an object")
+        })?;
+    assert_eq!(file_c.data.as_bstr(), "c\n");
+
+    let missing_file_b = repo
+        .rev_parse_single(format!("{squashed_id}:file-b").as_str())
+        .expect_err("squashing C into A should not pull in B's file");
+    assert!(
+        missing_file_b.to_string().contains("file-b"),
+        "missing file-b error should mention the absent path"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn squash_cross_stack_commit_with_deeper_stacks_does_not_pull_in_ancestor_tree_state() -> Result<()>
+{
+    let (_tmp, graph, repo, mut meta, _description) =
+        writable_scenario("ws-ref-ws-commit-double-stack-triple-stack-files", |meta| {
+            add_stack_with_segments(meta, 1, "D", StackState::InWorkspace, &["A"]);
+            add_stack_with_segments(meta, 2, "E", StackState::InWorkspace, &["B", "C"]);
+        })?;
+
+    let normalized = visualize_commit_graph_all(&repo)?.replace("  \n", "\n");
+    insta::assert_snapshot!(normalized, @r"
+    *   8cf5961 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\
+    | * e352141 (D) D
+    | * 26e45af (A) A
+    * | b9b4be4 (E) E
+    * | 356de85 (C) C
+    * | f25f65c (B) B
+    |/
+    * 893d602 (origin/main, main) M
+    ");
+
+    let a_id = repo.rev_parse_single("A")?.detach();
+    let d_id = repo.rev_parse_single("D")?.detach();
+    let b_id = repo.rev_parse_single("B")?.detach();
+    let c_id = repo.rev_parse_single("C")?.detach();
+    let e_id = repo.rev_parse_single("E")?.detach();
+
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+    let outcome = squash_commits(
+        editor,
+        vec![e_id],
+        d_id,
+        squash_commits::MessageCombinationStrategy::KeepBoth,
+    )?;
+
+    let materialized = outcome.rebase.materialize()?;
+    let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
+
+    let normalized = visualize_commit_graph_all(&repo)?.replace("  \n", "\n");
+    insta::assert_snapshot!(normalized, @r"
+    *   7dd4136 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\
+    | * 62c025c (D) D
+    | * 26e45af (A) A
+    * | 356de85 (E, C) C
+    * | f25f65c (B) B
+    |/
+    * 893d602 (origin/main, main) M
+    ");
+
+    let file_a = repo
+        .rev_parse_single(format!("{squashed_id}:file-a").as_str())
+        .with_context(|| format!("expected squashed commit {squashed_id} to contain file-a"))?
+        .object()
+        .with_context(|| {
+            format!("expected squashed commit {squashed_id}:file-a to resolve to an object")
+        })?;
+    assert_eq!(
+        file_a.data.as_bstr(),
+        "a\n",
+        "squashed commit should have file A"
+    );
+
+    let file_d = repo
+        .rev_parse_single(format!("{squashed_id}:file-d").as_str())
+        .with_context(|| format!("expected squashed commit {squashed_id} to contain file-d"))?
+        .object()
+        .with_context(|| {
+            format!("expected squashed commit {squashed_id}:file-d to resolve to an object")
+        })?;
+    assert_eq!(
+        file_d.data.as_bstr(),
+        "d\n",
+        "squashed commit should have file D"
+    );
+
+    let file_e = repo
+        .rev_parse_single(format!("{squashed_id}:file-e").as_str())
+        .with_context(|| format!("expected squashed commit {squashed_id} to contain file-e"))?
+        .object()
+        .with_context(|| {
+            format!("expected squashed commit {squashed_id}:file-e to resolve to an object")
+        })?;
+    assert_eq!(
+        file_e.data.as_bstr(),
+        "e\n",
+        "squashed commti should have file E"
+    );
+
+    let missing_file_b = repo
+        .rev_parse_single(format!("{squashed_id}:file-b").as_str())
+        .expect_err("squashing E into D should not pull in B's file");
+    assert!(
+        missing_file_b.to_string().contains("file-b"),
+        "missing file-b error should mention the absent path"
+    );
+
+    let missing_file_c = repo
+        .rev_parse_single(format!("{squashed_id}:file-c").as_str())
+        .expect_err("squashing E into D should not pull in C's file");
+    assert!(
+        missing_file_c.to_string().contains("file-c"),
+        "missing file-c error should mention the absent path"
+    );
+
+    let file_a_in_a = repo
+        .rev_parse_single(format!("{a_id}:file-a").as_str())
+        .with_context(|| format!("expected commit A ({a_id}) to contain file-a"))?
+        .object()
+        .with_context(|| format!("expected commit A ({a_id}):file-a to resolve to an object"))?;
+    assert_eq!(
+        file_a_in_a.data.as_bstr(),
+        "a\n",
+        "commit A should have file A"
+    );
+
+    let file_a_in_d = repo
+        .rev_parse_single(format!("{d_id}:file-a").as_str())
+        .with_context(|| format!("expected commit D ({d_id}) to contain file-a"))?
+        .object()
+        .with_context(|| format!("expected commit D ({d_id}):file-a to resolve to an object"))?;
+    assert_eq!(
+        file_a_in_d.data.as_bstr(),
+        "a\n",
+        "commit D should retain file A"
+    );
+
+    let file_d_in_d = repo
+        .rev_parse_single(format!("{d_id}:file-d").as_str())
+        .with_context(|| format!("expected commit D ({d_id}) to contain file-d"))?
+        .object()
+        .with_context(|| format!("expected commit D ({d_id}):file-d to resolve to an object"))?;
+    assert_eq!(
+        file_d_in_d.data.as_bstr(),
+        "d\n",
+        "commit D should have file D"
+    );
+
+    let file_b_in_b = repo
+        .rev_parse_single(format!("{b_id}:file-b").as_str())
+        .with_context(|| format!("expected commit B ({b_id}) to contain file-b"))?
+        .object()
+        .with_context(|| format!("expected commit B ({b_id}):file-b to resolve to an object"))?;
+    assert_eq!(file_b_in_b.data.as_bstr(), "b\n");
+
+    let file_b_in_c = repo
+        .rev_parse_single(format!("{c_id}:file-b").as_str())
+        .with_context(|| format!("expected commit C ({c_id}) to contain file-b"))?
+        .object()
+        .with_context(|| format!("expected commit C ({c_id}):file-b to resolve to an object"))?;
+    assert_eq!(file_b_in_c.data.as_bstr(), "b\n");
+
+    let file_c_in_c = repo
+        .rev_parse_single(format!("{c_id}:file-c").as_str())
+        .with_context(|| format!("expected commit C ({c_id}) to contain file-c"))?
+        .object()
+        .with_context(|| format!("expected commit C ({c_id}):file-c to resolve to an object"))?;
+    assert_eq!(file_c_in_c.data.as_bstr(), "c\n");
+
+    let file_b_in_e = repo
+        .rev_parse_single(format!("{e_id}:file-b").as_str())
+        .with_context(|| format!("expected commit E ({e_id}) to contain file-b"))?
+        .object()
+        .with_context(|| format!("expected commit E ({e_id}):file-b to resolve to an object"))?;
+    assert_eq!(file_b_in_e.data.as_bstr(), "b\n");
+
+    let file_c_in_e = repo
+        .rev_parse_single(format!("{e_id}:file-c").as_str())
+        .with_context(|| format!("expected commit E ({e_id}) to contain file-c"))?
+        .object()
+        .with_context(|| format!("expected commit E ({e_id}):file-c to resolve to an object"))?;
+    assert_eq!(file_c_in_e.data.as_bstr(), "c\n");
+
+    let file_e_in_e = repo
+        .rev_parse_single(format!("{e_id}:file-e").as_str())
+        .with_context(|| format!("expected commit E ({e_id}) to contain file-e"))?
+        .object()
+        .with_context(|| format!("expected commit E ({e_id}):file-e to resolve to an object"))?;
+    assert_eq!(
+        file_e_in_e.data.as_bstr(),
+        "e\n",
+        "commit E should have file E"
+    );
 
     Ok(())
 }

--- a/crates/but/tests/but/command/undo.rs
+++ b/crates/but/tests/but/command/undo.rs
@@ -345,7 +345,7 @@ fn can_undo_but_squash_with_three_commits() {
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-177ce51 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Squashed commit (a7a1cd4)
+f6b7464 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Squashed commit (a7a1cd4)
 a7a1cd4 2000-01-02 00:00:00 [SQUASH] Squashed commit
 c763bf9 2000-01-02 00:00:00 [REWORD] Updated commit message
 3d40c95 2000-01-02 00:00:00 [INSERT_COMMIT] Inserted blank commit


### PR DESCRIPTION
Use merge arithmetic instead of reordering the commits for a faster,
more reliable squash.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #13881 
- <kbd>&nbsp;2&nbsp;</kbd> #13873 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #13765 
<!-- GitButler Footer Boundary Bottom -->

