### PR TITLE
graphy remote branch integration

### DIFF
--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -7,8 +7,9 @@ use but_ctx::Context;
 use but_oplog::legacy::{OperationKind, SnapshotDetails, Trailer};
 use but_rebase::graph_rebase::{Editor, SuccessfulRebase};
 use but_workspace::branch::{
-    OnWorkspaceMergeConflict,
+    BranchIntegrationStrategy, InitialBranchIntegration, OnWorkspaceMergeConflict,
     apply::{WorkspaceMerge, WorkspaceReferenceNaming},
+    integrate_branch_upstream::InteractiveIntegration,
 };
 use tracing::instrument;
 
@@ -18,11 +19,20 @@ pub struct MoveBranchResult {
     pub workspace: WorkspaceState,
 }
 
+/// Outcome after integrating a branch with an interactive integration plan.
+pub struct IntegrateBranchResult {
+    /// Workspace state after applying or previewing the integration.
+    pub workspace: WorkspaceState,
+}
+
 /// JSON transport types for branch APIs.
 pub mod json {
-    use serde::Serialize;
+    use serde::{Deserialize, Serialize};
 
-    use crate::branch::MoveBranchResult as InternalMoveBranchResult;
+    use crate::branch::{
+        IntegrateBranchResult as InternalIntegrateBranchResult,
+        MoveBranchResult as InternalMoveBranchResult,
+    };
 
     /// JSON sibling of [`but_workspace::branch::apply::Outcome`].
     #[derive(Debug, Serialize)]
@@ -75,6 +85,327 @@ pub mod json {
         fn try_from(value: InternalMoveBranchResult) -> Result<Self, Self::Error> {
             Ok(Self {
                 workspace: value.workspace.try_into()?,
+            })
+        }
+    }
+
+    #[derive(Debug, Serialize)]
+    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+    #[serde(rename_all = "camelCase")]
+    /// JSON transport type for integrating a branch.
+    pub struct IntegrateBranchResult {
+        /// Workspace state after applying or previewing the integration.
+        pub workspace: crate::json::WorkspaceState,
+    }
+    #[cfg(feature = "export-schema")]
+    but_schemars::register_sdk_type!(IntegrateBranchResult);
+
+    impl TryFrom<InternalIntegrateBranchResult> for IntegrateBranchResult {
+        type Error = anyhow::Error;
+
+        fn try_from(value: InternalIntegrateBranchResult) -> Result<Self, Self::Error> {
+            Ok(Self {
+                workspace: value.workspace.try_into()?,
+            })
+        }
+    }
+
+    /// JSON transport type for a divergence commit row.
+    #[derive(Debug, Serialize)]
+    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+    #[serde(rename_all = "camelCase", tag = "kind")]
+    pub enum IntegrationDivergenceTargetRelation {
+        /// The commit is not present in the target branch.
+        NotIntegrated,
+        /// The exact commit is reachable from target branch history.
+        HistoricallyIntegrated {
+            /// The target branch commit that establishes the relation.
+            #[serde(rename = "targetCommitId")]
+            #[cfg_attr(feature = "export-schema", schemars(rename = "targetCommitId"))]
+            target_commit_id: crate::json::HexHashString,
+        },
+    }
+
+    #[cfg(feature = "export-schema")]
+    but_schemars::register_sdk_type!(IntegrationDivergenceTargetRelation);
+
+    impl From<but_workspace::branch::IntegrationDivergenceTargetRelation>
+        for IntegrationDivergenceTargetRelation
+    {
+        fn from(value: but_workspace::branch::IntegrationDivergenceTargetRelation) -> Self {
+            match value {
+                but_workspace::branch::IntegrationDivergenceTargetRelation::NotIntegrated => {
+                    Self::NotIntegrated
+                }
+                but_workspace::branch::IntegrationDivergenceTargetRelation::HistoricallyIntegrated {
+                    target_commit_id,
+                } => Self::HistoricallyIntegrated {
+                    target_commit_id: target_commit_id.into(),
+                },
+            }
+        }
+    }
+
+    /// JSON transport type for a divergence commit row.
+    #[derive(Debug, Serialize)]
+    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+    #[serde(rename_all = "camelCase")]
+    pub struct IntegrationDivergenceCommit {
+        /// The commit shown in the graph row.
+        pub id: crate::json::HexHashString,
+        /// The first-line subject shown for the commit.
+        pub subject: String,
+        /// The explicit GitButler Change-Id stored in the commit headers, if present.
+        pub change_id: Option<String>,
+        /// Commit creation time in Epoch milliseconds.
+        pub created_at: i128,
+        /// The author of the commit.
+        pub author: but_workspace::ui::Author,
+        /// Human-facing ref labels rendered inline on the commit row.
+        pub refs: Vec<String>,
+        /// How this commit relates to the configured target branch.
+        pub target_relation: IntegrationDivergenceTargetRelation,
+    }
+    #[cfg(feature = "export-schema")]
+    but_schemars::register_sdk_type!(IntegrationDivergenceCommit);
+
+    impl From<but_workspace::branch::IntegrationDivergenceCommit> for IntegrationDivergenceCommit {
+        fn from(value: but_workspace::branch::IntegrationDivergenceCommit) -> Self {
+            let but_workspace::branch::IntegrationDivergenceCommit {
+                id,
+                subject,
+                change_id,
+                created_at,
+                author,
+                refs,
+                target_relation,
+            } = value;
+            Self {
+                id: id.into(),
+                subject,
+                change_id,
+                created_at,
+                author,
+                refs,
+                target_relation: target_relation.into(),
+            }
+        }
+    }
+
+    /// JSON transport type for current branch/upstream divergence information.
+    #[derive(Debug, Serialize)]
+    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+    #[serde(rename_all = "camelCase")]
+    pub struct IntegrationDivergenceDisplay {
+        /// The local branch being integrated.
+        pub branch_ref_name: crate::json::FullRefName,
+        /// The upstream branch this local branch integrates with.
+        pub upstream_ref_name: crate::json::FullRefName,
+        /// Commits only reachable from the local branch tip down to the shared section.
+        pub local_only: Vec<IntegrationDivergenceCommit>,
+        /// Commits only reachable from the upstream branch tip down to the shared section.
+        pub upstream_only: Vec<IntegrationDivergenceCommit>,
+        /// The merge-base row shown once at the bottom.
+        pub merge_base: IntegrationDivergenceCommit,
+    }
+    #[cfg(feature = "export-schema")]
+    but_schemars::register_sdk_type!(IntegrationDivergenceDisplay);
+
+    impl From<but_workspace::branch::IntegrationDivergenceDisplay> for IntegrationDivergenceDisplay {
+        fn from(value: but_workspace::branch::IntegrationDivergenceDisplay) -> Self {
+            let but_workspace::branch::IntegrationDivergenceDisplay {
+                branch_ref_name,
+                upstream_ref_name,
+                local_only,
+                upstream_only,
+                merge_base,
+            } = value;
+            Self {
+                branch_ref_name: branch_ref_name.into(),
+                upstream_ref_name: upstream_ref_name.into(),
+                local_only: local_only.into_iter().map(Into::into).collect(),
+                upstream_only: upstream_only.into_iter().map(Into::into).collect(),
+                merge_base: merge_base.into(),
+            }
+        }
+    }
+
+    /// JSON transport type for the preset used to generate initial branch integration steps.
+    #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+    #[serde(rename_all = "camelCase")]
+    pub enum BranchIntegrationStrategy {
+        /// Rebase local commits on top of the upstream commits.
+        PullRebase,
+        /// Keep local commits first, then merge the upstream tip.
+        Merge,
+        /// Rebuild the branch by picking upstream commits only.
+        PickRemote,
+        /// Fold upstream commits with matching explicit Change-Ids into local commits.
+        SmartSquash,
+    }
+    #[cfg(feature = "export-schema")]
+    but_schemars::register_sdk_type!(BranchIntegrationStrategy);
+
+    impl From<BranchIntegrationStrategy> for but_workspace::branch::BranchIntegrationStrategy {
+        fn from(value: BranchIntegrationStrategy) -> Self {
+            match value {
+                BranchIntegrationStrategy::PullRebase => Self::PullRebase,
+                BranchIntegrationStrategy::Merge => Self::Merge,
+                BranchIntegrationStrategy::PickRemote => Self::PickRemote,
+                BranchIntegrationStrategy::SmartSquash => Self::SmartSquash,
+            }
+        }
+    }
+
+    /// JSON transport type for a branch integration step.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+    #[serde(rename_all = "camelCase", tag = "kind")]
+    pub enum InteractiveIntegrationStep {
+        /// Pick a commit, keeping it in the branch.
+        Pick {
+            /// The local commit to keep in the rewritten branch.
+            #[serde(rename = "commitId")]
+            #[cfg_attr(feature = "export-schema", schemars(rename = "commitId"))]
+            commit_id: crate::json::HexHashString,
+        },
+        /// Squash multiple commits into one.
+        Squash {
+            /// The ordered commits to squash together.
+            commits: Vec<crate::json::HexHashString>,
+            /// Optional replacement message for the squash commit.
+            message: Option<String>,
+        },
+        /// Merge a commit into the previous one.
+        Merge {
+            /// The commit whose change range should be merged.
+            #[serde(rename = "commitId")]
+            #[cfg_attr(feature = "export-schema", schemars(rename = "commitId"))]
+            commit_id: crate::json::HexHashString,
+        },
+    }
+    #[cfg(feature = "export-schema")]
+    but_schemars::register_sdk_type!(InteractiveIntegrationStep);
+
+    impl TryFrom<InteractiveIntegrationStep>
+        for but_workspace::branch::integrate_branch_upstream::InteractiveIntegrationStep
+    {
+        type Error = anyhow::Error;
+
+        fn try_from(value: InteractiveIntegrationStep) -> Result<Self, Self::Error> {
+            Ok(match value {
+                InteractiveIntegrationStep::Pick { commit_id } => Self::Pick {
+                    commit_id: commit_id.try_into()?,
+                },
+                InteractiveIntegrationStep::Squash { commits, message } => Self::Squash {
+                    commits: commits
+                        .into_iter()
+                        .map(TryInto::try_into)
+                        .collect::<Result<_, _>>()?,
+                    message,
+                },
+                InteractiveIntegrationStep::Merge { commit_id } => Self::Merge {
+                    commit_id: commit_id.try_into()?,
+                },
+            })
+        }
+    }
+
+    /// JSON transport type describing an interactive branch integration plan.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+    #[serde(rename_all = "camelCase")]
+    pub struct InteractiveIntegration {
+        /// Merge base between the upstream and the local reference.
+        #[serde(rename = "mergeBase")]
+        #[cfg_attr(feature = "export-schema", schemars(rename = "mergeBase"))]
+        pub merge_base: crate::json::HexHashString,
+        /// The first parent-to-child local commit that is not historically integrated into target.
+        pub first_local_not_integrated: Option<crate::json::HexHashString>,
+        /// The ordered integration steps to apply.
+        pub steps: Vec<InteractiveIntegrationStep>,
+    }
+    #[cfg(feature = "export-schema")]
+    but_schemars::register_sdk_type!(InteractiveIntegration);
+
+    impl TryFrom<InteractiveIntegration>
+        for but_workspace::branch::integrate_branch_upstream::InteractiveIntegration
+    {
+        type Error = anyhow::Error;
+
+        fn try_from(value: InteractiveIntegration) -> Result<Self, Self::Error> {
+            let InteractiveIntegration {
+                merge_base,
+                first_local_not_integrated,
+                steps,
+            } = value;
+            Ok(Self {
+                merge_base: merge_base.try_into()?,
+                first_local_not_integrated: first_local_not_integrated
+                    .map(TryInto::try_into)
+                    .transpose()?,
+                steps: steps
+                    .into_iter()
+                    .map(TryInto::try_into)
+                    .collect::<Result<_, _>>()?,
+            })
+        }
+    }
+
+    /// JSON transport type for the initial branch integration proposal.
+    #[derive(Debug, Serialize)]
+    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+    #[serde(rename_all = "camelCase")]
+    pub struct InitialBranchIntegration {
+        /// The editable execution plan for integrating the branch upstream.
+        pub integration: InteractiveIntegration,
+        /// The current divergence between local branch and upstream for display.
+        pub divergence: IntegrationDivergenceDisplay,
+    }
+    #[cfg(feature = "export-schema")]
+    but_schemars::register_sdk_type!(InitialBranchIntegration);
+
+    impl TryFrom<but_workspace::branch::InitialBranchIntegration> for InitialBranchIntegration {
+        type Error = anyhow::Error;
+
+        fn try_from(
+            value: but_workspace::branch::InitialBranchIntegration,
+        ) -> Result<Self, Self::Error> {
+            let but_workspace::branch::InitialBranchIntegration {
+                integration,
+                divergence,
+            } = value;
+            Ok(Self {
+                integration: InteractiveIntegration {
+                    merge_base: integration.merge_base.into(),
+                    first_local_not_integrated: integration
+                        .first_local_not_integrated
+                        .map(Into::into),
+                    steps: integration
+                        .steps
+                        .into_iter()
+                        .map(|step| match step {
+                            but_workspace::branch::integrate_branch_upstream::InteractiveIntegrationStep::Pick { commit_id } => {
+                                InteractiveIntegrationStep::Pick {
+                                    commit_id: commit_id.into(),
+                                }
+                            }
+                            but_workspace::branch::integrate_branch_upstream::InteractiveIntegrationStep::Squash { commits, message } => {
+                                InteractiveIntegrationStep::Squash {
+                                    commits: commits.into_iter().map(Into::into).collect(),
+                                    message,
+                                }
+                            }
+                            but_workspace::branch::integrate_branch_upstream::InteractiveIntegrationStep::Merge { commit_id } => {
+                                InteractiveIntegrationStep::Merge {
+                                    commit_id: commit_id.into(),
+                                }
+                            }
+                        })
+                        .collect(),
+                },
+                divergence: divergence.into(),
             })
         }
     }
@@ -185,6 +516,81 @@ pub fn branch_diff(ctx: &Context, branch: String) -> anyhow::Result<TreeChanges>
     let (_guard, repo, ws, _) = ctx.workspace_and_db()?;
     let branch = repo.find_reference(&branch)?;
     but_workspace::ui::diff::changes_in_branch(&repo, &ws, branch.name())
+}
+
+/// Get the initial upstream integration script for `branch`.
+#[but_api(napi, try_from = json::InitialBranchIntegration)]
+#[instrument(err(Debug))]
+pub fn get_initial_branch_integration(
+    ctx: &Context,
+    branch: &gix::refs::FullNameRef,
+    strategy: Option<json::BranchIntegrationStrategy>,
+) -> anyhow::Result<InitialBranchIntegration> {
+    let mut meta = ctx.meta()?;
+    let (_guard, repo, ws, _) = ctx.workspace_and_db()?;
+    let mut ws = ws.clone();
+    let strategy = strategy
+        .map(BranchIntegrationStrategy::from)
+        .unwrap_or_default();
+    but_workspace::branch::integrate_branch_upstream::get_initial_integration_steps_for_branch(
+        branch, strategy, &mut ws, &mut meta, &repo,
+    )
+}
+
+/// Apply `integration` to `branch`.
+///
+/// This acquires exclusive worktree access from `ctx`, applies the integration
+/// steps to the branch, and records an oplog snapshot on success. When
+/// `dry_run` is enabled, the returned workspace previews the integration
+/// result and no oplog entry is persisted.
+#[but_api(napi, try_from = json::IntegrateBranchResult)]
+#[instrument(err(Debug))]
+pub fn apply_branch_integration(
+    ctx: &mut but_ctx::Context,
+    branch: &gix::refs::FullNameRef,
+    integration: json::InteractiveIntegration,
+    dry_run: DryRun,
+) -> anyhow::Result<IntegrateBranchResult> {
+    let integration: InteractiveIntegration = integration.try_into()?;
+    let mut guard = ctx.exclusive_worktree_access();
+    apply_branch_integration_with_perm(ctx, branch, integration, dry_run, guard.write_permission())
+}
+
+/// Apply `integration` to `branch` under caller-held exclusive repository access.
+///
+/// It prepares a best-effort oplog snapshot, runs the interactive branch
+/// integration, and commits the snapshot only if the operation succeeds. The
+/// returned [`IntegrateBranchResult`] contains the post-operation workspace
+/// view. When `dry_run` is enabled, it returns a preview of the resulting
+/// workspace state and skips oplog persistence.
+pub fn apply_branch_integration_with_perm(
+    ctx: &mut but_ctx::Context,
+    branch: &gix::refs::FullNameRef,
+    integration: InteractiveIntegration,
+    dry_run: DryRun,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<IntegrateBranchResult> {
+    branch_mutation_with_snapshot(
+        ctx,
+        perm,
+        OperationKind::GenericBranchUpdate,
+        dry_run,
+        |ctx, perm| {
+            let mut meta = ctx.meta()?;
+            let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
+            let rebase = but_workspace::branch::integrate_branch_with_steps(
+                branch,
+                integration,
+                &mut ws,
+                &mut meta,
+                &repo,
+            )?;
+
+            Ok(IntegrateBranchResult {
+                workspace: WorkspaceState::from_successful_rebase(rebase, &repo, dry_run)?,
+            })
+        },
+    )
 }
 
 /// Moves a branch using the behavior described by [`move_branch_with_perm()`].
@@ -299,15 +705,15 @@ pub fn tear_off_branch_with_perm(
     )
 }
 
-fn branch_mutation_with_snapshot<F>(
+fn branch_mutation_with_snapshot<T, F>(
     ctx: &mut but_ctx::Context,
     perm: &mut RepoExclusive,
     operation_kind: OperationKind,
     dry_run: DryRun,
     operation: F,
-) -> anyhow::Result<MoveBranchResult>
+) -> anyhow::Result<T>
 where
-    F: FnOnce(&mut but_ctx::Context, &mut RepoExclusive) -> anyhow::Result<MoveBranchResult>,
+    F: FnOnce(&mut but_ctx::Context, &mut RepoExclusive) -> anyhow::Result<T>,
 {
     let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
         ctx,

--- a/crates/but-api/src/json.rs
+++ b/crates/but-api/src/json.rs
@@ -131,6 +131,9 @@ mod hex_hash {
 }
 pub use hex_hash::{HexHash, HexHashString};
 
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(HexHashString);
+
 /// Shared JSON transport type for mutation workspace results.
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -546,6 +546,14 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
         .route("/branch_diff", but_post(but_api::branch::branch_diff_cmd))
         .route("/move_branch", but_post(but_api::branch::move_branch_cmd))
         .route(
+            "/get_initial_branch_integration",
+            but_post(but_api::branch::get_initial_branch_integration_cmd),
+        )
+        .route(
+            "/apply_branch_integration",
+            but_post(but_api::branch::apply_branch_integration_cmd),
+        )
+        .route(
             "/tear_off_branch",
             but_post(but_api::branch::tear_off_branch_cmd),
         )

--- a/crates/but-workspace/src/branch/integrate_branch_upstream/display.rs
+++ b/crates/but-workspace/src/branch/integrate_branch_upstream/display.rs
@@ -1,0 +1,266 @@
+//! Display-oriented types and helpers for branch upstream integration.
+
+use std::{collections::HashMap, fmt};
+
+use anyhow::Result;
+use bstr::ByteSlice;
+use but_core::commit::Headers;
+
+use crate::{divergence::TargetCommitRelation, ui::Author};
+
+/// A single commit row in the divergence display.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationDivergenceCommit {
+    /// The commit shown in the graph row.
+    pub id: gix::ObjectId,
+    /// The first-line subject shown for the commit.
+    pub subject: String,
+    /// The explicit GitButler Change-Id stored in the commit headers, if present.
+    pub change_id: Option<String>,
+    /// Commit creation time in Epoch milliseconds.
+    pub created_at: i128,
+    /// The author of the commit.
+    pub author: Author,
+    /// Human-facing ref labels rendered inline on the commit row.
+    pub refs: Vec<String>,
+    /// How the commit relates to the configured target branch.
+    pub target_relation: IntegrationDivergenceTargetRelation,
+}
+
+/// How a divergence commit relates to the configured target branch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IntegrationDivergenceTargetRelation {
+    /// The commit is not present in the target branch.
+    NotIntegrated,
+    /// The exact commit is reachable from target branch history.
+    HistoricallyIntegrated {
+        /// The target branch commit that establishes the relation.
+        target_commit_id: gix::ObjectId,
+    },
+}
+
+impl From<TargetCommitRelation> for IntegrationDivergenceTargetRelation {
+    fn from(value: TargetCommitRelation) -> Self {
+        match value {
+            TargetCommitRelation::NotIntegrated => Self::NotIntegrated,
+            TargetCommitRelation::HistoricallyIntegrated { target_commit_id } => {
+                Self::HistoricallyIntegrated { target_commit_id }
+            }
+        }
+    }
+}
+
+/// Current branch/upstream divergence information for display purposes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationDivergenceDisplay {
+    /// The local branch being integrated.
+    pub branch_ref_name: gix::refs::FullName,
+    /// The upstream branch this local branch integrates with.
+    pub upstream_ref_name: gix::refs::FullName,
+    /// Commits only reachable from the local branch tip down to the shared section.
+    pub local_only: Vec<IntegrationDivergenceCommit>,
+    /// Commits only reachable from the upstream branch tip down to the shared section.
+    pub upstream_only: Vec<IntegrationDivergenceCommit>,
+    /// The merge-base row shown once at the bottom.
+    pub merge_base: IntegrationDivergenceCommit,
+}
+
+impl fmt::Display for IntegrationDivergenceDisplay {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for commit in &self.local_only {
+            writeln!(f, "{}", graph_commit_string("* ", commit))?;
+        }
+        for commit in &self.upstream_only {
+            let prefix = if self.local_only.is_empty() {
+                "* "
+            } else {
+                "| * "
+            };
+            writeln!(f, "{}", graph_commit_string(prefix, commit))?;
+        }
+        if !self.local_only.is_empty() && !self.upstream_only.is_empty() {
+            writeln!(f, "|/")?;
+        }
+        write!(f, "{}", graph_commit_string("* ", &self.merge_base))
+    }
+}
+
+/// Build a display row for a single divergence commit.
+///
+/// `repo` provides commit decoding so the commit subject can be loaded.
+///
+/// `commit_id` is the commit that should be rendered in the divergence view.
+///
+/// `target_relation` describes how `commit_id` relates to the configured target
+/// branch.
+///
+/// Returns the populated display row with subject text and target relation.
+pub(super) fn divergence_commit(
+    repo: &gix::Repository,
+    commit_id: gix::ObjectId,
+    target_relation: TargetCommitRelation,
+) -> Result<IntegrationDivergenceCommit> {
+    let commit_object = repo.find_commit(commit_id)?;
+    let commit = commit_object.decode()?;
+    let headers = Headers::try_from_commit_headers(|| commit.extra_headers());
+    Ok(IntegrationDivergenceCommit {
+        id: commit_id,
+        subject: commit
+            .message
+            .lines()
+            .next()
+            .unwrap_or_default()
+            .to_str_lossy()
+            .into_owned(),
+        change_id: headers
+            .and_then(|headers| headers.change_id)
+            .map(|change_id| change_id.to_string()),
+        created_at: i128::from(commit.time()?.seconds) * 1000,
+        author: commit.author()?.into(),
+        refs: Vec::new(),
+        target_relation: target_relation.into(),
+    })
+}
+
+/// Attach a ref label to the matching displayed commit row.
+///
+/// `primary` is the primary list of display rows to search first, such as the
+/// local-only or upstream-only side of the divergence.
+///
+/// `merge_base` is the shared merge-base row that should receive the label if
+/// the labeled commit is not present in `primary`.
+///
+/// `id` is the optional commit id that should receive `label`.
+///
+/// `label` is the human-facing ref label to append when the target row is
+/// found.
+///
+/// Returns `()` after applying the label in place when a matching commit row
+/// exists.
+pub(super) fn add_ref_label(
+    primary: &mut [IntegrationDivergenceCommit],
+    merge_base: &mut IntegrationDivergenceCommit,
+    id: Option<gix::ObjectId>,
+    label: String,
+) {
+    let Some(id) = id else {
+        return;
+    };
+    if let Some(commit) = primary.iter_mut().find(|commit| commit.id == id) {
+        if !commit.refs.contains(&label) {
+            commit.refs.push(label);
+        }
+        return;
+    }
+    if merge_base.id == id && !merge_base.refs.contains(&label) {
+        merge_base.refs.push(label);
+    }
+}
+
+/// Look up the target-branch relation for a displayed commit.
+///
+/// `target_relations` is the precomputed map of commit ids to their target
+/// branch relation.
+///
+/// `commit_id` is the commit whose relation should be retrieved.
+///
+/// Returns the stored relation for `commit_id`, or `NotIntegrated` when the
+/// commit is absent from the map.
+pub(super) fn relation_for(
+    target_relations: &HashMap<gix::ObjectId, TargetCommitRelation>,
+    commit_id: gix::ObjectId,
+) -> TargetCommitRelation {
+    target_relations
+        .get(&commit_id)
+        .copied()
+        .unwrap_or(TargetCommitRelation::NotIntegrated)
+}
+
+fn graph_commit_string(prefix: &str, commit: &IntegrationDivergenceCommit) -> String {
+    let refs = if commit.refs.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", commit.refs.join(", "))
+    };
+    format!(
+        "{prefix}{}{} {}",
+        commit.id.to_hex_with_len(7),
+        refs,
+        commit.subject
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn oid(hex: &str) -> gix::ObjectId {
+        gix::ObjectId::from_hex(hex.as_bytes()).expect("valid object id")
+    }
+
+    #[test]
+    fn divergence_display_renders_git_style_graph() {
+        let display = IntegrationDivergenceDisplay {
+            branch_ref_name: gix::refs::Category::LocalBranch
+                .to_full_name("feature")
+                .expect("valid local branch"),
+            upstream_ref_name: gix::refs::Category::RemoteBranch
+                .to_full_name("origin/feature")
+                .expect("valid remote branch"),
+            local_only: vec![IntegrationDivergenceCommit {
+                id: oid("1111111111111111111111111111111111111111"),
+                subject: "local tip".into(),
+                change_id: None,
+                created_at: 0,
+                author: author(),
+                refs: vec!["feature".into()],
+                target_relation: IntegrationDivergenceTargetRelation::NotIntegrated,
+            }],
+            upstream_only: vec![IntegrationDivergenceCommit {
+                id: oid("2222222222222222222222222222222222222222"),
+                subject: "remote tip".into(),
+                change_id: None,
+                created_at: 0,
+                author: author(),
+                refs: vec!["origin/feature".into()],
+                target_relation: IntegrationDivergenceTargetRelation::NotIntegrated,
+            }],
+            merge_base: IntegrationDivergenceCommit {
+                id: oid("3333333333333333333333333333333333333333"),
+                subject: "base".into(),
+                change_id: None,
+                created_at: 0,
+                author: author(),
+                refs: Vec::new(),
+                target_relation: IntegrationDivergenceTargetRelation::NotIntegrated,
+            },
+        };
+
+        insta::assert_snapshot!(
+            display.to_string(),
+            "graph output should stay stable because the CLI and frontend consume it directly",
+            @r"
+        * 1111111 (feature) local tip
+        | * 2222222 (origin/feature) remote tip
+        |/
+        * 3333333 base
+        "
+        );
+    }
+
+    fn gravatar_url_from_email(email: &str) -> url::Url {
+        let gravatar_url = format!(
+            "https://www.gravatar.com/avatar/{:x}?s=100&r=g&d=retro",
+            md5::compute(email.to_lowercase())
+        );
+        url::Url::parse(gravatar_url.as_str()).unwrap()
+    }
+
+    fn author() -> Author {
+        Author {
+            name: "Author".into(),
+            email: "author@example.com".into(),
+            gravatar_url: gravatar_url_from_email("author@example.com"),
+        }
+    }
+}

--- a/crates/but-workspace/src/branch/integrate_branch_upstream/mod.rs
+++ b/crates/but-workspace/src/branch/integrate_branch_upstream/mod.rs
@@ -1,0 +1,358 @@
+use std::{collections::HashMap, fmt};
+
+use anyhow::{Result, bail};
+use but_core::{RefMetadata, commit::Headers};
+use but_rebase::graph_rebase::{
+    Editor, ExtraRef, GraphEditorOptions, LookupStep, SuccessfulRebase, ToSelector,
+    mutate::{SegmentDelimiter, SelectorSet},
+};
+
+use crate::graph_manipulation::{EdgeSelection, connect_segment_to_edges, selected_edges_from_set};
+use crate::{
+    branch::integrate_branch_upstream::plan::{
+        editable_local_commits, initial_integration_steps, integration_steps_into_segment_nodes,
+    },
+    divergence::{
+        BranchMergeBaseCommits, classify_selectors_against_target_ref, commit_ids_from_selectors,
+        get_commits_until_merge_base,
+    },
+};
+use crate::{
+    divergence::resolve_tracking_branch_ref_name, graph_manipulation::determine_parent_selector,
+};
+
+mod display;
+mod plan;
+
+pub use display::{
+    IntegrationDivergenceCommit, IntegrationDivergenceDisplay, IntegrationDivergenceTargetRelation,
+};
+use display::{add_ref_label, divergence_commit, relation_for};
+pub use plan::BranchIntegrationStrategy;
+use plan::prepare_integration_steps_for_editor;
+/// The steps to be followed when integrating upstream changes into the local one.
+#[derive(Debug)]
+pub enum InteractiveIntegrationStep {
+    /// Pick a commit, keeping it in the branch.
+    Pick {
+        /// The SHA of the commit being picked.
+        commit_id: gix::ObjectId,
+    },
+    /// Squash the commits into one.
+    Squash {
+        /// The SHAs of the commits to squash.
+        commits: Vec<gix::ObjectId>,
+        /// Optionally, the message to use for the squash commit.
+        message: Option<String>,
+    },
+    /// Merge a commit into the previous one.
+    Merge {
+        /// The SHA of the commit to merge.
+        commit_id: gix::ObjectId,
+    },
+}
+
+impl fmt::Display for InteractiveIntegrationStep {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Pick { commit_id } => write!(f, "pick {commit_id}"),
+            Self::Merge { commit_id } => write!(f, "merge {commit_id}"),
+            Self::Squash { commits, message } => {
+                write!(f, "squash")?;
+                for commit_id in commits {
+                    write!(f, " {commit_id}")?;
+                }
+                if let Some(message) = message {
+                    write!(f, " | message={message:?}")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+/// The necessary information about the integration to be performed.
+#[derive(Debug)]
+pub struct InteractiveIntegration {
+    /// The list of steps to follow in order to integrate the upstream changes into the local.
+    pub steps: Vec<InteractiveIntegrationStep>,
+    /// Merge base between the upstream and the local reference.
+    pub merge_base: gix::ObjectId,
+    /// The first parent-to-child local commit that is not historically integrated into target.
+    pub first_local_not_integrated: Option<gix::ObjectId>,
+}
+
+impl fmt::Display for InteractiveIntegration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "merge-base {}", self.merge_base)?;
+        for step in &self.steps {
+            writeln!(f, "{step}")?;
+        }
+        Ok(())
+    }
+}
+
+/// The initial integration proposal for a branch.
+#[derive(Debug)]
+pub struct InitialBranchIntegration {
+    /// The editable execution plan for integrating the branch upstream.
+    pub integration: InteractiveIntegration,
+    /// The current divergence between local branch and upstream for display.
+    pub divergence: IntegrationDivergenceDisplay,
+}
+
+/// Integrate the upstream changes in the order of the provided steps.
+///
+/// `ref_name` - The full reference name of the local branch we're integrating the upstream changes into.
+///
+/// `steps` - The vector of steps in the application order (parent to child) that describe the actions to perform
+///   for the integration of the changes.
+pub fn integrate_branch_with_steps<'ws, 'meta, M: RefMetadata>(
+    ref_name: &gix::refs::FullNameRef,
+    integration: InteractiveIntegration,
+    workspace: &'ws mut but_graph::Workspace,
+    meta: &'meta mut M,
+    repo: &gix::Repository,
+) -> Result<SuccessfulRebase<'ws, 'meta, M>> {
+    if integration.steps.is_empty() {
+        bail!("Integration steps cannot be empty")
+    }
+    let upstream_ref_name = resolve_tracking_branch_ref_name(ref_name, repo)?;
+
+    let upstream_ref_name = upstream_ref_name.as_ref();
+    // We build an editor that also maps the remote reference of the branch we're integrating into.
+    let editor_options = GraphEditorOptions {
+        extra_refs: vec![ExtraRef::immutable(upstream_ref_name)],
+        ..GraphEditorOptions::default()
+    };
+    let mut editor = Editor::create_with_opts(workspace, meta, repo, &editor_options)?;
+    // Step 1: We prepare the steps before building.
+    // At this point, we construct the commits for the squash steps in memory.
+    let prepared_steps = prepare_integration_steps_for_editor(&editor, &integration.steps)?;
+
+    let delimiter_child = editor.select_reference(ref_name)?;
+    let delimiter_parent =
+        if let Some(first_local_not_integrated_commit) = integration.first_local_not_integrated {
+            editor.select_commit(first_local_not_integrated_commit)?
+        } else {
+            editor.select_reference(ref_name)?
+        };
+    // Segment, from local-ref to the parent-most non-integrated local commit.
+    // This represents the bounds of the commit chain we're about to manipulate and rebuild.
+    let segment_delimiter = SegmentDelimiter {
+        child: delimiter_child,
+        parent: delimiter_parent,
+    };
+
+    // Step 2: We determine which children and parents to disconnect from the segment above.
+    // We keep track of them so that we can reconnect them after we've done the chain-rebuild.
+    let children_to_disconnect = SelectorSet::All;
+    let parents_to_disconnect = determine_parent_selector(&editor, delimiter_parent)?;
+
+    let children_to_reconnect = selected_edges_from_set(
+        &editor,
+        segment_delimiter.child,
+        &children_to_disconnect,
+        EdgeSelection::Children,
+    )?;
+    let parents_to_reconnect = selected_edges_from_set(
+        &editor,
+        segment_delimiter.parent,
+        &parents_to_disconnect,
+        EdgeSelection::Parents,
+    )?;
+
+    // Step 3: Disconnect the segment, isolating it so that we can freely manipulate it.
+    editor.disconnect_segment_from(
+        segment_delimiter,
+        children_to_disconnect,
+        parents_to_disconnect,
+        true,
+    )?;
+
+    // Step 4: Based on the prepared steps, we rebuild the chain.
+    let new_segment_delimiter =
+        integration_steps_into_segment_nodes(&mut editor, ref_name, &prepared_steps)?;
+    // Step 5: Once we have our new chain, we reconnect it to the original children and parents.
+    connect_segment_to_edges(
+        &mut editor,
+        new_segment_delimiter,
+        &children_to_reconnect,
+        &parents_to_reconnect,
+    )?;
+
+    editor.rebase()
+}
+
+/// Get the initial integration steps for a branch.
+///
+/// The returned steps are ordered for application from parent to child so they
+/// can be passed directly to integration without reordering by the caller.
+///
+/// `ref_name` - The full reference name of the local branch to get the integration steps for.
+///
+/// `repo` - The repository handle.
+///
+/// `workspace` - The current workspace graph projection used to construct the editor.
+///
+/// `meta` - Reference metadata used while constructing the editor.
+///
+/// Returns the initial integration script and current divergence display state.
+pub fn get_initial_integration_steps_for_branch<M: RefMetadata>(
+    ref_name: &gix::refs::FullNameRef,
+    strategy: BranchIntegrationStrategy,
+    workspace: &mut but_graph::Workspace,
+    meta: &mut M,
+    repo: &gix::Repository,
+) -> Result<InitialBranchIntegration> {
+    // Step 1: We create the editor with the remote branch to integrate, and the project's target
+    // ref, if there's any.
+    let upstream_ref_name = resolve_tracking_branch_ref_name(ref_name, repo)?;
+    let target_ref_name = workspace
+        .target_ref
+        .as_ref()
+        .map(|target| target.ref_name.clone())
+        .filter(|target_ref_name| target_ref_name.as_ref() != upstream_ref_name.as_ref());
+
+    let mut extra_refs = vec![ExtraRef::immutable(upstream_ref_name.as_ref())];
+    if let Some(target_ref_name) = target_ref_name.as_ref()
+        && target_ref_name.as_ref() != upstream_ref_name.as_ref()
+    {
+        extra_refs.push(ExtraRef::immutable(target_ref_name.as_ref()));
+    }
+
+    let editor_options = GraphEditorOptions {
+        extra_refs,
+        ..GraphEditorOptions::default()
+    };
+    let editor = Editor::create_with_opts(workspace, meta, repo, &editor_options)?;
+
+    // Step 2: We traverse the editor graph and determine the divergence between the local and remote branch.
+    let BranchMergeBaseCommits {
+        local_commits: local_commit_selectors,
+        upstream_commits: upstream_commit_selectors,
+        merge_base: merge_base_selector,
+    } = get_commits_until_merge_base(ref_name, upstream_ref_name.clone(), &editor)?;
+    let local_commits = commit_ids_from_selectors(&editor, local_commit_selectors.iter().copied())?;
+    let upstream_commits =
+        commit_ids_from_selectors(&editor, upstream_commit_selectors.iter().copied())?;
+    let merge_base = editor.lookup_pick(merge_base_selector)?;
+
+    // Step 3: We determine the integration state of all the relevant commits, to know which are editable
+    // and for display purposes.
+    // All upstream commits are editable, regardless of integration.
+    // Only the non-integrated local commits are editable.
+    let candidate_selectors = local_commit_selectors
+        .iter()
+        .chain(upstream_commit_selectors.iter())
+        .copied()
+        .chain(std::iter::once(merge_base_selector))
+        .collect::<Vec<_>>();
+    let target_relations = target_ref_name
+        .as_ref()
+        .map(|target_ref_name| {
+            let target_ref_selector = target_ref_name.as_ref().to_selector(&editor)?;
+            classify_selectors_against_target_ref(
+                &editor,
+                target_ref_selector,
+                &candidate_selectors,
+            )
+        })
+        .transpose()?
+        .unwrap_or_default();
+
+    // Step 4: Build the initial set of integration steps.
+    let change_ids = if matches!(strategy, BranchIntegrationStrategy::SmartSquash) {
+        explicit_change_ids(
+            repo,
+            local_commits.iter().chain(upstream_commits.iter()).copied(),
+        )?
+    } else {
+        HashMap::new()
+    };
+    let initial_steps = initial_integration_steps(
+        strategy,
+        &local_commits,
+        &upstream_commits,
+        &target_relations,
+        &change_ids,
+    );
+
+    // Step 5: Build the return payload, including the integration steps recommended
+    // and the divergence display information.
+
+    // We turn the commits into divergence commits, which are just decorated with extra information,
+    // for display purposes.
+    let divergence_local_only = local_commits
+        .iter()
+        .copied()
+        .map(|commit_id| {
+            divergence_commit(repo, commit_id, relation_for(&target_relations, commit_id))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let divergence_upstream_only = upstream_commits
+        .iter()
+        .copied()
+        .map(|commit_id| {
+            divergence_commit(repo, commit_id, relation_for(&target_relations, commit_id))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let integration = InteractiveIntegration {
+        steps: initial_steps,
+        merge_base,
+        first_local_not_integrated: editable_local_commits(&local_commits, &target_relations)
+            .next(),
+    };
+    let mut divergence = IntegrationDivergenceDisplay {
+        branch_ref_name: ref_name.to_owned(),
+        upstream_ref_name: upstream_ref_name.into_owned(),
+        local_only: divergence_local_only,
+        upstream_only: divergence_upstream_only,
+        merge_base: divergence_commit(
+            repo,
+            merge_base,
+            relation_for(&target_relations, merge_base),
+        )?,
+    };
+    let local_tip = divergence.local_only.first().map(|commit| commit.id);
+    let upstream_tip = divergence.upstream_only.first().map(|commit| commit.id);
+    add_ref_label(
+        &mut divergence.local_only,
+        &mut divergence.merge_base,
+        local_tip,
+        divergence.branch_ref_name.shorten().to_string(),
+    );
+    add_ref_label(
+        &mut divergence.upstream_only,
+        &mut divergence.merge_base,
+        upstream_tip,
+        divergence.upstream_ref_name.shorten().to_string(),
+    );
+
+    Ok(InitialBranchIntegration {
+        integration,
+        divergence,
+    })
+}
+
+fn explicit_change_ids(
+    repo: &gix::Repository,
+    commit_ids: impl IntoIterator<Item = gix::ObjectId>,
+) -> Result<HashMap<gix::ObjectId, but_core::ChangeId>> {
+    commit_ids
+        .into_iter()
+        .map(|commit_id| {
+            let raw_commit = repo.find_commit(commit_id)?;
+            let commit = raw_commit.decode()?;
+            let change_id = Headers::try_from_commit_headers(|| commit.extra_headers())
+                .and_then(|headers| headers.change_id);
+            Ok((commit_id, change_id))
+        })
+        .filter_map(|result| match result {
+            Ok((commit_id, Some(change_id))) => Some(Ok((commit_id, change_id))),
+            Ok((_, None)) => None,
+            Err(err) => Some(Err(err)),
+        })
+        .collect()
+}

--- a/crates/but-workspace/src/branch/integrate_branch_upstream/plan.rs
+++ b/crates/but-workspace/src/branch/integrate_branch_upstream/plan.rs
@@ -1,0 +1,460 @@
+//! Feature-local planning helpers for editable upstream integration.
+
+use std::collections::{HashMap, HashSet};
+
+use anyhow::{Context as _, Result, bail};
+use bstr::BStr;
+use but_core::{
+    ChangeId, RefMetadata, RepositoryExt,
+    commit::{add_conflict_markers, write_conflicted_tree},
+};
+use but_rebase::{
+    commit::DateMode,
+    graph_rebase::{
+        Editor, LookupStep, Selector, Step,
+        merge_commit_changes::MergeCommitChangesOutcome,
+        mutate::{SegmentDelimiter, SelectorSet},
+    },
+};
+
+use crate::graph_manipulation::{
+    already_connected_parent_for_step, connect_parent_step, disconnect_selector_from_all_parents,
+};
+use crate::{divergence::TargetCommitRelation, graph_manipulation::determine_parent_selector};
+
+use super::{InteractiveIntegrationStep, display::relation_for};
+
+/// Preset used to generate the initial editable branch integration steps.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum BranchIntegrationStrategy {
+    /// Rebase local commits on top of the upstream commits.
+    #[default]
+    PullRebase,
+    /// Keep local commits first, then merge the upstream tip.
+    Merge,
+    /// Rebuild the branch by picking upstream commits only.
+    PickRemote,
+    /// Fold upstream commits with matching explicit Change-Ids into local commits.
+    SmartSquash,
+}
+
+/// Build the initial editable integration script for the selected strategy.
+///
+/// `local_commits` and `upstream_commits` are ordered child-to-parent from the
+/// graph traversal. The returned steps are ordered parent-to-child for
+/// execution by the integration editor.
+pub(super) fn initial_integration_steps(
+    strategy: BranchIntegrationStrategy,
+    local_commits: &[gix::ObjectId],
+    upstream_commits: &[gix::ObjectId],
+    target_relations: &HashMap<gix::ObjectId, TargetCommitRelation>,
+    change_ids: &HashMap<gix::ObjectId, ChangeId>,
+) -> Vec<InteractiveIntegrationStep> {
+    match strategy {
+        BranchIntegrationStrategy::PullRebase => {
+            pull_rebase_steps(local_commits, upstream_commits, target_relations)
+        }
+        BranchIntegrationStrategy::Merge => {
+            let mut steps = editable_local_commits(local_commits, target_relations)
+                .map(|commit_id| InteractiveIntegrationStep::Pick { commit_id })
+                .collect::<Vec<_>>();
+            if let Some(upstream_tip) = upstream_commits.first().copied() {
+                steps.push(InteractiveIntegrationStep::Merge {
+                    commit_id: upstream_tip,
+                });
+            }
+            steps
+        }
+        BranchIntegrationStrategy::PickRemote => upstream_commits
+            .iter()
+            .rev()
+            .copied()
+            .map(|commit_id| InteractiveIntegrationStep::Pick { commit_id })
+            .collect::<Vec<_>>(),
+        BranchIntegrationStrategy::SmartSquash => smart_squash_steps(
+            local_commits,
+            upstream_commits,
+            target_relations,
+            change_ids,
+        ),
+    }
+}
+
+fn pull_rebase_steps(
+    local_commits: &[gix::ObjectId],
+    upstream_commits: &[gix::ObjectId],
+    target_relations: &HashMap<gix::ObjectId, TargetCommitRelation>,
+) -> Vec<InteractiveIntegrationStep> {
+    upstream_commits
+        .iter()
+        .rev()
+        .copied()
+        .map(|commit_id| InteractiveIntegrationStep::Pick { commit_id })
+        .chain(
+            editable_local_commits(local_commits, target_relations)
+                .map(|commit_id| InteractiveIntegrationStep::Pick { commit_id }),
+        )
+        .collect()
+}
+
+pub(super) fn editable_local_commits<'a>(
+    local_commits: &'a [gix::ObjectId],
+    target_relations: &'a HashMap<gix::ObjectId, TargetCommitRelation>,
+) -> impl Iterator<Item = gix::ObjectId> + 'a {
+    local_commits
+        .iter()
+        .rev()
+        .copied()
+        .filter(|commit_id| !relation_for(target_relations, *commit_id).is_integrated())
+}
+
+fn smart_squash_steps(
+    local_commits: &[gix::ObjectId],
+    upstream_commits: &[gix::ObjectId],
+    target_relations: &HashMap<gix::ObjectId, TargetCommitRelation>,
+    change_ids: &HashMap<gix::ObjectId, ChangeId>,
+) -> Vec<InteractiveIntegrationStep> {
+    // Step 1: Find all the local commits associated with a change ID.
+    // If multiple local commits are associated with the same change ID,
+    // pick the child-most.
+    let mut local_targets_by_change_id = HashMap::<ChangeId, gix::ObjectId>::new();
+    // Iterate over all the non-integrated commits.
+    for commit_id in local_commits
+        .iter()
+        .copied()
+        .filter(|commit_id| !relation_for(target_relations, *commit_id).is_integrated())
+    {
+        if let Some(change_id) = change_ids.get(&commit_id) {
+            local_targets_by_change_id
+                .entry(change_id.clone())
+                .or_insert(commit_id);
+        }
+    }
+
+    // If there are no local commits that have change IDs, fallback to returning pull-rebase steps.
+    if local_targets_by_change_id.is_empty() {
+        return pull_rebase_steps(local_commits, upstream_commits, target_relations);
+    }
+
+    // Step 2: Figure out which upstream-commits to squash into which local commits.
+    // We already know which local commits are associated to which change IDs.
+    // Based on that, we find all upstream commits that are associated with the same
+    // change ID and track them.
+    let mut upstream_commits_by_target = HashMap::<gix::ObjectId, Vec<gix::ObjectId>>::new();
+    let mut matched_upstream_commits = HashSet::<gix::ObjectId>::new();
+    // Iterate over the upstream-only commits.
+    for upstream_commit_id in upstream_commits.iter().rev().copied() {
+        let Some(change_id) = change_ids.get(&upstream_commit_id) else {
+            continue;
+        };
+        let Some(local_target) = local_targets_by_change_id.get(change_id) else {
+            continue;
+        };
+        upstream_commits_by_target
+            .entry(*local_target)
+            .or_default()
+            .push(upstream_commit_id);
+        matched_upstream_commits.insert(upstream_commit_id);
+    }
+
+    // If there are no upstream commits tha have matched change IDs, fallback to returning the pull-rebase steps.
+    if matched_upstream_commits.is_empty() {
+        return pull_rebase_steps(local_commits, upstream_commits, target_relations);
+    }
+
+    // Step 3: Return the steps in the right order.
+    // We pick the unmatched upstream commits first, and then the local non-integrated
+    // commits. If they have matching upstream commits, we return squash steps of all the
+    // matching upstream commits into the local commit.
+    upstream_commits
+        .iter()
+        .rev()
+        .copied()
+        .filter(|commit_id| !matched_upstream_commits.contains(commit_id))
+        .map(|commit_id| InteractiveIntegrationStep::Pick { commit_id })
+        .chain(
+            editable_local_commits(local_commits, target_relations).map(|commit_id| {
+                if let Some(upstream_commits) = upstream_commits_by_target.get(&commit_id) {
+                    let mut commits = Vec::with_capacity(upstream_commits.len() + 1);
+                    commits.push(commit_id);
+                    commits.extend(upstream_commits.iter().copied());
+                    InteractiveIntegrationStep::Squash {
+                        commits,
+                        message: None,
+                    }
+                } else {
+                    InteractiveIntegrationStep::Pick { commit_id }
+                }
+            }),
+        )
+        .collect()
+}
+
+#[derive(Debug, Clone)]
+pub(super) enum PreparedIntegrationStep {
+    Pick { commit_id: gix::ObjectId },
+    Merge { commit_id: gix::ObjectId },
+}
+
+/// Prepare user-facing integration steps for execution in the graph editor.
+///
+/// The main role of this function is to pre-compute the squash commits, before
+/// we start altering the editor graph. Turning them into normal pick steps for the
+/// chain build.
+///
+/// `editor` provides the current repository and graph state needed to
+/// materialize derived steps such as scripted squashes.
+///
+/// `steps` is the editable integration script in parent-to-child execution
+/// order.
+///
+/// Returns the normalized execution plan used by later graph-building helpers.
+pub(super) fn prepare_integration_steps_for_editor<M: RefMetadata>(
+    editor: &Editor<'_, '_, M>,
+    steps: &[InteractiveIntegrationStep],
+) -> Result<Vec<PreparedIntegrationStep>> {
+    steps
+        .iter()
+        .map(|step| match step {
+            InteractiveIntegrationStep::Pick { commit_id } => Ok(PreparedIntegrationStep::Pick {
+                commit_id: *commit_id,
+            }),
+            InteractiveIntegrationStep::Merge { commit_id } => Ok(PreparedIntegrationStep::Merge {
+                commit_id: *commit_id,
+            }),
+            InteractiveIntegrationStep::Squash { commits, message } => {
+                Ok(PreparedIntegrationStep::Pick {
+                    commit_id: prepare_squash_step_for_editor(editor, commits, message.as_deref())?,
+                })
+            }
+        })
+        .collect()
+}
+
+/// Precompute the squash payload from the current editor/repository state,
+/// before later integration graph mutations can rewire step-graph ancestry.
+fn prepare_squash_step_for_editor<M: RefMetadata>(
+    editor: &Editor<'_, '_, M>,
+    commit_ids: &[gix::ObjectId],
+    message: Option<&str>,
+) -> Result<gix::ObjectId> {
+    if commit_ids.len() < 2 {
+        bail!("Squash step must have at least two commits");
+    }
+
+    let maybe_selectors = commit_ids
+        .iter()
+        .map(|commit_id| editor.try_select_commit(*commit_id))
+        .collect::<Vec<_>>();
+    let ordered_commit_ids = if maybe_selectors.iter().all(Option::is_some) {
+        let ordered_selectors = editor.order_commit_selectors_by_parentage(
+            maybe_selectors
+                .into_iter()
+                .map(|selector| selector.expect("checked all selectors are present"))
+                .collect::<Vec<_>>(),
+        )?;
+        ordered_selectors
+            .iter()
+            .map(|selector| {
+                editor
+                    .find_selectable_commit(*selector)
+                    .map(|(_, commit)| commit.id)
+            })
+            .collect::<Result<Vec<_>>>()?
+    } else {
+        commit_ids.to_vec()
+    };
+
+    let target_commit_id = *ordered_commit_ids
+        .first()
+        .expect("validated non-empty squash commit list");
+    let merge_subject_ids = commit_ids
+        .iter()
+        .copied()
+        .filter(|commit_id| *commit_id != target_commit_id)
+        .collect::<Vec<_>>();
+    let merge_outcome = editor.merge_commit_changes_to_tree(
+        target_commit_id,
+        merge_subject_ids,
+        editor.repo().merge_options_force_ours()?,
+    )?;
+    let squashed_parent = editor
+        .repo()
+        .merge_base_octopus(ordered_commit_ids.iter().copied())
+        .context("failed to compute squash merge-base")?
+        .detach();
+
+    let tip_commit_id = *ordered_commit_ids
+        .last()
+        .expect("validated non-empty squash commit list");
+    let mut squashed_commit = editor.find_commit(tip_commit_id)?;
+    squashed_commit.inner.parents = vec![squashed_parent].into();
+    let commit_message = message
+        .map(|message| message.as_bytes().to_vec())
+        .unwrap_or_else(|| Vec::from(squashed_commit.message.clone()));
+    apply_merge_commit_changes_outcome(
+        editor.repo(),
+        &mut squashed_commit,
+        merge_outcome,
+        commit_message,
+    )?;
+
+    editor.new_commit_untracked(squashed_commit, DateMode::CommitterUpdateAuthorKeep)
+}
+
+fn apply_merge_commit_changes_outcome(
+    repo: &gix::Repository,
+    commit: &mut but_core::CommitOwned,
+    outcome: MergeCommitChangesOutcome,
+    message: Vec<u8>,
+) -> Result<()> {
+    if let Some(conflict) = outcome.conflict {
+        commit.tree = write_conflicted_tree(
+            repo,
+            outcome.tree_id,
+            conflict.base_tree_id,
+            conflict.ours_tree_id,
+            conflict.theirs_tree_id,
+            &conflict.conflict_entries,
+        )?;
+        commit.message = add_conflict_markers(BStr::new(&message));
+    } else {
+        commit.tree = outcome.tree_id;
+        commit.message = message.into();
+    }
+
+    Ok(())
+}
+
+/// Builds and inserts the integrated commit chain under `ref_name` down to the last step.
+///
+/// `editor` is the mutable graph editor that will receive the rebuilt chain.
+///
+/// `ref_name` is the branch reference whose parent chain should be rebuilt.
+///
+/// `steps` is the prepared execution plan to insert under `ref_name`, ending
+/// at the deepest rebuilt parent step.
+///
+/// Returns the delimiter spanning from the reference node to the deepest
+/// inserted parent.
+pub(crate) fn integration_steps_into_segment_nodes<M: RefMetadata>(
+    editor: &mut Editor<'_, '_, M>,
+    ref_name: &gix::refs::FullNameRef,
+    steps: &[PreparedIntegrationStep],
+) -> Result<SegmentDelimiter<Selector, Selector>> {
+    // Step 1: We interpret the integration steps and transform them into graph steps disconnected from their parents.
+    // We disconnect them in order to be able to allow for reordering.
+    let segment_steps = integration_steps_to_segment_steps_for_editor(editor, ref_name, steps)?;
+
+    // Step 2. We build the new local branch out of the steps.
+    // We start by disconnecting all the parents of the local branch reference step, as we will connect it to the new
+    // set of commits.
+    let child_most = editor.select_reference(ref_name)?;
+    disconnect_selector_from_all_parents(editor, child_most)?;
+    let mut parent_most = child_most;
+
+    for step in segment_steps.into_iter().skip(1) {
+        if let Some(existing_parent) =
+            already_connected_parent_for_step(editor, parent_most, &step)?
+        {
+            parent_most = existing_parent;
+            continue;
+        }
+
+        parent_most = connect_parent_step(editor, parent_most, step)?;
+    }
+
+    Ok(SegmentDelimiter {
+        child: child_most,
+        parent: parent_most,
+    })
+}
+
+/// Convert user-provided integration steps into graph steps in insertion order.
+///
+/// `editor` is the mutable graph editor used to reuse existing picks, create
+/// synthetic merge steps, and detach reusable commits from their current parent
+/// edges.
+///
+/// `ref_name` is the branch reference that anchors the rebuilt segment.
+///
+/// `steps` is the prepared integration plan in execution order.
+///
+/// Returns the graph steps to insert, starting with a reference step and then
+/// the parent chain steps in insertion order.
+fn integration_steps_to_segment_steps_for_editor<M: RefMetadata>(
+    editor: &mut Editor<'_, '_, M>,
+    ref_name: &gix::refs::FullNameRef,
+    steps: &[PreparedIntegrationStep],
+) -> Result<Vec<Step>> {
+    let mut out = vec![Step::Reference {
+        refname: ref_name.to_owned(),
+    }];
+
+    for step in steps.iter().rev() {
+        match step {
+            PreparedIntegrationStep::Pick { commit_id, .. } => {
+                out.push(existing_or_new_pick_step(editor, *commit_id)?);
+            }
+            PreparedIntegrationStep::Merge { commit_id } => {
+                let mut merge_commit = editor.empty_commit()?;
+                merge_commit.message = format!("Merge {commit_id} into previous commit").into();
+                let merge_commit = editor.new_commit_untracked(
+                    merge_commit,
+                    but_rebase::commit::DateMode::CommitterKeepAuthorKeep,
+                )?;
+                let preserved_parents = editor
+                    .find_commit(*commit_id)?
+                    .inner
+                    .parents
+                    .iter()
+                    .copied()
+                    .collect::<Vec<_>>();
+                let mut commit_to_merge = Step::new_untracked_pick(*commit_id);
+                let Step::Pick(pick) = &mut commit_to_merge else {
+                    bail!("BUG: expected merge side parent to be a pick step");
+                };
+                pick.preserved_parents = Some(preserved_parents);
+                let commit_to_merge = editor.add_step(commit_to_merge)?;
+                let merge_commit = editor.add_step(Step::new_untracked_pick(merge_commit))?;
+                editor.add_edge(merge_commit, commit_to_merge, 1)?;
+                out.push(editor.lookup_step(merge_commit)?);
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+/// Produce a pick step for `commit_id`, detaching selected parent edges when needed.
+///
+/// `editor` is the mutable graph editor used to inspect or detach an existing
+/// selectable commit.
+///
+/// `commit_id` is the commit that should be represented as a pick step in the
+/// rebuilt integration segment.
+///
+/// Returns either the existing pick step for `commit_id` after detaching the
+/// selected parent edges, or a brand-new pick step when the commit is not yet
+/// selectable in the editor.
+fn existing_or_new_pick_step<M: RefMetadata>(
+    editor: &mut Editor<'_, '_, M>,
+    commit_id: gix::ObjectId,
+) -> Result<Step> {
+    if let Some(existing) = editor.try_select_commit(commit_id) {
+        let parents_to_disconnect = determine_parent_selector(editor, existing)?;
+        editor.disconnect_segment_from(
+            SegmentDelimiter {
+                child: existing,
+                parent: existing,
+            },
+            SelectorSet::None,
+            parents_to_disconnect,
+            true,
+        )?;
+
+        return editor.lookup_step(existing);
+    }
+
+    Ok(Step::new_pick(commit_id))
+}

--- a/crates/but-workspace/src/branch/mod.rs
+++ b/crates/but-workspace/src/branch/mod.rs
@@ -613,3 +613,11 @@ pub use create_reference::function::create_reference;
 /// Functions and types related to moving branches across stacks.
 pub mod move_branch;
 pub use move_branch::function::{move_branch, tear_off_branch};
+
+/// Functions and types for integrating remote changes into local branches.
+pub mod integrate_branch_upstream;
+pub use integrate_branch_upstream::{
+    BranchIntegrationStrategy, InitialBranchIntegration, IntegrationDivergenceCommit,
+    IntegrationDivergenceDisplay, IntegrationDivergenceTargetRelation, InteractiveIntegrationStep,
+    get_initial_integration_steps_for_branch, integrate_branch_with_steps,
+};

--- a/crates/but-workspace/src/divergence.rs
+++ b/crates/but-workspace/src/divergence.rs
@@ -1,0 +1,346 @@
+//! Shared helpers for branch/upstream divergence discovery.
+
+use anyhow::{Context as _, Result, bail};
+use but_core::RefMetadata;
+use but_rebase::graph_rebase::{Editor, LookupStep, Pick, Selector, Step, ToSelector};
+use gix::remote::Direction;
+use std::{borrow::Cow, collections::HashMap};
+
+use crate::graph_manipulation::traverse_nodes;
+
+/// Commit ancestry information for a branch and its configured upstream.
+#[derive(Debug)]
+pub(crate) struct BranchMergeBaseCommits {
+    /// Local branch first-parent commits from tip down to, but excluding, the merge base.
+    pub(crate) local_commits: Vec<Selector>,
+    /// Upstream branch first-parent commits from tip down to, but excluding, the merge base.
+    pub(crate) upstream_commits: Vec<Selector>,
+    /// Shared merge base between the local branch and its upstream.
+    pub(crate) merge_base: Selector,
+}
+
+/// How a candidate commit relates to a comparison target branch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TargetCommitRelation {
+    /// The commit is not reachable from the target branch.
+    NotIntegrated,
+    /// The exact commit is reachable from target branch history.
+    HistoricallyIntegrated {
+        /// The target branch commit that establishes the relation.
+        target_commit_id: gix::ObjectId,
+    },
+}
+
+impl TargetCommitRelation {
+    /// Return true when this relation means the commit is already integrated.
+    pub(crate) fn is_integrated(self) -> bool {
+        matches!(self, Self::HistoricallyIntegrated { .. })
+    }
+}
+
+/// Resolve the remote-tracking ref that corresponds to a local branch ref.
+///
+/// `ref_name` is the full name of the local branch whose effective tracking ref
+/// should be discovered.
+///
+/// `repo` provides branch configuration and ref lookup access used to resolve
+/// the configured tracking branch or a unique fallback under `refs/remotes/*`.
+///
+/// Returns the resolved remote-tracking ref name as a borrowed or owned value.
+pub fn resolve_tracking_branch_ref_name<'a>(
+    ref_name: &'a gix::refs::FullNameRef,
+    repo: &'a gix::Repository,
+) -> Result<Cow<'a, gix::refs::FullNameRef>> {
+    if let Some(upstream_ref_name) = repo
+        .branch_remote_tracking_ref_name(ref_name, Direction::Fetch)
+        .transpose()?
+        && repo
+            .try_find_reference(upstream_ref_name.as_ref())?
+            .is_some()
+    {
+        return Ok(upstream_ref_name);
+    }
+
+    let branch_name = ref_name.shorten();
+    let mut remote_matches = repo
+        .remote_names()
+        .iter()
+        .filter_map(|remote_name| {
+            let full_name = format!("refs/remotes/{remote_name}/{branch_name}");
+            repo.try_find_reference(&full_name)
+                .transpose()
+                .map(|reference| {
+                    reference.map(|_| {
+                        full_name
+                            .try_into()
+                            .expect("constructed remote-tracking refname must be valid")
+                    })
+                })
+        })
+        .collect::<Result<Vec<gix::refs::FullName>, _>>()?;
+
+    if remote_matches.len() == 1 {
+        return Ok(Cow::Owned(
+            remote_matches
+                .pop()
+                .expect("exactly one remote match exists"),
+        ));
+    }
+
+    bail!("Branch '{ref_name}' has no tracking branch")
+}
+
+/// Compute local and upstream commit lists together with their merge base.
+///
+/// `ref_name` is the local branch whose first-parent-only divergence should be
+/// described.
+///
+/// `upstream_ref_name` is the effective tracking ref paired with `ref_name`.
+///
+/// `editor` provides the in-memory graph view used to walk refs, picks, and
+/// preserved parentage consistently within the current operation.
+///
+/// Returns the local-only selectors, upstream-only selectors, and the selector
+/// for their shared merge base.
+pub(crate) fn get_commits_until_merge_base<'a, M: RefMetadata>(
+    ref_name: &'a gix::refs::FullNameRef,
+    upstream_ref_name: Cow<'a, gix::refs::FullNameRef>,
+    editor: &Editor<'_, '_, M>,
+) -> Result<BranchMergeBaseCommits> {
+    let local_tip = tip_for_ref(editor, ref_name, editor.repo())
+        .with_context(|| format!("Could not determine tip commit for '{ref_name}'"))?;
+    let upstream_tip = tip_for_ref(editor, upstream_ref_name.as_ref(), editor.repo())
+        .with_context(|| {
+            format!("Could not determine tip commit for upstream '{upstream_ref_name}'")
+        })?;
+    let upstream_ancestor_ids = traverse_pick_ancestor_ids(editor, upstream_tip)?;
+    let merge_base = find_first_parent_merge_base(editor, local_tip, &upstream_ancestor_ids)?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "No merge-base found between '{ref_name}' and its tracking branch '{upstream_ref_name}'"
+            )
+        })?;
+    let merge_base_selector = editor.select_commit(merge_base)?;
+    let local_commits = first_parent_path_until(editor, local_tip, |selector| {
+        editor.lookup_pick(*selector).ok() == Some(merge_base)
+    })?
+    .into_iter()
+    .take_while(|selector| *selector != merge_base_selector)
+    .collect::<Vec<_>>();
+    let upstream_commits = first_parent_path_until(editor, upstream_tip, |selector| {
+        editor.lookup_pick(*selector).ok() == Some(merge_base)
+    })?
+    .into_iter()
+    .take_while(|selector| *selector != merge_base_selector)
+    .collect::<Vec<_>>();
+    Ok(BranchMergeBaseCommits {
+        local_commits,
+        upstream_commits,
+        merge_base: merge_base_selector,
+    })
+}
+
+/// Convert selectors into their current picked commit ids.
+///
+/// `editor` provides the graph lookup used to resolve each selector to its
+/// current picked commit id.
+///
+/// `selectors` is the sequence of graph selectors to convert.
+///
+/// Returns the commit ids for all provided selectors in iteration order.
+pub(crate) fn commit_ids_from_selectors<M: RefMetadata>(
+    editor: &Editor<'_, '_, M>,
+    selectors: impl IntoIterator<Item = Selector>,
+) -> Result<Vec<gix::ObjectId>> {
+    selectors
+        .into_iter()
+        .map(|selector| editor.lookup_pick(selector))
+        .collect()
+}
+
+/// Classify candidate selectors by whether the target branch reaches them.
+///
+/// `editor` provides the graph traversal and pick lookup operations used during
+/// classification.
+///
+/// `target_ref_selector` is the selector whose reachable history defines what
+/// counts as already integrated.
+///
+/// `candidate_selectors` are the selectors to classify against the target
+/// branch reachability set.
+///
+/// Returns a map keyed by candidate commit id describing whether each candidate
+/// is historically integrated into the target branch.
+pub(crate) fn classify_selectors_against_target_ref<M: RefMetadata>(
+    editor: &Editor<'_, '_, M>,
+    target_ref_selector: Selector,
+    candidate_selectors: &[Selector],
+) -> Result<HashMap<gix::ObjectId, TargetCommitRelation>> {
+    let target_reachable_selectors = traverse_nodes(editor, target_ref_selector)?;
+    candidate_selectors
+        .iter()
+        .copied()
+        .map(|candidate_selector| {
+            let candidate_commit_id = editor.lookup_pick(candidate_selector)?;
+            let relation = if target_reachable_selectors.contains(&candidate_selector) {
+                TargetCommitRelation::HistoricallyIntegrated {
+                    target_commit_id: candidate_commit_id,
+                }
+            } else {
+                TargetCommitRelation::NotIntegrated
+            };
+            Ok((candidate_commit_id, relation))
+        })
+        .collect()
+}
+
+fn first_pick_parent<M: RefMetadata>(
+    editor: &Editor<'_, '_, M>,
+    selector: Selector,
+) -> Result<Selector> {
+    let mut adjacent = editor.direct_parents(selector)?;
+    adjacent.extend(editor.direct_children(selector)?);
+    adjacent.sort_by_key(|(_, order)| *order);
+    adjacent
+        .into_iter()
+        .find_map(|(candidate, _)| {
+            matches!(editor.lookup_step(candidate).ok()?, Step::Pick(_)).then_some(candidate)
+        })
+        .ok_or_else(|| anyhow::anyhow!("Expected reference selector to point to a commit"))
+}
+
+fn tip_for_ref<M: RefMetadata>(
+    editor: &Editor<'_, '_, M>,
+    ref_name: &gix::refs::FullNameRef,
+    repo: &gix::Repository,
+) -> Result<Selector> {
+    let reference_selector = ref_name.to_selector(editor)?;
+    first_pick_parent(editor, reference_selector).or_else(|_| {
+        let tip = repo.find_reference(ref_name)?.id().detach();
+        editor.select_commit(tip)
+    })
+}
+
+fn find_first_parent_merge_base<M: RefMetadata>(
+    editor: &Editor<'_, '_, M>,
+    local_tip: Selector,
+    upstream_ancestors: &HashMap<gix::ObjectId, Selector>,
+) -> Result<Option<gix::ObjectId>> {
+    let mut current = Some(local_tip);
+    while let Some(selector) = current {
+        let Step::Pick(Pick {
+            id,
+            preserved_parents,
+            ..
+        }) = editor.lookup_step(selector)?
+        else {
+            return Ok(None);
+        };
+        if upstream_ancestors.contains_key(&id) {
+            return Ok(Some(id));
+        }
+        if let Some(preserved_parents) = preserved_parents {
+            for parent_id in preserved_parents {
+                if upstream_ancestors.contains_key(&parent_id) {
+                    return Ok(Some(parent_id));
+                }
+            }
+        }
+        if let Some(parent) = first_parent(editor, selector)? {
+            current = Some(parent);
+        } else {
+            return Ok(None);
+        }
+    }
+    Ok(None)
+}
+
+fn traverse_pick_ancestor_ids<M: RefMetadata>(
+    editor: &Editor<'_, '_, M>,
+    tip: Selector,
+) -> Result<HashMap<gix::ObjectId, Selector>> {
+    let mut out = HashMap::new();
+    let mut seen = std::collections::HashSet::from([tip]);
+    let mut tips = vec![tip];
+
+    while let Some(tip) = tips.pop() {
+        let preserved_parents = match editor.lookup_step(tip)? {
+            Step::Pick(Pick {
+                id,
+                preserved_parents,
+                ..
+            }) => {
+                out.entry(id).or_insert(tip);
+                preserved_parents
+            }
+            Step::Reference { .. } | Step::None => None,
+        };
+
+        for (parent, _) in editor.direct_parents(tip)? {
+            if seen.insert(parent) {
+                tips.push(parent);
+            }
+        }
+
+        if let Some(preserved_parents) = preserved_parents {
+            for parent_id in preserved_parents {
+                out.entry(parent_id).or_insert(tip);
+                if let Some(parent) = editor.try_select_commit(parent_id)
+                    && seen.insert(parent)
+                {
+                    tips.push(parent);
+                }
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+fn first_parent<M: RefMetadata>(
+    editor: &Editor<'_, '_, M>,
+    selector: Selector,
+) -> Result<Option<Selector>> {
+    let mut parents = editor.direct_parents(selector)?;
+    parents.sort_by_key(|(_, order)| *order);
+    for (parent, _) in parents {
+        match editor.lookup_step(parent)? {
+            Step::Pick(_) => return Ok(Some(parent)),
+            Step::Reference { .. } | Step::None => {
+                if let Some(parent) = first_parent(editor, parent)? {
+                    return Ok(Some(parent));
+                }
+            }
+        }
+    }
+
+    let Step::Pick(Pick {
+        preserved_parents: Some(parents),
+        ..
+    }) = editor.lookup_step(selector)?
+    else {
+        return Ok(None);
+    };
+
+    Ok(parents
+        .first()
+        .copied()
+        .and_then(|parent| editor.try_select_commit(parent)))
+}
+
+fn first_parent_path_until<M: RefMetadata>(
+    editor: &Editor<'_, '_, M>,
+    tip: Selector,
+    mut stop: impl FnMut(&Selector) -> bool,
+) -> Result<Vec<Selector>> {
+    let mut path = Vec::new();
+    let mut current = Some(tip);
+    while let Some(selector) = current {
+        path.push(selector);
+        if stop(&selector) {
+            return Ok(path);
+        }
+        current = first_parent(editor, selector)?;
+    }
+    Ok(path)
+}

--- a/crates/but-workspace/src/graph_manipulation.rs
+++ b/crates/but-workspace/src/graph_manipulation.rs
@@ -1,10 +1,13 @@
-use anyhow::{Context, bail};
+//! Shared graph editor traversal and edge-manipulation helpers.
+
+use anyhow::{Context, Result, bail};
 use but_core::RefMetadata;
 use but_graph::workspace::{Stack, StackSegment};
 use but_rebase::graph_rebase::{
-    Editor, LookupStep, Selector, Step,
+    Editor, LookupStep, Selector, Step, ToSelector,
     mutate::{SegmentDelimiter, SelectorSet, SomeSelectors},
 };
+use std::collections::HashSet;
 
 /// Payload containing information about how to disconnect a segment in the graph.
 pub struct DisconnectParameters {
@@ -206,4 +209,227 @@ impl SegmentLike for but_graph::Segment {
     fn tip(&self) -> Option<gix::ObjectId> {
         self.tip()
     }
+}
+/// Which direct edge set to resolve from a selector.
+#[derive(Clone, Copy)]
+pub(crate) enum EdgeSelection {
+    /// Resolve direct child edges.
+    Children,
+    /// Resolve direct parent edges.
+    Parents,
+}
+
+/// Disconnect all parent edges from a single selector without reconnecting them.
+///
+/// `editor` is the mutable graph editor whose connectivity will be updated.
+///
+/// `selector` is the node whose parent edges should be removed.
+///
+/// Returns `Ok(())` after all direct parent edges of `selector` have been
+/// removed from the editor graph.
+pub(crate) fn disconnect_selector_from_all_parents<M: RefMetadata>(
+    editor: &mut Editor<'_, '_, M>,
+    selector: Selector,
+) -> Result<()> {
+    editor.disconnect_segment_from(
+        SegmentDelimiter {
+            child: selector,
+            parent: selector,
+        },
+        SelectorSet::None,
+        SelectorSet::All,
+        true,
+    )?;
+
+    Ok(())
+}
+
+/// Resolve concrete direct edges selected by a selector set, preserving edge order.
+///
+/// `editor` provides the direct parent or child edges that can be selected.
+///
+/// `target` is the node whose adjacent edges should be filtered.
+///
+/// `selectors` describes which neighboring selectors to keep, or whether to
+/// keep all or none of them.
+///
+/// `edge_selection` chooses whether neighbors are read from direct children or
+/// direct parents of `target`.
+///
+/// Returns the selected neighboring selectors paired with their existing edge
+/// order values.
+pub(crate) fn selected_edges_from_set<M: RefMetadata>(
+    editor: &Editor<'_, '_, M>,
+    target: Selector,
+    selectors: &SelectorSet,
+    edge_selection: EdgeSelection,
+) -> Result<Vec<(Selector, usize)>> {
+    let available = match edge_selection {
+        EdgeSelection::Children => editor.direct_children(target)?,
+        EdgeSelection::Parents => editor.direct_parents(target)?,
+    };
+
+    match selectors {
+        SelectorSet::All => Ok(available),
+        SelectorSet::None => Ok(Vec::new()),
+        SelectorSet::Some(some_selectors) => {
+            let mut selected = Vec::new();
+            for selector in some_selectors.as_slice() {
+                let selector = selector.to_selector(editor)?;
+                let Some((_, order)) = available
+                    .iter()
+                    .find(|(candidate, _)| *candidate == selector)
+                else {
+                    bail!("Selected edge endpoint wasn't found among direct neighbors")
+                };
+                selected.push((selector, *order));
+            }
+            Ok(selected)
+        }
+    }
+}
+
+/// Reconnect a rebuilt segment to previously selected children and parents.
+///
+/// `editor` is the mutable graph editor whose edges will be recreated.
+///
+/// `delimiter` identifies the rebuilt segment's child-most and parent-most
+/// selectors.
+///
+/// `children` are the previously captured child edges that should point back to
+/// `delimiter.child` with their original order.
+///
+/// `parents` are the previously captured parent edges that should be restored
+/// from `delimiter.parent`, with fresh order values appended after any existing
+/// parents already connected there.
+///
+/// Returns `Ok(())` after the captured child and parent edges have been
+/// reattached to the rebuilt segment.
+pub(crate) fn connect_segment_to_edges<M: RefMetadata>(
+    editor: &mut Editor<'_, '_, M>,
+    delimiter: SegmentDelimiter<Selector, Selector>,
+    children: &[(Selector, usize)],
+    parents: &[(Selector, usize)],
+) -> Result<()> {
+    for (child, order) in children {
+        editor.add_edge(*child, delimiter.child, *order)?;
+    }
+
+    let parent_order_offset = editor
+        .direct_parents(delimiter.parent)?
+        .into_iter()
+        .map(|(_, order)| order)
+        .max()
+        .map(|max| max + 1)
+        .unwrap_or(0);
+
+    for (parent, order) in parents {
+        editor.add_edge(delimiter.parent, *parent, parent_order_offset + *order)?;
+    }
+
+    Ok(())
+}
+
+/// Return a direct parent of `child` when `step` refers to a pick that is already connected.
+///
+/// This is useful when rebuilding an editor segment and we want to reuse an existing
+/// pick node without adding a duplicate edge to the same commit.
+///
+/// `editor` provides access to the current parent edges and commit selectors.
+///
+/// `child` is the node whose direct parents should be inspected.
+///
+/// `step` is the candidate step whose pick commit should be matched against the
+/// already-connected parents of `child`.
+///
+/// Returns the matching direct parent selector when `step` already corresponds
+/// to an attached pick parent, or `None` otherwise.
+pub(crate) fn already_connected_parent_for_step<M: RefMetadata>(
+    editor: &Editor<'_, '_, M>,
+    child: Selector,
+    step: &Step,
+) -> Result<Option<Selector>> {
+    let Step::Pick(pick) = step else {
+        return Ok(None);
+    };
+
+    let Some(existing_pick) = editor.try_select_commit(pick.id) else {
+        return Ok(None);
+    };
+
+    let direct_parents = editor.direct_parents(child)?;
+    Ok(direct_parents
+        .into_iter()
+        .find_map(|(parent, _)| (parent == existing_pick).then_some(parent)))
+}
+
+/// Connect `child` to `parent_step`, reusing an existing pick node when possible.
+///
+/// The new edge gets the smallest currently unused parent order on `child`, which keeps
+/// parent ordering stable while allowing callers to splice additional parents into a node.
+///
+/// `editor` is the mutable graph editor that may reuse an existing pick or add a
+/// new step before creating the edge.
+///
+/// `child` is the selector that should gain a new direct parent.
+///
+/// `parent_step` describes the parent node to connect, either by reusing an
+/// existing pick/reference selector or by inserting a new pick step first.
+///
+/// Returns the selector of the connected parent node.
+pub(crate) fn connect_parent_step<M: RefMetadata>(
+    editor: &mut Editor<'_, '_, M>,
+    child: Selector,
+    parent_step: Step,
+) -> Result<Selector> {
+    let parent = match parent_step {
+        Step::Pick(pick) => {
+            if let Some(existing_pick) = editor.try_select_commit(pick.id) {
+                existing_pick
+            } else {
+                editor.add_step(Step::Pick(pick))?
+            }
+        }
+        Step::Reference { ref refname } => editor.select_reference(refname.as_ref())?,
+        Step::None => bail!("BUG: trying to connect to none"),
+    };
+
+    let used_orders = editor
+        .direct_parents(child)?
+        .into_iter()
+        .map(|(_, order)| order)
+        .collect::<HashSet<_>>();
+    let mut order = 0;
+    while used_orders.contains(&order) {
+        order += 1;
+    }
+
+    editor.add_edge(child, parent, order)?;
+    Ok(parent)
+}
+
+/// Find all parent-reachable nodes from and including the provided tip.
+///
+/// `editor` provides the parent-edge traversal used for the walk.
+///
+/// `tip` is the starting selector whose ancestors should be collected.
+///
+/// Returns the set containing `tip` and every selector reachable from it by
+/// repeatedly following direct parent edges.
+pub(crate) fn traverse_nodes<M: RefMetadata>(
+    editor: &Editor<'_, '_, M>,
+    tip: Selector,
+) -> Result<HashSet<Selector>> {
+    let mut seen = HashSet::from([tip]);
+    let mut tips = vec![tip];
+
+    while let Some(tip) = tips.pop() {
+        for (parent, _) in editor.direct_parents(tip)? {
+            if seen.insert(parent) {
+                tips.push(parent);
+            }
+        }
+    }
+
+    Ok(seen)
 }

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -44,6 +44,8 @@ pub use tree_manipulation::discard_worktree_changes::discard_workspace_changes;
 pub mod branch;
 
 mod changeset;
+mod divergence;
+pub use divergence::resolve_tracking_branch_ref_name;
 mod graph_manipulation;
 
 /// Utility types for the [`WorkspaceCommit`].

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -16,6 +16,7 @@ use but_rebase::{
 };
 
 use crate::changeset::compute_similarity_by_commit_ids;
+use crate::graph_manipulation::traverse_nodes;
 
 /// Whether a bottom most commit should be rebased, or a merge commit should be
 /// created at the top of the commit run.
@@ -461,23 +462,4 @@ fn commit_ids<'ws, 'meta, M: RefMetadata>(
                 .transpose()
         })
         .collect()
-}
-
-/// Find all the parent nodes from and including the provided tip.
-fn traverse_nodes<'ws, 'meta, M: RefMetadata>(
-    editor: &Editor<'ws, 'meta, M>,
-    tip: Selector,
-) -> Result<HashSet<Selector>> {
-    let mut seen = HashSet::from([tip]);
-    let mut tips = vec![tip];
-
-    while let Some(tip) = tips.pop() {
-        for (parent, _) in editor.direct_parents(tip)? {
-            if seen.insert(parent) {
-                tips.push(parent);
-            }
-        }
-    }
-
-    Ok(seen)
 }

--- a/crates/but-workspace/tests/fixtures/scenario/remote-diverged-with-workspace.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/remote-diverged-with-workspace.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git init
+
+commit "init-integration"
+setup_target_to_match_main
+
+git checkout -b A main
+commit "shared local/remote"
+remote_tracking_caught_up A
+
+# Local branch diverges from origin/A.
+commit "local change in A 1"
+commit "local change in A 2"
+
+# Simulate a different remote tip for A.
+git checkout -b new-origin A~2
+commit "remote change in A 1"
+commit "remote change in A 2"
+setup_remote_tracking new-origin A 'move'
+
+git checkout A
+
+create_workspace_commit_once A

--- a/crates/but-workspace/tests/workspace/branch/integrate_branch_upstream.rs
+++ b/crates/but-workspace/tests/workspace/branch/integrate_branch_upstream.rs
@@ -1,0 +1,2725 @@
+use std::vec;
+
+use anyhow::{Result, bail};
+use bstr::ByteSlice;
+use but_core::{ChangeId, Commit, commit::Headers};
+use but_testsupport::gix_testtools::tempfile::TempDir;
+use but_testsupport::{InMemoryRefMetadata, visualize_commit_graph_all, visualize_tree};
+use but_workspace::branch::integrate_branch_upstream::{
+    BranchIntegrationStrategy, InitialBranchIntegration, IntegrationDivergenceCommit,
+    IntegrationDivergenceTargetRelation, InteractiveIntegration, InteractiveIntegrationStep,
+    get_initial_integration_steps_for_branch, integrate_branch_with_steps,
+};
+use but_workspace::resolve_tracking_branch_ref_name;
+use gix::prelude::ObjectIdExt;
+
+use crate::{
+    ref_info::with_workspace_commit::utils::{
+        StackState, add_stack_with_segments, named_writable_scenario_with_description_and_graph,
+    },
+    utils::{read_only_in_memory_scenario, read_only_in_memory_scenario_named},
+};
+
+fn normalized_graph_snapshot(repo: &gix::Repository) -> Result<String> {
+    let rendered = visualize_commit_graph_all(repo)?;
+    Ok(rendered
+        .lines()
+        .map(str::trim_end)
+        .collect::<Vec<_>>()
+        .join("\n"))
+}
+
+fn normalized_tree_snapshot(tree_id: gix::ObjectId, repo: &gix::Repository) -> Result<String> {
+    Ok(visualize_tree(tree_id.attach(repo))
+        .to_string()
+        .lines()
+        .map(str::trim_end)
+        .collect::<Vec<_>>()
+        .join("\n"))
+}
+
+fn labeled_integration_snapshot(
+    integration: &InteractiveIntegration,
+    labels: &[(gix::ObjectId, &str)],
+) -> String {
+    let mut out = String::new();
+    out.push_str("merge-base ");
+    out.push_str(&label_for(integration.merge_base, labels));
+    out.push('\n');
+
+    for step in &integration.steps {
+        match step {
+            InteractiveIntegrationStep::Pick { commit_id } => {
+                out.push_str("pick ");
+                out.push_str(&label_for(*commit_id, labels));
+            }
+            InteractiveIntegrationStep::Merge { commit_id } => {
+                out.push_str("merge ");
+                out.push_str(&label_for(*commit_id, labels));
+            }
+            InteractiveIntegrationStep::Squash { commits, message } => {
+                out.push_str("squash");
+                for commit_id in commits {
+                    out.push(' ');
+                    out.push_str(&label_for(*commit_id, labels));
+                }
+                if let Some(message) = message {
+                    out.push_str(" | message=");
+                    out.push_str(&format!("{message:?}"));
+                }
+            }
+        }
+        out.push('\n');
+    }
+
+    out.lines()
+        .map(str::trim_end)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn labeled_divergence_snapshot(
+    initial: &InitialBranchIntegration,
+    labels: &[(gix::ObjectId, &str)],
+) -> String {
+    fn render_commit(
+        prefix: &str,
+        commit: &IntegrationDivergenceCommit,
+        labels: &[(gix::ObjectId, &str)],
+    ) -> String {
+        let refs = if commit.refs.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", commit.refs.join(", "))
+        };
+        let relation = match &commit.target_relation {
+            IntegrationDivergenceTargetRelation::NotIntegrated => String::new(),
+            IntegrationDivergenceTargetRelation::HistoricallyIntegrated { target_commit_id } => {
+                format!(
+                    " [historically-integrated:{}]",
+                    label_for(*target_commit_id, labels)
+                )
+            }
+        };
+        format!(
+            "{prefix}{}{}{} {}",
+            label_for(commit.id, labels),
+            refs,
+            relation,
+            commit.subject
+        )
+    }
+
+    let mut out = Vec::new();
+    for commit in &initial.divergence.local_only {
+        out.push(render_commit("* ", commit, labels));
+    }
+    for commit in &initial.divergence.upstream_only {
+        let prefix = if initial.divergence.local_only.is_empty() {
+            "* "
+        } else {
+            "| * "
+        };
+        out.push(render_commit(prefix, commit, labels));
+    }
+    if !initial.divergence.local_only.is_empty() && !initial.divergence.upstream_only.is_empty() {
+        out.push("|/".into());
+    }
+    out.push(render_commit("* ", &initial.divergence.merge_base, labels));
+    out.join("\n")
+}
+
+fn labeled_graph_snapshot(
+    repo: &gix::Repository,
+    labels: &[(gix::ObjectId, &str)],
+) -> Result<String> {
+    let mut snapshot = normalized_graph_snapshot(repo)?;
+    for (id, label) in labels {
+        let short_id = id.to_string();
+        let short_id = &short_id[..7];
+        snapshot = snapshot.replace(short_id, label);
+    }
+    Ok(snapshot)
+}
+
+fn label_for(id: gix::ObjectId, labels: &[(gix::ObjectId, &str)]) -> String {
+    labels
+        .iter()
+        .find_map(|(candidate, label)| (*candidate == id).then_some(*label))
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| id.to_string())
+}
+
+fn initial_integration_for_branch(
+    ref_name: &gix::refs::FullNameRef,
+    repo: &gix::Repository,
+    target_ref_name: Option<&gix::refs::FullNameRef>,
+) -> Result<InitialBranchIntegration> {
+    initial_integration_for_branch_with_strategy(
+        ref_name,
+        repo,
+        target_ref_name,
+        BranchIntegrationStrategy::PullRebase,
+    )
+}
+
+fn initial_integration_for_branch_with_strategy(
+    ref_name: &gix::refs::FullNameRef,
+    repo: &gix::Repository,
+    target_ref_name: Option<&gix::refs::FullNameRef>,
+    strategy: BranchIntegrationStrategy,
+) -> Result<InitialBranchIntegration> {
+    let mut meta = InMemoryRefMetadata::default();
+    let graph = integration_graph_for_branch(ref_name, repo, target_ref_name, &meta)?;
+    let mut workspace = graph.into_workspace()?;
+    get_initial_integration_steps_for_branch(ref_name, strategy, &mut workspace, &mut meta, repo)
+}
+
+fn integration_graph_for_branch(
+    ref_name: &gix::refs::FullNameRef,
+    repo: &gix::Repository,
+    target_ref_name: Option<&gix::refs::FullNameRef>,
+    meta: &InMemoryRefMetadata,
+) -> Result<but_graph::Graph> {
+    if let Some(target_ref_name) = target_ref_name {
+        let head = repo.head()?;
+        let (head_id, head_ref_name) = match head.kind {
+            gix::head::Kind::Symbolic(reference) => {
+                let ref_name = reference.name;
+                let head_id = repo.find_reference(ref_name.as_ref())?.id().detach();
+                (head_id, Some(ref_name))
+            }
+            gix::head::Kind::Detached { target, peeled } => (peeled.unwrap_or(target), None),
+            gix::head::Kind::Unborn(_) => bail!("test repositories should not be unborn"),
+        };
+        let target_id = repo.find_reference(target_ref_name)?.id().detach();
+        let upstream_ref_name = resolve_tracking_branch_ref_name(ref_name, repo)?;
+        let upstream_id = repo
+            .find_reference(upstream_ref_name.as_ref())?
+            .id()
+            .detach();
+        but_graph::Graph::from_commit_traversal_tips(
+            repo,
+            [
+                but_graph::init::Tip::entrypoint(head_id, head_ref_name),
+                but_graph::init::Tip::reachable(upstream_id, Some(upstream_ref_name.into_owned())),
+                but_graph::init::Tip::integrated(target_id, Some(target_ref_name.to_owned())),
+            ],
+            meta,
+            Default::default(),
+        )
+    } else if let Ok(upstream_ref_name) = resolve_tracking_branch_ref_name(ref_name, repo) {
+        let head = repo.head()?;
+        let (head_id, head_ref_name) = match head.kind {
+            gix::head::Kind::Symbolic(reference) => {
+                let ref_name = reference.name;
+                let head_id = repo.find_reference(ref_name.as_ref())?.id().detach();
+                (head_id, Some(ref_name))
+            }
+            gix::head::Kind::Detached { target, peeled } => (peeled.unwrap_or(target), None),
+            gix::head::Kind::Unborn(_) => bail!("test repositories should not be unborn"),
+        };
+        let upstream_id = repo
+            .find_reference(upstream_ref_name.as_ref())?
+            .id()
+            .detach();
+        but_graph::Graph::from_commit_traversal_tips(
+            repo,
+            [
+                but_graph::init::Tip::entrypoint(head_id, head_ref_name),
+                but_graph::init::Tip::reachable(upstream_id, Some(upstream_ref_name.into_owned())),
+            ],
+            meta,
+            Default::default(),
+        )
+    } else {
+        but_graph::Graph::from_head(repo, meta, Default::default())
+    }
+}
+
+fn integration_workspace_for_branch(
+    ref_name: &gix::refs::FullNameRef,
+    repo: &gix::Repository,
+    target_ref_name: Option<&gix::refs::FullNameRef>,
+) -> Result<(but_graph::Workspace, InMemoryRefMetadata)> {
+    let meta = InMemoryRefMetadata::default();
+    let graph = integration_graph_for_branch(ref_name, repo, target_ref_name, &meta)?;
+    Ok((graph.into_workspace()?, meta))
+}
+
+#[test]
+fn errors_when_branch_has_no_tracking_branch() -> Result<()> {
+    let repo = read_only_in_memory_scenario("merge-with-two-branches-line-offset")
+        .expect("fixture repo should be available");
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @r"
+    *   2a6d103 (HEAD -> merge) Merge branch 'A' into merge
+    |\
+    | * 7f389ed (A) add 10 to the beginning
+    * | 91ef6f6 (B) add 10 to the end
+    |/
+    * ff045ef (main) init
+    ");
+
+    let err = initial_integration_for_branch(r("refs/heads/A"), &repo, None)
+        .expect_err("branch without tracking must fail");
+
+    assert!(
+        err.to_string().contains("has no tracking branch"),
+        "unexpected error: {err:#}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn partitions_diverged_branch_into_application_order() -> Result<()> {
+    let mut repo =
+        read_only_in_memory_scenario_named("with-remotes-no-workspace", "remote-diverged")?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @"
+    * 1a265a4 (HEAD -> A) local change in A
+    | * 89cc2d3 (origin/A) change in A
+    |/
+    * d79bba9 new file in A
+    * c166d42 (origin/main, origin/HEAD, main) init-integration
+    ");
+
+    let local_tip = repo.rev_parse_single("A")?.detach();
+    let upstream_tip = repo.rev_parse_single("origin/A")?.detach();
+    let merge_base = repo.rev_parse_single("A~1")?.detach();
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let initial = initial_integration_for_branch(
+        r("refs/heads/A"),
+        &repo,
+        Some(r("refs/remotes/origin/main")),
+    )?;
+
+    insta::assert_snapshot!(
+        labeled_integration_snapshot(
+            &initial.integration,
+            &[
+                (merge_base, "merge-base"),
+                (local_tip, "local-tip"),
+                (upstream_tip, "upstream-tip"),
+            ]
+        ),
+        @"
+    merge-base merge-base
+    pick upstream-tip
+    pick local-tip
+    "
+    );
+
+    insta::assert_snapshot!(
+        labeled_divergence_snapshot(
+            &initial,
+            &[
+                (merge_base, "merge-base"),
+                (local_tip, "local-tip"),
+                (upstream_tip, "upstream-tip"),
+            ]
+        ),
+        @"
+        * local-tip (A) local change in A
+        | * upstream-tip (origin/A) change in A
+        |/
+        * merge-base new file in A
+        "
+    );
+
+    let step_ids = pick_step_ids(&initial.integration.steps);
+
+    assert_eq!(
+        step_ids,
+        vec![upstream_tip, local_tip],
+        "expected application order to replay the upstream commit before the local tip"
+    );
+    Ok(())
+}
+
+#[test]
+fn falls_back_to_unique_remote_branch_without_tracking_config() -> Result<()> {
+    let repo = read_only_in_memory_scenario_named("with-remotes-no-workspace", "remote-diverged")?;
+
+    let local_tip = repo.rev_parse_single("A")?.detach();
+    let upstream_tip = repo.rev_parse_single("origin/A")?.detach();
+    let merge_base = repo.rev_parse_single("A~1")?.detach();
+
+    let initial = initial_integration_for_branch(r("refs/heads/A"), &repo, None)?;
+
+    insta::assert_snapshot!(
+        labeled_integration_snapshot(
+            &initial.integration,
+            &[
+                (merge_base, "merge-base"),
+                (local_tip, "local-tip"),
+                (upstream_tip, "upstream-tip"),
+            ]
+        ),
+        @"
+    merge-base merge-base
+    pick upstream-tip
+    pick local-tip
+    "
+    );
+
+    insta::assert_snapshot!(
+        labeled_divergence_snapshot(
+            &initial,
+            &[
+                (merge_base, "merge-base"),
+                (local_tip, "local-tip"),
+                (upstream_tip, "upstream-tip"),
+            ]
+        ),
+        @"
+        * local-tip (A) local change in A
+        | * upstream-tip (origin/A) change in A
+        |/
+        * merge-base new file in A
+        "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn keeps_graph_truth_even_when_change_ids_match() -> Result<()> {
+    let mut repo = read_only_in_memory_scenario_named(
+        "journey03",
+        "01-rewritten-local-commit-is-paired-with-remote",
+    )?;
+    configure_tracking_for_branch_a(&mut repo)?;
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @"
+    * 0b1ed50 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * e9c9d74 (A) A2
+    * 550b6ac A1
+    | * ad92cce (origin/A) A2
+    | * e1f216e A1
+    |/
+    * fafd9d0 (origin/main, main) init
+    ");
+
+    let local_only = repo.rev_parse_single("A~1")?.detach();
+    let remote_only = repo.rev_parse_single("origin/A~1")?.detach();
+    let local_tip = repo.rev_parse_single("A")?.detach();
+    let remote_tip = repo.rev_parse_single("origin/A")?.detach();
+    let merge_base = repo.rev_parse_single("A~2")?.detach();
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let initial = initial_integration_for_branch(
+        r("refs/heads/A"),
+        &repo,
+        Some(r("refs/remotes/origin/main")),
+    )?;
+
+    insta::assert_snapshot!(
+        labeled_integration_snapshot(
+            &initial.integration,
+            &[
+                (merge_base, "merge-base"),
+                (local_only, "local-only"),
+                (remote_only, "remote-only"),
+                (local_tip, "local-tip"),
+                (remote_tip, "remote-tip"),
+            ]
+        ),
+        @"
+    merge-base merge-base
+    pick remote-only
+    pick remote-tip
+    pick local-only
+    pick local-tip
+    "
+    );
+
+    insta::assert_snapshot!(
+        labeled_divergence_snapshot(
+            &initial,
+            &[
+                (merge_base, "merge-base"),
+                (local_only, "local-only"),
+                (remote_only, "remote-only"),
+                (local_tip, "local-tip"),
+                (remote_tip, "remote-tip"),
+            ]
+        ),
+        @"
+    * local-tip (A) A2
+    * local-only A1
+    | * remote-tip (origin/A) A2
+    | * remote-only A1
+    |/
+    * merge-base [historically-integrated:merge-base] init
+    "
+    );
+
+    let step_ids = pick_step_ids(&initial.integration.steps);
+
+    assert_eq!(
+        step_ids,
+        vec![remote_only, remote_tip, local_only, local_tip],
+        "expected application order to follow the graph, even for rewritten commits"
+    );
+    Ok(())
+}
+
+#[test]
+fn initial_steps_strategy_variants_are_distinct_presets() -> Result<()> {
+    let mut repo = read_only_in_memory_scenario_named(
+        "journey03",
+        "01-rewritten-local-commit-is-paired-with-remote",
+    )?;
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let local_only = repo.rev_parse_single("A~1")?.detach();
+    let remote_only = repo.rev_parse_single("origin/A~1")?.detach();
+    let local_tip = repo.rev_parse_single("A")?.detach();
+    let remote_tip = repo.rev_parse_single("origin/A")?.detach();
+    let merge_base = repo.rev_parse_single("A~2")?.detach();
+    let labels = [
+        (merge_base, "merge-base"),
+        (local_only, "local-only"),
+        (remote_only, "remote-only"),
+        (local_tip, "local-tip"),
+        (remote_tip, "remote-tip"),
+    ];
+
+    let mut snapshot = String::new();
+    for (name, strategy) in [
+        ("pull-rebase", BranchIntegrationStrategy::PullRebase),
+        ("merge", BranchIntegrationStrategy::Merge),
+        ("pick-remote", BranchIntegrationStrategy::PickRemote),
+    ] {
+        let initial = initial_integration_for_branch_with_strategy(
+            r("refs/heads/A"),
+            &repo,
+            Some(r("refs/remotes/origin/main")),
+            strategy,
+        )?;
+        snapshot.push_str(name);
+        snapshot.push('\n');
+        snapshot.push_str(&labeled_integration_snapshot(&initial.integration, &labels));
+        snapshot.push_str("\n\n");
+    }
+
+    insta::assert_snapshot!(
+        snapshot.trim_end(),
+        "strategy presets should remain distinct and ordered for editable integration",
+        @"
+    pull-rebase
+    merge-base merge-base
+    pick remote-only
+    pick remote-tip
+    pick local-only
+    pick local-tip
+
+    merge
+    merge-base merge-base
+    pick local-only
+    pick local-tip
+    merge remote-tip
+
+    pick-remote
+    merge-base merge-base
+    pick remote-only
+    pick remote-tip
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn initial_steps_smart_squash_folds_matching_upstream_commits_into_child_most_local_commit()
+-> Result<()> {
+    let (_tmp, mut repo) = build_smart_squash_example_repo()?;
+    configure_tracking_for_branch_a(&mut repo)?;
+    let change_id = ChangeId::from_number_for_testing(1);
+    let change_id_string = change_id.to_string();
+
+    let [local_parent, local_tip] = rewrite_commits_with_change_ids(
+        &repo,
+        "refs/heads/A",
+        &["A~1", "A"],
+        &[Some(change_id.clone()), Some(change_id.clone())],
+    )?
+    .try_into()
+    .expect("rewrote two local commits");
+    let [remote_parent, remote_tip] = rewrite_commits_with_change_ids(
+        &repo,
+        "refs/remotes/origin/A",
+        &["origin/A~1", "origin/A"],
+        &[Some(change_id.clone()), Some(change_id)],
+    )?
+    .try_into()
+    .expect("rewrote two upstream commits");
+    let merge_base = repo.rev_parse_single("A~2")?.detach();
+
+    let initial = initial_integration_for_branch_with_strategy(
+        r("refs/heads/A"),
+        &repo,
+        Some(r("refs/remotes/origin/main")),
+        BranchIntegrationStrategy::SmartSquash,
+    )?;
+
+    insta::assert_snapshot!(
+        labeled_integration_snapshot(
+            &initial.integration,
+            &[
+                (merge_base, "merge-base"),
+                (local_parent, "local-parent"),
+                (local_tip, "local-tip"),
+                (remote_parent, "remote-parent"),
+                (remote_tip, "remote-tip"),
+            ]
+        ),
+        "smart-squash should fold matched upstream commits into the child-most matching local commit",
+        @"
+    merge-base merge-base
+    pick local-parent
+    squash local-tip remote-parent remote-tip
+    "
+    );
+
+    assert_eq!(
+        initial
+            .integration
+            .steps
+            .iter()
+            .filter(|step| matches!(step, InteractiveIntegrationStep::Pick { commit_id } if *commit_id == remote_parent || *commit_id == remote_tip))
+            .count(),
+        0,
+        "matched upstream commits should not also be emitted as standalone picks"
+    );
+    let local_tip_display = initial
+        .divergence
+        .local_only
+        .iter()
+        .find(|commit| commit.id == local_tip)
+        .expect("local tip should be visible in divergence rows");
+    assert_eq!(
+        local_tip_display.change_id.as_deref(),
+        Some(change_id_string.as_str()),
+        "divergence rows should expose explicit Change-Ids"
+    );
+    assert!(
+        local_tip_display.created_at > 0,
+        "divergence rows should expose commit timestamps"
+    );
+    assert!(
+        !local_tip_display.author.name.is_empty(),
+        "divergence rows should expose commit authors"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn initial_steps_smart_squash_falls_back_to_pull_rebase_without_matching_explicit_change_ids()
+-> Result<()> {
+    let (_tmp, mut repo) = build_smart_squash_example_repo()?;
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let local_parent = repo.rev_parse_single("A~1")?.detach();
+    let remote_parent = repo.rev_parse_single("origin/A~1")?.detach();
+    let local_tip = repo.rev_parse_single("A")?.detach();
+    let remote_tip = repo.rev_parse_single("origin/A")?.detach();
+    let merge_base = repo.rev_parse_single("A~2")?.detach();
+    let labels = [
+        (merge_base, "merge-base"),
+        (local_parent, "local-parent"),
+        (local_tip, "local-tip"),
+        (remote_parent, "remote-parent"),
+        (remote_tip, "remote-tip"),
+    ];
+
+    let pull_rebase = initial_integration_for_branch_with_strategy(
+        r("refs/heads/A"),
+        &repo,
+        Some(r("refs/remotes/origin/main")),
+        BranchIntegrationStrategy::PullRebase,
+    )?;
+    let smart_squash = initial_integration_for_branch_with_strategy(
+        r("refs/heads/A"),
+        &repo,
+        Some(r("refs/remotes/origin/main")),
+        BranchIntegrationStrategy::SmartSquash,
+    )?;
+
+    insta::assert_snapshot!(
+        labeled_integration_snapshot(&smart_squash.integration, &labels),
+        "smart-squash should match pull-rebase when there are no explicit Change-Id headers",
+        @"
+    merge-base merge-base
+    pick remote-parent
+    pick remote-tip
+    pick local-parent
+    pick local-tip
+    "
+    );
+    assert_eq!(
+        labeled_integration_snapshot(&smart_squash.integration, &labels),
+        labeled_integration_snapshot(&pull_rebase.integration, &labels),
+        "headerless commits should not use synthetic Change-Ids for smart-squash matching",
+    );
+
+    let [local_parent, local_tip] = rewrite_commits_with_change_ids(
+        &repo,
+        "refs/heads/A",
+        &["A~1", "A"],
+        &[
+            Some(ChangeId::from_number_for_testing(1)),
+            Some(ChangeId::from_number_for_testing(2)),
+        ],
+    )?
+    .try_into()
+    .expect("rewrote two local commits");
+    let [remote_parent, remote_tip] = rewrite_commits_with_change_ids(
+        &repo,
+        "refs/remotes/origin/A",
+        &["origin/A~1", "origin/A"],
+        &[
+            Some(ChangeId::from_number_for_testing(3)),
+            Some(ChangeId::from_number_for_testing(4)),
+        ],
+    )?
+    .try_into()
+    .expect("rewrote two upstream commits");
+    let labels = [
+        (merge_base, "merge-base"),
+        (local_parent, "local-parent"),
+        (local_tip, "local-tip"),
+        (remote_parent, "remote-parent"),
+        (remote_tip, "remote-tip"),
+    ];
+    let smart_squash = initial_integration_for_branch_with_strategy(
+        r("refs/heads/A"),
+        &repo,
+        Some(r("refs/remotes/origin/main")),
+        BranchIntegrationStrategy::SmartSquash,
+    )?;
+
+    insta::assert_snapshot!(
+        labeled_integration_snapshot(&smart_squash.integration, &labels),
+        "smart-squash should match pull-rebase when explicit Change-Ids do not match",
+        @"
+    merge-base merge-base
+    pick remote-parent
+    pick remote-tip
+    pick local-parent
+    pick local-tip
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn initial_steps_smart_squash_does_not_target_integrated_local_commits() -> Result<()> {
+    let (_tmp, mut repo) = build_branch_integration_example_repo(
+        ExampleScenario::LocalCommitHistoricallyIntegratedOnTarget,
+    )?;
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let integrated_change_id = ChangeId::from_number_for_testing(1);
+    let [integrated_local, editable_local] = rewrite_commits_with_change_ids(
+        &repo,
+        "refs/heads/A",
+        &["A~1", "A"],
+        &[Some(integrated_change_id.clone()), None],
+    )?
+    .try_into()
+    .expect("rewrote two local commits");
+    let [upstream] = rewrite_commits_with_change_ids(
+        &repo,
+        "refs/remotes/origin/A",
+        &["origin/A"],
+        &[Some(integrated_change_id)],
+    )?
+    .try_into()
+    .expect("rewrote one upstream commit");
+    repo.reference(
+        "refs/remotes/origin/main",
+        integrated_local,
+        gix::refs::transaction::PreviousValue::Any,
+        "make rewritten local commit integrated"
+            .as_bytes()
+            .as_bstr(),
+    )?;
+    let merge_base = repo.rev_parse_single("A~2")?.detach();
+
+    let initial = initial_integration_for_branch_with_strategy(
+        r("refs/heads/A"),
+        &repo,
+        Some(r("refs/remotes/origin/main")),
+        BranchIntegrationStrategy::SmartSquash,
+    )?;
+
+    insta::assert_snapshot!(
+        labeled_integration_snapshot(
+            &initial.integration,
+            &[
+                (merge_base, "merge-base"),
+                (integrated_local, "integrated-local"),
+                (editable_local, "editable-local"),
+                (upstream, "upstream"),
+            ]
+        ),
+        "smart-squash should not squash into local commits already integrated into the target",
+        @"
+    merge-base merge-base
+    pick upstream
+    pick editable-local
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn initial_steps_merge_strategy_picks_local_commits_then_merges_upstream_tip() -> Result<()> {
+    let mut repo =
+        read_only_in_memory_scenario_named("with-remotes-no-workspace", "remote-diverged")?;
+
+    let local_tip = repo.rev_parse_single("A")?.detach();
+    let upstream_tip = repo.rev_parse_single("origin/A")?.detach();
+    let merge_base = repo.rev_parse_single("A~1")?.detach();
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let initial = initial_integration_for_branch_with_strategy(
+        r("refs/heads/A"),
+        &repo,
+        Some(r("refs/remotes/origin/main")),
+        BranchIntegrationStrategy::Merge,
+    )?;
+
+    insta::assert_snapshot!(
+        labeled_integration_snapshot(
+            &initial.integration,
+            &[
+                (merge_base, "merge-base"),
+                (local_tip, "local-tip"),
+                (upstream_tip, "upstream-tip"),
+            ]
+        ),
+        @"
+    merge-base merge-base
+    pick local-tip
+    merge upstream-tip
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn initial_steps_merge_strategy_skips_integrated_local_commits() -> Result<()> {
+    let (_tmp, mut repo) = build_branch_integration_example_repo(
+        ExampleScenario::LocalCommitHistoricallyIntegratedOnTarget,
+    )?;
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let a = repo.rev_parse_single("main")?.detach();
+    let b = repo.rev_parse_single("A~1")?.detach();
+    let c = repo.rev_parse_single("A")?.detach();
+    let d = repo.rev_parse_single("origin/A")?.detach();
+
+    let initial = initial_integration_for_branch_with_strategy(
+        r("refs/heads/A"),
+        &repo,
+        Some(r("refs/remotes/origin/main")),
+        BranchIntegrationStrategy::Merge,
+    )?;
+
+    insta::assert_snapshot!(
+        labeled_integration_snapshot(&initial.integration, &[(a, "A"), (b, "B"), (c, "C"), (d, "D")]),
+        @"
+    merge-base A
+    pick C
+    merge D
+    "
+    );
+
+    assert!(
+        !pick_step_ids(&initial.integration.steps).contains(&b),
+        "merge strategy should skip local commits already integrated into the target"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn initial_steps_pick_remote_strategy_picks_only_upstream_commits() -> Result<()> {
+    let mut repo = read_only_in_memory_scenario_named(
+        "journey03",
+        "01-rewritten-local-commit-is-paired-with-remote",
+    )?;
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let local_only = repo.rev_parse_single("A~1")?.detach();
+    let remote_only = repo.rev_parse_single("origin/A~1")?.detach();
+    let local_tip = repo.rev_parse_single("A")?.detach();
+    let remote_tip = repo.rev_parse_single("origin/A")?.detach();
+    let merge_base = repo.rev_parse_single("A~2")?.detach();
+
+    let initial = initial_integration_for_branch_with_strategy(
+        r("refs/heads/A"),
+        &repo,
+        Some(r("refs/remotes/origin/main")),
+        BranchIntegrationStrategy::PickRemote,
+    )?;
+
+    insta::assert_snapshot!(
+        labeled_integration_snapshot(
+            &initial.integration,
+            &[
+                (merge_base, "merge-base"),
+                (local_only, "local-only"),
+                (remote_only, "remote-only"),
+                (local_tip, "local-tip"),
+                (remote_tip, "remote-tip"),
+            ]
+        ),
+        @"
+    merge-base merge-base
+    pick remote-only
+    pick remote-tip
+    "
+    );
+
+    assert_eq!(
+        pick_step_ids(&initial.integration.steps),
+        vec![remote_only, remote_tip],
+        "pick-remote should keep only upstream commits in parent-to-child order",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn integrate_branch_with_steps_empty_errors_early() -> Result<()> {
+    let (_tmp, graph, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-ws-commit-single-stack-double-stack",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "C", StackState::InWorkspace, &["B"]);
+            },
+        )?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @r"
+    *   f3e1bf2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\
+    | * 09d8e52 (A) A
+    * | 09bc93e (C) C
+    * | c813d8d (B) B
+    |/
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    let merge_base = repo.rev_parse_single("main")?.detach();
+    let integration = InteractiveIntegration {
+        merge_base,
+        first_local_not_integrated: None,
+        steps: vec![],
+    };
+
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let err =
+        integrate_branch_with_steps(r("refs/heads/B"), integration, &mut ws, &mut meta, &repo)
+            .expect_err("expected early validation error for empty integration steps");
+    assert!(
+        err.to_string()
+            .contains("Integration steps cannot be empty"),
+        "unexpected error: {err:#}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn integrate_branch_with_merge_step_does_not_require_preceding_commit() -> Result<()> {
+    let (_tmp, graph, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "remote-diverged-with-workspace",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            },
+        )?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @"
+    * a7060f8 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 8347946 (A) local change in A 2
+    * 86838ae local change in A 1
+    | * 6a17628 (origin/A) remote change in A 2
+    | * 715d7b0 remote change in A 1
+    |/
+    * 621b98a shared local/remote
+    * cfbcc20 (origin/main, main) init-integration
+    ");
+
+    let mut ws = graph.into_workspace()?;
+
+    let remote_commit_1 = repo.rev_parse_single("origin/A~1")?.detach();
+    let local_commit_1 = repo.rev_parse_single("A~1")?.detach();
+    let local_and_remote = repo.rev_parse_single("A~2")?.detach();
+    let remote_tip_before = repo.rev_parse_single("origin/A")?.detach();
+    let integration = InteractiveIntegration {
+        merge_base: local_and_remote,
+        first_local_not_integrated: Some(local_commit_1),
+        steps: vec![InteractiveIntegrationStep::Merge {
+            commit_id: remote_commit_1,
+        }],
+    };
+
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let rebase =
+        integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
+    rebase.materialize()?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @r"
+    * 1934603 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   dc8c3e4 (A) Merge 715d7b0b14844b459ef031a7332283932e99a6a5 into previous commit
+    |\
+    | | * 6a17628 (origin/A) remote change in A 2
+    | |/
+    |/|
+    * | 715d7b0 remote change in A 1
+    |/
+    * 621b98a shared local/remote
+    * cfbcc20 (origin/main, main) init-integration
+    ");
+
+    assert_eq!(
+        repo.rev_parse_single("origin/A")?.detach(),
+        remote_tip_before
+    );
+
+    Ok(())
+}
+
+#[test]
+fn integrate_upstream_commits_into_local() -> Result<()> {
+    let (_tmp, graph, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "remote-diverged-with-workspace",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            },
+        )?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @"
+    * a7060f8 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 8347946 (A) local change in A 2
+    * 86838ae local change in A 1
+    | * 6a17628 (origin/A) remote change in A 2
+    | * 715d7b0 remote change in A 1
+    |/
+    * 621b98a shared local/remote
+    * cfbcc20 (origin/main, main) init-integration
+    ");
+
+    let mut ws = graph.into_workspace()?;
+
+    let local_commit_2 = repo.rev_parse_single("A")?.detach();
+    let local_commit_1 = repo.rev_parse_single("A~1")?.detach();
+    let remote_commit_2 = repo.rev_parse_single("origin/A")?.detach();
+    let remote_commit_1 = repo.rev_parse_single("origin/A~1")?.detach();
+    let remote_tip_before = remote_commit_2;
+    let local_and_remote = repo.rev_parse_single("A~2")?.detach();
+    let steps = vec![
+        InteractiveIntegrationStep::Pick {
+            commit_id: remote_commit_1,
+        },
+        InteractiveIntegrationStep::Pick {
+            commit_id: remote_commit_2,
+        },
+        InteractiveIntegrationStep::Pick {
+            commit_id: local_commit_1,
+        },
+        InteractiveIntegrationStep::Pick {
+            commit_id: local_commit_2,
+        },
+    ];
+
+    let integration = InteractiveIntegration {
+        merge_base: local_and_remote,
+        first_local_not_integrated: Some(local_commit_1),
+        steps,
+    };
+
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let rebase =
+        integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
+    rebase.materialize()?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * 455d393 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 298d472 (A) local change in A 2
+    * 422a07d local change in A 1
+    * 6a17628 (origin/A) remote change in A 2
+    * 715d7b0 remote change in A 1
+    * 621b98a shared local/remote
+    * cfbcc20 (origin/main, main) init-integration
+    ");
+
+    assert_eq!(
+        repo.rev_parse_single("origin/A")?.detach(),
+        remote_tip_before
+    );
+
+    Ok(())
+}
+
+#[test]
+fn integrate_upstream_commits_into_local_with_merge_step() -> Result<()> {
+    let (_tmp, graph, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "remote-diverged-with-workspace",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            },
+        )?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @"
+    * a7060f8 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 8347946 (A) local change in A 2
+    * 86838ae local change in A 1
+    | * 6a17628 (origin/A) remote change in A 2
+    | * 715d7b0 remote change in A 1
+    |/
+    * 621b98a shared local/remote
+    * cfbcc20 (origin/main, main) init-integration
+    ");
+
+    let mut ws = graph.into_workspace()?;
+
+    let local_commit_2 = repo.rev_parse_single("A")?.detach();
+    let local_commit_1 = repo.rev_parse_single("A~1")?.detach();
+    let remote_commit_1 = repo.rev_parse_single("origin/A~1")?.detach();
+    let local_and_remote = repo.rev_parse_single("A~2")?.detach();
+    let integration = InteractiveIntegration {
+        merge_base: local_and_remote,
+        first_local_not_integrated: Some(local_commit_1),
+        steps: vec![
+            InteractiveIntegrationStep::Pick {
+                commit_id: local_commit_1,
+            },
+            InteractiveIntegrationStep::Merge {
+                commit_id: remote_commit_1,
+            },
+            InteractiveIntegrationStep::Pick {
+                commit_id: local_commit_2,
+            },
+        ],
+    };
+
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let rebase =
+        integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
+    rebase.materialize()?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @r"
+    * a74b8e3 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * fdc285b (A) local change in A 2
+    *   0d584c5 Merge 715d7b0b14844b459ef031a7332283932e99a6a5 into previous commit
+    |\
+    * | 86838ae local change in A 1
+    | | * 6a17628 (origin/A) remote change in A 2
+    | |/
+    | * 715d7b0 remote change in A 1
+    |/
+    * 621b98a shared local/remote
+    * cfbcc20 (origin/main, main) init-integration
+    ");
+
+    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?.detach())?;
+    let branch_tip_parents = branch_tip.parent_ids().collect::<Vec<_>>();
+    assert_eq!(
+        branch_tip_parents.len(),
+        1,
+        "tip should remain a non-merge commit"
+    );
+
+    let merge_commit_id = branch_tip_parents[0].detach();
+    let merge_commit = repo.find_commit(merge_commit_id)?;
+    assert_eq!(
+        merge_commit.message_raw()?,
+        format!("Merge {remote_commit_1} into previous commit")
+    );
+
+    let merge_parents = merge_commit.parent_ids().collect::<Vec<_>>();
+    assert_eq!(
+        merge_parents.len(),
+        2,
+        "merge step should produce a merge commit"
+    );
+    assert_eq!(
+        merge_parents[1].detach(),
+        remote_commit_1,
+        "merge step should retain the selected remote commit as the second parent"
+    );
+
+    let merged_previous_commit = merge_parents[0].detach();
+    let merged_previous = repo.find_commit(merged_previous_commit)?;
+    assert_eq!(merged_previous.message_raw()?, "local change in A 1\n");
+
+    insta::assert_snapshot!(visualize_tree(merge_commit.tree_id()?), @"4b825dc");
+
+    Ok(())
+}
+
+#[test]
+fn integrate_upstream_commits_into_local_with_all_locals_then_merge_second_remote() -> Result<()> {
+    let (_tmp, graph, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "remote-diverged-with-workspace",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            },
+        )?;
+
+    let mut ws = graph.into_workspace()?;
+
+    let local_commit_2 = repo.rev_parse_single("A")?.detach();
+    let local_commit_1 = repo.rev_parse_single("A~1")?.detach();
+    let remote_commit_2 = repo.rev_parse_single("origin/A")?.detach();
+    let local_and_remote = repo.rev_parse_single("A~2")?.detach();
+    let integration = InteractiveIntegration {
+        merge_base: local_and_remote,
+        first_local_not_integrated: Some(local_commit_1),
+        steps: vec![
+            InteractiveIntegrationStep::Pick {
+                commit_id: local_commit_1,
+            },
+            InteractiveIntegrationStep::Pick {
+                commit_id: local_commit_2,
+            },
+            InteractiveIntegrationStep::Merge {
+                commit_id: remote_commit_2,
+            },
+        ],
+    };
+
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let rebase =
+        integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
+    rebase.materialize()?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @r"
+    * a11c807 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   93bbd52 (A) Merge 6a176285f918d0e4249373b102abe662d4eeeb29 into previous commit
+    |\
+    | * 6a17628 (origin/A) remote change in A 2
+    | * 715d7b0 remote change in A 1
+    * | 8347946 local change in A 2
+    * | 86838ae local change in A 1
+    |/
+    * 621b98a shared local/remote
+    * cfbcc20 (origin/main, main) init-integration
+    ");
+
+    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?.detach())?;
+    assert_eq!(
+        branch_tip.message_raw()?,
+        format!("Merge {remote_commit_2} into previous commit")
+    );
+
+    let merge_parents = branch_tip.parent_ids().collect::<Vec<_>>();
+    assert_eq!(merge_parents.len(), 2, "tip should be a merge commit");
+    assert_eq!(merge_parents[1].detach(), remote_commit_2);
+
+    let first_parent = repo.find_commit(merge_parents[0].detach())?;
+    assert_eq!(first_parent.message_raw()?, "local change in A 2\n");
+
+    Ok(())
+}
+
+#[test]
+fn integrate_upstream_commits_into_local_with_two_merges_in_sequence() -> Result<()> {
+    let (_tmp, graph, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "remote-diverged-with-workspace",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            },
+        )?;
+
+    let mut ws = graph.into_workspace()?;
+
+    let local_commit_2 = repo.rev_parse_single("A")?.detach();
+    let local_commit_1 = repo.rev_parse_single("A~1")?.detach();
+    let remote_commit_1 = repo.rev_parse_single("origin/A~1")?.detach();
+    let remote_commit_2 = repo.rev_parse_single("origin/A")?.detach();
+    let local_and_remote = repo.rev_parse_single("A~2")?.detach();
+    let integration = InteractiveIntegration {
+        merge_base: local_and_remote,
+        first_local_not_integrated: Some(local_commit_1),
+        steps: vec![
+            InteractiveIntegrationStep::Pick {
+                commit_id: local_commit_1,
+            },
+            InteractiveIntegrationStep::Merge {
+                commit_id: remote_commit_1,
+            },
+            InteractiveIntegrationStep::Pick {
+                commit_id: local_commit_2,
+            },
+            InteractiveIntegrationStep::Merge {
+                commit_id: remote_commit_2,
+            },
+        ],
+    };
+
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let rebase =
+        integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
+    rebase.materialize()?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @r"
+    * d69c4de (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   ab7f588 (A) Merge 6a176285f918d0e4249373b102abe662d4eeeb29 into previous commit
+    |\
+    | * 6a17628 (origin/A) remote change in A 2
+    * | fdc285b local change in A 2
+    * | 0d584c5 Merge 715d7b0b14844b459ef031a7332283932e99a6a5 into previous commit
+    |\|
+    | * 715d7b0 remote change in A 1
+    * | 86838ae local change in A 1
+    |/
+    * 621b98a shared local/remote
+    * cfbcc20 (origin/main, main) init-integration
+    ");
+
+    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?.detach())?;
+    assert_eq!(
+        branch_tip.message_raw()?,
+        format!("Merge {remote_commit_2} into previous commit")
+    );
+
+    let branch_tip_parents = branch_tip.parent_ids().collect::<Vec<_>>();
+    assert_eq!(branch_tip_parents.len(), 2, "tip should be a merge commit");
+    assert_eq!(
+        branch_tip_parents[1].detach(),
+        remote_commit_2,
+        "second merge should keep the selected commit as second parent"
+    );
+
+    let first_parent = repo.find_commit(branch_tip_parents[0].detach())?;
+    assert_eq!(first_parent.message_raw()?, "local change in A 2\n");
+    let first_parent_parents = first_parent.parent_ids().collect::<Vec<_>>();
+    assert_eq!(
+        first_parent_parents.len(),
+        1,
+        "the picked local commit before the self-merge should remain linear"
+    );
+    let remote_merge = repo.find_commit(first_parent_parents[0].detach())?;
+    assert_eq!(
+        remote_merge.message_raw()?,
+        format!("Merge {remote_commit_1} into previous commit"),
+        "the later merge should preserve the earlier remote merge in first-parent history"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn integrate_upstream_commits_into_local_with_remote_on_top() -> Result<()> {
+    let (_tmp, graph, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "remote-diverged-with-workspace",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            },
+        )?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @"
+    * a7060f8 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 8347946 (A) local change in A 2
+    * 86838ae local change in A 1
+    | * 6a17628 (origin/A) remote change in A 2
+    | * 715d7b0 remote change in A 1
+    |/
+    * 621b98a shared local/remote
+    * cfbcc20 (origin/main, main) init-integration
+    ");
+
+    let mut ws = graph.into_workspace()?;
+
+    let local_commit_2 = repo.rev_parse_single("A")?.detach();
+    let local_commit_1 = repo.rev_parse_single("A~1")?.detach();
+    let remote_commit_2 = repo.rev_parse_single("origin/A")?.detach();
+    let remote_commit_1 = repo.rev_parse_single("origin/A~1")?.detach();
+    let local_and_remote = repo.rev_parse_single("A~2")?.detach();
+    let steps = vec![
+        InteractiveIntegrationStep::Pick {
+            commit_id: local_commit_1,
+        },
+        InteractiveIntegrationStep::Pick {
+            commit_id: local_commit_2,
+        },
+        InteractiveIntegrationStep::Pick {
+            commit_id: remote_commit_1,
+        },
+        InteractiveIntegrationStep::Pick {
+            commit_id: remote_commit_2,
+        },
+    ];
+
+    let integration = InteractiveIntegration {
+        merge_base: local_and_remote,
+        first_local_not_integrated: Some(local_commit_1),
+        steps,
+    };
+
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let rebase =
+        integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
+    rebase.materialize()?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @"
+    * fb437fd (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 85ce57b (A) remote change in A 2
+    * 01b7a91 remote change in A 1
+    * 8347946 local change in A 2
+    * 86838ae local change in A 1
+    | * 6a17628 (origin/A) remote change in A 2
+    | * 715d7b0 remote change in A 1
+    |/
+    * 621b98a shared local/remote
+    * cfbcc20 (origin/main, main) init-integration
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn integrate_upstream_commits_into_local_with_remote_interlaced() -> Result<()> {
+    let (_tmp, graph, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "remote-diverged-with-workspace",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            },
+        )?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @"
+    * a7060f8 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 8347946 (A) local change in A 2
+    * 86838ae local change in A 1
+    | * 6a17628 (origin/A) remote change in A 2
+    | * 715d7b0 remote change in A 1
+    |/
+    * 621b98a shared local/remote
+    * cfbcc20 (origin/main, main) init-integration
+    ");
+
+    let mut ws = graph.into_workspace()?;
+
+    let local_commit_2 = repo.rev_parse_single("A")?.detach();
+    let local_commit_1 = repo.rev_parse_single("A~1")?.detach();
+    let remote_commit_2 = repo.rev_parse_single("origin/A")?.detach();
+    let remote_commit_1 = repo.rev_parse_single("origin/A~1")?.detach();
+    let local_and_remote = repo.rev_parse_single("A~2")?.detach();
+    let steps = vec![
+        InteractiveIntegrationStep::Pick {
+            commit_id: remote_commit_1,
+        },
+        InteractiveIntegrationStep::Pick {
+            commit_id: local_commit_1,
+        },
+        InteractiveIntegrationStep::Pick {
+            commit_id: remote_commit_2,
+        },
+        InteractiveIntegrationStep::Pick {
+            commit_id: local_commit_2,
+        },
+    ];
+
+    let integration = InteractiveIntegration {
+        merge_base: local_and_remote,
+        first_local_not_integrated: Some(local_commit_1),
+        steps,
+    };
+
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let rebase =
+        integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
+    rebase.materialize()?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @"
+    * 0ce7098 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * ad12639 (A) local change in A 2
+    * a6a4994 remote change in A 2
+    * 593d2d6 local change in A 1
+    | * 6a17628 (origin/A) remote change in A 2
+    |/
+    * 715d7b0 remote change in A 1
+    * 621b98a shared local/remote
+    * cfbcc20 (origin/main, main) init-integration
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn integrate_upstream_commits_into_local_with_remote_one_local_one_remote() -> Result<()> {
+    let (_tmp, graph, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "remote-diverged-with-workspace",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            },
+        )?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @"
+    * a7060f8 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 8347946 (A) local change in A 2
+    * 86838ae local change in A 1
+    | * 6a17628 (origin/A) remote change in A 2
+    | * 715d7b0 remote change in A 1
+    |/
+    * 621b98a shared local/remote
+    * cfbcc20 (origin/main, main) init-integration
+    ");
+
+    let mut ws = graph.into_workspace()?;
+
+    let local_commit_1 = repo.rev_parse_single("A~1")?.detach();
+    let remote_commit_2 = repo.rev_parse_single("origin/A")?.detach();
+    let local_and_remote = repo.rev_parse_single("A~2")?.detach();
+    let steps = vec![
+        InteractiveIntegrationStep::Pick {
+            commit_id: local_commit_1,
+        },
+        InteractiveIntegrationStep::Pick {
+            commit_id: remote_commit_2,
+        },
+    ];
+
+    let integration = InteractiveIntegration {
+        merge_base: local_and_remote,
+        first_local_not_integrated: Some(local_commit_1),
+        steps,
+    };
+
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let rebase =
+        integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
+    rebase.materialize()?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @"
+    * ab8c010 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 801c92f (A) remote change in A 2
+    * 86838ae local change in A 1
+    | * 6a17628 (origin/A) remote change in A 2
+    | * 715d7b0 remote change in A 1
+    |/
+    * 621b98a shared local/remote
+    * cfbcc20 (origin/main, main) init-integration
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn integrate_upstream_commits_into_local_with_remote_one_local_one_remote_and_extra_local_ref()
+-> Result<()> {
+    let (_tmp, graph, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "remote-diverged-with-workspace",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            },
+        )?;
+
+    add_local_ref_at_ref(&repo, "A-shadow", "A")?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @"
+    * a7060f8 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 8347946 (A-shadow, A) local change in A 2
+    * 86838ae local change in A 1
+    | * 6a17628 (origin/A) remote change in A 2
+    | * 715d7b0 remote change in A 1
+    |/
+    * 621b98a shared local/remote
+    * cfbcc20 (origin/main, main) init-integration
+    ");
+
+    let mut ws = graph.into_workspace()?;
+
+    let local_commit_1 = repo.rev_parse_single("A~1")?.detach();
+    let remote_commit_2 = repo.rev_parse_single("origin/A")?.detach();
+    let local_and_remote = repo.rev_parse_single("A~2")?.detach();
+    let steps = vec![
+        InteractiveIntegrationStep::Pick {
+            commit_id: local_commit_1,
+        },
+        InteractiveIntegrationStep::Pick {
+            commit_id: remote_commit_2,
+        },
+    ];
+
+    let integration = InteractiveIntegration {
+        merge_base: local_and_remote,
+        first_local_not_integrated: Some(local_commit_1),
+        steps,
+    };
+
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let rebase =
+        integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
+    rebase.materialize()?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @"
+    * 8347946 (A-shadow) local change in A 2
+    | * ab8c010 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    | * 801c92f (A) remote change in A 2
+    |/
+    * 86838ae local change in A 1
+    | * 6a17628 (origin/A) remote change in A 2
+    | * 715d7b0 remote change in A 1
+    |/
+    * 621b98a shared local/remote
+    * cfbcc20 (origin/main, main) init-integration
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn integrate_upstream_commits_into_local_with_only_remote_commits() -> Result<()> {
+    let (_tmp, graph, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "remote-diverged-with-workspace",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            },
+        )?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @"
+    * a7060f8 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 8347946 (A) local change in A 2
+    * 86838ae local change in A 1
+    | * 6a17628 (origin/A) remote change in A 2
+    | * 715d7b0 remote change in A 1
+    |/
+    * 621b98a shared local/remote
+    * cfbcc20 (origin/main, main) init-integration
+    ");
+
+    let mut ws = graph.into_workspace()?;
+
+    let remote_commit_2 = repo.rev_parse_single("origin/A")?.detach();
+    let remote_commit_1 = repo.rev_parse_single("origin/A~1")?.detach();
+    let local_commit_1 = repo.rev_parse_single("A~1")?.detach();
+    let local_and_remote = repo.rev_parse_single("A~2")?.detach();
+    let steps = vec![
+        InteractiveIntegrationStep::Pick {
+            commit_id: remote_commit_1,
+        },
+        InteractiveIntegrationStep::Pick {
+            commit_id: remote_commit_2,
+        },
+    ];
+
+    let integration = InteractiveIntegration {
+        merge_base: local_and_remote,
+        first_local_not_integrated: Some(local_commit_1),
+        steps,
+    };
+
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let rebase =
+        integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
+    rebase.materialize()?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @"
+    * b3d4566 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 6a17628 (origin/A, A) remote change in A 2
+    * 715d7b0 remote change in A 1
+    * 621b98a shared local/remote
+    * cfbcc20 (origin/main, main) init-integration
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn integrate_upstream_commits_into_local_with_squashed_local_commits() -> Result<()> {
+    let (_tmp, graph, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "remote-diverged-with-workspace",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            },
+        )?;
+
+    let mut ws = graph.into_workspace()?;
+
+    let local_commit_2 = repo.rev_parse_single("A")?.detach();
+    let local_commit_1 = repo.rev_parse_single("A~1")?.detach();
+    let remote_commit_2 = repo.rev_parse_single("origin/A")?.detach();
+    let remote_commit_1 = repo.rev_parse_single("origin/A~1")?.detach();
+    let local_and_remote = repo.rev_parse_single("A~2")?.detach();
+    let steps = vec![
+        InteractiveIntegrationStep::Pick {
+            commit_id: remote_commit_1,
+        },
+        InteractiveIntegrationStep::Pick {
+            commit_id: remote_commit_2,
+        },
+        InteractiveIntegrationStep::Squash {
+            commits: vec![local_commit_1, local_commit_2],
+            message: Some("squashed local commits".to_string()),
+        },
+    ];
+
+    let integration = InteractiveIntegration {
+        merge_base: local_and_remote,
+        first_local_not_integrated: Some(local_commit_1),
+        steps,
+    };
+
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let rebase =
+        integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
+    rebase.materialize()?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @"
+    * 5ef31c2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * c297225 (A) squashed local commits
+    * 6a17628 (origin/A) remote change in A 2
+    * 715d7b0 remote change in A 1
+    * 621b98a shared local/remote
+    * cfbcc20 (origin/main, main) init-integration
+    ");
+
+    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?.detach())?;
+    assert_eq!(branch_tip.message_raw()?, "squashed local commits");
+
+    Ok(())
+}
+
+#[test]
+fn integrate_upstream_commits_into_local_with_squashed_remote_commits() -> Result<()> {
+    let (_tmp, graph, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "remote-diverged-with-workspace",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            },
+        )?;
+
+    let mut ws = graph.into_workspace()?;
+
+    let local_commit_2 = repo.rev_parse_single("A")?.detach();
+    let local_commit_1 = repo.rev_parse_single("A~1")?.detach();
+    let remote_commit_2 = repo.rev_parse_single("origin/A")?.detach();
+    let remote_commit_1 = repo.rev_parse_single("origin/A~1")?.detach();
+    let local_and_remote = repo.rev_parse_single("A~2")?.detach();
+    let steps = vec![
+        InteractiveIntegrationStep::Pick {
+            commit_id: local_commit_1,
+        },
+        InteractiveIntegrationStep::Pick {
+            commit_id: local_commit_2,
+        },
+        InteractiveIntegrationStep::Squash {
+            commits: vec![remote_commit_1, remote_commit_2],
+            message: Some("squashed remote commits".to_string()),
+        },
+    ];
+
+    let integration = InteractiveIntegration {
+        merge_base: local_and_remote,
+        first_local_not_integrated: Some(local_commit_1),
+        steps,
+    };
+
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let rebase =
+        integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
+    rebase.materialize()?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @"
+    * 3699070 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 3838b79 (A) squashed remote commits
+    * 8347946 local change in A 2
+    * 86838ae local change in A 1
+    | * 6a17628 (origin/A) remote change in A 2
+    | * 715d7b0 remote change in A 1
+    |/
+    * 621b98a shared local/remote
+    * cfbcc20 (origin/main, main) init-integration
+    ");
+
+    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?.detach())?;
+    assert_eq!(branch_tip.message_raw()?, "squashed remote commits");
+
+    Ok(())
+}
+
+#[test]
+fn integrate_upstream_commits_into_local_with_squashed_remote_into_local_commits() -> Result<()> {
+    let (_tmp, graph, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "remote-diverged-with-workspace",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            },
+        )?;
+
+    let mut ws = graph.into_workspace()?;
+
+    let local_commit_2 = repo.rev_parse_single("A")?.detach();
+    let local_commit_1 = repo.rev_parse_single("A~1")?.detach();
+    let remote_commit_2 = repo.rev_parse_single("origin/A")?.detach();
+    let remote_commit_1 = repo.rev_parse_single("origin/A~1")?.detach();
+    let local_and_remote = repo.rev_parse_single("A~2")?.detach();
+    let steps = vec![
+        InteractiveIntegrationStep::Squash {
+            commits: vec![remote_commit_1, local_commit_1],
+            message: Some("squash commits 1".to_string()),
+        },
+        InteractiveIntegrationStep::Squash {
+            commits: vec![remote_commit_2, local_commit_2],
+            message: Some("squash commits 2".to_string()),
+        },
+    ];
+
+    let integration = InteractiveIntegration {
+        merge_base: local_and_remote,
+        first_local_not_integrated: Some(local_commit_1),
+        steps,
+    };
+
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let rebase =
+        integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
+    rebase.materialize()?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @"
+    * 8a9dd44 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * c6b942b (A) squash commits 2
+    * a524f0a squash commits 1
+    | * 6a17628 (origin/A) remote change in A 2
+    | * 715d7b0 remote change in A 1
+    |/
+    * 621b98a shared local/remote
+    * cfbcc20 (origin/main, main) init-integration
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn integrate_upstream_commits_into_local_with_squashed_remote_into_local_conflicts() -> Result<()> {
+    let (_tmp, graph, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "remote-diverged-with-workspace-conflicting",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            },
+        )?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @"
+    * 8fd8fb6 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 61c4a24 (A) local change in A 1
+    | * f03fc2c (origin/A, new-origin) remote change in A 1
+    |/
+    * 2b73dee (origin/main, main) init-integration
+    ");
+
+    let mut ws = graph.into_workspace()?;
+
+    let local_commit_1 = repo.rev_parse_single("A")?.detach();
+    let remote_commit_1 = repo.rev_parse_single("origin/A")?.detach();
+    let local_and_remote = repo.rev_parse_single("main")?.detach();
+    let steps = vec![InteractiveIntegrationStep::Squash {
+        commits: vec![remote_commit_1, local_commit_1],
+        message: Some("squashed conflicting commits".to_string()),
+    }];
+
+    let integration = InteractiveIntegration {
+        merge_base: local_and_remote,
+        first_local_not_integrated: Some(local_commit_1),
+        steps,
+    };
+
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let rebase =
+        integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
+    rebase.materialize()?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @"
+    * f03fc2c (origin/A, new-origin) remote change in A 1
+    | * 1b052b4 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    | * 20ebfcc (A) [conflict] squashed conflicting commits
+    |/
+    * 2b73dee (origin/main, main) init-integration
+    ");
+
+    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?.detach())?;
+    assert!(Commit::from_id(branch_tip.id.attach(&repo))?.is_conflicted());
+    insta::assert_snapshot!(branch_tip.message_raw()?, @r#"
+    [conflict] squashed conflicting commits
+
+    GitButler-Conflict: This is a GitButler-managed conflicted commit. Files are auto-resolved
+       using the "ours" side. The commit tree contains additional directories:
+         .conflict-side-0  — our tree
+         .conflict-side-1  — their tree
+         .conflict-base-0  — the merge base tree
+         .auto-resolution  — the auto-resolved tree
+         .conflict-files   — metadata about conflicted files
+       To manually resolve, check out this commit, remove the directories
+       listed above, resolve the conflicts, and amend the commit.
+    "#);
+    insta::assert_snapshot!(normalized_tree_snapshot(branch_tip.tree_id()?.detach(), &repo)?, @r#"
+    450d676
+    ├── .auto-resolution:276d2b4
+    │   └── shared.txt:100644:4083037 "local\n"
+    ├── .conflict-base-0:48e531d
+    │   └── shared.txt:100644:df967b9 "base\n"
+    ├── .conflict-files:100644:d0a3da4 "ancestorEntries = [\"shared.txt\"]\nourEntries = [\"shared.txt\"]\ntheirEntries = [\"shared.txt\"]\n"
+    ├── .conflict-side-0:276d2b4
+    │   └── shared.txt:100644:4083037 "local\n"
+    ├── .conflict-side-1:cd74779
+    │   └── shared.txt:100644:9c998f7 "remote\n"
+    └── shared.txt:100644:4083037 "local\n"
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn integrate_upstream_commits_into_local_with_merge_remote_into_local_conflicts() -> Result<()> {
+    let (_tmp, graph, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "remote-diverged-with-workspace-conflicting",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            },
+        )?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @"
+    * 8fd8fb6 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 61c4a24 (A) local change in A 1
+    | * f03fc2c (origin/A, new-origin) remote change in A 1
+    |/
+    * 2b73dee (origin/main, main) init-integration
+    ");
+
+    let mut ws = graph.into_workspace()?;
+
+    let local_commit_1 = repo.rev_parse_single("A")?.detach();
+    let remote_commit_1 = repo.rev_parse_single("origin/A")?.detach();
+    let local_and_remote = repo.rev_parse_single("main")?.detach();
+    let integration = InteractiveIntegration {
+        merge_base: local_and_remote,
+        first_local_not_integrated: Some(local_commit_1),
+        steps: vec![
+            InteractiveIntegrationStep::Pick {
+                commit_id: local_commit_1,
+            },
+            InteractiveIntegrationStep::Merge {
+                commit_id: remote_commit_1,
+            },
+        ],
+    };
+
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let rebase =
+        integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
+    rebase.materialize()?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @r"
+    * 9b44771 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   c813ff0 (A) [conflict] Merge f03fc2cb7251fb1707fa0f7bee28eb507ec1405c into previous commit
+    |\
+    | * f03fc2c (origin/A, new-origin) remote change in A 1
+    * | 61c4a24 local change in A 1
+    |/
+    * 2b73dee (origin/main, main) init-integration
+    ");
+
+    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?.detach())?;
+    assert!(
+        Commit::from_id(branch_tip.id.attach(&repo))?.is_conflicted(),
+        "merge integration should materialize a conflicted commit when upstream and local changes conflict",
+    );
+    assert_eq!(
+        branch_tip.message_raw()?,
+        format!(
+            "[conflict] Merge {remote_commit_1} into previous commit\n\nGitButler-Conflict: This is a GitButler-managed conflicted commit. Files are auto-resolved\n   using the \"ours\" side. The commit tree contains additional directories:\n     .conflict-side-0  — our tree\n     .conflict-side-1  — their tree\n     .conflict-base-0  — the merge base tree\n     .auto-resolution  — the auto-resolved tree\n     .conflict-files   — metadata about conflicted files\n   To manually resolve, check out this commit, remove the directories\n   listed above, resolve the conflicts, and amend the commit.\n"
+        ),
+        "merge integration should write the standard conflicted-commit message",
+    );
+
+    let merge_parents = branch_tip.parent_ids().collect::<Vec<_>>();
+    assert_eq!(
+        merge_parents.len(),
+        2,
+        "conflicted merge integration should still produce a merge commit",
+    );
+    assert_eq!(
+        merge_parents[1].detach(),
+        remote_commit_1,
+        "merge integration should retain the upstream commit as the second parent even when conflicted",
+    );
+
+    let first_parent = repo.find_commit(merge_parents[0].detach())?;
+    assert_eq!(
+        first_parent.message_raw()?,
+        "local change in A 1\n",
+        "merge integration should retain the local commit as first parent even when conflicted",
+    );
+
+    insta::assert_snapshot!(normalized_tree_snapshot(branch_tip.tree_id()?.detach(), &repo)?, @r#"
+    450d676
+    ├── .auto-resolution:276d2b4
+    │   └── shared.txt:100644:4083037 "local\n"
+    ├── .conflict-base-0:48e531d
+    │   └── shared.txt:100644:df967b9 "base\n"
+    ├── .conflict-files:100644:d0a3da4 "ancestorEntries = [\"shared.txt\"]\nourEntries = [\"shared.txt\"]\ntheirEntries = [\"shared.txt\"]\n"
+    ├── .conflict-side-0:276d2b4
+    │   └── shared.txt:100644:4083037 "local\n"
+    ├── .conflict-side-1:cd74779
+    │   └── shared.txt:100644:9c998f7 "remote\n"
+    └── shared.txt:100644:4083037 "local\n"
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn integrate_upstream_commits_into_local_with_merge_remote_into_local_conflicts_preview()
+-> Result<()> {
+    let (_tmp, graph, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "remote-diverged-with-workspace-conflicting",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            },
+        )?;
+
+    let mut ws = graph.into_workspace()?;
+
+    let local_commit_1 = repo.rev_parse_single("A")?.detach();
+    let remote_commit_1 = repo.rev_parse_single("origin/A")?.detach();
+    let local_and_remote = repo.rev_parse_single("main")?.detach();
+    let integration = InteractiveIntegration {
+        merge_base: local_and_remote,
+        first_local_not_integrated: Some(local_commit_1),
+        steps: vec![
+            InteractiveIntegrationStep::Pick {
+                commit_id: local_commit_1,
+            },
+            InteractiveIntegrationStep::Merge {
+                commit_id: remote_commit_1,
+            },
+        ],
+    };
+
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let rebase =
+        integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
+    let preview_graph = rebase.overlayed_graph()?;
+    let preview_workspace = preview_graph.into_workspace()?;
+    let ref_info = but_workspace::graph_to_ref_info(
+        &preview_workspace,
+        rebase.repo(),
+        but_workspace::ref_info::Options {
+            traversal: but_graph::init::Options::limited(),
+            expensive_commit_info: true,
+            ..Default::default()
+        },
+    )?
+    .pruned_to_entrypoint();
+
+    assert!(
+        !ref_info.stacks.is_empty(),
+        "dry-run branch integration preview should produce stack information"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn integrate_upstream_precomputes_squash_before_later_step_graph_rewiring() -> Result<()> {
+    let (_tmp, graph, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "remote-diverged-with-workspace",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            },
+        )?;
+
+    let mut ws = graph.into_workspace()?;
+
+    let local_commit_2 = repo.rev_parse_single("A")?.detach();
+    let local_commit_1 = repo.rev_parse_single("A~1")?.detach();
+    let local_and_remote = repo.rev_parse_single("A~2")?.detach();
+    let expected_squash_tree = repo.find_commit(local_commit_2)?.tree_id()?.detach();
+    let steps = vec![
+        InteractiveIntegrationStep::Squash {
+            commits: vec![local_commit_1, local_commit_2],
+            message: Some("squashed local commits".to_string()),
+        },
+        InteractiveIntegrationStep::Pick {
+            commit_id: local_commit_2,
+        },
+    ];
+
+    let integration = InteractiveIntegration {
+        merge_base: local_and_remote,
+        first_local_not_integrated: Some(local_commit_1),
+        steps,
+    };
+
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let rebase =
+        integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
+    rebase.materialize()?;
+
+    let mut current_commit_id = repo.rev_parse_single("A")?.detach();
+    let squashed_commit_id = loop {
+        let commit = repo.find_commit(current_commit_id)?;
+        if commit.message_raw()? == "squashed local commits" {
+            break current_commit_id;
+        }
+        let Some(parent_id) = commit.parent_ids().next() else {
+            panic!("prepared squash should still be materialized into first-parent history");
+        };
+        current_commit_id = parent_id.detach();
+    };
+    let squashed_commit = repo.find_commit(squashed_commit_id)?;
+    assert_eq!(
+        squashed_commit.tree_id()?.detach(),
+        expected_squash_tree,
+        "squash tree should be computed from the original repo topology before later graph rewiring",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn initial_steps_remote_diverged_with_workspace_are_in_application_order() -> Result<()> {
+    let (_tmp, _graph, mut repo, mut _meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "remote-diverged-with-workspace",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            },
+        )?;
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @"
+    * a7060f8 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 8347946 (A) local change in A 2
+    * 86838ae local change in A 1
+    | * 6a17628 (origin/A) remote change in A 2
+    | * 715d7b0 remote change in A 1
+    |/
+    * 621b98a shared local/remote
+    * cfbcc20 (origin/main, main) init-integration
+    ");
+
+    let local_commit_2 = repo.rev_parse_single("A")?.detach();
+    let local_commit_1 = repo.rev_parse_single("A~1")?.detach();
+    let remote_commit_2 = repo.rev_parse_single("origin/A")?.detach();
+    let remote_commit_1 = repo.rev_parse_single("origin/A~1")?.detach();
+    let merge_base = repo.rev_parse_single("A~2")?.detach();
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let initial = initial_integration_for_branch(
+        r("refs/heads/A"),
+        &repo,
+        Some(r("refs/remotes/origin/main")),
+    )?;
+
+    insta::assert_snapshot!(
+        labeled_integration_snapshot(
+            &initial.integration,
+            &[
+                (merge_base, "merge-base"),
+                (local_commit_2, "local-commit-2"),
+                (local_commit_1, "local-commit-1"),
+                (remote_commit_2, "remote-commit-2"),
+                (remote_commit_1, "remote-commit-1"),
+            ]
+        ),
+        @"
+    merge-base merge-base
+    pick remote-commit-1
+    pick remote-commit-2
+    pick local-commit-1
+    pick local-commit-2
+    "
+    );
+
+    insta::assert_snapshot!(
+        labeled_divergence_snapshot(
+            &initial,
+            &[
+                (merge_base, "merge-base"),
+                (local_commit_2, "local-commit-2"),
+                (local_commit_1, "local-commit-1"),
+                (remote_commit_2, "remote-commit-2"),
+                (remote_commit_1, "remote-commit-1"),
+            ]
+        ),
+        @"
+        * local-commit-2 (A) local change in A 2
+        * local-commit-1 local change in A 1
+        | * remote-commit-2 (origin/A) remote change in A 2
+        | * remote-commit-1 remote change in A 1
+        |/
+        * merge-base shared local/remote
+        "
+    );
+
+    assert_eq!(
+        pick_step_ids(&initial.integration.steps),
+        vec![
+            remote_commit_1,
+            remote_commit_2,
+            local_commit_1,
+            local_commit_2
+        ],
+        "expected parent-to-child application order for the integrated branch"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn initial_steps_example_1_keep_integrated_target_history_out_of_divergence() -> Result<()> {
+    let (_tmp, mut repo) = build_branch_integration_example_repo(
+        ExampleScenario::ExtraTargetHistoryExcludedFromDivergence,
+    )?;
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let b = repo.rev_parse_single("main")?.detach();
+    let c = repo.rev_parse_single("A")?.detach();
+    let d = repo.rev_parse_single("origin/A")?.detach();
+    let x = repo.rev_parse_single("origin/main")?.detach();
+
+    let initial = initial_integration_for_branch(
+        r("refs/heads/A"),
+        &repo,
+        Some(r("refs/remotes/origin/main")),
+    )?;
+
+    insta::assert_snapshot!(
+        labeled_divergence_snapshot(&initial, &[(b, "B"), (c, "C"), (d, "D"), (x, "X")]),
+        @"
+        * C (A) C
+        | * D (origin/A) D
+        |/
+        * B [historically-integrated:B] B
+        "
+    );
+    insta::assert_snapshot!(
+        labeled_integration_snapshot(&initial.integration, &[(b, "B"), (c, "C"), (d, "D")]),
+        @"
+    merge-base B
+    pick D
+    pick C
+    "
+    );
+
+    assert_eq!(
+        initial.integration.merge_base, b,
+        "example 1 merge-base should remain B"
+    );
+    assert_eq!(
+        pick_step_ids(&initial.integration.steps),
+        vec![d, c],
+        "example 1 should keep upstream then local editable commits in application order",
+    );
+    assert_eq!(
+        initial
+            .divergence
+            .local_only
+            .iter()
+            .map(|commit| commit.id)
+            .collect::<Vec<_>>(),
+        vec![c],
+        "example 1 should only show the local tip above the merge-base",
+    );
+    assert_eq!(
+        initial
+            .divergence
+            .upstream_only
+            .iter()
+            .map(|commit| commit.id)
+            .collect::<Vec<_>>(),
+        vec![d],
+        "example 1 should only show the upstream tip above the merge-base",
+    );
+    assert!(
+        !initial
+            .divergence
+            .local_only
+            .iter()
+            .chain(initial.divergence.upstream_only.iter())
+            .any(|commit| commit.id == x),
+        "example 1 keeps target-only history out of divergence rows",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn initial_steps_example_2_excludes_integrated_local_commits_but_keeps_them_visible() -> Result<()>
+{
+    let (_tmp, mut repo) = build_branch_integration_example_repo(
+        ExampleScenario::LocalCommitHistoricallyIntegratedOnTarget,
+    )?;
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let a = repo.rev_parse_single("main")?.detach();
+    let b = repo.rev_parse_single("A~1")?.detach();
+    let c = repo.rev_parse_single("A")?.detach();
+    let d = repo.rev_parse_single("origin/A")?.detach();
+
+    let initial = initial_integration_for_branch(
+        r("refs/heads/A"),
+        &repo,
+        Some(r("refs/remotes/origin/main")),
+    )?;
+
+    assert_eq!(
+        initial.integration.merge_base, a,
+        "example 2 merge-base should remain A"
+    );
+    assert_eq!(
+        initial.integration.first_local_not_integrated,
+        Some(c),
+        "example 2 should record the first editable local commit as execution metadata",
+    );
+    // Pick only commit D and commit C.
+    assert_eq!(
+        pick_step_ids(&initial.integration.steps),
+        vec![d, c],
+        "example 2 should skip integrated local B while keeping local C editable",
+    );
+    insta::assert_snapshot!(
+        labeled_divergence_snapshot(
+            &initial,
+            &[(a, "A"), (b, "B"), (c, "C"), (d, "D")]
+        ),
+        @"
+        * C (A) C
+        * B [historically-integrated:B] B
+        | * D (origin/A) D
+        |/
+        * A [historically-integrated:A] A
+        "
+    );
+    assert_eq!(
+        initial.divergence.local_only[1].target_relation,
+        IntegrationDivergenceTargetRelation::HistoricallyIntegrated {
+            target_commit_id: b
+        },
+        "example 2 should annotate integrated local B with the target commit that contains it",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn apply_initial_steps_example_2_also_applies_integrated_local_commits() -> Result<()> {
+    let (_tmp, mut repo) = build_branch_integration_example_repo(
+        ExampleScenario::LocalCommitHistoricallyIntegratedOnTarget,
+    )?;
+    configure_tracking_for_branch_a(&mut repo)?;
+    let a = repo.rev_parse_single("main")?.detach();
+    let b = repo.rev_parse_single("A~1")?.detach();
+    let c = repo.rev_parse_single("A")?.detach();
+    let d = repo.rev_parse_single("origin/A")?.detach();
+    let x = repo.rev_parse_single("origin/main")?.detach();
+
+    let initial = initial_integration_for_branch(
+        r("refs/heads/A"),
+        &repo,
+        Some(r("refs/remotes/origin/main")),
+    )?;
+    assert_eq!(
+        initial.integration.first_local_not_integrated,
+        Some(c),
+        "example 2 should pick c as the first non-integrated local commit"
+    );
+    assert_eq!(
+        pick_step_ids(&initial.integration.steps),
+        vec![d, c],
+        "example 2 should still omit integrated local commits from the editable plan"
+    );
+
+    let (mut workspace, mut meta) = integration_workspace_for_branch(
+        r("refs/heads/A"),
+        &repo,
+        Some(r("refs/remotes/origin/main")),
+    )?;
+    let rebase = integrate_branch_with_steps(
+        r("refs/heads/A"),
+        initial.integration,
+        &mut workspace,
+        &mut meta,
+        &repo,
+    )?;
+
+    rebase.materialize()?;
+    let c_prime = repo.rev_parse_single("A")?.detach();
+    let d_prime = repo.rev_parse_single("A~1")?.detach();
+
+    insta::assert_snapshot!(
+        labeled_graph_snapshot(
+            &repo,
+            &[
+                (a, "A"),
+                (b, "B"),
+                (d, "D"),
+                (x, "X"),
+                (d_prime, "D'"),
+                (c_prime, "C'"),
+            ]
+        )?,
+        @"
+    * C' (HEAD -> A) C
+    * D' [conflict] D
+    | * X (origin/main, target-main) X
+    |/
+    * B B
+    | * D (origin/A, upstream-a) D
+    |/
+    * A (main) A
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn initial_steps_example_3_keeps_integrated_upstream_commits_editable() -> Result<()> {
+    let (_tmp, mut repo) = build_branch_integration_example_repo(
+        ExampleScenario::UpstreamCommitHistoricallyIntegratedOnTarget,
+    )?;
+    configure_tracking_for_branch_a(&mut repo)?;
+
+    let b = repo.rev_parse_single("A~1")?.detach();
+    let c = repo.rev_parse_single("A")?.detach();
+    let x = repo.rev_parse_single("origin/A~1")?.detach();
+    let d = repo.rev_parse_single("origin/A")?.detach();
+
+    let initial = initial_integration_for_branch(
+        r("refs/heads/A"),
+        &repo,
+        Some(r("refs/remotes/origin/main")),
+    )?;
+
+    assert_eq!(
+        initial.integration.merge_base, b,
+        "example 3 merge-base should remain B"
+    );
+    // Pick X, D and C
+    assert_eq!(
+        pick_step_ids(&initial.integration.steps),
+        vec![x, d, c],
+        "example 3 should keep integrated upstream X editable before D and local C",
+    );
+    insta::assert_snapshot!(
+        labeled_divergence_snapshot(&initial, &[(b, "B"), (c, "C"), (d, "D"), (x, "X")]),
+        @"
+        * C (A) C
+        | * D (origin/A) D
+        | * X [historically-integrated:X] X
+        |/
+        * B [historically-integrated:B] B
+        "
+    );
+
+    Ok(())
+}
+
+fn configure_tracking_for_branch_a(repo: &mut gix::Repository) -> Result<()> {
+    let mut cfg = repo.config_snapshot_mut();
+    cfg.set_raw_value(
+        "remote.origin.fetch",
+        gix::bstr::BStr::new(b"+refs/heads/*:refs/remotes/origin/*"),
+    )?;
+    cfg.set_raw_value("remote.origin.url", gix::bstr::BStr::new(b"."))?;
+    cfg.set_raw_value("branch.A.remote", gix::bstr::BStr::new(b"origin"))?;
+    cfg.set_raw_value("branch.A.merge", gix::bstr::BStr::new(b"refs/heads/A"))?;
+    Ok(())
+}
+
+fn pick_step_ids(steps: &[InteractiveIntegrationStep]) -> Vec<gix::ObjectId> {
+    steps
+        .iter()
+        .map(|step| match step {
+            InteractiveIntegrationStep::Pick { commit_id, .. }
+            | InteractiveIntegrationStep::Merge { commit_id, .. } => *commit_id,
+            InteractiveIntegrationStep::Squash { commits, .. } => {
+                *commits.last().expect("squash step should contain commits")
+            }
+        })
+        .collect()
+}
+
+fn add_local_ref_at_ref(repo: &gix::Repository, new_branch: &str, target: &str) -> Result<()> {
+    let workdir = repo.workdir().expect("writable scenarios are non-bare");
+    let target_id = repo.rev_parse_single(target)?.detach();
+
+    let status = std::process::Command::new("git")
+        .arg("-C")
+        .arg(workdir)
+        .arg("update-ref")
+        .arg(format!("refs/heads/{new_branch}"))
+        .arg(target_id.to_string())
+        .status()?;
+
+    if !status.success() {
+        bail!("failed to create local reference refs/heads/{new_branch}");
+    }
+
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum ExampleScenario {
+    ExtraTargetHistoryExcludedFromDivergence,
+    LocalCommitHistoricallyIntegratedOnTarget,
+    UpstreamCommitHistoricallyIntegratedOnTarget,
+}
+
+fn build_branch_integration_example_repo(
+    scenario: ExampleScenario,
+) -> Result<(TempDir, gix::Repository)> {
+    let tmp = TempDir::new()?;
+    let repo_dir = tmp.path().to_path_buf();
+
+    run_git(&repo_dir, &["init", "--initial-branch=main"])?;
+    run_git(&repo_dir, &["config", "user.name", "GitButler Tests"])?;
+    run_git(&repo_dir, &["config", "user.email", "tests@gitbutler.com"])?;
+    run_git(&repo_dir, &["config", "commit.gpgsign", "false"])?;
+
+    write_file(&repo_dir, "story.txt", "A\n")?;
+    run_git(&repo_dir, &["add", "story.txt"])?;
+    run_git(&repo_dir, &["commit", "-m", "A"])?;
+    let a = git_rev_parse(&repo_dir, "HEAD")?;
+
+    match scenario {
+        ExampleScenario::ExtraTargetHistoryExcludedFromDivergence => {
+            append_and_commit(&repo_dir, "story.txt", "B\n", "B")?;
+            let b = git_rev_parse(&repo_dir, "HEAD")?;
+
+            run_git(&repo_dir, &["checkout", "-b", "A", &b])?;
+            append_and_commit(&repo_dir, "story.txt", "C\n", "C")?;
+
+            run_git(&repo_dir, &["checkout", "-b", "target-main", &b])?;
+            append_and_commit(&repo_dir, "story.txt", "X\n", "X")?;
+
+            run_git(&repo_dir, &["checkout", "-b", "upstream-a", &b])?;
+            append_and_commit(&repo_dir, "story.txt", "D\n", "D")?;
+        }
+        ExampleScenario::LocalCommitHistoricallyIntegratedOnTarget => {
+            run_git(&repo_dir, &["checkout", "-b", "A", &a])?;
+            append_and_commit(&repo_dir, "story.txt", "B\n", "B")?;
+            let b = git_rev_parse(&repo_dir, "HEAD")?;
+            append_and_commit(&repo_dir, "story.txt", "C\n", "C")?;
+
+            run_git(&repo_dir, &["checkout", "-b", "target-main", &b])?;
+            append_and_commit(&repo_dir, "story.txt", "X\n", "X")?;
+
+            run_git(&repo_dir, &["checkout", "-b", "upstream-a", &a])?;
+            append_and_commit(&repo_dir, "story.txt", "D\n", "D")?;
+        }
+        ExampleScenario::UpstreamCommitHistoricallyIntegratedOnTarget => {
+            run_git(&repo_dir, &["checkout", "-b", "A", &a])?;
+            append_and_commit(&repo_dir, "story.txt", "B\n", "B")?;
+            let b = git_rev_parse(&repo_dir, "HEAD")?;
+            append_and_commit(&repo_dir, "story.txt", "C\n", "C")?;
+
+            run_git(&repo_dir, &["checkout", "-b", "target-main", &b])?;
+            append_and_commit(&repo_dir, "story.txt", "X\n", "X")?;
+            let x = git_rev_parse(&repo_dir, "HEAD")?;
+
+            run_git(&repo_dir, &["checkout", "-b", "upstream-a", &x])?;
+            append_and_commit(&repo_dir, "story.txt", "D\n", "D")?;
+        }
+    }
+
+    let target_tip = git_rev_parse(&repo_dir, "target-main")?;
+    let upstream_tip = git_rev_parse(&repo_dir, "upstream-a")?;
+    run_git(
+        &repo_dir,
+        &["update-ref", "refs/remotes/origin/main", &target_tip],
+    )?;
+    run_git(
+        &repo_dir,
+        &["update-ref", "refs/remotes/origin/A", &upstream_tip],
+    )?;
+    run_git(&repo_dir, &["checkout", "A"])?;
+
+    Ok((tmp, gix::open(repo_dir)?))
+}
+
+fn build_smart_squash_example_repo() -> Result<(TempDir, gix::Repository)> {
+    let tmp = TempDir::new()?;
+    let repo_dir = tmp.path().to_path_buf();
+
+    run_git(&repo_dir, &["init", "--initial-branch=main"])?;
+    run_git(&repo_dir, &["config", "user.name", "GitButler Tests"])?;
+    run_git(&repo_dir, &["config", "user.email", "tests@gitbutler.com"])?;
+    run_git(&repo_dir, &["config", "commit.gpgsign", "false"])?;
+
+    write_file(&repo_dir, "story.txt", "base\n")?;
+    run_git(&repo_dir, &["add", "story.txt"])?;
+    run_git(&repo_dir, &["commit", "-m", "base"])?;
+    let merge_base = git_rev_parse(&repo_dir, "HEAD")?;
+
+    run_git(&repo_dir, &["checkout", "-b", "A", &merge_base])?;
+    append_and_commit(&repo_dir, "story.txt", "local parent\n", "local parent")?;
+    append_and_commit(&repo_dir, "story.txt", "local tip\n", "local tip")?;
+
+    run_git(&repo_dir, &["checkout", "-b", "upstream-a", &merge_base])?;
+    append_and_commit(&repo_dir, "story.txt", "remote parent\n", "remote parent")?;
+    append_and_commit(&repo_dir, "story.txt", "remote tip\n", "remote tip")?;
+
+    let main_tip = git_rev_parse(&repo_dir, "main")?;
+    let upstream_tip = git_rev_parse(&repo_dir, "upstream-a")?;
+    run_git(
+        &repo_dir,
+        &["update-ref", "refs/remotes/origin/main", &main_tip],
+    )?;
+    run_git(
+        &repo_dir,
+        &["update-ref", "refs/remotes/origin/A", &upstream_tip],
+    )?;
+    run_git(&repo_dir, &["checkout", "A"])?;
+
+    Ok((tmp, gix::open(repo_dir)?))
+}
+
+fn append_and_commit(
+    repo_dir: &std::path::Path,
+    path: &str,
+    content: &str,
+    message: &str,
+) -> Result<()> {
+    let file_path = repo_dir.join(path);
+    let mut current = std::fs::read_to_string(&file_path).unwrap_or_default();
+    current.push_str(content);
+    std::fs::write(file_path, current)?;
+    run_git(repo_dir, &["add", path])?;
+    run_git(repo_dir, &["commit", "-m", message])?;
+    Ok(())
+}
+
+fn rewrite_commits_with_change_ids(
+    repo: &gix::Repository,
+    ref_name: &str,
+    revs_parent_to_child: &[&str],
+    change_ids: &[Option<ChangeId>],
+) -> Result<Vec<gix::ObjectId>> {
+    assert_eq!(
+        revs_parent_to_child.len(),
+        change_ids.len(),
+        "test helper must get one Change-Id option per commit"
+    );
+    let mut rewritten_commit_ids = Vec::with_capacity(revs_parent_to_child.len());
+    let old_commit_ids = revs_parent_to_child
+        .iter()
+        .map(|rev| repo.rev_parse_single(*rev).map(|id| id.detach()))
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    for (old_commit_id, change_id) in old_commit_ids.iter().zip(change_ids) {
+        let mut commit = repo.find_commit(*old_commit_id)?.decode()?.to_owned()?;
+        commit.tree = repo.find_commit(*old_commit_id)?.tree_id()?.detach();
+        if let Some(parent_id) = rewritten_commit_ids.last().copied() {
+            commit.parents = vec![parent_id].into();
+        }
+
+        if let Some(change_id) = change_id {
+            Headers::from_change_id(change_id.clone()).set_in_commit(&mut commit);
+        } else {
+            Headers::remove_in_commit(&mut commit);
+        }
+
+        rewritten_commit_ids.push(repo.write_object(commit)?.detach());
+    }
+
+    let tip = *rewritten_commit_ids
+        .last()
+        .expect("test helper should be called with at least one commit");
+    repo.reference(
+        ref_name,
+        tip,
+        gix::refs::transaction::PreviousValue::Any,
+        "rewrite commits with Change-Ids".as_bytes().as_bstr(),
+    )?;
+
+    Ok(rewritten_commit_ids)
+}
+
+fn write_file(repo_dir: &std::path::Path, path: &str, content: &str) -> Result<()> {
+    std::fs::write(repo_dir.join(path), content)?;
+    Ok(())
+}
+
+fn git_rev_parse(repo_dir: &std::path::Path, rev: &str) -> Result<String> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(repo_dir)
+        .arg("rev-parse")
+        .arg(rev)
+        .output()?;
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "git rev-parse failed for {rev}"
+    );
+    Ok(String::from_utf8(output.stdout)?.trim().to_owned())
+}
+
+fn run_git(repo_dir: &std::path::Path, args: &[&str]) -> Result<()> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(repo_dir)
+        .args(args)
+        .output()?;
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "git command failed: git {args:?}",
+    );
+    Ok(())
+}
+
+fn r(name: &str) -> &gix::refs::FullNameRef {
+    name.try_into().expect("statically known valid ref-name")
+}

--- a/crates/but-workspace/tests/workspace/branch/mod.rs
+++ b/crates/but-workspace/tests/workspace/branch/mod.rs
@@ -1,6 +1,7 @@
 /// Various journeys with apply and unapply operations.
 mod apply_unapply;
 mod create_reference;
+mod integrate_branch_upstream;
 mod move_branch;
 mod remove_reference;
 mod tear_off_branch;

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -14,7 +14,7 @@
 use std::sync::Arc;
 
 use anyhow::{Context, bail};
-use but_api::{commit, diff, github, gitlab, legacy, open, platform, workspace};
+use but_api::{branch, commit, diff, github, gitlab, legacy, open, platform, workspace};
 #[cfg(feature = "irc")]
 use but_irc::IrcManager;
 use but_settings::AppSettingsWithDiskSync;
@@ -358,6 +358,8 @@ fn main() -> anyhow::Result<()> {
                 legacy::virtual_branches::tauri_upstream_integration_statuses::upstream_integration_statuses,
                 legacy::virtual_branches::tauri_integrate_upstream::integrate_upstream,
                 legacy::virtual_branches::tauri_resolve_upstream_integration::resolve_upstream_integration,
+                branch::tauri_get_initial_branch_integration::get_initial_branch_integration,
+                branch::tauri_apply_branch_integration::apply_branch_integration,
                 legacy::stack::tauri_create_reference::create_reference,
                 legacy::stack::tauri_create_branch::create_branch,
                 legacy::stack::tauri_remove_branch::remove_branch,

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -28,6 +28,16 @@ export declare function absorptionPlan(projectId: string, target: AbsorptionTarg
 export declare function apply(projectId: string, existingBranch: string): Promise<ApplyOutcome>
 
 /**
+ * Apply `integration` to `branch`.
+ *
+ * This acquires exclusive worktree access from `ctx`, applies the integration
+ * steps to the branch, and records an oplog snapshot on success. When
+ * `dry_run` is enabled, the returned workspace previews the integration
+ * result and no oplog entry is persisted.
+ */
+export declare function applyBranchIntegration(projectId: string, branch: string, integration: InteractiveIntegration, dryRun: boolean): Promise<IntegrateBranchResult>
+
+/**
  * Persists `assignments` for the current workspace and records an oplog
  * snapshot on success.
  *
@@ -200,6 +210,9 @@ export declare function commitUncommitChanges(projectId: string, commitId: strin
  * This is determined by the forge the base branch is pointing to.
  */
 export declare function forgeProvider(projectId: string): Promise<ForgeName | null>
+
+/** Get the initial upstream integration script for `branch`. */
+export declare function getInitialBranchIntegration(projectId: string, branch: string, strategy: BranchIntegrationStrategy | null): Promise<InitialBranchIntegration>
 
 /**
  * Get the snapshot that a redo operation should restore to.
@@ -602,6 +615,9 @@ export type BranchDetails = {
  *   name of the virtual branch.
  */
 export type BranchIdentity = string;
+
+/** JSON transport type for the preset used to generate initial branch integration steps. */
+export type BranchIntegrationStrategy = "pullRebase" | "merge" | "pickRemote" | "smartSquash";
 
 /**
  * Represents a branch that exists for the repository
@@ -1306,6 +1322,12 @@ export type HeadSha = {
   headSha: string;
 };
 
+/**
+ * A type that deserializes a hexadecimal hash into a string, unchanged.
+ * This is to workaround `schemars` which doesn't (always) work with transformations.
+ */
+export type HexHashString = string;
+
 export type HunkAssignment = {
   /**
    * A stable identifier for the hunk assignment.
@@ -1432,12 +1454,94 @@ export type IgnoredWorktreeChange = {
 /** The status we can't handle, which always originated in the worktree. */
 export type IgnoredWorktreeTreeChangeStatus = "Conflict" | "TreeIndex" | "TreeIndexWorktreeChangeIneffective";
 
+/** JSON transport type for the initial branch integration proposal. */
+export type InitialBranchIntegration = {
+  /** The editable execution plan for integrating the branch upstream. */
+  integration: InteractiveIntegration;
+  /** The current divergence between local branch and upstream for display. */
+  divergence: IntegrationDivergenceDisplay;
+};
+
 /** Describes where relative to the selector a step should be inserted */
 export type InsertSide = "above" | "below";
+
+/** JSON transport type for integrating a branch. */
+export type IntegrateBranchResult = {
+  /** Workspace state after applying or previewing the integration. */
+  workspace: WorkspaceState;
+};
+
+/** JSON transport type for a divergence commit row. */
+export type IntegrationDivergenceCommit = {
+  /** The commit shown in the graph row. */
+  id: HexHashString;
+  /** The first-line subject shown for the commit. */
+  subject: string;
+  /** The explicit GitButler Change-Id stored in the commit headers, if present. */
+  changeId: string | null;
+  /** Commit creation time in Epoch milliseconds. */
+  createdAt: number;
+  /** The author of the commit. */
+  author: Author;
+  /** Human-facing ref labels rendered inline on the commit row. */
+  refs: Array<string>;
+  /** How this commit relates to the configured target branch. */
+  targetRelation: IntegrationDivergenceTargetRelation;
+};
+
+/** JSON transport type for current branch/upstream divergence information. */
+export type IntegrationDivergenceDisplay = {
+  /** The local branch being integrated. */
+  branchRefName: FullRefName;
+  /** The upstream branch this local branch integrates with. */
+  upstreamRefName: FullRefName;
+  /** Commits only reachable from the local branch tip down to the shared section. */
+  localOnly: Array<IntegrationDivergenceCommit>;
+  /** Commits only reachable from the upstream branch tip down to the shared section. */
+  upstreamOnly: Array<IntegrationDivergenceCommit>;
+  /** The merge-base row shown once at the bottom. */
+  mergeBase: IntegrationDivergenceCommit;
+};
+
+/** JSON transport type for a divergence commit row. */
+export type IntegrationDivergenceTargetRelation = {
+  kind: "notIntegrated";
+} | {
+  /** The target branch commit that establishes the relation. */
+  targetCommitId: HexHashString;
+  kind: "historicallyIntegrated";
+};
 
 export type IntegrationOutcome = {
   /** The list of branches that have been deleted as a result of the upstream integration */
   deletedBranches: Array<string>;
+};
+
+/** JSON transport type describing an interactive branch integration plan. */
+export type InteractiveIntegration = {
+  /** Merge base between the upstream and the local reference. */
+  mergeBase: HexHashString;
+  /** The first parent-to-child local commit that is not historically integrated into target. */
+  firstLocalNotIntegrated: HexHashString | null;
+  /** The ordered integration steps to apply. */
+  steps: Array<InteractiveIntegrationStep>;
+};
+
+/** JSON transport type for a branch integration step. */
+export type InteractiveIntegrationStep = {
+  /** The local commit to keep in the rewritten branch. */
+  commitId: HexHashString;
+  kind: "pick";
+} | {
+  /** The ordered commits to squash together. */
+  commits: Array<HexHashString>;
+  /** Optional replacement message for the squash commit. */
+  message: string | null;
+  kind: "squash";
+} | {
+  /** The commit whose change range should be merged. */
+  commitId: HexHashString;
+  kind: "merge";
 };
 
 export type IrcConnectionSettings = {

--- a/packages/but-sdk/src/generated/index.js
+++ b/packages/but-sdk/src/generated/index.js
@@ -579,10 +579,11 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { absorb, absorptionPlan, apply, assignHunk, branchDetails, branchDiff, changesInWorktree, changesInWorktreeWithPerm, commitAmend, commitCreate, commitDetailsWithLineStats, commitDiscard, commitInsertBlank, commitMove, commitMoveChangesBetween, commitReword, commitSquash, commitUncommit, commitUncommitChanges, forgeProvider, getRedoTargetSnapshot, getReview, getUndoTargetSnapshot, headInfo, listAvailableReviewTemplates, listBranches, listCiChecksAndUpdateCache, listProjectsStateless, listReviews, listReviewsForBranch, mergeReview, moveBranch, peelRestoreSnapshot, publishReview, pushStack, removeBranch, restoreSnapshotWithKind, reviewTemplate, setReviewAutoMerge, setReviewDraftiness, setReviewTemplate, tearOffBranch, treeChangeDiffs, unapplyStack, updateBranchName, updateReviewFooters, warmCiChecksCache, workspaceBranchAndAncestorsPush, workspaceIntegrateUpstream, WatcherHandle, watcherStart } = nativeBinding
+const { absorb, absorptionPlan, apply, applyBranchIntegration, assignHunk, branchDetails, branchDiff, changesInWorktree, changesInWorktreeWithPerm, commitAmend, commitCreate, commitDetailsWithLineStats, commitDiscard, commitInsertBlank, commitMove, commitMoveChangesBetween, commitReword, commitSquash, commitUncommit, commitUncommitChanges, forgeProvider, getInitialBranchIntegration, getRedoTargetSnapshot, getReview, getUndoTargetSnapshot, headInfo, listAvailableReviewTemplates, listBranches, listCiChecksAndUpdateCache, listProjectsStateless, listReviews, listReviewsForBranch, mergeReview, moveBranch, peelRestoreSnapshot, publishReview, pushStack, removeBranch, restoreSnapshotWithKind, reviewTemplate, setReviewAutoMerge, setReviewDraftiness, setReviewTemplate, tearOffBranch, treeChangeDiffs, unapplyStack, updateBranchName, updateReviewFooters, warmCiChecksCache, workspaceBranchAndAncestorsPush, workspaceIntegrateUpstream, WatcherHandle, watcherStart } = nativeBinding
 export { absorb }
 export { absorptionPlan }
 export { apply }
+export { applyBranchIntegration }
 export { assignHunk }
 export { branchDetails }
 export { branchDiff }
@@ -600,6 +601,7 @@ export { commitSquash }
 export { commitUncommit }
 export { commitUncommitChanges }
 export { forgeProvider }
+export { getInitialBranchIntegration }
 export { getRedoTargetSnapshot }
 export { getReview }
 export { getUndoTargetSnapshot }


### PR DESCRIPTION
Implement the APIs for remote branch integration backed by the new rebase engine an repo graph.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #13969 
- <kbd>&nbsp;2&nbsp;</kbd> #13881 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #14044 
<!-- GitButler Footer Boundary Bottom -->

