### PR TITLE
but-graph improvements for usability

### DIFF
--- a/crates/but-graph/src/api.rs
+++ b/crates/but-graph/src/api.rs
@@ -862,8 +862,7 @@ impl Graph {
 
     /// Lookup the segment of `sidx` and then find its sibling segment, if it has one.
     pub fn lookup_sibling_segment(&self, sidx: SegmentIndex) -> Option<&Segment> {
-        self.inner
-            .node_weight(self.inner.node_weight(sidx)?.sibling_segment_id?)
+        self.inner.node_weight(sidx)?.sibling_segment(self)
     }
 
     /// Lookup the segment of `sidx` and then find its remote tracking branch segment, if it has one.

--- a/crates/but-graph/src/api.rs
+++ b/crates/but-graph/src/api.rs
@@ -846,8 +846,8 @@ impl Graph {
     }
 
     /// Return `true` if this graph is possibly partial as the hard limit was hit,
-    /// meaning that the core traversal algorithm was interrupted without necessarily
-    /// satisfying all constraints.
+    /// meaning that the core traversal algorithm stopped queueing new commits without
+    /// necessarily satisfying all constraints.
     ///
     /// Such a graph is possibly partial, which can affect algorithms
     /// relying on it being complete.

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -458,11 +458,13 @@ pub struct Options {
     /// commits to traverse back to `commit_limit_hint`.
     /// Imagine it like a gas station that can be chosen to direct where the commit-budge should be spent.
     pub commits_limit_recharge_location: Vec<gix::ObjectId>,
-    /// As opposed to the limit-hint, if not `None` we will stop after pretty much this many commits have been seen.
+    /// As opposed to the limit-hint, if not `None` we will stop queuing new commits after pretty much this many
+    /// commits have been seen.
     ///
-    /// This is a last line of defense against runaway traversals and for not it's recommended to set it to a high
+    /// This is a last line of defense against runaway traversals and for now it's recommended to set it to a high
     /// but manageable value. Note that depending on the commit-graph, we may need more commits to find the local branch
-    /// for a remote branch, leaving remote branches unconnected.
+    /// for a remote branch, leaving remote branches unconnected. Commits that are already queued are still processed so
+    /// their existing graph connections can be completed.
     ///
     /// Due to multiple paths being taken, more commits may be queued (which is what's counted here) than actually
     /// end up in the graph, so usually one will see many less.
@@ -825,6 +827,9 @@ impl Graph {
         )?;
         max_commits_recharge_location.sort();
         let mut points_of_interest_to_traverse_first = next.iter().count();
+        if next.is_exhausted() {
+            ctx.hard_limit = true;
+        }
         while let Some((info, mut propagated_flags, instruction, mut limit)) = next.pop_front() {
             points_of_interest_to_traverse_first =
                 points_of_interest_to_traverse_first.saturating_sub(1);
@@ -942,7 +947,7 @@ impl Graph {
             let segment = &mut graph[segment_idx_for_id];
             let commit_idx_for_possible_fork = segment.commits.len();
             let propagated_flags = propagated_flags | maybe_make_id_a_goal_so_remote_can_find_local;
-            let hard_limit_hit = queue_parents(
+            let hard_limit_reached = queue_parents(
                 &mut next,
                 &info.parent_ids,
                 propagated_flags,
@@ -954,8 +959,8 @@ impl Graph {
                 repo.for_find_only(),
                 &mut buf,
             )?;
-            if hard_limit_hit {
-                return graph.post_processed(meta, tip, ctx.with_hard_limit());
+            if hard_limit_reached {
+                ctx.hard_limit = true;
             }
 
             segment.commits.push(
@@ -977,7 +982,10 @@ impl Graph {
 
             for item in remote_items_to_queue_later {
                 if next.push_back_exhausted(item) {
-                    return graph.post_processed(meta, tip, ctx.with_hard_limit());
+                    ctx.hard_limit = true;
+                    // The break here means we may end up with unconnected remote tracking ref segments,
+                    // that's fine. If it ever is not, we should remove the hard limit.
+                    break;
                 }
             }
 

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -827,9 +827,6 @@ impl Graph {
         )?;
         max_commits_recharge_location.sort();
         let mut points_of_interest_to_traverse_first = next.iter().count();
-        if next.is_exhausted() {
-            ctx.hard_limit = true;
-        }
         while let Some((info, mut propagated_flags, instruction, mut limit)) = next.pop_front() {
             points_of_interest_to_traverse_first =
                 points_of_interest_to_traverse_first.saturating_sub(1);
@@ -947,7 +944,7 @@ impl Graph {
             let segment = &mut graph[segment_idx_for_id];
             let commit_idx_for_possible_fork = segment.commits.len();
             let propagated_flags = propagated_flags | maybe_make_id_a_goal_so_remote_can_find_local;
-            let hard_limit_reached = queue_parents(
+            queue_parents(
                 &mut next,
                 &info.parent_ids,
                 propagated_flags,
@@ -959,9 +956,6 @@ impl Graph {
                 repo.for_find_only(),
                 &mut buf,
             )?;
-            if hard_limit_reached {
-                ctx.hard_limit = true;
-            }
 
             segment.commits.push(
                 info.into_commit(
@@ -982,7 +976,6 @@ impl Graph {
 
             for item in remote_items_to_queue_later {
                 if next.push_back_exhausted(item) {
-                    ctx.hard_limit = true;
                     // The break here means we may end up with unconnected remote tracking ref segments,
                     // that's fine. If it ever is not, we should remove the hard limit.
                     break;
@@ -995,6 +988,7 @@ impl Graph {
             }
         }
 
+        ctx.hard_limit = next.hard_limit_hit();
         graph.post_processed(meta, tip, ctx)
     }
 

--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -34,13 +34,6 @@ pub(super) struct Context<'a> {
     pub worktree_by_branch: WorktreeByBranch,
 }
 
-impl Context<'_> {
-    pub(super) fn with_hard_limit(mut self) -> Self {
-        self.hard_limit = true;
-        self
-    }
-}
-
 /// Processing
 impl Graph {
     /// Now that the graph is complete, perform additional structural improvements with

--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -13,7 +13,7 @@ use tracing::instrument;
 use crate::{
     Commit, CommitFlags, CommitIndex, Edge, EntryPointCommit, Graph, SegmentIndex, SegmentMetadata,
     init::{
-        PetGraph, branch_segment_from_name_and_meta,
+        PetGraph, TipRole, branch_segment_from_name_and_meta,
         overlay::{OverlayMetadata, OverlayRepo},
         remotes,
         types::{EdgeOwned, TopoWalk},
@@ -91,6 +91,7 @@ impl Graph {
         // because it can't reorder existing empty segments (which are not natural).
         self.improve_remote_segments(
             repo,
+            meta,
             symbolic_remote_names,
             configured_remote_tracking_branches,
             &worktree_by_branch,
@@ -1107,17 +1108,27 @@ impl Graph {
         Ok(())
     }
 
-    /// Name ambiguous segments if they are reachable by remote tracking branch and
-    /// if the first commit has (unambiguously) the matching local tracking branch.
-    /// Also, link up all remote segments with their local ones, and vice versa.
+    /// Name ambiguous segments if they are reachable by a remote-tracking branch
+    /// and the first commit has the unambiguous matching local tracking branch.
+    /// Also link all paired local and remote segments in both directions.
     ///
     /// Additionally, restore possibly broken linkage to their siblings
     /// (from remote to local tracking branch), as this connection might have been destroyed by
     /// the insertion of empty segments. Again, instead of making that smarter, we fix it up here
     /// because it's simpler.
+    ///
+    /// Target remote refs need one extra repair. Their local tracking branch may
+    /// point at the same commit while another branch segment owns that commit,
+    /// leaving the local branch only as a commit ref. In that case, create an
+    /// empty local tracking segment that points at the owning segment, remove the
+    /// duplicate commit ref, and set the remote/local sibling links. This is
+    /// restricted to named target-remote traversal tips so ordinary remote refs
+    /// keep their historical presentation unless an earlier disambiguation step
+    /// already paired them.
     fn improve_remote_segments(
         &mut self,
         repo: &OverlayRepo<'_>,
+        meta: &OverlayMetadata<'_, impl RefMetadata>,
         symbolic_remote_names: &[String],
         configured_remote_tracking_branches: &BTreeSet<gix::refs::FullName>,
         worktree_by_branch: &WorktreeByBranch,
@@ -1246,6 +1257,28 @@ impl Graph {
                 links_from_remote_to_local.push((remote_sidx, segment.id));
             }
         }
+        let workspace_target_refs: BTreeSet<_> = self
+            .traversal_tips
+            .iter()
+            .filter(|tip| matches!(tip.role, TipRole::TargetRemote))
+            .filter_map(|tip| tip.ref_name.clone())
+            .collect();
+        for (remote_ref_name, remote_sidx) in remote_sidx_by_ref_name {
+            if !workspace_target_refs.contains(&remote_ref_name) {
+                continue;
+            }
+            let Some(local_sidx) = self.ensure_local_tracking_segment_for_remote(
+                repo,
+                meta,
+                remote_ref_name,
+                remote_sidx,
+                worktree_by_branch,
+            )?
+            else {
+                continue;
+            };
+            links_from_remote_to_local.push((remote_sidx, local_sidx));
+        }
         for (remote_sidx, local_sidx) in links_from_remote_to_local {
             self[remote_sidx].sibling_segment_id = Some(local_sidx);
 
@@ -1281,6 +1314,116 @@ impl Graph {
             }
         }
         Ok(())
+    }
+
+    /// Ensure `remote_sidx` can reach the local branch configured to track
+    /// `remote_ref_name`.
+    ///
+    /// Most local/remote tracking pairs are established earlier in this pass:
+    /// either an anonymous local segment is disambiguated by walking down from
+    /// the remote, or a named local segment already advertises
+    /// `remote_tracking_ref_name`. The remaining target-ref edge case is a
+    /// missing local-side segment:
+    ///
+    /// * `refs/remotes/origin/main` is a target segment.
+    /// * `refs/heads/main` is configured as its local tracking branch.
+    /// * The local branch's tip commit is already owned by another segment, for
+    ///   example because branch metadata disambiguated a shared tip.
+    /// * `main` is therefore only a ref on that owning commit, so the target
+    ///   segment has no `sibling_segment_id`.
+    ///
+    /// If a segment named after the local tracking branch already exists, return
+    /// it as-is. Otherwise, create an empty local tracking segment named after
+    /// the configured local branch and point it at the segment/commit that owns
+    /// the local branch tip. The local and remote tips do not have to be the
+    /// same commit; the sibling relationship represents the configured tracking
+    /// pair, while the new empty segment preserves where the local ref points in
+    /// the graph. The caller records the reverse `sibling_segment_id` link on
+    /// the remote segment afterwards.
+    ///
+    /// Returning `None` means the graph should keep its current presentation.
+    /// That happens when there is no configured local tracking branch, the local
+    /// ref no longer exists, its tip was not traversed, or the local tip is not
+    /// the first commit of the segment that owns it. The last case keeps this
+    /// synthetic empty segment from pointing into the middle of an existing
+    /// segment.
+    fn ensure_local_tracking_segment_for_remote<T: RefMetadata>(
+        &mut self,
+        repo: &OverlayRepo<'_>,
+        meta: &OverlayMetadata<'_, T>,
+        remote_ref_name: gix::refs::FullName,
+        remote_sidx: SegmentIndex,
+        worktree_by_branch: &WorktreeByBranch,
+    ) -> anyhow::Result<Option<SegmentIndex>> {
+        let Some((local_ref_name, _remote)) =
+            repo.upstream_branch_and_remote_for_tracking_branch(remote_ref_name.as_ref())?
+        else {
+            return Ok(None);
+        };
+
+        let Some(local_tip) = repo
+            .try_find_reference(local_ref_name.as_ref())?
+            .map(|mut r| r.peel_to_id().map(|id| id.detach()))
+            .transpose()?
+        else {
+            return Ok(None);
+        };
+
+        let (sidx_with_local_ref_name, commit_owner) =
+            self.segment_by_ref_name_or_commit_id(local_ref_name.as_ref(), local_tip);
+        if let Some(local_sidx) = sidx_with_local_ref_name {
+            return Ok(Some(local_sidx));
+        }
+        let Some((owner_sidx, owner_cidx)) = commit_owner else {
+            return Ok(None);
+        };
+        if owner_cidx != 0 {
+            return Ok(None);
+        }
+
+        let local_segment = crate::Segment {
+            metadata: meta
+                .branch_opt(local_ref_name.as_ref())?
+                .map(SegmentMetadata::Branch),
+            ref_info: Some(crate::RefInfo::from_ref(
+                local_ref_name.clone(),
+                local_tip,
+                worktree_by_branch,
+            )),
+            remote_tracking_ref_name: Some(remote_ref_name),
+            remote_tracking_branch_segment_id: Some(remote_sidx),
+            ..Default::default()
+        };
+        let local_sidx = self.insert_segment(local_segment);
+        self.connect_segments_with_ids(
+            local_sidx,
+            None,
+            None,
+            owner_sidx,
+            Some(owner_cidx),
+            Some(local_tip),
+            0,
+        );
+        self[owner_sidx].commits[owner_cidx]
+            .refs
+            .retain(|ri| ri.ref_name != local_ref_name);
+        Ok(Some(local_sidx))
+    }
+
+    fn segment_by_ref_name_or_commit_id(
+        &self,
+        ref_name: &gix::refs::FullNameRef,
+        commit_id: gix::ObjectId,
+    ) -> (Option<SegmentIndex>, Option<(SegmentIndex, CommitIndex)>) {
+        for segment in self.inner.node_weights() {
+            if segment.ref_name().is_some_and(|rn| rn == ref_name) {
+                return (Some(segment.id), None);
+            }
+            if let Some(commit_idx) = segment.commit_index_of(commit_id) {
+                return (None, Some((segment.id, commit_idx)));
+            }
+        }
+        (None, None)
     }
 
     fn push_commit_and_reconnect_outgoing(

--- a/crates/but-graph/src/init/types.rs
+++ b/crates/but-graph/src/init/types.rs
@@ -165,6 +165,7 @@ impl Queue {
             inner: Default::default(),
             count: 0,
             max: limit,
+            exhausted: false,
             sorted: false,
         }
     }
@@ -178,6 +179,8 @@ pub struct Queue {
     count: usize,
     /// The maximum number of queuing operations, each representing one commit.
     max: Option<usize>,
+    /// Whether no more items should be queued for reasons other than the hard limit.
+    exhausted: bool,
     /// Whether new items must maintain `inner` in traversal order.
     sorted: bool,
 }
@@ -202,6 +205,13 @@ impl Queue {
     }
     #[must_use]
     pub fn push_back_exhausted(&mut self, item: QueueItem) -> bool {
+        if self.is_exhausted() {
+            return true;
+        }
+        self.push_back_even_if_exhausted(item)
+    }
+
+    pub(crate) fn push_back_even_if_exhausted(&mut self, item: QueueItem) -> bool {
         if self.sorted {
             self.insert_sorted(item);
         } else {
@@ -211,6 +221,9 @@ impl Queue {
     }
     #[must_use]
     pub fn push_front_exhausted(&mut self, item: QueueItem) -> bool {
+        if self.is_exhausted() {
+            return true;
+        }
         if self.sorted {
             self.insert_sorted(item);
         } else {
@@ -228,7 +241,20 @@ impl Queue {
 
     fn is_exhausted_after_increment(&mut self) -> bool {
         self.count += 1;
+        self.is_exhausted()
+    }
+
+    pub fn is_exhausted(&self) -> bool {
+        self.exhausted || self.is_hard_limit_exhausted()
+    }
+
+    pub(crate) fn is_hard_limit_exhausted(&self) -> bool {
         self.max.is_some_and(|l| self.count >= l)
+    }
+
+    /// Stop accepting new items while leaving already queued items to drain.
+    pub(crate) fn exhaust(&mut self) {
+        self.exhausted = true;
     }
 
     /// Add `goal` as additional goal to `id` or panic if `id` was not found.

--- a/crates/but-graph/src/init/types.rs
+++ b/crates/but-graph/src/init/types.rs
@@ -165,6 +165,7 @@ impl Queue {
             inner: Default::default(),
             count: 0,
             max: limit,
+            hard_limit_hit: false,
             exhausted: false,
             sorted: false,
         }
@@ -179,6 +180,8 @@ pub struct Queue {
     count: usize,
     /// The maximum number of queuing operations, each representing one commit.
     max: Option<usize>,
+    /// Whether the hard limit stopped further queuing at least once.
+    hard_limit_hit: bool,
     /// Whether no more items should be queued for reasons other than the hard limit.
     exhausted: bool,
     /// Whether new items must maintain `inner` in traversal order.
@@ -205,7 +208,7 @@ impl Queue {
     }
     #[must_use]
     pub fn push_back_exhausted(&mut self, item: QueueItem) -> bool {
-        if self.is_exhausted() {
+        if self.exhausted || self.record_hard_limit_if_exhausted() {
             return true;
         }
         self.push_back_even_if_exhausted(item)
@@ -221,7 +224,7 @@ impl Queue {
     }
     #[must_use]
     pub fn push_front_exhausted(&mut self, item: QueueItem) -> bool {
-        if self.is_exhausted() {
+        if self.exhausted || self.record_hard_limit_if_exhausted() {
             return true;
         }
         if self.sorted {
@@ -241,7 +244,7 @@ impl Queue {
 
     fn is_exhausted_after_increment(&mut self) -> bool {
         self.count += 1;
-        self.is_exhausted()
+        self.exhausted || self.record_hard_limit_if_exhausted()
     }
 
     pub fn is_exhausted(&self) -> bool {
@@ -250,6 +253,16 @@ impl Queue {
 
     pub(crate) fn is_hard_limit_exhausted(&self) -> bool {
         self.max.is_some_and(|l| self.count >= l)
+    }
+
+    pub(crate) fn hard_limit_hit(&self) -> bool {
+        self.hard_limit_hit
+    }
+
+    fn record_hard_limit_if_exhausted(&mut self) -> bool {
+        let hard_limit_exhausted = self.is_hard_limit_exhausted();
+        self.hard_limit_hit |= hard_limit_exhausted;
+        hard_limit_exhausted
     }
 
     /// Stop accepting new items while leaving already queued items to drain.
@@ -551,5 +564,41 @@ impl TopoWalk {
                 Some(range)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Queue;
+
+    #[test]
+    fn explicit_exhaustion_does_not_count_as_hard_limit_hit() {
+        let mut queue = Queue::new_with_limit(Some(1));
+
+        queue.exhaust();
+
+        assert!(queue.is_exhausted(), "explicit exhaustion stops queueing");
+        assert!(
+            !queue.record_hard_limit_if_exhausted(),
+            "hard-limit state stays separate from explicit exhaustion"
+        );
+        assert!(
+            !queue.hard_limit_hit(),
+            "explicit exhaustion must not mark the hard limit as hit"
+        );
+    }
+
+    #[test]
+    fn hard_limit_exhaustion_records_hard_limit_hit() {
+        let mut queue = Queue::new_with_limit(Some(0));
+
+        assert!(
+            queue.record_hard_limit_if_exhausted(),
+            "a depleted hard limit stops queueing"
+        );
+        assert!(
+            queue.hard_limit_hit(),
+            "the queue records when the hard limit stopped queueing"
+        );
     }
 }

--- a/crates/but-graph/src/init/walk/mod.rs
+++ b/crates/but-graph/src/init/walk/mod.rs
@@ -434,14 +434,14 @@ pub fn queue_parents(
     }
     // Don't enqueue new parents if we don't have space anymore.
     if next.is_exhausted() {
-        return Ok(next.is_hard_limit_exhausted());
+        return Ok(next.hard_limit_hit());
     }
     if limit.is_exhausted_or_decrement(flags, next) {
         return Ok(false);
     }
+    let mut queue_is_exhausted = false;
     if parent_ids.len() > 1 {
         let limit_per_parent = limit.per_parent(parent_ids.len());
-        let mut hard_limit_reached = false;
         for (parent_order, pid) in parent_ids.iter().enumerate() {
             let instruction = Instruction::ConnectNewSegment {
                 parent_above: current_sidx,
@@ -453,27 +453,20 @@ pub fn queue_parents(
                     .context("commit parent position does not fit into u32")?,
             };
             let info = find(commit_graph, objects, *pid, buf)?;
-            hard_limit_reached |=
+            queue_is_exhausted =
                 next.push_back_even_if_exhausted((info, flags, instruction, limit_per_parent));
-        }
-        if hard_limit_reached {
-            // All parents were queued and will be processed, but nothing new will be queued
-            // to wrap up the traversal.
-            return Ok(true);
         }
     } else if !parent_ids.is_empty() {
         let info = find(commit_graph, objects, parent_ids[0], buf)?;
-        if next.push_back_exhausted((
+        queue_is_exhausted |= next.push_back_exhausted((
             info,
             flags,
             Instruction::CollectCommit { into: current_sidx },
             limit,
-        )) {
-            return Ok(true);
-        }
+        ));
     }
 
-    Ok(false)
+    Ok(queue_is_exhausted)
 }
 
 /// As convenience, if `ref_name` is `Some` and the metadata is not set, it will look it up for you.

--- a/crates/but-graph/src/init/walk/mod.rs
+++ b/crates/but-graph/src/init/walk/mod.rs
@@ -415,7 +415,7 @@ pub fn try_split_non_empty_segment_at_branch<T: RefMetadata>(
 /// are used.
 /// `limit` is used to determine if the tip is NOT supposed to be dropped, with `0` meaning it's depleted.
 ///
-/// Returns `true` if queueing a parent exhausts the queue's hard limit.
+/// Returns `true` if queueing a parent reaches the queue's hard limit.
 #[expect(clippy::too_many_arguments)]
 pub fn queue_parents(
     next: &mut Queue,
@@ -432,11 +432,16 @@ pub fn queue_parents(
     if is_shallow_boundary {
         return Ok(false);
     }
+    // Don't enqueue new parents if we don't have space anymore.
+    if next.is_exhausted() {
+        return Ok(next.is_hard_limit_exhausted());
+    }
     if limit.is_exhausted_or_decrement(flags, next) {
         return Ok(false);
     }
     if parent_ids.len() > 1 {
         let limit_per_parent = limit.per_parent(parent_ids.len());
+        let mut hard_limit_reached = false;
         for (parent_order, pid) in parent_ids.iter().enumerate() {
             let instruction = Instruction::ConnectNewSegment {
                 parent_above: current_sidx,
@@ -448,9 +453,13 @@ pub fn queue_parents(
                     .context("commit parent position does not fit into u32")?,
             };
             let info = find(commit_graph, objects, *pid, buf)?;
-            if next.push_back_exhausted((info, flags, instruction, limit_per_parent)) {
-                return Ok(true);
-            }
+            hard_limit_reached |=
+                next.push_back_even_if_exhausted((info, flags, instruction, limit_per_parent));
+        }
+        if hard_limit_reached {
+            // All parents were queued and will be processed, but nothing new will be queued
+            // to wrap up the traversal.
+            return Ok(true);
         }
     } else if !parent_ids.is_empty() {
         let info = find(commit_graph, objects, parent_ids[0], buf)?;
@@ -1172,11 +1181,13 @@ fn propagate_goals_of_reachable_tips(
     }
 }
 
-/// Remove tips with only integrated commits and delete empty segments of pruned tips,
-/// as these are uninteresting.
+/// Stop traversal once only integrated tips with reached goals are left.
 /// However, do so only if our entrypoint isn't integrated itself and is not in a workspace. The reason for this is that we
 /// always also traverse workspaces and their targets, even if the traversal starts outside a workspace.
 pub fn prune_integrated_tips(graph: &mut Graph, next: &mut Queue) -> anyhow::Result<()> {
+    if next.is_exhausted() {
+        return Ok(());
+    }
     let all_integated_and_done = next.iter().all(|(_id, flags, _instruction, tip_limit)| {
         flags.contains(CommitFlags::Integrated) && tip_limit.goal_reached()
     });
@@ -1192,15 +1203,7 @@ pub fn prune_integrated_tips(graph: &mut Graph, next: &mut Queue) -> anyhow::Res
         return Ok(());
     }
 
-    next.inner
-        .retain_mut(|(_id, _flags, instruction, _tip_limit)| {
-            let sidx = instruction.segment_idx();
-            let s = &graph[sidx];
-            if s.commits.is_empty() {
-                graph.inner.remove_node(sidx);
-            }
-            false
-        });
+    next.exhaust();
     Ok(())
 }
 

--- a/crates/but-graph/src/init/walk/mod.rs
+++ b/crates/but-graph/src/init/walk/mod.rs
@@ -1188,10 +1188,10 @@ pub fn prune_integrated_tips(graph: &mut Graph, next: &mut Queue) -> anyhow::Res
     if next.is_exhausted() {
         return Ok(());
     }
-    let all_integated_and_done = next.iter().all(|(_id, flags, _instruction, tip_limit)| {
+    let all_integrated_and_done = next.iter().all(|(_id, flags, _instruction, tip_limit)| {
         flags.contains(CommitFlags::Integrated) && tip_limit.goal_reached()
     });
-    if !all_integated_and_done {
+    if !all_integrated_and_done {
         return Ok(());
     }
     let ep = graph.entrypoint()?;

--- a/crates/but-graph/src/lib.rs
+++ b/crates/but-graph/src/lib.rs
@@ -378,10 +378,21 @@ pub struct Edge {
     /// and widening this field pushes hot edge storage over an important size boundary.
     ///
     /// This limit would only be reached if there is a merge with 4.3 billion commits.
-    pub parent_order: u32,
+    pub(crate) parent_order: u32,
 }
 
 impl Edge {
+    /// Return the 0-based position of this edge's destination among the source commit's parents.
+    /// For instance, if the source is a merge commit and this is edge represents the connection
+    /// to the second parent, the output will be `Some(1)`.
+    ///
+    /// This is `None` when the edge does not point at a concrete destination commit.
+    /// That happens for synthetic graph structure such as empty virtual segments,
+    /// where there is no Git commit parent for this edge to identify.
+    pub fn parent_order(&self) -> Option<u32> {
+        self.dst_id.map(|_| self.parent_order)
+    }
+
     /// Useful when reusing an edge to assure it doesn't list commits that don't exist in `src_idx` and `dst_idx` anymore.
     pub(crate) fn adjusted_for(
         mut self,

--- a/crates/but-graph/src/lib.rs
+++ b/crates/but-graph/src/lib.rs
@@ -383,7 +383,7 @@ pub struct Edge {
 
 impl Edge {
     /// Return the 0-based position of this edge's destination among the source commit's parents.
-    /// For instance, if the source is a merge commit and this is edge represents the connection
+    /// For instance, if the source is a merge commit and this edge represents the connection
     /// to the second parent, the output will be `Some(1)`.
     ///
     /// This is `None` when the edge does not point at a concrete destination commit.

--- a/crates/but-graph/src/projection/stack.rs
+++ b/crates/but-graph/src/projection/stack.rs
@@ -265,7 +265,7 @@ impl StackSegment {
 
     /// Return `true` if this segment *would* be anonymous if it wasn't for the out-of-workspace segment to be projected onto this one.
     ///
-    /// This is signaled by its underlying graph segment being unnamed, with a sybling set.
+    /// This is signaled by its underlying graph segment being unnamed, with a sibling set.
     pub fn is_projected_from_outside(&self, graph: &Graph) -> bool {
         let segment = &graph[self.id];
         segment.ref_info.is_none() && segment.sibling_segment_id.is_some()

--- a/crates/but-graph/src/projection/workspace/api/queries.rs
+++ b/crates/but-graph/src/projection/workspace/api/queries.rs
@@ -5,7 +5,7 @@
 
 use anyhow::Context;
 
-use crate::{SegmentIndex, Workspace, segment, workspace::TargetRef};
+use crate::{RefInfo, SegmentIndex, Workspace, segment, workspace::TargetRef};
 
 /// Legacy query helpers kept for callers that still depend on compatibility
 /// semantics.
@@ -108,14 +108,27 @@ impl Workspace {
     }
 }
 
-/// # Sets of Interest
+/// # Refs of Interest
 impl Workspace {
     /// Return the configured target reference name if the workspace target was
     /// resolved to a branch during graph traversal.
+    /// This is mere convenience and it should only be used for displaying the target ref.
+    /// For everything else, use [`Self::target_ref`].
     pub fn target_ref_name(&self) -> Option<&gix::refs::FullNameRef> {
         self.target_ref
             .as_ref()
             .map(|target| target.ref_name.as_ref())
+    }
+
+    /// Return the local tracking branch reference information with the configured
+    ///  [target reference](Self::target_ref). This is available as long as a target
+    /// ref exists (i.e. `refs/remotes/origin/main`) and a local tracking ref for it
+    /// was configured or inferred.
+    pub fn target_local_tracking_ref_info(&self) -> Option<&RefInfo> {
+        self.target_ref
+            .as_ref()
+            .and_then(|target_ref| self.graph[target_ref.segment_index].sibling_segment_id)
+            .and_then(|local_target_ref_sidx| self.graph[local_target_ref_sidx].ref_info.as_ref())
     }
 }
 

--- a/crates/but-graph/src/segment.rs
+++ b/crates/but-graph/src/segment.rs
@@ -2,7 +2,7 @@ use bitflags::bitflags;
 use bstr::{BString, ByteSlice};
 use but_core::ref_metadata::MaybeDebug;
 
-use crate::{CommitIndex, SegmentIndex};
+use crate::{CommitIndex, Graph, SegmentIndex};
 
 /// A commit with must useful information extracted from the Git commit itself.
 #[derive(Clone, Eq, PartialEq)]
@@ -342,6 +342,23 @@ impl Segment {
     pub fn ref_name(&self) -> Option<&gix::refs::FullNameRef> {
         self.ref_info.as_ref().map(|ri| ri.ref_name.as_ref())
     }
+
+    /// Return the segment that this segment treats as its sibling, if any.
+    ///
+    /// A sibling is a paired segment that represents the same logical ref
+    /// relationship from another side of the graph. For remote-tracking
+    /// segments, this points back to the local branch segment configured to
+    /// track them, such as `refs/remotes/origin/main` pointing to
+    /// `refs/heads/main`. For anonymous workspace-reconstruction segments, this
+    /// can point to the named segment that gives the otherwise anonymous segment
+    /// its intended workspace identity.
+    ///
+    /// The sibling id is graph-local, so the lookup must happen in the `graph`
+    /// that owns this segment.
+    pub fn sibling_segment<'graph>(&self, graph: &'graph Graph) -> Option<&'graph Segment> {
+        graph.inner.node_weight(self.sibling_segment_id?)
+    }
+
     /// Return the top-most commit id of the segment.
     pub fn tip(&self) -> Option<gix::ObjectId> {
         self.commits.first().map(|commit| commit.id)

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -1342,6 +1342,7 @@ EOF
   (cd no-ws-ref-no-ws-commit-two-branches
     commit M1
     commit M2
+    setup_target_to_match_main
 
     git branch A
     git branch B

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -924,24 +924,28 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
             └── ·e255adc
     ");
 
-    // The hard limit is always respected though, despite yielding an incorrect result overall.
-    // That's why it's the *hard* limit.
+    // The hard limit stops queueing deeper commits, but queued commits are still processed
+    // so existing work can complete its graph connections.
     let graph =
-        Graph::from_head(&repo, &*meta, standard_options().with_hard_limit(7))?.validated()?;
+        Graph::from_head(&repo, &*meta, standard_options().with_hard_limit(5))?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @"
 
     ├── 👉►:0[0]:B[🌳] <> origin/B →:1:
     │   └── ·312f819 (⌂|001)
-    │       └── ►:2[1]:A <> origin/A →:4:
+    │       └── ►:2[1]:A <> origin/A →:5:
     │           └── ❌·e255adc (⌂|101)
     ├── ►:1[0]:origin/B →:0:
     │   └── 🟣682be32 (0x0|010)
-    │       └── ►:4[1]:origin/A →:2:
-    │           └── ❌🟣e29c23d (0x0|010)
+    │       └── ►:5[1]:origin/A →:2:
+    │           └── 🟣e29c23d (0x0|010)
+    │               └── ►:4[2]:main
+    │                   └── 🏁🟣fafd9d0 (0x0|010)
     └── ►:3[0]:origin/A
     ");
-    // As the remotes don't connect, they are entirely unknown.
-    // And if it's weird, it's due to the hard limit
+    assert!(
+        graph.hard_limit_hit(),
+        "graph should record that traversal stopped queueing after hitting the hard limit"
+    );
     insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     ⌂:0:B[🌳] <> ✓refs/remotes/origin/B⇣1 on 312f819
     └── ≡:0:B[🌳] <> origin/B →:1:⇣1 on e255adc {1}
@@ -1094,6 +1098,26 @@ fn with_limits() -> anyhow::Result<()> {
         └── :0:C[🌳]
             ├── ·2a95729
             └── ✂️·6861158
+    ");
+
+    // Hitting the hard limit while queueing merge parents still queues the
+    // complete parent set. The hard limit only prevents traversal beyond them.
+    let graph =
+        Graph::from_head(&repo, &*meta, standard_options().with_hard_limit(2))?.validated()?;
+    assert!(
+        graph.hard_limit_hit(),
+        "graph should record that traversal stopped queueing after hitting the hard limit"
+    );
+    insta::assert_snapshot!(graph_tree(&graph), @"
+
+    └── 👉►:0[0]:C[🌳]
+        └── ·2a95729 (⌂|1)
+            ├── ►:1[1]:anon:
+            │   └── ❌·6861158 (⌂|1)
+            ├── ►:2[1]:A
+            │   └── ❌·20a823c (⌂|1)
+            └── ►:3[1]:B
+                └── ❌·9908c99 (⌂|1)
     ");
 
     // The merge commit, then we witness lane-duplication of the limit so we get more than requested.

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -7058,6 +7058,17 @@ fn integrated_commits_above_target_are_kept() -> anyhow::Result<()> {
         └── 📙:5:my-branch
     ");
 
+    let graph = Graph::from_head(
+        &repo,
+        &*meta,
+        standard_options().with_hard_limit(usize::MAX),
+    )?
+    .validated()?;
+    assert!(
+        !graph.hard_limit_hit(),
+        "pruning integrated tips should not report a hard-limit traversal stop"
+    );
+
     Ok(())
 }
 

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -2173,20 +2173,22 @@ fn target_with_remote_on_stack_tip() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @"
 
-    └── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
-        └── ·dd0cca8 (⌂|🏘|01)
-            └── 📙►:2[1]:A
-                └── ·e255adc (⌂|🏘|11) ►main
-                    └── ►:1[2]:origin/main
-                        └── 🏁·fafd9d0 (⌂|🏘|✓|11)
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
+    │   └── ·dd0cca8 (⌂|🏘|01)
+    │       └── 📙►:2[1]:A
+    │           └── ·e255adc (⌂|🏘|11)
+    │               └── ►:1[2]:origin/main →:3:
+    │                   └── 🏁·fafd9d0 (⌂|🏘|✓|11)
+    └── ►:3[0]:main <> origin/main →:1:
+        └── →:2: (A)
     ");
 
     // The main branch is not present, as it's the target.
-    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡📙:2:A on fafd9d0 {1}
         └── 📙:2:A
-            └── ·e255adc (🏘️) ►main
+            └── ·e255adc (🏘️)
     ");
 
     // But mention it if it's in the workspace. It should retain order.
@@ -6297,7 +6299,6 @@ fn shared_target_base_keeps_exact_target_segment_with_inactive_unapplied_branch(
 
     let target_ref: gix::refs::FullName = "refs/remotes/origin/main".try_into()?;
     let target_head_ref: gix::refs::FullName = "refs/remotes/origin/HEAD".try_into()?;
-    let main_ref: gix::refs::FullName = "refs/heads/main".try_into()?;
 
     assert!(
         repo.try_find_reference(target_ref.as_ref())?.is_some(),
@@ -6317,10 +6318,11 @@ fn shared_target_base_keeps_exact_target_segment_with_inactive_unapplied_branch(
     │           ├── ·4ca0966 (⌂|🏘|01)
     │           └── ·a3b180e (⌂|🏘|01)
     │               └── 📙►:2[2]:unapplied
-    │                   ├── ·ce09734 (⌂|🏘|✓|11) ►base-peer, ►base-peer-1, ►base-peer-2, ►base-peer-3, ►base-peer-4, ►base-peer-5, ►base-peer-6, ►base-peer-7, ►base-peer-8, ►main
+    │                   ├── ·ce09734 (⌂|🏘|✓|11) ►base-peer, ►base-peer-1, ►base-peer-2, ►base-peer-3, ►base-peer-4, ►base-peer-5, ►base-peer-6, ►base-peer-7, ►base-peer-8
     │                   └── 🏁·fafd9d0 (⌂|🏘|✓|11)
-    └── ►:1[0]:origin/main
-        └── →:2: (unapplied)
+    └── ►:1[0]:origin/main →:4:
+        └── ►:4[1]:main <> origin/main →:1:
+            └── →:2: (unapplied)
     ");
     let debug_graph = graph_tree(&graph);
     let target_segment = graph
@@ -6334,10 +6336,6 @@ fn shared_target_base_keeps_exact_target_segment_with_inactive_unapplied_branch(
     assert!(
         target_segment.commits.is_empty(),
         "expected exact target segment to stay empty when the target rests on main, graph was:\n{debug_graph}"
-    );
-    assert!(
-        graph.segment_by_ref_name(main_ref.as_ref()).is_none(),
-        "main should remain only as a commit ref in this fixture, as 'unapplied' takes precedence, graph was:\n{debug_graph}"
     );
 
     let ws = graph.into_workspace()?;
@@ -6448,7 +6446,7 @@ fn unapplied_branch_on_base_no_target() -> anyhow::Result<()> {
 fn no_ws_commit_two_branches_no_target() -> anyhow::Result<()> {
     let (repo, mut meta) = read_only_in_memory_scenario("ws/no-ws-ref-no-ws-commit-two-branches")?;
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * bce0c5e (HEAD -> gitbutler/workspace, main, B, A) M2
+    * bce0c5e (HEAD -> gitbutler/workspace, origin/main, main, B, A) M2
     * 3183e43 M1
     ");
     remove_target(&mut meta);
@@ -6456,22 +6454,23 @@ fn no_ws_commit_two_branches_no_target() -> anyhow::Result<()> {
     add_stack_with_segments(&mut meta, 1, "A", StackState::InWorkspace, &[]);
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    insta::assert_snapshot!(graph_tree(&graph), @"
+    insta::assert_snapshot!(graph_tree(&graph), "notably the target ref and local tracking branch have sibling links setup", @"
 
-    └── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
-        ├── 📙►:2[1]:main
-        │   └── ►:1[2]:anon:
-        │       ├── ·bce0c5e (⌂|🏘|1) ►B
-        │       └── 🏁·3183e43 (⌂|🏘|1)
-        └── 📙►:3[1]:A
-            └── →:1:
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
+    │   ├── 📙►:3[1]:main <> origin/main →:1:
+    │   │   └── ►:2[2]:anon:
+    │   │       └── ✂·bce0c5e (⌂|🏘|✓|1) ►B
+    │   └── 📙►:4[1]:A
+    │       └── →:2:
+    └── ►:1[0]:origin/main →:3:
+        └── →:3: (main →:1:)
     ");
-    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
-    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on bce0c5e
-    ├── ≡📙:2:main on bce0c5e {0}
-    │   └── 📙:2:main
-    └── ≡📙:3:A on bce0c5e {1}
-        └── 📙:3:A
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), "sibling links between origin/main and main are also set", @"
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+    ├── ≡📙:3:main <> origin/main →:1: {0}
+    │   └── 📙:3:main <> origin/main →:1:
+    └── ≡📙:4:A {1}
+        └── 📙:4:A
     ");
     Ok(())
 }

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -2368,7 +2368,8 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     │               └── ►:5[2]:A
     │                   ├── ·79bbb29 (⌂|🏘|✓|1)
     │                   ├── ·fc98174 (⌂|🏘|✓|1)
-    │                   └── ✂·a381df5 (⌂|🏘|✓|1)
+    │                   ├── ·a381df5 (⌂|🏘|✓|1)
+    │                   └── ✂·777b552 (⌂|🏘|✓|1)
     └── ►:1[0]:origin/main →:4:
         ├── 🟣d0df794 (✓)
         └── 🟣09c6e08 (✓)
@@ -2407,7 +2408,9 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     │                   ├── ·79bbb29 (⌂|🏘|✓|1)
     │                   ├── ·fc98174 (⌂|🏘|✓|1)
     │                   ├── ·a381df5 (⌂|🏘|✓|1)
-    │                   └── ✂·777b552 (⌂|🏘|✓|1)
+    │                   └── ·777b552 (⌂|🏘|✓|1)
+    │                       └── ►:6[3]:anon:
+    │                           └── ✂·ce4a760 (⌂|🏘|✓|1)
     └── ►:1[0]:origin/main →:5:
         ├── 🟣d0df794 (✓)
         └── 🟣09c6e08 (✓)
@@ -3440,7 +3443,8 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     │               │           ├── ·dca4960 (⌂|🏘|✓|1)
     │               │           ├── ·11c29b8 (⌂|🏘|✓|1)
     │               │           ├── ·c32dd03 (⌂|🏘|✓|1)
-    │               │           └── ✂·b625665 (⌂|🏘|✓|1)
+    │               │           ├── ·b625665 (⌂|🏘|✓|1)
+    │               │           └── ✂·a821094 (⌂|🏘|✓|1)
     │               └── ►:6[3]:long-main-to-workspace
     │                   ├── ·77f31a0 (⌂|🏘|✓|1)
     │                   ├── ·eb17e31 (⌂|🏘|✓|1)

--- a/crates/but-graph/tests/graph/workspace/remote_name.rs
+++ b/crates/but-graph/tests/graph/workspace/remote_name.rs
@@ -1,4 +1,6 @@
+use but_core::RefMetadata;
 use but_graph::Graph;
+use but_testsupport::{graph_tree, visualize_commit_graph_all};
 
 use crate::init::utils::{
     add_workspace, add_workspace_without_target, read_only_in_memory_scenario, standard_options,
@@ -38,6 +40,52 @@ fn returns_none_when_no_target_and_no_push_remote() -> anyhow::Result<()> {
     assert!(
         ws.remote_name().is_none(),
         "should return None without target or metadata"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn target_local_tracking_ref_exists_when_other_branch_metadata_names_the_same_tip()
+-> anyhow::Result<()> {
+    let (repo, mut meta) = read_only_in_memory_scenario("ws/no-ws-ref-no-ws-commit-two-branches")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * bce0c5e (HEAD -> gitbutler/workspace, origin/main, main, B, A) M2
+    * 3183e43 M1
+    ");
+
+    add_workspace(&mut meta);
+    // This is the state left by unapplying the last workspace stack: the branch
+    // is no longer applied, but its branch metadata still disambiguates the
+    // same commit that `main` and `origin/main` also point to.
+    let branch_name = "refs/heads/A";
+    let mut branch = meta.branch(branch_name.try_into()?)?;
+    branch.update_times(false);
+    meta.set_branch(&branch)?;
+
+    let ws = Graph::from_head(&repo, &*meta, standard_options())?
+        .validated()?
+        .into_workspace()?;
+    insta::assert_snapshot!(graph_tree(&ws.graph), "the target remote and its local tracking branch get sibling links even when another branch owns the shared commit", @"
+
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
+    │   └── 📙►:2[2]:A
+    │       └── ✂·bce0c5e (⌂|🏘|✓|1) ►B
+    └── ►:1[0]:origin/main →:3:
+        └── ►:3[1]:main <> origin/main →:1:
+            └── →:2: (A)
+    ");
+
+    assert_eq!(
+        ws.target_ref_name().map(|rn| rn.as_bstr()),
+        Some("refs/remotes/origin/main".into()),
+        "fixture should resolve the workspace target as origin/main"
+    );
+    assert_eq!(
+        ws.target_local_tracking_ref_info()
+            .map(|ri| ri.ref_name.to_string()),
+        Some("refs/heads/main".to_string()),
+        "target/local tracking relationship should be available from the graph projection"
     );
 
     Ok(())

--- a/crates/but-rebase/src/graph_rebase/creation.rs
+++ b/crates/but-rebase/src/graph_rebase/creation.rs
@@ -256,7 +256,8 @@ impl<'ws, 'meta, M: RefMetadata> Editor<'ws, 'meta, M> {
                     continue 'inner;
                 };
 
-                let order = edge.weight().parent_order as usize;
+                // TODO: does it have relevance when `parent_order()` is `None` for edges to virtual segments?
+                let order = edge.weight().parent_order().unwrap_or(0) as usize;
                 graph.add_edge(*source, *target, Edge { order });
             }
         }

--- a/crates/but-rebase/tests/rebase/graph_rebase/rebase_identities.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/rebase_identities.rs
@@ -63,7 +63,9 @@ fn four_commits_with_short_traversal() -> Result<()> {
     └── ≡:0:main[🌳] {1}
         └── :0:main[🌳]
             ├── ·120e3a9
-            └── ❌·a96434e
+            ├── ·a96434e
+            ├── ·d591dfe
+            └── ·35b8235
     ");
 
     let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
@@ -73,7 +75,9 @@ fn four_commits_with_short_traversal() -> Result<()> {
 
     └── 👉►:0[0]:main[🌳]
         ├── ·120e3a9 (⌂|1)
-        └── ❌·a96434e (⌂|1)
+        ├── ·a96434e (⌂|1)
+        ├── ·d591dfe (⌂|1)
+        └── 🏁·35b8235 (⌂|1)
     ");
     let outcome = outcome.materialize()?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -3878,7 +3878,7 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
                         ref_name: "►unrelated",
                         remote_tracking_ref_name: "None",
                         commits: [
-                            LocalCommit(c166d42, "init-integration\n", integrated(c166d42), ►main),
+                            LocalCommit(c166d42, "init-integration\n", integrated(c166d42)),
                         ],
                         commits_on_remote: [],
                         commits_outside: None,


### PR DESCRIPTION
`but-rebase` has to make sense of the Graph and process it, so any inconcistency may cause trouble even
if it's no trouble for the workspace projection, which is the consumer that drove a lot of its capabilities.

This PR should make it more predictable for other downstream users, like `but-rebase`or new graph formats for Lite.

### Tasks

* [x] always process all queued commits
* [x] `edge.parent_order() -> Option<u32>`  to clearly indicate connections to synthetic/virtual segments.
* [x] Make RTB<->LTB relationships in the graph reliable (via sibling links) to avoid extra-lookups with the repository.