### PR TITLE
Use `head_info` rather than `stacks` or `stack_details` when possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3957,6 +3957,7 @@ dependencies = [
  "gitbutler-workspace",
  "gix",
  "glob",
+ "insta",
  "itertools",
  "md5",
  "pretty_assertions",

--- a/apps/desktop/src/components/branch/BranchCard.svelte
+++ b/apps/desktop/src/components/branch/BranchCard.svelte
@@ -207,6 +207,7 @@
 				onclick={args.disableClick ? undefined : args.onclick}
 				disableClick={args.disableClick}
 				menu={args.menu}
+				buttons={args.buttons}
 				conflicts={args.isConflicted}
 				{showPrCreation}
 				changedFiles={args.changedFiles}
@@ -228,12 +229,6 @@
 							: undefined,
 				}}
 			>
-				{#snippet buttons()}
-					{#if args.buttons}
-						{@render args.buttons()}
-					{/if}
-				{/snippet}
-
 				{#snippet emptyState()}
 					<span class="branch-header__empty-state-span">This is an empty branch.</span>
 					<span class="branch-header__empty-state-span">Click for details.</span>

--- a/apps/desktop/src/components/branch/BranchDetails.svelte
+++ b/apps/desktop/src/components/branch/BranchDetails.svelte
@@ -1,23 +1,32 @@
 <script lang="ts">
 	import BranchBadge from "$components/branch/BranchBadge.svelte";
 	import { AvatarGroup, Button } from "@gitbutler/ui";
-	import type { BranchDetails } from "@gitbutler/but-sdk";
+	import type { Author, PushStatus } from "@gitbutler/but-sdk";
 	import type { Snippet } from "svelte";
 
 	type Props = {
-		branch: BranchDetails;
+		pushStatus: PushStatus;
+		authors: Author[];
+		isConflicted: boolean;
 		children?: Snippet;
 		conflictedCommits?: Snippet;
 		onResolveConflicts?: () => void;
 	};
 
-	const { branch, children, conflictedCommits, onResolveConflicts }: Props = $props();
+	const {
+		pushStatus,
+		authors,
+		isConflicted,
+		children,
+		conflictedCommits,
+		onResolveConflicts,
+	}: Props = $props();
 </script>
 
 <div class="branch-view">
 	<div class="text-12 branch-view__header-container">
 		<div class="factoid-wrap">
-			<BranchBadge pushStatus={branch.pushStatus} unstyled />
+			<BranchBadge {pushStatus} unstyled />
 			<span class="branch-view__details-divider">•</span>
 		</div>
 
@@ -25,7 +34,7 @@
 			<span class="factoid-label">Contribs:</span>
 			<AvatarGroup
 				maxAvatars={2}
-				avatars={branch.authors.map((a) => ({
+				avatars={authors.map((a) => ({
 					username: a.name,
 					srcUrl: a.gravatarUrl,
 				}))}
@@ -35,7 +44,7 @@
 
 	{@render children?.()}
 
-	{#if branch.isConflicted && conflictedCommits}
+	{#if isConflicted && conflictedCommits}
 		<div class="header-details__conflicts">
 			{@render conflictedCommits?.()}
 

--- a/apps/desktop/src/components/branch/BranchHeaderContextMenu.svelte
+++ b/apps/desktop/src/components/branch/BranchHeaderContextMenu.svelte
@@ -1,6 +1,8 @@
 <script lang="ts" module>
+	import type { Segment } from "@gitbutler/but-sdk";
+
 	export type BranchHeaderContextData = {
-		branch: BranchDetails;
+		branch: Segment;
 		prNumber?: number;
 		first?: boolean;
 		stackLength: number;
@@ -33,7 +35,6 @@
 
 	import { tick } from "svelte";
 	import type { AnchorPosition } from "$lib/stacks/stack";
-	import type { BranchDetails } from "@gitbutler/but-sdk";
 
 	type Props = {
 		projectId: string;
@@ -67,18 +68,28 @@
 	const isReadOnly = $derived(!stackId);
 
 	const aiGenEnabled = $derived(projectAiGenEnabled(projectId));
+	const branchName = $derived(contextData.branch.refName?.displayName);
+	const branchReference = $derived(
+		contextData.branch.refName
+			? new TextDecoder().decode(new Uint8Array(contextData.branch.refName.fullNameBytes))
+			: undefined,
+	);
+	const remoteTrackingBranch = $derived(contextData.branch.remoteTrackingRefName);
+	const branchCommits = $derived(contextData.branch.commits);
 
 	const allCommits = $derived.by(() => {
+		if (!branchName) return;
 		return stackId
-			? stackService.commits(projectId, stackId, contextData.branch.name)
-			: stackService.unstackedCommits(projectId, contextData.branch.name);
+			? stackService.commits(projectId, stackId, branchName)
+			: stackService.unstackedCommits(projectId, branchName);
 	});
 
 	async function getAllCommits() {
+		if (!branchName) return [];
 		if (stackId) {
-			return stackService.fetchCommits(projectId, stackId, contextData.branch.name);
+			return stackService.fetchCommits(projectId, stackId, branchName);
 		}
-		return stackService.fetchUnstackedCommits(projectId, contextData.branch.name);
+		return stackService.fetchUnstackedCommits(projectId, branchName);
 	}
 
 	const commits = $derived(allCommits?.response);
@@ -127,6 +138,7 @@
 	}
 
 	async function handleCreateNewRef(stackId: string, position: AnchorPosition) {
+		if (!branchName) return;
 		const newName = await stackService.fetchNewBranchName(projectId);
 		await createRef({
 			projectId,
@@ -136,7 +148,7 @@
 				anchor: {
 					type: "atReference",
 					subject: {
-						short_name: contextData.branch.name,
+						short_name: branchName,
 						position,
 					},
 				},
@@ -155,10 +167,9 @@
 	contextMenuTestId={TestId.BranchHeaderContextMenu}
 >
 	{#snippet contextMenu({ close })}
-		{@const { branch, prNumber, first, stackLength } = contextData}
-		{@const branchName = branch.name}
+		{@const { prNumber, first, stackLength } = contextData}
 		<ContextMenuSection>
-			{#if branch.remoteTrackingBranch}
+			{#if remoteTrackingBranch && branchName}
 				<ContextMenuItem
 					label="Open in browser"
 					icon="open-in-browser"
@@ -175,9 +186,12 @@
 				icon="copy"
 				testId={TestId.BranchHeaderContextMenu_CopyBranchName}
 				onclick={() => {
-					clipboardService.write(branch?.name, { message: "Branch name copied" });
+					if (branchName) {
+						clipboardService.write(branchName, { message: "Branch name copied" });
+					}
 					close();
 				}}
+				disabled={!branchName}
 			/>
 		</ContextMenuSection>
 		{#if stackId}
@@ -216,17 +230,18 @@
 					icon="commit-plus"
 					testId={TestId.BranchHeaderContextMenu_AddEmptyCommit}
 					onclick={async () => {
+						if (!branchReference) return;
 						await insertBlankCommitInBranch({
 							projectId,
-							relativeTo: { type: "reference", subject: contextData.branch.reference },
+							relativeTo: { type: "reference", subject: branchReference },
 							side: "below",
 							dryRun: false,
 						});
 						close();
 					}}
-					disabled={isReadOnly || commitInsertion.current.isLoading}
+					disabled={isReadOnly || commitInsertion.current.isLoading || !branchReference}
 				/>
-				{#if branch.commits.length > 1}
+				{#if branchCommits.length > 1 && branchName}
 					<ContextMenuItem
 						label="Squash all commits"
 						icon="commit-double-chevron-down"
@@ -244,7 +259,7 @@
 				{/if}
 			</ContextMenuSection>
 			<ContextMenuSection>
-				{#if $aiGenEnabled && aiConfigurationValid && !branch.remoteTrackingBranch && stackId}
+				{#if $aiGenEnabled && aiConfigurationValid && !remoteTrackingBranch && stackId && branchName}
 					<ContextMenuItem
 						label="Generate branch name"
 						icon="edit-ai"
@@ -256,7 +271,7 @@
 						}}
 					/>
 				{/if}
-				{#if branchType !== "Integrated"}
+				{#if branchType !== "Integrated" && branchName}
 					<ContextMenuItem
 						label="Rename"
 						icon="edit"
@@ -268,7 +283,7 @@
 								stackId,
 								laneId,
 								branchName,
-								isPushed: !!branch.remoteTrackingBranch,
+								isPushed: !!remoteTrackingBranch,
 							};
 							await tick();
 							renameBranchModal?.show();
@@ -276,7 +291,7 @@
 						}}
 					/>
 				{/if}
-				{#if stackLength && (stackLength > 1 || (stackLength === 1 && branch.commits.length === 0))}
+				{#if branchName && stackLength && (stackLength > 1 || (stackLength === 1 && branchCommits.length === 0))}
 					<ContextMenuItem
 						label="Delete"
 						icon="bin"

--- a/apps/desktop/src/components/branch/CreateBranchModal.svelte
+++ b/apps/desktop/src/components/branch/CreateBranchModal.svelte
@@ -5,6 +5,7 @@
 	import newStackRightSvg from "$components/stackTabs/assets/new-stack-right.svg?raw";
 	import { autoSelectBranchCreationFeature } from "$lib/config/uiFeatureFlags";
 	import { useSettingsModal } from "$lib/settings/settingsModal.svelte";
+	import { getStackName } from "$lib/stacks/stack";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import { persisted } from "@gitbutler/shared/persisted";
@@ -54,9 +55,9 @@
 		allStacks
 			.map((stack) => {
 				if (!stack.id) return;
-				const firstBranchName = stack.heads[0]?.name ?? `Stack ${stack?.id.slice(0, 8)}`;
 				return {
-					label: firstBranchName,
+					// TODO(CTO): Change this not to error out if stack name is undefined
+					label: getStackName(stack),
 					value: stack.id,
 				};
 			})

--- a/apps/desktop/src/components/branchesPage/BranchesViewStack.svelte
+++ b/apps/desktop/src/components/branchesPage/BranchesViewStack.svelte
@@ -30,7 +30,7 @@
 
 	const stackService = inject(STACK_SERVICE);
 
-	const stackQuery = $derived(stackService.branchesPageStack(projectId, stackId, inWorkspace));
+	const stackQuery = $derived(stackService.stackById(projectId, stackId));
 </script>
 
 <ReduxResult result={stackQuery.result} {projectId} {stackId} {onerror}>
@@ -39,12 +39,7 @@
 			<p>Stack not found.</p>
 		{:else}
 			{#each getStackBranchNames(stack) as branchName, idx}
-				{@const branchDetailsQuery = stackService.branchesPageBranchDetails(
-					projectId,
-					stackId,
-					branchName,
-					inWorkspace,
-				)}
+				{@const branchDetailsQuery = stackService.branchDetails(projectId, stackId, branchName)}
 				{@const branchDetails = branchDetailsQuery.response}
 				{@const lineColor = branchDetails
 					? getColorFromPushStatus(branchDetails.pushStatus)
@@ -60,7 +55,6 @@
 					{branchName}
 					isTopBranch={idx === 0}
 					{inWorkspace}
-					branchesPage
 					{isTarget}
 					{selectedCommitId}
 					{onCommitClick}

--- a/apps/desktop/src/components/branchesPage/BranchesViewStack.svelte
+++ b/apps/desktop/src/components/branchesPage/BranchesViewStack.svelte
@@ -2,7 +2,7 @@
 	import BranchDividerLine from "$components/branch/BranchDividerLine.svelte";
 	import ReduxResult from "$components/shared/ReduxResult.svelte";
 	import BranchesViewBranch from "$components/views/BranchesViewBranch.svelte";
-	import { getColorFromPushStatus, getStackBranchNames } from "$lib/stacks/stack";
+	import { getColorFromPushStatus } from "$lib/stacks/stack";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { inject } from "@gitbutler/core/context";
 
@@ -38,12 +38,9 @@
 		{#if stack === null}
 			<p>Stack not found.</p>
 		{:else}
-			{#each getStackBranchNames(stack) as branchName, idx}
-				{@const branchDetailsQuery = stackService.branchDetails(projectId, stackId, branchName)}
-				{@const branchDetails = branchDetailsQuery.response}
-				{@const lineColor = branchDetails
-					? getColorFromPushStatus(branchDetails.pushStatus)
-					: "var(--commit-local)"}
+			{#each stack.segments as segment, idx}
+				{@const branchName = segment.refName?.displayName}
+				{@const lineColor = getColorFromPushStatus(segment.pushStatus)}
 
 				{#if idx > 0}
 					<BranchDividerLine {lineColor} />
@@ -53,6 +50,7 @@
 					{projectId}
 					{stackId}
 					{branchName}
+					{segment}
 					isTopBranch={idx === 0}
 					{inWorkspace}
 					{isTarget}

--- a/apps/desktop/src/components/branchesPage/BranchesViewStack.svelte
+++ b/apps/desktop/src/components/branchesPage/BranchesViewStack.svelte
@@ -30,7 +30,7 @@
 
 	const stackService = inject(STACK_SERVICE);
 
-	const stackQuery = $derived(stackService.allStackById(projectId, stackId));
+	const stackQuery = $derived(stackService.branchesPageStack(projectId, stackId, inWorkspace));
 </script>
 
 <ReduxResult result={stackQuery.result} {projectId} {stackId} {onerror}>
@@ -39,7 +39,12 @@
 			<p>Stack not found.</p>
 		{:else}
 			{#each getStackBranchNames(stack) as branchName, idx}
-				{@const branchDetailsQuery = stackService.branchDetails(projectId, stackId, branchName)}
+				{@const branchDetailsQuery = stackService.branchesPageBranchDetails(
+					projectId,
+					stackId,
+					branchName,
+					inWorkspace,
+				)}
 				{@const branchDetails = branchDetailsQuery.response}
 				{@const lineColor = branchDetails
 					? getColorFromPushStatus(branchDetails.pushStatus)
@@ -55,6 +60,7 @@
 					{branchName}
 					isTopBranch={idx === 0}
 					{inWorkspace}
+					branchesPage
 					{isTarget}
 					{selectedCommitId}
 					{onCommitClick}

--- a/apps/desktop/src/components/commit/CherryApplyModal.svelte
+++ b/apps/desktop/src/components/commit/CherryApplyModal.svelte
@@ -107,14 +107,15 @@
 							<form onchange={(e) => handleStackSelectionChange(e.currentTarget)}>
 								{#each stacks as stack}
 									{@const isDisabled = !canSelectStack && selectedStackId !== stack.id}
+									{@const branchesCount = stack.segments.length}
 
 									<CardGroup.Item labelFor="stack-{stack.id}" disabled={isDisabled}>
 										{#snippet title()}
 											{getStackName(stack)}
 										{/snippet}
 										{#snippet caption()}
-											{stack.heads.length}
-											{stack.heads.length === 1 ? "branch" : "branches"}
+											{branchesCount}
+											{branchesCount === 1 ? "branch" : "branches"}
 										{/snippet}
 										{#snippet actions()}
 											<RadioButton

--- a/apps/desktop/src/components/commit/CommitFailedFileEntry.svelte
+++ b/apps/desktop/src/components/commit/CommitFailedFileEntry.svelte
@@ -84,7 +84,7 @@
 											{@const commitBranch = branch?.find((b) =>
 												b.commits.some((c) => c.id === lock.commitId),
 											)}
-											{@const branchName = commitBranch?.name || "Unknown branch"}
+											{@const branchName = commitBranch?.refName?.displayName || "Unknown branch"}
 											{@const commitMessage = commitBranch?.commits.find(
 												(c) => c.id === lock.commitId,
 											)}

--- a/apps/desktop/src/components/commit/CommitListItem.svelte
+++ b/apps/desktop/src/components/commit/CommitListItem.svelte
@@ -13,7 +13,7 @@
 
 	type BaseProps = {
 		type: CommitStatusType;
-		branchName: string;
+		branchName?: string;
 		commitId: string;
 		commitMessage: string;
 		createdAt: number;

--- a/apps/desktop/src/components/commit/NewCommitView.svelte
+++ b/apps/desktop/src/components/commit/NewCommitView.svelte
@@ -42,7 +42,7 @@
 
 	const selectedLines = $derived(uncommittedService.selectedLines(stackId));
 	const topBranchQuery = $derived(stackId ? stackService.branches(projectId, stackId) : undefined);
-	const topBranchName = $derived(topBranchQuery?.response?.at(0)?.name);
+	const topBranchName = $derived(topBranchQuery?.response?.at(0)?.refName?.displayName);
 
 	const draftBranchName = $derived(uiState.global.draftBranchName.current);
 	const canCommit = $derived(selectedLines.current.length > 0);

--- a/apps/desktop/src/components/forge/CreateReviewBox.svelte
+++ b/apps/desktop/src/components/forge/CreateReviewBox.svelte
@@ -30,9 +30,9 @@
 
 	const forge = inject(DEFAULT_FORGE_FACTORY);
 
-	const branch = $derived(stackService.branchByName(projectId, stackId, branchName));
+	const branch = $derived(stackService.branchDetails(projectId, stackId, branchName));
 
-	const prNumber = $derived(branch.response?.prNumber ?? undefined);
+	const prNumber = $derived(branch.response?.metadata?.review.pullRequest ?? undefined);
 	const prService = $derived(forge.current.prService);
 	const reviewUnit = $derived(prService?.unit.abbr ?? "PR");
 	const prQuery = $derived(prNumber ? prService?.get(prNumber) : undefined);

--- a/apps/desktop/src/components/forge/PushButton.svelte
+++ b/apps/desktop/src/components/forge/PushButton.svelte
@@ -67,10 +67,7 @@
 	const branchDetails = $derived(stackService.branchDetails(projectId, stackId, branchName));
 	const branchesQuery = $derived(stackService.branches(projectId, stackId));
 	const [pushStack, pushQuery] = stackService.pushStack;
-	const upstreamCommitsQuery = $derived(
-		stackService.upstreamCommits(projectId, stackId, branchName),
-	);
-	const upstreamCommits = $derived(upstreamCommitsQuery.response);
+
 	function handleClick(args: {
 		withForce: boolean;
 		skipForcePushProtection: boolean;
@@ -176,6 +173,10 @@
 		{@const withForce = partialStackRequestsForcePush(branchName, branches)}
 		{@const hasThingsToPush = branchHasUnpushedCommits(branchDetails)}
 		{@const hasConflicts = branchHasConflicts(branchDetails)}
+		{@const upstreamCommits = branchDetails.commitsOnRemote}
+		{@const remoteTrackingBranch = branchDetails.remoteTrackingRefName
+			? new TextDecoder().decode(new Uint8Array(branchDetails.remoteTrackingRefName.fullNameBytes))
+			: null}
 		{@const buttonDisabled = isReadOnly || !hasThingsToPush || hasConflicts}
 
 		<Button
@@ -185,12 +186,7 @@
 			style="gray"
 			{loading}
 			disabled={buttonDisabled}
-			tooltip={getButtonTooltip(
-				hasThingsToPush,
-				hasConflicts,
-				withForce,
-				branchDetails.remoteTrackingBranch,
-			)}
+			tooltip={getButtonTooltip(hasThingsToPush, hasConflicts, withForce, remoteTrackingBranch)}
 			onclick={() => handleClick({ withForce, skipForcePushProtection: false, gerritFlags: [] })}
 			icon={multipleBranches && !isLastBranchInStack ? "push-all" : "push"}
 		>

--- a/apps/desktop/src/components/forge/ReviewCreation.svelte
+++ b/apps/desktop/src/components/forge/ReviewCreation.svelte
@@ -73,8 +73,10 @@
 		stackService.branchParentByName(projectId, stackId, branchName),
 	);
 	const branchParent = $derived(branchParentQuery.response);
+	const branchParentName = $derived(branchParent?.refName?.displayName);
+	const branchParentPrNumber = $derived(branchParent?.metadata?.review.pullRequest);
 	const branchParentDetailsQuery = $derived(
-		branchParent ? stackService.branchDetails(projectId, stackId, branchParent.name) : undefined,
+		branchParentName ? stackService.branchDetails(projectId, stackId, branchParentName) : undefined,
 	);
 	const branchParentDetails = $derived(branchParentDetailsQuery?.response);
 	const branchDetailsQuery = $derived(stackService.branchDetails(projectId, stackId, branchName));
@@ -245,7 +247,7 @@
 		}
 
 		// All ids that existed prior to creating a new one (including archived).
-		const prNumbers = branches.map((branch) => branch.prNumber);
+		const prNumbers = branches.map((branch) => branch.metadata?.review.pullRequest);
 
 		try {
 			if (!baseBranchName) {
@@ -264,7 +266,7 @@
 			}
 
 			// Find the index of the current branch so we know where we want to point the pr.
-			const currentIndex = branches.findIndex((b) => b.name === params.branchName);
+			const currentIndex = branches.findIndex((b) => b.refName?.displayName === params.branchName);
 			if (currentIndex === -1) {
 				throw new Error("Branch index not found.");
 			}
@@ -274,12 +276,12 @@
 			let base = baseBranch?.shortName || "master";
 
 			if (
-				branchParent &&
-				branchParent.prNumber &&
+				branchParentName &&
+				branchParentPrNumber &&
 				branchParentDetails &&
 				branchParentDetails.pushStatus !== "integrated"
 			) {
-				base = branchParent.name;
+				base = branchParentName;
 			}
 
 			const pushRemoteName = baseBranch?.pushRemoteName;

--- a/apps/desktop/src/components/forge/StackedPullRequestCard.svelte
+++ b/apps/desktop/src/components/forge/StackedPullRequestCard.svelte
@@ -27,24 +27,28 @@
 	const repoService = $derived(forge.current.repoService);
 	const prService = $derived(forge.current.prService);
 
-	const branchQuery = $derived(stackService.branchByName(projectId, stackId, branchName));
-	const branch = $derived(branchQuery.response);
 	const branchDetailsQuery = $derived(stackService.branchDetails(projectId, stackId, branchName));
 	const branchDetails = $derived(branchDetailsQuery.response);
 	const isPushed = $derived(branchDetails?.pushStatus !== "completelyUnpushed");
-	const prQuery = $derived(branch?.prNumber ? prService?.get(branch?.prNumber) : undefined);
+	const prQuery = $derived(
+		branchDetails?.metadata?.review.pullRequest
+			? prService?.get(branchDetails.metadata.review.pullRequest)
+			: undefined,
+	);
 	const pr = $derived(prQuery?.response);
 
 	const parentQuery = $derived(stackService.branchParentByName(projectId, stackId, branchName));
 	const parent = $derived(parentQuery.response);
 	const hasParent = $derived(!!parent);
+	const parentName = $derived(parent?.refName?.displayName);
 	const parentBranchDetailsQuery = $derived(
-		parent ? stackService.branchDetails(projectId, stackId, parent.name) : undefined,
+		parentName ? stackService.branchDetails(projectId, stackId, parentName) : undefined,
 	);
 	const parentBranchDetails = $derived(parentBranchDetailsQuery?.response);
 	const parentIsPushed = $derived(parentBranchDetails?.pushStatus !== "completelyUnpushed");
 	const childQuery = $derived(stackService.branchChildByName(projectId, stackId, branchName));
 	const child = $derived(childQuery.response);
+	const childPrNumber = $derived(child?.metadata?.review.pullRequest);
 
 	const baseBranchQuery = $derived(baseBranchService.baseBranch(projectId));
 	const baseBranch = $derived(baseBranchQuery.response);
@@ -54,7 +58,7 @@
 	const repoInfo = $derived(repoQuery?.response);
 
 	let shouldUpdateTargetBaseBranch = $derived(
-		repoInfo?.deleteBranchAfterMerge === false && !!child?.prNumber,
+		repoInfo?.deleteBranchAfterMerge === false && !!childPrNumber,
 	);
 	const baseIsTargetBranch = $derived.by(() => {
 		if (forge.current.name === "gitlab") return true;
@@ -76,9 +80,9 @@
 
 		// In a stack, after merging, update the new bottom PR target
 		// base branch to master if necessary
-		if (baseBranch && shouldUpdateTargetBaseBranch && prService && child?.prNumber) {
+		if (baseBranch && shouldUpdateTargetBaseBranch && prService && childPrNumber) {
 			const targetBase = baseBranch.branchName.replace(`${baseBranch.remoteName}/`, "");
-			await prService.update(child.prNumber, { targetBase });
+			await prService.update(childPrNumber, { targetBase });
 		}
 
 		await Promise.all([

--- a/apps/desktop/src/components/upstream/IntegrateUpstreamModal.svelte
+++ b/apps/desktop/src/components/upstream/IntegrateUpstreamModal.svelte
@@ -4,6 +4,7 @@
 	import { BASE_BRANCH_SERVICE } from "$lib/baseBranch/baseBranchService.svelte";
 	import { descriptionTitle } from "$lib/commits/commit";
 	import { DEFAULT_FORGE_FACTORY } from "$lib/forge/forgeFactory.svelte";
+	import { getStackBranchNames } from "$lib/stacks/stack";
 	import {
 		getBaseBranchResolution,
 		stackFullyIntegrated,
@@ -107,7 +108,7 @@
 		results.clear();
 		for (const status of statusesTmp) {
 			if (status.stack.id) {
-				const dontDelete = someBranchesShouldNotBeDeleted(status.stack.heads.map((b) => b.name));
+				const dontDelete = someBranchesShouldNotBeDeleted(getStackBranchNames(status.stack));
 
 				results.set(status.stack.id, {
 					stackId: status.stack.id,

--- a/apps/desktop/src/components/views/BranchCommitList.svelte
+++ b/apps/desktop/src/components/views/BranchCommitList.svelte
@@ -35,7 +35,6 @@
 	import { getStackContext } from "$lib/stacks/stackController.svelte";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 
-	import { combineResults } from "$lib/state/helpers";
 	import { UI_STATE, withStackBusy } from "$lib/state/uiState.svelte";
 	import { ensureValue } from "$lib/utils/validation";
 	import { inject } from "@gitbutler/core/context";
@@ -44,17 +43,17 @@
 	import { focusable } from "@gitbutler/ui/focus/focusable";
 	import { getTimeAgo } from "@gitbutler/ui/utils/timeAgo";
 	import { isDefined } from "@gitbutler/ui/utils/typeguards";
-	import type { BranchDetails } from "@gitbutler/but-sdk";
+	import type { Segment } from "@gitbutler/but-sdk";
 
 	interface Props {
-		branchName: string;
+		branchName?: string;
 		lastBranch: boolean;
-		branchDetails: BranchDetails;
+		segment: Segment;
 		stackingReorderDropzoneManager: ReorderCommitDzFactory;
 		roundedTop?: boolean;
 	}
 
-	let { branchName, branchDetails, lastBranch, stackingReorderDropzoneManager, roundedTop }: Props =
+	let { branchName, segment, lastBranch, stackingReorderDropzoneManager, roundedTop }: Props =
 		$props();
 
 	const controller = getStackContext();
@@ -85,18 +84,18 @@
 	const selectedBranchName = $derived(selection.current?.branchName);
 	const selectedCommitId = $derived(selection.current?.commitId);
 
-	const localAndRemoteCommits = $derived(stackService.commits(projectId, stackId, branchName));
-	const upstreamOnlyCommits = $derived(
-		stackService.upstreamCommits(projectId, stackId, branchName),
-	);
+	const localAndRemoteCommits = $derived(segment.commits);
+	const upstreamOnlyCommits = $derived(segment.commitsOnRemote);
+	const hasRemoteCommits = $derived(upstreamOnlyCommits.length > 0);
+	const hasCommits = $derived(localAndRemoteCommits.length > 0);
 
 	/**
 	 * Returns a flat ordered list of all commit IDs in this branch
 	 * (upstream-only first, then local-and-remote), used for Shift+Click range selection.
 	 */
 	function getAllCommitIds(): string[] {
-		const ups = upstreamOnlyCommits.response ?? [];
-		const local = localAndRemoteCommits.response ?? [];
+		const ups = upstreamOnlyCommits;
+		const local = localAndRemoteCommits;
 		return [...ups.map((c) => c.id), ...local.map((c) => c.id)];
 	}
 
@@ -240,7 +239,7 @@
 		const selectedIds = controller.selectedCommitIds;
 		if (selectedIds.length <= 1 || !selectedIds.includes(commitId)) return undefined;
 
-		const allCommits = localAndRemoteCommits.response ?? [];
+		const allCommits = localAndRemoteCommits;
 		return selectedIds
 			.map((id) => {
 				const c = allCommits.find((c) => c.id === id);
@@ -256,6 +255,7 @@
 	}
 
 	function startEditingCommitMessage(commitId: string) {
+		if (!branchName) return;
 		controller.selection.set({ branchName, commitId, previewOpen: true });
 		controller.projectState.exclusiveAction.set({
 			type: "edit-commit-message",
@@ -276,281 +276,274 @@
 	{/if}
 {/snippet}
 
-<ReduxResult
-	{stackId}
-	{projectId}
-	result={combineResults(upstreamOnlyCommits.result, localAndRemoteCommits.result)}
->
-	{#snippet children([upstreamOnlyCommits, localAndRemoteCommits], { stackId })}
-		{@const hasRemoteCommits = upstreamOnlyCommits.length > 0}
-		{@const hasCommits = localAndRemoteCommits.length > 0}
+<!-- {@render commitReorderDz(stackingReorderDropzoneManager.top(branchName))} -->
 
-		<!-- {@render commitReorderDz(stackingReorderDropzoneManager.top(branchName))} -->
-
-		{#if hasCommits || hasRemoteCommits}
-			<div
-				class="commit-list hide-when-empty"
-				class:rounded={roundedTop}
-				use:focusable={{ vertical: true }}
-			>
-				{#if hasRemoteCommits}
-					{#each upstreamOnlyCommits as commit, i (commit.id)}
-						{@const first = i === 0}
-						{@const lastCommit = i === upstreamOnlyCommits.length - 1}
-						{@const selected =
-							controller.isCommitSelected(commit.id) && branchName === selectedBranchName}
-						{@const commitId = commit.id}
-						{#if !controller.isCommitting}
-							<CommitListItem
-								type="Remote"
-								{stackId}
-								{commitId}
-								commitMessage={commit.message}
-								createdAt={commitCreatedAt(commit)}
-								tooltip="Upstream"
-								{branchName}
-								{first}
-								{lastCommit}
-								{selected}
-								active={controller.active && commit.id === selectedCommitId}
-								reactions={commitReactions[commit.id]}
-								onclick={(e) => handleCommitClick(commit.id, true, e)}
-								disableCommitActions={false}
-								editable={!!stackId}
-							/>
-						{/if}
-					{/each}
-
-					<UpstreamActionRow testId={TestId.UpstreamCommitsCommitAction} isLast={!hasCommits}>
-						{#snippet action()}
-							<h3 class="text-13 text-semibold m-b-4">Upstream has new commits</h3>
-							<p class="text-12 text-body clr-text-2 m-b-14">Update your branch to stay current.</p>
-							<UpstreamIntegrationActions {projectId} {stackId} {branchName} />
-						{/snippet}
-					</UpstreamActionRow>
+{#if hasCommits || hasRemoteCommits}
+	<div
+		class="commit-list hide-when-empty"
+		class:rounded={roundedTop}
+		use:focusable={{ vertical: true }}
+	>
+		{#if hasRemoteCommits}
+			{#each upstreamOnlyCommits as commit, i (commit.id)}
+				{@const first = i === 0}
+				{@const lastCommit = i === upstreamOnlyCommits.length - 1}
+				{@const selected =
+					controller.isCommitSelected(commit.id) && branchName === selectedBranchName}
+				{@const commitId = commit.id}
+				{#if !controller.isCommitting}
+					<CommitListItem
+						type="Remote"
+						{stackId}
+						{commitId}
+						commitMessage={commit.message}
+						createdAt={commitCreatedAt(commit)}
+						tooltip="Upstream"
+						{branchName}
+						{first}
+						{lastCommit}
+						{selected}
+						active={controller.active && commit.id === selectedCommitId}
+						reactions={commitReactions[commit.id]}
+						onclick={(e) => handleCommitClick(commit.id, true, e)}
+						disableCommitActions={false}
+						editable={!!stackId}
+					/>
 				{/if}
+			{/each}
 
-				{@render commitReorderDz(stackingReorderDropzoneManager.top(branchName))}
+			<UpstreamActionRow testId={TestId.UpstreamCommitsCommitAction} isLast={!hasCommits}>
+				{#snippet action()}
+					<h3 class="text-13 text-semibold m-b-4">Upstream has new commits</h3>
+					<p class="text-12 text-body clr-text-2 m-b-14">Update your branch to stay current.</p>
+					{#if branchName}
+						<UpstreamIntegrationActions {projectId} {stackId} {branchName} />
+					{/if}
+				{/snippet}
+			</UpstreamActionRow>
+		{/if}
 
-				<LazyList items={localAndRemoteCommits} chunkSize={100}>
-					{#snippet template(commit, { first, last })}
-						{@const commitId = commit.id}
-						{@const selected =
-							controller.isCommitSelected(commit.id) && branchName === selectedBranchName}
-						{#if controller.isCommitting}
-							<!-- Only commits to the base can be `last`, see next `CommitPositionIndicator`. -->
-							<CommitPositionIndicator
-								{commitId}
-								selected={(commitAction?.parentCommitId === commitId ||
-									(first && commitAction?.parentCommitId === undefined)) &&
-									!commitAction?.insertBelow &&
-									commitAction?.branchName === branchName}
-								{first}
-								last={false}
-								onclick={() => {
-									controller.projectState.exclusiveAction.set({
-										type: "commit",
-										stackId,
-										branchName,
-										parentCommitId: commitId,
-									});
-								}}
-							/>
-						{/if}
-						{@const dzCommit: DzCommitData = {
+		{#if branchName}
+			{@render commitReorderDz(stackingReorderDropzoneManager.top(branchName))}
+		{/if}
+
+		<LazyList items={localAndRemoteCommits} chunkSize={100}>
+			{#snippet template(commit, { first, last })}
+				{@const commitId = commit.id}
+				{@const selected =
+					controller.isCommitSelected(commit.id) && branchName === selectedBranchName}
+				{#if controller.isCommitting}
+					<!-- Only commits to the base can be `last`, see next `CommitPositionIndicator`. -->
+					<CommitPositionIndicator
+						{commitId}
+						selected={(commitAction?.parentCommitId === commitId ||
+							(first && commitAction?.parentCommitId === undefined)) &&
+							!commitAction?.insertBelow &&
+							commitAction?.branchName === branchName}
+						{first}
+						last={false}
+						onclick={() => {
+							if (!branchName) return;
+							controller.projectState.exclusiveAction.set({
+								type: "commit",
+								stackId,
+								branchName,
+								parentCommitId: commitId,
+							});
+						}}
+					/>
+				{/if}
+				{@const dzCommit: DzCommitData = {
 							id: commit.id,
 							isRemote: isUpstreamCommit(commit),
 							isIntegrated: isLocalAndRemoteCommit(commit) && commit.state.type === 'Integrated',
 							hasConflicts: isLocalAndRemoteCommit(commit) && commit.hasConflicts
 						}}
-						{@const { amendHandler, squashHandler, hunkHandler } = createCommitDropHandlers({
-							projectId,
-							stackId,
-							commit: dzCommit,
-							runHooks: $runHooks,
-							okWithForce: true,
-							onCommitIdChange: (newId) => {
-								const wasSelected = controller.selection.current?.commitId === commitId;
-								if (stackId && wasSelected) {
-									const previewOpen = selection.current?.previewOpen ?? false;
-									controller.laneState.selection.set({ branchName, commitId: newId, previewOpen });
-								}
-							},
-						})}
-						{@const tooltip = commitStatusLabel(commit.state.type)}
-						<Dropzone handlers={[amendHandler, squashHandler, hunkHandler].filter(isDefined)}>
-							{#snippet overlay({ hovered, activated, handler })}
-								{@const label =
-									handler instanceof AmendCommitWithChangeDzHandler ||
-									handler instanceof AmendCommitWithHunkDzHandler
-										? "Amend"
-										: "Squash"}
-								<DropzoneOverlay {hovered} {activated} {label} />
-							{/snippet}
-							<div
-								data-remove-from-panning
-								use:draggableCommitV3={{
-									disabled: false,
-									label: commit.message.split("\n")[0],
-									sha: commit.id.slice(0, 7),
-									date: getTimeAgo(commitCreatedAt(commit)),
-									authorImgUrl: undefined,
-									commitType: commit.state.type,
-									data: stackId
-										? new CommitDropData(
-												stackId,
-												{
-													id: commitId,
-													isRemote: !!branchDetails.remoteTrackingBranch,
-													hasConflicts: isLocalAndRemoteCommit(commit) && commit.hasConflicts,
-													isIntegrated:
-														isLocalAndRemoteCommit(commit) && commit.state.type === "Integrated",
-												},
-												false,
-												branchName,
-												getDragAllCommits(commitId),
-											)
-										: undefined,
-									dropzoneRegistry,
-									dragStateService,
-								}}
-							>
-								<CommitListItem
-									commitId={commit.id}
-									commitMessage={commit.message}
-									type={commit.state.type}
-									hasConflicts={commit.hasConflicts}
-									busy={controller.busyCommitId === commit.id}
-									diverged={commit.state.type === "LocalAndRemote" &&
-										commit.id !== commit.state.subject}
-									createdAt={commitCreatedAt(commit)}
-									gerritReviewUrl={commit.gerritReviewUrl ?? undefined}
-									{stackId}
-									{branchName}
-									{first}
-									lastCommit={last}
-									{lastBranch}
-									{selected}
-									expandChangedFiles={commit.id === selectedCommitId &&
-										branchName === selectedBranchName &&
-										controller.selectedCommitIds.length <= 1}
-									{tooltip}
-									active={controller.active && commit.id === selectedCommitId}
-									reactions={commitReactions[commit.id]}
-									onclick={(e) => handleCommitClick(commit.id, false, e)}
-									disableCommitActions={false}
-									editable={!!stackId}
-								>
-									{#snippet menu({ rightClickTrigger })}
-										{@const selectedIds = controller.selectedCommitIds}
-										{@const isMultiSelect =
-											selectedIds.length > 1 &&
-											branchName === selectedBranchName &&
-											selectedIds.includes(commitId)}
-										{@const data = {
+				{@const { amendHandler, squashHandler, hunkHandler } = createCommitDropHandlers({
+					projectId,
+					stackId,
+					commit: dzCommit,
+					runHooks: $runHooks,
+					okWithForce: true,
+					onCommitIdChange: (newId) => {
+						const wasSelected = controller.selection.current?.commitId === commitId;
+						if (stackId && wasSelected) {
+							const previewOpen = selection.current?.previewOpen ?? false;
+							controller.laneState.selection.set({ branchName, commitId: newId, previewOpen });
+						}
+					},
+				})}
+				{@const tooltip = commitStatusLabel(commit.state.type)}
+				<Dropzone
+					handlers={branchName ? [amendHandler, squashHandler, hunkHandler].filter(isDefined) : []}
+				>
+					{#snippet overlay({ hovered, activated, handler })}
+						{@const label =
+							handler instanceof AmendCommitWithChangeDzHandler ||
+							handler instanceof AmendCommitWithHunkDzHandler
+								? "Amend"
+								: "Squash"}
+						<DropzoneOverlay {hovered} {activated} {label} />
+					{/snippet}
+					<div
+						data-remove-from-panning
+						use:draggableCommitV3={{
+							disabled: false,
+							label: commit.message.split("\n")[0],
+							sha: commit.id.slice(0, 7),
+							date: getTimeAgo(commitCreatedAt(commit)),
+							authorImgUrl: undefined,
+							commitType: commit.state.type,
+							data:
+								stackId && branchName
+									? new CommitDropData(
 											stackId,
-											commitId,
-											commitMessage: commit.message,
-											commitStatus: commit.state.type,
-											commitUrl: forge.current.commitUrl(commitId),
-											onUncommitClick: () => handleUncommit(commit.id),
-											onEditMessageClick: () => startEditingCommitMessage(commit.id),
-											multiSelect: isMultiSelect
-												? {
-														commitIds: selectedIds,
-														onSquashSelected: () => handleSquashSelected(selectedIds),
-														onUncommitSelected: () => handleUncommitSelected(selectedIds),
-													}
-												: undefined,
-										}}
-										<CommitContextMenu
-											showOnHover
+											{
+												id: commitId,
+												isRemote: !!segment.remoteTrackingRefName,
+												hasConflicts: isLocalAndRemoteCommit(commit) && commit.hasConflicts,
+												isIntegrated:
+													isLocalAndRemoteCommit(commit) && commit.state.type === "Integrated",
+											},
+											false,
+											branchName,
+											getDragAllCommits(commitId),
+										)
+									: undefined,
+							dropzoneRegistry,
+							dragStateService,
+						}}
+					>
+						<CommitListItem
+							commitId={commit.id}
+							commitMessage={commit.message}
+							type={commit.state.type}
+							hasConflicts={commit.hasConflicts}
+							busy={controller.busyCommitId === commit.id}
+							diverged={commit.state.type === "LocalAndRemote" &&
+								commit.id !== commit.state.subject}
+							createdAt={commitCreatedAt(commit)}
+							gerritReviewUrl={commit.gerritReviewUrl ?? undefined}
+							{stackId}
+							{branchName}
+							{first}
+							lastCommit={last}
+							{lastBranch}
+							{selected}
+							expandChangedFiles={commit.id === selectedCommitId &&
+								branchName === selectedBranchName &&
+								controller.selectedCommitIds.length <= 1}
+							{tooltip}
+							active={controller.active && commit.id === selectedCommitId}
+							reactions={commitReactions[commit.id]}
+							onclick={(e) => handleCommitClick(commit.id, false, e)}
+							disableCommitActions={false}
+							editable={!!stackId}
+						>
+							{#snippet menu({ rightClickTrigger })}
+								{@const selectedIds = controller.selectedCommitIds}
+								{@const isMultiSelect =
+									selectedIds.length > 1 &&
+									branchName === selectedBranchName &&
+									selectedIds.includes(commitId)}
+								{@const data = {
+									stackId,
+									commitId,
+									commitMessage: commit.message,
+									commitStatus: commit.state.type,
+									commitUrl: forge.current.commitUrl(commitId),
+									onUncommitClick: () => handleUncommit(commit.id),
+									onEditMessageClick: () => startEditingCommitMessage(commit.id),
+									multiSelect: isMultiSelect
+										? {
+												commitIds: selectedIds,
+												onSquashSelected: () => handleSquashSelected(selectedIds),
+												onUncommitSelected: () => handleUncommitSelected(selectedIds),
+											}
+										: undefined,
+								}}
+								<CommitContextMenu showOnHover {projectId} {rightClickTrigger} contextData={data} />
+							{/snippet}
+
+							{#snippet changedFiles()}
+								{@const changesQuery = stackService.commitChanges(projectId, commitId)}
+
+								<ReduxResult {projectId} {stackId} result={changesQuery.result}>
+									{#snippet children(changesResult)}
+										{@const commitsQuery = stackId ? localAndRemoteCommits : []}
+										{@const commits = commitsQuery || []}
+										{@const firstConflictedCommitId = findEarliestConflict(commits)?.id}
+
+										<ChangedFilesPanel
+											title="Changed files"
 											{projectId}
-											{rightClickTrigger}
-											contextData={data}
+											{stackId}
+											visibleRange={controller.visibleRange}
+											draggableFiles
+											selectionId={createCommitSelection({ commitId: commitId, stackId })}
+											persistId={`commit-${commitId}`}
+											changes={changesResult.changes.filter(
+												(change) =>
+													!(change.path in (changesResult.conflictEntries?.entries ?? {})),
+											)}
+											stats={changesResult.stats ?? undefined}
+											conflictEntries={changesResult.conflictEntries}
+											ancestorMostConflictedCommitId={firstConflictedCommitId}
+											autoselect
+											allowUnselect={false}
+											onFileClick={(index) => {
+												// Ensure the commit is selected so the preview shows it
+												const currentSelection = controller.selection.current;
+												if (
+													currentSelection?.commitId !== commitId ||
+													currentSelection?.branchName !== branchName
+												) {
+													controller.selection.set({
+														branchName,
+														commitId,
+														upstream: false,
+														previewOpen: true,
+													});
+												}
+												controller.jumpToIndex(index);
+											}}
 										/>
 									{/snippet}
-
-									{#snippet changedFiles()}
-										{@const changesQuery = stackService.commitChanges(projectId, commitId)}
-
-										<ReduxResult {projectId} {stackId} result={changesQuery.result}>
-											{#snippet children(changesResult)}
-												{@const commitsQuery = stackId
-													? stackService.commits(projectId, stackId, branchName)
-													: undefined}
-												{@const commits = commitsQuery?.response || []}
-												{@const firstConflictedCommitId = findEarliestConflict(commits)?.id}
-
-												<ChangedFilesPanel
-													title="Changed files"
-													{projectId}
-													{stackId}
-													visibleRange={controller.visibleRange}
-													draggableFiles
-													selectionId={createCommitSelection({ commitId: commitId, stackId })}
-													persistId={`commit-${commitId}`}
-													changes={changesResult.changes.filter(
-														(change) =>
-															!(change.path in (changesResult.conflictEntries?.entries ?? {})),
-													)}
-													stats={changesResult.stats ?? undefined}
-													conflictEntries={changesResult.conflictEntries}
-													ancestorMostConflictedCommitId={firstConflictedCommitId}
-													autoselect
-													allowUnselect={false}
-													onFileClick={(index) => {
-														// Ensure the commit is selected so the preview shows it
-														const currentSelection = controller.selection.current;
-														if (
-															currentSelection?.commitId !== commitId ||
-															currentSelection?.branchName !== branchName
-														) {
-															controller.selection.set({
-																branchName,
-																commitId,
-																upstream: false,
-																previewOpen: true,
-															});
-														}
-														controller.jumpToIndex(index);
-													}}
-												/>
-											{/snippet}
-										</ReduxResult>
-									{/snippet}
-								</CommitListItem>
-							</div>
-						</Dropzone>
-						{@render commitReorderDz(
-							stackingReorderDropzoneManager.belowCommit(branchName, commit.id),
-						)}
-						{#if controller.isCommitting && last}
-							<CommitPositionIndicator
-								commitId={commit.id}
-								{first}
-								{last}
-								selected={exclusiveAction?.type === "commit" &&
-									exclusiveAction.parentCommitId === commit.id &&
-									exclusiveAction.insertBelow === true &&
-									commitAction?.branchName === branchName}
-								onclick={() => {
-									controller.projectState.exclusiveAction.set({
-										type: "commit",
-										stackId,
-										branchName,
-										parentCommitId: commit.id,
-										insertBelow: true,
-									});
-								}}
-							/>
-						{/if}
-					{/snippet}
-				</LazyList>
-			</div>
-		{/if}
-	{/snippet}
-</ReduxResult>
+								</ReduxResult>
+							{/snippet}
+						</CommitListItem>
+					</div>
+				</Dropzone>
+				{#if branchName}
+					{@render commitReorderDz(
+						stackingReorderDropzoneManager.belowCommit(branchName, commit.id),
+					)}
+				{/if}
+				{#if controller.isCommitting && last}
+					<CommitPositionIndicator
+						commitId={commit.id}
+						{first}
+						{last}
+						selected={exclusiveAction?.type === "commit" &&
+							exclusiveAction.parentCommitId === commit.id &&
+							exclusiveAction.insertBelow === true &&
+							commitAction?.branchName === branchName}
+						onclick={() => {
+							if (!branchName) return;
+							controller.projectState.exclusiveAction.set({
+								type: "commit",
+								stackId,
+								branchName,
+								parentCommitId: commit.id,
+								insertBelow: true,
+							});
+						}}
+					/>
+				{/if}
+			{/snippet}
+		</LazyList>
+	</div>
+{/if}
 
 <style lang="postcss">
 	.commit-list {

--- a/apps/desktop/src/components/views/BranchList.svelte
+++ b/apps/desktop/src/components/views/BranchList.svelte
@@ -19,16 +19,15 @@
 	import { createBranchSelection } from "$lib/selection/key";
 	import { getStackContext } from "$lib/stacks/stackController.svelte";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
-	import { combineResults } from "$lib/state/helpers";
 	import { ensureValue } from "$lib/utils/validation";
 	import { inject } from "@gitbutler/core/context";
 	import { Button, TestId } from "@gitbutler/ui";
 	import { QueryStatus } from "@reduxjs/toolkit/query";
 	import { tick } from "svelte";
-	import type { BranchDetails } from "@gitbutler/but-sdk";
+	import type { Segment } from "@gitbutler/but-sdk";
 
 	type Props = {
-		branches: BranchDetails[];
+		branches: Segment[];
 	};
 
 	const { branches }: Props = $props();
@@ -65,7 +64,13 @@
 		stackingReorderDropzoneManagerFactory.build(
 			projectId,
 			laneId,
-			branches.map((s) => ({ name: s.name, commitIds: s.commits.map((p) => p.id) })),
+			branches
+				.map((s) =>
+					s.refName
+						? { name: s.refName.displayName, commitIds: s.commits.map((p) => p.id) }
+						: undefined,
+				)
+				.filter((branch): branch is { name: string; commitIds: string[] } => branch !== undefined),
 		),
 	);
 
@@ -76,245 +81,240 @@
 
 <div class="branches-wrapper">
 	{#each branches as branch, i}
-		{@const branchName = branch.name}
-		{@const localAndRemoteCommits = stackService.commits(projectId, stackId, branchName)}
-		{@const upstreamOnlyCommits = stackService.upstreamCommits(projectId, stackId, branchName)}
-		{@const branchDetailsQuery = stackService.branchDetails(projectId, stackId, branchName)}
-		{@const commitQuery = stackService.commitAt(projectId, stackId, branchName, 0)}
-		{@const prQuery = branch.prNumber ? forge.current.prService?.get(branch.prNumber) : undefined}
+		{@const branchName = branch.refName?.displayName}
+		{@const branchLabel = branchName ?? "Unnamed segment"}
+		{@const remoteTrackingBranch = branch.remoteTrackingRefName
+			? new TextDecoder().decode(new Uint8Array(branch.remoteTrackingRefName.fullNameBytes))
+			: undefined}
+		{@const prNumber = branch.metadata?.review.pullRequest ?? undefined}
+		{@const reviewId = branch.metadata?.review.reviewId ?? undefined}
+		{@const prQuery = prNumber ? forge.current.prService?.get(prNumber) : undefined}
+		{@const commit = branch.commits.at(0)}
 
 		{@const first = i === 0}
 
-		<ReduxResult
-			{projectId}
-			{stackId}
-			result={combineResults(
-				localAndRemoteCommits.result,
-				upstreamOnlyCommits.result,
-				branchDetailsQuery.result,
-				commitQuery.result,
-			)}
-		>
-			{#snippet children(
-				[localAndRemoteCommits, upstreamOnlyCommits, branchDetails, commit],
-				{ projectId, stackId },
-			)}
-				{@const firstBranch = i === 0}
-				{@const lastBranch = i === branches.length - 1}
-				{@const iconName = getIconFromCommitState(commit?.id, commit?.state)}
-				{@const lineColor = commit
-					? getColorFromCommitState(
-							commit.state.type,
-							commit.state.type === "LocalAndRemote" && commit.id !== commit.state.subject,
-						)
-					: "var(--commit-local)"}
-				{@const isNewBranch =
-					upstreamOnlyCommits.length === 0 && localAndRemoteCommits.length === 0}
-				{@const selected =
-					selection?.current?.branchName === branchName &&
-					selection?.current.commitId === undefined}
-				{@const pushStatus = branchDetails.pushStatus}
-				{@const isConflicted = branchDetails.isConflicted}
-				{@const reviewId = branch.reviewId || undefined}
-				{@const prNumber = branch.prNumber || undefined}
-				{@const allOtherPrNumbersInStack = branches
-					.filter((b) => b.name !== branchName)
-					.map((b) => b.prNumber)
-					.filter((n): n is number => n !== undefined)}
-				{@const startCommittingDz = new StartCommitDzHandler(projectId, stackId, branchName)}
-				{#if stackId}
-					<BranchReorderDropzone
-						{projectId}
-						{stackId}
-						{branchName}
-						{lineColor}
-						isCommitting={controller.isCommitting}
-						{baseBranchName}
-						prService={forge.current.prService}
-						isFirst={firstBranch}
-					/>
-				{:else if !firstBranch}
-					<BranchDividerLine {lineColor} />
-				{/if}
-				<BranchCard
-					type="stack-branch"
-					{projectId}
-					{stackId}
-					{laneId}
-					{branchName}
-					{lineColor}
-					{first}
-					isCommitting={controller.isCommitting}
-					{iconName}
-					{selected}
-					{isNewBranch}
-					{pushStatus}
-					{isConflicted}
-					{reviewId}
-					{prNumber}
-					{allOtherPrNumbersInStack}
-					numberOfCommits={localAndRemoteCommits.length}
-					numberOfUpstreamCommits={upstreamOnlyCommits.length}
-					numberOfBranchesInStack={branches.length}
-					baseCommit={branchDetails.baseCommit}
-					dropzones={[stackingReorderDropzoneManager.top(branchName), startCommittingDz]}
-					trackingBranch={branch.remoteTrackingBranch ?? undefined}
-					readonly={!!branch.remoteTrackingBranch}
-					onclick={() => {
-						const currentSelection = controller.selection.current;
-						// Toggle: if this branch is already selected, clear the selection
-						if (currentSelection?.branchName === branchName && !currentSelection?.commitId) {
-							controller.selection.set(undefined);
-						} else {
-							controller.selection.set({ branchName, previewOpen: true });
-						}
-						controller.clearWorktreeSelection();
-					}}
-				>
-					{#snippet buttons()}
-						{#if first}
-							<Button
-								icon="stack-plus"
-								size="tag"
-								kind="outline"
-								tooltip={controller.isReadOnly ? "Read-only mode" : "Create new branch"}
-								onclick={async () => {
-									addDependentBranchModalContext = {
-										projectId,
-										stackId: ensureValue(stackId),
-									};
-
-									await tick();
-									addDependentBranchModal?.show();
-								}}
-								disabled={controller.isReadOnly}
-							/>
-						{/if}
-
-						{#if canPublishPR && !isNewBranch}
-							{#if !branch.prNumber}
-								<Button
-									size="tag"
-									kind="outline"
-									shrinkable
-									onclick={(e) => {
-										e.stopPropagation();
-										controller.projectState.exclusiveAction.set({
-											type: "create-pr",
-											stackId,
-											branchName,
-										});
-									}}
-									testId={TestId.CreateReviewButton}
-									disabled={!!controller.exclusiveAction}
-									icon="pr-plus"
-								>
-									{`Create ${forge.current.name === "gitlab" ? "MR" : "PR"}`}
-								</Button>
-							{:else}
-								{@const prUrl = prQuery?.response?.htmlUrl}
-								<Button
-									size="tag"
-									kind="outline"
-									shrinkable
-									disabled={!prUrl}
-									onclick={() => {
-										if (prUrl) {
-											urlService.openExternalUrl(prUrl);
-										}
-									}}
-									icon="arrow-up-righ"
-								>
-									{`View ${forge.current.name === "gitlab" ? "MR" : "PR"}`}
-								</Button>
-							{/if}
-						{/if}
-						<PushButton
-							{branchName}
-							{projectId}
-							{stackId}
-							multipleBranches={branches.length > 1}
-							isFirstBranchInStack={firstBranch}
-							isLastBranchInStack={lastBranch}
-						/>
-					{/snippet}
-
-					{#snippet menu({ rightClickTrigger })}
-						{@const data = {
-							branch,
-							prNumber,
-							first,
-							stackLength: branches.length,
-						}}
-						<BranchHeaderContextMenu
-							{projectId}
-							{stackId}
-							{laneId}
-							{rightClickTrigger}
-							contextData={data}
-						/>
-					{/snippet}
-
-					{#snippet changedFiles()}
-						<!--
+		{@const firstBranch = i === 0}
+		{@const lastBranch = i === branches.length - 1}
+		{@const iconName = getIconFromCommitState(commit?.id, commit?.state)}
+		{@const lineColor = commit
+			? getColorFromCommitState(
+					commit.state.type,
+					commit.state.type === "LocalAndRemote" && commit.id !== commit.state.subject,
+				)
+			: "var(--commit-local)"}
+		{@const isNewBranch = branch.commitsOnRemote.length === 0 && branch.commits.length === 0}
+		{@const selected =
+			selection?.current?.branchName === branchName && selection?.current?.commitId === undefined}
+		{@const allOtherPrNumbersInStack = branches
+			.filter((b) => b.refName?.displayName !== branchName)
+			.map((b) => b.metadata?.review.pullRequest)
+			.filter((n): n is number => n !== undefined && n !== null)}
+		{@const isConflicted = branch.commits.some((commit) => commit.hasConflicts)}
+		{@const startCommittingDz = branchName
+			? new StartCommitDzHandler(projectId, stackId, branchName)
+			: undefined}
+		{#if stackId && branchName}
+			<BranchReorderDropzone
+				{projectId}
+				{stackId}
+				{branchName}
+				{lineColor}
+				isCommitting={controller.isCommitting}
+				{baseBranchName}
+				prService={forge.current.prService}
+				isFirst={firstBranch}
+			/>
+		{:else if !firstBranch}
+			<BranchDividerLine {lineColor} />
+		{/if}
+		{#snippet changedFiles()}
+			<!--
 							Based on anecdotal evidence the type for `items` seems incorrect. It's
 							likely that during some kind of unmount event items can become `undefined`
 							due to some subtle reactivity condition, causing `branchChanges` to be
 							called without a branch name.
 						-->
-						{#if selected && branchName}
-							{@const changesQuery = stackService.branchChanges({
-								projectId,
-								stackId,
-								branch: branchName,
+			{#if selected && branchName}
+				{@const changesQuery = stackService.branchChanges({
+					projectId,
+					stackId,
+					branch: branchName,
+				})}
+				<ReduxResult {projectId} {stackId} result={changesQuery.result}>
+					{#snippet children(result, { projectId, stackId })}
+						<ChangedFilesPanel
+							title="All Changes"
+							{projectId}
+							{stackId}
+							draggableFiles
+							autoselect
+							foldedByDefault
+							selectionId={createBranchSelection({
+								stackId: stackId,
+								branchName,
+								remote: undefined,
 							})}
-							<ReduxResult {projectId} {stackId} result={changesQuery.result}>
-								{#snippet children(result, { projectId, stackId })}
-									<ChangedFilesPanel
-										title="All Changes"
-										{projectId}
-										{stackId}
-										draggableFiles
-										autoselect
-										foldedByDefault
-										selectionId={createBranchSelection({
-											stackId: stackId,
-											branchName,
-											remote: undefined,
-										})}
-										persistId={`branch-${branchName}`}
-										changes={result.changes}
-										stats={result.stats}
-										allowUnselect={false}
-										visibleRange={controller.visibleRange}
-										onFileClick={(index) => {
-											// Ensure the branch is selected so the preview shows it
-											const currentSelection = controller.selection.current;
-											if (
-												currentSelection?.branchName !== branchName ||
-												currentSelection?.commitId !== undefined
-											) {
-												controller.selection.set({ branchName, previewOpen: true });
-											}
-											controller.jumpToIndex(index);
-										}}
-									/>
-								{/snippet}
-							</ReduxResult>
-						{/if}
-					{/snippet}
-
-					{#snippet branchContent()}
-						<BranchCommitList
-							{lastBranch}
-							{branchName}
-							{branchDetails}
-							{stackingReorderDropzoneManager}
+							persistId={`branch-${branchName}`}
+							changes={result.changes}
+							stats={result.stats}
+							allowUnselect={false}
+							visibleRange={controller.visibleRange}
+							onFileClick={(index) => {
+								// Ensure the branch is selected so the preview shows it
+								const currentSelection = controller.selection.current;
+								if (
+									currentSelection?.branchName !== branchName ||
+									currentSelection?.commitId !== undefined
+								) {
+									controller.selection.set({ branchName, previewOpen: true });
+								}
+								controller.jumpToIndex(index);
+							}}
 						/>
 					{/snippet}
-				</BranchCard>
+				</ReduxResult>
+			{/if}
+		{/snippet}
+
+		{#snippet buttons()}
+			{#if first && branchName}
+				<Button
+					icon="stack-plus"
+					size="tag"
+					kind="outline"
+					tooltip={controller.isReadOnly ? "Read-only mode" : "Create new branch"}
+					onclick={async () => {
+						addDependentBranchModalContext = {
+							projectId,
+							stackId: ensureValue(stackId),
+						};
+
+						await tick();
+						addDependentBranchModal?.show();
+					}}
+					disabled={controller.isReadOnly}
+				/>
+			{/if}
+
+			{#if canPublishPR && !isNewBranch && branchName}
+				{#if !prNumber}
+					<Button
+						size="tag"
+						kind="outline"
+						shrinkable
+						onclick={(e) => {
+							e.stopPropagation();
+							controller.projectState.exclusiveAction.set({
+								type: "create-pr",
+								stackId,
+								branchName,
+							});
+						}}
+						testId={TestId.CreateReviewButton}
+						disabled={!!controller.exclusiveAction}
+						icon="pr-plus"
+					>
+						{`Create ${forge.current.name === "gitlab" ? "MR" : "PR"}`}
+					</Button>
+				{:else}
+					{@const prUrl = prQuery?.response?.htmlUrl}
+					<Button
+						size="tag"
+						kind="outline"
+						shrinkable
+						disabled={!prUrl}
+						onclick={() => {
+							if (prUrl) {
+								urlService.openExternalUrl(prUrl);
+							}
+						}}
+						icon="arrow-up-righ"
+					>
+						{`View ${forge.current.name === "gitlab" ? "MR" : "PR"}`}
+					</Button>
+				{/if}
+			{/if}
+			{#if branchName}
+				<PushButton
+					{branchName}
+					{projectId}
+					{stackId}
+					multipleBranches={branches.length > 1}
+					isFirstBranchInStack={firstBranch}
+					isLastBranchInStack={lastBranch}
+				/>
+			{/if}
+		{/snippet}
+
+		{#snippet menu({ rightClickTrigger }: { rightClickTrigger?: HTMLElement })}
+			{#if branchName}
+				{@const data = {
+					branch,
+					prNumber,
+					first,
+					stackLength: branches.length,
+				}}
+				<BranchHeaderContextMenu
+					{projectId}
+					{stackId}
+					{laneId}
+					{rightClickTrigger}
+					contextData={data}
+				/>
+			{/if}
+		{/snippet}
+
+		<BranchCard
+			type="stack-branch"
+			{projectId}
+			stackId={branchName ? stackId : undefined}
+			{laneId}
+			branchName={branchLabel}
+			{lineColor}
+			{first}
+			isCommitting={controller.isCommitting}
+			{iconName}
+			{selected}
+			{isNewBranch}
+			pushStatus={branch.pushStatus}
+			{isConflicted}
+			{reviewId}
+			{prNumber}
+			{allOtherPrNumbersInStack}
+			numberOfCommits={branch.commits.length}
+			numberOfUpstreamCommits={branch.commitsOnRemote.length}
+			numberOfBranchesInStack={branches.length}
+			baseCommit={branch.base ?? undefined}
+			dropzones={branchName && startCommittingDz
+				? [stackingReorderDropzoneManager.top(branchName), startCommittingDz]
+				: []}
+			trackingBranch={remoteTrackingBranch}
+			readonly={!branchName || !!remoteTrackingBranch}
+			disableClick={!branchName}
+			onclick={() => {
+				if (!branchName) return;
+				const currentSelection = controller.selection.current;
+				// Toggle: if this branch is already selected, clear the selection
+				if (currentSelection?.branchName === branchName && !currentSelection?.commitId) {
+					controller.selection.set(undefined);
+				} else {
+					controller.selection.set({ branchName, previewOpen: true });
+				}
+				controller.clearWorktreeSelection();
+			}}
+			changedFiles={branch.refName ? changedFiles : undefined}
+			buttons={branch.refName ? buttons : undefined}
+			menu={branch.refName ? menu : undefined}
+		>
+			{#snippet branchContent()}
+				<BranchCommitList
+					{lastBranch}
+					{branchName}
+					segment={branch}
+					{stackingReorderDropzoneManager}
+				/>
 			{/snippet}
-		</ReduxResult>
+		</BranchCard>
 	{/each}
 </div>
 

--- a/apps/desktop/src/components/views/BranchView.svelte
+++ b/apps/desktop/src/components/views/BranchView.svelte
@@ -53,7 +53,6 @@
 
 	const branchQuery = $derived(stackService.branchDetails(projectId, stackId, branchName));
 	const branchesQuery = $derived(stackService.branches(projectId, stackId));
-	const topCommitQuery = $derived(stackService.commitAt(projectId, stackId, branchName, 0));
 
 	// Get conflicted commits for this branch
 	const conflictedCommitsInBranch = $derived(
@@ -84,14 +83,28 @@
 	{stackId}
 	{projectId}
 	{onerror}
-	result={combineResults(branchesQuery.result, branchQuery.result, topCommitQuery.result)}
+	result={combineResults(branchesQuery.result, branchQuery.result)}
 >
-	{#snippet children([branches, branch, topCommit], { stackId, projectId })}
-		{@const hasCommits = !!topCommit || branch.upstreamCommits.length > 0}
-		{@const remoteTrackingBranch = branch.remoteTrackingBranch}
+	{#snippet children([branches, branch], { stackId, projectId })}
+		{@const topCommit = branch.commits.at(0)}
+		{@const hasCommits = !!topCommit || branch.commitsOnRemote.length > 0}
+		{@const remoteTrackingBranch = branch.remoteTrackingRefName
+			? new TextDecoder().decode(new Uint8Array(branch.remoteTrackingRefName.fullNameBytes))
+			: undefined}
+		{@const prNumber = branch.metadata?.review.pullRequest ?? undefined}
+		{@const reviewId = branch.metadata?.review.reviewId ?? undefined}
+		{@const authors = Array.from(
+			new Map(
+				[...branch.commits, ...branch.commitsOnRemote].map((commit) => [
+					JSON.stringify(commit.author),
+					commit.author,
+				]),
+			).values(),
+		)}
+		{@const isConflicted = branch.commits.some((commit) => commit.hasConflicts)}
 		<Drawer
 			bind:clientHeight
-			persistId="branch-view-drawer-{projectId}-{stackId}-{branch.name}"
+			persistId="branch-view-drawer-{projectId}-{stackId}-{branchName}"
 			testId={TestId.BranchView}
 			{grow}
 			{onclose}
@@ -123,14 +136,14 @@
 							</div>
 						</Tooltip>
 					{/if}
-					<h3 class="text-15 text-bold truncate">{branch.name}</h3>
+					<h3 class="text-15 text-bold truncate">{branchName}</h3>
 				</div>
 			{/snippet}
 
 			{#snippet actions()}
 				{@const data = {
 					branch,
-					prNumber: branch.prNumber || undefined,
+					prNumber,
 					stackLength: branches.length,
 				}}
 				<BranchHeaderContextMenu {projectId} {stackId} {laneId} contextData={data} />
@@ -138,14 +151,13 @@
 
 			{#if hasCommits}
 				<div class="branch-view">
-					<BranchDetails {branch} onResolveConflicts={handleResolveConflicts}>
-						<BranchReview
-							{stackId}
-							{projectId}
-							branchName={branch.name}
-							prNumber={branch.prNumber || undefined}
-							reviewId={branch.reviewId || undefined}
-						/>
+					<BranchDetails
+						pushStatus={branch.pushStatus}
+						{authors}
+						{isConflicted}
+						onResolveConflicts={handleResolveConflicts}
+					>
+						<BranchReview {stackId} {projectId} {branchName} {prNumber} {reviewId} />
 
 						{#snippet conflictedCommits()}
 							{#if conflictedCommitsInBranch.length > 0}
@@ -197,16 +209,11 @@
 			{projectId}
 			{stackId}
 			{laneId}
-			branchName={branch.name}
+			{branchName}
 			bind:this={renameBranchModal}
-			isPushed={!!branch.remoteTrackingBranch}
+			isPushed={!!remoteTrackingBranch}
 		/>
-		<DeleteBranchModal
-			{projectId}
-			{stackId}
-			branchName={branch.name}
-			bind:this={deleteBranchModal}
-		/>
+		<DeleteBranchModal {projectId} {stackId} {branchName} bind:this={deleteBranchModal} />
 	{/snippet}
 </ReduxResult>
 

--- a/apps/desktop/src/components/views/BranchesViewBranch.svelte
+++ b/apps/desktop/src/components/views/BranchesViewBranch.svelte
@@ -10,12 +10,13 @@
 	import { getColorFromPushStatus, pushStatusToIcon } from "$lib/stacks/stack";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { inject } from "@gitbutler/core/context";
-	import type { BranchDetails, Commit } from "@gitbutler/but-sdk";
+	import type { BranchDetails, Commit, Segment } from "@gitbutler/but-sdk";
 
 	type Props = {
 		projectId: string;
 		stackId?: string;
-		branchName: string;
+		branchName?: string;
+		segment?: Segment;
 		remote?: string;
 		isTopBranch?: boolean;
 		isTarget?: boolean;
@@ -30,6 +31,7 @@
 		projectId,
 		stackId,
 		branchName,
+		segment,
 		remote,
 		isTopBranch = true,
 		inWorkspace,
@@ -41,20 +43,26 @@
 	}: Props = $props();
 
 	const stackService = inject(STACK_SERVICE);
-	const branchQuery = $derived(
-		stackId
-			? stackService.branchDetails(projectId, stackId, branchName)
-			: stackService.unstackedBranchDetails(projectId, branchName, remote),
-	);
-
 	let cherryApplyModal = $state<CherryApplyModal>();
 </script>
 
-<ReduxResult result={branchQuery.result} {projectId} {stackId} {onerror}>
-	{#snippet children(branch, env)}
-		{@render branchCard(branch, env)}
-	{/snippet}
-</ReduxResult>
+{#if segment}
+	{@render branchCard(segment, { projectId, stackId })}
+{:else if stackId && branchName}
+	{@const branchQuery = stackService.branchDetails(projectId, stackId, branchName)}
+	<ReduxResult result={branchQuery.result} {projectId} {stackId} {onerror}>
+		{#snippet children(branch, env)}
+			{@render branchCard(branch, env)}
+		{/snippet}
+	</ReduxResult>
+{:else if branchName}
+	{@const branchQuery = stackService.unstackedBranchDetails(projectId, branchName, remote)}
+	<ReduxResult result={branchQuery.result} {projectId} {stackId} {onerror}>
+		{#snippet children(branch, env)}
+			{@render branchCard(branch, env)}
+		{/snippet}
+	</ReduxResult>
+{/if}
 
 {#snippet commitMenu(rightClickTrigger: HTMLElement)}
 	<BranchesViewCommitContextMenu
@@ -117,21 +125,29 @@
 	</CommitListItem>
 {/snippet}
 
-{#snippet branchCard(branch: BranchDetails, env: { projectId: string; stackId?: string })}
+{#snippet branchCard(branch: BranchDetails | Segment, env: { projectId: string; stackId?: string })}
 	{@const commitColor = getColorFromPushStatus(branch.pushStatus)}
 	{@const localCount = branch.commits?.length ?? 0}
 	{@const hasCommits = localCount > 0}
+	{@const trackingBranch =
+		"refName" in branch
+			? branch.remoteTrackingRefName
+				? new TextDecoder().decode(new Uint8Array(branch.remoteTrackingRefName.fullNameBytes))
+				: undefined
+			: branch.remoteTrackingBranch || undefined}
+	{@const displayBranchName =
+		branchName ?? ("refName" in branch ? branch.refName?.displayName : branch.name)}
 
 	<BranchCard
 		type="normal-branch"
 		first={isTopBranch}
 		lineColor={commitColor}
 		projectId={env.projectId}
-		branchName={branch.name}
+		branchName={displayBranchName ?? "Unnamed segment"}
 		{isTopBranch}
 		isNewBranch={localCount === 0}
 		iconName={pushStatusToIcon(branch.pushStatus)}
-		trackingBranch={branch.remoteTrackingBranch || undefined}
+		{trackingBranch}
 		readonly
 		roundedBottom={!hasCommits}
 		selected={false}

--- a/apps/desktop/src/components/views/BranchesViewBranch.svelte
+++ b/apps/desktop/src/components/views/BranchesViewBranch.svelte
@@ -20,6 +20,7 @@
 		isTopBranch?: boolean;
 		isTarget?: boolean;
 		inWorkspace?: boolean;
+		branchesPage?: boolean;
 		selectedCommitId?: string;
 		onCommitClick: (commitId: string) => void;
 		onFileClick: (index: number) => void;
@@ -33,6 +34,7 @@
 		remote,
 		isTopBranch = true,
 		inWorkspace,
+		branchesPage = false,
 		isTarget,
 		selectedCommitId,
 		onCommitClick,
@@ -42,9 +44,11 @@
 
 	const stackService = inject(STACK_SERVICE);
 	const branchQuery = $derived(
-		stackId
-			? stackService.branchDetails(projectId, stackId, branchName)
-			: stackService.unstackedBranchDetails(projectId, branchName, remote),
+		stackId && branchesPage
+			? stackService.branchesPageBranchDetails(projectId, stackId, branchName, inWorkspace ?? false)
+			: stackId
+				? stackService.branchDetails(projectId, stackId, branchName)
+				: stackService.unstackedBranchDetails(projectId, branchName, remote),
 	);
 
 	let cherryApplyModal = $state<CherryApplyModal>();

--- a/apps/desktop/src/components/views/BranchesViewBranch.svelte
+++ b/apps/desktop/src/components/views/BranchesViewBranch.svelte
@@ -20,7 +20,6 @@
 		isTopBranch?: boolean;
 		isTarget?: boolean;
 		inWorkspace?: boolean;
-		branchesPage?: boolean;
 		selectedCommitId?: string;
 		onCommitClick: (commitId: string) => void;
 		onFileClick: (index: number) => void;
@@ -34,7 +33,6 @@
 		remote,
 		isTopBranch = true,
 		inWorkspace,
-		branchesPage = false,
 		isTarget,
 		selectedCommitId,
 		onCommitClick,
@@ -44,11 +42,9 @@
 
 	const stackService = inject(STACK_SERVICE);
 	const branchQuery = $derived(
-		stackId && branchesPage
-			? stackService.branchesPageBranchDetails(projectId, stackId, branchName, inWorkspace ?? false)
-			: stackId
-				? stackService.branchDetails(projectId, stackId, branchName)
-				: stackService.unstackedBranchDetails(projectId, branchName, remote),
+		stackId
+			? stackService.branchDetails(projectId, stackId, branchName)
+			: stackService.unstackedBranchDetails(projectId, branchName, remote),
 	);
 
 	let cherryApplyModal = $state<CherryApplyModal>();

--- a/apps/desktop/src/components/views/MultiStackView.svelte
+++ b/apps/desktop/src/components/views/MultiStackView.svelte
@@ -20,6 +20,7 @@
 	import { WorkspaceAutoPanner } from "$lib/dragging/workspaceAutoPanner";
 	import { branchesPath } from "$lib/routes/routes.svelte";
 	import { type SelectionId } from "$lib/selection/key";
+	import { getStackBranchNames, type Stack } from "$lib/stacks/stack";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { UI_STATE } from "$lib/state/uiState.svelte";
 	import { throttle } from "$lib/utils/misc";
@@ -28,7 +29,6 @@
 	import { resizeObserver } from "@gitbutler/ui/utils/resizeObserver";
 	import { isDefined } from "@gitbutler/ui/utils/typeguards";
 	import { flip } from "svelte/animate";
-	import type { Stack } from "$lib/stacks/stack";
 
 	type Props = {
 		projectId: string;
@@ -263,7 +263,7 @@
 				>
 					{#if stack.id && foldedStackIds.includes(stack.id)}
 						<FoldedStack
-							branchNames={stack.heads.map((head) => head.name)}
+							branchNames={getStackBranchNames(stack)}
 							onUnfold={() => unfoldStack(stack.id)}
 						/>
 					{:else}
@@ -273,7 +273,7 @@
 								laneId={stack.id || "banana"}
 								stackId={stack.id ?? undefined}
 								onFoldStack={() => foldStack(stack.id)}
-								topBranchName={stack.heads.at(0)?.name}
+								topBranchName={stack.segments.at(0)?.refName?.displayName}
 								bind:clientWidth={laneWidths[i]}
 								bind:clientHeight={lineHeights[i]}
 								onVisible={(visible) => {

--- a/apps/desktop/src/components/views/StackPanel.svelte
+++ b/apps/desktop/src/components/views/StackPanel.svelte
@@ -24,10 +24,10 @@
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import { Button, TestId } from "@gitbutler/ui";
-	import type { BranchDetails } from "@gitbutler/but-sdk";
+	import type { Segment } from "@gitbutler/but-sdk";
 
 	type Props = {
-		branches: BranchDetails[];
+		branches: Segment[];
 		topBranchName?: string;
 		onFoldStack?: () => void;
 		ircEnabled: boolean;

--- a/apps/desktop/src/lib/analytics/commitAnalytics.ts
+++ b/apps/desktop/src/lib/analytics/commitAnalytics.ts
@@ -10,7 +10,7 @@ import type RulesService from "$lib/rules/rulesService.svelte";
 import type { Stack } from "$lib/stacks/stack";
 import type { EventProperties } from "$lib/state/customHooks.svelte";
 import type { HunkAssignment } from "@gitbutler/but-sdk";
-import type { BranchDetails, Commit } from "@gitbutler/but-sdk";
+import type { Commit, Segment } from "@gitbutler/but-sdk";
 import type { FModeManager } from "@gitbutler/ui/focus/fModeManager";
 
 export const COMMIT_ANALYTICS = new InjectionToken<CommitAnalytics>("CommitAnalytics");
@@ -76,7 +76,7 @@ export class CommitAnalytics {
 				// Number of commits in the branch in the stack that we are committing to
 				branchCommitCount: this.getBranchCommitCount(commits),
 				// Whether this commit is the last/top commit in the branch
-				isLastCommit: this.getIsLastCommit(stack, args.parentId),
+				isLastCommit: this.getIsLastCommit(branches, args.parentId),
 				// Number of characters in the commit message
 				messageCharacterCount: this.getMessageCharacterCount(args.message),
 				// Number of new lines in the commit message
@@ -107,10 +107,10 @@ export class CommitAnalytics {
 	}
 
 	private getBranchCount(stack: Stack | undefined): number {
-		return stack?.heads.length || 0;
+		return stack?.segments.length || 0;
 	}
 
-	private getLaneCommitCount(branches: BranchDetails[]): number {
+	private getLaneCommitCount(branches: Segment[]): number {
 		return branches.reduce((total, branch) => total + branch.commits.length, 0);
 	}
 
@@ -118,13 +118,14 @@ export class CommitAnalytics {
 		return commits.length;
 	}
 
-	private getIsLastCommit(stack: Stack | undefined, parentId: string | undefined): boolean {
+	private getIsLastCommit(branches: Segment[], parentId: string | undefined): boolean {
 		// If there is no parent, then this is implicitly the top of the stack.
 		if (!parentId) {
 			return true;
 		}
 
-		return stack?.tip === parentId;
+		const topBranch = branches.at(0);
+		return (topBranch?.commits.at(0)?.id ?? topBranch?.base) === parentId;
 	}
 
 	private getMessageCharacterCount(message: string): number {

--- a/apps/desktop/src/lib/dragging/dropHandlers/stackDropHandler.ts
+++ b/apps/desktop/src/lib/dragging/dropHandlers/stackDropHandler.ts
@@ -11,7 +11,7 @@ import { parseError } from "$lib/error/parser";
 import { unstackPRs, updateStackPrs } from "$lib/forge/shared/prFooter";
 import { toCommitMovePlacement } from "$lib/stacks/commitMovePlacement";
 import StackMacros from "$lib/stacks/macros";
-import { getStackName, toMoveBranchWarning } from "$lib/stacks/stack";
+import { toMoveBranchWarning } from "$lib/stacks/stack";
 import { withStackBusy } from "$lib/state/uiState.svelte";
 import { ensureValue } from "$lib/utils/validation";
 import { untrack } from "svelte";
@@ -220,7 +220,7 @@ export class OutsideLaneDzHandler implements DropzoneHandler {
 		});
 
 		const stackId = ensureValue(stack.id);
-		const branchName = getStackName(stack);
+		const branchName = ensureValue(stack.heads.at(0)?.name);
 
 		const { relativeTo, side } = toCommitMovePlacement({
 			targetBranchName: branchName,

--- a/apps/desktop/src/lib/forge/shared/prFooter.ts
+++ b/apps/desktop/src/lib/forge/shared/prFooter.ts
@@ -1,6 +1,6 @@
 import { isDefined } from "@gitbutler/ui/utils/typeguards";
 import type { ForgePrService } from "$lib/forge/interface/forgePrService";
-import type { BranchDetails } from "@gitbutler/but-sdk";
+import type { Segment } from "@gitbutler/but-sdk";
 
 export const STACKING_FOOTER_BOUNDARY_TOP = "<!-- GitButler Footer Boundary Top -->";
 export const STACKING_FOOTER_BOUNDARY_BOTTOM = "<!-- GitButler Footer Boundary Bottom -->";
@@ -39,26 +39,28 @@ type PrUpdate = {
 
 export async function updateStackPrs(
 	prService: ForgePrService,
-	branchDetails: BranchDetails[],
+	branchDetails: Segment[],
 	baseBranchName: string,
 ) {
 	if (branchDetails.length <= 1) return;
-	const allPrNumbers = branchDetails.map((b) => b.prNumber).filter(isDefined);
+	const allPrNumbers = branchDetails.map((b) => b.metadata?.review.pullRequest).filter(isDefined);
 	const updates: PrUpdate[] = [];
 	let prevBranch: string | undefined = undefined;
 
 	for (let i = branchDetails.length - 1; i >= 0; i--) {
 		const details = branchDetails[i];
 		if (!details) continue;
-		const prNumber = details.prNumber;
+		const branchName = details.refName?.displayName;
+		if (!branchName) continue;
+		const prNumber = details.metadata?.review.pullRequest;
 		if (!isDefined(prNumber)) {
-			prevBranch = details.name;
+			prevBranch = branchName;
 			continue;
 		}
 		const pr = await prService.fetch(prNumber);
 
 		if (!isDefined(pr)) {
-			prevBranch = details.name;
+			prevBranch = branchName;
 			continue;
 		}
 
@@ -67,7 +69,7 @@ export async function updateStackPrs(
 			description: updateBody(pr.body, pr.number, allPrNumbers, prService.unit.symbol),
 			targetBase: prevBranch ?? baseBranchName,
 		});
-		prevBranch = details.name;
+		prevBranch = branchName;
 	}
 
 	if (updates.length > 0) {

--- a/apps/desktop/src/lib/stacks/headInfoAdapters.test.ts
+++ b/apps/desktop/src/lib/stacks/headInfoAdapters.test.ts
@@ -1,0 +1,151 @@
+import { transformWorkspaceDetails } from "$lib/stacks/headInfoAdapters";
+import { describe, expect, test } from "vitest";
+import type { Author, Commit, RefInfo, Segment, UpstreamCommit } from "@gitbutler/but-sdk";
+
+const encoder = new TextEncoder();
+
+function bytes(value: string): number[] {
+	return [...encoder.encode(value)];
+}
+
+const author: Author = {
+	name: "Ada",
+	email: "ada@example.com",
+	gravatarUrl: "",
+};
+
+const localCommit: Commit = {
+	id: "1111111111111111111111111111111111111111",
+	parentIds: ["0000000000000000000000000000000000000000"],
+	message: "Local commit",
+	hasConflicts: true,
+	state: { type: "LocalOnly" },
+	createdAt: 1000,
+	author,
+	changeId: "I111",
+	gerritReviewUrl: null,
+};
+
+const upstreamCommit: UpstreamCommit = {
+	id: "2222222222222222222222222222222222222222",
+	message: "Remote commit",
+	createdAt: 2000,
+	author,
+	changeId: "I222",
+};
+
+function segment(overrides: Partial<Segment> = {}): Segment {
+	return {
+		refName: {
+			fullNameBytes: bytes("refs/heads/feature/top"),
+			displayName: "feature/top",
+		},
+		remoteTrackingRefName: {
+			fullNameBytes: bytes("refs/remotes/origin/feature/top"),
+			displayName: "feature/top",
+			remoteName: "origin",
+		},
+		commits: [localCommit],
+		commitsOnRemote: [upstreamCommit],
+		commitsOutside: null,
+		metadata: {
+			refInfo: {
+				createdAt: null,
+				updatedAt: { seconds: 123, offset: 0 },
+			},
+			review: {
+				pullRequest: 7,
+				reviewId: "review-7",
+			},
+		},
+		isEntrypoint: true,
+		pushStatus: "unpushedCommits",
+		base: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		...overrides,
+	};
+}
+
+function refInfo(stacks: RefInfo["stacks"]): RefInfo {
+	return {
+		workspaceRef: null,
+		stacks,
+		target: null,
+		isManagedRef: true,
+		isManagedCommit: true,
+		isEntrypoint: true,
+	};
+}
+
+describe("headInfoAdapters", () => {
+	test("maps head_info stacks to legacy stack entries and stack details", () => {
+		const result = transformWorkspaceDetails(
+			refInfo([
+				{
+					id: "stack-1",
+					base: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+					segments: [segment()],
+				},
+			]),
+		);
+
+		expect(result.stacks.ids).toEqual(["stack-1"]);
+		expect(result.stacks.entities["stack-1"]).toMatchObject({
+			id: "stack-1",
+			tip: localCommit.id,
+			order: 0,
+			isCheckedOut: true,
+			heads: [
+				{
+					name: "feature/top",
+					tip: localCommit.id,
+					reviewId: 7,
+					isCheckedOut: true,
+				},
+			],
+		});
+
+		const details = result.stackDetails["stack-1"]!;
+		expect(details.stackInfo).toMatchObject({
+			derivedName: "feature/top",
+			pushStatus: "unpushedCommits",
+			isConflicted: true,
+		});
+		expect(details.stackInfo.branchDetails[0]).toMatchObject({
+			name: "feature/top",
+			reference: "refs/heads/feature/top",
+			remoteTrackingBranch: "refs/remotes/origin/feature/top",
+			prNumber: 7,
+			reviewId: "review-7",
+			tip: localCommit.id,
+			baseCommit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			lastUpdatedAt: 123000,
+			commits: [localCommit],
+			upstreamCommits: [upstreamCommit],
+			isRemoteHead: false,
+		});
+		expect(details.commits.ids).toEqual([localCommit.id]);
+		expect(details.upstreamCommits.ids).toEqual([upstreamCommit.id]);
+	});
+
+	test("uses the stack base as the tip for empty segments", () => {
+		const result = transformWorkspaceDetails(
+			refInfo([
+				{
+					id: "stack-1",
+					base: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+					segments: [
+						segment({
+							commits: [],
+							base: null,
+						}),
+					],
+				},
+			]),
+		);
+
+		expect(result.stacks.entities["stack-1"]?.tip).toBe("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+		expect(result.stackDetails["stack-1"]?.stackInfo.branchDetails[0]?.tip).toBe(
+			"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		);
+	});
+});

--- a/apps/desktop/src/lib/stacks/headInfoAdapters.test.ts
+++ b/apps/desktop/src/lib/stacks/headInfoAdapters.test.ts
@@ -77,7 +77,7 @@ function refInfo(stacks: RefInfo["stacks"]): RefInfo {
 }
 
 describe("headInfoAdapters", () => {
-	test("maps head_info stacks to legacy stack entries and stack details", () => {
+	test("keeps head_info stacks and indexes segment commits", () => {
 		const result = transformWorkspaceDetails(
 			refInfo([
 				{
@@ -91,43 +91,43 @@ describe("headInfoAdapters", () => {
 		expect(result.stacks.ids).toEqual(["stack-1"]);
 		expect(result.stacks.entities["stack-1"]).toMatchObject({
 			id: "stack-1",
-			tip: localCommit.id,
-			order: 0,
-			isCheckedOut: true,
-			heads: [
-				{
-					name: "feature/top",
-					tip: localCommit.id,
-					reviewId: 7,
-					isCheckedOut: true,
-				},
+			base: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			segments: [
+				expect.objectContaining({
+					refName: {
+						fullNameBytes: bytes("refs/heads/feature/top"),
+						displayName: "feature/top",
+					},
+				}),
 			],
 		});
 
 		const details = result.stackDetails["stack-1"]!;
-		expect(details.stackInfo).toMatchObject({
-			derivedName: "feature/top",
-			pushStatus: "unpushedCommits",
-			isConflicted: true,
-		});
-		expect(details.stackInfo.branchDetails[0]).toMatchObject({
-			name: "feature/top",
-			reference: "refs/heads/feature/top",
-			remoteTrackingBranch: "refs/remotes/origin/feature/top",
-			prNumber: 7,
-			reviewId: "review-7",
-			tip: localCommit.id,
-			baseCommit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-			lastUpdatedAt: 123000,
+		expect(details.stack).toBe(result.stacks.entities["stack-1"]);
+		expect(details.segments[0]).toMatchObject({
+			refName: {
+				fullNameBytes: bytes("refs/heads/feature/top"),
+				displayName: "feature/top",
+			},
+			remoteTrackingRefName: {
+				fullNameBytes: bytes("refs/remotes/origin/feature/top"),
+				displayName: "feature/top",
+				remoteName: "origin",
+			},
+			metadata: {
+				review: {
+					pullRequest: 7,
+					reviewId: "review-7",
+				},
+			},
 			commits: [localCommit],
-			upstreamCommits: [upstreamCommit],
-			isRemoteHead: false,
+			commitsOnRemote: [upstreamCommit],
 		});
 		expect(details.commits.ids).toEqual([localCommit.id]);
 		expect(details.upstreamCommits.ids).toEqual([upstreamCommit.id]);
 	});
 
-	test("uses the stack base as the tip for empty segments", () => {
+	test("preserves empty segments without manufacturing legacy tips", () => {
 		const result = transformWorkspaceDetails(
 			refInfo([
 				{
@@ -143,9 +143,9 @@ describe("headInfoAdapters", () => {
 			]),
 		);
 
-		expect(result.stacks.entities["stack-1"]?.tip).toBe("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
-		expect(result.stackDetails["stack-1"]?.stackInfo.branchDetails[0]?.tip).toBe(
+		expect(result.stacks.entities["stack-1"]?.base).toBe(
 			"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 		);
+		expect(result.stackDetails["stack-1"]?.segments[0]?.commits).toEqual([]);
 	});
 });

--- a/apps/desktop/src/lib/stacks/headInfoAdapters.ts
+++ b/apps/desktop/src/lib/stacks/headInfoAdapters.ts
@@ -1,35 +1,28 @@
 import { createEntityAdapter, type EntityState } from "@reduxjs/toolkit";
 import type {
-	BranchDetails,
 	Commit,
 	RefInfo,
 	Segment,
 	Stack as RefInfoStack,
-	StackDetails,
-	StackEntry,
 	UpstreamCommit,
 } from "@gitbutler/but-sdk";
 
 export type WorkspaceStackDetails = {
-	stackInfo: StackDetails;
-	branchDetails: EntityState<BranchDetails, string>;
+	stack: RefInfoStack;
+	segments: Segment[];
 	commits: EntityState<Commit, string>;
 	upstreamCommits: EntityState<UpstreamCommit, string>;
 };
 
 export type WorkspaceDetails = {
-	stacks: EntityState<StackEntry, string>;
+	stacks: EntityState<RefInfoStack, string>;
 	stackDetails: Record<string, WorkspaceStackDetails>;
 };
 
 const NULL_SHA = "0000000000000000000000000000000000000000";
 
-const stackAdapter = createEntityAdapter<StackEntry, string>({
-	selectId: (stack) => stack.id ?? stack.heads.at(0)?.name ?? stack.tip,
-});
-
-const branchDetailsAdapter = createEntityAdapter<BranchDetails, string>({
-	selectId: (branch) => branch.name,
+const stackAdapter = createEntityAdapter<RefInfoStack, string>({
+	selectId: (stack) => stackKey(stack),
 });
 
 const commitAdapter = createEntityAdapter<Commit, string>({
@@ -40,122 +33,25 @@ const upstreamCommitAdapter = createEntityAdapter<UpstreamCommit, string>({
 	selectId: (commit) => commit.id,
 });
 
-function decodeBytes(bytes: number[]): string {
-	return new TextDecoder().decode(new Uint8Array(bytes));
-}
-
-function stackKey(stack: StackEntry): string {
-	return stack.id ?? stack.heads.at(0)?.name ?? stack.tip;
-}
-
-function segmentName(segment: Segment): string {
-	if (!segment.refName) {
-		throw new Error("Cannot map anonymous head_info segment to legacy branch details");
-	}
-	return segment.refName.displayName;
-}
-
-function segmentReference(segment: Segment): string {
-	if (!segment.refName) {
-		throw new Error("Cannot map anonymous head_info segment to legacy branch details");
-	}
-	return decodeBytes(segment.refName.fullNameBytes);
-}
-
-function segmentTip(stack: RefInfoStack, segment: Segment): string {
-	return segment.commits.at(0)?.id ?? segment.base ?? stack.base ?? NULL_SHA;
-}
-
-function branchLastUpdatedAt(segment: Segment): number | null {
-	const seconds = segment.metadata?.refInfo.updatedAt?.seconds;
-	return seconds === undefined ? null : seconds * 1000;
-}
-
-function branchAuthors(segment: Segment): BranchDetails["authors"] {
-	const authors = [...segment.commits, ...segment.commitsOnRemote].map((commit) => commit.author);
-	return Array.from(
-		new Map(authors.map((author) => [JSON.stringify(author), author])).values(),
-	).sort((a, b) => (a.name ?? "").localeCompare(b.name ?? ""));
-}
-
-export function stackEntryFromHeadInfoStack(stack: RefInfoStack, index: number): StackEntry {
-	const heads = stack.segments.map((segment) => ({
-		name: segmentName(segment),
-		tip: segmentTip(stack, segment),
-		reviewId: segment.metadata?.review.pullRequest ?? null,
-		isCheckedOut: segment.isEntrypoint,
-	}));
-	const tip = heads.at(0)?.tip ?? stack.base ?? NULL_SHA;
-
-	return {
-		id: stack.id,
-		heads,
-		tip,
-		order: index,
-		isCheckedOut: heads.some((head) => head.isCheckedOut),
-	};
-}
-
-export function stackDetailsFromHeadInfoStack(stack: RefInfoStack): StackDetails {
-	const branchDetails = stack.segments.map((segment): BranchDetails => {
-		const baseCommit = segment.base ?? stack.base ?? NULL_SHA;
-		const remoteTrackingBranch = segment.remoteTrackingRefName
-			? decodeBytes(segment.remoteTrackingRefName.fullNameBytes)
-			: null;
-
-		return {
-			name: segmentName(segment),
-			reference: segmentReference(segment),
-			linkedWorktreeId: null,
-			remoteTrackingBranch,
-			prNumber: segment.metadata?.review.pullRequest ?? null,
-			reviewId: segment.metadata?.review.reviewId ?? null,
-			tip: segmentTip(stack, segment),
-			baseCommit,
-			pushStatus: segment.pushStatus,
-			lastUpdatedAt: branchLastUpdatedAt(segment),
-			authors: branchAuthors(segment),
-			isConflicted: segment.commits.some((commit) => commit.hasConflicts),
-			commits: segment.commits,
-			upstreamCommits: segment.commitsOnRemote,
-			isRemoteHead: segmentReference(segment).startsWith("refs/remotes/"),
-		};
-	});
-	const topmostBranch = branchDetails.at(0);
-
-	if (!topmostBranch) {
-		throw new Error("Cannot map empty head_info stack to legacy stack details");
-	}
-
-	return {
-		derivedName: topmostBranch.name,
-		pushStatus: topmostBranch.pushStatus,
-		branchDetails,
-		isConflicted: topmostBranch.isConflicted,
-	};
+function stackKey(stack: RefInfoStack): string {
+	return stack.id ?? stack.segments.at(0)?.refName?.displayName ?? stack.base ?? NULL_SHA;
 }
 
 export function transformWorkspaceDetails(response: RefInfo): WorkspaceDetails {
-	const stacks = response.stacks.map(stackEntryFromHeadInfoStack);
 	const stackDetails = Object.fromEntries(
-		response.stacks.map((stack, index) => {
-			const entry = stacks[index]!;
-			const details = stackDetailsFromHeadInfoStack(stack);
+		response.stacks.map((stack) => {
 			return [
-				stackKey(entry),
+				stackKey(stack),
 				{
-					stackInfo: details,
-					branchDetails: branchDetailsAdapter.addMany(
-						branchDetailsAdapter.getInitialState(),
-						details.branchDetails,
-					),
+					stack,
+					segments: stack.segments,
 					commits: commitAdapter.addMany(
 						commitAdapter.getInitialState(),
-						details.branchDetails.flatMap((branch) => branch.commits),
+						stack.segments.flatMap((segment) => segment.commits),
 					),
 					upstreamCommits: upstreamCommitAdapter.addMany(
 						upstreamCommitAdapter.getInitialState(),
-						details.branchDetails.flatMap((branch) => branch.upstreamCommits),
+						stack.segments.flatMap((segment) => segment.commitsOnRemote),
 					),
 				},
 			];
@@ -163,7 +59,7 @@ export function transformWorkspaceDetails(response: RefInfo): WorkspaceDetails {
 	);
 
 	return {
-		stacks: stackAdapter.addMany(stackAdapter.getInitialState(), stacks),
+		stacks: stackAdapter.addMany(stackAdapter.getInitialState(), response.stacks),
 		stackDetails,
 	};
 }
@@ -176,7 +72,7 @@ export function selectWorkspaceStackDetails(
 	if (stackId) return workspaceDetails.stackDetails[stackId];
 	if (branchName) {
 		return Object.values(workspaceDetails.stackDetails).find((details) =>
-			details.stackInfo.branchDetails.some((branch) => branch.name === branchName),
+			details.segments.some((segment) => segment.refName?.displayName === branchName),
 		);
 	}
 	return Object.values(workspaceDetails.stackDetails).at(0);
@@ -185,7 +81,7 @@ export function selectWorkspaceStackDetails(
 export function selectWorkspaceStackById(
 	workspaceDetails: WorkspaceDetails,
 	stackId: string,
-): StackEntry | undefined {
+): RefInfoStack | undefined {
 	return stackAdapter.getSelectors().selectById(workspaceDetails.stacks, stackId);
 }
 

--- a/apps/desktop/src/lib/stacks/headInfoAdapters.ts
+++ b/apps/desktop/src/lib/stacks/headInfoAdapters.ts
@@ -1,0 +1,194 @@
+import { createEntityAdapter, type EntityState } from "@reduxjs/toolkit";
+import type {
+	BranchDetails,
+	Commit,
+	RefInfo,
+	Segment,
+	Stack as RefInfoStack,
+	StackDetails,
+	StackEntry,
+	UpstreamCommit,
+} from "@gitbutler/but-sdk";
+
+export type WorkspaceStackDetails = {
+	stackInfo: StackDetails;
+	branchDetails: EntityState<BranchDetails, string>;
+	commits: EntityState<Commit, string>;
+	upstreamCommits: EntityState<UpstreamCommit, string>;
+};
+
+export type WorkspaceDetails = {
+	stacks: EntityState<StackEntry, string>;
+	stackDetails: Record<string, WorkspaceStackDetails>;
+};
+
+const NULL_SHA = "0000000000000000000000000000000000000000";
+
+const stackAdapter = createEntityAdapter<StackEntry, string>({
+	selectId: (stack) => stack.id ?? stack.heads.at(0)?.name ?? stack.tip,
+});
+
+const branchDetailsAdapter = createEntityAdapter<BranchDetails, string>({
+	selectId: (branch) => branch.name,
+});
+
+const commitAdapter = createEntityAdapter<Commit, string>({
+	selectId: (commit) => commit.id,
+});
+
+const upstreamCommitAdapter = createEntityAdapter<UpstreamCommit, string>({
+	selectId: (commit) => commit.id,
+});
+
+function decodeBytes(bytes: number[]): string {
+	return new TextDecoder().decode(new Uint8Array(bytes));
+}
+
+function stackKey(stack: StackEntry): string {
+	return stack.id ?? stack.heads.at(0)?.name ?? stack.tip;
+}
+
+function segmentName(segment: Segment): string {
+	if (!segment.refName) {
+		throw new Error("Cannot map anonymous head_info segment to legacy branch details");
+	}
+	return segment.refName.displayName;
+}
+
+function segmentReference(segment: Segment): string {
+	if (!segment.refName) {
+		throw new Error("Cannot map anonymous head_info segment to legacy branch details");
+	}
+	return decodeBytes(segment.refName.fullNameBytes);
+}
+
+function segmentTip(stack: RefInfoStack, segment: Segment): string {
+	return segment.commits.at(0)?.id ?? segment.base ?? stack.base ?? NULL_SHA;
+}
+
+function branchLastUpdatedAt(segment: Segment): number | null {
+	const seconds = segment.metadata?.refInfo.updatedAt?.seconds;
+	return seconds === undefined ? null : seconds * 1000;
+}
+
+function branchAuthors(segment: Segment): BranchDetails["authors"] {
+	const authors = [...segment.commits, ...segment.commitsOnRemote].map((commit) => commit.author);
+	return Array.from(
+		new Map(authors.map((author) => [JSON.stringify(author), author])).values(),
+	).sort((a, b) => (a.name ?? "").localeCompare(b.name ?? ""));
+}
+
+export function stackEntryFromHeadInfoStack(stack: RefInfoStack, index: number): StackEntry {
+	const heads = stack.segments.map((segment) => ({
+		name: segmentName(segment),
+		tip: segmentTip(stack, segment),
+		reviewId: segment.metadata?.review.pullRequest ?? null,
+		isCheckedOut: segment.isEntrypoint,
+	}));
+	const tip = heads.at(0)?.tip ?? stack.base ?? NULL_SHA;
+
+	return {
+		id: stack.id,
+		heads,
+		tip,
+		order: index,
+		isCheckedOut: heads.some((head) => head.isCheckedOut),
+	};
+}
+
+export function stackDetailsFromHeadInfoStack(stack: RefInfoStack): StackDetails {
+	const branchDetails = stack.segments.map((segment): BranchDetails => {
+		const baseCommit = segment.base ?? stack.base ?? NULL_SHA;
+		const remoteTrackingBranch = segment.remoteTrackingRefName
+			? decodeBytes(segment.remoteTrackingRefName.fullNameBytes)
+			: null;
+
+		return {
+			name: segmentName(segment),
+			reference: segmentReference(segment),
+			linkedWorktreeId: null,
+			remoteTrackingBranch,
+			prNumber: segment.metadata?.review.pullRequest ?? null,
+			reviewId: segment.metadata?.review.reviewId ?? null,
+			tip: segmentTip(stack, segment),
+			baseCommit,
+			pushStatus: segment.pushStatus,
+			lastUpdatedAt: branchLastUpdatedAt(segment),
+			authors: branchAuthors(segment),
+			isConflicted: segment.commits.some((commit) => commit.hasConflicts),
+			commits: segment.commits,
+			upstreamCommits: segment.commitsOnRemote,
+			isRemoteHead: segmentReference(segment).startsWith("refs/remotes/"),
+		};
+	});
+	const topmostBranch = branchDetails.at(0);
+
+	if (!topmostBranch) {
+		throw new Error("Cannot map empty head_info stack to legacy stack details");
+	}
+
+	return {
+		derivedName: topmostBranch.name,
+		pushStatus: topmostBranch.pushStatus,
+		branchDetails,
+		isConflicted: topmostBranch.isConflicted,
+	};
+}
+
+export function transformWorkspaceDetails(response: RefInfo): WorkspaceDetails {
+	const stacks = response.stacks.map(stackEntryFromHeadInfoStack);
+	const stackDetails = Object.fromEntries(
+		response.stacks.map((stack, index) => {
+			const entry = stacks[index]!;
+			const details = stackDetailsFromHeadInfoStack(stack);
+			return [
+				stackKey(entry),
+				{
+					stackInfo: details,
+					branchDetails: branchDetailsAdapter.addMany(
+						branchDetailsAdapter.getInitialState(),
+						details.branchDetails,
+					),
+					commits: commitAdapter.addMany(
+						commitAdapter.getInitialState(),
+						details.branchDetails.flatMap((branch) => branch.commits),
+					),
+					upstreamCommits: upstreamCommitAdapter.addMany(
+						upstreamCommitAdapter.getInitialState(),
+						details.branchDetails.flatMap((branch) => branch.upstreamCommits),
+					),
+				},
+			];
+		}),
+	);
+
+	return {
+		stacks: stackAdapter.addMany(stackAdapter.getInitialState(), stacks),
+		stackDetails,
+	};
+}
+
+export function selectWorkspaceStackDetails(
+	workspaceDetails: WorkspaceDetails,
+	stackId?: string,
+	branchName?: string,
+): WorkspaceStackDetails | undefined {
+	if (stackId) return workspaceDetails.stackDetails[stackId];
+	if (branchName) {
+		return Object.values(workspaceDetails.stackDetails).find((details) =>
+			details.stackInfo.branchDetails.some((branch) => branch.name === branchName),
+		);
+	}
+	return Object.values(workspaceDetails.stackDetails).at(0);
+}
+
+export function selectWorkspaceStackById(
+	workspaceDetails: WorkspaceDetails,
+	stackId: string,
+): StackEntry | undefined {
+	return stackAdapter.getSelectors().selectById(workspaceDetails.stacks, stackId);
+}
+
+export function workspaceStackDetailTags(workspaceDetails: WorkspaceDetails): string[] {
+	return Object.keys(workspaceDetails.stackDetails);
+}

--- a/apps/desktop/src/lib/stacks/macros.ts
+++ b/apps/desktop/src/lib/stacks/macros.ts
@@ -1,4 +1,3 @@
-import { getStackName } from "$lib/stacks/stack";
 import { ensureValue } from "$lib/utils/validation";
 import type { CreateCommitRequestWorktreeChanges } from "$lib/stacks/stackEndpoints";
 import type { StackService } from "$lib/stacks/stackService.svelte";
@@ -56,7 +55,7 @@ export default class StackMacros {
 			projectId: this.projectId,
 			branch: { name },
 		});
-		const branchName = getStackName(stack);
+		const branchName = ensureValue(stack.heads.at(0)?.name);
 		const outcome = await this.stackService.createCommitMutation({
 			projectId: this.projectId,
 			stackId: ensureValue(stack.id),

--- a/apps/desktop/src/lib/stacks/stack.ts
+++ b/apps/desktop/src/lib/stacks/stack.ts
@@ -2,13 +2,7 @@ import { showToast } from "$lib/notifications/toasts";
 import { TestId } from "@gitbutler/ui";
 import type { BranchIconName } from "$lib/branches/branchIcon";
 import type { DropResult } from "$lib/dragging/dropResult";
-import type {
-	BranchDetails,
-	PushStatus,
-	StackDetails,
-	StackEntry,
-	StackHeadInfo,
-} from "@gitbutler/but-sdk";
+import type { PushStatus, Segment, Stack as RefInfoStack } from "@gitbutler/but-sdk";
 
 export type CreateBranchFromBranchOutcome = {
 	stackId: string;
@@ -55,10 +49,7 @@ You can always re-apply them later from the branches page.`,
 	}
 }
 
-/**
- * Return type of Tauri `stacks` command.
- */
-export type Stack = StackEntry;
+export type Stack = RefInfoStack;
 
 export type GerritPushFlag =
 	| { type: "wip" }
@@ -68,52 +59,25 @@ export type GerritPushFlag =
 	| { type: "topic"; subject: string };
 
 /**
- * Return (future) type of Tauri `stacks` command.
- * It's currently used to assure the frontend doesn't accidentally see
- * an optional stack-id yet, and to show what it would have to be.
- *
- * This is only useful if one wants to go from `Stack` -> `StackOpt` -> `RefInfo`.
- * Ultimately, this is just a step on the way to deal with the entire workspace at once.
- */
-export type StackOpt = {
-	/**
-	 * The id of the stack, or null if there is no permanent id.
-	 * This can happen if no workspace is known, or even (rare) the workspace
-	 * would be out-of-sync with the workspace data that only we can attach.
-	 * Ideally there is no catastrophic failure if this is null for one
-	 * stack but set for the others.
-	 */
-	id?: string;
-	/**
-	 * Information about the branches contained in the stack.
-	 */
-	heads: StackHeadInfo[];
-	/**
-	 * The commit hash of the tip of the stack.
-	 */
-	tip: string;
-	/**
-	 * Zero-based index for sorting the stacks.
-	 */
-	order: number;
-};
-
-/**
  * Returns the name of the stack.
  *
  * This is the name of the top-most branch in the stack.
  */
 export function getStackName(stack: Stack): string {
-	if (stack.heads.length === 0) {
-		// Should not happen
-		throw new Error("Stack has no heads");
+	const firstSegment = stack.segments.at(0);
+	if (!firstSegment?.refName) {
+		return "Unnamed segment";
 	}
-	const lastBranch = stack.heads.at(0)!.name;
-	return lastBranch;
+	return firstSegment.refName.displayName;
 }
 
 export function getStackBranchNames(stack: Stack): string[] {
-	return stack.heads.map((head) => head.name);
+	return stack.segments.map((segment) => {
+		if (!segment.refName) {
+			return "Unnamed segment";
+		}
+		return segment.refName.displayName;
+	});
 }
 
 /**
@@ -145,11 +109,11 @@ export function pushStatusToIcon(pushStatus: PushStatus): BranchIconName {
 	}
 }
 
-export function stackRequiresForcePush(stack: StackDetails): boolean {
-	return stack.pushStatus === "unpushedCommitsRequiringForce";
+export function stackRequiresForcePush(stack: Stack): boolean {
+	return stack.segments.at(0)?.pushStatus === "unpushedCommitsRequiringForce";
 }
 
-export function branchRequiresForcePush(branch: BranchDetails): boolean {
+export function branchRequiresForcePush(branch: Segment): boolean {
 	return branch.pushStatus === "unpushedCommitsRequiringForce";
 }
 
@@ -159,14 +123,11 @@ export function branchRequiresForcePush(branch: BranchDetails): boolean {
  * @param branchName The name of the branch to check
  * @param allBranches Complete list of branches in the stack. The order is expected to be child-to-parent
  */
-export function partialStackRequestsForcePush(
-	branchName: string,
-	allBranches: BranchDetails[],
-): boolean {
+export function partialStackRequestsForcePush(branchName: string, allBranches: Segment[]): boolean {
 	let foundBranch = false;
 
 	for (const branch of allBranches) {
-		if (branch.name === branchName && !foundBranch) {
+		if (branch.refName?.displayName === branchName && !foundBranch) {
 			foundBranch = true;
 		}
 		if (!foundBranch) continue;
@@ -176,19 +137,20 @@ export function partialStackRequestsForcePush(
 	return false;
 }
 
-export function stackHasConflicts(stack: StackDetails): boolean {
-	return stack.isConflicted;
+export function stackHasConflicts(stack: Stack): boolean {
+	return stack.segments.at(0)?.commits.some((commit) => commit.hasConflicts) ?? false;
 }
 
-export function branchHasConflicts(branch: BranchDetails): boolean {
-	return branch.isConflicted;
+export function branchHasConflicts(branch: Segment): boolean {
+	return branch.commits.some((commit) => commit.hasConflicts);
 }
 
-export function stackHasUnpushedCommits(stack: StackDetails): boolean {
-	return requiresPush(stack.pushStatus);
+export function stackHasUnpushedCommits(stack: Stack): boolean {
+	const pushStatus = stack.segments.at(0)?.pushStatus;
+	return pushStatus ? requiresPush(pushStatus) : false;
 }
 
-export function branchHasUnpushedCommits(branch: BranchDetails): boolean {
+export function branchHasUnpushedCommits(branch: Segment): boolean {
 	return requiresPush(branch.pushStatus);
 }
 

--- a/apps/desktop/src/lib/stacks/stackEndpoints.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.ts
@@ -1,10 +1,16 @@
 import { ConflictEntries, type ConflictEntriesObj } from "$lib/files/conflicts";
 import { normalizeReferenceSubject } from "$lib/stacks/commitMovePlacement";
+import {
+	transformWorkspaceDetails,
+	workspaceStackDetailTags,
+	type WorkspaceDetails,
+} from "$lib/stacks/headInfoAdapters";
 import { createSelectByIds, createSelectNth } from "$lib/state/customSelectors";
 import {
 	invalidatesItem,
 	invalidatesList,
 	providesItem,
+	providesItems,
 	providesList,
 	ReduxTag,
 } from "$lib/state/tags";
@@ -39,6 +45,7 @@ import type {
 	UncommitResult,
 	InsertSide,
 	RelativeTo,
+	RefInfo,
 } from "@gitbutler/but-sdk";
 
 export type BranchParams = {
@@ -208,6 +215,17 @@ export const branchDetailsSelectors = branchDetailsAdapter.getSelectors();
 
 export function buildStackEndpoints(build: BackendEndpointBuilder) {
 	return {
+		workspaceDetails: build.query<WorkspaceDetails, { projectId: string }>({
+			extraOptions: { command: "head_info" },
+			query: (args) => args,
+			providesTags: (result) => {
+				const stackIds = result ? workspaceStackDetailTags(result) : [];
+				return [providesList(ReduxTag.Stacks), ...providesItems(ReduxTag.StackDetails, stackIds)];
+			},
+			transformResponse(response: RefInfo) {
+				return transformWorkspaceDetails(response);
+			},
+		}),
 		stacks: build.query<EntityState<Stack, string>, { projectId: string; all?: boolean }>({
 			extraOptions: { command: "stacks" },
 			query: (args) => {

--- a/apps/desktop/src/lib/stacks/stackEndpoints.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.ts
@@ -26,7 +26,6 @@ import type { BackendEndpointBuilder } from "$lib/state/backendApi";
 import type {
 	AbsorptionTarget,
 	CommitAbsorption,
-	StackDetails,
 	BranchDetails,
 	UpstreamCommit,
 	Commit,
@@ -147,10 +146,6 @@ export function normalizeCreateCommitOutcome(response: CommitCreateResult): Crea
 	};
 }
 
-export function transformStacksResponse(response: Stack[]) {
-	return stackAdapter.addMany(stackAdapter.getInitialState(), response);
-}
-
 export function toCommitCreatePlacement(args: CreateCommitRequest): {
 	relativeTo: RelativeTo;
 	side: "above" | "below";
@@ -226,17 +221,6 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 				return transformWorkspaceDetails(response);
 			},
 		}),
-		stacks: build.query<EntityState<Stack, string>, { projectId: string; all?: boolean }>({
-			extraOptions: { command: "stacks" },
-			query: (args) => {
-				const filter = args.all ? "All" : undefined;
-				return { projectId: args.projectId, filter };
-			},
-			providesTags: [providesList(ReduxTag.Stacks)],
-			transformResponse(response: Stack[]) {
-				return transformStacksResponse(response);
-			},
-		}),
 		createStack: build.mutation<Stack, { projectId: string; branch: BranchParams }>({
 			extraOptions: {
 				command: "create_virtual_branch",
@@ -264,55 +248,10 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 			// reload, however, so leaving it like this for now.
 			// invalidatesTags: [invalidatesList(ReduxTag.Stacks)]
 		}),
-		stackDetails: build.query<
-			{
-				stackInfo: StackDetails;
-				branchDetails: EntityState<BranchDetails, string>;
-				commits: EntityState<Commit, string>;
-				upstreamCommits: EntityState<UpstreamCommit, string>;
-			},
-			// TODO(single-branch): stackId is actually `stackId?` in the backend to be able to query details in single-branch mode.
-			// 	  however, ideally all this goes away in favor of consuming `RefInfo` from the backend.
-			{ projectId: string; stackId?: string }
-		>({
-			extraOptions: { command: "stack_details" },
-			query: (args) => args,
-			providesTags: (_result, _error, { stackId }) => [
-				...providesItem(ReduxTag.StackDetails, stackId || "undefined"),
-			],
-			transformResponse(response: StackDetails) {
-				const branchDetailsEntity = branchDetailsAdapter.addMany(
-					branchDetailsAdapter.getInitialState(),
-					response.branchDetails,
-				);
-
-				// This is a list of all the commits across all branches in the stack.
-				// If you want to access the commits of a specific branch, use the
-				// `commits` property of the `BranchDetails` struct.
-				const commitsEntity = commitAdapter.addMany(
-					commitAdapter.getInitialState(),
-					response.branchDetails.flatMap((branch) => branch.commits),
-				);
-
-				// This is a list of all the upstream commits across all the branches in the stack.
-				// If you want to access the upstream commits of a specific branch, use the
-				// `upstreamCommits` property of the `BranchDetails` struct.
-				const upstreamCommitsEntity = upstreamCommitAdapter.addMany(
-					upstreamCommitAdapter.getInitialState(),
-					response.branchDetails.flatMap((branch) => branch.upstreamCommits),
-				);
-
-				return {
-					stackInfo: response,
-					branchDetails: branchDetailsEntity,
-					commits: commitsEntity,
-					upstreamCommits: upstreamCommitsEntity,
-				};
-			},
-		}),
 		/**
 		 * Note: This is specifically for looking up branches outside of
-		 * a stacking context. You almost certainly want `stackDetails`
+		 * a stacking context. Stacked workspace branches should be read from
+		 * the `head_info`-backed workspace details query.
 		 */
 		unstackedBranchDetails: build.query<
 			{

--- a/apps/desktop/src/lib/stacks/stackEndpoints.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.ts
@@ -45,6 +45,7 @@ import type {
 	InsertSide,
 	RelativeTo,
 	RefInfo,
+	StackEntry,
 } from "@gitbutler/but-sdk";
 
 export type BranchParams = {
@@ -171,7 +172,7 @@ export function toCommitCreatePlacement(args: CreateCommitRequest): {
 // Entity adapters and selectors
 
 export const stackAdapter = createEntityAdapter<Stack, string>({
-	selectId: (stack) => stack.id || stack.heads.at(0)?.name || stack.tip,
+	selectId: (stack) => stack.id ?? stack.segments.at(0)?.refName?.displayName ?? stack.base ?? "",
 });
 export const stackSelectors = {
 	...stackAdapter.getSelectors(),
@@ -202,12 +203,6 @@ export const changesSelectors = changesAdapter.getSelectors();
 
 export const selectChangesByPaths = createSelectByIds<TreeChange>();
 
-export const branchDetailsAdapter = createEntityAdapter<BranchDetails, string>({
-	selectId: (branch) => branch.name,
-});
-
-export const branchDetailsSelectors = branchDetailsAdapter.getSelectors();
-
 export function buildStackEndpoints(build: BackendEndpointBuilder) {
 	return {
 		workspaceDetails: build.query<WorkspaceDetails, { projectId: string }>({
@@ -221,7 +216,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 				return transformWorkspaceDetails(response);
 			},
 		}),
-		createStack: build.mutation<Stack, { projectId: string; branch: BranchParams }>({
+		createStack: build.mutation<StackEntry, { projectId: string; branch: BranchParams }>({
 			extraOptions: {
 				command: "create_virtual_branch",
 				actionName: "Create Stack",

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -2,6 +2,10 @@ import { getBranchNameFromRef } from "$lib/branches/branchUtils";
 import { sortLikeFileTree } from "$lib/files/filetreeV3";
 import { showToast } from "$lib/notifications/toasts";
 import {
+	selectWorkspaceStackById,
+	selectWorkspaceStackDetails,
+} from "$lib/stacks/headInfoAdapters";
+import {
 	branchDetailsSelectors,
 	changesSelectors,
 	commitSelectors,
@@ -47,67 +51,84 @@ export class StackService {
 	) {}
 
 	stacks(projectId: string) {
-		return this.backendApi.endpoints.stacks.useQuery(
+		return this.backendApi.endpoints.workspaceDetails.useQuery(
 			{ projectId },
 			{
-				transform: (stacks) => stackSelectors.selectAll(stacks),
+				transform: (workspaceDetails) => stackSelectors.selectAll(workspaceDetails.stacks),
 			},
 		);
 	}
 
 	async fetchStacks(projectId: string) {
-		return await this.backendApi.endpoints.stacks.fetch(
+		return await this.backendApi.endpoints.workspaceDetails.fetch(
 			{ projectId },
 			{
-				transform: (stacks) => stackSelectors.selectAll(stacks),
+				transform: (workspaceDetails) => stackSelectors.selectAll(workspaceDetails.stacks),
 			},
 		);
 	}
 
 	stackAt(projectId: string, index: number) {
-		return this.backendApi.endpoints.stacks.useQuery(
+		return this.backendApi.endpoints.workspaceDetails.useQuery(
 			{ projectId },
 			{
-				transform: (stacks) => stackSelectors.selectNth(stacks, index),
+				transform: (workspaceDetails) => stackSelectors.selectNth(workspaceDetails.stacks, index),
 			},
 		);
 	}
 
 	stackById(projectId: string, id: string) {
-		return this.backendApi.endpoints.stacks.useQuery(
+		return this.backendApi.endpoints.workspaceDetails.useQuery(
 			{ projectId },
 			{
-				transform: (stacks) => stackSelectors.selectById(stacks, id) ?? null,
+				transform: (workspaceDetails) => selectWorkspaceStackById(workspaceDetails, id) ?? null,
 			},
 		);
 	}
 
-	allStackById(projectId: string, id: string) {
+	branchesPageStack(projectId: string, stackId: string, inWorkspace: boolean) {
+		if (inWorkspace) {
+			return this.stackById(projectId, stackId);
+		}
 		return this.backendApi.endpoints.stacks.useQuery(
 			{ projectId, all: true },
 			{
-				transform: (stacks) => stackSelectors.selectById(stacks, id) ?? null,
+				transform: (stacks) => stackSelectors.selectById(stacks, stackId) ?? null,
 			},
 		);
+	}
+
+	branchesPageBranchDetails(
+		projectId: string,
+		stackId: string,
+		branchName: string,
+		inWorkspace: boolean,
+	) {
+		if (inWorkspace) {
+			return this.branchDetails(projectId, stackId, branchName);
+		}
+		return this.unstackedBranchDetails(projectId, branchName);
 	}
 
 	defaultBranch(projectId: string, stackId?: string) {
 		if (!stackId) return null;
-		return this.backendApi.endpoints.stacks.useQuery(
+		return this.backendApi.endpoints.workspaceDetails.useQuery(
 			{ projectId },
 			{
-				transform: (stacks) => stackSelectors.selectById(stacks, stackId)?.heads[0]?.name ?? null,
+				transform: (workspaceDetails) =>
+					selectWorkspaceStackById(workspaceDetails, stackId)?.heads[0]?.name ?? null,
 			},
 		);
 	}
 
 	branchDetails(projectId: string, stackId: string | undefined, branchName?: string) {
-		return this.backendApi.endpoints.stackDetails.useQuery(
-			{ projectId, stackId },
+		return this.backendApi.endpoints.workspaceDetails.useQuery(
+			{ projectId },
 			{
-				transform: ({ branchDetails }) => {
+				transform: (workspaceDetails) => {
+					const details = selectWorkspaceStackDetails(workspaceDetails, stackId, branchName);
 					return branchName
-						? branchDetailsSelectors.selectById(branchDetails, branchName)
+						? details && branchDetailsSelectors.selectById(details.branchDetails, branchName)
 						: undefined;
 				},
 			},
@@ -127,17 +148,23 @@ export class StackService {
 	}
 
 	branches(projectId: string, stackId?: string) {
-		return this.backendApi.endpoints.stackDetails.useQuery(
-			{ projectId, stackId },
-			{ transform: ({ branchDetails }) => branchDetailsSelectors.selectAll(branchDetails) },
+		return this.backendApi.endpoints.workspaceDetails.useQuery(
+			{ projectId },
+			{
+				transform: (workspaceDetails) => {
+					const details = selectWorkspaceStackDetails(workspaceDetails, stackId);
+					return details ? branchDetailsSelectors.selectAll(details.branchDetails) : [];
+				},
+			},
 		);
 	}
 
 	branchAt(projectId: string, stackId: string | undefined, index: number) {
-		return this.backendApi.endpoints.stackDetails.useQuery(
-			{ projectId, stackId },
+		return this.backendApi.endpoints.workspaceDetails.useQuery(
+			{ projectId },
 			{
-				transform: ({ stackInfo }) => stackInfo.branchDetails[index],
+				transform: (workspaceDetails) =>
+					selectWorkspaceStackDetails(workspaceDetails, stackId)?.stackInfo.branchDetails[index],
 			},
 		);
 	}
@@ -158,96 +185,137 @@ export class StackService {
 		name: string,
 		offset: number,
 	) {
-		return this.backendApi.endpoints.stackDetails.useQuery(
-			{ projectId, stackId },
+		return this.backendApi.endpoints.workspaceDetails.useQuery(
+			{ projectId },
 			{
-				transform: ({ stackInfo, branchDetails }) => {
-					const names = stackInfo.branchDetails.map((branch) => branch.name);
+				transform: (workspaceDetails) => {
+					const details = selectWorkspaceStackDetails(workspaceDetails, stackId, name);
+					if (!details) return;
+					const names = details.stackInfo.branchDetails.map((branch) => branch.name);
 					const index = names.indexOf(name);
 					if (index === -1) return;
 
 					const relativeName = names[index + offset];
 					if (!relativeName) return;
 
-					return branchDetailsSelectors.selectById(branchDetails, relativeName);
+					return branchDetailsSelectors.selectById(details.branchDetails, relativeName);
 				},
 			},
 		);
 	}
 
 	branchByName(projectId: string, stackId: string | undefined, name: string) {
-		return this.backendApi.endpoints.stackDetails.useQuery(
-			{ projectId, stackId },
-			{ transform: ({ branchDetails }) => branchDetailsSelectors.selectById(branchDetails, name) },
+		return this.backendApi.endpoints.workspaceDetails.useQuery(
+			{ projectId },
+			{
+				transform: (workspaceDetails) => {
+					const details = selectWorkspaceStackDetails(workspaceDetails, stackId, name);
+					return details && branchDetailsSelectors.selectById(details.branchDetails, name);
+				},
+			},
 		);
 	}
 
 	commits(projectId: string, stackId: string | undefined, branchName: string) {
-		return this.backendApi.endpoints.stackDetails.useQuery(
-			{ projectId, stackId },
+		return this.backendApi.endpoints.workspaceDetails.useQuery(
+			{ projectId },
 			{
-				transform: ({ branchDetails }) =>
-					branchDetailsSelectors.selectById(branchDetails, branchName)?.commits,
+				transform: (workspaceDetails) => {
+					const details = selectWorkspaceStackDetails(workspaceDetails, stackId, branchName);
+					return (
+						details && branchDetailsSelectors.selectById(details.branchDetails, branchName)?.commits
+					);
+				},
 			},
 		);
 	}
 
 	fetchCommits(projectId: string, stackId: string | undefined, branchName: string) {
-		return this.backendApi.endpoints.stackDetails.fetch(
-			{ projectId, stackId },
+		return this.backendApi.endpoints.workspaceDetails.fetch(
+			{ projectId },
 			{
-				transform: ({ branchDetails }) =>
-					branchDetailsSelectors.selectById(branchDetails, branchName)?.commits,
+				transform: (workspaceDetails) => {
+					const details = selectWorkspaceStackDetails(workspaceDetails, stackId, branchName);
+					return (
+						details && branchDetailsSelectors.selectById(details.branchDetails, branchName)?.commits
+					);
+				},
 			},
 		);
 	}
 
 	async fetchStackById(projectId: string, stackId: string) {
-		return await this.backendApi.endpoints.stacks.fetch(
+		return await this.backendApi.endpoints.workspaceDetails.fetch(
 			{ projectId },
 			{
-				transform: (stacks) => stackSelectors.selectById(stacks, stackId),
+				transform: (workspaceDetails) => selectWorkspaceStackById(workspaceDetails, stackId),
 			},
 		);
 	}
 
 	async fetchBranches(projectId: string, stackId: string) {
-		return await this.backendApi.endpoints.stackDetails.fetch(
-			{ projectId, stackId },
+		return await this.backendApi.endpoints.workspaceDetails.fetch(
+			{ projectId },
 			{
-				transform: ({ branchDetails }) => branchDetailsSelectors.selectAll(branchDetails),
+				transform: (workspaceDetails) => {
+					const details = selectWorkspaceStackDetails(workspaceDetails, stackId);
+					return details ? branchDetailsSelectors.selectAll(details.branchDetails) : [];
+				},
 			},
 		);
 	}
 
 	commitAt(projectId: string, stackId: string | undefined, branchName: string, index: number) {
-		return this.backendApi.endpoints.stackDetails.useQuery(
-			{ projectId, stackId },
+		return this.backendApi.endpoints.workspaceDetails.useQuery(
+			{ projectId },
 			{
-				transform: ({ branchDetails }) =>
-					branchDetailsSelectors.selectById(branchDetails, branchName)?.commits[index] ?? null,
+				transform: (workspaceDetails) => {
+					const details = selectWorkspaceStackDetails(workspaceDetails, stackId, branchName);
+					return (
+						(details &&
+							branchDetailsSelectors.selectById(details.branchDetails, branchName)?.commits[
+								index
+							]) ??
+						null
+					);
+				},
 			},
 		);
 	}
 
 	allLocalCommits(projectId: string) {
-		const stacks = $derived(this.stacks(projectId));
-		const stackIds = $derived(stacks.response?.map((s) => s.id).filter(isDefined) || []);
-		const args = $derived(stackIds?.map((stackId) => ({ projectId, stackId })));
 		const details = $derived(
-			this.backendApi.endpoints.stackDetails.useQueries(args, {
-				transform: ({ commits, stackInfo }) => ({
-					commits: commitSelectors.selectAll(commits),
-					branches: stackInfo.branchDetails.map((b) => b.name),
-					baseCommitShas: stackInfo.branchDetails.map((b) => b.baseCommit),
-					stackInfo,
-				}),
-			}),
+			this.backendApi.endpoints.workspaceDetails.useQuery(
+				{ projectId },
+				{
+					transform: (workspaceDetails) => {
+						const stacks = stackSelectors.selectAll(workspaceDetails.stacks);
+						const stackIds = stacks.map((stack) => stack.id).filter(isDefined);
+						const detailsData = stackIds
+							.map((stackId) => workspaceDetails.stackDetails[stackId])
+							.filter(isDefined);
+						return {
+							stackIds,
+							detailsData,
+							allCommits: detailsData.flatMap((details) =>
+								commitSelectors.selectAll(details.commits),
+							),
+							allBranches: detailsData.flatMap((details) =>
+								details.stackInfo.branchDetails.map((branch) => branch.name),
+							),
+							allBaseCommitShas: detailsData.flatMap((details) =>
+								details.stackInfo.branchDetails.map((branch) => branch.baseCommit),
+							),
+						};
+					},
+				},
+			),
 		);
-		const detailsData = $derived(details.current);
-		const allCommits = $derived(detailsData.flatMap((d) => d.data?.commits ?? []));
-		const allBranches = $derived(detailsData.flatMap((d) => d.data?.branches ?? []));
-		const allBaseCommitShas = $derived(detailsData.flatMap((d) => d.data?.baseCommitShas ?? []));
+		const stackIds = $derived(details.response?.stackIds ?? []);
+		const detailsData = $derived(details.response?.detailsData ?? []);
+		const allCommits = $derived(details.response?.allCommits ?? []);
+		const allBranches = $derived(details.response?.allBranches ?? []);
+		const allBaseCommitShas = $derived(details.response?.allBaseCommitShas ?? []);
 
 		$effect(() => {
 			updateStaleProjectState(
@@ -284,7 +352,7 @@ export class StackService {
 
 			const nextSnapshot: Record<string, StackDetails> = {};
 			stackIds.forEach((stackId, i) => {
-				const stackInfo = detailsData[i]?.data?.stackInfo;
+				const stackInfo = detailsData[i]?.stackInfo;
 				if (!stackInfo) return;
 				// Only run when the StackDetails object is actually new (different reference).
 				// During a re-fetch, RTK Query keeps the cached data object unchanged while
@@ -308,25 +376,33 @@ export class StackService {
 	}
 
 	commitById(projectId: string, stackId: string | undefined, commitId: string) {
-		return this.backendApi.endpoints.stackDetails.useQuery(
-			{ projectId, stackId },
+		return this.backendApi.endpoints.workspaceDetails.useQuery(
+			{ projectId },
 			{
-				transform: ({ commits, upstreamCommits }) =>
-					commitSelectors.selectById(commits, commitId) ??
-					upstreamCommitSelectors.selectById(upstreamCommits, commitId),
+				transform: (workspaceDetails) => {
+					const details = selectWorkspaceStackDetails(workspaceDetails, stackId);
+					return (
+						(details &&
+							(commitSelectors.selectById(details.commits, commitId) ??
+								upstreamCommitSelectors.selectById(details.upstreamCommits, commitId))) ??
+						undefined
+					);
+				},
 			},
 		);
 	}
 
 	commitsByIds(projectId: string, stackId: string | undefined, commitIds: string[]) {
-		return this.backendApi.endpoints.stackDetails.useQuery(
-			{ projectId, stackId },
+		return this.backendApi.endpoints.workspaceDetails.useQuery(
+			{ projectId },
 			{
-				transform: ({ commits, upstreamCommits }) => {
+				transform: (workspaceDetails) => {
+					const details = selectWorkspaceStackDetails(workspaceDetails, stackId);
+					if (!details) return [];
 					const commitDetails = commitIds.map((id) => {
 						return (
-							commitSelectors.selectById(commits, id) ??
-							upstreamCommitSelectors.selectById(upstreamCommits, id)
+							commitSelectors.selectById(details.commits, id) ??
+							upstreamCommitSelectors.selectById(details.upstreamCommits, id)
 						);
 					});
 					return commitDetails.filter(isDefined);
@@ -336,25 +412,32 @@ export class StackService {
 	}
 
 	fetchCommitById(projectId: string, stackId: string, commitId: string) {
-		return this.backendApi.endpoints.stackDetails.fetch(
-			{ projectId, stackId },
+		return this.backendApi.endpoints.workspaceDetails.fetch(
+			{ projectId },
 			{
-				transform: ({ commits, upstreamCommits }) =>
-					commitSelectors.selectById(commits, commitId) ??
-					upstreamCommitSelectors.selectById(upstreamCommits, commitId),
+				transform: (workspaceDetails) => {
+					const details = selectWorkspaceStackDetails(workspaceDetails, stackId);
+					return (
+						details &&
+						(commitSelectors.selectById(details.commits, commitId) ??
+							upstreamCommitSelectors.selectById(details.upstreamCommits, commitId))
+					);
+				},
 			},
 		);
 	}
 
 	fetchCommitsByIds(projectId: string, stackId: string, commitIds: string[]) {
-		return this.backendApi.endpoints.stackDetails.fetch(
-			{ projectId, stackId },
+		return this.backendApi.endpoints.workspaceDetails.fetch(
+			{ projectId },
 			{
-				transform: ({ commits, upstreamCommits }) => {
+				transform: (workspaceDetails) => {
+					const details = selectWorkspaceStackDetails(workspaceDetails, stackId);
+					if (!details) return [];
 					const commitDetails = commitIds.map((id) => {
 						return (
-							commitSelectors.selectById(commits, id) ??
-							upstreamCommitSelectors.selectById(upstreamCommits, id)
+							commitSelectors.selectById(details.commits, id) ??
+							upstreamCommitSelectors.selectById(details.upstreamCommits, id)
 						);
 					});
 					return commitDetails.filter(isDefined);
@@ -364,32 +447,46 @@ export class StackService {
 	}
 
 	upstreamCommits(projectId: string, stackId: string | undefined, branchName: string) {
-		return this.backendApi.endpoints.stackDetails.useQuery(
-			{ projectId, stackId },
+		return this.backendApi.endpoints.workspaceDetails.useQuery(
+			{ projectId },
 			{
-				transform: ({ branchDetails }) =>
-					branchDetailsSelectors.selectById(branchDetails, branchName)?.upstreamCommits,
+				transform: (workspaceDetails) => {
+					const details = selectWorkspaceStackDetails(workspaceDetails, stackId, branchName);
+					return (
+						details &&
+						branchDetailsSelectors.selectById(details.branchDetails, branchName)?.upstreamCommits
+					);
+				},
 			},
 		);
 	}
 
 	upstreamCommitAt(projectId: string, stackId: string, branchName: string, index: number) {
-		return this.backendApi.endpoints.stackDetails.useQuery(
-			{ projectId, stackId },
+		return this.backendApi.endpoints.workspaceDetails.useQuery(
+			{ projectId },
 			{
-				transform: ({ branchDetails }) =>
-					branchDetailsSelectors.selectById(branchDetails, branchName)?.upstreamCommits[index] ??
-					null,
+				transform: (workspaceDetails) => {
+					const details = selectWorkspaceStackDetails(workspaceDetails, stackId, branchName);
+					return (
+						(details &&
+							branchDetailsSelectors.selectById(details.branchDetails, branchName)?.upstreamCommits[
+								index
+							]) ??
+						null
+					);
+				},
 			},
 		);
 	}
 
 	fetchUpstreamCommitById(projectId: string, stackId: string, commitId: string) {
-		return this.backendApi.endpoints.stackDetails.fetch(
-			{ projectId, stackId },
+		return this.backendApi.endpoints.workspaceDetails.fetch(
+			{ projectId },
 			{
-				transform: ({ upstreamCommits }) =>
-					upstreamCommitSelectors.selectById(upstreamCommits, commitId),
+				transform: (workspaceDetails) => {
+					const details = selectWorkspaceStackDetails(workspaceDetails, stackId);
+					return details && upstreamCommitSelectors.selectById(details.upstreamCommits, commitId);
+				},
 			},
 		);
 	}
@@ -741,11 +838,15 @@ export class StackService {
 		stackId: string;
 		branchName: string;
 	}) {
-		const allCommits = await this.backendApi.endpoints.stackDetails.fetch(
-			{ projectId, stackId },
+		const allCommits = await this.backendApi.endpoints.workspaceDetails.fetch(
+			{ projectId },
 			{
-				transform: ({ branchDetails }) =>
-					branchDetailsSelectors.selectById(branchDetails, branchName)?.commits,
+				transform: (workspaceDetails) => {
+					const details = selectWorkspaceStackDetails(workspaceDetails, stackId, branchName);
+					return (
+						details && branchDetailsSelectors.selectById(details.branchDetails, branchName)?.commits
+					);
+				},
 			},
 		);
 
@@ -777,11 +878,13 @@ export class StackService {
 	}
 
 	isBranchConflicted(projectId: string, stackId: string, branchName: string) {
-		return this.backendApi.endpoints.stackDetails.useQuery(
-			{ projectId, stackId },
+		return this.backendApi.endpoints.workspaceDetails.useQuery(
+			{ projectId },
 			{
-				transform: ({ branchDetails }) => {
-					const branch = branchDetailsSelectors.selectById(branchDetails, branchName);
+				transform: (workspaceDetails) => {
+					const details = selectWorkspaceStackDetails(workspaceDetails, stackId, branchName);
+					const branch =
+						details && branchDetailsSelectors.selectById(details.branchDetails, branchName);
 					return branch?.isConflicted ?? false;
 				},
 			},

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -6,7 +6,6 @@ import {
 	selectWorkspaceStackDetails,
 } from "$lib/stacks/headInfoAdapters";
 import {
-	branchDetailsSelectors,
 	changesSelectors,
 	commitSelectors,
 	selectChangesByPaths,
@@ -28,7 +27,7 @@ import type { ReduxError } from "$lib/error/reduxError";
 import type { DefaultForgeFactory } from "$lib/forge/forgeFactory.svelte";
 import type { BackendApi } from "$lib/state/backendApi";
 import type { AppDispatch } from "$lib/state/clientState.svelte";
-import type { AbsorptionTarget, DiffSpec, StackDetails } from "@gitbutler/but-sdk";
+import type { AbsorptionTarget, DiffSpec, Stack } from "@gitbutler/but-sdk";
 
 export { REJECTTION_REASONS } from "$lib/stacks/stackEndpoints";
 
@@ -92,7 +91,8 @@ export class StackService {
 			{ projectId },
 			{
 				transform: (workspaceDetails) =>
-					selectWorkspaceStackById(workspaceDetails, stackId)?.heads[0]?.name ?? null,
+					selectWorkspaceStackById(workspaceDetails, stackId)?.segments.at(0)?.refName
+						?.displayName ?? null,
 			},
 		);
 	}
@@ -104,7 +104,7 @@ export class StackService {
 				transform: (workspaceDetails) => {
 					const details = selectWorkspaceStackDetails(workspaceDetails, stackId, branchName);
 					return branchName
-						? details && branchDetailsSelectors.selectById(details.branchDetails, branchName)
+						? details?.segments.find((segment) => segment.refName?.displayName === branchName)
 						: undefined;
 				},
 			},
@@ -129,18 +129,8 @@ export class StackService {
 			{
 				transform: (workspaceDetails) => {
 					const details = selectWorkspaceStackDetails(workspaceDetails, stackId);
-					return details ? branchDetailsSelectors.selectAll(details.branchDetails) : [];
+					return details?.segments ?? [];
 				},
-			},
-		);
-	}
-
-	branchAt(projectId: string, stackId: string | undefined, index: number) {
-		return this.backendApi.endpoints.workspaceDetails.useQuery(
-			{ projectId },
-			{
-				transform: (workspaceDetails) =>
-					selectWorkspaceStackDetails(workspaceDetails, stackId)?.stackInfo.branchDetails[index],
 			},
 		);
 	}
@@ -167,26 +157,14 @@ export class StackService {
 				transform: (workspaceDetails) => {
 					const details = selectWorkspaceStackDetails(workspaceDetails, stackId, name);
 					if (!details) return;
-					const names = details.stackInfo.branchDetails.map((branch) => branch.name);
+					const names = details.segments.map((segment) => segment.refName?.displayName);
 					const index = names.indexOf(name);
 					if (index === -1) return;
 
 					const relativeName = names[index + offset];
 					if (!relativeName) return;
 
-					return branchDetailsSelectors.selectById(details.branchDetails, relativeName);
-				},
-			},
-		);
-	}
-
-	branchByName(projectId: string, stackId: string | undefined, name: string) {
-		return this.backendApi.endpoints.workspaceDetails.useQuery(
-			{ projectId },
-			{
-				transform: (workspaceDetails) => {
-					const details = selectWorkspaceStackDetails(workspaceDetails, stackId, name);
-					return details && branchDetailsSelectors.selectById(details.branchDetails, name);
+					return details.segments.find((segment) => segment.refName?.displayName === relativeName);
 				},
 			},
 		);
@@ -198,9 +176,8 @@ export class StackService {
 			{
 				transform: (workspaceDetails) => {
 					const details = selectWorkspaceStackDetails(workspaceDetails, stackId, branchName);
-					return (
-						details && branchDetailsSelectors.selectById(details.branchDetails, branchName)?.commits
-					);
+					return details?.segments.find((segment) => segment.refName?.displayName === branchName)
+						?.commits;
 				},
 			},
 		);
@@ -212,9 +189,8 @@ export class StackService {
 			{
 				transform: (workspaceDetails) => {
 					const details = selectWorkspaceStackDetails(workspaceDetails, stackId, branchName);
-					return (
-						details && branchDetailsSelectors.selectById(details.branchDetails, branchName)?.commits
-					);
+					return details?.segments.find((segment) => segment.refName?.displayName === branchName)
+						?.commits;
 				},
 			},
 		);
@@ -235,25 +211,7 @@ export class StackService {
 			{
 				transform: (workspaceDetails) => {
 					const details = selectWorkspaceStackDetails(workspaceDetails, stackId);
-					return details ? branchDetailsSelectors.selectAll(details.branchDetails) : [];
-				},
-			},
-		);
-	}
-
-	commitAt(projectId: string, stackId: string | undefined, branchName: string, index: number) {
-		return this.backendApi.endpoints.workspaceDetails.useQuery(
-			{ projectId },
-			{
-				transform: (workspaceDetails) => {
-					const details = selectWorkspaceStackDetails(workspaceDetails, stackId, branchName);
-					return (
-						(details &&
-							branchDetailsSelectors.selectById(details.branchDetails, branchName)?.commits[
-								index
-							]) ??
-						null
-					);
+					return details?.segments ?? [];
 				},
 			},
 		);
@@ -277,10 +235,12 @@ export class StackService {
 								commitSelectors.selectAll(details.commits),
 							),
 							allBranches: detailsData.flatMap((details) =>
-								details.stackInfo.branchDetails.map((branch) => branch.name),
+								details.segments.map((segment) => segment.refName?.displayName).filter(isDefined),
 							),
 							allBaseCommitShas: detailsData.flatMap((details) =>
-								details.stackInfo.branchDetails.map((branch) => branch.baseCommit),
+								details.segments
+									.map((segment) => segment.base ?? details.stack.base)
+									.filter(isDefined),
 							),
 						};
 					},
@@ -304,12 +264,12 @@ export class StackService {
 			);
 		});
 
-		// Tracks the previous StackDetails per stackId for amend detection.
+		// Tracks the previous stack per stackId for amend detection.
 		// A plain object is used so that entries for removed stacks are naturally
 		// dropped each time the snapshot is replaced (no manual cleanup needed).
 		// Scoped here rather than on the service instance so it is tied to the
 		// lifetime of this project session and not shared across project switches.
-		let prevInfoSnapshot: Record<string, StackDetails> = {};
+		let prevInfoSnapshot: Record<string, Stack> = {};
 
 		// Having lots of commits in a GitButler workspace is an extreme edge case that
 		// is not a realistic usage scenario. We skip selection repair at this scale to
@@ -326,21 +286,21 @@ export class StackService {
 				return;
 			}
 
-			const nextSnapshot: Record<string, StackDetails> = {};
+			const nextSnapshot: Record<string, Stack> = {};
 			stackIds.forEach((stackId, i) => {
-				const stackInfo = detailsData[i]?.stackInfo;
-				if (!stackInfo) return;
-				// Only run when the StackDetails object is actually new (different reference).
+				const stack = detailsData[i]?.stack;
+				if (!stack) return;
+				// Only run when the Stack object is actually new (different reference).
 				// During a re-fetch, RTK Query keeps the cached data object unchanged while
-				// isFetching=true, so stackInfo === prevInfo. Running updateStackSelection in
+				// isFetching=true, so stack === prevInfo. Running updateStackSelection in
 				// that window would see stale commit SHAs while selection.commitId may already
 				// hold the new SHA (set by the caller), incorrectly treating the amend as a
 				// deletion and clearing the drawer.
 				const prevInfo = prevInfoSnapshot[stackId];
-				if (stackInfo !== prevInfo) {
-					updateStackSelection(this.uiState, stackId, stackInfo, prevInfo);
+				if (stack !== prevInfo) {
+					updateStackSelection(this.uiState, stackId, stack, prevInfo);
 				}
-				nextSnapshot[stackId] = stackInfo;
+				nextSnapshot[stackId] = stack;
 			});
 			prevInfoSnapshot = nextSnapshot;
 		});
@@ -417,51 +377,6 @@ export class StackService {
 						);
 					});
 					return commitDetails.filter(isDefined);
-				},
-			},
-		);
-	}
-
-	upstreamCommits(projectId: string, stackId: string | undefined, branchName: string) {
-		return this.backendApi.endpoints.workspaceDetails.useQuery(
-			{ projectId },
-			{
-				transform: (workspaceDetails) => {
-					const details = selectWorkspaceStackDetails(workspaceDetails, stackId, branchName);
-					return (
-						details &&
-						branchDetailsSelectors.selectById(details.branchDetails, branchName)?.upstreamCommits
-					);
-				},
-			},
-		);
-	}
-
-	upstreamCommitAt(projectId: string, stackId: string, branchName: string, index: number) {
-		return this.backendApi.endpoints.workspaceDetails.useQuery(
-			{ projectId },
-			{
-				transform: (workspaceDetails) => {
-					const details = selectWorkspaceStackDetails(workspaceDetails, stackId, branchName);
-					return (
-						(details &&
-							branchDetailsSelectors.selectById(details.branchDetails, branchName)?.upstreamCommits[
-								index
-							]) ??
-						null
-					);
-				},
-			},
-		);
-	}
-
-	fetchUpstreamCommitById(projectId: string, stackId: string, commitId: string) {
-		return this.backendApi.endpoints.workspaceDetails.fetch(
-			{ projectId },
-			{
-				transform: (workspaceDetails) => {
-					const details = selectWorkspaceStackDetails(workspaceDetails, stackId);
-					return details && upstreamCommitSelectors.selectById(details.upstreamCommits, commitId);
 				},
 			},
 		);
@@ -819,9 +734,8 @@ export class StackService {
 			{
 				transform: (workspaceDetails) => {
 					const details = selectWorkspaceStackDetails(workspaceDetails, stackId, branchName);
-					return (
-						details && branchDetailsSelectors.selectById(details.branchDetails, branchName)?.commits
-					);
+					return details?.segments.find((segment) => segment.refName?.displayName === branchName)
+						?.commits;
 				},
 			},
 		);
@@ -850,20 +764,6 @@ export class StackService {
 		return await this.backendApi.endpoints.newBranchName.fetch(
 			{ projectId },
 			{ forceRefetch: true },
-		);
-	}
-
-	isBranchConflicted(projectId: string, stackId: string, branchName: string) {
-		return this.backendApi.endpoints.workspaceDetails.useQuery(
-			{ projectId },
-			{
-				transform: (workspaceDetails) => {
-					const details = selectWorkspaceStackDetails(workspaceDetails, stackId, branchName);
-					const branch =
-						details && branchDetailsSelectors.selectById(details.branchDetails, branchName);
-					return branch?.isConflicted ?? false;
-				},
-			},
 		);
 	}
 

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -86,30 +86,6 @@ export class StackService {
 		);
 	}
 
-	branchesPageStack(projectId: string, stackId: string, inWorkspace: boolean) {
-		if (inWorkspace) {
-			return this.stackById(projectId, stackId);
-		}
-		return this.backendApi.endpoints.stacks.useQuery(
-			{ projectId, all: true },
-			{
-				transform: (stacks) => stackSelectors.selectById(stacks, stackId) ?? null,
-			},
-		);
-	}
-
-	branchesPageBranchDetails(
-		projectId: string,
-		stackId: string,
-		branchName: string,
-		inWorkspace: boolean,
-	) {
-		if (inWorkspace) {
-			return this.branchDetails(projectId, stackId, branchName);
-		}
-		return this.unstackedBranchDetails(projectId, branchName);
-	}
-
 	defaultBranch(projectId: string, stackId?: string) {
 		if (!stackId) return null;
 		return this.backendApi.endpoints.workspaceDetails.useQuery(

--- a/apps/desktop/src/lib/stacks/staleStateUpdaters.test.ts
+++ b/apps/desktop/src/lib/stacks/staleStateUpdaters.test.ts
@@ -1,7 +1,7 @@
 import { updateStackSelection } from "$lib/stacks/staleStateUpdaters";
 import { describe, expect, test } from "vitest";
 import type { StackSelection, UiState } from "$lib/state/uiState.svelte";
-import type { StackDetails } from "@gitbutler/but-sdk";
+import type { Stack } from "@gitbutler/but-sdk";
 
 /**
  * Minimal mock of UiState that tracks the lane selection without Svelte reactivity.
@@ -28,30 +28,32 @@ function makeMockUiState(initialSelection: StackSelection | undefined): {
 	return { uiState, getSelection: () => selection };
 }
 
-/** Minimal StackDetails with just the fields updateStackSelection reads. */
+/** Minimal Stack with just the fields updateStackSelection reads. */
 function makeDetails(
 	branches: Array<{
 		name: string;
 		commits?: Array<{ id: string }>;
 		upstreamCommits?: Array<{ id: string }>;
 	}>,
-): StackDetails {
+): Stack {
 	return {
-		derivedName: "test-stack",
-		pushStatus: "nothingToPush",
-		isConflicted: false,
-		branchDetails: branches.map((b) => ({
-			name: b.name,
+		id: STACK_ID,
+		base: null,
+		segments: branches.map((b) => ({
+			refName: {
+				displayName: b.name,
+				fullNameBytes: [],
+			},
+			remoteTrackingRefName: null,
 			commits: (b.commits ?? []) as any,
-			upstreamCommits: (b.upstreamCommits ?? []) as any,
-			reference: `refs/heads/${b.name}`,
+			commitsOnRemote: (b.upstreamCommits ?? []) as any,
+			commitsOutside: null,
+			metadata: null,
+			isEntrypoint: false,
 			pushStatus: "nothingToPush",
-			isConflicted: false,
-			prNumber: undefined,
-			reviewId: undefined,
-			linkedTo: undefined,
+			base: null,
 		})),
-	} as unknown as StackDetails;
+	} as unknown as Stack;
 }
 
 const STACK_ID = "stack-1";

--- a/apps/desktop/src/lib/stacks/staleStateUpdaters.ts
+++ b/apps/desktop/src/lib/stacks/staleStateUpdaters.ts
@@ -1,3 +1,4 @@
+import { isDefined } from "@gitbutler/ui/utils/typeguards";
 import type {
 	ExclusiveAction,
 	WritableReactiveStore,
@@ -5,7 +6,7 @@ import type {
 	StackSelection,
 	UiState,
 } from "$lib/state/uiState.svelte";
-import type { StackDetails } from "@gitbutler/but-sdk";
+import type { Stack } from "@gitbutler/but-sdk";
 
 export function replaceBranchInExclusiveAction(
 	action: ExclusiveAction,
@@ -48,12 +49,12 @@ export function replaceBranchInStackSelection(
 export function updateStackSelection(
 	uiState: UiState,
 	stackId: string,
-	details: StackDetails,
-	prevDetails?: StackDetails,
+	stack: Stack,
+	prevStack?: Stack,
 ): void {
 	const laneState = uiState.lane(stackId);
 	const selection = laneState.selection.current;
-	const branches = details.branchDetails.map((branch) => branch.name);
+	const branches = stack.segments.map((segment) => segment.refName?.displayName).filter(isDefined);
 
 	// If no selection, do nothing
 	if (!selection) return;
@@ -68,30 +69,28 @@ export function updateStackSelection(
 	if (!selection.commitId) return;
 
 	const selectedBranch = selection.branchName;
-	const branchDetails = details.branchDetails.find((branch) => branch.name === selectedBranch);
+	const segment = stack.segments.find((segment) => segment.refName?.displayName === selectedBranch);
 
-	if (!branchDetails) {
+	if (!segment) {
 		// Should not happen since we already checked the branch exists
 		return;
 	}
 
-	const branchCommits = branchDetails.commits;
+	const branchCommits = segment.commits;
 	const branchCommitIds = branchCommits.map((commit) => commit.id);
 
 	// If the selected commit is not in the branch, it may have been amended (SHA changed)
 	// or deleted/squashed. Distinguish between the two using the previous state.
 	if (!selection.upstream && !branchCommitIds.includes(selection.commitId)) {
-		const prevBranchDetails = prevDetails?.branchDetails.find(
-			(branch) => branch.name === selectedBranch,
+		const prevSegment = prevStack?.segments.find(
+			(segment) => segment.refName?.displayName === selectedBranch,
 		);
-		const oldIndex = prevBranchDetails?.commits.findIndex(
-			(commit) => commit.id === selection.commitId,
-		);
+		const oldIndex = prevSegment?.commits.findIndex((commit) => commit.id === selection.commitId);
 
 		// If the commit existed at position N, the count stayed the same, and position N still
 		// exists, the commit was amended (same position, new SHA). Update the selection.
 		// A count decrease means the commit was truly deleted or squashed — clear it instead.
-		const sameCount = (prevBranchDetails?.commits.length ?? 0) === branchCommits.length;
+		const sameCount = (prevSegment?.commits.length ?? 0) === branchCommits.length;
 		if (oldIndex !== undefined && oldIndex !== -1 && oldIndex < branchCommits.length && sameCount) {
 			laneState.selection.set({ ...selection, commitId: branchCommits[oldIndex]!.id });
 			return;
@@ -106,7 +105,7 @@ export function updateStackSelection(
 		return;
 	}
 
-	const upstreamCommits = branchDetails.upstreamCommits;
+	const upstreamCommits = segment.commitsOnRemote;
 	const upstreamCommitIds = upstreamCommits.map((commit) => commit.id);
 
 	// If the selection is for an upstream commit and the commit is not in the upstream commits, clear the selection

--- a/apps/desktop/src/lib/telemetry/posthog.ts
+++ b/apps/desktop/src/lib/telemetry/posthog.ts
@@ -109,9 +109,7 @@ type EventDescription = {
 	command: string;
 };
 
-const HIGH_VOLUME_EVENTS: EventDescription[] = [
-	{ name: "tauri_command", command: "stack_details" },
-];
+const HIGH_VOLUME_EVENTS: EventDescription[] = [{ name: "tauri_command", command: "head_info" }];
 
 const MID_VOLUME_EVENTS: EventDescription[] = [
 	{ name: "tauri_command", command: "get_base_branch_data" },

--- a/apps/desktop/src/lib/testing/mockStackService.ts
+++ b/apps/desktop/src/lib/testing/mockStackService.ts
@@ -53,6 +53,10 @@ export function getStackServiceMock() {
 	StackServiceMock.prototype.stacks = vi.fn();
 	StackServiceMock.prototype.stackAt = vi.fn();
 	StackServiceMock.prototype.stackById = vi.fn();
+	StackServiceMock.prototype.branchesPageStack = vi.fn();
+	StackServiceMock.prototype.branchesPageBranchDetails = vi.fn(() => {
+		return reactive(() => mockReduxFulfilled(BRANCH_DETAILS_A));
+	});
 	StackServiceMock.prototype.defaultBranch = vi.fn();
 	StackServiceMock.prototype.branchDetails = vi.fn(() => {
 		return reactive(() => mockReduxFulfilled(BRANCH_DETAILS_A));

--- a/apps/desktop/src/lib/testing/mockStackService.ts
+++ b/apps/desktop/src/lib/testing/mockStackService.ts
@@ -53,10 +53,6 @@ export function getStackServiceMock() {
 	StackServiceMock.prototype.stacks = vi.fn();
 	StackServiceMock.prototype.stackAt = vi.fn();
 	StackServiceMock.prototype.stackById = vi.fn();
-	StackServiceMock.prototype.branchesPageStack = vi.fn();
-	StackServiceMock.prototype.branchesPageBranchDetails = vi.fn(() => {
-		return reactive(() => mockReduxFulfilled(BRANCH_DETAILS_A));
-	});
 	StackServiceMock.prototype.defaultBranch = vi.fn();
 	StackServiceMock.prototype.branchDetails = vi.fn(() => {
 		return reactive(() => mockReduxFulfilled(BRANCH_DETAILS_A));

--- a/crates/gitbutler-branch-actions/Cargo.toml
+++ b/crates/gitbutler-branch-actions/Cargo.toml
@@ -70,6 +70,7 @@ glob = "0.3.3"
 tempfile.workspace = true
 but-hunk-assignment.workspace = true
 ctor = "0.6.3"
+insta.workspace = true
 
 [lints]
 workspace = true

--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -62,29 +62,33 @@ pub fn list_branches(
     }
 
     let remote_names = repo.remote_names();
-    let mut workspace_target_ref_name = None;
-    let stacks = {
-        if let Some(workspace_ref) = repo.try_find_reference(WORKSPACE_REF_NAME)? {
-            // Let's get this here for convenience, and hope this isn't ever called by a writer (or there will be a deadlock).
-            let meta = ctx.meta()?;
-            workspace_target_ref_name = meta.workspace(workspace_ref.name())?.target_ref.clone();
-            let info = but_workspace::ref_info(
-                workspace_ref,
-                &meta,
-                but_workspace::ref_info::Options {
-                    traversal: but_graph::init::Options::limited(),
-                    expensive_commit_info: false,
-                    ..Default::default()
-                },
-            )?;
-            info.stacks
-                .into_iter()
-                .filter_map(|s| GitButlerStack::try_new(s, &remote_names).transpose())
-                .collect::<Result<Vec<_>, _>>()?
-        } else {
-            Vec::new()
-        }
+    let meta = ctx.meta()?;
+    let gerrit_mode_enabled = repo.git_settings()?.gitbutler_gerrit_mode.unwrap_or(false);
+    let db = gerrit_mode_enabled
+        .then(|| ctx.db.get_cache())
+        .transpose()?;
+    let gerrit_mode = match db.as_ref() {
+        Some(db) => but_workspace::ref_info::GerritMode::Enabled(db.gerrit_metadata()),
+        None => but_workspace::ref_info::GerritMode::Disabled,
     };
+
+    // This head_info call is intended to match the but-api head_info, such that
+    // the current tauri frontend can look them up consistently.
+    let info = but_workspace::head_info(
+        &repo,
+        &meta,
+        but_workspace::ref_info::Options {
+            traversal: but_graph::init::Options::limited(),
+            expensive_commit_info: false,
+            gerrit_mode,
+        },
+    )?;
+    let stacks = info
+        .stacks
+        .into_iter()
+        .filter_map(|s| GitButlerStack::try_new(s, &remote_names).transpose())
+        .collect::<Result<Vec<_>, _>>()?;
+    let workspace_target_ref_name = info.target_ref.map(|r| r.ref_name);
 
     branches.extend(stacks.iter().map(|s| GroupBranch::Virtual(s.clone())));
     let target_ref_name = if let Some(target_ref_name) = workspace_target_ref_name {

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/list_details.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/list_details.rs
@@ -1,3 +1,4 @@
+use but_testsupport::visualize_commit_graph_all;
 use gitbutler_branch_actions::BranchListingDetails;
 
 use crate::virtual_branches::list;
@@ -8,20 +9,35 @@ fn one_vbranch_in_workspace_empty_details() -> anyhow::Result<()> {
         &list::project_ctx("one-vbranch-in-workspace")?,
         Some("virtual"),
     )?;
-    assert_eq!(list.len(), 1);
-    assert_eq!(
-        list[0],
+
+    insta::assert_debug_snapshot!(list, @r#"
+    [
         BranchListingDetails {
-            name: "virtual".into(),
+            name: BranchIdentity(
+                PartialName(
+                    "virtual",
+                ),
+            ),
             lines_added: 0,
             lines_removed: 0,
             number_of_files: 0,
             number_of_commits: 0,
-            authors: vec![],
-            stack: list[0].stack.clone()
-        }
-    );
-    assert!(list[0].stack.is_some());
+            authors: [],
+            stack: Some(
+                StackReference {
+                    given_name: "virtual",
+                    id: 00000000-0000-0000-0000-000000000001,
+                    in_workspace: true,
+                    branches: [
+                        "virtual",
+                    ],
+                    pull_requests: {},
+                },
+            ),
+        },
+    ]
+    "#);
+
     Ok(())
 }
 
@@ -52,33 +68,120 @@ fn one_vbranch_in_workspace_single_commit() -> anyhow::Result<()> {
 fn many_commits_in_all_branch_types() -> anyhow::Result<()> {
     let ctx = project_ctx("complex-repo")?;
     let list = branch_details(&ctx, ["feature", "non-virtual-feature"])?;
-    assert_eq!(list.len(), 2);
-    assert_eq!(
-        list[0],
+    let repo = ctx.repo.get()?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * 010a408 (feature) feat-10
+    * 0321c2d feat-9
+    * 0418d31 feat-8
+    * a06934b feat-7
+    * 76f0b9e feat-6
+    * f733b14 feat-5
+    * 814f19d feat-4
+    * a6687e9 feat-3
+    * 30d2a44 feat-2
+    * 494ba0f feat-1
+    | * 1f13cc4 (gitbutler/workspace) GitButler Workspace Commit
+    | * f179ebf (origin/main, origin/HEAD, a-branch-1) virt-3
+    | * 56122fd virt-2
+    | * 00ca34e virt-1
+    |/  
+    | * 21f9396 (HEAD -> non-virtual-feature) non-virtual-feat-10
+    | * f721808 non-virtual-feat-9
+    | * bcb3226 non-virtual-feat-8
+    | * fa23cf8 non-virtual-feat-7
+    | * 350bf8a non-virtual-feat-6
+    | * 39192f7 non-virtual-feat-5
+    | * 40a444b non-virtual-feat-4
+    | * 0996ec4 non-virtual-feat-3
+    | * 1562511 non-virtual-feat-2
+    | * 15264e2 non-virtual-feat-1
+    |/  
+    * c214aea (main) main-5
+    * 0223093 main-4
+    * a6590f8 main-3
+    * 9ade221 main-2
+    * eeb938e main-1
+    * 9483946 init
+    ");
+
+    insta::assert_debug_snapshot!(list, @r#"
+    [
         BranchListingDetails {
-            name: "feature".into(),
+            name: BranchIdentity(
+                PartialName(
+                    "feature",
+                ),
+            ),
             lines_added: 10,
             lines_removed: 0,
             number_of_files: 1,
             number_of_commits: 10,
-            authors: vec![default_author()],
-            stack: None
+            authors: [
+                Author {
+                    name: Some(
+                        BStringForFrontend(
+                            "author",
+                        ),
+                    ),
+                    email: Some(
+                        BStringForFrontend(
+                            "author@example.com",
+                        ),
+                    ),
+                    gravatar_url: Some(
+                        BStringForFrontend(
+                            "https://www.gravatar.com/avatar/5c1e6d6e64e12aca17657581a48005d1?s=100&r=g&d=retro",
+                        ),
+                    ),
+                },
+            ],
+            stack: None,
         },
-        "local branches use the *current* local tracking branch…"
-    );
-    assert_eq!(
-        list[1],
         BranchListingDetails {
-            name: "non-virtual-feature".into(),
+            name: BranchIdentity(
+                PartialName(
+                    "non-virtual-feature",
+                ),
+            ),
             lines_added: 10,
             lines_removed: 0,
             number_of_files: 1,
             number_of_commits: 10,
-            authors: vec![default_author()],
-            stack: None
+            authors: [
+                Author {
+                    name: Some(
+                        BStringForFrontend(
+                            "author",
+                        ),
+                    ),
+                    email: Some(
+                        BStringForFrontend(
+                            "author@example.com",
+                        ),
+                    ),
+                    gravatar_url: Some(
+                        BStringForFrontend(
+                            "https://www.gravatar.com/avatar/5c1e6d6e64e12aca17657581a48005d1?s=100&r=g&d=retro",
+                        ),
+                    ),
+                },
+            ],
+            stack: Some(
+                StackReference {
+                    given_name: "non-virtual-feature",
+                    id: 00000000-0000-0000-0000-000000000001,
+                    in_workspace: true,
+                    branches: [
+                        "non-virtual-feature",
+                    ],
+                    pull_requests: {},
+                },
+            ),
         },
-        "This is a non-virtual branch, so it sees the local tracking branch as well"
-    );
+    ]
+    "#);
+
     Ok(())
 }
 

--- a/crates/gitbutler-tauri/permissions/default.toml
+++ b/crates/gitbutler-tauri/permissions/default.toml
@@ -186,8 +186,6 @@ commands.allow = [
   "show_graph_svg",
   "show_in_finder",
   "snapshot_diff",
-  "stack_details",
-  "stacks",
   "stash_into_branch",
   "store_author_globally_if_unset",
   "store_github_enterprise_pat",

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -405,8 +405,6 @@ fn main() -> anyhow::Result<()> {
                 legacy::rules::tauri_update_workspace_rule::update_workspace_rule,
                 legacy::rules::tauri_list_workspace_rules::list_workspace_rules,
                 legacy::workspace::tauri_head_info::head_info,
-                legacy::workspace::tauri_stacks::stacks,
-                legacy::workspace::tauri_stack_details::stack_details,
                 legacy::workspace::tauri_branch_details::branch_details,
                 legacy::workspace::tauri_discard_worktree_changes::discard_worktree_changes,
                 legacy::workspace::tauri_stash_into_branch::stash_into_branch,

--- a/packages/but-sdk/src/test.ts
+++ b/packages/but-sdk/src/test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
-import { listProjectsStatelessNapi, stackDetailsNapi, stacksNapi } from "./generated/index.js";
+import { headInfo, listProjectsStateless } from "./generated/index.js";
 
 async function main() {
-	const projects = await listProjectsStatelessNapi();
+	const projects = await listProjectsStateless();
 	console.log(projects);
 
 	if (projects.length === 0) {
@@ -12,12 +12,8 @@ async function main() {
 	const project = projects.at(0);
 	if (!project) throw new Error("The world is wrong");
 
-	const stacks = await stacksNapi(project.id, null);
-	for (const stack of stacks) {
-		const details = await stackDetailsNapi(project.id, stack.id);
-		console.log("This are the details for stack with id: " + stack.id);
-		console.log(details);
-	}
+	const info = await headInfo(project.id);
+	console.log(info);
 }
 
 main();


### PR DESCRIPTION
We still need some usage of `stacks` for the branch listing page AFAIK, but using `head_info` for the main projection is a big help since it avoids the issues with some strange inconsistency issues between `stack_details` and `stacks`.