### PR TITLE
Staged files resizer

### DIFF
--- a/apps/desktop/src/components/files/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/files/WorktreeChanges.svelte
@@ -35,6 +35,8 @@
 		onFileClick?: (index: number) => void;
 		onscrollexists?: (exists: boolean) => void;
 		visibleRange?: { start: number; end: number };
+		maxListHeight?: string;
+		scrollAreaEl?: HTMLDivElement;
 	};
 
 	let {
@@ -49,6 +51,8 @@
 		onFileClick,
 		onscrollexists,
 		visibleRange,
+		maxListHeight,
+		scrollAreaEl = $bindable(),
 	}: Props = $props();
 
 	// Create a unique persist ID based on stackId and mode (both are static props)
@@ -169,6 +173,8 @@
 					scrollTopIsVisible = visible;
 				}}
 				enableDragScroll={mode === "assigned"}
+				maxHeight={maxListHeight}
+				bind:scrollableEl={scrollAreaEl}
 			>
 				{@render fileList()}
 			</ScrollableContainer>

--- a/apps/desktop/src/components/shared/AppScrollableContainer.svelte
+++ b/apps/desktop/src/components/shared/AppScrollableContainer.svelte
@@ -5,6 +5,7 @@
 
 	let {
 		viewport = $bindable(),
+		scrollableEl = $bindable(),
 		viewportHeight = $bindable(),
 		...restProps
 	}: ScrollableProps = $props();
@@ -30,6 +31,7 @@
 <ScrollableContainer
 	bind:this={scrollableContainer}
 	bind:viewport
+	bind:scrollableEl
 	bind:viewportHeight
 	whenToShow={uiState.global.scrollbarVisibilityState.current}
 	{...restProps}

--- a/apps/desktop/src/components/views/StackPanel.svelte
+++ b/apps/desktop/src/components/views/StackPanel.svelte
@@ -12,6 +12,8 @@
 	import NewCommitView from "$components/commit/NewCommitView.svelte";
 	import WorktreeChanges from "$components/files/WorktreeChanges.svelte";
 	import IrcRow from "$components/irc/IrcRow.svelte";
+	import Resizer from "$components/shared/Resizer.svelte";
+	import SashLayer from "$components/shared/SashLayer.svelte";
 	import StackDragHandle from "$components/stack/StackDragHandle.svelte";
 	import BranchList from "$components/views/BranchList.svelte";
 	import { stagingBehaviorFeature } from "$lib/config/uiFeatureFlags";
@@ -48,6 +50,19 @@
 
 	let dropzoneActivated = $state(false);
 	let dropzoneHovered = $state(false);
+	let stagedListEl = $state<HTMLDivElement | undefined>();
+	let stagedHeight = $state("40vh");
+	let stagedContentHeightRem = $state(60);
+
+	$effect(() => {
+		const viewport = stagedListEl?.querySelector<HTMLElement>(".viewport");
+		if (!viewport) return;
+		const observer = new ResizeObserver(() => {
+			stagedContentHeightRem = viewport.scrollHeight / 16;
+		});
+		observer.observe(viewport);
+		return () => observer.disconnect();
+	});
 
 	function selectedPathsForSelection(selectionId: SelectionId): string[] {
 		return idSelection.values(selectionId).map((entry) => entry.path);
@@ -138,41 +153,58 @@
 		class="assignments-wrap"
 		class:assignments__empty={changes.current.length === 0 && !controller.isCommitting}
 	>
-		<div
-			class="worktree-wrap"
-			class:remove-border-bottom={(controller.isCommitting && changes.current.length === 0) ||
-				!startCommitVisible.current}
-			class:dropzone-activated={dropzoneActivated && changes.current.length === 0}
-			class:dropzone-hovered={dropzoneHovered && changes.current.length === 0}
-		>
-			<WorktreeChanges
-				title="Staged"
-				projectId={controller.projectId}
-				stackId={controller.stackId}
-				mode="assigned"
-				visibleRange={controller.visibleRange}
-				onDropzoneActivated={(activated) => {
-					dropzoneActivated = activated;
-				}}
-				onDropzoneHovered={(hovered) => {
-					dropzoneHovered = hovered;
-				}}
-				onFileClick={(index) => {
-					controller.selection.set(undefined);
-					controller.jumpToIndex(index);
-				}}
+		<SashLayer>
+			<div
+				class="worktree-wrap"
+				class:remove-border-bottom={(controller.isCommitting && changes.current.length === 0) ||
+					!startCommitVisible.current}
+				class:dropzone-activated={dropzoneActivated && changes.current.length === 0}
+				class:dropzone-hovered={dropzoneHovered && changes.current.length === 0}
 			>
-				{#snippet emptyPlaceholder()}
-					{#if !controller.isCommitting}
-						<div class="assigned-changes-empty">
-							<p class="text-12 text-body assigned-changes-empty__text">
-								Drop files to stage or commit directly
-							</p>
-						</div>
-					{/if}
-				{/snippet}
-			</WorktreeChanges>
-		</div>
+				<WorktreeChanges
+					title="Staged"
+					projectId={controller.projectId}
+					stackId={controller.stackId}
+					mode="assigned"
+					visibleRange={controller.visibleRange}
+					maxListHeight={stagedHeight}
+					bind:scrollAreaEl={stagedListEl}
+					onDropzoneActivated={(activated) => {
+						dropzoneActivated = activated;
+					}}
+					onDropzoneHovered={(hovered) => {
+						dropzoneHovered = hovered;
+					}}
+					onFileClick={(index) => {
+						controller.selection.set(undefined);
+						controller.jumpToIndex(index);
+					}}
+				>
+					{#snippet emptyPlaceholder()}
+						{#if !controller.isCommitting}
+							<div class="assigned-changes-empty">
+								<p class="text-12 text-body assigned-changes-empty__text">
+									Drop files to stage or commit directly
+								</p>
+							</div>
+						{/if}
+					{/snippet}
+				</WorktreeChanges>
+				{#if stagedListEl && changes.current.length > 0}
+					<Resizer
+						viewport={stagedListEl}
+						direction="down"
+						defaultValue={undefined}
+						minHeight={3}
+						maxHeight={stagedContentHeightRem}
+						unsetMaxHeight="40vh"
+						persistId="staged-changes-height-{controller.stackId ?? 'unassigned'}"
+						onWidth={(h) => (stagedHeight = `${h}rem`)}
+						onDblClick={() => (stagedHeight = "40vh")}
+					/>
+				{/if}
+			</div>
+		</SashLayer>
 
 		{#if startCommitVisible.current || controller.isCommitting}
 			{#if !controller.isCommitting}

--- a/packages/ui/src/lib/components/scroll/ScrollableContainer.svelte
+++ b/packages/ui/src/lib/components/scroll/ScrollableContainer.svelte
@@ -23,6 +23,7 @@
 		onscroll?: (e: Event) => void;
 		onscrollexists?: (exists: boolean) => void;
 		viewport?: HTMLDivElement;
+		scrollableEl?: HTMLDivElement;
 		viewportHeight?: number;
 		childrenWrapHeight?: string;
 		childrenWrapDisplay?: "block" | "contents" | "flex"; // 'contents' is used for virtual lists to avoid unnecessary height calculations
@@ -53,6 +54,7 @@
 		onscrollexists,
 		zIndex,
 		viewport = $bindable(),
+		scrollableEl = $bindable(),
 		viewportHeight = $bindable(),
 		childrenWrapHeight,
 		childrenWrapDisplay = "block",
@@ -138,7 +140,12 @@
 	}
 </script>
 
-<div class="scrollable" style:flex-grow={wide ? 1 : 0} style:max-height={maxHeight}>
+<div
+	bind:this={scrollableEl}
+	class="scrollable"
+	style:flex-grow={wide ? 1 : 0}
+	style:max-height={maxHeight}
+>
 	<div
 		bind:this={viewport}
 		bind:offsetHeight={viewportHeight}


### PR DESCRIPTION


https://github.com/user-attachments/assets/0830c899-cbdb-4416-ae6c-244e100d247e



This pull request introduces resizable staged changes in the `StackPanel` view by integrating a resizer component and making several updates to the scrollable container infrastructure. The changes allow users to adjust the height of the staged changes list dynamically, improving usability when managing large numbers of changes. The implementation involves passing and binding new props for scrollable elements and maximum heights, and observing content height for responsive resizing.

Resizable staged changes in StackPanel:

* Added a `Resizer` component below the staged changes list in `StackPanel.svelte`, allowing users to drag to resize the height of the staged changes area. The height is persisted per stack and double-click resets to the default.
* Introduced state variables (`stagedListEl`, `stagedHeight`, `stagedContentHeightRem`) and a `ResizeObserver` to track and limit the resizer based on content height in `StackPanel.svelte`.
* Wrapped the staged changes and resizer in a new `SashLayer` for better visual separation and interaction.

Scrollable container infrastructure updates:

* Updated `WorktreeChanges.svelte`, `AppScrollableContainer.svelte`, and `ScrollableContainer.svelte` to accept and bind new props: `maxListHeight`/`maxHeight` and `scrollAreaEl`/`scrollableEl`, enabling external control and measurement of the scrollable area. [[1]](diffhunk://#diff-9fb50e113afe5096124242f0ce9a7d7c73af239389e3885df240cac97cf5bcc9R38-R39) [[2]](diffhunk://#diff-9fb50e113afe5096124242f0ce9a7d7c73af239389e3885df240cac97cf5bcc9R54-R55) [[3]](diffhunk://#diff-9fb50e113afe5096124242f0ce9a7d7c73af239389e3885df240cac97cf5bcc9R176-R177) [[4]](diffhunk://#diff-38ece5beaf24b6e9b24cc3819bb5808d797d027947502ba16f667012f52efdf8R8) [[5]](diffhunk://#diff-38ece5beaf24b6e9b24cc3819bb5808d797d027947502ba16f667012f52efdf8R34) [[6]](diffhunk://#diff-e28711311673448a29abb261ba1f36b7339af55817ec9493b98be1c223b28e7cR26) [[7]](diffhunk://#diff-e28711311673448a29abb261ba1f36b7339af55817ec9493b98be1c223b28e7cR57) [[8]](diffhunk://#diff-e28711311673448a29abb261ba1f36b7339af55817ec9493b98be1c223b28e7cL141-R148)
* Passed the new props through the component hierarchy to ensure the resizer and scrollable container are properly connected.

Component imports:

* Added imports for `Resizer` and `SashLayer` in `StackPanel.svelte` to support the new UI elements.