### PR TITLE
Support Git-style external subcommands (but-<command>)

### DIFF
--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -580,6 +580,14 @@ Available on most commands:
 - `-C, --current-dir <PATH>` - Run as if started in different directory
 - `-h, --help` - Show help for command
 
+## External commands (PATH helpers)
+
+> Important: Not available for Windows yet
+
+Similar to Git, if `<command>` is not a built-in `but` command and `but-<command>` exists on `PATH`, `but` runs that executable instead (for example `but forecast …` invokes `but-forecast …`).
+
+Restriction: `<command>` must consist of characters in the set `[a-zA-Z_-]`
+
 ## Getting More Help
 
 ```bash

--- a/crates/but/src/args/metrics.rs
+++ b/crates/but/src/args/metrics.rs
@@ -61,6 +61,8 @@ pub enum CommandName {
     Clean,
     #[default]
     Unknown,
+    #[cfg(unix)]
+    External,
 }
 
 impl CommandName {

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -6,6 +6,8 @@
 ///
 /// Nearly all documentation for the CLI is defined here using `clap` attributes,
 /// which are then used to generate help messages and online documentation.
+#[cfg(unix)]
+use std::ffi::OsString;
 use std::path::PathBuf;
 
 #[derive(Debug, clap::Parser)]
@@ -50,7 +52,10 @@ pub struct Args {
     /// {"result": ..., "status_error": ...} if the status query fails (in which case "status" is absent).
     #[clap(long = "status-after", global = true)]
     pub status_after: bool,
-    /// Subcommand to run.
+    /// Subcommand to run (`but <COMMAND>`).
+    ///
+    /// On UNIX, if `<COMMAND>` is not built in and `but-<COMMAND>` exists on the PATH, that program
+    /// is executed with the remaining arguments (`but <COMMAND> [ARGS]`).
     #[clap(subcommand)]
     pub cmd: Option<Subcommands>,
 }
@@ -1189,6 +1194,11 @@ pub enum Subcommands {
     #[clap(hide = true)]
     #[clap(verbatim_doc_comment)]
     EvalHook,
+
+    #[cfg(unix)]
+    #[strum(disabled)]
+    #[clap(hide = true, external_subcommand)]
+    External(Vec<OsString>),
 }
 
 pub mod alias;

--- a/crates/but/src/command/external.rs
+++ b/crates/but/src/command/external.rs
@@ -1,0 +1,73 @@
+//! Run `but-{name}` executables discovered on [`std::env::var_os`]("PATH"), akin to Git's `git-send-email`-style helpers.
+
+use std::{
+    ffi::{OsStr, OsString},
+    io::ErrorKind,
+    os::unix::ffi::OsStrExt,
+    path::Path,
+    process::{Command, Stdio},
+};
+
+use anyhow::Context;
+
+use crate::{CliError, CliResult, bad_input};
+
+pub(crate) fn dispatch(current_dir: &Path, extra: &[std::ffi::OsString]) -> CliResult<()> {
+    let subcommand_name = match extra {
+        [head, ..] => head,
+        _ => {
+            return Err(
+                anyhow::anyhow!("BUG: external subcommand parsed without any arguments").into(),
+            );
+        }
+    };
+
+    if !is_allowed_command_name(subcommand_name) {
+        return Err(bad_input("Subcommand contains illegal characters")
+            .arg_value(subcommand_name.to_string_lossy())
+            .hint("Are you trying to write an extension command 'but-<command>'? Make sure that '<command>' only contains characters in the set [a-zA-Z_-]")
+            .into());
+    }
+
+    let mut prefixed = OsString::from("but-");
+    prefixed.push(subcommand_name);
+
+    let status = match Command::new(&prefixed)
+        .args(&extra[1..])
+        .current_dir(current_dir)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+    {
+        Ok(status) => status,
+        Err(e) if e.kind() == ErrorKind::NotFound => {
+            return Err(CliError::ExternalCommandNotFound(
+                subcommand_name.to_owned(),
+            ));
+        }
+        Err(e) => {
+            return Err(e)
+                .with_context(|| format!("could not invoke `{prefixed:?}` from PATH"))
+                .map_err(CliError::from);
+        }
+    };
+
+    if status.success() {
+        Ok(())
+    } else {
+        std::process::exit(status.code().unwrap_or(1));
+    }
+}
+
+/// A command name must consist of characters [a-zA-Z_-].
+///
+/// This is overly restrictive, but I just want to prevent people from doing anything funny here. We
+/// can loosen this as we need to in the future.
+fn is_allowed_command_name(command_name: &OsStr) -> bool {
+    command_name
+        .as_bytes()
+        .iter()
+        .copied()
+        .all(|c| c.is_ascii_uppercase() || c.is_ascii_lowercase() || c == b'-' || c == b'_')
+}

--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -44,6 +44,11 @@ pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
         .collect::<IndexMap<_, Vec<_>>>();
 
     for subcommand_variant in SubcommandDiscriminant::iter() {
+        #[cfg(unix)]
+        if matches!(subcommand_variant, SubcommandDiscriminant::External) {
+            continue;
+        }
+
         if let Some(clap_subcommand) = clap_subcommands.iter().find(|clap_subcommand| {
             clap_subcommand.get_name().to_lowercase().replace('-', "")
                 == subcommand_variant.as_ref().to_lowercase()
@@ -141,6 +146,8 @@ pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
                 SubcommandDiscriminant::Completions => continue,
                 SubcommandDiscriminant::Onboarding => continue,
                 SubcommandDiscriminant::EvalHook => continue,
+                #[cfg(unix)]
+                SubcommandDiscriminant::External => continue,
 
                 #[cfg(feature = "legacy")]
                 SubcommandDiscriminant::Worktree => continue,

--- a/crates/but/src/command/mod.rs
+++ b/crates/but/src/command/mod.rs
@@ -8,6 +8,8 @@ pub mod commit;
 pub mod completions;
 pub mod config;
 pub mod eval_hook;
+#[cfg(unix)]
+pub(crate) mod external;
 pub(crate) mod git_config;
 pub mod gui;
 pub mod help;

--- a/crates/but/src/error.rs
+++ b/crates/but/src/error.rs
@@ -2,6 +2,9 @@
 
 use std::fmt::Display;
 
+#[cfg(unix)]
+use std::ffi::OsString;
+
 use crate::theme::{self, Paint};
 
 /// Signifies that a command could not complete its intended action due to the user providing input
@@ -75,16 +78,18 @@ impl Display for BadInput {
                 writeln!(f, "Bad input for '{}'", t.attention.paint(name),)?;
                 writeln!(f)?;
             }
-            (None, Some(value)) => writeln!(f, "Bad input '{}'", t.attention.paint(value))?,
+            (None, Some(value)) => {
+                writeln!(f, "Bad input '{}'", t.attention.paint(value))?;
+                writeln!(f)?;
+            }
             _ => (),
         }
 
-        write!(f, "{}", self.message)?;
+        writeln!(f, "{}", self.message)?;
 
         if let Some(hint) = &self.hint {
             writeln!(f)?;
-            writeln!(f)?;
-            write!(f, "{}", t.hint.paint(format!("Hint: {hint}")))?;
+            writeln!(f, "{}", t.hint.paint(format!("Hint: {hint}")))?;
         }
 
         Ok(())
@@ -114,6 +119,10 @@ impl CliError {
     {
         match self {
             Self::BadInput(value) => Self::BadInput(value),
+            #[cfg(unix)]
+            Self::ExternalCommandNotFound(command_name) => {
+                Self::ExternalCommandNotFound(command_name)
+            }
             Self::Internal(value) => Self::Internal(value.context(context)),
         }
     }
@@ -123,6 +132,14 @@ impl Display for CliError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::BadInput(value) => value.fmt(f),
+            #[cfg(unix)]
+            Self::ExternalCommandNotFound(command_name) => {
+                writeln!(
+                    f,
+                    "{}",
+                    bad_input("Unrecognized subcommand").arg_value(command_name.to_string_lossy())
+                )
+            }
             Self::Internal(value) => value.fmt(f),
         }
     }
@@ -132,6 +149,9 @@ impl Display for CliError {
 pub enum CliError {
     /// User provided bad input.
     BadInput(BadInput),
+    /// We tried to execute the subcommand as an external command, but that command was not found.
+    #[cfg(unix)]
+    ExternalCommandNotFound(OsString),
     /// Something went wrong internally.
     Internal(anyhow::Error),
 }

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -26,6 +26,8 @@ use std::ffi::OsString;
 
 use anyhow::{Context as _, Result};
 use cfg_if::cfg_if;
+#[cfg(unix)]
+use clap::CommandFactory;
 use clap::Parser;
 
 pub mod args;
@@ -177,10 +179,13 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
         };
         return run_agentlog_command(&args.current_dir, cmd, &mut out);
     }
-
     let app_settings = AppSettings::load_from_default_path_creating_without_customization()?;
 
     let result = match args.cmd.take() {
+        #[cfg(unix)]
+        Some(Subcommands::External(extra)) => {
+            command::external::dispatch(&args.current_dir, &extra)
+        }
         None => {
             // No arguments means run the default alias
             // The default alias expands to "status" which provides a helpful entry point
@@ -219,14 +224,35 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     };
 
     match result {
-        Err(CliError::BadInput(bad_input)) => {
-            use std::io::Write;
-            writeln!(std::io::stderr(), "{bad_input}")?;
-            std::process::exit(1);
-        }
         Err(CliError::Internal(err)) => Err(err),
+        Err(CliError::BadInput(bad_input)) => print_and_exit_non_zero(bad_input),
+        #[cfg(unix)]
+        Err(CliError::ExternalCommandNotFound(command_name)) => {
+            // We reparse without external subcommands allowed, which _should_ result in a proper
+            // clap error, including suggestions for "near matches". This gives richer error
+            // information than the plain ExternalCommandNotFound error.
+            let cmd = Args::command();
+            let argv = [OsString::from(cmd.get_name()), command_name.clone()];
+
+            // This should fail to parse, print a nicely formatted Clap error and exit on its own.
+            let _ = cmd
+                .external_subcommand_value_parser(None)
+                .allow_external_subcommands(false)
+                .get_matches_from(argv);
+
+            // If for some reason we succeeded to parse now, we'll print the original error.
+            // This shouldn't happen in practice but logically it could.
+            print_and_exit_non_zero(CliError::ExternalCommandNotFound(command_name))
+        }
         Ok(()) => Ok(()),
     }
+}
+
+fn print_and_exit_non_zero<T: std::fmt::Display>(err: T) -> ! {
+    use std::io::Write;
+    // We swallow this error, there is nothing more to do at this point
+    let _ = write!(std::io::stderr(), "{err}");
+    std::process::exit(1)
 }
 
 async fn match_subcommand(
@@ -1439,6 +1465,10 @@ async fn match_subcommand(
         }
         Subcommands::AgentLog { .. } => {
             unreachable!("agentlog command is handled before metrics setup")
+        }
+        #[cfg(unix)]
+        Subcommands::External(_) => {
+            unreachable!("external commands are delegated before reaching match_subcommand")
         }
     }
 }

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -207,6 +207,8 @@ impl Subcommands {
             Subcommands::Clean { .. } => Clean,
             Subcommands::Onboarding | Subcommands::EvalHook => Unknown,
             Subcommands::AgentLog { .. } => Unknown,
+            #[cfg(unix)]
+            Subcommands::External(_) => External,
         }
     }
 }

--- a/crates/but/tests/but/command/external.rs
+++ b/crates/but/tests/but/command/external.rs
@@ -1,0 +1,157 @@
+//! `but-<COMMAND>` PATH delegation (Git-style).
+
+use std::{fs, os::unix::fs::PermissionsExt};
+
+use snapbox::str;
+
+use crate::utils::Sandbox;
+
+#[test]
+fn delegates_plain_name_to_but_prefixed_executable() -> anyhow::Result<()> {
+    let env = Sandbox::empty()?;
+    let bin = env.projects_root().join("external-cmd-bin");
+    fs::create_dir_all(&bin)?;
+    let helper = bin.join("but-forecast");
+    fs::write(
+        &helper,
+        "#!/bin/sh\nprintf 'args:'\nprintf ' %s' \"$@\"\nprintf '\\n'\n",
+    )?;
+    let mut perms = fs::metadata(&helper)?.permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&helper, perms)?;
+
+    let path = std::env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{path}", bin.display());
+
+    env.but("forecast one two")
+        .env("PATH", new_path)
+        .assert()
+        .success()
+        .stderr_eq(str![[]])
+        .stdout_eq(str![[r#"
+args: one two
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn prefers_builtin_command_when_external_command_clashes() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    let bin = env.projects_root().join("external-cmd-bin");
+    fs::create_dir_all(&bin)?;
+    let helper = bin.join("but-alias");
+    fs::write(
+        &helper,
+        "#!/bin/sh\nprintf 'args:'\nprintf ' %s' \"$@\"\nprintf '\\n'\n",
+    )?;
+    let mut perms = fs::metadata(&helper)?.permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&helper, perms)?;
+
+    let path = std::env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{path}", bin.display());
+
+    env.but("alias")
+        .env("PATH", new_path)
+        .assert()
+        .success()
+        .stderr_eq(str![[]])
+        .stdout_eq(str![[r#"
+Default aliases (overridable):
+
+  default  →  status
+  st       →  status
+  stf      →  status --files
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn propagates_reasonable_error_when_program_is_not_executable() -> anyhow::Result<()> {
+    let env = Sandbox::empty()?;
+    let bin = env.projects_root().join("external-cmd-bin");
+    fs::create_dir_all(&bin)?;
+    let helper = bin.join("but-forecast");
+    fs::write(
+        &helper,
+        "#!/bin/sh\nprintf 'args:'\nprintf ' %s' \"$@\"\nprintf '\\n'\n",
+    )?;
+
+    let path = std::env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{path}", bin.display());
+
+    env.but("forecast one two")
+        .env("PATH", new_path)
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: could not invoke `"but-forecast"` from PATH
+
+Caused by:
+    Permission denied (os error 13)
+
+"#]])
+        .stdout_eq(str![[]]);
+
+    Ok(())
+}
+
+#[test]
+fn refuses_to_execute_command_with_forward_slash() -> anyhow::Result<()> {
+    let env = Sandbox::empty()?;
+
+    env.but("bad/command")
+            .assert()
+            .failure()
+            .stderr_eq(str![[r#"
+Error: Bad input 'bad/command'
+
+Subcommand contains illegal characters
+
+Hint: Are you trying to write an extension command 'but-<command>'? Make sure that '<command>' only contains characters in the set [a-zA-Z_-]
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn refuses_to_execute_command_with_dot() -> anyhow::Result<()> {
+    let env = Sandbox::empty()?;
+
+    env.but("bad.command")
+            .assert()
+            .failure()
+            .stderr_eq(str![[r#"
+Error: Bad input 'bad.command'
+
+Subcommand contains illegal characters
+
+Hint: Are you trying to write an extension command 'but-<command>'? Make sure that '<command>' only contains characters in the set [a-zA-Z_-]
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn friendly_error_when_no_such_command_exists() -> anyhow::Result<()> {
+    let env = Sandbox::empty()?;
+
+    env.but("comit").assert().failure().stderr_eq(str![[r#"
+error: unrecognized subcommand 'comit'
+
+  tip: some similar subcommands exist: [..]
+
+Usage: but [OPTIONS] [COMMAND]
+
+For more information, try '--help'.
+
+"#]]);
+
+    Ok(())
+}

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -16,6 +16,8 @@ mod config;
 mod diff;
 #[cfg(feature = "legacy")]
 mod discard;
+#[cfg(unix)]
+mod external;
 mod format;
 mod gui;
 mod help;


### PR DESCRIPTION
<details>
<summary>Original description by @schacon </summary>
Allow unknown subcommands to invoke PATH helpers named but-<command>
(e.g. `but forecast` runs `but-forecast`) while preserving legacy
behavior for filesystem paths. Add argument/docs updates, an external
dispatcher (command/external.rs), wiring into the command dispatch and
metrics, tests for Unix PATH delegation, and update help tests and docs.
Map spawning NotFound errors to the friendly “not a command”
message.
</details>

I (@slarse) have completely clobbered this PR with my own stuff now. I pushed to this PR to retain the discussion.

Anyhow, this PR adds in support for Git-style external subcommands by allowing `but <COMMAND> [ARGS]` to delegate to any program on PATH called `but-<COMMAND>`, under the following conditions:

* `<COMMAND>` is not a built-in command
* `<COMMAND>` only consists of characters in the set `[a-zA-Z_-]`. This is _overly_ restrictive but I figured we can loosen it up later, I just didn't feel confident you couldn't pull any shenanigans with this.

An important design goal here is that this external command execution shouldn't make error messages worse. If we fail to match `<COMMAND>` against anything on PATH (we currently just try to execute), we reparse the command alone with external command support disabled, which will still print the nice Clap error message about the subcommand not being recognized, including any potential near matches. See tests for details.

> Note: Given that I could solve the "deterioration" of error messages when failing to match against an external command, I find no good reason to put this behind an app setting, feature toggle or environment variable. It'll just become available to everyone, and most will never notice it's there.

> Windows? Nope, not in this PR. I will try to add that separately but I need to setup a Windows dev environment first.