### PR TITLE
Make agentlog available in all but builds

### DIFF
--- a/crates/but-agentlog/src/cli.rs
+++ b/crates/but-agentlog/src/cli.rs
@@ -25,7 +25,6 @@ const DEFAULT_RECORD_LIMIT: usize = 20;
 #[derive(Debug, clap::Subcommand)]
 pub enum Command {
     /// Capture an agent transcript from hook input.
-    #[clap(hide = true)]
     Hook {
         #[clap(long, value_enum)]
         agent: Option<Agent>,

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -41,7 +41,6 @@ legacy = [
 ]
 # Feature that enables profiling related features of the TUI.
 tui-profiling = []
-agentlog = ["dep:but-agentlog"]
 
 [dependencies]
 but-core.workspace = true
@@ -62,7 +61,7 @@ but-workspace = { workspace = true }
 but-api = { workspace = true, features = ["path-bytes"] }
 but-graph.workspace = true
 but-llm.workspace = true
-but-agentlog = { workspace = true, optional = true }
+but-agentlog.workspace = true
 but-transaction.workspace = true
 but-db.workspace = true
 

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -1160,7 +1160,6 @@ pub enum Subcommands {
     },
 
     /// AI: capture agent logs into GitMeta.
-    #[cfg(feature = "agentlog")]
     #[clap(name = "agentlog", hide = true)]
     AgentLog {
         #[clap(subcommand)]

--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -152,7 +152,6 @@ pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
                 SubcommandDiscriminant::Actions => continue,
                 #[cfg(feature = "legacy")]
                 SubcommandDiscriminant::Fetch => continue,
-                #[cfg(feature = "agentlog")]
                 SubcommandDiscriminant::AgentLog => continue,
             };
             groups.entry(group).or_default().push(*clap_subcommand);

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -176,7 +176,6 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
         )?;
     }
 
-    #[cfg(feature = "agentlog")]
     if let Some(Subcommands::AgentLog { .. }) = &args.cmd {
         let Some(Subcommands::AgentLog { cmd }) = args.cmd.take() else {
             unreachable!("agentlog command was checked above")
@@ -262,7 +261,6 @@ async fn match_subcommand(
 ) -> CliResult<()> {
     let out = &mut output;
 
-    #[cfg(feature = "agentlog")]
     let cmd = match cmd {
         Subcommands::AgentLog { cmd } => {
             return Ok(run_agentlog_command(&args.current_dir, cmd, out)?);
@@ -1456,14 +1454,12 @@ async fn match_subcommand(
                 .emit_metrics(metrics_ctx)
                 .show_root_cause_error_then_exit_without_destructors(output)
         }
-        #[cfg(feature = "agentlog")]
         Subcommands::AgentLog { .. } => {
             unreachable!("agentlog command is handled before metrics setup")
         }
     }
 }
 
-#[cfg(feature = "agentlog")]
 fn run_agentlog_command(
     current_dir: &std::path::Path,
     mut cmd: but_agentlog::Command,

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -203,7 +203,6 @@ impl Subcommands {
             #[cfg(feature = "legacy")]
             Subcommands::Clean { .. } => Clean,
             Subcommands::Onboarding | Subcommands::EvalHook => Unknown,
-            #[cfg(feature = "agentlog")]
             Subcommands::AgentLog { .. } => Unknown,
         }
     }


### PR DESCRIPTION
[Agentic Trail](https://trail.but.dev/gitbutlerapp/gitbutler/pull/13948)

Summary:
- remove the agentlog Cargo feature gate and make but-agentlog a normal but dependency
- keep top-level but agentlog hidden
- show the nested but agentlog hook command in agentlog help