### PR TITLE
feat: add but-transaction crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,6 +812,7 @@ dependencies = [
  "but-cherry-apply",
  "but-core",
  "but-ctx",
+ "but-db",
  "but-forge",
  "but-forge-storage",
  "but-gerrit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,6 +829,7 @@ dependencies = [
  "but-server",
  "but-settings",
  "but-testsupport",
+ "but-transaction",
  "but-update",
  "but-workspace",
  "but-worktrees",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1642,6 +1642,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "but-transaction"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "bstr",
+ "but-api",
+ "but-core",
+ "but-ctx",
+ "but-oplog",
+ "but-rebase",
+ "but-testsupport",
+ "but-workspace",
+ "gix",
+ "snapbox",
+]
+
+[[package]]
 name = "but-ts"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ members = [
     "crates/but-irc", # 📄IRC client with WebSocket transport and GitButler protocol support.
     # 👉Experimental; needs docs, it's used from `but` CLI and not a library
     "crates/but-agentlog",       # 📄Capture coding-agent logs into Git metadata.
+    "crates/but-transaction", # 📄TBD
 
     ##
     ### Soon obsolete
@@ -184,6 +185,7 @@ but-oplog = { path = "crates/but-oplog" }
 but-llm = { path = "crates/but-llm" }
 but-server = { path = "crates/but-server" }
 but-agentlog = { path = "crates/but-agentlog" }
+but-transaction = { path = "crates/but-transaction" }
 
 gitbutler-git = { path = "crates/gitbutler-git" }
 gitbutler-watcher = { path = "crates/gitbutler-watcher" }

--- a/crates/but-api/src/workspace_state.rs
+++ b/crates/but-api/src/workspace_state.rs
@@ -53,7 +53,7 @@ impl WorkspaceState {
     ///
     /// The `replaced_commits` map should describe the commit rewrites visible in the
     /// preview graph, which typically comes from `rebase.history.commit_mappings()`.
-    pub(crate) fn from_rebase_preview<M: RefMetadata>(
+    pub fn from_rebase_preview<M: RefMetadata>(
         rebase: &SuccessfulRebase<'_, '_, M>,
         replaced_commits: BTreeMap<gix::ObjectId, gix::ObjectId>,
     ) -> anyhow::Result<WorkspaceState> {
@@ -66,13 +66,13 @@ impl WorkspaceState {
 
     /// Build a [`WorkspaceState`] from a successful rebase, materializing it when needed.
     ///
-    /// Use this as the default entry point when an operation ends with a
-    /// [`SuccessfulRebase`] and the API should return the resulting workspace state.
-    /// When `dry_run` is `true`, this delegates to [`from_rebase_preview`] so the caller
-    /// sees the projected state without changing the repository. Otherwise it
-    /// materializes the rebase, then reports the workspace state together with the final
-    /// commit-replacement mappings returned by the materialized history.
-    pub(crate) fn from_successful_rebase<M: RefMetadata>(
+    /// Use this as the default entry point when an operation ends with a [`SuccessfulRebase`] and
+    /// the API should return the resulting workspace state. When `dry_run` is `true`, this
+    /// delegates to [`WorkspaceState::from_rebase_preview`] so the caller sees the projected state
+    /// without changing the repository. Otherwise it materializes the rebase, then reports the
+    /// workspace state together with the final commit-replacement mappings returned by the
+    /// materialized history.
+    pub fn from_successful_rebase<M: RefMetadata>(
         rebase: SuccessfulRebase<'_, '_, M>,
         repo: &gix::Repository,
         dry_run: DryRun,

--- a/crates/but-transaction/Cargo.toml
+++ b/crates/but-transaction/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "but-transaction"
+version = "0.0.0"
+edition.workspace = true
+authors.workspace = true
+publish = false
+rust-version.workspace = true
+
+[lib]
+doctest = true
+
+[dependencies]
+but-api.workspace = true
+but-ctx.workspace = true
+but-oplog.workspace = true
+but-core.workspace = true
+but-workspace.workspace = true
+but-rebase.workspace = true
+
+gix.workspace = true
+anyhow.workspace = true
+bstr.workspace = true
+
+[dev-dependencies]
+but-api = { workspace = true, features = ["legacy"] }
+but-testsupport = { workspace = true, features = ["sandbox-but-api"] }
+
+snapbox = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/but-transaction/src/lib.rs
+++ b/crates/but-transaction/src/lib.rs
@@ -1,0 +1,399 @@
+use std::collections::BTreeMap;
+
+use bstr::BStr;
+use but_api::WorkspaceState;
+use but_core::{DiffSpec, DryRun, RefMetadata, tree::create_tree::RejectionReason};
+use but_ctx::Context;
+use but_oplog::legacy::SnapshotDetails;
+use but_rebase::graph_rebase::{
+    Editor, LookupStep as _, SuccessfulRebase,
+    mutate::{InsertSide, RelativeTo},
+};
+use but_workspace::commit::{SquashCommitsOutcome, squash_commits::MessageCombinationStrategy};
+use gix::{ObjectId, refs::FullNameRef};
+
+#[cfg(test)]
+mod tests;
+
+/// Run a workspace transaction.
+///
+/// This allows chaining multiple operations and having them all succeed or fail together.
+///
+/// Note this isn't fully ACID compliant database transactions but rather a "best effort" version
+/// using our in-memory repositories and rebases.
+///
+/// # Committing
+///
+/// The transaction will be committed if:
+///
+/// - The callback doesn't return an error.
+/// - The success value is either `()` or [`DynamicOutcome::Commit`].
+///
+/// Use [`DynamicOutcome::Rollback`] to conditionally rollback the transaction without returning
+/// an error.
+///
+/// Use [`Transaction::rollback`] to rollback unconditionally without returning an error.
+///
+/// When the transaction is committed a single oplog entry with `snapshot_details` will be created.
+/// This enables a single `but undo` to undo the whole transaction.
+///
+/// # Commit mapping
+///
+/// The transaction will automatically map between source commits and rebased commits in the
+/// in-memory repository.
+///
+/// For example this means commits can be squashed like this:
+///
+/// ```ignore
+/// tx.squash_commits([source_one], target)?;
+/// tx.squash_commits([source_two], target)?;
+/// tx.squash_commits([source_three], target)?;
+/// ```
+///
+/// The SHA for `target` will change after the first squash which would normally require looking up
+/// the new SHA to perform the second squash. `Transaction` does this automatically so callers can
+/// continue using the source commits.
+///
+/// Commits can still manually be mapped using [`Transaction::get_mapped_commit`] if necessary.
+pub fn with_transaction<M, F, T>(
+    ctx: &mut Context,
+    meta: &mut M,
+    snapshot_details: SnapshotDetails,
+    dry_run: DryRun,
+    f: F,
+) -> anyhow::Result<T::Outcome>
+where
+    F: FnOnce(Transaction<'_, '_, M>) -> anyhow::Result<T>,
+    M: RefMetadata,
+    T: TransactionOutcome,
+{
+    let mut guard = ctx.exclusive_worktree_access();
+    let perm = guard.write_permission();
+
+    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
+        ctx,
+        snapshot_details,
+        perm.read_permission(),
+        dry_run,
+    );
+
+    let context_lines = ctx.settings.context_lines;
+    let (repo, mut ws, _db) = ctx.workspace_mut_and_db_with_perm(perm)?;
+
+    let editor = Editor::create(&mut ws, meta, &repo)?;
+    let rebase = editor.rebase()?;
+
+    let mut inner = Inner {
+        rebase: Some(rebase),
+        commit_mappings: CommitMappings::default(),
+        context_lines,
+    };
+
+    let callback_outcome = {
+        let tx = Transaction { inner: &mut inner };
+        f(tx)?
+    };
+
+    let rebase = inner.rebase.take().expect("rebase is always Some(_)");
+    let should_rollback = callback_outcome.should_rollback();
+
+    let outcome = callback_outcome.maybe_commit(&repo, rebase, dry_run)?;
+
+    if !should_rollback && let Some(snapshot) = maybe_oplog_entry {
+        snapshot.commit(ctx, perm)?;
+    }
+
+    Ok(outcome)
+}
+
+/// A workspace transaction that allows changing multiple operations and having them all succeed or
+/// fail together.
+///
+/// See [`with_transaction`] for more details.
+pub struct Transaction<'inner, 'rebase, M>
+where
+    M: RefMetadata,
+{
+    // Store a mutable reference so the callback for `with_transaction` can get an owned
+    // `Transaction`. It needs to be owned to verify statically that `Transaction::rollback` is
+    // only called once.
+    inner: &'inner mut Inner<'rebase, M>,
+}
+
+struct Inner<'rebase, M>
+where
+    M: RefMetadata,
+{
+    // an Option so we can "take" the rebase, convert it into an editor, perform another rebase,
+    // and put the result back.
+    rebase: Option<SuccessfulRebase<'rebase, 'rebase, M>>,
+    // Commits given to `squash_commits`, `reword_commit`, etc are allowed to be the original
+    // commits from live repo. This is used to map those to the rebased in-memory commits.
+    //
+    // Doing this mapping automatically makes the API simpler for the callers because they don't
+    // need to map commits after each operation.
+    commit_mappings: CommitMappings,
+    context_lines: u32,
+}
+
+impl<'rebase, M> Transaction<'_, 'rebase, M>
+where
+    M: RefMetadata,
+{
+    /// Rollback the transaction, without returning an error.
+    ///
+    /// If the transaction needs to be rolled back conditionally use [`DynamicOutcome::Rollback`].
+    // TODO(david): not sure if we actually need this
+    pub fn rollback<T>(self, outcome: T) -> Rollback<T> {
+        Rollback(outcome)
+    }
+
+    pub fn squash_commits(
+        &mut self,
+        subjects: impl IntoIterator<Item = ObjectId>,
+        target: ObjectId,
+        how_to_combine_messages: MessageCombinationStrategy,
+    ) -> anyhow::Result<ObjectId> {
+        self.rebase(|editor, commit_mappings| {
+            let SquashCommitsOutcome {
+                rebase,
+                commit_selector,
+            } = but_workspace::commit::squash_commits(
+                editor,
+                subjects
+                    .into_iter()
+                    .map(|commit| commit_mappings.map(commit))
+                    .collect(),
+                commit_mappings.map(target),
+                how_to_combine_messages,
+            )?;
+            let new_commit = rebase.lookup_pick(commit_selector)?;
+            Ok((new_commit, rebase))
+        })
+    }
+
+    pub fn reword_commit(&mut self, commit: ObjectId, message: &BStr) -> anyhow::Result<ObjectId> {
+        self.rebase(|editor, commit_mappings| {
+            let (rebase, edited_commit_selector) =
+                but_workspace::commit::reword(editor, commit_mappings.map(commit), message)?;
+            let new_commit = rebase.lookup_pick(edited_commit_selector)?;
+            Ok((new_commit, rebase))
+        })
+    }
+
+    pub fn discard_commits(
+        &mut self,
+        subjects: impl IntoIterator<Item = gix::ObjectId>,
+    ) -> anyhow::Result<()> {
+        self.rebase(|editor, commit_mappings| {
+            let rebase = but_workspace::commit::discard_commits(
+                editor,
+                subjects
+                    .into_iter()
+                    .map(|commit| commit_mappings.map(commit)),
+            )?;
+            Ok(((), rebase))
+        })
+    }
+
+    pub fn remove_reference(&mut self, ref_name: &FullNameRef) -> anyhow::Result<()> {
+        self.rebase(|mut editor, _| {
+            let selector = editor.select_reference(ref_name)?;
+            editor.replace(selector, but_rebase::graph_rebase::Step::None)?;
+            let rebase = editor.rebase()?;
+            Ok(((), rebase))
+        })
+    }
+
+    pub fn create_commit(
+        &mut self,
+        relative_to: RelativeTo,
+        side: InsertSide,
+        changes: Vec<DiffSpec>,
+        message: String,
+    ) -> anyhow::Result<IntermediateCommitCreateResult> {
+        let context_lines = self.inner.context_lines;
+        self.rebase(|editor, commit_mappings| {
+            let relative_to = match relative_to {
+                RelativeTo::Commit(object_id) => RelativeTo::Commit(commit_mappings.map(object_id)),
+                RelativeTo::Reference(full_name) => RelativeTo::Reference(full_name),
+            };
+
+            let but_workspace::commit::CommitCreateOutcome {
+                rebase,
+                commit_selector,
+                rejected_specs,
+            } = but_workspace::commit::commit_create(
+                editor,
+                changes,
+                relative_to,
+                side,
+                &message,
+                context_lines,
+            )?;
+
+            let new_commit = commit_selector
+                .map(|commit_selector| rebase.lookup_pick(commit_selector))
+                .transpose()?;
+
+            Ok((
+                IntermediateCommitCreateResult {
+                    new_commit,
+                    rejected_specs,
+                },
+                rebase,
+            ))
+        })
+    }
+
+    /// Look up a commit that has been rewritten as part of a rebase.
+    ///
+    /// In most cases this shouldn't be necessary. See [`with_transaction`] for more details.
+    pub fn get_mapped_commit(&self, original_commit: ObjectId) -> Option<ObjectId> {
+        self.inner.commit_mappings.try_map(original_commit)
+    }
+
+    /// Returns the in-memory repository that backs this transaction.
+    pub fn repo(&self) -> &gix::Repository {
+        self.inner
+            .rebase
+            .as_ref()
+            .expect("rebase is always Some(_)")
+            .repo()
+    }
+
+    pub fn context_lines(&self) -> u32 {
+        self.inner.context_lines
+    }
+
+    fn rebase<F, T>(&mut self, f: F) -> anyhow::Result<T>
+    where
+        F: FnOnce(
+            Editor<'rebase, 'rebase, M>,
+            &CommitMappings,
+        ) -> anyhow::Result<(T, SuccessfulRebase<'rebase, 'rebase, M>)>,
+    {
+        let editor = self
+            .inner
+            .rebase
+            .take()
+            .expect("rebase is always Some(_)")
+            .into_editor();
+        let (outcome, new_rebase) = f(editor, &self.inner.commit_mappings)?;
+        self.inner.commit_mappings = CommitMappings(new_rebase.history.commit_mappings());
+        self.inner.rebase = Some(new_rebase);
+        Ok(outcome)
+    }
+}
+
+#[derive(Debug, Default)]
+struct CommitMappings(BTreeMap<gix::ObjectId, gix::ObjectId>);
+
+impl CommitMappings {
+    fn map(&self, commit: ObjectId) -> ObjectId {
+        self.try_map(commit).unwrap_or(commit)
+    }
+
+    fn try_map(&self, commit: ObjectId) -> Option<ObjectId> {
+        self.0.get(&commit).copied()
+    }
+}
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for () {}
+    impl<T> Sealed for super::Rollback<T> {}
+    impl<T, K> Sealed for super::DynamicOutcome<T, K> {}
+}
+
+pub trait TransactionOutcome: sealed::Sealed {
+    type Outcome;
+
+    fn should_rollback(&self) -> bool;
+
+    fn maybe_commit<M: RefMetadata>(
+        self,
+        repo: &gix::Repository,
+        rebase: SuccessfulRebase<'_, '_, M>,
+        dry_run: DryRun,
+    ) -> anyhow::Result<Self::Outcome>;
+}
+
+impl TransactionOutcome for () {
+    type Outcome = WorkspaceState;
+
+    fn should_rollback(&self) -> bool {
+        false
+    }
+
+    fn maybe_commit<M: RefMetadata>(
+        self,
+        repo: &gix::Repository,
+        rebase: SuccessfulRebase<'_, '_, M>,
+        dry_run: DryRun,
+    ) -> anyhow::Result<Self::Outcome> {
+        WorkspaceState::from_successful_rebase(rebase, repo, dry_run)
+    }
+}
+
+/// Statically roll back the current transaction.
+#[must_use = "`Rollback` must be returned from `with_transaction` for the transaction to be rolled back"]
+pub struct Rollback<T>(T);
+
+impl<T> TransactionOutcome for Rollback<T> {
+    type Outcome = T;
+
+    fn should_rollback(&self) -> bool {
+        true
+    }
+
+    fn maybe_commit<M: RefMetadata>(
+        self,
+        _repo: &gix::Repository,
+        _rebase: SuccessfulRebase<'_, '_, M>,
+        _dry_run: DryRun,
+    ) -> anyhow::Result<Self::Outcome> {
+        Ok(self.0)
+    }
+}
+
+/// Dynamically either commit or roll back the current transaction.
+#[must_use = "`DynamicOutcome` must be returned from `with_transaction` otherwise the transaction will be committed"]
+pub enum DynamicOutcome<T, K> {
+    Commit(T),
+    Rollback(K),
+}
+
+impl<T, K> TransactionOutcome for DynamicOutcome<T, K> {
+    type Outcome = DynamicOutcome<(T, WorkspaceState), K>;
+
+    fn should_rollback(&self) -> bool {
+        matches!(self, Self::Rollback(_))
+    }
+
+    fn maybe_commit<M: RefMetadata>(
+        self,
+        repo: &gix::Repository,
+        rebase: SuccessfulRebase<'_, '_, M>,
+        dry_run: DryRun,
+    ) -> anyhow::Result<Self::Outcome> {
+        match self {
+            DynamicOutcome::Commit(value) => {
+                let workspace = WorkspaceState::from_successful_rebase(rebase, repo, dry_run)?;
+                Ok(DynamicOutcome::Commit((value, workspace)))
+            }
+            DynamicOutcome::Rollback(value) => Ok(DynamicOutcome::Rollback(value)),
+        }
+    }
+}
+
+/// Intermediate outcome after creating a commit.
+///
+/// It is intermediate in the sense that the commit hasn't been materialized yet and only exists
+/// in-memory.
+pub struct IntermediateCommitCreateResult {
+    /// If the commit was successfully created. This should only be none if all the DiffSpecs were rejected.
+    pub new_commit: Option<gix::ObjectId>,
+    /// Any specs that failed to be committed.
+    pub rejected_specs: Vec<(RejectionReason, DiffSpec)>,
+}

--- a/crates/but-transaction/src/tests.rs
+++ b/crates/but-transaction/src/tests.rs
@@ -1,0 +1,292 @@
+use but_api::WorkspaceState;
+use but_core::DryRun;
+use but_ctx::Context;
+use but_oplog::legacy::{OperationKind, SnapshotDetails};
+use but_testsupport::Sandbox;
+use but_workspace::commit::squash_commits::MessageCombinationStrategy;
+use gix::{ObjectId, refs::FullName};
+
+use crate::{DynamicOutcome, with_transaction};
+
+// TODO(david): shared.sh is copy-pasted from but tests
+
+#[track_caller]
+fn find_commits<const N: usize>(env: &Sandbox, commits: [&str; N]) -> [ObjectId; N] {
+    let repo = env.open_repo().unwrap();
+    commits.map(|commit| repo.rev_parse_single(commit).unwrap().detach())
+}
+
+#[track_caller]
+fn assert_num_snapshots(ctx: &Context, expected: usize) {
+    assert_eq!(
+        expected,
+        but_api::legacy::oplog::snapshots_iter(ctx, None, None, None)
+            .unwrap()
+            .count(),
+    );
+}
+
+#[test]
+fn squashing_three_commits() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    let [three, two, one] = find_commits(&env, ["1e25c58", "9b3b3d5", "dbdbcea"]);
+
+    let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
+    let mut ctx = Context::from_repo(repo)
+        .map(Context::with_memory_app_cache)
+        .unwrap();
+
+    assert_num_snapshots(&ctx, 0);
+
+    let mut meta = ctx.meta().unwrap();
+    let snapshot_details = SnapshotDetails::new(OperationKind::SquashCommit);
+
+    let _must_return_workspace: WorkspaceState = with_transaction(
+        &mut ctx,
+        &mut meta,
+        snapshot_details,
+        DryRun::No,
+        |mut tx| {
+            let new_two = tx.squash_commits(
+                Vec::from([three]),
+                two,
+                MessageCombinationStrategy::KeepBoth,
+            )?;
+            let new_one = tx.squash_commits(
+                Vec::from([new_two]),
+                one,
+                MessageCombinationStrategy::KeepBoth,
+            )?;
+            tx.reword_commit(new_one, "squashed".into())?;
+
+            Ok(())
+        },
+    )
+    .unwrap();
+
+    snapbox::assert_data_eq!(
+        env.git_log().unwrap(),
+        snapbox::str![[r#"
+* ec6f55f (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* a2fc6dc (branch) squashed
+* 6674d4f (origin/main, origin/HEAD, main, gitbutler/target) add random-file
+
+"#]]
+    );
+
+    assert_num_snapshots(&ctx, 1);
+}
+
+#[test]
+fn rollback() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    let [three, two, one] = find_commits(&env, ["1e25c58", "9b3b3d5", "dbdbcea"]);
+
+    let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
+    let mut ctx = Context::from_repo(repo)
+        .map(Context::with_memory_app_cache)
+        .unwrap();
+
+    assert_num_snapshots(&ctx, 0);
+
+    let mut meta = ctx.meta().unwrap();
+    let snapshot_details = SnapshotDetails::new(OperationKind::SquashCommit);
+
+    let _must_return_unit: () = with_transaction(
+        &mut ctx,
+        &mut meta,
+        snapshot_details,
+        DryRun::No,
+        |mut tx| {
+            tx.squash_commits([three], two, MessageCombinationStrategy::KeepBoth)?;
+            tx.squash_commits([two], one, MessageCombinationStrategy::KeepBoth)?;
+
+            Ok(tx.rollback(()))
+        },
+    )
+    .unwrap();
+
+    snapbox::assert_data_eq!(
+        env.git_log().unwrap(),
+        snapbox::str![[r#"
+* ebaef69 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 1e25c58 (branch) add file-three
+* 9b3b3d5 add file-two
+* dbdbcea add file-one
+* 6674d4f (origin/main, origin/HEAD, main) add random-file
+
+"#]]
+    );
+
+    assert_num_snapshots(&ctx, 0);
+}
+
+#[test]
+fn dynamic_rollback() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    let [three, two, one] = find_commits(&env, ["1e25c58", "9b3b3d5", "dbdbcea"]);
+
+    let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
+    let mut ctx = Context::from_repo(repo)
+        .map(Context::with_memory_app_cache)
+        .unwrap();
+
+    assert_num_snapshots(&ctx, 0);
+
+    let mut meta = ctx.meta().unwrap();
+    let snapshot_details = SnapshotDetails::new(OperationKind::SquashCommit);
+
+    let outcome = with_transaction(
+        &mut ctx,
+        &mut meta,
+        snapshot_details,
+        DryRun::No,
+        |mut tx| {
+            tx.squash_commits([three], two, MessageCombinationStrategy::KeepBoth)?;
+            tx.squash_commits([two], one, MessageCombinationStrategy::KeepBoth)?;
+
+            if 2 == 4 {
+                Ok(DynamicOutcome::Commit(1))
+            } else {
+                Ok(DynamicOutcome::Rollback(2))
+            }
+        },
+    )
+    .unwrap();
+
+    assert!(matches!(outcome, DynamicOutcome::Rollback(2)));
+
+    snapbox::assert_data_eq!(
+        env.git_log().unwrap(),
+        snapbox::str![[r#"
+* ebaef69 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 1e25c58 (branch) add file-three
+* 9b3b3d5 add file-two
+* dbdbcea add file-one
+* 6674d4f (origin/main, origin/HEAD, main) add random-file
+
+"#]]
+    );
+
+    assert_num_snapshots(&ctx, 0);
+}
+
+#[test]
+fn discarding_three_commits() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    snapbox::assert_data_eq!(
+        env.git_log().unwrap(),
+        snapbox::str![[r#"
+* ebaef69 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 1e25c58 (branch) add file-three
+* 9b3b3d5 add file-two
+* dbdbcea add file-one
+* 6674d4f (origin/main, origin/HEAD, main) add random-file
+
+"#]]
+    );
+
+    let [three, two, one] = find_commits(&env, ["1e25c58", "9b3b3d5", "dbdbcea"]);
+
+    let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
+    let mut ctx = Context::from_repo(repo)
+        .map(Context::with_memory_app_cache)
+        .unwrap();
+
+    assert_num_snapshots(&ctx, 0);
+
+    let mut meta = ctx.meta().unwrap();
+    let snapshot_details = SnapshotDetails::new(OperationKind::SquashCommit);
+
+    with_transaction(
+        &mut ctx,
+        &mut meta,
+        snapshot_details,
+        DryRun::No,
+        |mut tx| {
+            tx.discard_commits([one])?;
+            tx.discard_commits([two])?;
+            tx.discard_commits([three])?;
+
+            Ok(())
+        },
+    )
+    .unwrap();
+
+    snapbox::assert_data_eq!(
+        env.git_log().unwrap(),
+        snapbox::str![[r#"
+* 8413d71 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 6674d4f (origin/main, origin/HEAD, main, gitbutler/target, branch) add random-file
+
+"#]]
+    );
+
+    assert_num_snapshots(&ctx, 1);
+}
+
+#[test]
+fn remove_references() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    snapbox::assert_data_eq!(
+        env.git_log().unwrap(),
+        snapbox::str![[r#"
+* ebaef69 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 1e25c58 (branch) add file-three
+* 9b3b3d5 add file-two
+* dbdbcea add file-one
+* 6674d4f (origin/main, origin/HEAD, main) add random-file
+
+"#]]
+    );
+
+    let [three, two, one] = find_commits(&env, ["1e25c58", "9b3b3d5", "dbdbcea"]);
+
+    let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
+    let mut ctx = Context::from_repo(repo)
+        .map(Context::with_memory_app_cache)
+        .unwrap();
+
+    assert_num_snapshots(&ctx, 0);
+
+    let mut meta = ctx.meta().unwrap();
+    let snapshot_details = SnapshotDetails::new(OperationKind::SquashCommit);
+
+    let refname = FullName::try_from("refs/heads/branch").unwrap();
+
+    with_transaction(
+        &mut ctx,
+        &mut meta,
+        snapshot_details,
+        DryRun::No,
+        |mut tx| {
+            tx.remove_reference(refname.as_ref())?;
+
+            tx.discard_commits([one, two, three])?;
+
+            Ok(())
+        },
+    )
+    .unwrap();
+
+    snapbox::assert_data_eq!(
+        env.git_log().unwrap(),
+        snapbox::str![[r#"
+* 8413d71 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 6674d4f (origin/main, origin/HEAD, main, gitbutler/target) add random-file
+
+"#]]
+    );
+
+    assert_num_snapshots(&ctx, 1);
+}

--- a/crates/but-transaction/tests/fixtures/scenario/one-stack.sh
+++ b/crates/but-transaction/tests/fixtures/scenario/one-stack.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A ws-ref points to a workspace commit, with one stack inside, with its own commit.
+git-init-frozen
+commit-file random-file
+setup_target_to_match_main
+
+git checkout -b branch
+  commit-file file-one
+  commit-file file-two
+  commit-file file-three
+create_workspace_commit_once branch

--- a/crates/but-transaction/tests/fixtures/scenario/shared.sh
+++ b/crates/but-transaction/tests/fixtures/scenario/shared.sh
@@ -1,0 +1,52 @@
+# Just to save a line in the scripts that use this module
+set -eu -o pipefail
+
+function git-init-frozen() {
+  git init
+  git config gitbutler.testing.changeId 1
+}
+
+function setup_remote_tracking() {
+  local branch_name="${1:?}"
+  local remote_branch_name=${2:-"$branch_name"}
+  mkdir -p .git/refs/remotes/origin
+
+  cp ".git/refs/heads/$branch_name" ".git/refs/remotes/origin/$remote_branch_name"
+}
+
+function setup_target_to_match_main() {
+  setup_remote_tracking main
+  # This is for `but` which needs it right now to set a target.
+  echo "ref: refs/remotes/origin/main" >.git/refs/remotes/origin/HEAD
+
+  cat <<EOF >>.git/config
+[remote "origin"]
+	url = ./fake/local/path/which-is-fine-as-we-dont-fetch-or-push
+	fetch = +refs/heads/*:refs/remotes/origin/*
+EOF
+}
+
+# can only be called once per test setup
+function create_workspace_commit_once() {
+  local workspace_commit_subject="GitButler Workspace Commit"
+
+  if [ $# == 1 ]; then
+    local current_branch=$(git rev-parse --abbrev-ref HEAD)
+    if [[ "$current_branch" != "$1" ]]; then
+      echo "BUG: Must assure the current branch is the branch passed as argument: $current_branch != $1"
+      return 42
+    fi
+  fi
+
+  git checkout -b gitbutler/workspace
+  if [ $# == 1 ] || [ $# == 0 ]; then
+    git commit --allow-empty -m "$workspace_commit_subject"
+  else
+    git merge --no-ff -m "$workspace_commit_subject" "${@}"
+  fi
+}
+
+function commit-file() {
+  local name="${1:?First argument is the filename}"
+  echo $name >$name && git add $name && git commit -m "add $name"
+}

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -73,6 +73,7 @@ but-graph.workspace = true
 but-llm.workspace = true
 but-agentlog = { workspace = true, optional = true }
 but-transaction.workspace = true
+but-db.workspace = true
 
 # What follows is *basically* newly written crates that are built on top of legacy,
 # so need some refactoring/rethinking to become usable.

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -72,6 +72,7 @@ but-api = { workspace = true, features = ["path-bytes"] }
 but-graph.workspace = true
 but-llm.workspace = true
 but-agentlog = { workspace = true, optional = true }
+but-transaction.workspace = true
 
 # What follows is *basically* newly written crates that are built on top of legacy,
 # so need some refactoring/rethinking to become usable.

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -752,7 +752,7 @@ fn get_commit_message_from_editor(
             .cloned()
             .map(but_core::TreeChange::from)
             .collect();
-        estimate_diff_blob_size(&core_changes, ctx)
+        estimate_diff_blob_size(&core_changes, &*ctx.repo.get()?)
     })?;
 
     let diff_text = if should_show_diff {

--- a/crates/but/src/command/legacy/mod.rs
+++ b/crates/but/src/command/legacy/mod.rs
@@ -85,21 +85,17 @@ pub(crate) const MAX_DIFF_BLOB_SIZE_FOR_EDITOR_IF_UNSPECIFIED: u64 = 900_000;
 /// For modifications/renames, uses the larger of the two sides as an upper bound.
 pub(crate) fn estimate_diff_blob_size(
     changes: &[but_core::TreeChange],
-    ctx: &but_ctx::Context,
+    repo: &gix::Repository,
 ) -> Result<u64> {
     fn blob_size(repo: &gix::Repository, id: gix::ObjectId) -> u64 {
         repo.find_header(id).map(|h| h.size()).unwrap_or(0)
     }
 
-    let repo = ctx.repo.get()?;
-
     Ok(changes
         .iter()
         .map(|change| match &change.status {
-            but_core::TreeStatus::Addition { state, .. } => blob_size(&repo, state.id),
-            but_core::TreeStatus::Deletion { previous_state } => {
-                blob_size(&repo, previous_state.id)
-            }
+            but_core::TreeStatus::Addition { state, .. } => blob_size(repo, state.id),
+            but_core::TreeStatus::Deletion { previous_state } => blob_size(repo, previous_state.id),
             but_core::TreeStatus::Modification {
                 previous_state,
                 state,
@@ -110,8 +106,8 @@ pub(crate) fn estimate_diff_blob_size(
                 state,
                 ..
             } => {
-                let a = blob_size(&repo, previous_state.id);
-                let b = blob_size(&repo, state.id);
+                let a = blob_size(repo, previous_state.id);
+                let b = blob_size(repo, state.id);
                 a.max(b)
             }
         })

--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -123,7 +123,8 @@ fn prepare_provided_message(msg: Option<&str>, entity: &str) -> Option<Result<St
 }
 
 pub(crate) fn get_commit_message_from_editor(
-    ctx: &mut Context,
+    repo: &gix::Repository,
+    context_lines: u32,
     commit_details: but_core::diff::CommitDetails,
     editor_initial_message: String,
     current_message_for_comparison: &str,
@@ -132,14 +133,14 @@ pub(crate) fn get_commit_message_from_editor(
     let changed_files = get_changed_files_from_commit_details(&commit_details);
 
     let should_show_diff = show_diff_in_editor.should_show_diff(|| {
-        estimate_diff_blob_size(&commit_details.diff_with_first_parent, ctx)
+        estimate_diff_blob_size(&commit_details.diff_with_first_parent, repo)
     })?;
     let diff = should_show_diff
         .then(|| {
             commit_details
                 .diff_with_first_parent
                 .iter()
-                .map(|change| change.unified_diff(&*ctx.repo.get()?, ctx.settings.context_lines))
+                .map(|change| change.unified_diff(repo, context_lines))
                 .filter_map(|diff| diff.transpose())
                 .collect::<Result<Vec<_>>>()
         })
@@ -184,7 +185,8 @@ fn edit_commit_message_by_id_and_reword_commit(
         Some(prepare_provided_commit_message(message)?)
     } else {
         get_commit_message_from_editor(
-            ctx,
+            &*ctx.repo.get()?,
+            ctx.settings.context_lines,
             commit_details,
             current_message.clone(),
             &current_message,

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -12,16 +12,17 @@ use std::{
 use anyhow::Context as _;
 use bstr::{BString, ByteSlice};
 use but_api::{diff::ComputeLineStats, legacy::oplog::RestoreKind};
-use but_core::tree::create_tree::RejectionReason;
 use but_core::{DryRun, ref_metadata::StackId};
+use but_core::{diff::CommitDetails, tree::create_tree::RejectionReason};
 use but_ctx::Context;
 use but_rebase::graph_rebase::mutate::InsertSide;
 use but_settings::AppSettingsWithDiskSync;
+use but_transaction::DynamicOutcome;
 use but_workspace::commit::squash_commits::MessageCombinationStrategy;
 use crossterm::event::{self, Event, KeyCode, KeyEvent};
 use gitbutler_operating_modes::OperatingMode;
 use gitbutler_oplog::entry::{OperationKind, SnapshotDetails};
-use gix::refs::FullName;
+use gix::{prelude::ObjectIdExt as _, refs::FullName};
 use nonempty::NonEmpty;
 use ratatui::prelude::*;
 use ratatui_textarea::{CursorMove, TextArea};
@@ -30,6 +31,7 @@ use tracing::Level;
 use crate::{
     CliId, IdMap,
     command::legacy::{
+        self, ShowDiffInEditor,
         reword::get_branch_name_from_editor,
         status::{
             StatusFlags, StatusOutputLine, TuiLaunchOptions,
@@ -689,7 +691,9 @@ impl App {
             Message::Commit(commit_message) => match commit_message {
                 CommitMessage::CreateEmpty => self.handle_commit_create_empty(ctx, messages)?,
                 CommitMessage::Start => self.handle_commit_start(ctx)?,
-                CommitMessage::Confirm => self.handle_commit_confirm(ctx, messages)?,
+                CommitMessage::Confirm => {
+                    self.handle_commit_confirm(ctx, terminal_guard, messages)?
+                }
                 CommitMessage::ToggleMessageComposer(composer) => {
                     self.handle_commit_toggle_message_composer(composer);
                 }
@@ -1747,11 +1751,16 @@ impl App {
         Ok(())
     }
 
-    fn handle_commit_confirm(
+    fn handle_commit_confirm<T>(
         &mut self,
         ctx: &mut Context,
+        terminal_guard: &mut T,
         messages: &mut Vec<Message>,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<()>
+    where
+        T: TerminalGuard,
+        anyhow::Error: From<<T::Backend as Backend>::Error>,
+    {
         let Mode::Commit(CommitMode {
             source,
             scope_to_stack,
@@ -1795,21 +1804,123 @@ impl App {
             }
         };
 
-        let Some(commit_create_result) = operations::create_commit_legacy(
-            ctx,
-            target,
-            source,
-            *scope_to_stack,
-            InsertSide::Below,
-        )?
+        let Some((insert_commit_relative_to, insert_side)) =
+            operations::where_to_place_commit(ctx, target, InsertSide::Below)?
         else {
             return Ok(());
         };
 
-        let rejected_specs_error_msg = if !commit_create_result.rejected_specs.is_empty() {
-            let mut full_error_msg = "Some selected changes could not be committed:\n".to_owned();
-            let mut errors_per_diff_spec = commit_create_result
-                .rejected_specs
+        let changes_to_commit = {
+            let context_lines = ctx.settings.context_lines;
+            let guard = ctx.shared_worktree_access();
+            let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(guard.read_permission())?;
+            operations::prepare_changes_to_commit(
+                &mut db,
+                &repo,
+                &ws,
+                context_lines,
+                source,
+                *scope_to_stack,
+            )?
+        };
+        let Some(changes_to_commit) = changes_to_commit else {
+            return Ok(());
+        };
+
+        let mut meta = ctx.meta()?;
+        let snapshot_details = SnapshotDetails::new(OperationKind::CreateCommit);
+        let commit_create_result = but_transaction::with_transaction(
+            ctx,
+            &mut meta,
+            snapshot_details,
+            DryRun::No,
+            |mut tx| {
+                let commit_create_result = tx.create_commit(
+                    insert_commit_relative_to,
+                    insert_side,
+                    changes_to_commit,
+                    String::new(),
+                )?;
+
+                if commit_create_result.rejected_specs.is_empty() {
+                    if let Some(new_commit) = commit_create_result.new_commit {
+                        match message_composer {
+                            CommitMessageComposer::Editor => {
+                                let repo = tx.repo();
+                                let commit_details = CommitDetails::from_commit_id(
+                                    new_commit.attach(repo),
+                                    ComputeLineStats::No.into(),
+                                )?;
+                                let current_message =
+                                    commit_details.commit.inner.message.to_string();
+
+                                let _suspend_guard = terminal_guard.suspend()?;
+
+                                let message = legacy::reword::get_commit_message_from_editor(
+                                    tx.repo(),
+                                    tx.context_lines(),
+                                    commit_details,
+                                    String::new(),
+                                    &current_message,
+                                    ShowDiffInEditor::Unspecified,
+                                )?
+                                .unwrap_or_default();
+
+                                let reworded_commit =
+                                    tx.reword_commit(new_commit, BString::from(message).as_ref())?;
+
+                                Ok(DynamicOutcome::Commit((Some(reworded_commit), None)))
+                            }
+                            CommitMessageComposer::Inline => {
+                                Ok(DynamicOutcome::Commit((
+                                    commit_create_result.new_commit,
+                                    // TODO(david): rewording separately isn't great because it
+                                    // results in two oplog entries. One for creating the commit
+                                    // and one for rewording it.
+                                    //
+                                    // Fixing that is a little tricky because we'd have to show a
+                                    // "temp" commit in the status while composing the message and
+                                    // then only commit when the user confirms.
+                                    Some(Message::Reword(RewordMessage::InlineStart)),
+                                )))
+                            }
+                            CommitMessageComposer::Empty => Ok(DynamicOutcome::Commit((
+                                commit_create_result.new_commit,
+                                None,
+                            ))),
+                        }
+                    } else {
+                        Ok(DynamicOutcome::Commit((
+                            commit_create_result.new_commit,
+                            None,
+                        )))
+                    }
+                } else {
+                    Ok(DynamicOutcome::Rollback(
+                        commit_create_result.rejected_specs,
+                    ))
+                }
+            },
+        )?;
+
+        match commit_create_result {
+            DynamicOutcome::Commit(((new_commit, reword_msg), _workspace)) => {
+                messages.extend(
+                    [
+                        Message::EnterNormalModeAfterConfirmingOperation,
+                        Message::Reload(
+                            new_commit.map(SelectAfterReload::Commit),
+                            ReloadCause::Mutation,
+                        ),
+                    ]
+                    .into_iter()
+                    .chain(reword_msg),
+                );
+            }
+            DynamicOutcome::Rollback(rejected_specs) => {
+                let mut full_error_msg =
+                    "Some selected changes could not be committed:\n".to_owned();
+                let mut errors_per_diff_spec = rejected_specs
                 .iter()
                 .map(|(rejection_reason, diff_spec)| {
                     let human_reason = match rejection_reason {
@@ -1837,49 +1948,19 @@ impl App {
                     out
                 })
                 .peekable();
-            while let Some(line) = errors_per_diff_spec.next() {
-                full_error_msg.push_str(&line);
-                if errors_per_diff_spec.peek().is_some() {
-                    full_error_msg.push('\n');
+                while let Some(line) = errors_per_diff_spec.next() {
+                    full_error_msg.push_str(&line);
+                    if errors_per_diff_spec.peek().is_some() {
+                        full_error_msg.push('\n');
+                    }
                 }
-            }
-            Some(full_error_msg)
-        } else {
-            None
-        };
 
-        messages.extend(
-            [
-                Message::EnterNormalModeAfterConfirmingOperation,
-                Message::Reload(
-                    commit_create_result
-                        .new_commit
-                        .map(SelectAfterReload::Commit),
-                    ReloadCause::Mutation,
-                ),
-            ]
-            .into_iter()
-            // TODO(david): don't use a separate reword step, instead get message before creating
-            // commit. However that requires computing the diff which I haven't yet figured out how
-            // to do
-            .chain(if commit_create_result.new_commit.is_some() {
-                match message_composer {
-                    CommitMessageComposer::Editor => {
-                        Some(Message::Reword(RewordMessage::WithEditor))
-                    }
-                    CommitMessageComposer::Inline => {
-                        Some(Message::Reword(RewordMessage::InlineStart))
-                    }
-                    CommitMessageComposer::Empty => None,
-                }
-            } else {
-                None
-            })
-            .chain(rejected_specs_error_msg.map(|text| Message::ShowToast {
-                kind: ToastKind::Error,
-                text,
-            })),
-        );
+                messages.push(Message::ShowToast {
+                    kind: ToastKind::Error,
+                    text: full_error_msg,
+                });
+            }
+        }
 
         Ok(())
     }

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -12,14 +12,15 @@ use std::{
 use anyhow::Context as _;
 use bstr::{BString, ByteSlice};
 use but_api::{diff::ComputeLineStats, legacy::oplog::RestoreKind};
-use but_core::ref_metadata::StackId;
 use but_core::tree::create_tree::RejectionReason;
+use but_core::{DryRun, ref_metadata::StackId};
 use but_ctx::Context;
 use but_rebase::graph_rebase::mutate::InsertSide;
 use but_settings::AppSettingsWithDiskSync;
 use but_workspace::commit::squash_commits::MessageCombinationStrategy;
 use crossterm::event::{self, Event, KeyCode, KeyEvent};
 use gitbutler_operating_modes::OperatingMode;
+use gitbutler_oplog::entry::{OperationKind, SnapshotDetails};
 use gix::refs::FullName;
 use nonempty::NonEmpty;
 use ratatui::prelude::*;
@@ -769,7 +770,7 @@ impl App {
                 self.delayed_messages.push(*msg);
             }
             Message::Discard => {
-                self.handle_discard(ctx, messages);
+                self.handle_discard(ctx, messages)?;
             }
             Message::DropToBeDiscarded => {
                 self.to_be_discarded = None;
@@ -1406,12 +1407,16 @@ impl App {
         })
     }
 
-    fn handle_discard(&mut self, ctx: &mut Context, messages: &mut Vec<Message>) {
+    fn handle_discard(
+        &mut self,
+        ctx: &mut Context,
+        messages: &mut Vec<Message>,
+    ) -> anyhow::Result<()> {
         let Some(selection) = self.cursor.selected_line(&self.status_lines) else {
-            return;
+            return Ok(());
         };
         let Some(cli_id) = selection.data.cli_id() else {
-            return;
+            return Ok(());
         };
 
         self.modal = Some(Modal::Confirm {
@@ -1536,21 +1541,45 @@ impl App {
                 }
                 CliId::Branch { name, stack_id, .. } => {
                     let Some(stack_id) = *stack_id else {
-                        return;
+                        return Ok(());
                     };
 
                     let name = name.to_owned();
+
+                    let commits = commits_on_branch(ctx, stack_id, &name)?;
+
                     self.to_be_discarded = Some(Arc::clone(cli_id));
                     let select_after_reload = self
                         .cursor
                         .select_after_discarded_branch(&self.status_lines);
                     let drop_to_be_discarded =
                         message_on_drop::message_on_drop(Message::DropToBeDiscarded, messages);
+
                     Confirm::new(
                         NonEmpty::new(format!("Discard branch {name}?").into()),
                         self.theme,
                         move |ctx, messages| {
-                            operations::remove_branch_legacy(ctx, stack_id, name)?;
+                            let mut meta = ctx.meta()?;
+                            let snapshot_details =
+                                SnapshotDetails::new(OperationKind::DeleteBranch);
+
+                            let refname = FullName::try_from(format!("refs/heads/{name}"))?;
+                            but_transaction::with_transaction(
+                                ctx,
+                                &mut meta,
+                                snapshot_details,
+                                DryRun::No,
+                                |mut tx| {
+                                    tx.remove_reference(refname.as_ref())?;
+                                    if !commits.is_empty() {
+                                        tx.discard_commits(
+                                            commits.into_iter().map(|(commit, _)| commit),
+                                        )?;
+                                    }
+                                    Ok(())
+                                },
+                            )?;
+
                             messages
                                 .push(Message::Reload(select_after_reload, ReloadCause::Mutation));
                             drop(drop_to_be_discarded);
@@ -1558,10 +1587,12 @@ impl App {
                         },
                     )
                 }
-                CliId::PathPrefix { .. } | CliId::CommittedFile { .. } => return,
+                CliId::PathPrefix { .. } | CliId::CommittedFile { .. } => return Ok(()),
             },
             key_binds: confirm_key_binds(),
         });
+
+        Ok(())
     }
 
     /// Handles creating an empty commit relative to the current selection.
@@ -2865,30 +2896,12 @@ fn handle_mark_branch(
     stack_id: StackId,
     name: &str,
 ) -> anyhow::Result<()> {
-    let guard = ctx.shared_worktree_access();
-    let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
-
-    let Some(segment) = id_map
-        .stacks()
-        .iter()
-        .filter(|stack| stack.id.is_some_and(|id| id == stack_id))
-        .flat_map(|stack| &stack.segments)
-        .find(|segment| {
-            segment
-                .branch_name()
-                .is_some_and(|branch_name| branch_name == name)
-        })
-    else {
-        return Ok(());
-    };
-
-    let Some(commits) = segment
-        .workspace_commits
-        .iter()
-        .map(|commit| {
+    let Some(commits) = commits_on_branch(ctx, stack_id, name)?
+        .into_iter()
+        .map(|(commit_id, short_id)| {
             Markable::try_from_cli_id(&CliId::Commit {
-                commit_id: commit.commit_id(),
-                id: commit.short_id.clone(),
+                commit_id,
+                id: short_id,
             })
         })
         .collect::<Option<Vec<_>>>()
@@ -2919,6 +2932,35 @@ fn handle_mark_branch(
     }
 
     Ok(())
+}
+
+fn commits_on_branch(
+    ctx: &Context,
+    stack_id: StackId,
+    name: &str,
+) -> anyhow::Result<Vec<(gix::ObjectId, String)>> {
+    let guard = ctx.shared_worktree_access();
+    let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
+
+    let segment = id_map
+        .stacks()
+        .iter()
+        .filter(|stack| stack.id.is_some_and(|id| id == stack_id))
+        .flat_map(|stack| &stack.segments)
+        .find(|segment| {
+            segment
+                .branch_name()
+                .is_some_and(|branch_name| branch_name == name)
+        })
+        .context("segment not found")?;
+
+    let commits = segment
+        .workspace_commits
+        .iter()
+        .map(|commit| (commit.commit_id(), commit.short_id.clone()))
+        .collect::<Vec<_>>();
+
+    Ok(commits)
 }
 
 #[derive(Debug, Clone, strum::EnumDiscriminants)]

--- a/crates/but/src/command/legacy/status/tui/operations.rs
+++ b/crates/but/src/command/legacy/status/tui/operations.rs
@@ -566,14 +566,6 @@ pub(super) fn commit_discard(
     but_api::commit::discard_commit::commit_discard(ctx, commit_id, DryRun::No)
 }
 
-pub(super) fn remove_branch_legacy(
-    ctx: &mut Context,
-    stack_id: StackId,
-    branch_name: String,
-) -> anyhow::Result<()> {
-    but_api::legacy::stack::remove_branch(ctx, stack_id, branch_name)
-}
-
 pub(super) fn get_undo_target_snapshot_legacy(ctx: &Context) -> anyhow::Result<Option<Snapshot>> {
     but_api::legacy::oplog::get_undo_target_snapshot(ctx)
 }

--- a/crates/but/src/command/legacy/status/tui/operations.rs
+++ b/crates/but/src/command/legacy/status/tui/operations.rs
@@ -7,9 +7,7 @@
 use anyhow::Context as _;
 use bstr::BString;
 use but_api::{
-    commit::types::{
-        CommitCreateResult, CommitDiscardResult, CommitInsertBlankResult, CommitRewordResult,
-    },
+    commit::types::{CommitDiscardResult, CommitInsertBlankResult, CommitRewordResult},
     diff::ComputeLineStats,
     legacy::oplog::RestoreKind,
 };
@@ -91,43 +89,22 @@ pub(super) fn create_empty_commit_relative_to_commit(
     )
 }
 
-pub(super) fn create_commit_legacy(
-    ctx: &mut Context,
-    target: &CliId,
+pub(super) fn prepare_changes_to_commit(
+    db: &mut but_db::DbHandle,
+    repo: &gix::Repository,
+    workspace: &but_graph::Workspace,
+    context_lines: u32,
     source: &CommitSource,
     scope_to_stack: Option<StackId>,
-    insert_side: InsertSide,
-) -> anyhow::Result<Option<CommitCreateResult>> {
-    let mut guard = ctx.exclusive_worktree_access();
-    let (insert_commit_relative_to, insert_side) = match target {
-        CliId::Branch { name, .. } => {
-            let repo = ctx.repo.get()?;
-            let reference = repo.find_reference(name)?;
-            (
-                RelativeTo::Reference(reference.name().to_owned()),
-                InsertSide::Below,
-            )
-        }
-        CliId::Commit { commit_id, .. } => (RelativeTo::Commit(*commit_id), insert_side),
-        CliId::Uncommitted(_)
-        | CliId::PathPrefix { .. }
-        | CliId::CommittedFile { .. }
-        | CliId::Unassigned { .. }
-        | CliId::Stack { .. } => {
-            return Ok(None);
-        }
-    };
-
+) -> anyhow::Result<Option<Vec<DiffSpec>>> {
     // find what to commit
     let changes_to_commit = match source {
         CommitSource::Unassigned(..) => {
-            let context_lines = ctx.settings.context_lines;
-            let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(guard.read_permission())?;
-            let changes = but_core::diff::ui::worktree_changes(&repo)?.changes;
+            let changes = but_core::diff::ui::worktree_changes(repo)?.changes;
             let (assignments, _assignments_error) = but_hunk_assignment::assignments_with_fallback(
                 db.hunk_assignments_mut()?,
-                &repo,
-                &ws,
+                repo,
+                workspace,
                 Some(changes),
                 context_lines,
             )?;
@@ -145,13 +122,11 @@ pub(super) fn create_commit_legacy(
             .map(DiffSpec::from)
             .collect::<Vec<_>>(),
         CommitSource::Stack(StackCommitSource { stack_id, .. }) => {
-            let context_lines = ctx.settings.context_lines;
-            let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(guard.read_permission())?;
-            let changes = but_core::diff::ui::worktree_changes(&repo)?.changes;
+            let changes = but_core::diff::ui::worktree_changes(repo)?.changes;
             let (assignments, _assignments_error) = but_hunk_assignment::assignments_with_fallback(
                 db.hunk_assignments_mut()?,
-                &repo,
-                &ws,
+                repo,
+                workspace,
                 Some(changes),
                 context_lines,
             )?;
@@ -163,21 +138,30 @@ pub(super) fn create_commit_legacy(
         }
     };
 
-    let changes_to_commit = but_workspace::flatten_diff_specs(changes_to_commit);
+    Ok(Some(but_workspace::flatten_diff_specs(changes_to_commit)))
+}
 
-    // create commit
-    but_api::commit::create::commit_create(
-        ctx,
-        insert_commit_relative_to,
-        insert_side,
-        changes_to_commit,
-        // we reword the commit with the editor before the next render
-        String::new(),
-        DryRun::No,
-        guard.write_permission(),
-    )
-    .context("failed to create commit")
-    .map(Some)
+pub(super) fn where_to_place_commit(
+    ctx: &Context,
+    target: &CliId,
+    insert_side: InsertSide,
+) -> anyhow::Result<Option<(RelativeTo, InsertSide)>> {
+    match target {
+        CliId::Branch { name, .. } => {
+            let repo = ctx.repo.get()?;
+            let reference = repo.find_reference(name)?;
+            Ok(Some((
+                RelativeTo::Reference(reference.name().to_owned()),
+                InsertSide::Below,
+            )))
+        }
+        CliId::Commit { commit_id, .. } => Ok(Some((RelativeTo::Commit(*commit_id), insert_side))),
+        CliId::Uncommitted(_)
+        | CliId::PathPrefix { .. }
+        | CliId::CommittedFile { .. }
+        | CliId::Unassigned { .. }
+        | CliId::Stack { .. } => Ok(None),
+    }
 }
 
 pub(super) fn rub(
@@ -207,7 +191,8 @@ pub(super) fn reword_commit_with_editor_with_message_legacy(
     let commit_id = commit_details.commit.id;
     let current_message = commit_details.commit.inner.message.to_string();
     let new_message = legacy::reword::get_commit_message_from_editor(
-        ctx,
+        &*ctx.repo.get()?,
+        ctx.settings.context_lines,
         commit_details,
         editor_initial_message,
         &current_message,


### PR DESCRIPTION
Adds a basic "transaction API" built with but-workspace and but-rebase primitives.

Here is an example of how one can delete a reference and delete some commits in one go:

```rust
let snapshot_details = SnapshotDetails::new(OperationKind::SquashCommit);

but_transaction::with_transaction(&mut ctx, &mut meta, snapshot_details, DryRun::No, |tx| {
    tx.remove_reference(refname)?;

    tx.discard_commits([
        commit_one,
        commit_two,
        commit_three,
    ])?;

    Ok(())
});
```

The use case being atomically deleting branches with their commits from the TUI. We don't have an API for doing this but we do have the individual building blocks.

_Update:_ I've now also managed to use this to fix a long standing bug in the TUI. If you create a commit and write the message with the editor we'd create two snapshots: One for creating the commit and one for rewording it. This can now roughly be handled like this instead

```rust
let snapshot_details = SnapshotDetails::new(OperationKind::CreateCommit);

but_transaction::with_transaction(&mut ctx, &mut meta, snapshot_details, DryRun::No, |tx| {
    let create_commit_result = tx.create_commit()?;

    if create_commit_result.rejected_specs.is_empty() {
        tx.rollback();
    } else {
        let new_commit = create_commit_result.new_commit;
        let commit_details = get_commit_details(new_commit, tx.repo())?;

        // we need the commit details to show a diff in the $EDITOR
        let message = tui_get_message_from_user(new_commit, commit_details, tx.repo())?;

        tx.reword_commit(new_commit, message)?;
    }

    Ok(())
});
```