### PR TITLE
breaking(but): make name validation in `but branch new` strict

### DIFF
--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -1,4 +1,5 @@
 use anyhow::bail;
+use bstr::BStr;
 use but_api::json::HexHash;
 use but_core::{ref_metadata::StackId, sync::RepoExclusive};
 
@@ -52,15 +53,19 @@ pub fn new(
     out: &mut OutputChannel,
     branch_name: Option<String>,
     anchor: Option<String>,
-) -> Result<(), anyhow::Error> {
+) -> crate::CliResult<()> {
     let t = theme::get();
 
     let mut guard = ctx.exclusive_worktree_access();
     let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
     // Get branch name or use canned name
-    let branch_name = branch_name
-        .map(Ok)
-        .unwrap_or_else(|| but_api::legacy::workspace::canned_branch_name(ctx))?;
+    let branch_name = if let Some(branch_name) = branch_name {
+        let repo = ctx.repo.get()?;
+        check_can_create_branch_with_user_provided_name(&repo, &branch_name)?;
+        branch_name
+    } else {
+        but_api::legacy::workspace::canned_branch_name(ctx)?
+    };
 
     // Store anchor string for JSON output
     let anchor_for_json = anchor.clone();
@@ -71,12 +76,13 @@ pub fn new(
         // Resolve the anchor string to a CliId
         let anchor_ids = id_map.parse_using_context(&anchor_str, ctx)?;
         if anchor_ids.is_empty() {
-            return Err(anyhow::anyhow!("Could not find anchor: {anchor_str}"));
+            return BadInput::new(format!("Could not find anchor: {anchor_str}")).into_cli_result();
         }
         if anchor_ids.len() > 1 {
-            return Err(anyhow::anyhow!(
+            return BadInput::new(format!(
                 "Ambiguous anchor '{anchor_str}', matches multiple items"
-            ));
+            ))
+            .into_cli_result();
         }
         let anchor_id = &anchor_ids[0];
 
@@ -96,10 +102,11 @@ pub fn new(
                 },
             ),
             _ => {
-                return Err(anyhow::anyhow!(
+                return BadInput::new(format!(
                     "Invalid anchor type: {}, expected commit or branch",
                     anchor_id.kind_for_humans()
-                ));
+                ))
+                .into_cli_result();
             }
         }
     } else {
@@ -154,6 +161,51 @@ pub fn new(
         };
         out.write_value(value)?;
     }
+    Ok(())
+}
+
+/// Validate that `user_provided_branch_name` is a valid branch name that does not already exist.
+///
+/// Unlike the GUI, we don't normalize branch names for users in the CLI, as this could lead to
+/// unexpected behavior in scripts. This function rejects names that are possible to normalize.
+fn check_can_create_branch_with_user_provided_name(
+    repo: &gix::Repository,
+    user_provided_branch_name: &str,
+) -> Result<(), CliError> {
+    let normalized =
+        but_core::branch::normalize_short_name(user_provided_branch_name).map_err(|err| {
+            CliError::from(
+                BadInput::new(format!("Invalid branch name: {err}"))
+                    .arg_name("<BRANCH_NAME>")
+                    .arg_value(user_provided_branch_name),
+            )
+        })?;
+
+    let user_name_bstr: &BStr = user_provided_branch_name.into();
+    if normalized != user_name_bstr {
+        return BadInput::new("Invalid branch name")
+            .arg_name("<BRANCH_NAME>")
+            .arg_value(user_provided_branch_name)
+            .hint(format!("Try '{normalized}' instead"))
+            .into_cli_result();
+    }
+
+    let branch_ref_name = if user_provided_branch_name.starts_with("refs/heads") {
+        user_provided_branch_name.to_string()
+    } else {
+        format!("refs/heads/{user_provided_branch_name}")
+    };
+
+    if repo
+        .try_find_reference(&branch_ref_name.to_owned())?
+        .is_some()
+    {
+        return BadInput::new(format!(
+            "A branch named '{user_provided_branch_name}' already exists"
+        ))
+        .into_cli_result();
+    }
+
     Ok(())
 }
 

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -4,7 +4,7 @@ use but_api::json::HexHash;
 use but_core::{ref_metadata::StackId, sync::RepoExclusive};
 
 use crate::{
-    BadInput, CliError, CliId, CliResult, IdMap,
+    CliError, CliId, CliResult, IdMap, bad_input,
     theme::{self, Paint},
     utils::{Confirm, ConfirmDefault, OutputChannel, shorten_object_id},
 };
@@ -45,7 +45,7 @@ pub fn delete(
         }
     }
 
-    BadInput::new(format!("Branch '{branch_name}' not found in any stack")).into_cli_result()
+    Err(bad_input(format!("Branch '{branch_name}' not found in any stack")).into())
 }
 
 pub fn new(
@@ -76,13 +76,13 @@ pub fn new(
         // Resolve the anchor string to a CliId
         let anchor_ids = id_map.parse_using_context(&anchor_str, ctx)?;
         if anchor_ids.is_empty() {
-            return BadInput::new(format!("Could not find anchor: {anchor_str}")).into_cli_result();
+            return Err(bad_input(format!("Could not find anchor: {anchor_str}")).into());
         }
         if anchor_ids.len() > 1 {
-            return BadInput::new(format!(
+            return Err(bad_input(format!(
                 "Ambiguous anchor '{anchor_str}', matches multiple items"
             ))
-            .into_cli_result();
+            .into());
         }
         let anchor_id = &anchor_ids[0];
 
@@ -102,11 +102,11 @@ pub fn new(
                 },
             ),
             _ => {
-                return BadInput::new(format!(
+                return Err(bad_input(format!(
                     "Invalid anchor type: {}, expected commit or branch",
                     anchor_id.kind_for_humans()
                 ))
-                .into_cli_result();
+                .into());
             }
         }
     } else {
@@ -175,7 +175,7 @@ fn check_can_create_branch_with_user_provided_name(
     let normalized =
         but_core::branch::normalize_short_name(user_provided_branch_name).map_err(|err| {
             CliError::from(
-                BadInput::new(format!("Invalid branch name: {err}"))
+                bad_input(format!("Invalid branch name: {err}"))
                     .arg_name("<BRANCH_NAME>")
                     .arg_value(user_provided_branch_name),
             )
@@ -183,11 +183,11 @@ fn check_can_create_branch_with_user_provided_name(
 
     let user_name_bstr: &BStr = user_provided_branch_name.into();
     if normalized != user_name_bstr {
-        return BadInput::new("Invalid branch name")
+        return Err(bad_input("Invalid branch name")
             .arg_name("<BRANCH_NAME>")
             .arg_value(user_provided_branch_name)
             .hint(format!("Try '{normalized}' instead"))
-            .into_cli_result();
+            .into());
     }
 
     let branch_ref_name = if user_provided_branch_name.starts_with("refs/heads") {
@@ -200,10 +200,10 @@ fn check_can_create_branch_with_user_provided_name(
         .try_find_reference(&branch_ref_name.to_owned())?
         .is_some()
     {
-        return BadInput::new(format!(
+        return Err(bad_input(format!(
             "A branch named '{user_provided_branch_name}' already exists"
         ))
-        .into_cli_result();
+        .into());
     }
 
     Ok(())

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -90,7 +90,7 @@ pub(crate) fn insert_blank_commit(
                         && stack_head_ref == &reference.name
                     {
                         return BadInput::new("Cannot insert empty commit above stack head")
-                            .arg("--after")
+                            .arg_name("--after")
                             .hint("Use '--before' to insert at the tip of the stack")
                             .into_cli_result();
                     }

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -13,7 +13,7 @@ use gitbutler_repo::hooks;
 
 use super::{ShowDiffInEditor, estimate_diff_blob_size};
 use crate::{
-    BadInput, CliId, IdMap,
+    CliId, IdMap, bad_input,
     command::legacy::status::assignment::{CLIHunkAssignment, FileAssignment},
     theme::{self, Paint},
     tui,
@@ -33,15 +33,15 @@ pub(crate) fn insert_blank_commit(
     let cli_ids = id_map.parse_using_context(target, ctx)?;
 
     if cli_ids.is_empty() {
-        return BadInput::new(format!("Target '{target}' not found")).into_cli_result();
+        return Err(bad_input(format!("Target '{target}' not found")).into());
     }
 
     if cli_ids.len() > 1 {
-        return BadInput::new(format!(
+        return Err(bad_input(format!(
             "Target '{target}' is ambiguous. Found {} matches",
             cli_ids.len()
         ))
-        .into_cli_result();
+        .into());
     }
 
     let cli_id = &cli_ids[0];
@@ -89,10 +89,10 @@ pub(crate) fn insert_blank_commit(
                     if let Some(stack_head_ref) = stack.ref_name()
                         && stack_head_ref == &reference.name
                     {
-                        return BadInput::new("Cannot insert empty commit above stack head")
+                        return Err(bad_input("Cannot insert empty commit above stack head")
                             .arg_name("--after")
                             .hint("Use '--before' to insert at the tip of the stack")
-                            .into_cli_result();
+                            .into());
                     }
                 }
             }
@@ -113,11 +113,11 @@ pub(crate) fn insert_blank_commit(
             (outcome, success_message)
         }
         _ => {
-            return BadInput::new(format!(
+            return Err(bad_input(format!(
                 "Target must be a commit ID or branch name, not {}",
                 cli_id.kind_for_humans()
             ))
-            .into_cli_result();
+            .into());
         }
     };
 

--- a/crates/but/src/command/legacy/teardown.rs
+++ b/crates/but/src/command/legacy/teardown.rs
@@ -6,7 +6,7 @@ use gix::refs::{Category, transaction::PreviousValue};
 use serde::Serialize;
 
 use crate::{
-    BadInput, CliError, CliResult,
+    CliError, CliResult, bad_input,
     theme::{self, Paint},
     utils::{OutputChannel, shorten_object_id},
 };
@@ -51,7 +51,7 @@ pub(crate) fn teardown(
                     .paint("Teardown can only be run while on the gitbutler/workspace branch.")
             )?;
         }
-        return Err(BadInput::new("Not on gitbutler/workspace branch").into());
+        return Err(bad_input("Not on gitbutler/workspace branch").into());
     }
 
     // Note: Validate checkout_to before snapshot creation to prevent unnecessary snapshot
@@ -59,23 +59,25 @@ pub(crate) fn teardown(
         let repo = ctx.repo.get()?;
         let ref_name: gix::refs::PartialName = checkout_to.clone().try_into().map_err(|_| {
             CliError::from(
-                BadInput::new(format!("Invalid ref name: {checkout_to}")).arg_name("--checkout-to"),
+                bad_input(format!("Invalid ref name: {checkout_to}")).arg_name("--checkout-to"),
             )
         })?;
         let resolved_ref = match repo.try_find_reference(ref_name.as_ref())? {
             Some(resolved_ref) => resolved_ref,
             None => {
-                return BadInput::new(format!("The reference '{checkout_to}' did not exist"))
-                    .arg_name("--checkout-to")
-                    .into_cli_result();
+                return Err(
+                    bad_input(format!("The reference '{checkout_to}' did not exist"))
+                        .arg_name("--checkout-to")
+                        .into(),
+                );
             }
         };
         if !matches!(resolved_ref.name().category(), Some(Category::LocalBranch)) {
-            return BadInput::new(format!(
+            return Err(bad_input(format!(
                 "Invalid ref for checkout: '{checkout_to}' is not a local branch"
             ))
             .arg_name("--checkout-to")
-            .into_cli_result();
+            .into());
         }
         Some(resolved_ref.name().shorten().to_string())
     } else {
@@ -144,9 +146,9 @@ pub(crate) fn teardown(
                 .map(|h| h.name.to_string())
                 .ok_or_else(|| anyhow::anyhow!("Stack has no branches"))?
         } else {
-            return BadInput::new(
+            return Err(bad_input(
                 "Failed to determine checkout target branch. Specify a target branch with `--checkout-to <branch>`.",
-            ).into_cli_result();
+            ).into());
         }
     };
 

--- a/crates/but/src/command/legacy/teardown.rs
+++ b/crates/but/src/command/legacy/teardown.rs
@@ -59,14 +59,14 @@ pub(crate) fn teardown(
         let repo = ctx.repo.get()?;
         let ref_name: gix::refs::PartialName = checkout_to.clone().try_into().map_err(|_| {
             CliError::from(
-                BadInput::new(format!("Invalid ref name: {checkout_to}")).arg("--checkout-to"),
+                BadInput::new(format!("Invalid ref name: {checkout_to}")).arg_name("--checkout-to"),
             )
         })?;
         let resolved_ref = match repo.try_find_reference(ref_name.as_ref())? {
             Some(resolved_ref) => resolved_ref,
             None => {
                 return BadInput::new(format!("The reference '{checkout_to}' did not exist"))
-                    .arg("--checkout-to")
+                    .arg_name("--checkout-to")
                     .into_cli_result();
             }
         };
@@ -74,7 +74,7 @@ pub(crate) fn teardown(
             return BadInput::new(format!(
                 "Invalid ref for checkout: '{checkout_to}' is not a local branch"
             ))
-            .arg("--checkout-to")
+            .arg_name("--checkout-to")
             .into_cli_result();
         }
         Some(resolved_ref.name().shorten().to_string())

--- a/crates/but/src/error.rs
+++ b/crates/but/src/error.rs
@@ -11,11 +11,13 @@ use crate::theme::{self, Paint};
 #[derive(Debug)]
 pub struct BadInput {
     /// A message to print verbatim to the user
-    pub message: String,
-    /// If applicable, the input argument to which the bad input was passed
-    pub arg: Option<String>,
+    message: String,
+    /// If applicable, the name of the input argument to which the bad input was passed
+    arg_name: Option<String>,
+    /// If applicable, the bad value that was passed
+    arg_value: Option<String>,
     /// A hint to guide the user to proper usage of the command
-    pub hint: Option<String>,
+    hint: Option<String>,
 }
 
 impl BadInput {
@@ -23,14 +25,21 @@ impl BadInput {
     pub fn new<S: AsRef<str>>(message: S) -> Self {
         Self {
             message: message.as_ref().to_string(),
-            arg: None,
+            arg_name: None,
+            arg_value: None,
             hint: None,
         }
     }
 
-    /// Add the argument for which this message applies.
-    pub fn arg<S: AsRef<str>>(mut self, arg: S) -> Self {
-        self.arg = Some(arg.as_ref().to_string());
+    /// Add the name of the argument for which this message applies.
+    pub fn arg_name<S: AsRef<str>>(mut self, name: S) -> Self {
+        self.arg_name = Some(name.as_ref().to_string());
+        self
+    }
+
+    /// Add the value that was passed by the user.
+    pub fn arg_value<S: AsRef<str>>(mut self, value: S) -> Self {
+        self.arg_value = Some(value.as_ref().to_string());
         self
     }
 
@@ -50,18 +59,27 @@ impl Display for BadInput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let t = theme::get();
 
-        if let Some(arg) = &self.arg {
-            writeln!(
-                f,
-                "{} Bad input for '{}'",
-                t.error.paint("Error:"),
-                t.attention.paint(arg),
-            )?;
-            writeln!(f)?;
-            write!(f, "{}", self.message)?;
-        } else {
-            write!(f, "{} {}", t.error.paint("Error:"), self.message)?;
-        };
+        write!(f, "{}", t.error.paint("Error: "))?;
+
+        match (&self.arg_name, &self.arg_value) {
+            (Some(name), Some(value)) => {
+                writeln!(
+                    f,
+                    "Bad input '{}' for '{}'",
+                    t.attention.paint(value),
+                    t.attention.paint(name),
+                )?;
+                writeln!(f)?;
+            }
+            (Some(name), None) => {
+                writeln!(f, "Bad input for '{}'", t.attention.paint(name),)?;
+                writeln!(f)?;
+            }
+            (None, Some(value)) => writeln!(f, "Bad input '{}'", t.attention.paint(value))?,
+            _ => (),
+        }
+
+        write!(f, "{}", self.message)?;
 
         if let Some(hint) = &self.hint {
             writeln!(f)?;

--- a/crates/but/src/error.rs
+++ b/crates/but/src/error.rs
@@ -48,11 +48,11 @@ impl BadInput {
         self.hint = Some(hint.as_ref().to_string());
         self
     }
+}
 
-    /// Wrap this value as a [`CliError::BadInput`] in a [`CliResult`].
-    pub fn into_cli_result<T>(self) -> CliResult<T> {
-        Err(self.into())
-    }
+/// Convenience wrapper around [`BadInput::new`].
+pub(crate) fn bad_input<S: AsRef<str>>(message: S) -> BadInput {
+    BadInput::new(message)
 }
 
 impl Display for BadInput {

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -45,7 +45,7 @@ use crate::{
 };
 
 mod error;
-pub(crate) use error::{BadInput, CliError, CliResult};
+pub(crate) use error::{CliError, CliResult, bad_input};
 
 mod id;
 pub use id::{CliId, IdMap};
@@ -503,7 +503,7 @@ async fn match_subcommand(
                     let ctx = but_ctx::Context::discover(&args.current_dir)?;
                     command::branch::apply(ctx, &branch_name, out).map_err(CliError::from)
                 }
-                Some(branch::Subcommands::Move { .. }) => Err(BadInput::new(
+                Some(branch::Subcommands::Move { .. }) => Err(bad_input(
                     "`but branch move` has been removed. Use `but move` instead.",
                 )
                 .into()),
@@ -827,47 +827,46 @@ async fn match_subcommand(
 
                     // Validate that no regular commit options are specified with the empty subcommand
                     if commit_args.message.is_some() {
-                        return BadInput::new(
+                        return Err(bad_input(
                             "--message cannot be used with 'commit empty'. Empty commits have no message by default."
-                        ).into_cli_result();
+                        ).into());
                     }
                     if commit_args.message_file.is_some() {
-                        return BadInput::new(
+                        return Err(bad_input(
                             "--message-file cannot be used with 'commit empty'. Empty commits have no message by default."
-                        ).into_cli_result();
+                        ).into());
                     }
                     if commit_args.branch.is_some() {
-                        return BadInput::new(
+                        return Err(bad_input(
                             "branch argument cannot be used with 'commit empty'. Use the target positional argument or --before/--after flags."
-                        ).into_cli_result();
+                        ).into());
                     }
                     if commit_args.create {
-                        return BadInput::new("--create cannot be used with 'commit empty'.")
-                            .into_cli_result();
+                        return Err(
+                            bad_input("--create cannot be used with 'commit empty'.").into()
+                        );
                     }
                     if commit_args.only {
-                        return BadInput::new("--only cannot be used with 'commit empty'.")
-                            .into_cli_result();
+                        return Err(bad_input("--only cannot be used with 'commit empty'.").into());
                     }
                     if commit_args.all {
-                        return BadInput::new("--all cannot be used with 'commit empty'.")
-                            .into_cli_result();
+                        return Err(bad_input("--all cannot be used with 'commit empty'.").into());
                     }
                     if commit_args.no_hooks {
-                        return BadInput::new("--no-hooks cannot be used with 'commit empty'.")
-                            .into_cli_result();
+                        return Err(
+                            bad_input("--no-hooks cannot be used with 'commit empty'.").into()
+                        );
                     }
                     if commit_args.ai.is_some() {
-                        return BadInput::new("--ai cannot be used with 'commit empty'.")
-                            .into_cli_result();
+                        return Err(bad_input("--ai cannot be used with 'commit empty'.").into());
                     }
                     if commit_args.diff {
-                        return BadInput::new("--diff cannot be used with 'commit empty'.")
-                            .into_cli_result();
+                        return Err(bad_input("--diff cannot be used with 'commit empty'.").into());
                     }
                     if commit_args.no_diff {
-                        return BadInput::new("--no-diff cannot be used with 'commit empty'.")
-                            .into_cli_result();
+                        return Err(
+                            bad_input("--no-diff cannot be used with 'commit empty'.").into()
+                        );
                     }
                     // Note: --paths with commit empty is rejected by clap at parse time
                     // because --paths is not a flag on the empty subcommand
@@ -947,9 +946,9 @@ async fn match_subcommand(
                         && commit_args.message_file.is_none()
                         && commit_args.ai.is_none()
                     {
-                        return BadInput::new(
+                        return Err(bad_input(
                             "In JSON mode, either --message (-m), --message-file, or --ai (-i) must be specified"
-                        ).into_cli_result();
+                        ).into());
                     }
 
                     // Read message from file if provided, otherwise use message option
@@ -1179,15 +1178,15 @@ async fn match_subcommand(
                     // Check for non-interactive environment
                     if !out.can_prompt() {
                         if branch.is_none() {
-                            return BadInput::new(
+                            return Err(bad_input(
                                 "Non-interactive environment detected. Please specify a branch.",
                             )
-                            .into_cli_result();
+                            .into());
                         }
                         if review_message.is_none() && !default {
-                            return BadInput::new(
+                            return Err(bad_input(
                                 "Non-interactive environment detected. Provide one of: --message (-m), --file (-F), or --default (-t)."
-                            ).into_cli_result();
+                            ).into());
                         }
                     }
                     command::legacy::forge::review::create_review(
@@ -1348,9 +1347,9 @@ async fn match_subcommand(
                 // Interactive mode: but stage [--branch <branch>]
                 use std::io::IsTerminal;
                 if !std::io::stdout().is_terminal() {
-                    return BadInput::new(
+                    return Err(bad_input(
                         "Interactive stage requires a terminal. Use: but stage <file_or_hunk> <branch>"
-                    ).into_cli_result();
+                    ).into());
                 }
                 command::legacy::rub::handle_stage_tui(&mut ctx, out, branch.as_deref())
                     .context("Failed to stage.")

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -485,7 +485,6 @@ async fn match_subcommand(
                         out,
                     )?;
                     command::legacy::branch::new(&mut ctx, out, branch_name, anchor)
-                        .map_err(CliError::from)
                 }
                 #[cfg(feature = "legacy")]
                 Some(branch::Subcommands::Delete { branch_name, force }) => {

--- a/crates/but/tests/but/command/branch/new.rs
+++ b/crates/but/tests/but/command/branch/new.rs
@@ -42,7 +42,9 @@ fn rejects_head() -> anyhow::Result<()> {
         .assert()
         .failure()
         .stderr_eq(str![[r#"
-Error: Could not turn "HEAD" into a valid reference name
+Error: Bad input 'HEAD' for '<BRANCH_NAME>'
+
+Invalid branch name: Could not turn "HEAD" into a valid reference name
 
 "#]]);
 
@@ -58,7 +60,62 @@ fn rejects_name_that_normalizes_to_head() -> anyhow::Result<()> {
         .assert()
         .failure()
         .stderr_eq(str![[r#"
-Error: Could not turn "HEAD-" into a valid reference name
+Error: Bad input 'HEAD-' for '<BRANCH_NAME>'
+
+Invalid branch name: Could not turn "HEAD-" into a valid reference name
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn rejects_name_that_normalizes_to_something_else_and_suggests_alternative() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("branch new 'my branch'")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: Bad input 'my branch' for '<BRANCH_NAME>'
+
+Invalid branch name
+
+Hint: Try 'my-branch' instead
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn rejects_branch_name_already_applied_in_workspace() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("branch new A")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: A branch named 'A' already exists
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn rejects_name_that_exists_outside_workspace() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+    env.but("unapply A").assert().success();
+
+    env.but("branch new A")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: A branch named 'A' already exists
 
 "#]]);
 
@@ -90,31 +147,6 @@ fn with_json_output() -> anyhow::Result<()> {
 "#]]);
 
     // Test JSON output with anchor
-    env.but("branch new --json --anchor 9477ae7 my-anchored-feature")
-        .allow_json()
-        .assert()
-        .success()
-        .stderr_eq(str![])
-        .stdout_eq(str![[r#"
-{
-  "branch": "my-anchored-feature",
-  "anchor": "9477ae7"
-}
-
-"#]]);
-
-    // Test JSON output when branch already exists - it's idempotent.
-    env.but("branch --json new my-feature")
-        .allow_json()
-        .assert()
-        .success()
-        .stderr_eq(str![])
-        .stdout_eq(str![[r#"
-{
-  "branch": "my-feature"
-}
-
-"#]]);
     env.but("branch new --json --anchor 9477ae7 my-anchored-feature")
         .allow_json()
         .assert()


### PR DESCRIPTION
This solves several problems in `but branch new`:

1. The command would previously normalize branch names automatically, which is unexpected for a CLI. If you type `but branch new 'my branch'` and get a success back, you expect there to be a branch called 'my branch'. But the actual name of the new branch was normalized to 'my-branch' (although the output would lie and say it created `my branch`). The new behavior is to reject any non-normalized name and print hint with the normalized name instead.
2. Branch creation was idempotent for branches already applied in the workspace, which was very confusing as the CLI claimed to have successfully created a new branch while in fact it had done nothing. Such branch creation is now clearly rejected, which also falls in line with how Git handles such a situation.
3. Various obtuse error messages have been improved here. For example, when creating a new branch with a name that already existed and anchoring it to anywhere, you'd get an error like this::

```
Error: The reference "refs/heads/<name>" should have content b54c2567115498ffcb87b31a4f1f95f0bead2546, actual content was 6078e6bb61d3b1ac4f35f57f05e2cce3382359ff
```

The new error just says that the branch already exists.

> The rest of this PR body is more of a writeup than anything else, but I've done a great deal of thinking about how to provide good user feedback over the past few days and I think this is a good context to share it in.

## Better error messages side quest
Continuing down the path of better error messages to help users out, I've introduced the ability to specify argument name and argument value separately. This allows us to have a standardized way of saying "hey, you done goofed on this argument". I'm not yet convinced exactly when and how to use all this, but it's a start.

For example, when the input is malformed (i.e. the equivalent of a 400 Bad Request HTTP response), I think it's important to clearly connect the dots between the input argument and the badness and try to help the user (or agent) rectify the issue, like this:

<img width="556" height="160" alt="invalid_branch_name" src="https://github.com/user-attachments/assets/60d8fd5c-4fdc-45ce-8b15-aa7dd3459e32" />

> **Note:** Whether its helpful to name the positional argument in the output is something I'm still having an internal debate about. It can certainly be helpful if there are multiple positionals, but for just one it's rather questionable.
>
> The formatting here can probably also be improved, but it's a start, and the point is mostly to standardize what the errors look like at this point.

However, when the branch name is valid but the state of the repository doesn't allow it to be created (i.e. the equivalent of a 409 Conflict HTTP response), I think we can be much more concise with the amount of information in the output, like so:

<img width="515" height="68" alt="existing" src="https://github.com/user-attachments/assets/975ad036-1473-4eab-a6cb-f36eb5816cd5" />

## Look before you leap
This error handling is LBYL-based, rather than "better to ask for forgiveness than permission" using the new `PreconditionFailed` code. To a large extent I think we'll need to do LBYL-checks for _really_ solid error messages. Here are a few reasons.

### Not enough information from the underlying implementation
We simply don't have enough error information from the internals to directly correlate the error to the user's input. Even if the response code is `PreconditionFailed`, we don't know _what_ precondition. How can we tell if it's the name that's bad, or if it's the anchor?

### `PreconditionFailed` does not imply user error
It implies _caller error_. A trivial example in this piece of code is that we create a canned branch name if the user doesn't pass a branch name. If _that_ fails a precondition, it's still a system error, not a user error. While it's unlikely that we'd create an invalid branch name, it is logically possible and only meant to illustrate the fallacy of assuming that a failing precondition is the user's fault.

What's worse is that a `PreconditionFailed` code only directly implies caller error to the _direct_ caller, as the function that emits the code can only know about its direct inputs.  In fact, as long as it's possible that we generate or manipulate input that can cause a `PreconditionFailed`, the code itself doesn't really add much information to the application as a whole. A caller can never know if the code was emitted from the directly called function, or from a function further down where the inputs aren't necessarily directly controlled by the original caller.

To summarize, it is not _sound_ to assume that `PreconditionFailed` implies user error, or even caller error more than one stack frame away.

### `PreconditionFailed` is a moving target
Right now, `PreconditionFailed` can only be emitted when the branch name is bad. If you build the code around that assumption, adding another `PreconditionFailed` cause in the internals breaks that assumption without there being any mechanism to find out from the call site.

### There are downsides to LBYL, too
This is not to say that LBYL error handling is _perfect_.

* It adds overhead - because the checks should absolutely be performed again by the internals.
* It may be too strict and disallow use that should be allowed
* It adds more code to maintain

But to provide that terrific user feedback, I firmly believe at this point that we need to do input validation immediately, despite these drawbacks. We should also not attempt to do _perfect_ input validation - if we can provide great user feedback for most invalid inputs, and produce obtuse errors for some, that's still a win.

## Further notes
* This replaces https://github.com/gitbutlerapp/gitbutler/pull/13159
* The same name validation should be applied to renaming branches with `but reword`, and will thereby replace https://github.com/gitbutlerapp/gitbutler/pull/13160
* There's still a quirk I don't like: `but branch new refs/heads/my-branch` creates the branch `my-branch`. This is inconsistent with Git, which would literally create the branch `refs/heads/my-branch` (i.e. with full name `refs/heads/refs/heads/my-branch`).
