### PR TITLE
fix: update branch meta data when removing refs with but-transaction

### DIFF
--- a/crates/but-api/src/workspace_state.rs
+++ b/crates/but-api/src/workspace_state.rs
@@ -2,7 +2,7 @@ use super::WorkspaceState;
 use std::collections::BTreeMap;
 
 use but_core::{DryRun, RefMetadata};
-use but_rebase::graph_rebase::SuccessfulRebase;
+use but_rebase::graph_rebase::{MaterializeOutcome, SuccessfulRebase};
 
 use but_workspace::RefInfo;
 
@@ -61,6 +61,21 @@ impl WorkspaceState {
             &rebase.overlayed_graph()?.into_workspace()?,
             rebase.repo(),
             replaced_commits,
+        )
+    }
+
+    /// Build a [`WorkspaceState`] from an already-materialized rebase.
+    ///
+    /// Use this when the caller needs to perform additional bookkeeping after materialization
+    /// before constructing the final workspace state.
+    pub fn from_materialized_rebase<M: RefMetadata>(
+        materialized: MaterializeOutcome<'_, '_, M>,
+        repo: &gix::Repository,
+    ) -> anyhow::Result<WorkspaceState> {
+        Self::from_workspace(
+            materialized.workspace,
+            repo,
+            materialized.history.commit_mappings(),
         )
     }
 

--- a/crates/but-transaction/src/lib.rs
+++ b/crates/but-transaction/src/lib.rs
@@ -12,7 +12,10 @@ use but_rebase::graph_rebase::{
 use but_workspace::commit::{
     MoveChangesOutcome, SquashCommitsOutcome, squash_commits::MessageCombinationStrategy,
 };
-use gix::{ObjectId, refs::FullNameRef};
+use gix::{
+    ObjectId,
+    refs::{FullName, FullNameRef},
+};
 
 #[cfg(test)]
 mod tests;
@@ -92,6 +95,7 @@ where
             rebase: Some(rebase),
             db_tx,
             commit_mappings: CommitMappings::default(),
+            pending_metadata_removals: Vec::new(),
             context_lines,
         };
 
@@ -104,13 +108,20 @@ where
             mut rebase,
             db_tx,
             commit_mappings: _,
+            pending_metadata_removals,
             context_lines: _,
         } = inner;
         let rebase = rebase.take().expect("rebase is always Some(_)");
 
         (
             callback_outcome.should_rollback(),
-            callback_outcome.maybe_commit(&repo, rebase, db_tx, dry_run)?,
+            callback_outcome.maybe_commit(
+                &repo,
+                rebase,
+                db_tx,
+                pending_metadata_removals,
+                dry_run,
+            )?,
         )
     };
 
@@ -143,6 +154,12 @@ where
     // and put the result back.
     rebase: Option<SuccessfulRebase<'rebase, 'rebase, M>>,
     db_tx: but_db::Transaction<'rebase>,
+    // Metadata removals to apply only if the transaction commits. Applying them immediately would
+    // leak through dry-runs and rollbacks because the current metadata backend writes on drop.
+    //
+    // HACK: When all the meta data is backed by the database we should be able to remove this and
+    // instead use `db_tx`.
+    pending_metadata_removals: Vec<FullName>,
     // Commits given to `squash_commits`, `reword_commit`, etc are allowed to be the original
     // commits from live repo. This is used to map those to the rebased in-memory commits.
     //
@@ -218,7 +235,11 @@ where
             editor.replace(selector, but_rebase::graph_rebase::Step::None)?;
             let rebase = editor.rebase()?;
             Ok(((), rebase))
-        })
+        })?;
+        self.inner
+            .pending_metadata_removals
+            .push(ref_name.to_owned());
+        Ok(())
     }
 
     pub fn create_commit(
@@ -408,6 +429,7 @@ pub trait TransactionOutcome: sealed::Sealed {
         repo: &gix::Repository,
         rebase: SuccessfulRebase<'_, '_, M>,
         db_tx: but_db::Transaction<'_>,
+        pending_metadata_removals: Vec<FullName>,
         dry_run: DryRun,
     ) -> anyhow::Result<Self::Outcome>;
 }
@@ -424,9 +446,10 @@ impl TransactionOutcome for () {
         repo: &gix::Repository,
         rebase: SuccessfulRebase<'_, '_, M>,
         db_tx: but_db::Transaction<'_>,
+        pending_metadata_removals: Vec<FullName>,
         dry_run: DryRun,
     ) -> anyhow::Result<Self::Outcome> {
-        let ws = WorkspaceState::from_successful_rebase(rebase, repo, dry_run)?;
+        let ws = workspace_state_from_rebase(rebase, repo, pending_metadata_removals, dry_run)?;
         if dry_run == DryRun::No {
             db_tx.commit()?;
         }
@@ -450,6 +473,7 @@ impl<T> TransactionOutcome for Rollback<T> {
         _repo: &gix::Repository,
         _rebase: SuccessfulRebase<'_, '_, M>,
         _db_tx: but_db::Transaction<'_>,
+        _pending_metadata_removals: Vec<FullName>,
         _dry_run: DryRun,
     ) -> anyhow::Result<Self::Outcome> {
         Ok(self.0)
@@ -475,11 +499,13 @@ impl<T, K> TransactionOutcome for DynamicOutcome<T, K> {
         repo: &gix::Repository,
         rebase: SuccessfulRebase<'_, '_, M>,
         db_tx: but_db::Transaction<'_>,
+        pending_metadata_removals: Vec<FullName>,
         dry_run: DryRun,
     ) -> anyhow::Result<Self::Outcome> {
         match self {
             DynamicOutcome::Commit(value) => {
-                let workspace = WorkspaceState::from_successful_rebase(rebase, repo, dry_run)?;
+                let workspace =
+                    workspace_state_from_rebase(rebase, repo, pending_metadata_removals, dry_run)?;
                 if dry_run == DryRun::No {
                     db_tx.commit()?;
                 }
@@ -488,6 +514,24 @@ impl<T, K> TransactionOutcome for DynamicOutcome<T, K> {
             DynamicOutcome::Rollback(value) => Ok(DynamicOutcome::Rollback(value)),
         }
     }
+}
+
+fn workspace_state_from_rebase<M: RefMetadata>(
+    rebase: SuccessfulRebase<'_, '_, M>,
+    repo: &gix::Repository,
+    pending_metadata_removals: Vec<FullName>,
+    dry_run: DryRun,
+) -> anyhow::Result<WorkspaceState> {
+    if dry_run.into() {
+        return WorkspaceState::from_successful_rebase(rebase, repo, dry_run);
+    }
+
+    let materialized = rebase.materialize()?;
+    for ref_name in pending_metadata_removals {
+        materialized.meta.remove(ref_name.as_ref())?;
+    }
+
+    WorkspaceState::from_materialized_rebase(materialized, repo)
 }
 
 /// Intermediate outcome after creating a commit.

--- a/crates/but/src/command/legacy/status/tui/tests/branch_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/branch_tests.rs
@@ -80,6 +80,45 @@ fn focus_reload_preserves_branch_selection() {
 }
 
 #[test]
+fn deleted_branch_name_can_be_reused_without_restoring_old_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    let mut tui = test_tui(env);
+
+    tui.input_then_render(KeyCode::Down)
+        .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
+
+    tui.input_then_render('x')
+        .assert_rendered_contains("Discard branch A?");
+
+    tui.input_then_render('y');
+
+    tui.input_then_render(None)
+        .assert_current_line_eq(str!["╭┄zz [unassigned changes] (no changes)"]);
+
+    tui.input_then_render('b')
+        .assert_current_line_eq(str!["┊╭┄br [c-branch-1] (no commits)"]);
+
+    tui.input_then_render(KeyCode::Enter)
+        .assert_current_line_eq(str!["┊╭┄br [c-branch-1 ] (no commits)"]);
+
+    for _ in 0..10 {
+        tui.input_then_render(KeyCode::Backspace);
+    }
+
+    tui.input_then_render("A")
+        .assert_current_line_eq(str!["┊╭┄br [A ] (no commits)"]);
+
+    tui.input_then_render(KeyCode::Enter)
+        .assert_current_line_eq(str!["┊╭┄g0 [A] (no commits)"]);
+
+    let mut tui = tui.recreate();
+    tui.input_then_render(None)
+        .assert_rendered_contains("[A] (no commits)");
+}
+
+#[test]
 fn focus_reload_preserves_merge_base_selection() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
     env.setup_metadata(&["A"]).unwrap();


### PR DESCRIPTION
Had some issues with branches reappearing after having been deleted and the
issue seemed to be that I didn't correctly update the meta data in
`Transaction::remove_reference`. I was able to reproduce it with a TUI test and
this fixes it. Slightly hacky now, would be cleaned if all this was backed by
the database.