### PR TITLE
but-graph improvements for `unapply`

### DIFF
--- a/crates/but-graph/src/debug.rs
+++ b/crates/but-graph/src/debug.rs
@@ -130,6 +130,43 @@ impl Graph {
         hard_limit: bool,
         max_goals: Option<usize>,
     ) -> String {
+        Self::commit_debug_string_inner(
+            commit,
+            is_entrypoint,
+            stop_condition,
+            hard_limit,
+            max_goals,
+            false,
+        )
+    }
+
+    /// Like [`Self::commit_debug_string()`], but includes graph-contextual worktree ownership markers.
+    pub fn commit_debug_string_with_graph_context(
+        &self,
+        commit: &crate::Commit,
+        is_entrypoint: bool,
+        stop_condition: Option<StopCondition>,
+        hard_limit: bool,
+        max_goals: Option<usize>,
+    ) -> String {
+        Self::commit_debug_string_inner(
+            commit,
+            is_entrypoint,
+            stop_condition,
+            hard_limit,
+            max_goals,
+            self.has_multiple_worktrees(),
+        )
+    }
+
+    fn commit_debug_string_inner(
+        commit: &crate::Commit,
+        is_entrypoint: bool,
+        stop_condition: Option<StopCondition>,
+        hard_limit: bool,
+        max_goals: Option<usize>,
+        show_owned_by_repo: bool,
+    ) -> String {
         format!(
             "{ep}{end}{kind}{hex}{flags}{refs}",
             ep = if is_entrypoint { "👉" } else { "" },
@@ -156,7 +193,11 @@ impl Graph {
                         .refs
                         .iter()
                         .map(|ri| format!("►{}", {
-                            Self::ref_debug_string(ri.ref_name.as_ref(), ri.worktree.as_ref())
+                            Self::ref_debug_string_inner(
+                                ri.ref_name.as_ref(),
+                                ri.worktree.as_ref(),
+                                show_owned_by_repo,
+                            )
                         }))
                         .collect::<Vec<_>>()
                         .join(", ")
@@ -169,6 +210,23 @@ impl Graph {
     pub fn ref_debug_string(
         ref_name: &gix::refs::FullNameRef,
         worktree: Option<&crate::Worktree>,
+    ) -> String {
+        Self::ref_debug_string_inner(ref_name, worktree, false)
+    }
+
+    /// Like [`Self::ref_debug_string()`], but includes graph-contextual worktree ownership markers.
+    pub fn ref_debug_string_with_graph_context(
+        &self,
+        ref_name: &gix::refs::FullNameRef,
+        worktree: Option<&crate::Worktree>,
+    ) -> String {
+        Self::ref_debug_string_inner(ref_name, worktree, self.has_multiple_worktrees())
+    }
+
+    fn ref_debug_string_inner(
+        ref_name: &gix::refs::FullNameRef,
+        worktree: Option<&crate::Worktree>,
+        show_owned_by_repo: bool,
     ) -> String {
         let (cat, sn) = ref_name.category_and_short_name().expect("valid refs");
         // Only shorten those that look good and are unambiguous enough.
@@ -184,7 +242,7 @@ impl Graph {
                     .unwrap_or(ref_name.as_bstr())
             },
             ws = worktree
-                .map(|ws| ws.debug_string(ref_name))
+                .map(|wt| wt.debug_string_with_graph_context(ref_name, show_owned_by_repo))
                 .unwrap_or_default()
         )
     }
@@ -197,13 +255,50 @@ impl Graph {
         sibling_id: Option<SegmentIndex>,
         remote_tracking_branch_id: Option<SegmentIndex>,
     ) -> String {
+        Self::ref_and_remote_debug_string_inner(
+            ref_info,
+            remote_ref_name,
+            sibling_id,
+            remote_tracking_branch_id,
+            false,
+        )
+    }
+
+    /// Like [`Self::ref_and_remote_debug_string()`], but includes graph-contextual worktree ownership markers.
+    pub fn ref_and_remote_debug_string_with_graph_context(
+        &self,
+        ref_info: Option<&crate::RefInfo>,
+        remote_ref_name: Option<&gix::refs::FullName>,
+        sibling_id: Option<SegmentIndex>,
+        remote_tracking_branch_id: Option<SegmentIndex>,
+    ) -> String {
+        Self::ref_and_remote_debug_string_inner(
+            ref_info,
+            remote_ref_name,
+            sibling_id,
+            remote_tracking_branch_id,
+            self.has_multiple_worktrees(),
+        )
+    }
+
+    fn ref_and_remote_debug_string_inner(
+        ref_info: Option<&crate::RefInfo>,
+        remote_ref_name: Option<&gix::refs::FullName>,
+        sibling_id: Option<SegmentIndex>,
+        remote_tracking_branch_id: Option<SegmentIndex>,
+        show_owned_by_repo: bool,
+    ) -> String {
         format!(
             "{ref_name}{remote}",
             ref_name = ref_info
                 .as_ref()
                 .map(|ri| format!(
                     "{}{maybe_id}",
-                    Graph::ref_debug_string(ri.ref_name.as_ref(), ri.worktree.as_ref()),
+                    Graph::ref_debug_string_inner(
+                        ri.ref_name.as_ref(),
+                        ri.worktree.as_ref(),
+                        show_owned_by_repo,
+                    ),
                     maybe_id = sibling_id
                         .filter(|_| remote_ref_name.is_none())
                         .map(|id| format!(" →:{}:", id.index()))
@@ -312,6 +407,27 @@ impl Graph {
             .max()
     }
 
+    /// Return `true` if more than one unique worktree is referenced by the graph.
+    pub(crate) fn has_multiple_worktrees(&self) -> bool {
+        let mut first: Option<&crate::WorktreeKind> = None;
+        self.node_weights()
+            .flat_map(|segment| {
+                segment
+                    .ref_info
+                    .iter()
+                    .chain(segment.commits.iter().flat_map(|commit| commit.refs.iter()))
+            })
+            .filter_map(|ref_info| ref_info.worktree.as_ref())
+            .any(|worktree| {
+                if let Some(first) = first {
+                    first != &worktree.kind
+                } else {
+                    first = Some(&worktree.kind);
+                    false
+                }
+            })
+    }
+
     /// Produces a pruned dot-version of the graph.
     ///
     /// This best-effort rendering path prunes very large graphs from the bottom
@@ -332,14 +448,16 @@ impl Graph {
         const HEX: usize = 7;
         let entrypoint = self.entrypoint_location();
         let max_goals = self.max_goals();
+        let show_owned_by_repo = self.has_multiple_worktrees();
         let node_attrs = |_: &PetGraph, (sidx, s): (SegmentIndex, &Segment)| {
             let name = format!(
                 "{ref_name_and_remote}{maybe_centering_newline}",
-                ref_name_and_remote = Self::ref_and_remote_debug_string(
+                ref_name_and_remote = Self::ref_and_remote_debug_string_inner(
                     s.ref_info.as_ref(),
                     s.remote_tracking_ref_name.as_ref(),
                     s.sibling_segment_id,
                     s.remote_tracking_branch_segment_id,
+                    show_owned_by_repo,
                 ),
                 maybe_centering_newline = if s.commits.is_empty() { "" } else { "\n" },
             );
@@ -351,7 +469,7 @@ impl Graph {
                 .iter()
                 .enumerate()
                 .map(|(cidx, c)| {
-                    Self::commit_debug_string(
+                    Self::commit_debug_string_inner(
                         c,
                         !show_segment_entrypoint && Some((sidx, Some(cidx))) == entrypoint,
                         if cidx + 1 != s.commits.len() {
@@ -361,6 +479,7 @@ impl Graph {
                         },
                         self.hard_limit_hit,
                         max_goals,
+                        show_owned_by_repo,
                     )
                 })
                 .collect::<Vec<_>>()

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -561,7 +561,13 @@ impl Graph {
                 let wt_by_branch = {
                     // Assume linked worktrees are never unborn!
                     let mut m = BTreeMap::new();
-                    m.insert(ref_name.clone(), vec![crate::Worktree::Main]);
+                    m.insert(
+                        ref_name.clone(),
+                        vec![crate::Worktree {
+                            kind: crate::WorktreeKind::Main,
+                            owned_by_repo: true,
+                        }],
+                    );
                     m
                 };
                 graph.insert_segment_set_entrypoint(branch_segment_from_name_and_meta(

--- a/crates/but-graph/src/init/overlay.rs
+++ b/crates/but-graph/src/init/overlay.rs
@@ -430,7 +430,7 @@ impl<'repo> OverlayRepo<'repo> {
         if repo_is_linked && let Ok(main_repo) = self.inner.main_repo() {
             maybe_insert_head(
                 main_repo.head().ok(),
-                main_head_referent,
+                None,
                 &self.overriding_references,
                 &mut map,
                 false,

--- a/crates/but-graph/src/init/overlay.rs
+++ b/crates/but-graph/src/init/overlay.rs
@@ -8,7 +8,7 @@ use but_core::{RefMetadata, ref_metadata};
 use gix::{prelude::ReferenceExt, refs::Target};
 
 use crate::{
-    Worktree,
+    Worktree, WorktreeKind,
     init::{
         Entrypoint, Overlay,
         walk::{RefsById, WorktreeByBranch},
@@ -341,14 +341,18 @@ impl<'repo> OverlayRepo<'repo> {
             main_head_referent: Option<&gix::refs::FullNameRef>,
             overriding: &NameToReference,
             out: &mut WorktreeByBranch,
+            owned_by_repo: bool,
         ) -> anyhow::Result<()> {
             let Some((head, wd)) = head.and_then(|head| {
                 head.repo.worktree().map(|wt| {
                     (
                         head,
-                        match wt.id() {
-                            None => Worktree::Main,
-                            Some(id) => Worktree::LinkedId(id.to_owned()),
+                        Worktree {
+                            kind: match wt.id() {
+                                None => WorktreeKind::Main,
+                                Some(id) => WorktreeKind::LinkedId(id.to_owned()),
+                            },
+                            owned_by_repo,
                         },
                     )
                 })
@@ -394,14 +398,42 @@ impl<'repo> OverlayRepo<'repo> {
             main_head_referent,
             &self.overriding_references,
             &mut map,
+            true,
+        )?;
+
+        let mut repo_is_linked = false;
+        let current_dir = std::env::current_dir()?;
+        let repo_real_path = gix::path::realpath_opts(
+            self.inner.path(),
+            &current_dir,
+            gix::path::realpath::MAX_SYMLINKS,
         )?;
         for proxy in self.inner.worktrees()? {
             let repo = proxy.into_repo_with_possibly_inaccessible_worktree()?;
+            let linked_repo_real_path = gix::path::realpath_opts(
+                repo.path(),
+                &current_dir,
+                gix::path::realpath::MAX_SYMLINKS,
+            )?;
+            if linked_repo_real_path == repo_real_path {
+                repo_is_linked = true;
+                continue;
+            }
             maybe_insert_head(
                 repo.head().ok(),
                 None,
                 &self.overriding_references,
                 &mut map,
+                false,
+            )?;
+        }
+        if repo_is_linked && let Ok(main_repo) = self.inner.main_repo() {
+            maybe_insert_head(
+                main_repo.head().ok(),
+                main_head_referent,
+                &self.overriding_references,
+                &mut map,
+                false,
             )?;
         }
         Ok(map)

--- a/crates/but-graph/src/lib.rs
+++ b/crates/but-graph/src/lib.rs
@@ -203,6 +203,7 @@ mod segment;
 pub use petgraph;
 pub use segment::{
     Commit, CommitFlags, RefInfo, Segment, SegmentFlags, SegmentMetadata, StopCondition, Worktree,
+    WorktreeKind,
 };
 
 mod api;

--- a/crates/but-graph/src/projection/stack.rs
+++ b/crates/but-graph/src/projection/stack.rs
@@ -104,6 +104,25 @@ impl Stack {
             .segments
             .first()
             .map_or_else(|| "<anon>".into(), |s| s.debug_string());
+        self.push_debug_suffix(&mut dbg, id_override);
+        dbg
+    }
+
+    /// Like [`Self::debug_string()`], but includes graph-contextual worktree ownership markers.
+    pub fn debug_string_with_graph_context(
+        &self,
+        graph: &Graph,
+        id_override: Option<StackId>,
+    ) -> String {
+        let mut dbg = self.segments.first().map_or_else(
+            || "<anon>".into(),
+            |s| s.debug_string_with_graph_context(graph),
+        );
+        self.push_debug_suffix(&mut dbg, id_override);
+        dbg
+    }
+
+    fn push_debug_suffix(&self, dbg: &mut String, id_override: Option<StackId>) {
         if let Some(base) = self.base() {
             dbg.push_str(" on ");
             dbg.push_str(&base.to_hex_with_len(7).to_string());
@@ -120,7 +139,6 @@ impl Stack {
                 }
             ));
         }
-        dbg
     }
 }
 
@@ -386,6 +404,27 @@ impl StackSegment {
 
     /// Digest as much as possible into a single line.
     pub fn debug_string(&self) -> String {
+        self.debug_string_with_ref_name_remote(Graph::ref_and_remote_debug_string(
+            self.ref_info.as_ref(),
+            self.remote_tracking_ref_name.as_ref(),
+            self.sibling_segment_id,
+            self.remote_tracking_branch_segment_id,
+        ))
+    }
+
+    /// Like [`Self::debug_string()`], but includes graph-contextual worktree ownership markers.
+    pub fn debug_string_with_graph_context(&self, graph: &Graph) -> String {
+        self.debug_string_with_ref_name_remote(
+            graph.ref_and_remote_debug_string_with_graph_context(
+                self.ref_info.as_ref(),
+                self.remote_tracking_ref_name.as_ref(),
+                self.sibling_segment_id,
+                self.remote_tracking_branch_segment_id,
+            ),
+        )
+    }
+
+    fn debug_string_with_ref_name_remote(&self, ref_name_remote: String) -> String {
         let num_local_commits = if self.remote_tracking_ref_name.is_some() {
             self.commits
                 .iter()
@@ -403,12 +442,6 @@ impl StackSegment {
             ep = if self.is_entrypoint { "👉" } else { "" },
             meta = if self.metadata.is_some() { "📙" } else { "" },
             id = self.id.index(),
-            ref_name_remote = Graph::ref_and_remote_debug_string(
-                self.ref_info.as_ref(),
-                self.remote_tracking_ref_name.as_ref(),
-                self.sibling_segment_id,
-                self.remote_tracking_branch_segment_id,
-            ),
             local_commits = if num_local_commits == 0 {
                 "".into()
             } else {

--- a/crates/but-graph/src/projection/workspace/api/mod.rs
+++ b/crates/but-graph/src/projection/workspace/api/mod.rs
@@ -368,11 +368,17 @@ impl Workspace {
         let graph = &self.graph;
         let (name, sign) = match &self.kind {
             WorkspaceKind::Managed { ref_info } => (
-                Graph::ref_debug_string(ref_info.ref_name.as_ref(), ref_info.worktree.as_ref()),
+                graph.ref_debug_string_with_graph_context(
+                    ref_info.ref_name.as_ref(),
+                    ref_info.worktree.as_ref(),
+                ),
                 "🏘️",
             ),
             WorkspaceKind::ManagedMissingWorkspaceCommit { ref_info } => (
-                Graph::ref_debug_string(ref_info.ref_name.as_ref(), ref_info.worktree.as_ref()),
+                graph.ref_debug_string_with_graph_context(
+                    ref_info.ref_name.as_ref(),
+                    ref_info.worktree.as_ref(),
+                ),
                 "🏘️⚠️",
             ),
             WorkspaceKind::AdHoc => (
@@ -380,7 +386,10 @@ impl Workspace {
                     .ref_info
                     .as_ref()
                     .map_or("DETACHED".into(), |ri| {
-                        Graph::ref_debug_string(ri.ref_name.as_ref(), ri.worktree.as_ref())
+                        graph.ref_debug_string_with_graph_context(
+                            ri.ref_name.as_ref(),
+                            ri.worktree.as_ref(),
+                        )
                     }),
                 "⌂",
             ),

--- a/crates/but-graph/src/projection/workspace/init.rs
+++ b/crates/but-graph/src/projection/workspace/init.rs
@@ -11,11 +11,12 @@ use but_core::ref_metadata::{
 };
 use gix::{ObjectId, refs::Category};
 use itertools::Itertools;
-use petgraph::{Direction, visit::NodeRef};
+use petgraph::{Direction, prelude::EdgeRef, visit::NodeRef};
 use tracing::instrument;
 
 use crate::{
     CommitFlags, Graph, Segment, SegmentIndex, Workspace,
+    utils::SeenTable,
     workspace::{
         Stack, StackCommit, StackCommitFlags, StackSegment, TargetCommit, TargetRef, WorkspaceKind,
         workspace::{
@@ -321,6 +322,16 @@ impl Graph {
     fn workspace_stacks(&self, frame: &WorkspaceFrame) -> anyhow::Result<Vec<Stack>> {
         let mut stacks = vec![];
         let (lowest_base, lowest_base_sidx) = (frame.lower_bound, frame.lower_bound_segment_id);
+        let preferred_parent_order_by_commit = frame
+            .entrypoint_sidx
+            .map(|entrypoint| {
+                self.preferred_parent_order_by_commit(
+                    frame.ws_tip_segment_id,
+                    entrypoint,
+                    frame.lower_bound_segment_id,
+                )
+            })
+            .unwrap_or_default();
         if frame.kind.has_managed_ref() {
             let mut used_stack_ids = BTreeSet::default();
             for stack_top_sidx in self
@@ -333,6 +344,7 @@ impl Graph {
                     self.collect_stack_segments(
                         stack_top_sidx,
                         frame.entrypoint_sidx,
+                        &preferred_parent_order_by_commit,
                         |s| {
                             let stop = true;
                             // The lowest base is a segment that all stacks will run into.
@@ -405,6 +417,7 @@ impl Graph {
                 .collect_stack_segments(
                     start.id,
                     None,
+                    &preferred_parent_order_by_commit,
                     |s| {
                         let stop = true;
                         if segment_name_is_special(s) {
@@ -634,6 +647,90 @@ impl Graph {
             .and_then(|target| self.tip_skip_empty(target.segment_index))
             .is_some_and(|commit| commit.id == commit_id)
     }
+
+    /// Return commit-specific parent choices for the path from `start` down to `entrypoint`.
+    ///
+    /// Each graph edge knows which parent of its source commit it represents.
+    /// For a merge commit `M` with parents `[A, B]`, the edge from `M` to `A`
+    /// has parent order `0`, and the edge from `M` to `B` has parent order `1`.
+    /// This records the edge parent order for each source commit on the path
+    /// that reaches the entrypoint, then sorts by commit id so stack collection
+    /// can binary-search it while walking downward.
+    fn preferred_parent_order_by_commit(
+        &self,
+        start: SegmentIndex,
+        entrypoint: SegmentIndex,
+        lower_bound: Option<SegmentIndex>,
+    ) -> Vec<(ObjectId, u32)> {
+        let mut seen = self.seen_table();
+        let mut out = Vec::new();
+        if !self.collect_preferred_parent_order_by_commit(
+            start,
+            entrypoint,
+            lower_bound,
+            &mut seen,
+            &mut out,
+        ) {
+            return Vec::new();
+        }
+        out.sort_by_key(|lhs| lhs.0);
+        out.dedup_by(|lhs, rhs| lhs.0 == rhs.0);
+        out
+    }
+
+    /// Depth-first search for one downward segment path from `current` to `entrypoint`.
+    ///
+    /// Edges point from a segment toward its parents in commit history. When the recursion finds
+    /// `entrypoint`, it returns `true` and unwinds, appending one `(source_commit_id, parent_order)`
+    /// pair for each edge on the successful path. The source commit id is enough to identify the
+    /// merge commit during later stack walking, and `parent_order` identifies which parent edge
+    /// keeps that walk on the entrypoint path.
+    ///
+    /// If `lower_bound` is set, the search does not descend past it. Reaching the lower-bound
+    /// segment fails the current branch unless that segment is also `entrypoint`. This keeps the
+    /// entrypoint path search within the same workspace range that stack collection will later use.
+    ///
+    /// Branches that do not lead to `entrypoint` are backtracked by truncating `out` to its length
+    /// before that branch was explored. `seen` prevents revisiting shared history in the segmented
+    /// graph, so the search cost is linear in the bounded reachable segment subgraph from `current`:
+    /// `O(segments + edges)` up to the lower bound, with `O(segments)` visited storage and
+    /// `O(path length)` output.
+    fn collect_preferred_parent_order_by_commit(
+        &self,
+        current: SegmentIndex,
+        entrypoint: SegmentIndex,
+        lower_bound: Option<SegmentIndex>,
+        seen: &mut SeenTable,
+        out: &mut Vec<(ObjectId, u32)>,
+    ) -> bool {
+        if current == entrypoint {
+            return true;
+        }
+        if Some(current) == lower_bound {
+            return false;
+        }
+        if !seen.insert_unseen(current) {
+            return false;
+        }
+
+        for edge in self.inner.edges_directed(current, Direction::Outgoing) {
+            let before = out.len();
+            if self.collect_preferred_parent_order_by_commit(
+                edge.target(),
+                entrypoint,
+                lower_bound,
+                seen,
+                out,
+            ) {
+                if let Some(src_id) = edge.weight().src_id {
+                    out.push((src_id, edge.weight().parent_order));
+                }
+                return true;
+            }
+            out.truncate(before);
+        }
+        false
+    }
 }
 
 enum ComputeBaseTip {
@@ -702,9 +799,16 @@ fn find_matching_stack_id(
 
 /// Traversals
 impl Graph {
-    /// Return the ancestry of `start` along the first parents, itself included, until `stop` returns `true`.
+    /// Return the ancestry of `start` along the preferred parent path, itself included, until `stop` returns `true`.
     /// Also return the segment that we stopped at.
     /// **Important**: `stop` is not called with `start`, this is a feature.
+    ///
+    /// `preferred_parent_order_by_commit` is a sorted list of `(commit_id, parent_order)` pairs
+    /// produced from the path between the workspace tip and the traversal entrypoint. During the
+    /// stack walk, each outgoing edge is matched by its source commit id and parent order. If a
+    /// matching hint exists, that edge is followed so a merge can walk through the parent that
+    /// reaches the entrypoint. Without a hint for the current source commit, the preferred path
+    /// falls back to the first-parent edge.
     ///
     /// The `stop` signal is ignored for unnamed segments (no `ref_info`) whose `sibling_segment_id`
     /// points to a segment already collected in the output. This prevents the traversal from stopping
@@ -714,27 +818,82 @@ impl Graph {
     fn collect_first_parent_segments_until<'a>(
         &'a self,
         start: &'a Segment,
+        preferred_parent_order_by_commit: &[(ObjectId, u32)],
         mut stop: impl FnMut(&Segment) -> bool,
     ) -> (Vec<&'a Segment>, Option<&'a Segment>) {
         let mut out = vec![start.id];
         let mut stopped_at = None;
-        self.visit_segments_downward_along_first_parent_exclude_start(start.id, |next| {
-            if stop(next)
-                && !(next.ref_info.is_none()
-                    && next
-                        .sibling_segment_id
-                        .is_some_and(|sid| out.contains(&sid)))
-            {
-                stopped_at = Some(next.id);
-                return true;
-            }
-            out.push(next.id);
-            false
-        });
+        self.visit_segments_downward_with_parent_order_hints_exclude_start(
+            start.id,
+            preferred_parent_order_by_commit,
+            |next| {
+                if stop(next)
+                    && !(next.ref_info.is_none()
+                        && next
+                            .sibling_segment_id
+                            .is_some_and(|sid| out.contains(&sid)))
+                {
+                    stopped_at = Some(next.id);
+                    return true;
+                }
+                out.push(next.id);
+                false
+            },
+        );
         (
             out.into_iter().map(|sidx| &self[sidx]).collect(),
             stopped_at.map(|sidx| &self[sidx]),
         )
+    }
+
+    /// Visit the ancestry of `start` along the preferred parent path, itself excluded, until `stop` returns `true`.
+    /// **Important**: `stop` is not called with `start`, this is a feature.
+    ///
+    /// `preferred_parent_order_by_commit` is a sorted list of `(commit_id, parent_order)` pairs.
+    /// Each outgoing edge is matched by its source commit id and parent order. If a matching
+    /// hint exists, that edge is followed. Without a hint for the current source commit, the
+    /// walk falls back to the first-parent edge.
+    pub fn visit_segments_downward_with_parent_order_hints_exclude_start(
+        &self,
+        start: SegmentIndex,
+        preferred_parent_order_by_commit: &[(ObjectId, u32)],
+        mut stop: impl FnMut(&Segment) -> bool,
+    ) {
+        let mut next = self.next_segment_downward(start, preferred_parent_order_by_commit);
+        let mut seen = self.seen_table();
+        while let Some(sidx) = next {
+            let segment = &self[sidx];
+            if stop(segment) {
+                return;
+            }
+            next = if seen.insert_unseen(sidx) {
+                self.next_segment_downward(sidx, preferred_parent_order_by_commit)
+            } else {
+                None
+            };
+        }
+    }
+
+    fn next_segment_downward(
+        &self,
+        segment: SegmentIndex,
+        preferred_parent_order_by_commit: &[(ObjectId, u32)],
+    ) -> Option<SegmentIndex> {
+        let preferred_parent_order = self[segment]
+            .commits
+            .last()
+            .and_then(|commit| {
+                preferred_parent_order_by_commit
+                    .binary_search_by(|(id, _)| id.cmp(&commit.id))
+                    .ok()
+            })
+            .map(|hint_idx| preferred_parent_order_by_commit[hint_idx].1);
+        for edge in self.inner.edges_directed(segment, Direction::Outgoing) {
+            if preferred_parent_order.is_none_or(|order| edge.weight().parent_order == order) {
+                return Some(edge.target());
+            }
+        }
+        None
     }
 
     /// Visit all segments from `start`, excluding, and return once `find` returns something mapped from the
@@ -775,6 +934,7 @@ impl Graph {
         &self,
         from: SegmentIndex,
         mut entrypoint_sidx: Option<SegmentIndex>,
+        preferred_parent_order_by_commit: &[(ObjectId, u32)],
         mut is_one_past_end_of_stack_segment: impl FnMut(&Segment) -> bool,
         mut starts_next_stack_segment: impl FnMut(&Segment) -> bool,
         mut discard_stack: impl FnMut(&StackSegment) -> bool,
@@ -783,8 +943,11 @@ impl Graph {
         let mut next = Some(from);
         while let Some(from) = next.take() {
             let start = &self[from];
-            let (segments, stopped_at) = self
-                .collect_first_parent_segments_until(start, &mut is_one_past_end_of_stack_segment);
+            let (segments, stopped_at) = self.collect_first_parent_segments_until(
+                start,
+                preferred_parent_order_by_commit,
+                &mut is_one_past_end_of_stack_segment,
+            );
             let mut segment = StackSegment::from_graph_segments(&segments, self)?;
             if entrypoint_sidx.is_some_and(|id| segment.id == id) {
                 segment.is_entrypoint = true;

--- a/crates/but-graph/src/segment.rs
+++ b/crates/but-graph/src/segment.rs
@@ -52,9 +52,9 @@ pub struct RefInfo {
     pub worktree: Option<Worktree>,
 }
 
-/// Describes which worktree is checked out.
+/// Describes which kind of worktree is checked out by a [Ref](RefInfo).
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub enum Worktree {
+pub enum WorktreeKind {
     /// The main worktree, i.e. the primary workspace associated with this repository, is checked out.
     ///
     /// It cannot be removed.
@@ -64,15 +64,50 @@ pub enum Worktree {
     LinkedId(BString),
 }
 
+/// Describes which worktree is checked out and how it relates to the repository that produced the graph.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Worktree {
+    /// The kind of worktree that checks out the reference.
+    pub kind: WorktreeKind,
+    /// The repository that produced the graph is using this worktree.
+    ///
+    /// Only one worktree in a graph should have this flag set.
+    pub owned_by_repo: bool,
+}
+
 impl Worktree {
     /// Produce a string that identifies this instance concisely, and visually distinguishable.
-    /// Use `ref_name` to deduplicate the name we chose.
+    /// `ref_name` is the name from the [`RefInfo`] that owns this worktree,
+    /// used to deduplicate the name we chose.
+    ///
+    /// For example, `refs/heads/foo` in linked worktree id `foo` prints
+    /// `foo[📁]`, not `foo[📁foo]`.
     pub fn debug_string(&self, ref_name: &gix::refs::FullNameRef) -> String {
+        self.debug_string_with_graph_context(ref_name, false)
+    }
+
+    /// Like [`Self::debug_string()`], but includes graph-contextual worktree ownership markers.
+    pub fn debug_string_with_graph_context(
+        &self,
+        ref_name: &gix::refs::FullNameRef,
+        show_owned_by_repo: bool,
+    ) -> String {
+        let owned_by_repo = if show_owned_by_repo && self.owned_by_repo {
+            "@repo"
+        } else {
+            ""
+        };
+        self.kind.debug_string(ref_name, owned_by_repo)
+    }
+}
+
+impl WorktreeKind {
+    fn debug_string(&self, ref_name: &gix::refs::FullNameRef, owned_by_repo: &str) -> String {
         match self {
-            Worktree::Main => "[🌳]".to_owned(),
-            Worktree::LinkedId(id) => {
+            WorktreeKind::Main => format!("[🌳{owned_by_repo}]"),
+            WorktreeKind::LinkedId(id) => {
                 format!(
-                    "[📁{id}]",
+                    "[📁{id}{owned_by_repo}]",
                     id = if ref_name.shorten() != id {
                         id.as_bstr()
                     } else {

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -1332,15 +1332,37 @@ fn ambiguous_worktrees() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @"
 
-    └── 👉►:0[0]:main[🌳]
+    └── 👉►:0[0]:main[🌳@repo]
         └── 🏁·85efbe4 (⌂|1) ►wt-inside-ambiguous-worktree[📁], ►wt-outside-ambiguous-worktree[📁]
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
-    ⌂:0:main[🌳] <> ✓!
-    └── ≡:0:main[🌳] {1}
-        └── :0:main[🌳]
+    ⌂:0:main[🌳@repo] <> ✓!
+    └── ≡:0:main[🌳@repo] {1}
+        └── :0:main[🌳@repo]
             └── ·85efbe4 ►wt-inside-ambiguous-worktree[📁], ►wt-outside-ambiguous-worktree[📁]
+    ");
+
+    let linked_repo = gix::open_opts(
+        repo.path()
+            .parent()
+            .expect("repository git dir is inside the worktree")
+            .join("wt-inside-ambiguous-worktree"),
+        gix::open::Options::isolated(),
+    )?
+    .with_object_memory();
+    let graph = Graph::from_head(&linked_repo, &*meta, standard_options())?.validated()?;
+    insta::assert_snapshot!(graph_tree(&graph), "when the graph is built from the linked worktree repository, it can't see anything else without metadata", @"
+
+    └── 👉►:0[0]:wt-inside-ambiguous-worktree[📁@repo]
+        └── 🏁·85efbe4 (⌂|1) ►main[🌳], ►wt-outside-ambiguous-worktree[📁]
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), "workspace debug output should preserve that the linked worktree, not the main worktree, is owned by the repository used to build the graph", @"
+    ⌂:0:wt-inside-ambiguous-worktree[📁@repo] <> ✓!
+    └── ≡:0:wt-inside-ambiguous-worktree[📁@repo] {1}
+        └── :0:wt-inside-ambiguous-worktree[📁@repo]
+            └── ·85efbe4 ►main[🌳], ►wt-outside-ambiguous-worktree[📁]
     ");
     Ok(())
 }

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -990,6 +990,78 @@ fn minimal_merge() -> anyhow::Result<()> {
 }
 
 #[test]
+fn entrypoint_inside_second_parent_of_workspace_diamond_is_included() -> anyhow::Result<()> {
+    let (repo, mut meta) = read_only_in_memory_scenario("ws/dual-merge")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 47e1cf1 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   f40fb16 (merge-2) Merge branch 'C' into merge-2
+    |\  
+    | * c6d714c (C) C
+    * | 450c58a (D) D
+    |/  
+    *   0cc5a6f (merge, empty-2-on-merge, empty-1-on-merge) Merge branch 'A' into merge
+    |\  
+    | * e255adc (A) A
+    * | 7fdb58d (B) B
+    |/  
+    * fafd9d0 (origin/main, main) init
+    ");
+    add_workspace(&mut meta);
+    let (id, name) = id_at(&repo, "C");
+    let graph = Graph::from_commit_traversal(id, name, &*meta, standard_options())?.validated()?;
+    insta::assert_snapshot!(graph_tree(&graph), @r"
+
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
+    │   └── ·47e1cf1 (⌂|🏘)
+    │       └── ►:5[1]:merge-2
+    │           └── ·f40fb16 (⌂|🏘)
+    │               ├── ►:8[2]:D
+    │               │   └── ·450c58a (⌂|🏘)
+    │               │       └── ►:4[3]:anon:
+    │               │           └── ·0cc5a6f (⌂|🏘|01) ►empty-1-on-merge, ►empty-2-on-merge, ►merge
+    │               │               ├── ►:6[4]:B
+    │               │               │   └── ·7fdb58d (⌂|🏘|01)
+    │               │               │       └── ►:3[5]:main <> origin/main →:2:
+    │               │               │           └── 🏁·fafd9d0 (⌂|🏘|✓|11)
+    │               │               └── ►:7[4]:A
+    │               │                   └── ·e255adc (⌂|🏘|01)
+    │               │                       └── →:3: (main →:2:)
+    │               └── 👉►:0[2]:C
+    │                   └── ·c6d714c (⌂|🏘|01)
+    │                       └── →:4:
+    └── ►:2[0]:origin/main →:3:
+        └── →:3: (main →:2:)
+    ");
+
+    let ws = graph.into_workspace()?;
+    let entrypoint_stack_segment = ws
+        .stacks
+        .iter()
+        .flat_map(|stack| stack.segments.iter())
+        .find(|segment| segment.is_entrypoint)
+        .expect("entrypoint segment must stay in a workspace stack");
+    assert!(
+        entrypoint_stack_segment
+            .commits
+            .iter()
+            .any(|commit| commit.id == id.detach()),
+        "the entrypoint stack segment must contain the custom traversal commit"
+    );
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+    └── ≡:5:merge-2 on fafd9d0
+        ├── :5:merge-2
+        │   └── ·f40fb16 (🏘️)
+        ├── 👉:0:C
+        │   ├── ·c6d714c (🏘️)
+        │   └── ·0cc5a6f (🏘️) ►empty-1-on-merge, ►empty-2-on-merge, ►merge
+        └── :6:B
+            └── ·7fdb58d (🏘️)
+    ");
+    Ok(())
+}
+
+#[test]
 fn stack_configuration_is_respected_if_one_of_them_is_an_entrypoint() -> anyhow::Result<()> {
     let (repo, mut meta) = read_only_in_memory_scenario("ws/just-init-with-two-branches")?;
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* fafd9d0 (HEAD -> gitbutler/workspace, main, B, A) init");

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -6420,7 +6420,7 @@ fn ambiguous_worktrees() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @"
 
-    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳@repo]
     │   └── ·a5f94a2 (⌂|🏘|0001)
     │       ├── 📙►:6[1]:A <> origin/A →:4:
     │       │   └── ►:3[2]:anon:
@@ -6439,12 +6439,51 @@ fn ambiguous_worktrees() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
-    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 081bae9
+    📕🏘️:0:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main⇣1 on 081bae9
     ├── ≡📙:6:A <> origin/A →:4:⇣1 on 081bae9 {0}
     │   └── 📙:6:A <> origin/A →:4:⇣1
     │       └── 🟣197ddce
     └── ≡:5:B[📁wt-B-inside] on 081bae9
         └── :5:B[📁wt-B-inside]
+            └── ·3e01e28 (🏘️)
+    ");
+
+    let linked_repo = gix::open_opts(
+        repo.path()
+            .parent()
+            .expect("repository git dir is inside the worktree")
+            .join("wt-B-inside"),
+        gix::open::Options::isolated(),
+    )?
+    .with_object_memory();
+    let graph = Graph::from_head(&linked_repo, &*meta, standard_options())?.validated()?;
+    insta::assert_snapshot!(graph_tree(&graph), "when the graph is built from the B linked worktree repository, the workspace remains visible but the B worktree owns the entrypoint branch", @"
+
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
+    │   └── ·a5f94a2 (⌂|🏘)
+    │       ├── 📙►:6[1]:A <> origin/A →:5:
+    │       │   └── ►:4[2]:anon:
+    │       │       ├── ·081bae9 (⌂|🏘|✓|1111) ►A-inside[📁wt-A-inside], ►A-outside[📁wt-A-outside]
+    │       │       └── 🏁·3183e43 (⌂|🏘|✓|1111)
+    │       └── 👉►:0[1]:B[📁wt-B-inside@repo]
+    │           └── ·3e01e28 (⌂|🏘|0001)
+    │               └── →:4:
+    ├── ►:2[0]:origin/main →:3:
+    │   └── ►:3[1]:main <> origin/main →:2:
+    │       └── ·8dc508f (⌂|✓|0010)
+    │           └── →:4:
+    └── ►:5[0]:origin/A →:6:
+        └── 🟣197ddce (0x0|1000)
+            └── →:4:
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), "workspace projection should keep the linked-worktree ownership marker on the focused stack while leaving the workspace ref itself unowned", @"
+    📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 081bae9
+    ├── ≡📙:6:A <> origin/A →:5:⇣1 on 081bae9 {0}
+    │   └── 📙:6:A <> origin/A →:5:⇣1
+    │       └── 🟣197ddce
+    └── ≡👉:0:B[📁wt-B-inside@repo] on 081bae9
+        └── 👉:0:B[📁wt-B-inside@repo]
             └── ·3e01e28 (🏘️)
     ");
     Ok(())

--- a/crates/but-testsupport/src/graph.rs
+++ b/crates/but-testsupport/src/graph.rs
@@ -27,33 +27,41 @@ fn graph_workspace_inner(
     };
     let mut root = Tree::new(workspace.debug_string());
     for stack in &workspace.stacks {
-        root.push(tree_for_stack(stack, commit_flags, stack_id_map.as_mut()));
+        root.push(tree_for_stack(
+            &workspace.graph,
+            stack,
+            commit_flags,
+            stack_id_map.as_mut(),
+        ));
     }
     root
 }
 
 fn tree_for_stack(
+    graph: &Graph,
     stack: &but_graph::workspace::Stack,
     commit_flags: StackCommitDebugFlags,
     stack_id_map: Option<&mut BTreeMap<StackId, StackId>>,
 ) -> StringTree {
-    let mut root = Tree::new(
-        stack.debug_string(stack.id.zip(stack_id_map).map(|(id, map)| {
+    let mut root = Tree::new(stack.debug_string_with_graph_context(
+        graph,
+        stack.id.zip(stack_id_map).map(|(id, map)| {
             let next_id = StackId::from_number_for_testing((map.len() + 1) as u128);
             *map.entry(id).or_insert(next_id)
-        })),
-    );
+        }),
+    ));
     for segment in &stack.segments {
-        root.push(tree_for_stack_segment(segment, commit_flags));
+        root.push(tree_for_stack_segment(graph, segment, commit_flags));
     }
     root
 }
 
 fn tree_for_stack_segment(
+    graph: &Graph,
     segment: &but_graph::workspace::StackSegment,
     commit_flags: StackCommitDebugFlags,
 ) -> StringTree {
-    let mut root = Tree::new(segment.debug_string());
+    let mut root = Tree::new(segment.debug_string_with_graph_context(graph));
     if let Some(outside) = &segment.commits_outside {
         for commit in outside {
             root.push(format!("{}*", commit.debug_string(commit_flags)));
@@ -97,20 +105,22 @@ pub fn graph_tree(graph: &Graph) -> StringTree {
 }
 
 fn tree_for_commit(
+    graph: &Graph,
     commit: &but_graph::Commit,
     is_entrypoint: bool,
     stop_condition: Option<but_graph::StopCondition>,
     hard_limit_hit: bool,
     max_goals: Option<usize>,
 ) -> StringTree {
-    Graph::commit_debug_string(
-        commit,
-        is_entrypoint,
-        stop_condition,
-        hard_limit_hit,
-        max_goals,
-    )
-    .into()
+    graph
+        .commit_debug_string_with_graph_context(
+            commit,
+            is_entrypoint,
+            stop_condition,
+            hard_limit_hit,
+            max_goals,
+        )
+        .into()
 }
 fn recurse_segment(
     graph: &but_graph::Graph,
@@ -128,7 +138,10 @@ fn recurse_segment(
                 .as_ref()
                 .map(|ri| format!(
                     " ({}{maybe_sibling})",
-                    Graph::ref_debug_string(ri.ref_name.as_ref(), ri.worktree.as_ref()),
+                    graph.ref_debug_string_with_graph_context(
+                        ri.ref_name.as_ref(),
+                        ri.worktree.as_ref(),
+                    ),
                     maybe_sibling = segment
                         .remote_tracking_branch_segment_id
                         .or(segment.sibling_segment_id)
@@ -192,7 +205,7 @@ fn recurse_segment(
         } else {
             ""
         },
-        ref_name_and_remote = Graph::ref_and_remote_debug_string(
+        ref_name_and_remote = graph.ref_and_remote_debug_string_with_graph_context(
             segment.ref_info.as_ref(),
             segment.remote_tracking_ref_name.as_ref(),
             segment.sibling_segment_id,
@@ -201,6 +214,7 @@ fn recurse_segment(
     ));
     for (cidx, commit) in segment.commits.iter().enumerate() {
         let mut commit_tree = tree_for_commit(
+            graph,
             commit,
             segment_is_entrypoint && Some(cidx) == entrypoint_commit_index,
             if cidx + 1 != segment.commits.len() {

--- a/crates/but-workspace/src/legacy/stacks.rs
+++ b/crates/but-workspace/src/legacy/stacks.rs
@@ -450,9 +450,9 @@ impl ui::BranchDetails {
                 .is_some_and(|c| matches!(c, gix::refs::Category::RemoteBranch)),
             name: ref_info.ref_name.shorten().into(),
             reference: ref_info.ref_name,
-            linked_worktree_id: ref_info.worktree.and_then(|ws| match ws {
-                but_graph::Worktree::Main => None,
-                but_graph::Worktree::LinkedId(id) => Some(id),
+            linked_worktree_id: ref_info.worktree.and_then(|ws| match ws.kind {
+                but_graph::WorktreeKind::Main => None,
+                but_graph::WorktreeKind::LinkedId(id) => Some(id),
             }),
             remote_tracking_branch: remote_tracking_ref_name
                 .as_ref()

--- a/crates/but-workspace/tests/workspace/ref_info/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/mod.rs
@@ -129,7 +129,10 @@ fn unborn_untracked() -> anyhow::Result<()> {
                 ),
                 commit_id: None,
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -291,7 +294,10 @@ fn conflicted_in_local_branch() -> anyhow::Result<()> {
                     Sha1(84503317a1e1464381fcff65ece14bc1f4315b7c),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -410,7 +416,10 @@ fn single_branch() -> anyhow::Result<()> {
                     Sha1(b5743a3aa79957bcb7f654d7d4ad11d995ad5303),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -538,7 +547,10 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
                     Sha1(b5743a3aa79957bcb7f654d7d4ad11d995ad5303),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
@@ -31,7 +31,10 @@ fn j01_unborn() -> anyhow::Result<()> {
                     ),
                     commit_id: None,
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),
@@ -89,7 +92,10 @@ fn j02_first_commit() -> anyhow::Result<()> {
                         Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),
@@ -153,7 +159,10 @@ fn j03_main_pushed() -> anyhow::Result<()> {
                         Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),
@@ -212,7 +221,10 @@ fn j03_main_pushed() -> anyhow::Result<()> {
                         Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),
@@ -284,7 +296,10 @@ fn j04_create_workspace() -> anyhow::Result<()> {
                         Sha1(a26ae77fda20033f23c2b7790481e0b81d8cd9b9),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),
@@ -345,7 +360,10 @@ fn j05_empty_stack() -> anyhow::Result<()> {
                         Sha1(a26ae77fda20033f23c2b7790481e0b81d8cd9b9),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),
@@ -427,7 +445,10 @@ fn j06_create_commit_in_stack() -> anyhow::Result<()> {
                         Sha1(9a8283b423afb4f9c3feb18471ff2c543018c522),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),
@@ -497,7 +518,10 @@ fn j06_create_commit_in_stack() -> anyhow::Result<()> {
                         Sha1(9a8283b423afb4f9c3feb18471ff2c543018c522),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),
@@ -581,7 +605,10 @@ fn j07_push_commit() -> anyhow::Result<()> {
                         Sha1(9a8283b423afb4f9c3feb18471ff2c543018c522),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),
@@ -670,7 +697,10 @@ fn j08_next_local_commit() -> anyhow::Result<()> {
                         Sha1(9e1f2642e9591266fb00001789164f7960e508f5),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),
@@ -758,7 +788,10 @@ fn j09_rewritten_remote_and_local_commit() -> anyhow::Result<()> {
                         Sha1(4d230909d7fba6bf00af30c9db74695a315fc93f),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),
@@ -853,7 +886,10 @@ fn j10_squash_merge_stack() -> anyhow::Result<()> {
                         Sha1(4d230909d7fba6bf00af30c9db74695a315fc93f),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),
@@ -958,7 +994,10 @@ fn j11_squash_merge_remote_only() -> anyhow::Result<()> {
                         Sha1(4d230909d7fba6bf00af30c9db74695a315fc93f),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),
@@ -1071,7 +1110,10 @@ fn j12_local_only_multi_segment_squash_merge() -> anyhow::Result<()> {
                         Sha1(4da5b24e0457fb452972018e03505e0296ae0455),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_merges.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_merges.rs
@@ -41,7 +41,10 @@ fn two_commits_require_force_push() -> anyhow::Result<()> {
                         Sha1(946cdb70e5c527a30bf8154b445c188908d25806),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),
@@ -128,7 +131,10 @@ fn two_commits_require_force_push_merged() -> anyhow::Result<()> {
                         Sha1(946cdb70e5c527a30bf8154b445c188908d25806),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),
@@ -217,7 +223,10 @@ fn remote_diverged() -> anyhow::Result<()> {
                         Sha1(3ea274233577e8e949de8b2c0385ecd36b6df904),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),
@@ -316,7 +325,10 @@ fn remote_diverged_merge() -> anyhow::Result<()> {
                         Sha1(3ea274233577e8e949de8b2c0385ecd36b6df904),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),
@@ -399,7 +411,10 @@ fn remote_behind() -> anyhow::Result<()> {
                         Sha1(3ea274233577e8e949de8b2c0385ecd36b6df904),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),
@@ -491,7 +506,10 @@ fn remote_behind_merge_no_ff() -> anyhow::Result<()> {
                         Sha1(3ea274233577e8e949de8b2c0385ecd36b6df904),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),
@@ -575,7 +593,10 @@ fn remote_ahead() -> anyhow::Result<()> {
                         Sha1(8ee08de8bed7f60305c9b7fb5eefa64280c1c1cf),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),
@@ -664,7 +685,10 @@ fn remote_ahead_merge_ff() -> anyhow::Result<()> {
                         Sha1(8ee08de8bed7f60305c9b7fb5eefa64280c1c1cf),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_rebase.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_rebase.rs
@@ -41,7 +41,10 @@ fn two_commits_rebased_onto_target() -> anyhow::Result<()> {
                         Sha1(946cdb70e5c527a30bf8154b445c188908d25806),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),
@@ -135,7 +138,10 @@ fn two_commits_rebased_onto_target_one_amended_afterwards() -> anyhow::Result<()
                         Sha1(4c3a992a5090077f9a5d35df22e065360c35729d),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),
@@ -226,7 +232,10 @@ fn two_rewritten_commits_track_as_local_and_remote() -> anyhow::Result<()> {
                         Sha1(0b1ed50b03e220f38d6d0930980512dc10bc9ab9),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),
@@ -320,7 +329,10 @@ fn two_commits_rebased_onto_target_with_changeset_check() -> anyhow::Result<()> 
                         Sha1(f1caa513c52daf127b94c157060d1ad7f911b1b1),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/legacy.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/legacy.rs
@@ -553,7 +553,10 @@ mod stack_details {
                         Sha1(2076060e1915b4caf40eb51ab9a462eced434cc7),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             },
@@ -640,7 +643,10 @@ mod stack_details {
                         Sha1(2076060e1915b4caf40eb51ab9a462eced434cc7),
                     ),
                     worktree: Some(
-                        Main,
+                        Worktree {
+                            kind: Main,
+                            owned_by_repo: true,
+                        },
                     ),
                 },
             ),

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -51,7 +51,10 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
                     Sha1(fb27086e5fe152421aac3fbb76934b57a179263a),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -124,7 +127,10 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
                     Sha1(fb27086e5fe152421aac3fbb76934b57a179263a),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -201,7 +207,10 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
                     Sha1(fb27086e5fe152421aac3fbb76934b57a179263a),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -291,7 +300,10 @@ fn two_dependent_branches_rebased_with_remotes() -> anyhow::Result<()> {
                     Sha1(d909178c50bba05d43acb4bffb2e6e59329e7710),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -464,7 +476,10 @@ fn two_dependent_branches_rebased_explicit_remote_in_extra_segment() -> anyhow::
                     Sha1(d909178c50bba05d43acb4bffb2e6e59329e7710),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -580,7 +595,10 @@ fn two_dependent_branches_first_merged_no_ff() -> anyhow::Result<()> {
                     Sha1(4a62dfc214fe3aeb34debeb4831640fab49933ba),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -692,7 +710,10 @@ fn two_dependent_branches_first_merged_no_ff_second_merged_on_remote_into_base_b
                     Sha1(4a62dfc214fe3aeb34debeb4831640fab49933ba),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -767,7 +788,10 @@ fn two_dependent_branches_first_merged_no_ff_second_merged_on_remote_into_base_b
                     Sha1(4a62dfc214fe3aeb34debeb4831640fab49933ba),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -869,7 +893,10 @@ fn two_dependent_branches_first_rebased_and_merged_into_target() -> anyhow::Resu
                     Sha1(4f08b8d7e0d7d524a13ca13eaf2cdff9cf4f4719),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -953,7 +980,10 @@ fn two_dependent_branches_first_rebased_and_merged_into_target() -> anyhow::Resu
                     Sha1(4f08b8d7e0d7d524a13ca13eaf2cdff9cf4f4719),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -1053,7 +1083,10 @@ fn target_ahead_remote_rewritten() -> anyhow::Result<()> {
                     Sha1(03d2336cd39022a6898ff7678a0c1f985bd5ff60),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -1150,7 +1183,10 @@ fn single_commit_but_two_branches_one_in_ws_commit() -> anyhow::Result<()> {
                     Sha1(7f3248ecc611d6181c218e105599bb82e35d24d4),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -1293,7 +1329,10 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
                     Sha1(cbc6713ccfc78aa9a3c9cf8305a6fadce0bbe1a4),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -1445,7 +1484,10 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
                     Sha1(cbc6713ccfc78aa9a3c9cf8305a6fadce0bbe1a4),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -1598,7 +1640,10 @@ fn single_commit_but_two_branches_both_in_ws_commit() -> anyhow::Result<()> {
                     Sha1(335d6f2a960f387b039bd77476ae3d2d6649ed70),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -1706,7 +1751,10 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit() -> anyhow::Result<(
                     Sha1(335d6f2a960f387b039bd77476ae3d2d6649ed70),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -1797,7 +1845,10 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit_empty_dependent() -> 
                     Sha1(335d6f2a960f387b039bd77476ae3d2d6649ed70),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -1888,7 +1939,10 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit_empty_dependent() -> 
                     Sha1(335d6f2a960f387b039bd77476ae3d2d6649ed70),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -1990,7 +2044,10 @@ fn single_commit_pushed_ws_commit_empty_dependent() -> anyhow::Result<()> {
                     Sha1(f8f33a7e66ad836cf09ab249941dfae175fcfc60),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -2090,7 +2147,10 @@ fn single_commit_pushed_ws_commit_empty_dependent() -> anyhow::Result<()> {
                     Sha1(f8f33a7e66ad836cf09ab249941dfae175fcfc60),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -2203,7 +2263,10 @@ fn two_branches_stacked_with_remotes() -> anyhow::Result<()> {
                     Sha1(9b3cfd4456acdb1868ea982800025bdd50cbf5c8),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -2307,7 +2370,10 @@ fn two_branches_stacked_with_interesting_remote_setup() -> anyhow::Result<()> {
                     Sha1(a221221cec2713c3434087ce9da57431f2b41d84),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -2408,7 +2474,10 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
                     Sha1(cbc6713ccfc78aa9a3c9cf8305a6fadce0bbe1a4),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -2498,7 +2567,10 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
                     Sha1(cbc6713ccfc78aa9a3c9cf8305a6fadce0bbe1a4),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -2611,7 +2683,10 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                     Sha1(873d0566081b0c92d2ff06331e3455dcc3e4df29),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -2700,7 +2775,10 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                     Sha1(873d0566081b0c92d2ff06331e3455dcc3e4df29),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -2788,7 +2866,10 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                     Sha1(873d0566081b0c92d2ff06331e3455dcc3e4df29),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -2882,7 +2963,10 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                     Sha1(873d0566081b0c92d2ff06331e3455dcc3e4df29),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -2985,7 +3069,10 @@ fn disjoint() -> anyhow::Result<()> {
                     Sha1(32791d22e276ec0ed87d14f906321137356bc6d6),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -3065,7 +3152,10 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                     Sha1(820f2b3c5007e15ba4558556a81d241fcee06856),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -3187,7 +3277,10 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                     Sha1(820f2b3c5007e15ba4558556a81d241fcee06856),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -3309,7 +3402,10 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                     Sha1(820f2b3c5007e15ba4558556a81d241fcee06856),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -3432,7 +3528,10 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                     Sha1(820f2b3c5007e15ba4558556a81d241fcee06856),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -3567,7 +3666,10 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
                     Sha1(c7276fa4ef234bed041b4293f46615a99afc7f50),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -3635,7 +3737,10 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
                     Sha1(c7276fa4ef234bed041b4293f46615a99afc7f50),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),
@@ -3706,7 +3811,10 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
                     Sha1(c7276fa4ef234bed041b4293f46615a99afc7f50),
                 ),
                 worktree: Some(
-                    Main,
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
                 ),
             },
         ),

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -308,7 +308,8 @@ impl SegmentWithId {
     /// Returns the linked worktree ID.
     pub fn linked_worktree_id(&self) -> Option<&BStr> {
         if let Some(ref_info) = &self.inner.ref_info
-            && let Some(but_graph::Worktree::LinkedId(id)) = &ref_info.worktree
+            && let Some(worktree) = &ref_info.worktree
+            && let but_graph::WorktreeKind::LinkedId(id) = &worktree.kind
         {
             Some(id.as_bstr())
         } else {


### PR DESCRIPTION
This makes some improvements to support #10827, and one can see these as correctness fixes.

### Tasks

- [x] correctly gather worktree information, and show which worktree is associated with the current repo
- [x] ensure entrypoint is actually visible in the stack. This also lays the groundwork for choosing 'rails' in linear stacks.

