### PR TITLE
breaking(but): replace implicit `but <path>` with `but gui <path>`

### DIFF
--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -14,7 +14,6 @@ use std::path::PathBuf;
     about = "A GitButler CLI tool",
     version = option_env!("VERSION").unwrap_or("dev"),
     disable_help_subcommand = true,
-    override_usage = "but [OPTIONS] [COMMAND]\n       but [OPTIONS] [PATH]"
 )]
 pub struct Args {
     /// Enable tracing for debug and performance information printed to stderr.
@@ -51,9 +50,6 @@ pub struct Args {
     /// {"result": ..., "status_error": ...} if the status query fails (in which case "status" is absent).
     #[clap(long = "status-after", global = true)]
     pub status_after: bool,
-    /// If no command is specified, this is treated as a path to open with the GUI.
-    #[clap(value_name = "PATH")]
-    pub path: Option<PathBuf>,
     /// Subcommand to run.
     #[clap(subcommand)]
     pub cmd: Option<Subcommands>,
@@ -794,7 +790,10 @@ pub enum Subcommands {
     ///
     #[clap(visible_alias = ".")]
     #[clap(verbatim_doc_comment)]
-    Gui,
+    Gui {
+        /// Path to the directory to open as a GitButler project. Defaults to the current directory.
+        path: Option<PathBuf>,
+    },
 
     /// Show an interactive TUI.
     #[clap(verbatim_doc_comment)]

--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -171,7 +171,6 @@ pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
     )?;
     writeln!(out)?;
     writeln!(out, "Usage: but [OPTIONS] [COMMAND]")?;
-    writeln!(out, "       but [OPTIONS] [PATH]")?;
     writeln!(out)?;
     writeln!(
         out,
@@ -282,7 +281,6 @@ mod tests {
 The GitButler CLI change control system
 
 Usage: but [OPTIONS] [COMMAND]
-       but [OPTIONS] [PATH]
 
 The GitButler CLI can be used to do nearly anything the desktop client can do (and more).
 It is a drop in replacement for most of the Git workflows you would normally use, but Git
@@ -372,7 +370,6 @@ Environment variables:
 The GitButler CLI change control system
 
 Usage: but [OPTIONS] [COMMAND]
-       but [OPTIONS] [PATH]
 
 The GitButler CLI can be used to do nearly anything the desktop client can do (and more).
 It is a drop in replacement for most of the Git workflows you would normally use, but Git

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -132,11 +132,6 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     }
 
     let mut args: Args = Args::parse_from(args);
-    if args.path.is_some() && args.cmd.is_some() {
-        anyhow::bail!(
-            "PATH cannot be used together with a subcommand. To run a subcommand in a different directory, use `-C <path>` before the subcommand, for example: `but -C <path> status`"
-        );
-    }
     let output_format = if args.json {
         OutputFormat::Json
     } else {
@@ -186,27 +181,8 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     let app_settings = AppSettings::load_from_default_path_creating_without_customization()?;
 
     let result = match args.cmd.take() {
-        None if args.path.is_some() => {
-            // If one argument is provided without a subcommand, check if this is a valid path.
-            let maybe_path = args
-                .path
-                .as_ref()
-                .expect("path is checked to be Some in match guard");
-            let path = args.current_dir.join(maybe_path);
-
-            // Check if the path exists before trying to open the GUI
-            if !path.exists() {
-                anyhow::bail!(
-                    "\"but {}\" is not a command. Type \"but --help\" to see all available commands.",
-                    maybe_path.display()
-                );
-            }
-
-            command::gui::open(&path)?;
-            Ok(())
-        }
         None => {
-            // No subcommand and no path means run the default alias
+            // No arguments means run the default alias
             // The default alias expands to "status" which provides a helpful entry point
             let default_args = vec![OsString::from("but"), OsString::from("default")];
             let expanded = alias::expand_aliases(default_args)?;
@@ -282,9 +258,15 @@ async fn match_subcommand(
             utils::metrics::capture_event_blocking(&app_settings, event).await;
             Ok(())
         }
-        Subcommands::Gui => command::gui::open(&args.current_dir)
-            .emit_metrics(metrics_ctx)
-            .map_err(CliError::from),
+        Subcommands::Gui { path } => {
+            let path = path
+                .as_ref()
+                .map(|path| args.current_dir.join(path))
+                .unwrap_or_else(|| args.current_dir.clone());
+            command::gui::open(&path)
+                .emit_metrics(metrics_ctx)
+                .map_err(CliError::from)
+        }
         Subcommands::Completions { shell } => command::completions::generate_completions(shell)
             .emit_metrics(metrics_ctx)
             .map_err(CliError::from),

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -111,7 +111,7 @@ impl Subcommands {
             Subcommands::Mark { .. } => Mark,
             #[cfg(feature = "legacy")]
             Subcommands::Unmark => Unmark,
-            Subcommands::Gui => Gui,
+            Subcommands::Gui { .. } => Gui,
             #[cfg(feature = "legacy")]
             Subcommands::Commit(crate::args::commit::Platform { cmd, .. }) => match cmd {
                 None => Commit,

--- a/crates/but/tests/but/command/gui.rs
+++ b/crates/but/tests/but/command/gui.rs
@@ -8,7 +8,7 @@ fn good_error_message_for_non_directories() -> anyhow::Result<()> {
 
     env.file("not-a-dir", "content-does-not-matter");
 
-    env.but("not-a-dir")
+    env.but("gui not-a-dir")
         .assert()
         .failure()
         .stdout_eq(str![[]])

--- a/crates/but/tests/but/command/help.rs
+++ b/crates/but/tests/but/command/help.rs
@@ -102,31 +102,19 @@ Options:
 }
 
 #[test]
-fn nonexistent_path_shows_friendly_error() -> anyhow::Result<()> {
+fn nonexistent_comman_shows_friendly_error() -> anyhow::Result<()> {
     let env = Sandbox::empty()?;
 
-    env.but("nonexistent-directory-entry")
+    env.but("no-such-command")
         .assert()
         .failure()
         .stdout_eq(str![[]])
         .stderr_eq(str![[r#"
-Error: "but nonexistent-directory-entry" is not a command. Type "but --help" to see all available commands.
+error: unrecognized subcommand 'no-such-command'
 
-"#]]);
+Usage: but [OPTIONS] [COMMAND]
 
-    Ok(())
-}
-
-#[test]
-fn path_and_subcommand_are_rejected() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
-
-    env.but("some-path completions bash")
-        .assert()
-        .failure()
-        .stdout_eq(str![[]])
-        .stderr_eq(str![[r#"
-Error: PATH cannot be used together with a subcommand. To run a subcommand in a different directory, use `-C <path>` before the subcommand, for example: `but -C <path> status`
+For more information, try '--help'.
 
 "#]]);
 

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -9,27 +9,6 @@ use crate::{
     utils::{CommandExt, Sandbox},
 };
 
-#[test]
-fn shorthand_without_subcommand_is_rejected() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
-
-    env.but("nonexistent1 nonexistent2")
-        .assert()
-        .failure()
-        .stdout_eq(str![[]])
-        .stderr_eq(str![[r#"
-error: unexpected argument 'nonexistent2' found
-
-Usage: but [OPTIONS] [COMMAND]
-       but [OPTIONS] [PATH]
-
-For more information, try '--help'.
-
-"#]]);
-
-    Ok(())
-}
-
 fn assigned_uncommitted_file_env() -> anyhow::Result<Sandbox> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
 

--- a/crates/but/tests/but/command/snapshots/help/no-arg-no-legacy.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/help/no-arg-no-legacy.stdout.term.svg
@@ -25,8 +25,6 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan>Usage: but [OPTIONS] [COMMAND]</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>       but [OPTIONS] [PATH]</tspan>
-</tspan>
     <tspan x="10px" y="100px">
 </tspan>
     <tspan x="10px" y="118px"><tspan>The GitButler CLI can be used to do nearly anything the desktop client can do (and more).</tspan>

--- a/crates/but/tests/but/command/snapshots/help/no-arg.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/help/no-arg.stdout.term.svg
@@ -25,8 +25,6 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan>Usage: but [OPTIONS] [COMMAND]</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>       but [OPTIONS] [PATH]</tspan>
-</tspan>
     <tspan x="10px" y="100px">
 </tspan>
     <tspan x="10px" y="118px"><tspan>The GitButler CLI can be used to do nearly anything the desktop client can do (and more).</tspan>


### PR DESCRIPTION
The implicit `but <path>` is problematic from a parsing perspective and hardly adds any value. We decided to get rid of it last engineering meeting.