### PR TITLE
GB-1480/ensure-appstream-metadata-is-updated-on-release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -57,6 +57,15 @@ jobs:
           NEXT_VERSION=$(./scripts/next.sh "${CURRENT_VERSION}" "${{ env.bump }}")
           echo "version=$NEXT_VERSION" >> $GITHUB_ENV
           mkdir -p release && echo "$NEXT_VERSION" > release/version
+
+      - name: Check AppStream metadata contains release entry for next version
+        if: runner.os == 'Linux' && env.channel == 'release'
+        env:
+          VERSION: ${{ env.version }}
+        run: |
+          sudo apt update && sudo apt install -y xmlstarlet
+          ./scripts/check-appstream-metadata.sh "$VERSION" "./crates/gitbutler-tauri/com.gitbutler.gitbutler.metainfo.xml"
+
       - name: Init Node Environment
         uses: ./.github/actions/init-env-node
       - name: Build SvelteKit

--- a/crates/gitbutler-tauri/com.gitbutler.gitbutler.metainfo.xml
+++ b/crates/gitbutler-tauri/com.gitbutler.gitbutler.metainfo.xml
@@ -37,6 +37,72 @@
   </screenshots>
 
   <releases>
+    <release version="0.19.13" date="2026-05-19">
+      <url>https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.19.13</url>
+    </release>
+    <release version="0.19.12" date="2026-05-15">
+      <url>https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.19.12</url>
+    </release>
+    <release version="0.19.11" date="2026-05-15">
+      <url>https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.19.11</url>
+    </release>
+    <release version="0.19.10" date="2026-05-08">
+      <url>https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.19.10</url>
+    </release>
+    <release version="0.19.9" date="2026-04-21">
+      <url>https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.19.9</url>
+    </release>
+    <release version="0.19.8" date="2026-04-17">
+      <url>https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.19.8</url>
+    </release>
+    <release version="0.19.7" date="2026-04-02">
+      <url>https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.19.7</url>
+    </release>
+    <release version="0.19.6" date="2026-03-16">
+      <url>https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.19.6</url>
+    </release>
+    <release version="0.19.5" date="2026-03-03">
+      <url>https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.19.5</url>
+    </release>
+    <release version="0.19.4" date="2026-03-03">
+      <url>https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.19.4</url>
+    </release>
+    <release version="0.19.3" date="2026-02-19">
+      <url>https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.19.3</url>
+    </release>
+    <release version="0.19.2" date="2026-02-16">
+      <url>https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.19.2</url>
+    </release>
+    <release version="0.19.1" date="2026-02-08">
+      <url>https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.19.1</url>
+    </release>
+    <release version="0.19.0" date="2026-02-05">
+      <url>https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.19.0</url>
+    </release>
+    <release version="0.18.8" date="2026-02-03">
+      <url>https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.18.8</url>
+    </release>
+    <release version="0.18.7" date="2026-01-23">
+      <url>https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.18.7</url>
+    </release>
+    <release version="0.18.6" date="2026-01-22">
+      <url>https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.18.6</url>
+    </release>
+    <release version="0.18.5" date="2026-01-20">
+      <url>https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.18.5</url>
+    </release>
+    <release version="0.18.4" date="2026-01-20">
+      <url>https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.18.4</url>
+    </release>
+    <release version="0.18.3" date="2025-12-16">
+      <url>https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.18.3</url>
+    </release>
+    <release version="0.18.2" date="2025-11-29">
+      <url>https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.18.2</url>
+    </release>
+    <release version="0.18.1" date="2025-11-27">
+      <url>https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.18.1</url>
+    </release>
     <release version="0.18.0" date="2025-11-20"/>
     <release version="0.13.8" date="2024-10-30"/>
     <release version="0.13.7" date="2024-10-25"/>

--- a/scripts/check-appstream-metadata.sh
+++ b/scripts/check-appstream-metadata.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Checks that the provided AppStream metadata file contains release information
+# for the given version.
+#
+# This is meant to run in CI to prevent stale AppStream metadata.
+#
+# Requires software:
+#   - xmlstarlet
+
+set -euo pipefail
+
+VERSION="$1"
+METADATA_FILE="$2"
+
+if [ -z "$VERSION" ] || [ ! -f "$METADATA_FILE" ]; then 
+  echo "usage: check-appstream-metadata.sh <VERSION> <METADATA_FILE>"
+  exit 1
+fi
+
+element=$(xmlstarlet sel -t -c "/component/releases/release[@version=\"$VERSION\"]" -n "$METADATA_FILE")
+
+if [ -z "$element" ]; then
+  echo "ERROR: No release for $VERSION in '$METADATA_FILE'"
+  exit 1
+fi
+
+url=$(echo "$element" | xmlstarlet sel -t -v "/release/url" || echo '')
+expected_url="https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F$VERSION"
+if [ "$url" != "$expected_url" ]; then
+  echo "ERROR: Expected release URL for $VERSION not found in '$METADATA_FILE'."
+  echo ""
+  echo "Expected URL: $expected_url"
+  echo ""
+  echo "    $element"
+  exit 1
+fi
+
+echo "Release $VERSION in '$METADATA_FILE' looks OK"
+echo ""
+echo "    $element"


### PR DESCRIPTION
## 🧢 Changes
Backfills missing AppStream metadata and adds a CI check to validate its existence before publishing a release build.

Replaces #13936 by @yakushabb (credited in first commit)

### Sample script output

**Release missing entirely**
```bash
$ ./scripts/check-appstream-metadata.sh 0.19.14 ./crates/gitbutler-tauri/com.gitbutler.gitbutler.metainfo.xml
ERROR: No release for 0.19.14 in './crates/gitbutler-tauri/com.gitbutler.gitbutler.metainfo.xml'
```

**Release missing URL**
```bash
$ ./scripts/check-appstream-metadata.sh 0.18.0 ./crates/gitbutler-tauri/com.gitbutler.gitbutler.metainfo.xml
ERROR: Expected release URL for 0.18.0 not found in './crates/gitbutler-tauri/com.gitbutler.gitbutler.metainfo.xml'.

Expected URL: https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.18.0

    <release version="0.18.0" date="2025-11-20"/>
```

**Release with incorrect URL**
```bash
ERROR: Expected release URL for 0.19.13 not found in './crates/gitbutler-tauri/com.gitbutler.gitbutler.metainfo.xml'.

Expected URL: https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.19.13

    <release version="0.19.13" date="2026-05-19">
      <url>https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.19.14</url>
    </release>
```

**Release that's all good**
```bash
Release 0.19.13 in './crates/gitbutler-tauri/com.gitbutler.gitbutler.metainfo.xml' looks OK

    <release version="0.19.13" date="2026-05-19">
      <url>https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.19.13</url>
    </release>
```

## 🎫 Affected issues

Fixes: #13932