### PR TITLE
fix(but): short term fixes for `but commit empty`

### DIFF
--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -86,9 +86,9 @@ pub(crate) fn insert_blank_commit(
                 guard.write_permission(),
             )?;
             let success_message = match insert_side {
-                InsertSide::Above => format!("Created blank commit at the top of stack '{name}'"),
+                InsertSide::Above => format!("Created blank commit above branch '{name}'"),
                 InsertSide::Below => {
-                    format!("Created blank commit at the bottom of stack '{name}'")
+                    format!("Created blank commit at the tip of branch '{name}'")
                 }
             };
             (outcome, success_message)

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -13,7 +13,7 @@ use gitbutler_repo::hooks;
 
 use super::{ShowDiffInEditor, estimate_diff_blob_size};
 use crate::{
-    CliId, IdMap,
+    BadInput, CliId, IdMap,
     command::legacy::status::assignment::{CLIHunkAssignment, FileAssignment},
     theme::{self, Paint},
     tui,
@@ -25,7 +25,7 @@ pub(crate) fn insert_blank_commit(
     out: &mut OutputChannel,
     target: &str,
     insert_side: InsertSide,
-) -> Result<()> {
+) -> crate::CliResult<()> {
     let mut guard = ctx.exclusive_worktree_access();
     let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
 
@@ -33,15 +33,15 @@ pub(crate) fn insert_blank_commit(
     let cli_ids = id_map.parse_using_context(target, ctx)?;
 
     if cli_ids.is_empty() {
-        bail!("Target '{target}' not found");
+        return BadInput::new(format!("Target '{target}' not found")).into_cli_result();
     }
 
     if cli_ids.len() > 1 {
-        bail!(
-            "Target '{}' is ambiguous. Found {} matches",
-            target,
+        return BadInput::new(format!(
+            "Target '{target}' is ambiguous. Found {} matches",
             cli_ids.len()
-        );
+        ))
+        .into_cli_result();
     }
 
     let cli_id = &cli_ids[0];
@@ -78,6 +78,25 @@ pub(crate) fn insert_blank_commit(
                 let repo = ctx.repo.get()?;
                 repo.find_reference(name)?.detach()
             };
+
+            if matches!(insert_side, InsertSide::Above) {
+                // Must prevent inserting above a stack head, as that would create an anonymous
+                // segment as a direct child of the workspace commit. This is not well supported
+                // overall at the moment, and among other things causes `but status` to crash as it
+                // uses the stack's ref name to compute the CLI ID.
+                let head_info = but_api::legacy::workspace::head_info(ctx)?;
+                for stack in head_info.stacks {
+                    if let Some(stack_head_ref) = stack.ref_name()
+                        && stack_head_ref == &reference.name
+                    {
+                        return BadInput::new("Cannot insert empty commit above stack head")
+                            .arg("--after")
+                            .hint("Use '--before' to insert at the tip of the stack")
+                            .into_cli_result();
+                    }
+                }
+            }
+
             let outcome = but_api::commit::insert_blank::commit_insert_blank_with_perm(
                 ctx,
                 RelativeTo::Reference(reference.name),
@@ -94,10 +113,11 @@ pub(crate) fn insert_blank_commit(
             (outcome, success_message)
         }
         _ => {
-            bail!(
+            return BadInput::new(format!(
                 "Target must be a commit ID or branch name, not {}",
                 cli_id.kind_for_humans()
-            );
+            ))
+            .into_cli_result();
         }
     };
 

--- a/crates/but/src/error.rs
+++ b/crates/but/src/error.rs
@@ -14,6 +14,8 @@ pub struct BadInput {
     pub message: String,
     /// If applicable, the input argument to which the bad input was passed
     pub arg: Option<String>,
+    /// A hint to guide the user to proper usage of the command
+    pub hint: Option<String>,
 }
 
 impl BadInput {
@@ -22,12 +24,19 @@ impl BadInput {
         Self {
             message: message.as_ref().to_string(),
             arg: None,
+            hint: None,
         }
     }
 
     /// Add the argument for which this message applies.
     pub fn arg<S: AsRef<str>>(mut self, arg: S) -> Self {
         self.arg = Some(arg.as_ref().to_string());
+        self
+    }
+
+    /// Add a hint to guide the user to correct usage.
+    pub fn hint<S: AsRef<str>>(mut self, hint: S) -> Self {
+        self.hint = Some(hint.as_ref().to_string());
         self
     }
 
@@ -39,18 +48,28 @@ impl BadInput {
 
 impl Display for BadInput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let t = theme::get();
+
         if let Some(arg) = &self.arg {
             writeln!(
                 f,
                 "{} Bad input for '{}'",
-                theme::get().error.paint("Error:"),
-                theme::get().attention.paint(arg),
+                t.error.paint("Error:"),
+                t.attention.paint(arg),
             )?;
             writeln!(f)?;
-            write!(f, "{}", self.message)
+            write!(f, "{}", self.message)?;
         } else {
-            write!(f, "{} {}", theme::get().error.paint("Error:"), self.message)
+            write!(f, "{} {}", t.error.paint("Error:"), self.message)?;
+        };
+
+        if let Some(hint) = &self.hint {
+            writeln!(f)?;
+            writeln!(f)?;
+            write!(f, "{}", t.hint.paint(format!("Hint: {hint}")))?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -923,7 +923,7 @@ async fn match_subcommand(
                                 )
                             })?;
 
-                        TargetSpec::Owned(branch_name, InsertSide::Above)
+                        TargetSpec::Owned(branch_name, InsertSide::Below)
                     };
 
                     let (target_str, insert_side) = match &target_spec {

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -977,12 +977,13 @@ async fn match_subcommand(
                         ShowDiffInEditor::from_args(commit_args.diff, commit_args.no_diff)
                             .unwrap_or(ShowDiffInEditor::Unspecified),
                     )
+                    .map_err(CliError::from)
                     .emit_metrics(metrics_ctx)
                 }
             };
 
             maybe_run_status_after(status_after, &result, &mut ctx, out).await;
-            result.map_err(CliError::from)
+            result
         }
         #[cfg(feature = "legacy")]
         Subcommands::Push(push_args) => {
@@ -1588,9 +1589,9 @@ fn is_not_in_git_repository_error(err: &anyhow::Error) -> bool {
 /// Errors from the status query itself are logged to stderr but never mask
 /// the mutation's success.
 #[cfg(feature = "legacy")]
-async fn maybe_run_status_after(
+async fn maybe_run_status_after<T, E>(
     status_after: bool,
-    result: &anyhow::Result<()>,
+    result: &Result<T, E>,
     ctx: &mut but_ctx::Context,
     out: &mut OutputChannel,
 ) {

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -272,61 +272,100 @@ Created blank commit before commit 9477ae7
 }
 
 #[test]
-#[ignore = "Inserting after a branch reference is not currently supported by the underlying API"]
-fn commit_empty_with_after_flag() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
-    * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    * 9477ae7 (A) add A
-    * 0dc3733 (origin/main, origin/HEAD, main) add M
-    ");
-
+fn commit_empty_after_branch_for_non_stack_head() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits")?;
     env.setup_metadata(&["A"])?;
 
-    // Insert empty commit after (at top of) branch A
-    env.but("commit empty --after A")
+    env.but("branch new bottom")
+        .arg("-a")
+        .arg(env.open_repo()?.rev_parse("A~")?.to_string())
         .assert()
-        .success()
-        .stdout_eq(str![[r#"
-Created blank commit at the top of stack 'A'
+        .success();
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊│
+┊├┄bo [bottom]
+┊●   fe12bcd add first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
 
 "#]]);
 
-    // Verify a new commit was created
-    let log = env.git_log()?;
-    // Should have one more commit than before
-    assert!(log.lines().filter(|l| l.starts_with("*")).count() > 3);
+    // Insert empty commit after branch A, with a new branch created to prevent an anonymous segment
+    env.but("commit empty --after bottom")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Created blank commit above branch 'bottom'
+
+"#]]);
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   76b24fa add second
+┊●   32d198c (no commit message) (no changes)
+┊│
+┊├┄bo [bottom]
+┊●   fe12bcd add first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
 
     Ok(())
 }
 
 #[test]
-#[ignore = "Inserting before a branch reference is not currently supported by the underlying API"]
 fn commit_empty_with_before_branch() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
-    * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    * 9477ae7 (A) add A
-    * 0dc3733 (origin/main, origin/HEAD, main) add M
-    ");
-
     env.setup_metadata(&["A"])?;
 
-    // Insert empty commit before branch A (at bottom of stack)
-    // Note: This currently fails with "Commit has parents that are not referenced"
-    // which suggests the underlying API doesn't properly support InsertSide::Below with branches
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
     env.but("commit empty --before A")
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Created blank commit at the bottom of stack 'A'
+Created blank commit at the tip of branch 'A'
 
 "#]]);
 
-    // Verify a new commit was created
-    let log = env.git_log()?;
-    // Should have one more commit than before
-    assert!(log.lines().filter(|l| l.starts_with("*")).count() > 3);
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   2594ce3 (no commit message) (no changes)
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
 
     Ok(())
 }

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -215,6 +215,49 @@ Operations History
 }
 
 #[test]
+fn commit_empty_default() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("commit empty")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Created blank commit at the tip of branch 'A'
+
+"#]]);
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   2594ce3 (no commit message) (no changes)
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
 fn commit_empty_with_before_flag() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
     insta::assert_snapshot!(env.git_log()?, @r"

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -315,6 +315,44 @@ Created blank commit before commit 9477ae7
 }
 
 #[test]
+/// Creating a commit above a stack head creates an anonymous segment as a direct child of the
+/// workspace commit, i.e. an anonymous stack. This is not well supported and breaks `but status`.
+///
+/// We intend to support this together with the `--create` flag once `but commit empty` is migrated
+/// up to `but commit --empty`.
+fn commit_empty_after_stack_head_is_disallowed() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("commit empty --after A")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: Bad input for '--after'
+
+Cannot insert empty commit above stack head
+
+Hint: Use '--before' to insert at the tip of the stack
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
 fn commit_empty_after_branch_for_non_stack_head() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits")?;
     env.setup_metadata(&["A"])?;


### PR DESCRIPTION
## 🧢 Changes
> Note: @estib-vega and I have discussed and agreed upon these short term fixes.

Makes some short term fixes to `but commit empty` to prevent it from putting the workspace in a bad state by adding a commit above a stack head. See the individual commits for details.

The long term plan is to move `but commit empty` as a flag `but commit --empty`, as most of the arguments to `but commit` make sense for `but commit empty`, and all arguments for `but commit empty` make sense for `but commit`.

### Better error messages side quest
I'm continuing down the path of improving user feedback on errors. Here, I've added a `hint` to the `BadInput` struct that gets displayed at the bottom of the error, with the intention to guide the user to correct usage.

<img width="556" height="155" alt="error_with_hint" src="https://github.com/user-attachments/assets/d856600f-3479-40fb-bbe3-0e82ab31adce" />

### A note on testing of `git commit empty`
The tests of `git commit empty` largely only assert that a commit is added _somewhere_, using `git log` to count commits. This is very weak, as the placement of the commits is important. For example, the variations that add commits above stack heads aren't even detected with the current testing methodology.

I've strengthened a few of the tests by adding before/after status checks, and I think that we largely should go down that route for testing. It's verbose, but maintaining the snapshots is relatively easy using `SNAPSHOTS=overwrite` and the status output is a fairly good indication that the workspace is in a good state. Much more so than using Git commands.