### PR TITLE
EXPERIMENT: Start of super experimental graph views of the workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,6 +1736,7 @@ dependencies = [
  "insta",
  "itertools",
  "md5",
+ "sapling-renderdag",
  "schemars 1.2.1",
  "serde",
  "tempfile",
@@ -9791,6 +9792,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "sapling-renderdag"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edffb89cab87bd0901c5749d576f5d37a1f34e05160e936f463f4e94cc447b61"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ members = [
     # 👉Experimental IRC support
     "crates/but-irc", # 📄IRC client with WebSocket transport and GitButler protocol support.
     # 👉Experimental; needs docs, it's used from `but` CLI and not a library
-    "crates/but-agentlog",       # 📄Capture coding-agent logs into Git metadata.
+    "crates/but-agentlog", # 📄Capture coding-agent logs into Git metadata.
     "crates/but-transaction", # 📄TBD
 
     ##
@@ -215,7 +215,8 @@ zip = { version = "4", default-features = false, features = ["bzip2"] }
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
 # When adjusting this, update `gix-testtools` as well!
 gix = { version = "0.84.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "b5b2d54d6a63921621d48c492eaa77faf89e8cb5", default-features = false, features = [
-    "sha1", "sha256"
+    "sha1",
+    "sha256",
 ] }
 gix-testtools = { version = "0.19.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "b5b2d54d6a63921621d48c492eaa77faf89e8cb5" }
 
@@ -310,6 +311,7 @@ self_cell = "1.2.2"
 unicode-segmentation = "1.13.2"
 urlencoding = "2.1"
 inventory = "0.3"
+sapling-renderdag = "0.1.0"
 git-meta-lib = { version = "0.1.10" }
 
 [patch.crates-io]

--- a/apps/lite/electron/src/ipc.ts
+++ b/apps/lite/electron/src/ipc.ts
@@ -8,6 +8,7 @@ import type {
 	HunkAssignmentRequest,
 	CommitDetails,
 	DiffSpec,
+	GrStack,
 	InsertSide,
 	PushResult,
 	ProjectForFrontend,
@@ -271,6 +272,7 @@ export interface LiteElectronApi {
 	peelRestoreSnapshot: (params: PeelRestoreSnapshotParams) => Promise<Snapshot | null>;
 	pushStack: (params: PushStackParams) => Promise<PushResult>;
 	removeBranch: (params: RemoveBranchParams) => Promise<void>;
+	renderWorkspace: (projectId: string) => Promise<Array<GrStack>>;
 	restoreSnapshotWithKind: (params: RestoreSnapshotWithKindParams) => Promise<void>;
 	showNativeMenu: (params: ShowNativeMenuParams) => Promise<string | null>;
 	treeChangeDiffs: (params: TreeChangeDiffParams) => Promise<UnifiedPatch | null>;
@@ -316,6 +318,7 @@ export const liteIpcChannels = {
 	peelRestoreSnapshot: "workspace:peel-restore-snapshot",
 	pushStack: "workspace:push-stack",
 	removeBranch: "workspace:remove-branch",
+	renderWorkspace: "workspace:render-workspace",
 	restoreSnapshotWithKind: "workspace:restore-snapshot-with-kind",
 	showNativeMenu: "lite:show-native-menu",
 	treeChangeDiffs: "workspace:tree-change-diffs",

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -57,6 +57,7 @@ import {
 	moveBranch,
 	pushStack,
 	removeBranch,
+	renderWorkspace,
 	tearOffBranch,
 	treeChangeDiffs,
 	unapplyStack,
@@ -388,6 +389,9 @@ const registerIpcHandlers = (): void => {
 		liteIpcChannels.removeBranch,
 		(_e, { projectId, stackId, branchName }: RemoveBranchParams) =>
 			removeBranch(projectId, stackId, branchName),
+	);
+	senderValidatingHandle(liteIpcChannels.renderWorkspace, (_e, projectId: string) =>
+		renderWorkspace(projectId),
 	);
 	senderValidatingHandle(
 		liteIpcChannels.restoreSnapshotWithKind,

--- a/apps/lite/electron/src/preload.cts
+++ b/apps/lite/electron/src/preload.cts
@@ -17,6 +17,7 @@ import type {
 	CommitMoveResult,
 	CommitRewordResult,
 	CommitSquashResult,
+	GrStack,
 	MoveBranchResult,
 	MoveChangesResult,
 	UnifiedPatch,
@@ -105,6 +106,8 @@ const api: LiteElectronApi = {
 		ipcRenderer.invoke("workspace:peel-restore-snapshot", params) as Promise<Snapshot | null>,
 	pushStack: (params) => ipcRenderer.invoke("workspace:push-stack", params) as Promise<PushResult>,
 	removeBranch: (params) => ipcRenderer.invoke("workspace:remove-branch", params) as Promise<void>,
+	renderWorkspace: (projectId) =>
+		ipcRenderer.invoke("workspace:render-workspace", projectId) as Promise<Array<GrStack>>,
 	restoreSnapshotWithKind: (params) =>
 		ipcRenderer.invoke("workspace:restore-snapshot-with-kind", params) as Promise<void>,
 	showNativeMenu: (params) =>

--- a/apps/lite/ui/src/workspace/link-lines.ts
+++ b/apps/lite/ui/src/workspace/link-lines.ts
@@ -1,0 +1,67 @@
+import type { LinkLine } from "@gitbutler/but-sdk";
+
+/** This cell contains a horizontal line that connects to a parent. */
+export const HORIZ_PARENT: LinkLine = 0b0_0000_0000_0001;
+
+/** This cell contains a horizontal line that connects to an ancestor. */
+export const HORIZ_ANCESTOR: LinkLine = 0b0_0000_0000_0010;
+
+/** The descendent of this cell is connected to the parent. */
+export const VERT_PARENT: LinkLine = 0b0_0000_0000_0100;
+
+/** The descendent of this cell is connected to an ancestor. */
+export const VERT_ANCESTOR: LinkLine = 0b0_0000_0000_1000;
+
+/**
+ * The parent of this cell is linked in this link row and the child is to the
+ * left.
+ */
+export const LEFT_FORK_PARENT: LinkLine = 0b0_0000_0001_0000;
+
+/**
+ * The ancestor of this cell is linked in this link row and the child is to the
+ * left.
+ */
+export const LEFT_FORK_ANCESTOR: LinkLine = 0b0_0000_0010_0000;
+
+/**
+ * The parent of this cell is linked in this link row and the child is to the
+ * right.
+ */
+export const RIGHT_FORK_PARENT: LinkLine = 0b0_0000_0100_0000;
+
+/**
+ * The ancestor of this cell is linked in this link row and the child is to the
+ * right.
+ */
+export const RIGHT_FORK_ANCESTOR: LinkLine = 0b0_0000_1000_0000;
+
+/** The child of this cell is linked to parents on the left. */
+export const LEFT_MERGE_PARENT: LinkLine = 0b0_0001_0000_0000;
+
+/** The child of this cell is linked to ancestors on the left. */
+export const LEFT_MERGE_ANCESTOR: LinkLine = 0b0_0010_0000_0000;
+
+/** The child of this cell is linked to parents on the right. */
+export const RIGHT_MERGE_PARENT: LinkLine = 0b0_0100_0000_0000;
+
+/** The child of this cell is linked to ancestors on the right. */
+export const RIGHT_MERGE_ANCESTOR: LinkLine = 0b0_1000_0000_0000;
+
+/**
+ * The target node of this link line is the child of this column.
+ *
+ * This disambiguates between the node that is connected in this link line, and
+ * other nodes that are also connected vertically.
+ */
+export const CHILD: LinkLine = 0b1_0000_0000_0000;
+
+export const HORIZONTAL: LinkLine = HORIZ_PARENT | HORIZ_ANCESTOR;
+export const VERTICAL: LinkLine = VERT_PARENT | VERT_ANCESTOR;
+export const LEFT_FORK: LinkLine = LEFT_FORK_PARENT | LEFT_FORK_ANCESTOR;
+export const RIGHT_FORK: LinkLine = RIGHT_FORK_PARENT | RIGHT_FORK_ANCESTOR;
+export const LEFT_MERGE: LinkLine = LEFT_MERGE_PARENT | LEFT_MERGE_ANCESTOR;
+export const RIGHT_MERGE: LinkLine = RIGHT_MERGE_PARENT | RIGHT_MERGE_ANCESTOR;
+export const ANY_MERGE: LinkLine = LEFT_MERGE | RIGHT_MERGE;
+export const ANY_FORK: LinkLine = LEFT_FORK | RIGHT_FORK;
+export const ANY_FORK_OR_MERGE: LinkLine = ANY_MERGE | ANY_FORK;

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -50,6 +50,15 @@ pub fn head_info(ctx: &but_ctx::Context) -> Result<but_workspace::RefInfo> {
     .map(|info| info.pruned_to_entrypoint())
 }
 
+#[but_api(napi)]
+#[instrument(err(Debug))]
+pub fn render_workspace(
+    ctx: &mut but_ctx::Context,
+) -> Result<Vec<but_workspace::experiment::GrStack>> {
+    let (_, repo, ws, _) = ctx.workspace_mut_and_db()?;
+    but_workspace::experiment::render_workspace(&repo, &ws)
+}
+
 #[but_api]
 #[instrument(err(Debug))]
 pub fn stacks(

--- a/crates/but-workspace/Cargo.toml
+++ b/crates/but-workspace/Cargo.toml
@@ -52,6 +52,7 @@ itertools.workspace = true
 url = { version = "2.5.4", features = ["serde"] }
 md5.workspace = true
 tracing.workspace = true
+sapling-renderdag.workspace = true
 
 # For SPMC channel
 flume = "0.11.1"

--- a/crates/but-workspace/src/experiment.rs
+++ b/crates/but-workspace/src/experiment.rs
@@ -10,7 +10,9 @@ use but_graph::{
     Commit, FirstParent, Segment, SegmentIndex, SegmentMetadata,
     petgraph::{Direction, visit::EdgeRef},
 };
-use renderdag::{Ancestor, Renderer};
+use gitbutler_commit::commit_ext::CommitMessageBstr as _;
+use renderdag::{Ancestor, GraphRowRenderer, Renderer};
+use serde::Serialize;
 
 struct Subgraph {
     heads: Vec<SegmentIndex>,
@@ -29,6 +31,165 @@ struct Row<'a> {
     id: u64,
     ancestors: Vec<Ancestor<u64>>,
     data: RowData<'a>,
+}
+
+/// Some SubSegment
+#[derive(Serialize)]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+pub struct GrStack {
+    /// The rows!!!
+    pub rows: Vec<GraphRow>,
+    // /// Segments yey
+    // pub segments: Vec<GrSegment>,
+}
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(GrStack);
+
+/// Graph segment
+#[derive(Serialize)]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+pub struct GrSegment {
+    /// The rows!!!
+    pub rows: Vec<GraphRow>,
+}
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(GrSegment);
+
+/// A row...from graph <shocked pikachu face>
+#[derive(Serialize)]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+pub struct GraphRow {
+    /// The stuff the row contains
+    pub data: String,
+
+    /// The node columns for this row.
+    pub node_line: Vec<NodeLine>,
+
+    /// The link columns for this row, if a link row is necessary.
+    pub link_line: Option<Vec<LinkLine>>,
+
+    /// The location of any terminators, if necessary.  Other columns should be
+    /// filled in with pad lines.
+    pub term_line: Option<Vec<bool>>,
+
+    /// The pad columns for this row.
+    pub pad_lines: Vec<PadLine>,
+}
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(GraphRow);
+
+/// A column in the node row.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+pub enum NodeLine {
+    /// Blank.
+    Blank,
+
+    /// Vertical line indicating an ancestor.
+    Ancestor,
+
+    /// Vertical line indicating a parent.
+    Parent,
+
+    /// The node for this row.
+    Node,
+}
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(NodeLine);
+
+impl From<renderdag::NodeLine> for NodeLine {
+    fn from(value: renderdag::NodeLine) -> Self {
+        match value {
+            renderdag::NodeLine::Blank => Self::Blank,
+            renderdag::NodeLine::Ancestor => Self::Ancestor,
+            renderdag::NodeLine::Parent => Self::Parent,
+            renderdag::NodeLine::Node => Self::Node,
+        }
+    }
+}
+
+/// A column in a padding row.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+pub enum PadLine {
+    /// Blank.
+    Blank,
+
+    /// Vertical line indicating an ancestor.
+    Ancestor,
+
+    /// Vertical line indicating a parent.
+    Parent,
+}
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(PadLine);
+
+impl From<renderdag::PadLine> for PadLine {
+    fn from(value: renderdag::PadLine) -> Self {
+        match value {
+            renderdag::PadLine::Blank => Self::Blank,
+            renderdag::PadLine::Parent => Self::Parent,
+            renderdag::PadLine::Ancestor => Self::Ancestor,
+        }
+    }
+}
+
+/// A column in a linking row.
+#[derive(Default, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy, Serialize)]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+pub struct LinkLine(u16);
+
+impl From<renderdag::LinkLine> for LinkLine {
+    fn from(value: renderdag::LinkLine) -> Self {
+        Self(value.bits())
+    }
+}
+
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(LinkLine);
+
+/// The bestest workspace
+pub fn render_workspace(
+    repo: &gix::Repository,
+    workspace: &but_graph::Workspace,
+) -> Result<Vec<GrStack>> {
+    let stacks = render_stacks(workspace, GraphRowRenderer::new, |row_data| {
+        Ok(match &row_data {
+            RowData::Commit(commit) => repo.find_commit(commit.id)?.message_bstr().to_string(),
+            RowData::Reference(ref_name) => ref_name.to_string(),
+        })
+    })?;
+
+    let mut out = vec![];
+
+    for stack in stacks {
+        out.push(GrStack {
+            rows: stack
+                .into_iter()
+                .map(|row| GraphRow {
+                    data: row.message,
+                    node_line: row
+                        .node_line
+                        .iter()
+                        .cloned()
+                        .map(|n| n.into())
+                        .collect::<Vec<_>>(),
+                    link_line: row
+                        .link_line
+                        .map(|ll| ll.iter().cloned().map(|n| n.into()).collect::<Vec<_>>()),
+                    term_line: row.term_line,
+                    pad_lines: row
+                        .pad_lines
+                        .iter()
+                        .cloned()
+                        .map(|n| n.into())
+                        .collect::<Vec<_>>(),
+                })
+                .collect(),
+        })
+    }
+
+    Ok(out)
 }
 
 /// Render out stacks

--- a/crates/but-workspace/src/experiment.rs
+++ b/crates/but-workspace/src/experiment.rs
@@ -1,0 +1,253 @@
+//! Display graphs to the frontend yey
+
+use std::{
+    collections::{HashSet, VecDeque},
+    hash::{DefaultHasher, Hash as _, Hasher},
+};
+
+use anyhow::{Result, bail};
+use but_graph::{
+    Commit, FirstParent, Segment, SegmentIndex, SegmentMetadata,
+    petgraph::{Direction, visit::EdgeRef},
+};
+use renderdag::{Ancestor, Renderer};
+
+struct Subgraph {
+    heads: Vec<SegmentIndex>,
+    nodes: HashSet<SegmentIndex>,
+}
+
+/// A row, either a commit or a reference
+pub enum RowData<'a> {
+    /// A commit
+    Commit(&'a Commit),
+    /// A reference
+    Reference(&'a gix::refs::FullNameRef),
+}
+
+struct Row<'a> {
+    id: u64,
+    ancestors: Vec<Ancestor<u64>>,
+    data: RowData<'a>,
+}
+
+/// Render out stacks
+pub fn render_stacks<R>(
+    workspace: &but_graph::Workspace,
+    build_renderer: impl Fn() -> R,
+    format_message: impl Fn(&RowData) -> Result<String>,
+) -> Result<Vec<Vec<R::Output>>>
+where
+    R: Renderer<u64>,
+{
+    let stacks = build_stack_rows(workspace)?;
+
+    let mut renderings = vec![];
+
+    for subgraph in stacks {
+        let mut graph = build_renderer();
+
+        let mut out = Vec::with_capacity(subgraph.len());
+
+        for row in subgraph {
+            out.push(graph.next_row(
+                row.id,
+                row.ancestors,
+                if matches!(row.data, RowData::Commit(_)) {
+                    "●".into()
+                } else {
+                    "◎".into()
+                },
+                format_message(&row.data)?,
+            ));
+        }
+
+        renderings.push(out);
+    }
+
+    Ok(renderings)
+}
+
+/// Does nothing :D
+fn build_stack_rows<'ws>(workspace: &'ws but_graph::Workspace) -> Result<Vec<Vec<Row<'ws>>>> {
+    let graph = &workspace.graph;
+    let Some(target_commit) = &workspace.target_commit else {
+        bail!("Only bounded workspaces for experiment");
+    };
+    let entrypoint = graph.entrypoint()?;
+    let heads = if matches!(
+        entrypoint.segment.metadata,
+        Some(SegmentMetadata::Workspace(_))
+    ) {
+        let parents = graph.edges_directed(entrypoint.segment.id, Direction::Outgoing);
+        parents.map(|p| p.target()).collect::<Vec<_>>()
+    } else {
+        vec![entrypoint.segment.id]
+    };
+
+    let mut subgraphs: Vec<Subgraph> = vec![];
+    'outer: for head in &heads {
+        let segments = graph
+            .find_segments_reachable_from_a_not_b(
+                *head,
+                target_commit.segment_index,
+                FirstParent::No,
+            )
+            .collect::<Vec<_>>();
+
+        for subgraph in &mut subgraphs {
+            if segments.iter().any(|s| subgraph.nodes.contains(&s.id)) {
+                subgraph.heads.push(*head);
+                subgraph.nodes.extend(segments.iter().map(|s| s.id));
+                continue 'outer;
+            }
+        }
+
+        subgraphs.push(Subgraph {
+            heads: vec![*head],
+            nodes: segments.iter().map(|s| s.id).collect(),
+        });
+    }
+
+    let mut stepped_subgraphs: Vec<Vec<Row<'ws>>> = vec![];
+
+    for subgraph in subgraphs {
+        stepped_subgraphs.push(subgraph_to_steps(graph, &subgraph)?);
+    }
+
+    Ok(stepped_subgraphs)
+}
+
+fn subgraph_to_steps<'g>(graph: &'g but_graph::Graph, subgraph: &Subgraph) -> Result<Vec<Row<'g>>> {
+    let mut out = vec![];
+    let mut tips = subgraph.heads.iter().cloned().collect::<VecDeque<_>>();
+    let mut seen = subgraph.heads.iter().cloned().collect::<HashSet<_>>();
+
+    while let Some(tip) = tips.pop_front() {
+        let s = &graph[tip];
+        if let Some(ref_info) = &s.ref_info {
+            let refname = &ref_info.ref_name;
+            let ancestors = if let Some(c) = s.commits.first() {
+                vec![Ancestor::Parent(hash_oid(c.id))]
+            } else {
+                graph
+                    .edges_directed(tip, Direction::Outgoing)
+                    .map(|e| {
+                        Ok(if subgraph.nodes.contains(&e.target()) {
+                            Ancestor::Parent(hash_segment(&graph[e.target()])?)
+                        } else {
+                            Ancestor::Anonymous
+                        })
+                    })
+                    .collect::<Result<_>>()?
+            };
+            out.push(Row {
+                id: hash_reference(refname),
+                ancestors,
+                data: RowData::Reference(refname.as_ref()),
+            })
+        }
+
+        for (idx, commit) in s.commits.iter().enumerate() {
+            let ancestors = if idx == s.commits.len() - 1 {
+                graph
+                    .edges_directed(tip, Direction::Outgoing)
+                    .map(|e| {
+                        Ok(if subgraph.nodes.contains(&e.target()) {
+                            Ancestor::Parent(hash_segment(&graph[e.target()])?)
+                        } else {
+                            Ancestor::Anonymous
+                        })
+                    })
+                    .collect::<Result<_>>()?
+            } else {
+                vec![Ancestor::Parent(hash_oid(
+                    s.commits
+                        .get(idx + 1)
+                        .expect("BUG: This is the second to last commit in the array")
+                        .id,
+                ))]
+            };
+
+            out.push(Row {
+                id: hash_oid(commit.id),
+                ancestors,
+                data: RowData::Commit(commit),
+            });
+        }
+
+        for parent in graph.edges_directed(tip, Direction::Outgoing) {
+            if !subgraph.nodes.contains(&parent.target()) {
+                continue;
+            }
+            if seen.insert(parent.target()) {
+                tips.push_back(parent.target());
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn hash_segment(s: &Segment) -> Result<u64> {
+    if let Some(ref_info) = &s.ref_info {
+        return Ok(hash_reference(&ref_info.ref_name));
+    }
+    if let Some(c) = &s.commits.first() {
+        return Ok(hash_oid(c.id));
+    }
+
+    bail!("Tried to make a hash for an empty segment")
+}
+
+fn hash_oid(a: gix::ObjectId) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    a.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn hash_reference(a: &gix::refs::FullName) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    a.hash(&mut hasher);
+    hasher.finish()
+}
+
+#[cfg(test)]
+mod test {
+    use renderdag::{Ancestor, GraphRowRenderer, Renderer as _};
+
+    #[test]
+    fn foobar() {
+        // Imagining a graph a -> b -> c; a -> x -> c;
+        let mut graph = GraphRowRenderer::new().output().build_box_drawing();
+        let out = vec![
+            graph.next_row(
+                "A",
+                vec![Ancestor::Parent("B"), Ancestor::Parent("X")],
+                "*".into(),
+                "This is A".into(),
+            ),
+            graph.next_row(
+                "B",
+                vec![Ancestor::Parent("C")],
+                "*".into(),
+                "This is B".into(),
+            ),
+            graph.next_row(
+                "X",
+                vec![Ancestor::Parent("C")],
+                "*".into(),
+                "This is X".into(),
+            ),
+            graph.next_row(
+                "C",
+                vec![Ancestor::Anonymous],
+                "*".into(),
+                "This is C".into(),
+            ),
+        ];
+        for line in out {
+            print!("{line}");
+        }
+        println!();
+    }
+}

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -63,6 +63,8 @@ pub use upstream_integration::{
     BottomUpdate, BottomUpdateKind, IntegrateUpstreamOutcome, integrate_upstream,
 };
 
+pub mod experiment;
+
 /// Information about refs, as seen from within or outsie of a workspace.
 ///
 /// We always try to deduce a set of stacks that are currently applied to a workspace,

--- a/crates/but-workspace/tests/workspace/experiment.rs
+++ b/crates/but-workspace/tests/workspace/experiment.rs
@@ -1,0 +1,90 @@
+use anyhow::Result;
+use but_graph::init::Options;
+use but_meta::virtual_branches_legacy_types::Target;
+use but_testsupport::visualize_commit_graph_all;
+use but_workspace::experiment::{RowData, render_stacks};
+use gitbutler_commit::commit_ext::CommitMessageBstr as _;
+use renderdag::GraphRowRenderer;
+
+use crate::ref_info::with_workspace_commit::utils::{
+    StackState, add_stack, named_writable_scenario_with_description,
+};
+
+#[test]
+fn diamond_shape() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("diamond-partially-historically-integrated")?;
+    let o1_id = repo.rev_parse_single("o1")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "master"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: o1_id,
+        push_remote_name: None,
+    });
+    add_stack(&mut meta, 1, "E", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        Options {
+            extra_target_commit_id: Some(o1_id),
+            ..Options::limited()
+        },
+    )?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 61ee5f5 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 972cf74 (E) E
+    *   9e74c75 (C) C
+    |\  
+    | * d6a7004 (D) D
+    | | * 7de2393 (origin/master, master) o4
+    | | *   7d62953 (o3) o3
+    | | |\  
+    | |_|/  
+    |/| |   
+    * | | ffb801b (B) B
+    |/ /  
+    * | 448b195 (A) A
+    | * d1b2089 o2
+    |/  
+    * 85aa44b (o1) o1
+    ");
+
+    let stacks = render_stacks(
+        &graph.into_workspace()?,
+        || GraphRowRenderer::new().output().build_box_drawing(),
+        |row_data| {
+            Ok(match &row_data {
+                RowData::Commit(commit) => repo.find_commit(commit.id)?.message_bstr().to_string(),
+                RowData::Reference(ref_name) => ref_name.to_string(),
+            })
+        },
+    )?;
+
+    insta::assert_snapshot!(stacks[0].join(""), @"
+    ◎  refs/heads/E
+    │
+    ●  E
+    │
+    ◎  refs/heads/C
+    │
+    ●    C
+    ├─╮
+    ◎ │  refs/heads/B
+    │ │
+    ● │  B
+    │ │
+    │ ◎  refs/heads/D
+    │ │
+    │ ●  D
+    ├─╯
+    ◎  refs/heads/A
+    │
+    ●  A
+    │
+    ~
+    ");
+
+    Ok(())
+}

--- a/crates/but-workspace/tests/workspace/main.rs
+++ b/crates/but-workspace/tests/workspace/main.rs
@@ -11,4 +11,5 @@ mod tree_manipulation;
 mod ui;
 mod upstream_integration;
 
+mod experiment;
 mod utils;

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -277,6 +277,8 @@ export declare function pushStack(projectId: string, stackId: string, withForce:
  */
 export declare function removeBranch(projectId: string, stackId: string, branchName: string): Promise<void>
 
+export declare function renderWorkspace(projectId: string): Promise<Array<GrStack>>
+
 /**
  * Restores the project to a specific snapshot using a specific kind of restore. This operation
  * also creates a new snapshot in the oplog.
@@ -1296,6 +1298,35 @@ export type GixTime = {
   offset: number;
 };
 
+/** Graph segment */
+export type GrSegment = {
+  /** The rows!!! */
+  rows: Array<GraphRow>;
+};
+
+/** Some SubSegment */
+export type GrStack = {
+  /** The rows!!! */
+  rows: Array<GraphRow>;
+};
+
+/** A row...from graph <shocked pikachu face> */
+export type GraphRow = {
+  /** The stuff the row contains */
+  data: string;
+  /** The node columns for this row. */
+  node_line: Array<NodeLine>;
+  /** The link columns for this row, if a link row is necessary. */
+  link_line: Array<LinkLine> | null;
+  /**
+   * The location of any terminators, if necessary.  Other columns should be
+   * filled in with pad lines.
+   */
+  term_line: Array<boolean> | null;
+  /** The pad columns for this row. */
+  pad_lines: Array<PadLine>;
+};
+
 export type HeadAndMode = {
   head: string | null;
   operatingMode: OperatingMode;
@@ -1495,6 +1526,9 @@ export type LineStats = {
   filesChanged: number;
 };
 
+/** A column in a linking row. */
+export type LinkLine = number;
+
 /** How to combine messages of commits being squashed. */
 export type MessageCombinationStrategy = "KeepBoth" | "KeepSubject" | "KeepTarget";
 
@@ -1530,6 +1564,9 @@ export type NameAndStatus = {
   status: BranchStatus;
 };
 
+/** A column in the node row. */
+export type NodeLine = "Blank" | "Ancestor" | "Parent" | "Node";
+
 export type OperatingMode = {
   type: "OpenWorkspace";
 } | {
@@ -1548,6 +1585,9 @@ export type OutsideWorkspaceMetadata = {
   /** The paths of any files that would conflict with the workspace as it currently is */
   worktreeConflicts: Array<string>;
 };
+
+/** A column in a padding row. */
+export type PadLine = "Blank" | "Ancestor" | "Parent";
 
 /**
  * API-specific project type that can be enriched with computed/derived data

--- a/packages/but-sdk/src/generated/index.js
+++ b/packages/but-sdk/src/generated/index.js
@@ -579,7 +579,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { absorb, absorptionPlan, apply, assignHunk, branchDetails, branchDiff, changesInWorktree, changesInWorktreeWithPerm, commitAmend, commitCreate, commitDetailsWithLineStats, commitDiscard, commitInsertBlank, commitMove, commitMoveChangesBetween, commitReword, commitSquash, commitUncommit, commitUncommitChanges, forgeProvider, getRedoTargetSnapshot, getReview, getUndoTargetSnapshot, headInfo, listAvailableReviewTemplates, listBranches, listCiChecksAndUpdateCache, listProjectsStateless, listReviews, listReviewsForBranch, mergeReview, moveBranch, peelRestoreSnapshot, publishReview, pushStack, removeBranch, restoreSnapshotWithKind, reviewTemplate, setReviewAutoMerge, setReviewDraftiness, setReviewTemplate, tearOffBranch, treeChangeDiffs, unapplyStack, updateBranchName, updateReviewFooters, warmCiChecksCache, workspaceIntegrateUpstream, WatcherHandle, watcherStart } = nativeBinding
+const { absorb, absorptionPlan, apply, assignHunk, branchDetails, branchDiff, changesInWorktree, changesInWorktreeWithPerm, commitAmend, commitCreate, commitDetailsWithLineStats, commitDiscard, commitInsertBlank, commitMove, commitMoveChangesBetween, commitReword, commitSquash, commitUncommit, commitUncommitChanges, forgeProvider, getRedoTargetSnapshot, getReview, getUndoTargetSnapshot, headInfo, listAvailableReviewTemplates, listBranches, listCiChecksAndUpdateCache, listProjectsStateless, listReviews, listReviewsForBranch, mergeReview, moveBranch, peelRestoreSnapshot, publishReview, pushStack, removeBranch, renderWorkspace, restoreSnapshotWithKind, reviewTemplate, setReviewAutoMerge, setReviewDraftiness, setReviewTemplate, tearOffBranch, treeChangeDiffs, unapplyStack, updateBranchName, updateReviewFooters, warmCiChecksCache, workspaceIntegrateUpstream, WatcherHandle, watcherStart } = nativeBinding
 export { absorb }
 export { absorptionPlan }
 export { apply }
@@ -616,6 +616,7 @@ export { peelRestoreSnapshot }
 export { publishReview }
 export { pushStack }
 export { removeBranch }
+export { renderWorkspace }
 export { restoreSnapshotWithKind }
 export { reviewTemplate }
 export { setReviewAutoMerge }


### PR DESCRIPTION
This was some stuff I bashed together as an experiment. It shouldn’t be seen as some decision having been made.

I want to play with renderdag, the library that JJ and sapling use to render their graphs. It might be a good starting point for producing a list of rows that could be consumed by both the CLI and the web frontend