### PR TITLE
feat(but): expose theme via `BUT_THEME` environment variable

### DIFF
--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -1,6 +1,7 @@
 use crate::args::Args;
 use crate::theme::{self, Paint};
 use crate::tui::text::{terminal_width, truncate_text};
+use crate::utils::envs;
 
 pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
     use std::collections::HashSet;
@@ -155,6 +156,15 @@ pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
         let available_width = terminal_width.saturating_sub(flag.len() + 2);
         let truncated_desc = truncate_text(desc, available_width);
         writeln!(out, "{flag}  {truncated_desc}")?;
+    }
+
+    writeln!(out)?;
+    writeln!(out, "{}:", t.important.paint("Environment variables"))?;
+    for (env, desc) in envs::ALL_ENVS {
+        let env = format!("  {env}");
+        let available_width = terminal_width.saturating_sub(env.len() + 2);
+        let truncated_desc = truncate_text(desc, available_width);
+        writeln!(out, "{env}  {truncated_desc}")?;
     }
 
     Ok(())

--- a/crates/but/src/command/legacy/status/tui/details/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/details/mod.rs
@@ -26,7 +26,7 @@ use ratatui::{
 };
 use syntect::{
     easy::HighlightLines,
-    highlighting::{self, ThemeSet},
+    highlighting,
     parsing::{SyntaxReference, SyntaxSet},
 };
 use unicode_width::UnicodeWidthStr;
@@ -46,12 +46,6 @@ use crate::{
 use super::{HelpMessage, RubSource};
 
 mod details_cursor;
-
-const MONOKAI_THEME: &[u8] =
-    include_bytes!("../../../../../../assets/syntax-highlighting-themes/Monokai Extended.tmTheme");
-const MONOKAI_THEME_LIGHT: &[u8] = include_bytes!(
-    "../../../../../../assets/syntax-highlighting-themes/Monokai Extended Light.tmTheme"
-);
 
 #[derive(Debug, Default, Copy, Clone)]
 pub(super) enum DetailsVisibility {
@@ -112,18 +106,7 @@ impl Details {
             visibility: Default::default(),
             line_highlight_cache: Default::default(),
             syntax_set: OnDemand::new(|| Ok(SyntaxSet::load_defaults_newlines())).into(),
-            syntax_theme: OnDemand::new(|| {
-                Ok(
-                    if std::env::var_os("EXPERIMENTAL_BUT_LIGHT_THEME").is_some() {
-                        ThemeSet::load_from_reader(&mut std::io::Cursor::new(MONOKAI_THEME_LIGHT))
-                            .unwrap()
-                    } else {
-                        ThemeSet::load_from_reader(&mut std::io::Cursor::new(MONOKAI_THEME))
-                            .unwrap()
-                    },
-                )
-            })
-            .into(),
+            syntax_theme: OnDemand::new(|| theme.load_syntax_highlighting_theme()).into(),
             theme,
         }
     }

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -41,7 +41,7 @@ use theme::Paint;
 use crate::command::legacy::ShowDiffInEditor;
 use crate::{
     setup::{BackgroundSync, InitCtxOptions},
-    utils::{OutputChannel, ResultErrorExt, ResultMetricsExt},
+    utils::{OutputChannel, ResultErrorExt, ResultMetricsExt, envs},
 };
 
 mod id;
@@ -60,7 +60,7 @@ const CLI_DATE: CustomFormat = gix::date::time::format::ISO8601;
 /// Handle `args` which must be what's passed by `std::env::args_os()`.
 pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     let theme_preset_from_env: anyhow::Result<theme::ThemePreset> =
-        if let Some(theme_name) = std::env::var_os("BUT_THEME") {
+        if let Some(theme_name) = std::env::var_os(envs::BUT_THEME) {
             theme_name.to_string_lossy().parse()
         } else {
             Ok(theme::ThemePreset::Dark)

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -59,12 +59,30 @@ const CLI_DATE: CustomFormat = gix::date::time::format::ISO8601;
 
 /// Handle `args` which must be what's passed by `std::env::args_os()`.
 pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
+    let theme_preset_from_env: anyhow::Result<theme::ThemePreset> =
+        if let Some(theme_name) = std::env::var_os("BUT_THEME") {
+            theme_name.to_string_lossy().parse()
+        } else {
+            Ok(theme::ThemePreset::Dark)
+        };
+
     {
+        let theme_preset = match &theme_preset_from_env {
+            Ok(theme_preset) => theme_preset.clone(),
+            Err(_) => {
+                // ignore for now, we print a warning once the output channel has been initialized
+                theme::ThemePreset::Dark
+            }
+        };
+
+        // Note: Overrides in but-theme.json are hardwired to apply to the Dark theme at present.
+        // This is only for internal testing at the moment so it's not worthwhile to go through the
+        // motions of merging overrides with a configurable theme.
         let theme = dirs::config_dir()
             .map(|dir| dir.join("gitbutler").join("but-theme.json"))
             .filter(|p| p.exists())
             .and_then(|p| theme::load(&p).ok())
-            .unwrap_or_default();
+            .unwrap_or_else(|| theme::Theme::default_for(theme_preset));
         theme::init(theme);
     }
 
@@ -146,6 +164,14 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     but_secret::secret::set_application_namespace(namespace);
 
     let mut out = OutputChannel::new_with_optional_pager(output_format, use_pager);
+
+    if let (Err(theme_preset_err), Some(out)) = (theme_preset_from_env, out.for_human()) {
+        writeln!(
+            out,
+            "{}: {theme_preset_err}",
+            theme::get().attention.paint("Failed to set theme")
+        )?;
+    }
 
     #[cfg(feature = "agentlog")]
     if let Some(Subcommands::AgentLog { .. }) = &args.cmd {

--- a/crates/but/src/theme.rs
+++ b/crates/but/src/theme.rs
@@ -27,7 +27,7 @@
 //! Missing fields in a user-supplied file fall back to the built-in defaults thanks to
 //! `#[serde(default)]`.
 
-use std::{fmt::Display, path::Path, sync::OnceLock};
+use std::{fmt::Display, path::Path, str::FromStr, sync::OnceLock};
 
 use colored::{ColoredString, Colorize as _};
 use ratatui::{
@@ -36,6 +36,12 @@ use ratatui::{
     text::Span,
 };
 use serde::{Deserialize, Serialize};
+use syntect::highlighting::{self, ThemeSet};
+
+const MONOKAI_THEME: &[u8] =
+    include_bytes!("../assets/syntax-highlighting-themes/Monokai Extended.tmTheme");
+const MONOKAI_THEME_LIGHT: &[u8] =
+    include_bytes!("../assets/syntax-highlighting-themes/Monokai Extended Light.tmTheme");
 
 /// Global theme instance, initialized once at startup.
 static THEME: OnceLock<Theme> = OnceLock::new();
@@ -195,6 +201,28 @@ fn apply_modifiers(mut styled: ColoredString, modifiers: Modifier) -> ColoredStr
     styled
 }
 
+/// Identifiers for the theme presets.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum ThemePreset {
+    /// The dark preset.
+    Dark,
+    /// The light preset.
+    Light,
+}
+
+impl FromStr for ThemePreset {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let normalized = s.to_lowercase();
+        match normalized.trim() {
+            "dark" => Ok(ThemePreset::Dark),
+            "light" => Ok(ThemePreset::Light),
+            unknown => Err(anyhow::anyhow!("Unknown theme preset: {unknown}")),
+        }
+    }
+}
+
 /// The CLI color theme.
 ///
 /// Style fields ([`Style`]) control colors and text attributes for semantic
@@ -301,6 +329,10 @@ pub struct Theme {
     // This weirdness can be fixed by splitting the theme into two substructs: symbols and
     // styles.
     symbols: Option<ThemeSymbols>,
+
+    #[serde(skip_serializing, skip_deserializing)]
+    /// Serialized theme to use for syntax highlighting.
+    syntax_highlighting_theme_raw: &'static [u8],
 }
 
 /// Helper — builds a [`Style`] with the given foreground color.
@@ -316,15 +348,7 @@ const fn style_fg_bold(fg: Color) -> Style {
 impl Default for Theme {
     /// Produces the canonical color palette.
     fn default() -> Self {
-        // TODO move light/dark detection somewhere else. For now it's convenient to keep here as
-        // the serde deserialization automatically "fills in the blanks" with defaults
-        let mut t = if std::env::var_os("EXPERIMENTAL_BUT_LIGHT_THEME").is_some() {
-            Self::default_light()
-        } else {
-            Self::default_dark()
-        };
-        t.symbols = Some(ThemeSymbols::new(&t));
-        t
+        Self::default_for(ThemePreset::Dark)
     }
 }
 
@@ -334,6 +358,23 @@ impl Theme {
         self.symbols
             .as_ref()
             .expect("symbols must always be initialized")
+    }
+
+    /// Produces a specific default color palette.
+    pub fn default_for(preset: ThemePreset) -> Self {
+        let mut t = match preset {
+            ThemePreset::Light => Self::default_light(),
+            ThemePreset::Dark => Self::default_dark(),
+        };
+        t.symbols = Some(ThemeSymbols::new(&t));
+        t
+    }
+
+    /// Load the syntax highlighting theme.
+    pub fn load_syntax_highlighting_theme(&self) -> anyhow::Result<highlighting::Theme> {
+        Ok(ThemeSet::load_from_reader(&mut std::io::Cursor::new(
+            self.syntax_highlighting_theme_raw,
+        ))?)
     }
 
     fn default_dark() -> Self {
@@ -358,11 +399,6 @@ impl Theme {
             context: style_fg(Color::DarkGray),
             // Colors from Delta for preserving foreground syntax highlighting, with a lightness
             // adjustment for enhanced readability.
-            //
-            // IMPORTANT: These colors require 24 bit color (truecolor) support. Terminal.app on
-            // macOS does NOT support that, it only supports 8 bit (256) color.
-            //
-            // TODO detect if running in Terminal.app and use fallback 8 bit color
             addition_rich: Style::new().bg(Color::from_hsl(Hsl::new(
                 120.0,
                 1.0,
@@ -413,6 +449,8 @@ impl Theme {
                 .bg(Color::from_hsl(Hsl::new(236.8, 0.162, 0.229))),
             legend: Style::new().fg(Color::Blue),
 
+            syntax_highlighting_theme_raw: MONOKAI_THEME,
+
             // Symbols initialized below
             symbols: None,
         }
@@ -428,11 +466,6 @@ impl Theme {
         Self {
             // Modifications
             // Colors from Delta for preserving foreground syntax highlighting
-            //
-            // IMPORTANT: These colors require 24 bit color (truecolor) support. Terminal.app on
-            // macOS does NOT support that, it only supports 8 bit (256) color.
-            //
-            // TODO detect if running in Terminal.app and use fallback 8 bit color
             addition_rich: Style::new().bg(Color::Rgb(208, 255, 208)),
             addition_rich_subsection: Style::new().bg(Color::Rgb(160, 239, 160)),
             deletion_rich: Style::new().bg(Color::Rgb(255, 224, 224)),
@@ -458,6 +491,8 @@ impl Theme {
             // Layout
             selection_highlight: Style::new().fg(Color::Black).bg(Color::Indexed(252)),
             discrete_selection_highlight: Style::new().bg(Color::Indexed(255)),
+
+            syntax_highlighting_theme_raw: MONOKAI_THEME_LIGHT,
 
             ..dark_t
         }

--- a/crates/but/src/utils/envs.rs
+++ b/crates/but/src/utils/envs.rs
@@ -1,0 +1,13 @@
+//! Environment variables used by but.
+
+pub const BUT_PAGER: &str = "BUT_PAGER";
+pub const BUT_PAGER_DESCRIPTION: &str = "Sets the pager for large outputs. [default: less]";
+
+pub const BUT_THEME: &str = "BUT_THEME";
+pub const BUT_THEME_DESCRIPTION: &str =
+    "Sets the theme for but. Options: dark, light. [default: dark]";
+
+pub const ALL_ENVS: [(&str, &str); 2] = [
+    (BUT_PAGER, BUT_PAGER_DESCRIPTION),
+    (BUT_THEME, BUT_THEME_DESCRIPTION),
+];

--- a/crates/but/src/utils/mod.rs
+++ b/crates/but/src/utils/mod.rs
@@ -27,6 +27,8 @@ pub trait ResultErrorExt {
     fn show_root_cause_error_then_exit_without_destructors(self, out: OutputChannel) -> !;
 }
 
+pub mod envs;
+
 impl ResultErrorExt for anyhow::Result<()> {
     fn show_root_cause_error_then_exit_without_destructors(self, out: OutputChannel) -> ! {
         // Trigger the pager to be flushed before exiting early, or destructors aren't called.

--- a/crates/but/src/utils/pager.rs
+++ b/crates/but/src/utils/pager.rs
@@ -1,3 +1,5 @@
+use crate::utils::envs;
+
 pub(crate) enum Pager {
     /// An external pager process (e.g. `less`)
     External(std::process::Child, std::process::ChildStdin),
@@ -49,7 +51,7 @@ pub(crate) fn try_init_pager() -> Option<Pager> {
 fn try_spawn_external_pager() -> Option<(std::process::Child, std::process::ChildStdin)> {
     use std::process::{Command, Stdio};
 
-    let pager_override = std::env::var("BUT_PAGER").ok();
+    let pager_override = std::env::var(envs::BUT_PAGER).ok();
     let (program, is_default) = if let Some(cmd) = &pager_override {
         (cmd.as_ref(), false)
     } else if Command::new(DEFAULT_PAGER)


### PR DESCRIPTION
## 🧢 Changes
Exposes theme switching to users with the `BUT_THEME` environment variable.

Options are `dark` or `light` (case insensitive). If an invalid option is provided we print a warning but otherwise ignore it and just default to dark.

This also slightly reduces the usefulness of the (hidden) `but-theme.json` file, which now cannot be used to override the light theme anymore. If you have overrides, dark theme is assumed. This can be fixed but it's a bit more fiddly than it's worth right now.

Also documents the environment variables we have in `--help`.

## ☕️ Reasoning
Initially I wanted to set the theme in app settings, but configuration is somewhat messy right now and I failed to find a good way of doing it. I think `but config` needs a thorough refactor before we can reasonably add more to it.