### PR TITLE
Gracefully handle Lite project exceptions

### DIFF
--- a/apps/lite/ui/src/routes/RootLayout.tsx
+++ b/apps/lite/ui/src/routes/RootLayout.tsx
@@ -75,7 +75,6 @@ const ProjectSelect: FC = () => {
 			<ShortcutButton
 				aria-label="Select project"
 				className={classes(uiStyles.button, styles.picker)}
-				disabled={projects.length === 0}
 				hotkey={globalHotkeys.selectProject.hotkey}
 				hotkeyOptions={{ meta: globalHotkeys.selectProject.meta }}
 				onClick={openProjectPicker}

--- a/apps/lite/ui/src/routes/project/$id/route.tsx
+++ b/apps/lite/ui/src/routes/project/$id/route.tsx
@@ -14,12 +14,18 @@ export const Route = createRoute({
 		if (matches.at(-1)?.routeId === routeId) throw notFound();
 	},
 	loader: async ({ params, context }) => {
-		const subscriptionId = await window.lite.watcherSubscribe(params.id, (event) =>
-			handleWatcher(event, params.id, context.queryClient),
-		);
-		return { subscriptionId };
+		// Allow the route to render and handle failure via its queries.
+		try {
+			const subscriptionId = await window.lite.watcherSubscribe(params.id, (event) =>
+				handleWatcher(event, params.id, context.queryClient),
+			);
+			return { subscriptionId };
+		} catch {
+			return { subscriptionId: undefined };
+		}
 	},
 	onLeave: ({ loaderData }) => {
-		if (loaderData) void window.lite.watcherUnsubscribe(loaderData.subscriptionId);
+		if (loaderData?.subscriptionId !== undefined)
+			void window.lite.watcherUnsubscribe(loaderData.subscriptionId);
 	},
 });

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.module.css
@@ -33,3 +33,10 @@
 	width: 1px;
 	background-color: var(--border-2);
 }
+
+.notFound {
+	display: grid;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.module.css
@@ -40,3 +40,23 @@
 	justify-content: center;
 	height: 100%;
 }
+
+.error {
+	max-width: 500px;
+	margin: auto;
+	padding: 24px;
+}
+
+.errorTitle {
+	margin-block-end: 16px;
+	font-size: 15px;
+}
+
+.errorActions {
+	margin-block: 16px;
+}
+
+.errorMessage {
+	font-size: 13px;
+	word-break: break-word;
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -460,7 +460,7 @@ export const Route: FC = () => {
 
 	const { data: projects } = useSuspenseQuery(listProjectsQueryOptions);
 	const project = projects.find((project) => project.id === projectId);
-	if (!project) return <p>Project not found.</p>;
+	if (!project) return <p className={styles.notFound}>Project not found.</p>;
 
 	return <WorkspacePage />;
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -1,4 +1,5 @@
 import { FilesPanel } from "./FilesPanel.tsx";
+import uiStyles from "#ui/ui/ui.module.css";
 import {
 	headInfoQueryOptions,
 	listBranchesQueryOptions,
@@ -28,10 +29,15 @@ import {
 	useHotkeys,
 	useHotkeyRegistrations,
 } from "@tanstack/react-hotkeys";
-import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import {
+	QueryErrorResetBoundary,
+	useMutation,
+	useQuery,
+	useSuspenseQuery,
+} from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
 import { Match, Order } from "effect";
-import { FC } from "react";
+import { type FC, Component, ReactNode } from "react";
 import { Group, Separator, useDefaultLayout } from "react-resizable-panels";
 import { branchOperand, type BranchOperand } from "#ui/operands.ts";
 import { PickerDialog, type PickerDialogGroup } from "#ui/ui/PickerDialog/PickerDialog.tsx";
@@ -455,6 +461,48 @@ const WorkspacePage: FC = () => {
 	);
 };
 
+class WorkspacePageErrorBoundary extends Component<
+	{
+		onReset: () => void;
+		children: ReactNode;
+	},
+	{
+		error: Error | null;
+	}
+> {
+	state = { error: null as Error | null };
+
+	static getDerivedStateFromError(error: unknown) {
+		return {
+			error:
+				error instanceof Error
+					? error
+					: new Error(typeof error === "string" ? error : JSON.stringify(error)),
+		};
+	}
+
+	handleRetry(): void {
+		this.props.onReset();
+		this.setState({ error: null });
+	}
+
+	render(): ReactNode {
+		if (!this.state.error) return this.props.children;
+
+		return (
+			<div className={styles.error}>
+				<h1 className={styles.errorTitle}>Something went wrong.</h1>
+				<div className={styles.errorActions}>
+					<button type="button" className={uiStyles.button} onClick={() => this.handleRetry()}>
+						Retry
+					</button>
+				</div>
+				<code className={styles.errorMessage}>{this.state.error.message}</code>
+			</div>
+		);
+	}
+}
+
 export const Route: FC = () => {
 	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
 
@@ -462,5 +510,13 @@ export const Route: FC = () => {
 	const project = projects.find((project) => project.id === projectId);
 	if (!project) return <p className={styles.notFound}>Project not found.</p>;
 
-	return <WorkspacePage />;
+	return (
+		<QueryErrorResetBoundary>
+			{({ reset }) => (
+				<WorkspacePageErrorBoundary onReset={reset}>
+					<WorkspacePage />
+				</WorkspacePageErrorBoundary>
+			)}
+		</QueryErrorResetBoundary>
+	);
 };


### PR DESCRIPTION
Previously when a project was broken, for example because the repo moved, we would fail in the loader and then, if the failure is triggered after initial load, we would fail in the route. In both cases we’d blow up the app, potentially leaving you in a permanently broken state. This is problematic for dogfooding.

With this PR we now tolerate loader failure and catch uncaught errors (for example via suspense queries) via an error boundary, allowing you to switch projects or even retry if you think you’ve resolved the issue.

As per:
- https://discord.com/channels/1060193121130000425/1481308709001891961/1506416214195572736
- https://discord.com/channels/1060193121130000425/1504735476651921450/1506058876095824002