### PR TITLE
Improve error message for "worktree changes would be overwritten"

### DIFF
--- a/crates/but-core/src/worktree/checkout/utils.rs
+++ b/crates/but-core/src/worktree/checkout/utils.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeSet, VecDeque};
 
 use anyhow::bail;
 use bstr::{BStr, BString, ByteSlice, ByteVec};
+use but_error::bail_precondition;
 use gix::{
     diff::{
         rewrites::tracker::{Change, ChangeKind},
@@ -259,8 +260,8 @@ pub fn merge_worktree_changes_into_destination_or_keep_snapshot(
                                         .collect::<Vec<_>>();
                                     paths.sort();
                                     paths.dedup();
-                                    bail!(
-                                        "Worktree changes would be overwritten by checkout: {}",
+                                    bail_precondition!(
+                                        "Uncommitted files would be overwritten by checkout: {}",
                                         paths.join(", ")
                                     );
                                 }

--- a/crates/but-core/tests/core/worktree/checkout.rs
+++ b/crates/but-core/tests/core/worktree/checkout.rs
@@ -315,7 +315,7 @@ this will cause a conflict
     let err = safe_checkout(head_commit.id, new_commit.id, &repo, Default::default()).unwrap_err();
     assert_eq!(
         err.to_string(),
-        "Worktree changes would be overwritten by checkout: \"file\"",
+        "Uncommitted files would be overwritten by checkout: \"file\"",
         "we check for conflict markers, and fail."
     );
     // Nothing else changes
@@ -566,7 +566,7 @@ fn snapshot_fails_by_default_if_changed_file_turns_into_directory() -> anyhow::R
     let err = safe_checkout(head_commit.id, new_commit.id, &repo, Default::default()).unwrap_err();
     assert_eq!(
         err.to_string(),
-        "Worktree changes would be overwritten by checkout: \"file\", \"file-in-index\"",
+        "Uncommitted files would be overwritten by checkout: \"file\", \"file-in-index\"",
         "conflicting worktree changes prevent a commit"
     );
 
@@ -776,7 +776,7 @@ fn unrelated_additions_are_fine_even_with_conflicts_in_index() -> anyhow::Result
     let err = safe_checkout(head_commit.id, new_commit.id, &repo, Default::default()).unwrap_err();
     assert_eq!(
         err.to_string(),
-        "Worktree changes would be overwritten by checkout: \"file\"",
+        "Uncommitted files would be overwritten by checkout: \"file\"",
         "We don't allow to checkout conflicting files with default settings as there is no snapshot"
     );
 
@@ -1072,7 +1072,7 @@ fn partial_commit_with_adjacent_lines_conflicts_on_checkout() -> anyhow::Result<
     let err = safe_checkout(head_commit.id, new_commit.id, &repo, Default::default()).unwrap_err();
     assert!(
         err.to_string()
-            .contains("Worktree changes would be overwritten"),
+            .contains("Uncommitted files would be overwritten"),
         "checkout must abort on partial-commit conflict: {err}"
     );
 
@@ -1106,7 +1106,7 @@ fn partial_commit_with_deletion_plus_insertion_conflicts_on_checkout() -> anyhow
     let err = safe_checkout(head_commit.id, new_commit.id, &repo, Default::default()).unwrap_err();
     assert!(
         err.to_string()
-            .contains("Worktree changes would be overwritten"),
+            .contains("Uncommitted files would be overwritten"),
         "checkout must abort on partial-commit conflict: {err}"
     );
 

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
@@ -2005,7 +2005,14 @@ fn unapply_dirty_worktree_abort_keeps_refs_and_metadata() -> anyhow::Result<()> 
     let err =
         but_workspace::branch::unapply(r("refs/heads/B"), &ws, &repo, &mut meta, unapply_options())
             .unwrap_err();
-    insta::assert_debug_snapshot!(err, @r#""Worktree changes would be overwritten by checkout: \"B\"""#);
+    insta::assert_debug_snapshot!(err, @r#"
+    Context {
+        code: PreconditionFailed,
+        message: Some(
+            "Uncommitted files would be overwritten by checkout: \"B\"",
+        ),
+    }
+    "#);
 
     assert_eq!(
         visualize_disk_tree_with_hashes_skip_dot_git(repo.workdir().expect("worktree dir"))?


### PR DESCRIPTION
Also converts it from an error to a warning.