### PR TITLE
Handle gb-local target refs at branch tips

### DIFF
--- a/crates/but/tests/but/command/merge.rs
+++ b/crates/but/tests/but/command/merge.rs
@@ -135,3 +135,73 @@ To undo this operation:
 
     Ok(())
 }
+
+#[test]
+fn pull_integrates_branch_when_gb_local_target_points_at_branch_head() -> anyhow::Result<()> {
+    let env = Sandbox::open_with_default_settings("merge-gb-local-two-branches")?;
+
+    env.but("setup").assert().success();
+    env.but("branch new first-branch").assert().success();
+
+    env.file("file1.txt", "content1");
+    env.but("commit first-branch -m 'first commit on branch A'")
+        .assert()
+        .success();
+
+    let branch_head = env.invoke_git("rev-parse first-branch");
+    let main_before = env.invoke_git("rev-parse main");
+    assert_ne!(
+        branch_head, main_before,
+        "test setup must leave main behind the virtual branch"
+    );
+
+    env.invoke_git("update-ref refs/heads/main first-branch");
+
+    env.but("pull").assert().success().stdout_eq(str![[r#"
+
+Found 1 upstream commits on gb-local/main
+   [..] first commit on branch A
+
+Updating 1 active branches...
+
+
+Branch first-branch has been integrated upstream and removed locally
+
+Summary
+────────
+  first-branch - integrated
+
+To undo this operation:
+  Run `but undo`
+
+"#]]);
+
+    let main_after = env.invoke_git("rev-parse main");
+    assert_eq!(
+        main_after, branch_head,
+        "main should still point at the manually integrated branch head"
+    );
+
+    let status_after = env
+        .but("status --json")
+        .allow_json()
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let status_after_str = String::from_utf8_lossy(&status_after);
+    let status_after_json: serde_json::Value = serde_json::from_str(&status_after_str)?;
+    assert_eq!(
+        status_after_json["stacks"].as_array().unwrap().len(),
+        0,
+        "the branch should be removed from the workspace after base integration"
+    );
+    assert_eq!(
+        status_after_json["upstreamState"]["behind"].as_u64(),
+        Some(0),
+        "the stored base should be advanced to the updated gb-local target"
+    );
+
+    Ok(())
+}

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -373,12 +373,16 @@ pub(crate) fn target_to_base_branch(
     let target_sha_ahead_of_ref = !target_sha_not_ref.is_empty();
 
     // The longest first-parent list of upstream commit ids.
-    let upstream_commit_ids = ws
+    let mut upstream_commit_ids = ws
         .upstream_commits(repo, target_ref_name.as_ref(), FirstParent::Yes)?
         .into_iter()
         .map(|h| h.upstream_commits)
         .max_by_key(|us| us.len())
         .unwrap_or_default();
+    if upstream_commit_ids.is_empty() && target_ref_commit_id != target.sha {
+        upstream_commit_ids = first_parent_commit_ids_until(repo, target_ref_commit_id, target.sha)
+            .context("failed to get target commits since stored base")?;
+    }
 
     let upstream_commits = upstream_commit_ids
         .iter()

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -236,7 +236,7 @@ impl<'a> UpstreamIntegrationContext<'a> {
             )?;
         }
 
-        let (target_ref_name, old_target_id, upstream_commits) = {
+        let (target_ref_name, old_target_id, mut upstream_commits) = {
             let (repo, ws, _db) = ctx.workspace_and_db_with_perm(permission.read_permission())?;
             let target_ref_name = ws
                 .target_ref_name()
@@ -265,6 +265,10 @@ impl<'a> UpstreamIntegrationContext<'a> {
                     .id
             }
         };
+        if upstream_commits.is_empty() && new_target != old_target_id {
+            upstream_commits = first_parent_commit_ids_until(gix_repo, new_target, old_target_id)
+                .context("failed to get target commits since stored base")?;
+        }
 
         let stacks_in_workspace = stacks(ctx, gix_repo)?;
 


### PR DESCRIPTION
## Summary

Fix `but pull` for the `gb-local` target case where the target ref has been manually advanced to the head of an applied virtual branch. Previously, the branch could look integrated, but the upstream walk was empty because the target tip was hidden by the workspace stack head, so the stored base was not advanced.

This adds a fallback that walks the target ref from its current tip back to the stored workspace base when the workspace-hidden upstream walk is empty, and keeps the displayed base-branch behind count consistent with the integration path.