### PR TITLE
Add public agentlog projection API

### DIFF
--- a/crates/but-agentlog/src/cli.rs
+++ b/crates/but-agentlog/src/cli.rs
@@ -187,11 +187,11 @@ pub fn run_from_dir(dir: &Path, command: Command) -> anyhow::Result<impl Seriali
             turn,
             limit,
         } => {
-            let workdir = resolve_workdir(dir)?;
+            let repo_path = resolve_read_repo_path(dir)?;
             match turn {
                 Some(turn) => {
                     let records = get_session_records(
-                        &workdir,
+                        &repo_path,
                         &session_key,
                         &turn,
                         limit.unwrap_or(DEFAULT_RECORD_LIMIT),
@@ -201,7 +201,7 @@ pub fn run_from_dir(dir: &Path, command: Command) -> anyhow::Result<impl Seriali
                 }
                 None => {
                     let timeline = get_session_timeline_outline(
-                        &workdir,
+                        &repo_path,
                         &session_key,
                         Some(limit.unwrap_or(DEFAULT_TIMELINE_LIMIT)),
                     )
@@ -221,16 +221,20 @@ pub fn run_from_dir(dir: &Path, command: Command) -> anyhow::Result<impl Seriali
                 }
                 (None, None) => None,
             };
-            let workdir = resolve_workdir(dir)?;
+            let repo_path = if explicit_target.is_some() {
+                resolve_read_repo_path(dir)?
+            } else {
+                resolve_workdir(dir)?
+            };
             let (target, value) = match explicit_target {
                 Some(target) => target,
-                None => skim::resolve_default_branch_target(&workdir)?,
+                None => skim::resolve_default_branch_target(&repo_path)?,
             };
             let target_key = related_session_target_key(target, &value);
             let sessions =
-                find_related_sessions_limited(&workdir, target.related_target(&target_key), None)
+                find_related_sessions_limited(&repo_path, target.related_target(&target_key), None)
                     .context("failed to find related agent sessions")?;
-            let report = skim::report(&workdir, target, target_key, sessions)
+            let report = skim::report(&repo_path, target, target_key, sessions)
                 .context("failed to build agent skim")?;
             Ok(CommandOutput::Skim(report))
         }
@@ -311,12 +315,23 @@ fn record_agent_log(
 }
 
 fn resolve_workdir(dir: &Path) -> anyhow::Result<PathBuf> {
-    let repo =
-        gix::discover(dir).context("No git repository found. Use -C to choose a repository.")?;
+    let repo = discover_repo(dir)?;
     let workdir = repo
         .workdir()
         .context("Bare repositories are not supported.")?;
     std::fs::canonicalize(workdir).context("failed to resolve repository worktree")
+}
+
+fn resolve_read_repo_path(dir: &Path) -> anyhow::Result<PathBuf> {
+    let repo = discover_repo(dir)?;
+    let repo_path = repo.workdir().unwrap_or_else(|| repo.git_dir());
+    std::fs::canonicalize(repo_path).context("failed to resolve repository path")
+}
+
+fn discover_repo(dir: &Path) -> anyhow::Result<gix::Repository> {
+    gix::discover(dir)
+        .or_else(|_| gix::open(dir))
+        .context("No git repository found. Use -C to choose a repository.")
 }
 
 fn non_empty_value(value: &str) -> Result<String, String> {
@@ -455,6 +470,27 @@ mod tests {
     }
 
     #[test]
+    fn show_reads_bare_repo_metadata() {
+        let repo = setup_bare_repo();
+        let turn_key = write_turn_with_targets(repo.path());
+
+        let output = run_from_dir(
+            repo.path(),
+            Command::Show {
+                session_key: TEST_SESSION_KEY.to_owned(),
+                turn: Some(turn_key.clone()),
+                limit: Some(1),
+            },
+        )
+        .expect("show bare repo records");
+        let json = serde_json::to_value(&output).expect("serialize command output");
+
+        assert_eq!(json["session_key"], TEST_SESSION_KEY);
+        assert_eq!(json["turn_key"], turn_key);
+        assert_eq!(json["records"][0]["text"], "hello");
+    }
+
+    #[test]
     fn skim_outputs_all_turns_with_drill_down_keys_in_json() {
         let repo = setup_repo();
         let turn_key = write_user_turn_with_targets(repo.path());
@@ -500,6 +536,26 @@ mod tests {
             !human.contains(&turn_key),
             "human output should keep full turn keys in JSON for drill-down"
         );
+    }
+
+    #[test]
+    fn explicit_skim_reads_bare_repo_metadata() {
+        let repo = setup_bare_repo();
+        let turn_key = write_user_turn_with_targets(repo.path());
+
+        let output = run_from_dir(
+            repo.path(),
+            Command::Skim {
+                target: Some(RelatedSessionTarget::Branch),
+                value: Some("main".into()),
+            },
+        )
+        .expect("skim bare repo");
+        let json = serde_json::to_value(&output).expect("serialize command output");
+
+        assert_eq!(json["target_key"], TEST_BRANCH_KEY);
+        assert_eq!(json["sessions"][0]["session_key"], TEST_SESSION_KEY);
+        assert_eq!(json["sessions"][0]["turns"][0]["turn_key"], turn_key);
     }
 
     #[test]
@@ -800,6 +856,12 @@ mod tests {
             gix::open::Options::isolated().config_overrides(["init.defaultBranch=main"]),
         )
         .expect("gitoxide repo init");
+        dir
+    }
+
+    fn setup_bare_repo() -> TempDir {
+        let dir = TempDir::new().expect("temp bare repo");
+        gix::init_bare(dir.path()).expect("gitoxide bare repo init");
         dir
     }
 

--- a/crates/but-agentlog/src/environment.rs
+++ b/crates/but-agentlog/src/environment.rs
@@ -269,7 +269,8 @@ fn workspace_snapshot_with_meta(
                 key: format!("ref:{full_ref_name}"),
                 name: ref_info.ref_name.shorten().to_string(),
             };
-            let review = review_target(&branch.key, segment.metadata.as_ref());
+            let reviews = review_targets(&branch.key, segment.metadata.as_ref());
+            let review = reviews.first().cloned();
             for commit in &segment.commits {
                 let change_id = commit.change_id.as_ref().map(ToString::to_string);
                 if let Some(change_id) = &change_id {
@@ -281,9 +282,7 @@ fn workspace_snapshot_with_meta(
             }
 
             observed_targets.branches.push(branch.clone());
-            if let Some(review) = review.clone() {
-                observed_targets.reviews.push(review);
-            }
+            observed_targets.reviews.extend(reviews);
             branches.push(BranchSnapshot {
                 key: branch.key,
                 name: branch.name,
@@ -303,20 +302,26 @@ fn workspace_snapshot_with_meta(
     })
 }
 
-fn review_target(branch_key: &str, metadata: Option<&Branch>) -> Option<ReviewTarget> {
-    let review = &metadata?.review;
+fn review_targets(branch_key: &str, metadata: Option<&Branch>) -> Vec<ReviewTarget> {
+    let Some(review) = metadata.map(|metadata| &metadata.review) else {
+        return Vec::new();
+    };
+    let mut targets = Vec::new();
     if let Some(review_id) = &review.review_id {
-        return Some(ReviewTarget {
+        targets.push(ReviewTarget {
             key: format!("gitbutler-review:{review_id}"),
             pull_request: review.pull_request,
             review_id: Some(review_id.clone()),
         });
     }
-    review.pull_request.map(|pull_request| ReviewTarget {
-        key: format!("pull-request:{branch_key}#{pull_request}"),
-        pull_request: Some(pull_request),
-        review_id: None,
-    })
+    if let Some(pull_request) = review.pull_request {
+        targets.push(ReviewTarget {
+            key: format!("pull-request:{branch_key}#{pull_request}"),
+            pull_request: Some(pull_request),
+            review_id: None,
+        });
+    }
+    targets
 }
 
 fn paths_from_changes(changes: impl IntoIterator<Item = TreeChange>) -> Vec<String> {
@@ -478,6 +483,31 @@ impl RefMetadata for EmptyRefMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn review_targets_include_review_id_and_pull_request() {
+        let mut metadata = Branch::default();
+        metadata.review.review_id = Some("review-1".to_owned());
+        metadata.review.pull_request = Some(42);
+
+        let targets = review_targets("ref:refs/heads/feature", Some(&metadata));
+
+        assert_eq!(
+            targets,
+            [
+                ReviewTarget {
+                    key: "gitbutler-review:review-1".to_owned(),
+                    pull_request: Some(42),
+                    review_id: Some("review-1".to_owned()),
+                },
+                ReviewTarget {
+                    key: "pull-request:ref:refs/heads/feature#42".to_owned(),
+                    pull_request: Some(42),
+                    review_id: None,
+                }
+            ]
+        );
+    }
 
     #[test]
     fn environment_from_parts_classifies_partial_and_failed_observations() {

--- a/crates/but-agentlog/src/gitmeta/records_outline.rs
+++ b/crates/but-agentlog/src/gitmeta/records_outline.rs
@@ -36,8 +36,12 @@ pub(crate) struct RecordDetail {
     pub(crate) source_event_kind: Option<String>,
     pub(crate) role: Option<String>,
     pub(crate) text: Option<String>,
+    pub(crate) prompt_source: Option<String>,
     pub(crate) tool_name: Option<String>,
+    pub(crate) tool_kind: Option<String>,
     pub(crate) tool_input: Option<Value>,
+    pub(crate) exit_code: Option<i32>,
+    pub(crate) outcome: Option<String>,
     pub(crate) source_record: Value,
 }
 
@@ -95,8 +99,16 @@ struct StoredRecord {
     source_event_kind: Option<String>,
     role: Option<String>,
     text: Option<String>,
+    #[serde(default)]
+    prompt_source: Option<String>,
     tool_name: Option<String>,
+    #[serde(default)]
+    tool_kind: Option<String>,
     tool_input: Option<Value>,
+    #[serde(default)]
+    exit_code: Option<i32>,
+    #[serde(default)]
+    outcome: Option<String>,
     source_record: Value,
 }
 
@@ -131,8 +143,12 @@ fn record_detail(turn_record_index: usize, record: StoredRecord) -> RecordDetail
         source_event_kind: record.source_event_kind,
         role: record.role,
         text: record.text,
+        prompt_source: record.prompt_source,
         tool_name: record.tool_name,
+        tool_kind: record.tool_kind,
         tool_input: record.tool_input,
+        exit_code: record.exit_code,
+        outcome: record.outcome,
         source_record: record.source_record,
     }
 }

--- a/crates/but-agentlog/src/gitmeta/records_outline.rs
+++ b/crates/but-agentlog/src/gitmeta/records_outline.rs
@@ -29,6 +29,8 @@ pub(crate) struct RecordCoverage {
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub(crate) struct RecordDetail {
+    #[serde(skip)]
+    pub(crate) record_hash: String,
     pub(crate) turn_record_index: usize,
     pub(crate) source_record_index: Option<usize>,
     pub(crate) timestamp: Option<String>,
@@ -136,6 +138,7 @@ fn parse_record(raw: &str) -> Option<(String, StoredRecord)> {
 
 fn record_detail(turn_record_index: usize, record: StoredRecord) -> RecordDetail {
     RecordDetail {
+        record_hash: record.record_hash,
         turn_record_index,
         source_record_index: record.record_index,
         timestamp: record.timestamp,

--- a/crates/but-agentlog/src/gitmeta/tests.rs
+++ b/crates/but-agentlog/src/gitmeta/tests.rs
@@ -2,6 +2,11 @@ use super::*;
 use crate::agent::Agent;
 use crate::capture::record_transcript;
 use crate::environment::{EnvironmentObservation, ObservedTargets, capture_environment};
+use crate::projection::{
+    ProjectionEvidenceTier, ProjectionLimits, ProjectionMatchKind, ProjectionPrFacts,
+    ProjectionRequest, ProjectionSnapshotInput, ProjectionStatus, ProjectionWarningKind,
+    project_pr,
+};
 use crate::transcript::TranscriptBatch;
 use but_core::worktree::safe_checkout;
 use git_meta_lib::{MetaEdit, MetaValue, Session, Target};
@@ -13,6 +18,7 @@ const TEST_SESSION_KEY: &str = "sha256-11111111111111111111111111111111";
 const TEST_SOURCE_KEY: &str = "sha256-22222222222222222222222222222222";
 const TEST_BRANCH_KEY: &str = "ref:refs/heads/main";
 const TEST_REVIEW_KEY: &str = "gitbutler-review:review-1";
+const TEST_PR_REVIEW_KEY: &str = "pull-request:ref:refs/heads/main#1";
 const TEST_CHANGE_KEY: &str = "gitbutler-change:change-1";
 
 fn setup_repo() -> TempDir {
@@ -92,6 +98,26 @@ fn jsonl(records: impl IntoIterator<Item = serde_json::Value>) -> String {
         output.push('\n');
     }
     output
+}
+
+fn projection_request() -> ProjectionRequest {
+    ProjectionRequest::new(
+        ProjectionPrFacts {
+            agent_trail_host: "https://agent-trail.test".to_owned(),
+            github_repository_id: 42,
+            owner: "gitbutler".to_owned(),
+            repo: "gitbutler".to_owned(),
+            pull_request: 1,
+            base_ref: "main".to_owned(),
+            head_ref: "main".to_owned(),
+            head_sha: "0123456789abcdef".to_owned(),
+        },
+        ProjectionSnapshotInput {
+            metadata_oid: "sha256-test-metadata".to_owned(),
+            projection_version: 1,
+            generated_at_unix_seconds: 1_779_999_999,
+        },
+    )
 }
 
 fn codex_fixture() -> String {
@@ -393,6 +419,244 @@ fn find_related_sessions_returns_verified_turn_keys() {
     assert_eq!(branch.related_turn_keys, turn_keys);
     let review = only_related(repo.path(), RelatedTarget::Review(TEST_REVIEW_KEY));
     assert_eq!(review.related_turn_keys, branch.related_turn_keys);
+}
+
+#[test]
+fn project_pr_returns_public_review_projection_without_raw_storage_keys() {
+    let repo = setup_repo();
+    let turn_key = write_turn_with_targets(
+        repo.path(),
+        "Related PR work",
+        ObservedTargets::from_index_keys_for_testing(
+            TEST_BRANCH_KEY,
+            TEST_PR_REVIEW_KEY,
+            TEST_CHANGE_KEY,
+        ),
+    );
+
+    let projection = project_pr(repo.path(), &projection_request()).expect("project PR");
+
+    assert_eq!(projection.status, ProjectionStatus::Ready);
+    assert!(projection.warnings.is_empty());
+    assert_eq!(projection.sessions.len(), 1);
+    let session = &projection.sessions[0];
+    assert!(session.handle.starts_with("ps_"));
+    assert_eq!(session.evidence_tier, ProjectionEvidenceTier::Supporting);
+    assert_eq!(session.agents.len(), 1);
+    assert_eq!(session.agents[0].agent.as_deref(), Some("codex"));
+    assert_eq!(session.turns.len(), 1);
+    let turn = &session.turns[0];
+    assert!(turn.handle.starts_with("pt_"));
+    assert_eq!(turn.evidence_tier, ProjectionEvidenceTier::Supporting);
+    assert_eq!(
+        turn.match_reasons
+            .iter()
+            .map(|reason| reason.kind)
+            .collect::<Vec<_>>(),
+        [
+            ProjectionMatchKind::ReviewTarget,
+            ProjectionMatchKind::BranchTarget
+        ]
+    );
+    assert_eq!(turn.records.len(), 1);
+    let record = &turn.records[0];
+    assert!(record.handle.starts_with("pr_"));
+    assert_eq!(record.text.as_deref(), Some("Related PR work"));
+    assert_eq!(record.kind.as_deref(), Some("message"));
+
+    let json = serde_json::to_string(&projection).expect("projection json");
+    assert!(
+        !json.contains(TEST_SESSION_KEY),
+        "public projection must not expose raw session keys"
+    );
+    assert!(
+        !json.contains(TEST_SOURCE_KEY),
+        "public projection must not expose raw source keys"
+    );
+    assert!(
+        !json.contains(&turn_key),
+        "public projection must not expose raw turn keys"
+    );
+    assert!(
+        !json.contains("\"source_record\":"),
+        "public projection must not expose raw source records"
+    );
+    assert!(
+        !json.contains("\"tool_input\""),
+        "public projection must not expose raw tool payloads"
+    );
+    assert!(
+        !json.contains("record_hash"),
+        "public projection must not expose raw record hashes"
+    );
+}
+
+#[test]
+fn project_pr_marks_branch_only_matches_as_weak_evidence() {
+    let repo = setup_repo();
+    write_turn_with_targets(
+        repo.path(),
+        "Branch-only work",
+        ObservedTargets::from_index_keys_for_testing(
+            TEST_BRANCH_KEY,
+            "pull-request:ref:refs/heads/main#99",
+            TEST_CHANGE_KEY,
+        ),
+    );
+
+    let projection = project_pr(repo.path(), &projection_request()).expect("project PR");
+
+    assert_eq!(projection.status, ProjectionStatus::WeakMatches);
+    assert_eq!(projection.sessions.len(), 1);
+    assert_eq!(
+        projection
+            .warnings
+            .iter()
+            .map(|warning| warning.kind)
+            .collect::<Vec<_>>(),
+        [
+            ProjectionWarningKind::NoReviewMatch,
+            ProjectionWarningKind::WeakBranchOnly
+        ]
+    );
+    let session = &projection.sessions[0];
+    assert_eq!(session.evidence_tier, ProjectionEvidenceTier::Possible);
+    let turn = &session.turns[0];
+    assert_eq!(turn.evidence_tier, ProjectionEvidenceTier::Possible);
+    assert_eq!(turn.match_reasons.len(), 1);
+    assert_eq!(
+        turn.match_reasons[0].kind,
+        ProjectionMatchKind::BranchTarget
+    );
+}
+
+#[test]
+fn project_pr_filters_hidden_prompts_and_strips_tool_payloads() {
+    let repo = setup_repo();
+    let batch = TranscriptBatch::parse(
+        Agent::Codex,
+        jsonl([
+            serde_json::json!({
+                "timestamp": "2026-05-07T09:00:00Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "session-1",
+                    "model_provider": "openai",
+                    "cli_version": "0.1.0",
+                },
+            }),
+            serde_json::json!({
+                "timestamp": "2026-05-07T09:00:01Z",
+                "type": "turn_context",
+                "payload": { "model": "gpt-5.5" },
+            }),
+            serde_json::json!({
+                "timestamp": "2026-05-07T09:00:02Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": "Please update src/lib.rs",
+                },
+            }),
+            serde_json::json!({
+                "timestamp": "2026-05-07T09:00:03Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": "# AGENTS.md instructions\n\n<INSTRUCTIONS>rules</INSTRUCTIONS>\n<environment_context>ctx</environment_context>",
+                },
+            }),
+            serde_json::json!({
+                "timestamp": "2026-05-07T09:00:04Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "apply_patch",
+                    "call_id": "call-1",
+                    "arguments": serde_json::json!({
+                        "input": "*** Begin Patch\n*** Update File: src/lib.rs\n*** Add File: ../private.md\n*** Add File: ~/notes.md\n*** Add File: C:\\Users\\name\\secret.rs\n*** Add File: src/../secret.rs\n*** Add File: src//weird.rs\n@@\n-pub fn old() {}\n+pub fn new() {}\n*** End Patch\n",
+                    }).to_string(),
+                },
+            }),
+            serde_json::json!({
+                "timestamp": "2026-05-07T09:00:05Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call_output",
+                    "call_id": "call-1",
+                    "output": "Chunk ID: abc\nWall time: 0.01s\nProcess exited with code 0\nUpdated file\n",
+                },
+            }),
+        ])
+        .as_bytes(),
+    )
+    .expect("parse projection batch");
+    write_transcript_batch(
+        repo.path(),
+        Agent::Codex,
+        TEST_SESSION_KEY,
+        TEST_SOURCE_KEY,
+        batch,
+        || {
+            EnvironmentObservation::from_observed_targets_for_testing(
+                ObservedTargets::from_index_keys_for_testing(
+                    TEST_BRANCH_KEY,
+                    TEST_PR_REVIEW_KEY,
+                    TEST_CHANGE_KEY,
+                ),
+            )
+        },
+    )
+    .expect("write projection batch");
+    let mut request = projection_request();
+    request.limits = ProjectionLimits {
+        max_turns: 8,
+        max_records_per_turn: 16,
+        max_text_chars: 80,
+    };
+
+    let projection = project_pr(repo.path(), &request).expect("project PR");
+
+    let turn = &projection.sessions[0].turns[0];
+    assert_eq!(
+        turn.latest_user_preview
+            .as_ref()
+            .map(|preview| preview.text.as_str()),
+        Some("Please update src/lib.rs")
+    );
+    let records = &turn.records;
+    assert_eq!(records.len(), 3);
+    assert!(
+        records
+            .iter()
+            .all(|record| record.prompt_source.as_deref() != Some("system_injected")),
+        "public projection must not expose hidden setup prompts"
+    );
+    assert_eq!(records[0].role.as_deref(), Some("user"));
+    assert_eq!(records[0].prompt_source.as_deref(), Some("human"));
+    assert_eq!(records[0].text.as_deref(), Some("Please update src/lib.rs"));
+    assert_eq!(records[1].kind.as_deref(), Some("tool_call"));
+    assert_eq!(records[1].tool_name.as_deref(), Some("apply_patch"));
+    assert_eq!(records[1].tool_kind.as_deref(), Some("file_edit"));
+    assert_eq!(records[1].file_paths, ["src/lib.rs"]);
+    assert_eq!(records[2].kind.as_deref(), Some("tool_result"));
+    assert_eq!(records[2].tool_name.as_deref(), Some("apply_patch"));
+    assert_eq!(records[2].text.as_deref(), Some("Updated file"));
+    assert_eq!(records[2].exit_code, Some(0));
+    assert_eq!(records[2].outcome.as_deref(), Some("succeeded"));
+
+    let json = serde_json::to_string(&projection).expect("projection json");
+    assert!(!json.contains("# AGENTS.md instructions"));
+    assert!(!json.contains("\"tool_input\""));
+    assert!(!json.contains("\"command\""));
+    assert!(!json.contains("\"target_key\""));
+    assert!(!json.contains("../private.md"));
+    assert!(!json.contains("~/notes.md"));
+    assert!(!json.contains("secret.rs"));
+    assert!(!json.contains("Process exited"));
+    assert!(!json.contains("Chunk ID"));
 }
 
 #[test]

--- a/crates/but-agentlog/src/gitmeta/tests.rs
+++ b/crates/but-agentlog/src/gitmeta/tests.rs
@@ -472,6 +472,7 @@ fn get_session_timeline_outline_returns_compact_bounded_turns() {
                 "payload": {
                     "type": "function_call",
                     "name": "exec_command",
+                    "call_id": "call-1",
                     "arguments": "{\"cmd\":\"cargo test\"}",
                 },
             }),
@@ -633,6 +634,7 @@ fn get_session_records_returns_latest_bounded_records_without_storage_keys() {
                 "payload": {
                     "type": "function_call",
                     "name": "exec_command",
+                    "call_id": "call-1",
                     "arguments": "{\"cmd\":\"cargo test\"}",
                 },
             }),
@@ -682,6 +684,7 @@ fn get_session_records_returns_latest_bounded_records_without_storage_keys() {
         records.records[1].tool_name.as_deref(),
         Some("exec_command")
     );
+    assert_eq!(records.records[1].tool_kind.as_deref(), Some("exec"));
     assert_eq!(
         records.records[1].tool_input.as_ref().expect("tool input")["cmd"],
         "cargo test"
@@ -952,6 +955,90 @@ fn transcript_records_redact_secrets_and_copied_scalar_fields() {
 }
 
 #[test]
+fn transcript_records_store_prompt_source_tool_kind_and_outcome() {
+    let repo = setup_repo();
+    let transcript = write_transcript(
+        repo.path(),
+        &jsonl([
+            serde_json::json!({
+                "timestamp": "2026-05-07T09:00:00Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "session-1",
+                    "thread_source": "subagent",
+                },
+            }),
+            serde_json::json!({
+                "timestamp": "2026-05-07T09:00:01Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": "# AGENTS.md instructions\n\n<INSTRUCTIONS>rules</INSTRUCTIONS>\n<environment_context>ctx</environment_context>",
+                },
+            }),
+            serde_json::json!({
+                "timestamp": "2026-05-07T09:00:02Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": "Repo: /tmp/project. Review the code.",
+                },
+            }),
+            serde_json::json!({
+                "timestamp": "2026-05-07T09:00:03Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "exec_command",
+                    "call_id": "call-1",
+                    "arguments": "{\"cmd\":\"cargo test\"}",
+                },
+            }),
+            serde_json::json!({
+                "timestamp": "2026-05-07T09:00:04Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call_output",
+                    "call_id": "call-1",
+                    "output": "Process exited with code 0",
+                },
+            }),
+        ]),
+    );
+
+    assert_eq!(capture_project(repo.path(), Agent::Codex, &transcript), 4);
+    let session_key = only_session_key(repo.path());
+    let records = transcript_entries(repo.path(), &session_key)
+        .into_iter()
+        .map(|entry| {
+            serde_json::from_str::<serde_json::Value>(&entry).expect("transcript record json")
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(records[0]["prompt_source"], "system_injected");
+    assert_eq!(records[1]["prompt_source"], "spawned_agent");
+    assert_eq!(records[2]["tool_kind"], "exec");
+    assert_eq!(records[3]["tool_name"], "exec_command");
+    assert_eq!(records[3]["tool_kind"], "exec");
+    assert_eq!(records[3]["exit_code"], 0);
+    assert_eq!(records[3]["outcome"], "succeeded");
+
+    let turn_key = turn_summaries(repo.path(), &session_key)[0]["turn_key"]
+        .as_str()
+        .expect("turn key")
+        .to_owned();
+    let records = get_session_records(repo.path(), &session_key, &turn_key, 10).expect("records");
+    assert_eq!(
+        records.records[1].prompt_source.as_deref(),
+        Some("spawned_agent")
+    );
+    assert_eq!(records.records[3].exit_code, Some(0));
+    assert_eq!(records.records[3].outcome.as_deref(), Some("succeeded"));
+}
+
+#[test]
 fn tool_payloads_are_slimmed_before_storage() {
     let repo = setup_repo();
     let long_output = format!(
@@ -972,6 +1059,7 @@ fn tool_payloads_are_slimmed_before_storage() {
                 "payload": {
                     "type": "function_call",
                     "name": "exec_command",
+                    "call_id": "call-1",
                     "arguments": "{\"cmd\":\"cargo test\"}",
                 },
             }),
@@ -980,6 +1068,7 @@ fn tool_payloads_are_slimmed_before_storage() {
                 "type": "response_item",
                 "payload": {
                     "type": "function_call_output",
+                    "call_id": "call-1",
                     "output": long_output,
                 },
             }),
@@ -988,6 +1077,7 @@ fn tool_payloads_are_slimmed_before_storage() {
                 "type": "response_item",
                 "payload": {
                     "type": "function_call_output",
+                    "call_id": "call-1",
                     "output": {
                         "raw": "x".repeat(MAX_TOOL_RESULT_TEXT_BYTES + 1024),
                     },
@@ -1014,7 +1104,9 @@ fn tool_payloads_are_slimmed_before_storage() {
 
     assert_eq!(records[0]["kind"], "tool_call");
     assert_eq!(records[0]["tool_input"]["cmd"], "cargo test");
+    assert_eq!(records[0]["tool_kind"], "exec");
     assert_eq!(records[1]["kind"], "tool_result");
+    assert_eq!(records[1]["tool_kind"], "exec");
     let text = records[1]["text"].as_str().expect("tool result text");
     assert!(text.len() <= MAX_TOOL_RESULT_TEXT_BYTES);
     assert!(text.starts_with("start:"));

--- a/crates/but-agentlog/src/gitmeta/write.rs
+++ b/crates/but-agentlog/src/gitmeta/write.rs
@@ -10,7 +10,7 @@ use crate::{
     agent::Agent,
     environment::{EnvironmentObservation, ObservedTargets, SnapshotStatus},
     redaction::{redact_text, redact_value},
-    transcript::{RecordKind, TranscriptBatch},
+    transcript::{PromptSource, RecordKind, ToolKind, ToolOutcome, TranscriptBatch},
 };
 
 use super::{
@@ -123,8 +123,12 @@ pub(crate) fn write_transcript_batch(
             source_event_kind: redact_text(&record.source_event_kind),
             role: record.role.as_deref().map(redact_text),
             text: stored_text(record.kind, record.text.as_deref()),
+            prompt_source: record.prompt_source,
             tool_name: record.tool_name.as_deref().map(redact_text),
+            tool_kind: record.tool_kind,
             tool_input: record.tool_input.map(redact_value),
+            exit_code: record.exit_code,
+            outcome: record.tool_outcome,
             source_record: redact_value(record.source_record),
         };
         let transcript_record = serde_json::to_string(&transcript_record)
@@ -475,7 +479,15 @@ struct TranscriptRecord<'a> {
     source_event_kind: String,
     role: Option<String>,
     text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prompt_source: Option<PromptSource>,
     tool_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_kind: Option<ToolKind>,
     tool_input: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    exit_code: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    outcome: Option<ToolOutcome>,
     source_record: Value,
 }

--- a/crates/but-agentlog/src/lib.rs
+++ b/crates/but-agentlog/src/lib.rs
@@ -4,6 +4,7 @@ mod capture_lock;
 mod cli;
 mod environment;
 mod gitmeta;
+pub mod projection;
 mod redaction;
 mod skim;
 mod transcript;

--- a/crates/but-agentlog/src/projection.rs
+++ b/crates/but-agentlog/src/projection.rs
@@ -1,0 +1,831 @@
+//! Public/read projection primitives for Agent Trail.
+//!
+//! This module is the allowlisted boundary between captured GitMeta agent logs
+//! and public review-facing consumers. It exposes verified PR/head-branch
+//! matches, evidence tiers, opaque handles, and bounded redacted records without
+//! leaking raw storage keys or raw `source_record` payloads.
+
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, BTreeSet},
+    path::Path,
+};
+
+use anyhow::{Context as _, Result, bail};
+use git_meta_lib::{MetaValue, Session, Target};
+use serde::Serialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::gitmeta::{
+    RelatedSession, RelatedTarget, SessionRecords, find_related_sessions_limited,
+    get_session_records, get_session_timeline_outline,
+};
+
+const DEFAULT_MAX_TURNS: usize = 32;
+const DEFAULT_MAX_RECORDS_PER_TURN: usize = 512;
+const DEFAULT_MAX_TEXT_CHARS: usize = 1_200;
+/// Build a public/read projection for an Agent Trail pull-request view.
+///
+/// The returned value contains only allowlisted, redacted, bounded fields. Raw
+/// GitMeta storage keys, raw provider session ids, raw `source_record` JSON, and
+/// raw tool payloads are intentionally not present.
+pub fn project_pr(repo_path: &Path, request: &ProjectionRequest) -> Result<Projection> {
+    let review_target = request.review_target_key();
+    let branch_target = request.branch_target_key();
+    let review_sessions = find_related_sessions_limited(
+        repo_path,
+        RelatedTarget::Review(review_target.as_str()),
+        None,
+    )
+    .context("failed to find review-target agent sessions")?;
+    let branch_sessions = find_related_sessions_limited(
+        repo_path,
+        RelatedTarget::Branch(branch_target.as_str()),
+        None,
+    )
+    .context("failed to find branch-target agent sessions")?;
+
+    let has_review_matches = !review_sessions.is_empty();
+    let has_branch_matches = !branch_sessions.is_empty();
+    let mut warnings = Vec::new();
+    if !has_review_matches && has_branch_matches {
+        warnings.push(ProjectionWarning {
+            kind: ProjectionWarningKind::NoReviewMatch,
+            message: "No review-target match; showing branch-only evidence.".to_owned(),
+        });
+        warnings.push(ProjectionWarning {
+            kind: ProjectionWarningKind::WeakBranchOnly,
+            message: "Branch-only matches are weaker and may be unrelated.".to_owned(),
+        });
+    }
+    if !has_review_matches && !has_branch_matches {
+        warnings.push(ProjectionWarning {
+            kind: ProjectionWarningKind::NoMatches,
+            message: "Metadata exists, but no related agent sessions matched this PR.".to_owned(),
+        });
+    }
+
+    let mut candidates = BTreeMap::<String, CandidateSession>::new();
+    add_candidate_sessions(
+        &mut candidates,
+        review_sessions,
+        ProjectionMatchKind::ReviewTarget,
+    );
+    add_candidate_sessions(
+        &mut candidates,
+        branch_sessions,
+        ProjectionMatchKind::BranchTarget,
+    );
+
+    let source_metadata = session_source_metadata(repo_path, candidates.keys())?;
+    let mut turn_candidates = Vec::new();
+    for (session_key, candidate) in &candidates {
+        let timeline =
+            get_session_timeline_outline(repo_path, session_key, None).with_context(|| {
+                format!("failed to read projected timeline for session '{session_key}'")
+            })?;
+        for turn in &timeline.turns {
+            let reasons = candidate.turn_match_reasons(&turn.turn_key);
+            if reasons.is_empty() {
+                continue;
+            }
+            turn_candidates.push(CandidateTurn {
+                session_key: session_key.clone(),
+                turn_key: turn.turn_key.clone(),
+                captured_at: turn.captured_at.clone(),
+                turn_index: turn.turn_index,
+            });
+        }
+    }
+
+    turn_candidates.sort_by(|lhs, rhs| {
+        lhs.captured_at
+            .cmp(&rhs.captured_at)
+            .then_with(|| lhs.session_key.cmp(&rhs.session_key))
+            .then_with(|| lhs.turn_index.cmp(&rhs.turn_index))
+    });
+    let truncated = turn_candidates.len() > request.limits.max_turns;
+    if truncated {
+        warnings.push(ProjectionWarning {
+            kind: ProjectionWarningKind::ProjectionLimitReached,
+            message: "Older matching turns were dropped to keep the projection bounded.".to_owned(),
+        });
+    }
+    let selected_start = turn_candidates
+        .len()
+        .saturating_sub(request.limits.max_turns);
+    let selected_turns = turn_candidates
+        .into_iter()
+        .skip(selected_start)
+        .collect::<Vec<_>>();
+
+    let mut turns_by_session = BTreeMap::<String, Vec<ProjectionTurn>>::new();
+    let mut selected_handles = Vec::new();
+    let mut saw_partial_turn = false;
+    let mut saw_truncated_record_text = false;
+    for selected in selected_turns {
+        let candidate = candidates
+            .get(&selected.session_key)
+            .context("selected turn references an unknown candidate session")?;
+        let records = get_session_records(
+            repo_path,
+            &selected.session_key,
+            &selected.turn_key,
+            request.limits.max_records_per_turn,
+        )
+        .with_context(|| {
+            format!(
+                "failed to read projected records for session '{}' turn '{}'",
+                selected.session_key, selected.turn_key
+            )
+        })?;
+        let records_has_more_before = records.coverage.has_more_before;
+        saw_partial_turn |= records_has_more_before;
+        let turn_handle = turn_handle(request, &selected.session_key, &selected.turn_key);
+        let public_records = project_records(
+            request,
+            &selected.session_key,
+            &selected.turn_key,
+            records,
+            &mut saw_truncated_record_text,
+        );
+        let latest_user_preview = latest_public_preview(&public_records, "user");
+        let latest_assistant_preview = latest_public_preview(&public_records, "assistant");
+        selected_handles.push(turn_handle.clone());
+        selected_handles.extend(public_records.iter().map(|record| record.handle.clone()));
+
+        turns_by_session
+            .entry(selected.session_key.clone())
+            .or_default()
+            .push(ProjectionTurn {
+                handle: turn_handle,
+                captured_at: selected.captured_at,
+                coverage: ProjectionRecordCoverage {
+                    showing_records: public_records.len(),
+                    has_more_before: records_has_more_before,
+                },
+                evidence_tier: candidate.turn_evidence_tier(&selected.turn_key),
+                match_reasons: candidate.turn_match_reasons(&selected.turn_key),
+                latest_user_preview,
+                latest_assistant_preview,
+                records: public_records,
+            });
+    }
+
+    if saw_partial_turn {
+        warnings.push(ProjectionWarning {
+            kind: ProjectionWarningKind::PartialTurn,
+            message: "At least one turn has more records than this bounded projection includes."
+                .to_owned(),
+        });
+    }
+    if saw_truncated_record_text {
+        warnings.push(ProjectionWarning {
+            kind: ProjectionWarningKind::TruncatedRecord,
+            message: "At least one record text was truncated to keep the projection bounded."
+                .to_owned(),
+        });
+    }
+
+    let mut sessions = Vec::new();
+    for (session_key, candidate) in candidates {
+        let Some(turns) = turns_by_session.remove(&session_key) else {
+            continue;
+        };
+        let evidence_tier = candidate.session_evidence_tier();
+        let match_reasons = candidate.session_match_reasons();
+        sessions.push(ProjectionSession {
+            handle: session_handle(request, &session_key),
+            agents: source_metadata
+                .get(&session_key)
+                .cloned()
+                .unwrap_or_default(),
+            started_at: candidate.outline.started_at,
+            updated_at: candidate.outline.updated_at,
+            latest_captured_at: candidate.outline.latest_captured_at,
+            evidence_tier,
+            match_reasons,
+            turns,
+        });
+    }
+    sessions.sort_by(|lhs, rhs| {
+        evidence_rank(lhs.evidence_tier)
+            .cmp(&evidence_rank(rhs.evidence_tier))
+            .then_with(|| rhs.latest_captured_at.cmp(&lhs.latest_captured_at))
+            .then_with(|| lhs.handle.cmp(&rhs.handle))
+    });
+
+    selected_handles.extend(sessions.iter().map(|session| session.handle.clone()));
+    selected_handles.sort();
+    let status = match (has_review_matches, has_branch_matches) {
+        (true, _) => ProjectionStatus::Ready,
+        (false, true) => ProjectionStatus::WeakMatches,
+        (false, false) => ProjectionStatus::NoMatches,
+    };
+    Ok(Projection {
+        pr: request.pr.clone(),
+        snapshot: ProjectionSnapshot {
+            metadata_oid: request.snapshot.metadata_oid.clone(),
+            projection_version: request.snapshot.projection_version,
+            generated_at_unix_seconds: request.snapshot.generated_at_unix_seconds,
+            selected_evidence_digest: selected_evidence_digest(&selected_handles),
+            truncated,
+        },
+        status,
+        warnings,
+        sessions,
+    })
+}
+
+/// Public projection request. Agent Trail supplies GitHub PR facts and snapshot
+/// facts; `but-agentlog` owns target construction and verified metadata lookup.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProjectionRequest {
+    pub pr: ProjectionPrFacts,
+    pub snapshot: ProjectionSnapshotInput,
+    pub limits: ProjectionLimits,
+}
+
+impl ProjectionRequest {
+    /// Construct a request with default projection limits.
+    pub fn new(pr: ProjectionPrFacts, snapshot: ProjectionSnapshotInput) -> Self {
+        Self {
+            pr,
+            snapshot,
+            limits: ProjectionLimits::default(),
+        }
+    }
+
+    fn review_target_key(&self) -> String {
+        format!(
+            "pull-request:{}#{}",
+            normalize_branch_target_key(&self.pr.head_ref),
+            self.pr.pull_request
+        )
+    }
+
+    fn branch_target_key(&self) -> String {
+        normalize_branch_target_key(&self.pr.head_ref)
+    }
+}
+
+/// Pull-request facts used to construct review and fallback branch targets.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProjectionPrFacts {
+    pub agent_trail_host: String,
+    pub github_repository_id: u64,
+    pub owner: String,
+    pub repo: String,
+    pub pull_request: u64,
+    pub base_ref: String,
+    pub head_ref: String,
+    pub head_sha: String,
+}
+
+/// Snapshot facts supplied by the caller and echoed in the projection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProjectionSnapshotInput {
+    pub metadata_oid: String,
+    pub projection_version: u32,
+    pub generated_at_unix_seconds: u64,
+}
+
+/// Bounds for the public projection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct ProjectionLimits {
+    pub max_turns: usize,
+    pub max_records_per_turn: usize,
+    pub max_text_chars: usize,
+}
+
+impl Default for ProjectionLimits {
+    fn default() -> Self {
+        Self {
+            max_turns: DEFAULT_MAX_TURNS,
+            max_records_per_turn: DEFAULT_MAX_RECORDS_PER_TURN,
+            max_text_chars: DEFAULT_MAX_TEXT_CHARS,
+        }
+    }
+}
+
+/// Public projection returned by [`project_pr`].
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Projection {
+    pub pr: ProjectionPrFacts,
+    pub snapshot: ProjectionSnapshot,
+    pub status: ProjectionStatus,
+    pub warnings: Vec<ProjectionWarning>,
+    pub sessions: Vec<ProjectionSession>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProjectionSnapshot {
+    pub metadata_oid: String,
+    pub projection_version: u32,
+    pub generated_at_unix_seconds: u64,
+    pub selected_evidence_digest: String,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectionStatus {
+    Ready,
+    WeakMatches,
+    NoMatches,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ProjectionWarning {
+    pub kind: ProjectionWarningKind,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectionWarningKind {
+    NoReviewMatch,
+    WeakBranchOnly,
+    ProjectionLimitReached,
+    PartialTurn,
+    TruncatedRecord,
+    NoMatches,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ProjectionSession {
+    pub handle: String,
+    pub agents: Vec<ProjectionAgentLabel>,
+    pub started_at: Option<String>,
+    pub updated_at: String,
+    pub latest_captured_at: Option<String>,
+    pub evidence_tier: ProjectionEvidenceTier,
+    pub match_reasons: Vec<ProjectionMatchReason>,
+    pub turns: Vec<ProjectionTurn>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProjectionAgentLabel {
+    pub agent: Option<String>,
+    pub provider: Option<String>,
+    pub model: Option<String>,
+    pub tool_version: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ProjectionTurn {
+    pub handle: String,
+    pub captured_at: String,
+    pub coverage: ProjectionRecordCoverage,
+    pub evidence_tier: ProjectionEvidenceTier,
+    pub match_reasons: Vec<ProjectionMatchReason>,
+    pub latest_user_preview: Option<ProjectionPreview>,
+    pub latest_assistant_preview: Option<ProjectionPreview>,
+    pub records: Vec<ProjectionRecord>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectionEvidenceTier {
+    Supporting,
+    Direct,
+    Possible,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProjectionMatchReason {
+    pub kind: ProjectionMatchKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectionMatchKind {
+    ReviewTarget,
+    BranchTarget,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProjectionPreview {
+    pub timestamp: Option<String>,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProjectionRecordCoverage {
+    pub showing_records: usize,
+    pub has_more_before: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ProjectionRecord {
+    pub handle: String,
+    pub timestamp: Option<String>,
+    pub kind: Option<String>,
+    pub role: Option<String>,
+    pub prompt_source: Option<String>,
+    pub text: Option<String>,
+    pub text_truncated: bool,
+    pub tool_name: Option<String>,
+    pub tool_kind: Option<String>,
+    pub file_paths: Vec<String>,
+    pub exit_code: Option<i32>,
+    pub outcome: Option<String>,
+}
+
+struct CandidateSession {
+    outline: RelatedSession,
+    has_review_match: bool,
+    has_branch_match: bool,
+    review_turn_keys: BTreeSet<String>,
+    branch_turn_keys: BTreeSet<String>,
+}
+
+impl CandidateSession {
+    fn new(outline: RelatedSession) -> Self {
+        Self {
+            outline,
+            has_review_match: false,
+            has_branch_match: false,
+            review_turn_keys: BTreeSet::new(),
+            branch_turn_keys: BTreeSet::new(),
+        }
+    }
+
+    fn add_match(
+        &mut self,
+        kind: ProjectionMatchKind,
+        turn_keys: impl IntoIterator<Item = String>,
+    ) {
+        match kind {
+            ProjectionMatchKind::ReviewTarget => {
+                self.has_review_match = true;
+                self.review_turn_keys.extend(turn_keys);
+            }
+            ProjectionMatchKind::BranchTarget => {
+                self.has_branch_match = true;
+                self.branch_turn_keys.extend(turn_keys);
+            }
+        }
+    }
+
+    fn session_match_reasons(&self) -> Vec<ProjectionMatchReason> {
+        match_reasons(self.has_review_match, self.has_branch_match)
+    }
+
+    fn turn_match_reasons(&self, turn_key: &str) -> Vec<ProjectionMatchReason> {
+        match_reasons(
+            self.review_turn_keys.contains(turn_key),
+            self.branch_turn_keys.contains(turn_key),
+        )
+    }
+
+    fn session_evidence_tier(&self) -> ProjectionEvidenceTier {
+        evidence_tier(self.has_review_match, self.has_branch_match)
+    }
+
+    fn turn_evidence_tier(&self, turn_key: &str) -> ProjectionEvidenceTier {
+        evidence_tier(
+            self.review_turn_keys.contains(turn_key),
+            self.branch_turn_keys.contains(turn_key),
+        )
+    }
+}
+
+struct CandidateTurn {
+    session_key: String,
+    turn_key: String,
+    captured_at: String,
+    turn_index: usize,
+}
+
+fn add_candidate_sessions(
+    candidates: &mut BTreeMap<String, CandidateSession>,
+    sessions: Vec<RelatedSession>,
+    kind: ProjectionMatchKind,
+) {
+    for session in sessions {
+        let turn_keys = session.related_turn_keys.clone();
+        candidates
+            .entry(session.session_key.clone())
+            .or_insert_with(|| CandidateSession::new(session))
+            .add_match(kind, turn_keys);
+    }
+}
+
+fn match_reasons(has_review: bool, has_branch: bool) -> Vec<ProjectionMatchReason> {
+    let mut reasons = Vec::new();
+    if has_review {
+        reasons.push(ProjectionMatchReason {
+            kind: ProjectionMatchKind::ReviewTarget,
+        });
+    }
+    if has_branch {
+        reasons.push(ProjectionMatchReason {
+            kind: ProjectionMatchKind::BranchTarget,
+        });
+    }
+    reasons
+}
+
+fn evidence_tier(has_review: bool, has_branch: bool) -> ProjectionEvidenceTier {
+    match (has_review, has_branch) {
+        (true, true) => ProjectionEvidenceTier::Supporting,
+        (true, false) => ProjectionEvidenceTier::Direct,
+        (false, true) => ProjectionEvidenceTier::Possible,
+        (false, false) => unreachable!("candidate turns always have review or branch evidence"),
+    }
+}
+
+fn evidence_rank(tier: ProjectionEvidenceTier) -> usize {
+    match tier {
+        ProjectionEvidenceTier::Supporting => 0,
+        ProjectionEvidenceTier::Direct => 1,
+        ProjectionEvidenceTier::Possible => 2,
+    }
+}
+
+fn project_records(
+    request: &ProjectionRequest,
+    session_key: &str,
+    turn_key: &str,
+    records: SessionRecords,
+    saw_truncated_text: &mut bool,
+) -> Vec<ProjectionRecord> {
+    records
+        .records
+        .into_iter()
+        .filter(|record| {
+            record.prompt_source.as_deref() != Some("system_injected")
+                && !matches!(record.role.as_deref(), Some("system" | "developer"))
+        })
+        .map(|record| {
+            let (text, text_truncated) = public_text(&record.kind, record.text.as_deref(), request);
+            *saw_truncated_text |= text_truncated;
+            ProjectionRecord {
+                handle: record_handle(request, session_key, turn_key, &record.record_hash),
+                timestamp: record.timestamp,
+                kind: record.kind,
+                role: record.role,
+                prompt_source: record.prompt_source,
+                text,
+                text_truncated,
+                file_paths: file_paths_of(record.tool_input.as_ref()),
+                tool_name: record.tool_name,
+                tool_kind: record.tool_kind,
+                exit_code: record.exit_code,
+                outcome: record.outcome,
+            }
+        })
+        .collect()
+}
+
+fn latest_public_preview(records: &[ProjectionRecord], role: &str) -> Option<ProjectionPreview> {
+    records.iter().rev().find_map(|record| {
+        if record.role.as_deref() != Some(role) {
+            return None;
+        }
+        let text = record.text.as_deref()?.trim();
+        if text.is_empty() {
+            return None;
+        }
+        Some(ProjectionPreview {
+            timestamp: record.timestamp.clone(),
+            text: text.to_owned(),
+        })
+    })
+}
+
+fn public_text(
+    kind: &Option<String>,
+    text: Option<&str>,
+    request: &ProjectionRequest,
+) -> (Option<String>, bool) {
+    let Some(text) = text else {
+        return (None, false);
+    };
+    let cleaned = if kind.as_deref() == Some("tool_result") {
+        Cow::Owned(
+            text.lines()
+                .filter(|line| !is_plumbing_line(line))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        )
+    } else {
+        Cow::Borrowed(text)
+    };
+    let trimmed = cleaned.trim();
+    if trimmed.is_empty() {
+        return (None, false);
+    }
+    bounded_text(trimmed, request.limits.max_text_chars)
+}
+
+fn file_paths_of(input: Option<&Value>) -> Vec<String> {
+    let Some(input) = input else {
+        return Vec::new();
+    };
+    let patch = input
+        .get("patch")
+        .or_else(|| input.get("input"))
+        .or_else(|| input.get("content"))
+        .and_then(Value::as_str)
+        .or_else(|| input.as_str())
+        .unwrap_or_default();
+    let mut paths = Vec::new();
+    for line in patch.lines() {
+        let line = line.trim();
+        for marker in [
+            "*** Update File: ",
+            "*** Add File: ",
+            "*** Delete File: ",
+            "*** Move to: ",
+        ] {
+            let Some(path) = line.strip_prefix(marker).map(str::trim) else {
+                continue;
+            };
+            if is_public_repo_path(path) && !paths.iter().any(|existing| existing == path) {
+                paths.push(path.to_owned());
+            }
+        }
+    }
+    paths
+}
+
+fn is_public_repo_path(path: &str) -> bool {
+    !path.is_empty()
+        && !path.starts_with('/')
+        && !path.starts_with('~')
+        && !path.contains('\\')
+        && !path.contains(':')
+        && !path.contains("[local path]")
+        && !path.contains("[REDACTED")
+        && !path.contains('‹')
+        && path
+            .split('/')
+            .all(|component| !matches!(component, "" | "." | ".."))
+}
+
+fn bounded_text(text: &str, max_chars: usize) -> (Option<String>, bool) {
+    if max_chars == 0 {
+        return (None, !text.is_empty());
+    }
+    let mut chars = text.chars();
+    let out = chars.by_ref().take(max_chars).collect::<String>();
+    let truncated = chars.next().is_some();
+    (Some(out), truncated)
+}
+
+fn is_plumbing_line(line: &str) -> bool {
+    let text = line.trim();
+    if text.is_empty()
+        || matches!(text, "Output:" | "Input:" | "Result:")
+        || text.starts_with("Process exited")
+        || text.starts_with("Process running")
+    {
+        return true;
+    }
+    [
+        "Chunk ID",
+        "Wall time",
+        "Original token count",
+        "yield_time_ms",
+        "max_output_tokens",
+        "Token count",
+        "Tokens used",
+        "Duration:",
+    ]
+    .iter()
+    .any(|needle| text.starts_with(needle) || text.contains(needle))
+}
+
+fn session_source_metadata<'a>(
+    repo_path: &Path,
+    session_keys: impl IntoIterator<Item = &'a String>,
+) -> Result<BTreeMap<String, Vec<ProjectionAgentLabel>>> {
+    let gitmeta = Session::open(repo_path).context("failed to open GitMeta session")?;
+    let target = Target::project();
+    let handle = gitmeta.target(&target);
+    let mut output = BTreeMap::new();
+    for session_key in session_keys {
+        let session_prefix = format!("gitbutler:agent-session:{session_key}");
+        let sources_key = format!("{session_prefix}:sources");
+        let sources = match handle
+            .get_value(&sources_key)
+            .with_context(|| format!("failed to read GitMeta key '{sources_key}'"))?
+        {
+            None => BTreeSet::new(),
+            Some(MetaValue::Set(values)) => values.into_iter().collect(),
+            Some(_) => bail!("existing GitMeta key '{sources_key}' is not a set"),
+        };
+        let mut labels = Vec::new();
+        for source_key in sources {
+            let source_prefix = format!("{session_prefix}:source:{source_key}");
+            let label = ProjectionAgentLabel {
+                agent: optional_string_value(&handle, &format!("{source_prefix}:agent"))?,
+                provider: optional_string_value(&handle, &format!("{source_prefix}:provider"))?,
+                model: optional_string_value(&handle, &format!("{source_prefix}:model"))?,
+                tool_version: optional_string_value(
+                    &handle,
+                    &format!("{source_prefix}:tool-version"),
+                )?,
+            };
+            if label.agent.is_some() || label.provider.is_some() || label.model.is_some() {
+                labels.push(label);
+            }
+        }
+        labels.sort_by(|lhs, rhs| {
+            lhs.agent
+                .cmp(&rhs.agent)
+                .then_with(|| lhs.provider.cmp(&rhs.provider))
+                .then_with(|| lhs.model.cmp(&rhs.model))
+        });
+        labels.dedup();
+        output.insert(session_key.clone(), labels);
+    }
+    Ok(output)
+}
+
+fn optional_string_value(
+    handle: &git_meta_lib::SessionTargetHandle<'_>,
+    key: &str,
+) -> Result<Option<String>> {
+    match handle
+        .get_value(key)
+        .with_context(|| format!("failed to read GitMeta key '{key}'"))?
+    {
+        None => Ok(None),
+        Some(MetaValue::String(value)) => Ok(Some(value)),
+        Some(_) => bail!("existing GitMeta key '{key}' is not a string"),
+    }
+}
+
+fn session_handle(request: &ProjectionRequest, session_key: &str) -> String {
+    opaque_handle(
+        "ps",
+        &[
+            &request.pr.github_repository_id.to_string(),
+            &request.pr.pull_request.to_string(),
+            &request.snapshot.metadata_oid,
+            session_key,
+        ],
+    )
+}
+
+fn turn_handle(request: &ProjectionRequest, session_key: &str, turn_key: &str) -> String {
+    opaque_handle(
+        "pt",
+        &[
+            &request.pr.github_repository_id.to_string(),
+            &request.pr.pull_request.to_string(),
+            &request.snapshot.metadata_oid,
+            session_key,
+            turn_key,
+        ],
+    )
+}
+
+fn record_handle(
+    request: &ProjectionRequest,
+    session_key: &str,
+    turn_key: &str,
+    record_hash: &str,
+) -> String {
+    opaque_handle(
+        "pr",
+        &[
+            &request.pr.github_repository_id.to_string(),
+            &request.pr.pull_request.to_string(),
+            &request.snapshot.metadata_oid,
+            session_key,
+            turn_key,
+            record_hash,
+        ],
+    )
+}
+
+fn opaque_handle(prefix: &str, parts: &[&str]) -> String {
+    let mut hasher = Sha256::new();
+    for part in parts {
+        hasher.update(part.as_bytes());
+        hasher.update(b"\0");
+    }
+    let digest = hasher.finalize();
+    format!("{prefix}_{}", hex::encode(&digest[..16]))
+}
+
+fn selected_evidence_digest(handles: &[String]) -> String {
+    let mut hasher = Sha256::new();
+    for handle in handles {
+        hasher.update(handle.as_bytes());
+        hasher.update(b"\0");
+    }
+    format!("sha256-{}", hex::encode(hasher.finalize()))
+}
+
+fn normalize_branch_target_key(value: &str) -> String {
+    let value = value.strip_prefix("branch:").unwrap_or(value);
+    let value = value.strip_prefix("ref:").unwrap_or(value);
+    let value = value.strip_prefix("refs/heads/").unwrap_or(value);
+    format!("ref:refs/heads/{value}")
+}

--- a/crates/but-agentlog/src/redaction.rs
+++ b/crates/but-agentlog/src/redaction.rs
@@ -1,6 +1,7 @@
 use serde_json::Value;
 
 const REDACTION: &str = "[REDACTED:entropy]";
+const PATH_REDACTION: &str = "[REDACTED:path]";
 const MIN_CANDIDATE_LEN: usize = 20;
 const ENTROPY_THRESHOLD: f64 = 4.0;
 const HEX_ENTROPY_THRESHOLD: f64 = 3.0;
@@ -78,6 +79,10 @@ fn is_sensitive_key(key: &str) -> bool {
 fn redact_string(text: &str) -> Option<String> {
     let redacted = redact_named_secret_values(text).unwrap_or_else(|| text.to_owned());
     let named_secret_changed = redacted != text;
+    let (redacted, path_changed) = match redact_path_tokens(&redacted) {
+        Some(redacted) => (redacted, true),
+        None => (redacted, false),
+    };
     let text = redacted.as_str();
     let bytes = text.as_bytes();
     let mut entropy_redacted = String::new();
@@ -101,7 +106,9 @@ fn redact_string(text: &str) -> Option<String> {
         }
 
         let candidate = &text[start..index];
-        if should_redact(candidate) {
+        if is_relative_path_candidate(text, start, index) {
+            continue;
+        } else if should_redact(candidate) {
             entropy_redacted.push_str(&text[last_written..start]);
             entropy_redacted.push_str(REDACTION);
             last_written = index;
@@ -110,11 +117,37 @@ fn redact_string(text: &str) -> Option<String> {
     }
 
     if !entropy_changed {
-        return named_secret_changed.then_some(redacted);
+        return (named_secret_changed || path_changed).then_some(redacted);
     }
 
     entropy_redacted.push_str(&text[last_written..]);
     Some(entropy_redacted)
+}
+
+fn redact_path_tokens(text: &str) -> Option<String> {
+    let mut redacted = String::new();
+    let mut changed = false;
+    let mut last_written = 0;
+    let mut index = 0;
+
+    while index < text.len() {
+        if let Some(path_end) = absolute_path_token_end(text, index) {
+            redacted.push_str(&text[last_written..index]);
+            redacted.push_str(PATH_REDACTION);
+            last_written = path_end;
+            index = path_end;
+            changed = true;
+        } else {
+            index += 1;
+        }
+    }
+
+    if changed {
+        redacted.push_str(&text[last_written..]);
+        Some(redacted)
+    } else {
+        None
+    }
 }
 
 fn redact_named_secret_values(text: &str) -> Option<String> {
@@ -255,6 +288,87 @@ fn is_candidate_byte(byte: u8) -> bool {
     )
 }
 
+fn absolute_path_token_end(text: &str, start: usize) -> Option<usize> {
+    let bytes = text.as_bytes();
+    if !is_path_start_boundary(bytes, start) {
+        return None;
+    }
+
+    let token_start = if bytes.get(start) == Some(&b'/') && bytes.get(start + 1) != Some(&b'/') {
+        start + 1
+    } else if bytes
+        .get(start..)
+        .is_some_and(|remaining| remaining.starts_with(b"~/"))
+    {
+        start + 2
+    } else if is_windows_absolute_path_start(bytes, start) {
+        start + 3
+    } else {
+        return None;
+    };
+
+    let end = path_token_end(text, token_start);
+    (end > token_start).then_some(end)
+}
+
+fn is_path_start_boundary(bytes: &[u8], start: usize) -> bool {
+    start == 0
+        || bytes.get(start - 1).is_some_and(|byte| {
+            byte.is_ascii_whitespace()
+                || matches!(byte, b'"' | b'\'' | b'`' | b'(' | b'[' | b'{' | b'<' | b'=')
+        })
+}
+
+fn is_windows_absolute_path_start(bytes: &[u8], start: usize) -> bool {
+    bytes.get(start).is_some_and(u8::is_ascii_alphabetic)
+        && bytes.get(start + 1) == Some(&b':')
+        && matches!(bytes.get(start + 2).copied(), Some(b'\\' | b'/'))
+}
+
+fn is_relative_path_candidate(text: &str, start: usize, end: usize) -> bool {
+    let candidate = &text[start..end];
+    if !candidate.contains('/') {
+        return false;
+    }
+    candidate.split('/').any(|segment| {
+        matches!(
+            segment,
+            "." | ".." | "apps" | "crates" | "docs" | "e2e" | "packages" | "src" | "test" | "tests"
+        )
+    }) || has_file_extension_suffix(text, end)
+}
+
+fn has_file_extension_suffix(text: &str, end: usize) -> bool {
+    let Some(rest) = text.get(end..) else {
+        return false;
+    };
+    let Some(rest) = rest.strip_prefix('.') else {
+        return false;
+    };
+    let extension_len = rest
+        .bytes()
+        .take_while(u8::is_ascii_alphanumeric)
+        .take(10)
+        .count();
+    extension_len > 0
+        && rest
+            .as_bytes()
+            .get(extension_len)
+            .is_none_or(|byte| !is_candidate_byte(*byte) && *byte != b'.')
+}
+
+fn path_token_end(text: &str, mut end: usize) -> usize {
+    let bytes = text.as_bytes();
+    while bytes.get(end).is_some_and(|byte| is_path_token_byte(*byte)) {
+        end += 1;
+    }
+    end
+}
+
+fn is_path_token_byte(byte: u8) -> bool {
+    is_candidate_byte(byte) || matches!(byte, b'.' | b'\\' | b':')
+}
+
 fn is_random_hex(candidate: &str, entropy: f64) -> bool {
     candidate.len() >= 32
         && candidate.bytes().all(|byte| byte.is_ascii_hexdigit())
@@ -353,6 +467,38 @@ mod tests {
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         );
         assert_eq!(redact_text("2026-05-07T09-30-00Z"), "2026-05-07T09-30-00Z");
+        assert_eq!(
+            redact_text("*** Update File: crates/but-agentlog/src/transcript.rs"),
+            "*** Update File: crates/but-agentlog/src/transcript.rs"
+        );
+        assert_eq!(
+            redact_text("docs/quarterly-notes/agent-trail-review.md"),
+            "docs/quarterly-notes/agent-trail-review.md"
+        );
+        assert_eq!(
+            redact_text("token AbCdEfGhIjKl/MnOpQrSt/UvWxYz12+34= done"),
+            "token [REDACTED:entropy] done"
+        );
+    }
+
+    #[test]
+    fn redacts_absolute_paths_as_path_tokens() {
+        assert_eq!(
+            redact_text("see /tmp/gitbutler-zizmor-results.sarif for details"),
+            "see [REDACTED:path] for details"
+        );
+        assert_eq!(
+            redact_text("*** Update File: /Users/alice/src/project/src/lib.rs"),
+            "*** Update File: [REDACTED:path]"
+        );
+        assert_eq!(
+            redact_text("short /tmp/a path"),
+            "short [REDACTED:path] path"
+        );
+        assert_eq!(
+            redact_text(r"see C:\Users\alice\src\agent-trail\log.json"),
+            "see [REDACTED:path]"
+        );
     }
 
     #[test]

--- a/crates/but-agentlog/src/transcript.rs
+++ b/crates/but-agentlog/src/transcript.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::{Result, bail};
 use serde::Serialize;
@@ -13,6 +13,7 @@ pub(crate) struct TranscriptBatch {
     pub(crate) provider: Option<String>,
     pub(crate) model: Option<String>,
     pub(crate) tool_version: Option<String>,
+    pub(crate) thread_source: Option<String>,
     pub(crate) records: Vec<ParsedRecord>,
 }
 
@@ -32,8 +33,11 @@ impl TranscriptBatch {
             },
             model: None,
             tool_version: None,
+            thread_source: None,
             records: Vec::new(),
         };
+        let mut codex_tool_names = HashMap::new();
+        let mut codex_spawn_prompts = HashSet::new();
         let mut claude_tool_names = HashMap::new();
 
         while let Some((index, trimmed)) = raw_records.next() {
@@ -46,7 +50,14 @@ impl TranscriptBatch {
             let record = match agent {
                 Agent::Codex => {
                     transcript.apply_codex_metadata(&parsed);
-                    ParsedRecord::from_codex_source(index, trimmed, parsed)
+                    ParsedRecord::from_codex_source(
+                        index,
+                        trimmed,
+                        parsed,
+                        &mut codex_tool_names,
+                        &mut codex_spawn_prompts,
+                        transcript.thread_source.as_deref(),
+                    )
                 }
                 Agent::Claude => {
                     transcript.apply_claude_metadata(&parsed);
@@ -75,6 +86,15 @@ impl TranscriptBatch {
             if self.tool_version.is_none() {
                 self.tool_version =
                     str_at(source_record, &["payload", "cli_version"]).map(ToOwned::to_owned);
+            }
+            if self.thread_source.is_none() {
+                self.thread_source = str_at(source_record, &["payload", "thread_source"])
+                    .map(ToOwned::to_owned)
+                    .or_else(|| {
+                        value_at(source_record, &["payload", "source", "subagent"])
+                            .is_some()
+                            .then(|| "subagent".to_owned())
+                    });
             }
         }
 
@@ -108,6 +128,33 @@ pub(crate) enum RecordKind {
     ToolResult,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum PromptSource {
+    Human,
+    SpawnedAgent,
+    SystemInjected,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ToolKind {
+    Exec,
+    FileEdit,
+    SubAgent,
+    Housekeeping,
+    WebSearch,
+    Other,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ToolOutcome {
+    Succeeded,
+    Failed,
+    CouldNotExecute,
+}
+
 #[derive(Debug)]
 pub(crate) struct ParsedRecord {
     pub(crate) index: usize,
@@ -117,13 +164,24 @@ pub(crate) struct ParsedRecord {
     pub(crate) source_event_kind: String,
     pub(crate) role: Option<String>,
     pub(crate) text: Option<String>,
+    pub(crate) prompt_source: Option<PromptSource>,
     pub(crate) tool_name: Option<String>,
+    pub(crate) tool_kind: Option<ToolKind>,
     pub(crate) tool_input: Option<Value>,
+    pub(crate) exit_code: Option<i32>,
+    pub(crate) tool_outcome: Option<ToolOutcome>,
     pub(crate) source_record: Value,
 }
 
 impl ParsedRecord {
-    fn from_codex_source(index: usize, trimmed: &[u8], mut source_record: Value) -> Option<Self> {
+    fn from_codex_source(
+        index: usize,
+        trimmed: &[u8],
+        mut source_record: Value,
+        tool_names: &mut HashMap<String, String>,
+        spawn_prompts: &mut HashSet<String>,
+        thread_source: Option<&str>,
+    ) -> Option<Self> {
         let raw_event_kind = codex_event_kind(&source_record);
         let kind = codex_kind(&raw_event_kind)?;
         let role = str_at(&source_record, &["payload", "role"])
@@ -133,7 +191,7 @@ impl ParsedRecord {
             return None;
         }
         let text = codex_text(&source_record, kind);
-        let tool_name = [
+        let mut tool_name = [
             &["payload", "tool_name"][..],
             &["payload", "tool"],
             &["payload", "name"],
@@ -142,6 +200,32 @@ impl ParsedRecord {
         .iter()
         .find_map(|path| str_at(&source_record, path).map(ToOwned::to_owned));
         let tool_input = codex_tool_input(&source_record, kind);
+        if kind == RecordKind::ToolResult && tool_name.is_none() {
+            tool_name = codex_call_id(&source_record)
+                .and_then(|call_id| tool_names.get(call_id))
+                .cloned();
+        }
+        if kind == RecordKind::ToolCall
+            && let (Some(call_id), Some(name)) = (codex_call_id(&source_record), tool_name.as_ref())
+        {
+            tool_names.insert(call_id.to_owned(), name.clone());
+        }
+        if matches!(tool_name.as_deref(), Some("spawn_agent"))
+            && let Some(message) = tool_input.as_ref().and_then(spawn_prompt)
+        {
+            spawn_prompts.insert(normalized_prompt(message).to_owned());
+        }
+        let prompt_source = prompt_source(
+            role.as_deref(),
+            text.as_deref(),
+            thread_source == Some("subagent"),
+            spawn_prompts,
+        );
+        let tool_kind = tool_name.as_deref().map(classify_tool);
+        let exit_code = (kind == RecordKind::ToolResult)
+            .then(|| text.as_deref().and_then(parse_exit_code))
+            .flatten();
+        let tool_outcome = exit_code.map(|code| classify_outcome(code, text.as_deref()));
         prune_codex(&mut source_record, kind, tool_input.is_some());
 
         Some(ParsedRecord {
@@ -152,8 +236,12 @@ impl ParsedRecord {
             kind,
             role,
             text,
+            prompt_source,
             tool_name,
+            tool_kind,
             tool_input,
+            exit_code,
+            tool_outcome,
             source_record,
         })
     }
@@ -197,6 +285,14 @@ impl ParsedRecord {
             _ => {}
         }
         prune_claude(&mut source_record, kind, tool_input.is_some());
+        let mut spawn_prompts = HashSet::new();
+        let prompt_source =
+            prompt_source(role.as_deref(), text.as_deref(), false, &mut spawn_prompts);
+        let tool_kind = tool_name.as_deref().map(classify_tool);
+        let exit_code = (kind == RecordKind::ToolResult)
+            .then(|| text.as_deref().and_then(parse_exit_code))
+            .flatten();
+        let tool_outcome = exit_code.map(|code| classify_outcome(code, text.as_deref()));
 
         Some(ParsedRecord {
             index,
@@ -206,8 +302,12 @@ impl ParsedRecord {
             kind,
             role,
             text,
+            prompt_source,
             tool_name,
+            tool_kind,
             tool_input,
+            exit_code,
+            tool_outcome,
             source_record,
         })
     }
@@ -265,6 +365,116 @@ fn codex_tool_input(source_record: &Value, kind: RecordKind) -> Option<Value> {
     .iter()
     .find_map(|path| value_at(source_record, path))
     .map(json_value)
+}
+
+fn codex_call_id(source_record: &Value) -> Option<&str> {
+    [
+        &["payload", "call_id"][..],
+        &["payload", "item", "call_id"],
+        &["payload", "id"],
+        &["payload", "item", "id"],
+    ]
+    .iter()
+    .find_map(|path| str_at(source_record, path))
+}
+
+fn spawn_prompt(input: &Value) -> Option<&str> {
+    ["message", "prompt", "task"]
+        .into_iter()
+        .find_map(|key| input.get(key).and_then(Value::as_str))
+}
+
+fn prompt_source(
+    role: Option<&str>,
+    text: Option<&str>,
+    subagent_session: bool,
+    spawn_prompts: &mut HashSet<String>,
+) -> Option<PromptSource> {
+    if role != Some("user") {
+        return None;
+    }
+    let Some(text) = text else {
+        return Some(PromptSource::Human);
+    };
+    if is_system_injected_prompt(text) {
+        return Some(PromptSource::SystemInjected);
+    }
+    if subagent_session || spawn_prompts.remove(normalized_prompt(text)) {
+        return Some(PromptSource::SpawnedAgent);
+    }
+    Some(PromptSource::Human)
+}
+
+fn normalized_prompt(text: &str) -> &str {
+    text.trim()
+}
+
+fn is_system_injected_prompt(text: &str) -> bool {
+    let trimmed = text.trim_start();
+    trimmed.starts_with("# AGENTS.md instructions")
+        || trimmed.starts_with("<environment_context>")
+        || trimmed.starts_with("<subagent_notification>")
+        || (trimmed.contains("<INSTRUCTIONS>")
+            && trimmed.contains("</INSTRUCTIONS>")
+            && trimmed.contains("<environment_context>"))
+}
+
+fn classify_tool(tool_name: &str) -> ToolKind {
+    match tool_name {
+        "exec_command" | "Bash" | "bash" | "shell" | "local_shell" | "run_command" => {
+            ToolKind::Exec
+        }
+        "apply_patch" | "edit_file" | "write_file" | "str_replace" | "Edit" | "MultiEdit"
+        | "Write" => ToolKind::FileEdit,
+        "spawn_agent" | "Task" => ToolKind::SubAgent,
+        "write_stdin" | "wait_agent" | "close_agent" | "kill_agent" | "update_plan" | "Read"
+        | "Glob" | "Grep" | "LS" | "TodoWrite" => ToolKind::Housekeeping,
+        "web_search" | "web_search_call" => ToolKind::WebSearch,
+        _ => ToolKind::Other,
+    }
+}
+
+fn parse_exit_code(text: &str) -> Option<i32> {
+    let lower = text.to_ascii_lowercase();
+    for marker in ["exited with code ", "exit code ", "exit status "] {
+        if let Some(index) = lower.find(marker) {
+            let rest = &text[index + marker.len()..];
+            let digits = rest
+                .trim_start()
+                .chars()
+                .take_while(|ch| ch.is_ascii_digit() || *ch == '-')
+                .collect::<String>();
+            if let Ok(code) = digits.parse() {
+                return Some(code);
+            }
+        }
+    }
+    None
+}
+
+fn classify_outcome(exit_code: i32, text: Option<&str>) -> ToolOutcome {
+    match exit_code {
+        0 => ToolOutcome::Succeeded,
+        126 | 127 => ToolOutcome::CouldNotExecute,
+        101 if text.is_some_and(looks_like_cargo_invocation_error) => ToolOutcome::CouldNotExecute,
+        _ => ToolOutcome::Failed,
+    }
+}
+
+fn looks_like_cargo_invocation_error(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    [
+        "is ambiguous",
+        "package id specification",
+        "did not match any packages",
+        "could not find `cargo.toml`",
+        "could not find cargo.toml",
+        "no such command",
+        "no bin target",
+        "could not determine which binary to run",
+    ]
+    .into_iter()
+    .any(|needle| lower.contains(needle))
 }
 
 fn prune_codex(source_record: &mut Value, kind: RecordKind, has_tool_input: bool) {
@@ -484,11 +694,16 @@ mod tests {
         assert_eq!(transcript.records[0].role.as_deref(), Some("user"));
         assert_eq!(transcript.records[0].kind, RecordKind::Message);
         assert_eq!(
+            transcript.records[0].prompt_source,
+            Some(PromptSource::Human)
+        );
+        assert_eq!(
             transcript.records[0].text.as_deref(),
             Some("Implemented change")
         );
         assert_eq!(transcript.records[1].kind, RecordKind::ToolCall);
         assert_eq!(transcript.records[1].tool_name.as_deref(), Some("shell"));
+        assert_eq!(transcript.records[1].tool_kind, Some(ToolKind::Exec));
         assert_eq!(
             transcript.records[1]
                 .tool_input
@@ -516,6 +731,10 @@ mod tests {
         assert_eq!(transcript.records.len(), 4);
         assert_eq!(transcript.records[0].role.as_deref(), Some("user"));
         assert_eq!(transcript.records[0].kind, RecordKind::Message);
+        assert_eq!(
+            transcript.records[0].prompt_source,
+            Some(PromptSource::Human)
+        );
         assert_eq!(transcript.records[0].text.as_deref(), Some("hello"));
         assert_eq!(transcript.records[1].role.as_deref(), Some("assistant"));
         assert_eq!(transcript.records[1].text.as_deref(), Some("Done"));
@@ -525,6 +744,7 @@ mod tests {
         );
         assert_eq!(transcript.records[2].kind, RecordKind::ToolCall);
         assert_eq!(transcript.records[2].tool_name.as_deref(), Some("Bash"));
+        assert_eq!(transcript.records[2].tool_kind, Some(ToolKind::Exec));
         assert_eq!(
             transcript.records[2]
                 .tool_input
@@ -535,7 +755,88 @@ mod tests {
         assert_eq!(transcript.records[3].kind, RecordKind::ToolResult);
         assert_eq!(transcript.records[3].role.as_deref(), None);
         assert_eq!(transcript.records[3].tool_name.as_deref(), Some("Bash"));
+        assert_eq!(transcript.records[3].tool_kind, Some(ToolKind::Exec));
         assert_eq!(transcript.records[3].text.as_deref(), Some("ok"));
+    }
+
+    #[test]
+    fn tags_codex_prompt_sources() {
+        let data = br##"
+{"timestamp":"2026-05-07T09:00:00Z","type":"session_meta","payload":{"id":"session-1","thread_source":"subagent"}}
+{"timestamp":"2026-05-07T09:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"# AGENTS.md instructions\n\n<INSTRUCTIONS>rules</INSTRUCTIONS>\n<environment_context>ctx</environment_context>"}]}}
+{"timestamp":"2026-05-07T09:00:02Z","type":"response_item","payload":{"type":"message","role":"user","content":"Repo: /tmp/project. Review the code."}}
+"##;
+
+        let transcript = TranscriptBatch::parse(Agent::Codex, data).expect("parse transcript");
+
+        assert_eq!(transcript.thread_source.as_deref(), Some("subagent"));
+        assert_eq!(transcript.records.len(), 2);
+        assert_eq!(
+            transcript.records[0].prompt_source,
+            Some(PromptSource::SystemInjected)
+        );
+        assert_eq!(
+            transcript.records[1].prompt_source,
+            Some(PromptSource::SpawnedAgent)
+        );
+    }
+
+    #[test]
+    fn tags_user_prompt_matching_spawn_agent_message() {
+        let data = br#"
+{"timestamp":"2026-05-07T09:00:00Z","type":"session_meta","payload":{"id":"session-1"}}
+{"timestamp":"2026-05-07T09:00:01Z","type":"response_item","payload":{"type":"function_call","name":"spawn_agent","call_id":"call-1","arguments":"{\"message\":\"Review tests only\"}"}}
+{"timestamp":"2026-05-07T09:00:02Z","type":"response_item","payload":{"type":"message","role":"user","content":"Review tests only"}}
+{"timestamp":"2026-05-07T09:00:03Z","type":"response_item","payload":{"type":"message","role":"user","content":"A real follow-up"}}
+"#;
+
+        let transcript = TranscriptBatch::parse(Agent::Codex, data).expect("parse transcript");
+
+        assert_eq!(transcript.records.len(), 3);
+        assert_eq!(transcript.records[0].tool_kind, Some(ToolKind::SubAgent));
+        assert_eq!(
+            transcript.records[1].prompt_source,
+            Some(PromptSource::SpawnedAgent)
+        );
+        assert_eq!(
+            transcript.records[2].prompt_source,
+            Some(PromptSource::Human)
+        );
+    }
+
+    #[test]
+    fn parses_codex_tool_kind_exit_code_and_outcome() {
+        let data = br#"
+{"timestamp":"2026-05-07T09:00:00Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"call-1","arguments":"{\"cmd\":\"cargo test\"}"}}
+{"timestamp":"2026-05-07T09:00:01Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-1","output":"error[E0599]\nProcess exited with code 101"}}
+{"timestamp":"2026-05-07T09:00:02Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"call-2","arguments":"{\"cmd\":\"cargo fmt --check\"}"}}
+{"timestamp":"2026-05-07T09:00:03Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-2","output":"error: `git-meta-lib` is ambiguous\nProcess exited with code 101"}}
+{"timestamp":"2026-05-07T09:00:04Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"call-3","arguments":"{\"cmd\":\"missing-tool\"}"}}
+{"timestamp":"2026-05-07T09:00:05Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-3","output":"Process exited with code 127"}}
+"#;
+
+        let transcript = TranscriptBatch::parse(Agent::Codex, data).expect("parse transcript");
+
+        assert_eq!(
+            transcript.records[1].tool_name.as_deref(),
+            Some("exec_command")
+        );
+        assert_eq!(transcript.records[1].tool_kind, Some(ToolKind::Exec));
+        assert_eq!(transcript.records[1].exit_code, Some(101));
+        assert_eq!(
+            transcript.records[1].tool_outcome,
+            Some(ToolOutcome::Failed)
+        );
+        assert_eq!(transcript.records[3].exit_code, Some(101));
+        assert_eq!(
+            transcript.records[3].tool_outcome,
+            Some(ToolOutcome::CouldNotExecute)
+        );
+        assert_eq!(transcript.records[5].exit_code, Some(127));
+        assert_eq!(
+            transcript.records[5].tool_outcome,
+            Some(ToolOutcome::CouldNotExecute)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- capture prompt provenance, tool kind, tool outcomes, and review/branch target metadata
- add a bounded public PR projection API with opaque handles and agent labels
- tighten public projection output so raw storage keys, tool payloads, commands, and local paths stay out

## Validation
- cargo test -p but-agentlog
- cargo check -p but --features agentlog
- cargo clippy -p but-agentlog --all-targets --no-deps
- cargo machete