### PR TITLE
test(GB-1294): reproduce branch replace bug with test case

### DIFF
--- a/crates/but/tests/but/command/branch/new.rs
+++ b/crates/but/tests/but/command/branch/new.rs
@@ -66,6 +66,82 @@ Error: Could not turn "HEAD-" into a valid reference name
 }
 
 #[test]
+fn handles_adding_branch_anchored_on_branch_shared_by_other_stack() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("branch new -a A first-stack").assert().success();
+
+    env.file("first.txt", "first");
+    env.but("commit -m first").assert().success();
+    env.but("unapply first-stack").assert().success();
+
+    env.but("apply A").assert().success();
+    env.but("branch new -a A second-stack").assert().success();
+    env.file("second.txt", "second");
+    env.but("commit -m second").assert().success();
+
+    env.but("apply first-stack").assert().success();
+
+    // Precondition: Two stacks that share a branch
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄se [second-stack]
+┊●   187de8a second
+┊│
+┊├┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┊╭┄fi [first-stack]
+┊●   8673c86 first
+┊│
+┊├┄h0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    // Act: add a branch anchored to the shared branch in _one_ of the stacks
+    env.but("branch new -a h0 first-stack-middle")
+        .assert()
+        .success();
+
+    // Assert: branch is added only to the targeted stack
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄se [second-stack]
+┊●   187de8a second
+┊│
+┊├┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┊╭┄fi [first-stack]
+┊●   8673c86 first
+┊│
+┊├┄h0 [first-stack-middle] (no commits)
+┊│
+┊├┄i0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
 fn with_json_output() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
     insta::assert_snapshot!(env.git_log()?, @r"


### PR DESCRIPTION
Adds a test case to reproduce GB-1294.

The the problem appears when you have multiple stacks that share a branch applied at the same time, and you try to create a new branch anchored to the branch in one of those stacks.

I'm not entirely sure what semantics we even want to have here. @Caleb-T-Owens do you have any ideas? Before I dive further into this I think we should establish if this behavior is even supposed to be supported. But I think it feels sane to be able to have multiple stacks with a common base.

## Example
For example, you may have this state:

```bash
$ but status
╭┄zz [unassigned changes] (no changes)
┊
┊╭┄se [second-stack]
┊●   187de8a second
┊│
┊├┄g0 [A]
┊●   9477ae7 add A
├╯
┊
┊╭┄fi [first-stack]
┊●   8673c86 first
┊│
┊├┄h0 [A]
┊●   9477ae7 add A
├╯
┊
┴ 0dc3733 (common base) 2000-01-02 add M
Hint: run `but help` for all commands
```

And then you'd want to add a new branch `first-stack-middle` anchored at `h0`.

```bash
but branch new first-stack-middle -a h0
✓ Created branch first-stack-middle stacked on A
```

I would expect the result to be that the branch is added to only one of the stacks, or _possibly_ to both, but what actually happens is that `A` is replaced in the projection in _both_ stacks.

```bash
$ but status
╭┄zz [unassigned changes] (no changes)
┊
┊╭┄se [second-stack]
┊●   187de8a second
┊│
┊├┄g0 [first-stack-middle]
┊●   9477ae7 add A
├╯
┊
┊╭┄fi [first-stack]
┊●   8673c86 first
┊│
┊├┄h0 [first-stack-middle]
┊●   9477ae7 add A
├╯
┊
┴ 0dc3733 (common base) 2000-01-02 add M
Hint: run `but help` for all commands
```


## Funky variation
If you instead unapply e.g. `second-stack` and create a new branch anchored at `A`, then the branch is correctly inserted in the middle of `first-stack`. Applying `second-stack` afterwards leads to this (to me, expected) state:

```bash
╭┄zz [unassigned changes] (no changes)
┊
┊╭┄se [second-stack]
┊●   187de8a second
┊│
┊├┄g0 [A]
┊●   9477ae7 add A
├╯
┊
┊╭┄fi [first-stack]
┊●   8673c86 first
┊│
┊├┄h0 [first-stack-middle] (no commits)
┊│
┊├┄i0 [A]
┊●   9477ae7 add A
├╯
┊
┴ 0dc3733 (common base) 2000-01-02 add M

Hint: run `but help` for all commands
```

But if you then add a commit to `first-stack-middle`, then that branch and commit gets inserted into `second-stack` as well.