### PR TITLE
Tighten agentlog PR association evidence

### DIFF
--- a/crates/but-agentlog/src/cli.rs
+++ b/crates/but-agentlog/src/cli.rs
@@ -492,7 +492,7 @@ mod tests {
     #[test]
     fn skim_outputs_all_turns_with_drill_down_keys_in_json() {
         let repo = setup_repo();
-        let turn_key = write_user_turn_with_targets(repo.path());
+        let turn_key = write_user_session_with_targetless_prelude(repo.path());
 
         let output = run_from_dir(
             repo.path(),
@@ -507,19 +507,19 @@ mod tests {
         assert_eq!(json["target_kind"], "branch");
         assert_eq!(json["target_key"], TEST_BRANCH_KEY);
         assert_eq!(json["sessions"][0]["session_key"], TEST_SESSION_KEY);
-        assert_eq!(json["sessions"][0]["related_turn_count"], 1);
+        assert_eq!(json["sessions"][0]["related_turn_count"], 2);
         assert_eq!(json["coverage"]["showing_sessions"], 1);
-        assert_eq!(json["coverage"]["showing_turns"], 1);
-        assert_eq!(json["coverage"]["related_turn_count"], 1);
+        assert_eq!(json["coverage"]["showing_turns"], 2);
+        assert_eq!(json["coverage"]["related_turn_count"], 2);
         assert_eq!(json["sessions"][0]["turns"][0]["turn_key"], turn_key);
         assert_eq!(json["sessions"][0]["turns"][0]["related"], true);
 
         let human = output.to_string();
         assert!(human.starts_with(&format!("Skim for branch {TEST_BRANCH_KEY}\n")));
         assert!(human.contains(
-            "\nSessions: showing 1 related sessions, 1 turns total, 1 directly related turns."
+            "\nSessions: showing 1 related sessions, 2 turns total, 2 directly related turns."
         ));
-        assert!(human.contains("\nSession #1: 1 turns, 2 records, latest "));
+        assert!(human.contains("\nSession #1: 2 turns, 2 records, latest "));
         assert!(human.contains("\n- #0 "));
         assert!(human.contains("hello"));
         assert!(human.contains("\nThis is a skim: all related sessions and turns, abbreviated."));
@@ -540,7 +540,7 @@ mod tests {
     #[test]
     fn explicit_skim_reads_bare_repo_metadata() {
         let repo = setup_bare_repo();
-        let turn_key = write_user_turn_with_targets(repo.path());
+        let turn_key = write_user_session_with_targetless_prelude(repo.path());
 
         let output = run_from_dir(
             repo.path(),
@@ -562,10 +562,24 @@ mod tests {
         let repo = setup_repo();
         let probe_session_key = "sha256-33333333333333333333333333333333";
         let probe_source_key = "sha256-44444444444444444444444444444444";
-        write_active_turn_for_session(repo.path(), TEST_SESSION_KEY, TEST_SOURCE_KEY, "first");
-        write_active_turn_for_session(repo.path(), TEST_SESSION_KEY, TEST_SOURCE_KEY, "second");
-        write_active_turn_for_session(repo.path(), TEST_SESSION_KEY, TEST_SOURCE_KEY, "third");
-        write_active_turn_for_session(repo.path(), probe_session_key, probe_source_key, "probe");
+        write_targetless_turn_for_session(
+            repo.path(),
+            TEST_SESSION_KEY,
+            TEST_SOURCE_KEY,
+            "targetless setup",
+            None,
+        );
+        write_turn_for_session(repo.path(), TEST_SESSION_KEY, TEST_SOURCE_KEY, "first");
+        write_turn_for_session(repo.path(), TEST_SESSION_KEY, TEST_SOURCE_KEY, "second");
+        write_turn_for_session(repo.path(), TEST_SESSION_KEY, TEST_SOURCE_KEY, "third");
+        write_targetless_turn_for_session(
+            repo.path(),
+            probe_session_key,
+            probe_source_key,
+            "probe targetless setup",
+            None,
+        );
+        write_turn_for_session(repo.path(), probe_session_key, probe_source_key, "probe");
         set_session_updated_at(repo.path(), TEST_SESSION_KEY, "2026-05-07T09:00:00.000Z");
         set_session_updated_at(repo.path(), probe_session_key, "2026-05-07T10:00:00.000Z");
 
@@ -580,18 +594,25 @@ mod tests {
         let json = serde_json::to_value(&output).expect("serialize command output");
 
         assert_eq!(json["coverage"]["showing_sessions"], 2);
-        assert_eq!(json["coverage"]["showing_turns"], 4);
-        assert_eq!(json["coverage"]["related_turn_count"], 4);
+        assert_eq!(json["coverage"]["showing_turns"], 6);
+        assert_eq!(json["coverage"]["related_turn_count"], 6);
         assert_eq!(json["sessions"][0]["session_key"], TEST_SESSION_KEY);
-        assert_eq!(json["sessions"][0]["related_turn_count"], 3);
+        assert_eq!(json["sessions"][0]["related_turn_count"], 4);
         assert_eq!(json["sessions"][1]["session_key"], probe_session_key);
-        assert_eq!(json["sessions"][1]["related_turn_count"], 1);
+        assert_eq!(json["sessions"][1]["related_turn_count"], 2);
     }
 
     #[test]
     fn skim_marks_session_associated_follow_up_related() {
         let repo = setup_repo();
-        let related_turn_key = write_active_turn_for_session_with_targets(
+        write_targetless_turn_for_session(
+            repo.path(),
+            TEST_SESSION_KEY,
+            TEST_SOURCE_KEY,
+            "targetless setup",
+            Some("assistant"),
+        );
+        let related_turn_key = write_turn_for_session_with_targets(
             repo.path(),
             TEST_SESSION_KEY,
             TEST_SOURCE_KEY,
@@ -622,18 +643,19 @@ mod tests {
         .expect("read skim");
         let json = serde_json::to_value(&output).expect("serialize command output");
 
-        assert_eq!(json["coverage"]["showing_turns"], 2);
-        assert_eq!(json["coverage"]["related_turn_count"], 2);
-        assert_eq!(
-            json["sessions"][0]["turns"][0]["turn_key"],
-            related_turn_key
-        );
+        assert_eq!(json["coverage"]["showing_turns"], 3);
+        assert_eq!(json["coverage"]["related_turn_count"], 3);
         assert_eq!(json["sessions"][0]["turns"][0]["related"], true);
         assert_eq!(
             json["sessions"][0]["turns"][1]["turn_key"],
-            unrelated_turn_key
+            related_turn_key
         );
         assert_eq!(json["sessions"][0]["turns"][1]["related"], true);
+        assert_eq!(
+            json["sessions"][0]["turns"][2]["turn_key"],
+            unrelated_turn_key
+        );
+        assert_eq!(json["sessions"][0]["turns"][2]["related"], true);
         assert_eq!(
             json["sessions"][0]["previews"][0],
             "assistant: unrelated follow-up"
@@ -742,14 +764,22 @@ mod tests {
         write_turn_for_session(repo, TEST_SESSION_KEY, TEST_SOURCE_KEY, "hello")
     }
 
-    fn write_user_turn_with_targets(repo: &Path) -> String {
-        write_active_turn_for_session_with_role(
+    fn write_user_session_with_targetless_prelude(repo: &Path) -> String {
+        let first_turn_key = write_targetless_turn_for_session(
             repo,
             TEST_SESSION_KEY,
             TEST_SOURCE_KEY,
             "hello",
             Some("user"),
-        )
+        );
+        write_turn_for_session_with_role(
+            repo,
+            TEST_SESSION_KEY,
+            TEST_SOURCE_KEY,
+            "hello target",
+            Some("user"),
+        );
+        first_turn_key
     }
 
     fn write_turn_for_session(
@@ -759,15 +789,6 @@ mod tests {
         text: &str,
     ) -> String {
         write_turn_for_session_with_role(repo, session_key, source_key, text, None)
-    }
-
-    fn write_active_turn_for_session(
-        repo: &Path,
-        session_key: &str,
-        source_key: &str,
-        text: &str,
-    ) -> String {
-        write_active_turn_for_session_with_role(repo, session_key, source_key, text, None)
     }
 
     fn write_turn_for_session_with_role(
@@ -791,24 +812,20 @@ mod tests {
         )
     }
 
-    fn write_active_turn_for_session_with_role(
+    fn write_targetless_turn_for_session(
         repo: &Path,
         session_key: &str,
         source_key: &str,
         text: &str,
         role: Option<&str>,
     ) -> String {
-        write_active_turn_for_session_with_targets(
+        write_turn_for_session_with_targets(
             repo,
             session_key,
             source_key,
             text,
             role,
-            ObservedTargets::from_index_keys_for_testing(
-                TEST_BRANCH_KEY,
-                TEST_REVIEW_KEY,
-                TEST_CHANGE_KEY,
-            ),
+            ObservedTargets::default(),
         )
     }
 
@@ -835,47 +852,6 @@ mod tests {
                     r#"{{"timestamp":"2026-05-07T09:00:00Z","type":"session_meta","payload":{{"id":"session-1"}}}}"#,
                     "\n",
                     r#"{{"timestamp":"2026-05-07T09:00:01Z","type":"response_item","payload":{{"type":"message"{},"content":{}}}}}"#,
-                    "\n",
-                ),
-                role_fragment,
-                serde_json::to_string(text).expect("serialize message text")
-            )
-            .as_bytes(),
-        )
-        .expect("parse transcript");
-
-        write_transcript_batch(repo, Agent::Codex, session_key, source_key, batch, || {
-            EnvironmentObservation::from_observed_targets_for_testing(observed_targets)
-        })
-        .expect("write transcript batch");
-        latest_turn_key(repo, session_key)
-    }
-
-    fn write_active_turn_for_session_with_targets(
-        repo: &Path,
-        session_key: &str,
-        source_key: &str,
-        text: &str,
-        role: Option<&str>,
-        observed_targets: ObservedTargets,
-    ) -> String {
-        let role_fragment = role
-            .map(|role| {
-                format!(
-                    r#","role":{}"#,
-                    serde_json::to_string(role).expect("serialize role")
-                )
-            })
-            .unwrap_or_default();
-        let batch = TranscriptBatch::parse(
-            Agent::Codex,
-            format!(
-                concat!(
-                    r#"{{"timestamp":"2026-05-07T09:00:00Z","type":"session_meta","payload":{{"id":"session-1"}}}}"#,
-                    "\n",
-                    r#"{{"timestamp":"2026-05-07T09:00:01Z","type":"response_item","payload":{{"type":"message"{},"content":{}}}}}"#,
-                    "\n",
-                    r#"{{"timestamp":"2026-05-07T09:00:02Z","type":"response_item","payload":{{"type":"function_call","name":"exec_command","call_id":"call-activity","arguments":"{{\"cmd\":\"but pr new main\"}}"}}}}"#,
                     "\n",
                 ),
                 role_fragment,

--- a/crates/but-agentlog/src/cli.rs
+++ b/crates/but-agentlog/src/cli.rs
@@ -519,7 +519,7 @@ mod tests {
         assert!(human.contains(
             "\nSessions: showing 1 related sessions, 1 turns total, 1 directly related turns."
         ));
-        assert!(human.contains("\nSession #1: 1 turns, 1 records, latest "));
+        assert!(human.contains("\nSession #1: 1 turns, 2 records, latest "));
         assert!(human.contains("\n- #0 "));
         assert!(human.contains("hello"));
         assert!(human.contains("\nThis is a skim: all related sessions and turns, abbreviated."));
@@ -562,10 +562,10 @@ mod tests {
         let repo = setup_repo();
         let probe_session_key = "sha256-33333333333333333333333333333333";
         let probe_source_key = "sha256-44444444444444444444444444444444";
-        write_turn_for_session(repo.path(), TEST_SESSION_KEY, TEST_SOURCE_KEY, "first");
-        write_turn_for_session(repo.path(), TEST_SESSION_KEY, TEST_SOURCE_KEY, "second");
-        write_turn_for_session(repo.path(), TEST_SESSION_KEY, TEST_SOURCE_KEY, "third");
-        write_turn_for_session(repo.path(), probe_session_key, probe_source_key, "probe");
+        write_active_turn_for_session(repo.path(), TEST_SESSION_KEY, TEST_SOURCE_KEY, "first");
+        write_active_turn_for_session(repo.path(), TEST_SESSION_KEY, TEST_SOURCE_KEY, "second");
+        write_active_turn_for_session(repo.path(), TEST_SESSION_KEY, TEST_SOURCE_KEY, "third");
+        write_active_turn_for_session(repo.path(), probe_session_key, probe_source_key, "probe");
         set_session_updated_at(repo.path(), TEST_SESSION_KEY, "2026-05-07T09:00:00.000Z");
         set_session_updated_at(repo.path(), probe_session_key, "2026-05-07T10:00:00.000Z");
 
@@ -591,7 +591,7 @@ mod tests {
     #[test]
     fn skim_marks_session_associated_follow_up_related() {
         let repo = setup_repo();
-        let related_turn_key = write_turn_for_session_with_targets(
+        let related_turn_key = write_active_turn_for_session_with_targets(
             repo.path(),
             TEST_SESSION_KEY,
             TEST_SOURCE_KEY,
@@ -743,7 +743,7 @@ mod tests {
     }
 
     fn write_user_turn_with_targets(repo: &Path) -> String {
-        write_turn_for_session_with_role(
+        write_active_turn_for_session_with_role(
             repo,
             TEST_SESSION_KEY,
             TEST_SOURCE_KEY,
@@ -761,6 +761,15 @@ mod tests {
         write_turn_for_session_with_role(repo, session_key, source_key, text, None)
     }
 
+    fn write_active_turn_for_session(
+        repo: &Path,
+        session_key: &str,
+        source_key: &str,
+        text: &str,
+    ) -> String {
+        write_active_turn_for_session_with_role(repo, session_key, source_key, text, None)
+    }
+
     fn write_turn_for_session_with_role(
         repo: &Path,
         session_key: &str,
@@ -769,6 +778,27 @@ mod tests {
         role: Option<&str>,
     ) -> String {
         write_turn_for_session_with_targets(
+            repo,
+            session_key,
+            source_key,
+            text,
+            role,
+            ObservedTargets::from_index_keys_for_testing(
+                TEST_BRANCH_KEY,
+                TEST_REVIEW_KEY,
+                TEST_CHANGE_KEY,
+            ),
+        )
+    }
+
+    fn write_active_turn_for_session_with_role(
+        repo: &Path,
+        session_key: &str,
+        source_key: &str,
+        text: &str,
+        role: Option<&str>,
+    ) -> String {
+        write_active_turn_for_session_with_targets(
             repo,
             session_key,
             source_key,
@@ -805,6 +835,47 @@ mod tests {
                     r#"{{"timestamp":"2026-05-07T09:00:00Z","type":"session_meta","payload":{{"id":"session-1"}}}}"#,
                     "\n",
                     r#"{{"timestamp":"2026-05-07T09:00:01Z","type":"response_item","payload":{{"type":"message"{},"content":{}}}}}"#,
+                    "\n",
+                ),
+                role_fragment,
+                serde_json::to_string(text).expect("serialize message text")
+            )
+            .as_bytes(),
+        )
+        .expect("parse transcript");
+
+        write_transcript_batch(repo, Agent::Codex, session_key, source_key, batch, || {
+            EnvironmentObservation::from_observed_targets_for_testing(observed_targets)
+        })
+        .expect("write transcript batch");
+        latest_turn_key(repo, session_key)
+    }
+
+    fn write_active_turn_for_session_with_targets(
+        repo: &Path,
+        session_key: &str,
+        source_key: &str,
+        text: &str,
+        role: Option<&str>,
+        observed_targets: ObservedTargets,
+    ) -> String {
+        let role_fragment = role
+            .map(|role| {
+                format!(
+                    r#","role":{}"#,
+                    serde_json::to_string(role).expect("serialize role")
+                )
+            })
+            .unwrap_or_default();
+        let batch = TranscriptBatch::parse(
+            Agent::Codex,
+            format!(
+                concat!(
+                    r#"{{"timestamp":"2026-05-07T09:00:00Z","type":"session_meta","payload":{{"id":"session-1"}}}}"#,
+                    "\n",
+                    r#"{{"timestamp":"2026-05-07T09:00:01Z","type":"response_item","payload":{{"type":"message"{},"content":{}}}}}"#,
+                    "\n",
+                    r#"{{"timestamp":"2026-05-07T09:00:02Z","type":"response_item","payload":{{"type":"function_call","name":"exec_command","call_id":"call-activity","arguments":"{{\"cmd\":\"but pr new main\"}}"}}}}"#,
                     "\n",
                 ),
                 role_fragment,

--- a/crates/but-agentlog/src/environment.rs
+++ b/crates/but-agentlog/src/environment.rs
@@ -11,9 +11,14 @@ use but_core::{
     ref_metadata::{Branch, ValueInfo, Workspace},
 };
 use but_meta::VirtualBranchesTomlMetadata;
+use gix::prelude::ObjectIdExt as _;
 use serde::Serialize;
+use sha2::{Digest, Sha256};
 
 const MAX_PATHS: usize = 256;
+// Commit file paths are captured on every turn, so keep the synced GitMeta
+// payload bounded to recent branch tips.
+const MAX_COMMIT_SNAPSHOTS_PER_BRANCH: usize = 32;
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -42,6 +47,8 @@ enum SnapshotErrorKind {
     Workspace,
     #[serde(rename = "diff_unavailable")]
     Diff,
+    #[serde(rename = "truncated")]
+    Truncated,
 }
 
 #[derive(Debug, Serialize)]
@@ -62,8 +69,24 @@ struct StackSnapshot {
 struct BranchSnapshot {
     key: String,
     name: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    reviews: Vec<TargetKey>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    commits: Vec<CommitSnapshot>,
+}
+
+#[derive(Debug, Serialize)]
+struct CommitSnapshot {
+    id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    review: Option<ReviewTarget>,
+    change: Option<TargetKey>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    file_hashes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+struct TargetKey {
+    key: String,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
@@ -123,6 +146,93 @@ impl EnvironmentObservation {
                 stacks: Vec::new(),
             },
             observed_targets,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_branch_commits_for_testing(
+        observed_targets: ObservedTargets,
+        branches: Vec<TestBranchCommitSnapshot>,
+    ) -> Self {
+        Self::from_worktree_and_branch_commits_for_testing(&[], observed_targets, branches)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_worktree_and_branch_commits_for_testing(
+        worktree_files: &[&str],
+        observed_targets: ObservedTargets,
+        branches: Vec<TestBranchCommitSnapshot>,
+    ) -> Self {
+        Self {
+            environment: EnvironmentSnapshot {
+                snapshot_status: SnapshotStatus::Complete,
+                error_kind: None,
+                worktree: Some(path_list(
+                    worktree_files
+                        .iter()
+                        .map(|path| (*path).to_owned())
+                        .collect(),
+                )),
+                stacks: vec![StackSnapshot {
+                    stack_id: None,
+                    branches: branches
+                        .into_iter()
+                        .map(TestBranchCommitSnapshot::into_branch_snapshot)
+                        .collect(),
+                }],
+            },
+            observed_targets,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_partial_diff_for_testing(mut self) -> Self {
+        self.environment.snapshot_status = SnapshotStatus::Partial;
+        self.environment.error_kind = Some(SnapshotErrorKind::Diff);
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_partial_truncated_for_testing(mut self) -> Self {
+        self.environment.snapshot_status = SnapshotStatus::Partial;
+        self.environment.error_kind = Some(SnapshotErrorKind::Truncated);
+        self
+    }
+}
+
+#[cfg(test)]
+pub(crate) struct TestBranchCommitSnapshot {
+    pub(crate) branch_key: String,
+    pub(crate) review_keys: Vec<String>,
+    pub(crate) change_key: Option<String>,
+    pub(crate) commit_id: Option<String>,
+    pub(crate) files: Vec<String>,
+}
+
+#[cfg(test)]
+impl TestBranchCommitSnapshot {
+    fn into_branch_snapshot(self) -> BranchSnapshot {
+        let reviews = self
+            .review_keys
+            .into_iter()
+            .map(|key| TargetKey { key })
+            .collect::<Vec<_>>();
+        let change = self.change_key.map(|key| TargetKey { key });
+        let files = path_list(self.files);
+        let commits = self
+            .commit_id
+            .map(|id| CommitSnapshot {
+                id,
+                change,
+                file_hashes: file_hashes(&files.files),
+            })
+            .into_iter()
+            .collect();
+        BranchSnapshot {
+            key: self.branch_key.clone(),
+            name: self.branch_key,
+            reviews,
+            commits,
         }
     }
 }
@@ -317,6 +427,8 @@ fn workspace_snapshot_with_meta(
 
     let mut observed_targets = ObservedTargets::default();
     let mut stacks = Vec::new();
+    let mut commit_paths_failed = false;
+    let mut commit_snapshots_truncated = false;
     for stack in info.stacks {
         let stack_id = stack.id.map(|id| id.to_string());
         let mut branches = Vec::new();
@@ -330,23 +442,49 @@ fn workspace_snapshot_with_meta(
                 name: ref_info.ref_name.shorten().to_string(),
             };
             let reviews = review_targets(&branch.key, segment.metadata.as_ref());
-            let review = reviews.first().cloned();
-            for commit in &segment.commits {
-                let change_id = commit.change_id.as_ref().map(ToString::to_string);
-                if let Some(change_id) = &change_id {
-                    observed_targets.changes.push(ChangeTarget {
-                        key: format!("gitbutler-change:{change_id}"),
-                        change_id: change_id.clone(),
-                    });
+            let mut commits = Vec::new();
+            commit_snapshots_truncated |= segment.commits.len() > MAX_COMMIT_SNAPSHOTS_PER_BRANCH;
+            for (commit_index, commit) in segment.commits.iter().enumerate() {
+                let change = commit.change_id.as_ref().map(|change_id| ChangeTarget {
+                    key: format!("gitbutler-change:{change_id}"),
+                    change_id: change_id.to_string(),
+                });
+                if let Some(change) = &change {
+                    observed_targets.changes.push(change.clone());
                 }
+                let commit_change = change.as_ref().map(|change| TargetKey {
+                    key: change.key.clone(),
+                });
+                if commit_index >= MAX_COMMIT_SNAPSHOTS_PER_BRANCH {
+                    continue;
+                }
+                let files = match commit_paths(repo, commit.id) {
+                    Ok(files) => files,
+                    Err(_) => {
+                        commit_paths_failed = true;
+                        path_list(Vec::new())
+                    }
+                };
+                commits.push(CommitSnapshot {
+                    id: commit.id.to_hex().to_string(),
+                    change: commit_change,
+                    file_hashes: file_hashes(&files.files),
+                });
             }
 
             observed_targets.branches.push(branch.clone());
-            observed_targets.reviews.extend(reviews);
+            let branch_reviews = reviews
+                .iter()
+                .map(|review| TargetKey {
+                    key: review.key.clone(),
+                })
+                .collect();
+            observed_targets.reviews.extend(reviews.iter().cloned());
             branches.push(BranchSnapshot {
                 key: branch.key,
                 name: branch.name,
-                review,
+                reviews: branch_reviews,
+                commits,
             });
         }
         if !branches.is_empty() {
@@ -358,7 +496,13 @@ fn workspace_snapshot_with_meta(
     Ok(WorkspaceObservation {
         stacks,
         observed_targets,
-        error_kind: None,
+        error_kind: if commit_paths_failed {
+            Some(SnapshotErrorKind::Diff)
+        } else if commit_snapshots_truncated {
+            Some(SnapshotErrorKind::Truncated)
+        } else {
+            None
+        },
     })
 }
 
@@ -382,6 +526,11 @@ fn review_targets(branch_key: &str, metadata: Option<&Branch>) -> Vec<ReviewTarg
         });
     }
     targets
+}
+
+fn commit_paths(repo: &gix::Repository, commit_id: gix::ObjectId) -> anyhow::Result<PathList> {
+    let changes = but_core::diff::commit_changes(commit_id.attach(repo))?;
+    Ok(path_list(paths_from_changes(changes.into_tree_changes())))
 }
 
 fn paths_from_changes(changes: impl IntoIterator<Item = TreeChange>) -> Vec<String> {
@@ -410,6 +559,16 @@ fn path_list(mut files: Vec<String>) -> PathList {
 
 fn path_to_string(path: &BStr) -> String {
     path.to_str_lossy().into_owned()
+}
+
+fn file_hashes(files: &[String]) -> Vec<String> {
+    files.iter().map(|path| path_fingerprint(path)).collect()
+}
+
+pub(crate) fn path_fingerprint(path: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(path.as_bytes());
+    hex::encode(&hasher.finalize()[..16])
 }
 
 #[cfg(test)]
@@ -455,20 +614,38 @@ impl ObservedTargets {
         review_key: &str,
         change_key: &str,
     ) -> Self {
+        Self::from_index_key_sets_for_testing(&[branch_key], &[review_key], &[change_key])
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_index_key_sets_for_testing(
+        branch_keys: &[&str],
+        review_keys: &[&str],
+        change_keys: &[&str],
+    ) -> Self {
         Self {
-            branches: vec![BranchTarget {
-                key: branch_key.to_owned(),
-                name: branch_key.to_owned(),
-            }],
-            reviews: vec![ReviewTarget {
-                key: review_key.to_owned(),
-                pull_request: None,
-                review_id: Some(review_key.to_owned()),
-            }],
-            changes: vec![ChangeTarget {
-                key: change_key.to_owned(),
-                change_id: change_key.to_owned(),
-            }],
+            branches: branch_keys
+                .iter()
+                .map(|key| BranchTarget {
+                    key: (*key).to_owned(),
+                    name: (*key).to_owned(),
+                })
+                .collect(),
+            reviews: review_keys
+                .iter()
+                .map(|key| ReviewTarget {
+                    key: (*key).to_owned(),
+                    pull_request: None,
+                    review_id: Some((*key).to_owned()),
+                })
+                .collect(),
+            changes: change_keys
+                .iter()
+                .map(|key| ChangeTarget {
+                    key: (*key).to_owned(),
+                    change_id: (*key).to_owned(),
+                })
+                .collect(),
         }
     }
 }

--- a/crates/but-agentlog/src/gitmeta/mod.rs
+++ b/crates/but-agentlog/src/gitmeta/mod.rs
@@ -72,21 +72,69 @@ struct StoredTurnDetail {
     records: Vec<AcceptedRecord>,
     #[serde(default)]
     observed_targets: StoredObservedTargets,
+    #[serde(default)]
+    environment: StoredEnvironmentSnapshot,
 }
 
 #[derive(Default, Deserialize)]
 struct StoredObservedTargets {
     #[serde(default)]
-    branches: Vec<StoredObservedTarget>,
+    branches: Vec<StoredTargetKey>,
     #[serde(default)]
-    reviews: Vec<StoredObservedTarget>,
+    reviews: Vec<StoredTargetKey>,
     #[serde(default)]
-    changes: Vec<StoredObservedTarget>,
+    changes: Vec<StoredTargetKey>,
 }
 
 #[derive(Deserialize)]
-struct StoredObservedTarget {
+struct StoredTargetKey {
     key: String,
+}
+
+#[derive(Default, Deserialize)]
+struct StoredEnvironmentSnapshot {
+    #[serde(default)]
+    snapshot_status: Option<String>,
+    #[serde(default)]
+    error_kind: Option<String>,
+    #[serde(default)]
+    worktree: Option<StoredPathList>,
+    #[serde(default)]
+    stacks: Vec<StoredStackSnapshot>,
+}
+
+#[derive(Deserialize)]
+struct StoredPathList {
+    #[serde(default)]
+    files: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct StoredStackSnapshot {
+    #[serde(default)]
+    branches: Vec<StoredBranchSnapshot>,
+}
+
+#[derive(Deserialize)]
+struct StoredBranchSnapshot {
+    key: String,
+    #[serde(default, rename = "review")]
+    legacy_review: Option<StoredTargetKey>,
+    #[serde(default)]
+    reviews: Vec<StoredTargetKey>,
+    #[serde(default)]
+    commits: Vec<StoredCommitSnapshot>,
+}
+
+#[derive(Deserialize)]
+struct StoredCommitSnapshot {
+    id: String,
+    #[serde(default)]
+    change: Option<StoredTargetKey>,
+    #[serde(default)]
+    file_hashes: Vec<String>,
+    #[serde(default)]
+    files: Vec<String>,
 }
 
 struct SessionListEntry {

--- a/crates/but-agentlog/src/gitmeta/read.rs
+++ b/crates/but-agentlog/src/gitmeta/read.rs
@@ -8,11 +8,13 @@ use chrono::{DateTime, Utc};
 use git_meta_lib::{MetaValue, SessionTargetHandle};
 use serde::Deserialize;
 
+use crate::environment::path_fingerprint;
+
 use super::{
-    AcceptedRecord, IndexHit, SessionListEntry, StoredObservedTargets, index_key,
+    IndexHit, SessionListEntry, StoredBranchSnapshot, StoredCommitSnapshot,
+    StoredEnvironmentSnapshot, StoredObservedTargets, index_key,
     read_support::{
-        read_optional_turn_detail, read_transcript_entries, read_turn_detail, read_turn_summaries,
-        transcript_records_by_hash, with_project_target,
+        read_optional_turn_detail, read_turn_detail, read_turn_summaries, with_project_target,
     },
     session_outline::{RelatedSession, related_session_outline},
 };
@@ -241,189 +243,183 @@ fn session_has_target_activity(
     let session_prefix = format!("gitbutler:agent-session:{session_key}");
     let summaries = read_turn_summaries(handle, &format!("{session_prefix}:turns"))?;
     let mut saw_turn_before_target = false;
+    let mut previous_detail: Option<super::StoredTurnDetail> = None;
     for summary in summaries {
         let detail_key = format!("{session_prefix}:turn:{}", summary.turn_key);
         let detail = read_turn_detail(handle, &detail_key)?;
+        if previous_detail.as_ref().is_some_and(|previous| {
+            environment_promotes_worktree_to_target(
+                &previous.environment,
+                &detail.environment,
+                target,
+            )
+        }) {
+            return Ok(true);
+        }
         if observed_targets_observe(&detail.observed_targets, target) {
             if saw_turn_before_target
-                || turn_has_agent_activity(handle, &session_prefix, &detail.records)?
+                && target_appearance_is_specific(&detail.observed_targets, target)
             {
                 return Ok(true);
             }
         } else {
             saw_turn_before_target = true;
         }
+        previous_detail = Some(detail);
     }
     Ok(false)
 }
 
-#[derive(Deserialize)]
-struct StoredActivityRecord {
-    record_hash: String,
-    #[serde(default)]
-    tool_kind: Option<String>,
-    tool_input: Option<serde_json::Value>,
-}
-
-fn turn_has_agent_activity(
-    handle: &SessionTargetHandle<'_>,
-    session_prefix: &str,
-    accepted_records: &[AcceptedRecord],
-) -> Result<bool> {
-    if accepted_records.is_empty() {
-        return Ok(false);
+fn target_appearance_is_specific(
+    targets: &StoredObservedTargets,
+    target: RelatedTarget<'_>,
+) -> bool {
+    match target {
+        RelatedTarget::Branch(_) => targets.branches.len() == 1,
+        RelatedTarget::Review(_) => targets.branches.len() <= 1,
+        RelatedTarget::Change(_) => targets.changes.len() == 1,
     }
-    let transcript_key = format!("{session_prefix}:transcript");
-    let records = activity_records_by_hash(handle, &transcript_key, accepted_records)?;
-    Ok(records.values().any(activity_record_touches_target))
 }
 
-fn activity_records_by_hash(
-    handle: &SessionTargetHandle<'_>,
-    transcript_key: &str,
-    accepted_records: &[AcceptedRecord],
-) -> Result<BTreeMap<String, StoredActivityRecord>> {
-    let needed_hashes = accepted_records
+fn environment_promotes_worktree_to_target(
+    previous: &StoredEnvironmentSnapshot,
+    current: &StoredEnvironmentSnapshot,
+    target: RelatedTarget<'_>,
+) -> bool {
+    // Strong association: files dirty in one turn show up in a new commit on the
+    // target in the next turn. Ambient applied branches stay weak.
+    if !environment_is_complete(previous) || !environment_is_complete(current) {
+        return false;
+    }
+    let Some(previous_worktree) = previous.worktree.as_ref() else {
+        return false;
+    };
+    let previous_worktree_files = previous_worktree
+        .files
         .iter()
-        .map(|record| record.record_hash.clone())
-        .collect::<HashSet<_>>();
-    let entries = read_transcript_entries(handle, transcript_key)?;
-    Ok(
-        transcript_records_by_hash(entries, &needed_hashes, parse_activity_record)
-            .into_iter()
-            .collect(),
-    )
-}
-
-fn parse_activity_record(raw: &str) -> Option<(String, StoredActivityRecord)> {
-    let record = serde_json::from_str::<StoredActivityRecord>(raw).ok()?;
-    Some((record.record_hash.clone(), record))
-}
-
-fn activity_record_touches_target(record: &StoredActivityRecord) -> bool {
-    match record.tool_kind.as_deref() {
-        Some("exec") => record
-            .tool_input
-            .as_ref()
-            .and_then(command_text)
-            .is_some_and(is_mutating_repo_command),
-        _ => false,
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    if previous_worktree_files.is_empty() {
+        return false;
     }
+    let previous_worktree_file_hashes = previous_worktree_files
+        .iter()
+        .map(|file| path_fingerprint(file))
+        .collect::<BTreeSet<_>>();
+
+    environment_branches(current).any(|branch| {
+        let previous_branch = match previous_branch_snapshot(previous, &branch.key) {
+            PreviousBranchSnapshot::Absent => KnownPreviousBranch::default(),
+            PreviousBranchSnapshot::Known(snapshot) => snapshot,
+            PreviousBranchSnapshot::Unknown => return false,
+        };
+        branch_matches_target(branch, target)
+            && branch.commits.iter().any(|commit| {
+                commit_matches_target(commit, target)
+                    && !previous_branch.commit_ids.contains(&commit.id)
+                    && commit_contains_worktree_file(
+                        commit,
+                        &previous_worktree_files,
+                        &previous_worktree_file_hashes,
+                        &previous_branch,
+                    )
+            })
+    })
 }
 
-fn command_text(input: &serde_json::Value) -> Option<&str> {
-    if let Some(command) = input.as_str() {
-        return Some(command);
+fn environment_is_complete(environment: &StoredEnvironmentSnapshot) -> bool {
+    environment.snapshot_status.as_deref() == Some("complete") && environment.error_kind.is_none()
+}
+
+enum PreviousBranchSnapshot {
+    Absent,
+    Known(KnownPreviousBranch),
+    Unknown,
+}
+
+#[derive(Default)]
+struct KnownPreviousBranch {
+    commit_ids: BTreeSet<String>,
+    file_hashes: BTreeSet<String>,
+    files: BTreeSet<String>,
+}
+
+fn commit_contains_worktree_file(
+    commit: &StoredCommitSnapshot,
+    previous_worktree_files: &BTreeSet<&str>,
+    previous_worktree_file_hashes: &BTreeSet<String>,
+    previous_branch: &KnownPreviousBranch,
+) -> bool {
+    commit.file_hashes.iter().any(|hash| {
+        previous_worktree_file_hashes.contains(hash) && !previous_branch.file_hashes.contains(hash)
+    }) || commit.files.iter().any(|file| {
+        previous_worktree_files.contains(file.as_str())
+            && !previous_branch.files.contains(file)
+            && !previous_branch
+                .file_hashes
+                .contains(&path_fingerprint(file))
+    })
+}
+
+fn environment_branches(
+    environment: &StoredEnvironmentSnapshot,
+) -> impl Iterator<Item = &StoredBranchSnapshot> {
+    environment
+        .stacks
+        .iter()
+        .flat_map(|stack| stack.branches.iter())
+}
+
+fn previous_branch_snapshot(
+    environment: &StoredEnvironmentSnapshot,
+    branch_key: &str,
+) -> PreviousBranchSnapshot {
+    let mut branch_exists = false;
+    let mut snapshot = KnownPreviousBranch::default();
+    for branch in environment_branches(environment).filter(|branch| branch.key == branch_key) {
+        branch_exists = true;
+        for commit in &branch.commits {
+            snapshot.commit_ids.insert(commit.id.clone());
+            snapshot
+                .file_hashes
+                .extend(commit.file_hashes.iter().cloned());
+            snapshot
+                .file_hashes
+                .extend(commit.files.iter().map(|file| path_fingerprint(file)));
+            snapshot.files.extend(commit.files.iter().cloned());
+        }
     }
-    ["cmd", "command", "input"]
-        .into_iter()
-        .find_map(|key| input.get(key).and_then(serde_json::Value::as_str))
-}
-
-fn is_mutating_repo_command(command: impl AsRef<str>) -> bool {
-    command
-        .as_ref()
-        .lines()
-        .flat_map(|line| line.split("&&"))
-        .flat_map(|line| line.split(';'))
-        .any(|segment| {
-            let tokens = segment.split_whitespace().collect::<Vec<_>>();
-            mutating_but_subcommand(&tokens).is_some_and(is_mutating_but_subcommand)
-                || mutating_git_subcommand(&tokens).is_some_and(is_mutating_git_subcommand)
-        })
-}
-
-fn mutating_but_subcommand<'a>(tokens: &'a [&str]) -> Option<&'a str> {
-    let first = *tokens.first()?;
-    if first == "but" {
-        return first_non_option(&tokens[1..]);
-    }
-    if first == "cargo" && tokens.get(1).copied() == Some("run") {
-        let after_separator = tokens
-            .iter()
-            .position(|token| *token == "--")
-            .map(|index| &tokens[index + 1..])?;
-        return first_non_option(after_separator);
-    }
-    None
-}
-
-fn mutating_git_subcommand<'a>(tokens: &'a [&str]) -> Option<&'a str> {
-    if tokens.first().copied() == Some("git") {
-        first_non_option(&tokens[1..])
+    if !branch_exists {
+        PreviousBranchSnapshot::Absent
+    } else if snapshot.commit_ids.is_empty() {
+        PreviousBranchSnapshot::Unknown
     } else {
-        None
+        PreviousBranchSnapshot::Known(snapshot)
     }
 }
 
-fn first_non_option<'a>(tokens: &'a [&str]) -> Option<&'a str> {
-    let mut skip_next = false;
-    for token in tokens.iter().copied() {
-        if skip_next {
-            skip_next = false;
-            continue;
-        }
-        if matches!(
-            token,
-            "-C" | "--current-dir" | "--git-dir" | "--work-tree" | "-c"
-        ) {
-            skip_next = true;
-            continue;
-        }
-        if token.starts_with("-C")
-            || token.starts_with("--current-dir=")
-            || token.starts_with("--git-dir=")
-            || token.starts_with("--work-tree=")
-            || token.starts_with("-c")
-        {
-            continue;
-        }
-        if token.starts_with('-') || token.contains('=') {
-            continue;
-        }
-        return Some(token);
+fn branch_matches_target(branch: &StoredBranchSnapshot, target: RelatedTarget<'_>) -> bool {
+    match target {
+        RelatedTarget::Branch(key) => branch.key == key,
+        RelatedTarget::Review(key) => branch_reviews(branch).any(|review_key| review_key == key),
+        RelatedTarget::Change(_) => true,
     }
-    None
 }
 
-fn is_mutating_but_subcommand(subcommand: &str) -> bool {
-    matches!(
-        subcommand,
-        "absorb"
-            | "amend"
-            | "apply"
-            | "commit"
-            | "discard"
-            | "move"
-            | "pick"
-            | "pr"
-            | "push"
-            | "resolve"
-            | "reword"
-            | "rub"
-            | "squash"
-            | "stage"
-            | "unapply"
-            | "uncommit"
-    )
+fn branch_reviews(branch: &StoredBranchSnapshot) -> impl Iterator<Item = &str> {
+    branch
+        .legacy_review
+        .iter()
+        .chain(branch.reviews.iter())
+        .map(|review| review.key.as_str())
 }
 
-fn is_mutating_git_subcommand(subcommand: &str) -> bool {
-    matches!(
-        subcommand,
-        "add"
-            | "am"
-            | "apply"
-            | "checkout"
-            | "cherry-pick"
-            | "commit"
-            | "merge"
-            | "mv"
-            | "push"
-            | "rebase"
-            | "reset"
-            | "revert"
-            | "rm"
-            | "switch"
-    )
+fn commit_matches_target(commit: &StoredCommitSnapshot, target: RelatedTarget<'_>) -> bool {
+    match target {
+        RelatedTarget::Branch(_) | RelatedTarget::Review(_) => true,
+        RelatedTarget::Change(key) => commit
+            .change
+            .as_ref()
+            .is_some_and(|change| change.key == key),
+    }
 }

--- a/crates/but-agentlog/src/gitmeta/read.rs
+++ b/crates/but-agentlog/src/gitmeta/read.rs
@@ -9,8 +9,11 @@ use git_meta_lib::{MetaValue, SessionTargetHandle};
 use serde::Deserialize;
 
 use super::{
-    IndexHit, SessionListEntry, StoredObservedTargets, index_key,
-    read_support::{read_optional_turn_detail, read_turn_summaries, with_project_target},
+    AcceptedRecord, IndexHit, SessionListEntry, StoredObservedTargets, index_key,
+    read_support::{
+        read_optional_turn_detail, read_transcript_entries, read_turn_detail, read_turn_summaries,
+        transcript_records_by_hash, with_project_target,
+    },
     session_outline::{RelatedSession, related_session_outline},
 };
 
@@ -96,12 +99,12 @@ fn verified_related_turns_by_session(
     target: RelatedTarget<'_>,
 ) -> Result<BTreeMap<String, Vec<String>>> {
     let mut indexed_turns = BTreeMap::<String, HashSet<String>>::new();
-    let mut session_association_matches = BTreeMap::<String, bool>::new();
+    let mut session_activity_matches = BTreeMap::<String, bool>::new();
     for hit in target_index_hits(handle, target)? {
         let Ok(hit) = serde_json::from_str::<IndexHit>(&hit) else {
             continue;
         };
-        if turn_detail_observes_target(handle, &hit, target, &mut session_association_matches)? {
+        if turn_detail_observes_target(handle, &hit, target, &mut session_activity_matches)? {
             indexed_turns
                 .entry(hit.session_key)
                 .or_default()
@@ -158,7 +161,7 @@ fn turn_detail_observes_target(
     handle: &SessionTargetHandle<'_>,
     hit: &IndexHit,
     target: RelatedTarget<'_>,
-    session_association_matches: &mut BTreeMap<String, bool>,
+    session_activity_matches: &mut BTreeMap<String, bool>,
 ) -> Result<bool> {
     let detail_key = format!(
         "gitbutler:agent-session:{}:turn:{}",
@@ -167,14 +170,16 @@ fn turn_detail_observes_target(
     let Some(detail) = read_optional_turn_detail(handle, &detail_key)? else {
         return Ok(false);
     };
-    if observed_targets_observe(&detail.observed_targets, target) {
-        return Ok(true);
+    if !observed_targets_observe(&detail.observed_targets, target)
+        && !session_associations_observe_target(handle, &hit.session_key, target)?
+    {
+        return Ok(false);
     }
-    if let Some(matches) = session_association_matches.get(&hit.session_key) {
+    if let Some(matches) = session_activity_matches.get(&hit.session_key) {
         return Ok(*matches);
     }
-    let matches = session_associations_observe_target(handle, &hit.session_key, target)?;
-    session_association_matches.insert(hit.session_key.clone(), matches);
+    let matches = session_has_target_activity(handle, &hit.session_key, target)?;
+    session_activity_matches.insert(hit.session_key.clone(), matches);
     Ok(matches)
 }
 
@@ -226,4 +231,199 @@ impl StoredSessionAssociations {
             RelatedTarget::Change(key) => self.changes.contains(key),
         }
     }
+}
+
+fn session_has_target_activity(
+    handle: &SessionTargetHandle<'_>,
+    session_key: &str,
+    target: RelatedTarget<'_>,
+) -> Result<bool> {
+    let session_prefix = format!("gitbutler:agent-session:{session_key}");
+    let summaries = read_turn_summaries(handle, &format!("{session_prefix}:turns"))?;
+    let mut saw_turn_before_target = false;
+    for summary in summaries {
+        let detail_key = format!("{session_prefix}:turn:{}", summary.turn_key);
+        let detail = read_turn_detail(handle, &detail_key)?;
+        if observed_targets_observe(&detail.observed_targets, target) {
+            if saw_turn_before_target
+                || turn_has_agent_activity(handle, &session_prefix, &detail.records)?
+            {
+                return Ok(true);
+            }
+        } else {
+            saw_turn_before_target = true;
+        }
+    }
+    Ok(false)
+}
+
+#[derive(Deserialize)]
+struct StoredActivityRecord {
+    record_hash: String,
+    #[serde(default)]
+    tool_kind: Option<String>,
+    tool_input: Option<serde_json::Value>,
+}
+
+fn turn_has_agent_activity(
+    handle: &SessionTargetHandle<'_>,
+    session_prefix: &str,
+    accepted_records: &[AcceptedRecord],
+) -> Result<bool> {
+    if accepted_records.is_empty() {
+        return Ok(false);
+    }
+    let transcript_key = format!("{session_prefix}:transcript");
+    let records = activity_records_by_hash(handle, &transcript_key, accepted_records)?;
+    Ok(records.values().any(activity_record_touches_target))
+}
+
+fn activity_records_by_hash(
+    handle: &SessionTargetHandle<'_>,
+    transcript_key: &str,
+    accepted_records: &[AcceptedRecord],
+) -> Result<BTreeMap<String, StoredActivityRecord>> {
+    let needed_hashes = accepted_records
+        .iter()
+        .map(|record| record.record_hash.clone())
+        .collect::<HashSet<_>>();
+    let entries = read_transcript_entries(handle, transcript_key)?;
+    Ok(
+        transcript_records_by_hash(entries, &needed_hashes, parse_activity_record)
+            .into_iter()
+            .collect(),
+    )
+}
+
+fn parse_activity_record(raw: &str) -> Option<(String, StoredActivityRecord)> {
+    let record = serde_json::from_str::<StoredActivityRecord>(raw).ok()?;
+    Some((record.record_hash.clone(), record))
+}
+
+fn activity_record_touches_target(record: &StoredActivityRecord) -> bool {
+    match record.tool_kind.as_deref() {
+        Some("exec") => record
+            .tool_input
+            .as_ref()
+            .and_then(command_text)
+            .is_some_and(is_mutating_repo_command),
+        _ => false,
+    }
+}
+
+fn command_text(input: &serde_json::Value) -> Option<&str> {
+    if let Some(command) = input.as_str() {
+        return Some(command);
+    }
+    ["cmd", "command", "input"]
+        .into_iter()
+        .find_map(|key| input.get(key).and_then(serde_json::Value::as_str))
+}
+
+fn is_mutating_repo_command(command: impl AsRef<str>) -> bool {
+    command
+        .as_ref()
+        .lines()
+        .flat_map(|line| line.split("&&"))
+        .flat_map(|line| line.split(';'))
+        .any(|segment| {
+            let tokens = segment.split_whitespace().collect::<Vec<_>>();
+            mutating_but_subcommand(&tokens).is_some_and(is_mutating_but_subcommand)
+                || mutating_git_subcommand(&tokens).is_some_and(is_mutating_git_subcommand)
+        })
+}
+
+fn mutating_but_subcommand<'a>(tokens: &'a [&str]) -> Option<&'a str> {
+    let first = *tokens.first()?;
+    if first == "but" {
+        return first_non_option(&tokens[1..]);
+    }
+    if first == "cargo" && tokens.get(1).copied() == Some("run") {
+        let after_separator = tokens
+            .iter()
+            .position(|token| *token == "--")
+            .map(|index| &tokens[index + 1..])?;
+        return first_non_option(after_separator);
+    }
+    None
+}
+
+fn mutating_git_subcommand<'a>(tokens: &'a [&str]) -> Option<&'a str> {
+    if tokens.first().copied() == Some("git") {
+        first_non_option(&tokens[1..])
+    } else {
+        None
+    }
+}
+
+fn first_non_option<'a>(tokens: &'a [&str]) -> Option<&'a str> {
+    let mut skip_next = false;
+    for token in tokens.iter().copied() {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if matches!(
+            token,
+            "-C" | "--current-dir" | "--git-dir" | "--work-tree" | "-c"
+        ) {
+            skip_next = true;
+            continue;
+        }
+        if token.starts_with("-C")
+            || token.starts_with("--current-dir=")
+            || token.starts_with("--git-dir=")
+            || token.starts_with("--work-tree=")
+            || token.starts_with("-c")
+        {
+            continue;
+        }
+        if token.starts_with('-') || token.contains('=') {
+            continue;
+        }
+        return Some(token);
+    }
+    None
+}
+
+fn is_mutating_but_subcommand(subcommand: &str) -> bool {
+    matches!(
+        subcommand,
+        "absorb"
+            | "amend"
+            | "apply"
+            | "commit"
+            | "discard"
+            | "move"
+            | "pick"
+            | "pr"
+            | "push"
+            | "resolve"
+            | "reword"
+            | "rub"
+            | "squash"
+            | "stage"
+            | "unapply"
+            | "uncommit"
+    )
+}
+
+fn is_mutating_git_subcommand(subcommand: &str) -> bool {
+    matches!(
+        subcommand,
+        "add"
+            | "am"
+            | "apply"
+            | "checkout"
+            | "cherry-pick"
+            | "commit"
+            | "merge"
+            | "mv"
+            | "push"
+            | "rebase"
+            | "reset"
+            | "revert"
+            | "rm"
+            | "switch"
+    )
 }

--- a/crates/but-agentlog/src/gitmeta/tests.rs
+++ b/crates/but-agentlog/src/gitmeta/tests.rs
@@ -1,7 +1,9 @@
 use super::*;
 use crate::agent::Agent;
 use crate::capture::record_transcript;
-use crate::environment::{EnvironmentObservation, ObservedTargets, capture_environment};
+use crate::environment::{
+    EnvironmentObservation, ObservedTargets, TestBranchCommitSnapshot, capture_environment,
+};
 use crate::projection::{
     ProjectionEvidenceTier, ProjectionLimits, ProjectionMatchKind, ProjectionPrFacts,
     ProjectionRequest, ProjectionSnapshotInput, ProjectionStatus, ProjectionWarningKind,
@@ -270,20 +272,6 @@ fn write_turn_with_targets(repo: &Path, text: &str, observed_targets: ObservedTa
     )
 }
 
-fn write_active_turn_with_targets(
-    repo: &Path,
-    text: &str,
-    observed_targets: ObservedTargets,
-) -> String {
-    write_active_turn_for_session(
-        repo,
-        TEST_SESSION_KEY,
-        TEST_SOURCE_KEY,
-        text,
-        observed_targets,
-    )
-}
-
 fn write_readonly_command_turn_with_targets(
     repo: &Path,
     text: &str,
@@ -335,6 +323,22 @@ fn write_turn_for_session(
     text: &str,
     observed_targets: ObservedTargets,
 ) -> String {
+    write_turn_with_observation(
+        repo,
+        session_key,
+        source_key,
+        text,
+        EnvironmentObservation::from_observed_targets_for_testing(observed_targets),
+    )
+}
+
+fn write_turn_with_observation(
+    repo: &Path,
+    session_key: &str,
+    source_key: &str,
+    text: &str,
+    observation: EnvironmentObservation,
+) -> String {
     let transcript = jsonl([serde_json::json!({
         "timestamp": "2026-05-07T09:00:00Z",
         "type": "response_item",
@@ -347,7 +351,7 @@ fn write_turn_for_session(
     let batch =
         TranscriptBatch::parse(Agent::Codex, transcript.as_bytes()).expect("parse transcript");
     write_transcript_batch(repo, Agent::Codex, session_key, source_key, batch, || {
-        EnvironmentObservation::from_observed_targets_for_testing(observed_targets)
+        observation
     })
     .expect("write transcript batch");
     turn_summaries(repo, session_key)
@@ -357,45 +361,34 @@ fn write_turn_for_session(
         .to_owned()
 }
 
-fn write_active_turn_for_session(
-    repo: &Path,
-    session_key: &str,
-    source_key: &str,
-    text: &str,
-    observed_targets: ObservedTargets,
-) -> String {
-    let transcript = jsonl([
-        serde_json::json!({
-            "timestamp": "2026-05-07T09:00:00Z",
-            "type": "response_item",
-            "payload": {
-                "type": "message",
-                "role": "assistant",
-                "content": text,
-            },
-        }),
-        serde_json::json!({
-            "timestamp": "2026-05-07T09:00:01Z",
-            "type": "response_item",
-            "payload": {
-                "type": "function_call",
-                "name": "exec_command",
-                "call_id": "call-activity",
-                "arguments": "{\"cmd\":\"but pr new main\"}",
-            },
-        }),
-    ]);
-    let batch =
-        TranscriptBatch::parse(Agent::Codex, transcript.as_bytes()).expect("parse transcript");
-    write_transcript_batch(repo, Agent::Codex, session_key, source_key, batch, || {
-        EnvironmentObservation::from_observed_targets_for_testing(observed_targets)
-    })
-    .expect("write transcript batch");
-    turn_summaries(repo, session_key)
-        .last()
-        .and_then(|turn| turn["turn_key"].as_str())
-        .expect("latest turn key")
-        .to_owned()
+fn branch_commit(
+    branch_key: &str,
+    review_key: &str,
+    change_key: &str,
+    commit_id: &str,
+    files: &[&str],
+) -> TestBranchCommitSnapshot {
+    TestBranchCommitSnapshot {
+        branch_key: branch_key.to_owned(),
+        review_keys: vec![review_key.to_owned()],
+        change_key: Some(change_key.to_owned()),
+        commit_id: Some(commit_id.to_owned()),
+        files: files.iter().map(|file| (*file).to_owned()).collect(),
+    }
+}
+
+fn branch_without_commits(
+    branch_key: &str,
+    review_key: &str,
+    change_key: &str,
+) -> TestBranchCommitSnapshot {
+    TestBranchCommitSnapshot {
+        branch_key: branch_key.to_owned(),
+        review_keys: vec![review_key.to_owned()],
+        change_key: Some(change_key.to_owned()),
+        commit_id: None,
+        files: Vec::new(),
+    }
 }
 
 #[test]
@@ -479,15 +472,18 @@ fn find_related_sessions_returns_verified_turn_keys() {
             TEST_CHANGE_KEY,
         )
     };
-    let turn_key = write_active_turn_with_targets(repo.path(), "Related work", observed_targets());
+    let first_turn_key = write_turn_with_targets(
+        repo.path(),
+        "Initial targetless work",
+        ObservedTargets::default(),
+    );
+    let second_turn_key = write_turn_with_targets(repo.path(), "Related work", observed_targets());
+    let expected_turn_keys = vec![first_turn_key.clone(), second_turn_key.clone()];
 
     let branch = only_related(repo.path(), RelatedTarget::Branch(TEST_BRANCH_KEY));
     assert_eq!(branch.session_key, TEST_SESSION_KEY);
-    assert_eq!(
-        branch.related_turn_keys.as_slice(),
-        std::slice::from_ref(&turn_key)
-    );
-    assert_eq!(branch.turn_count, 1);
+    assert_eq!(branch.related_turn_keys, expected_turn_keys);
+    assert_eq!(branch.turn_count, 2);
     assert_eq!(branch.record_count, 2);
     assert_eq!(
         branch
@@ -502,13 +498,10 @@ fn find_related_sessions_returns_verified_turn_keys() {
         RelatedTarget::Change(TEST_CHANGE_KEY),
     ] {
         let related = only_related(repo.path(), target);
-        assert_eq!(
-            related.related_turn_keys.as_slice(),
-            std::slice::from_ref(&turn_key)
-        );
+        assert_eq!(related.related_turn_keys, branch.related_turn_keys);
     }
 
-    write_active_turn_with_targets(repo.path(), "Related follow-up", observed_targets());
+    write_turn_with_targets(repo.path(), "Related follow-up", observed_targets());
     let turn_keys = turn_summaries(repo.path(), TEST_SESSION_KEY)
         .iter()
         .map(|turn| turn["turn_key"].as_str().expect("turn key").to_owned())
@@ -624,9 +617,405 @@ fn applied_branch_targets_from_session_start_are_not_enough_evidence() {
 }
 
 #[test]
+fn worktree_files_promoted_to_target_commit_are_strong_evidence() {
+    let repo = setup_repo();
+    let first_turn_key = write_turn_with_observation(
+        repo.path(),
+        TEST_SESSION_KEY,
+        TEST_SOURCE_KEY,
+        "Update src/lib.rs",
+        EnvironmentObservation::from_worktree_and_branch_commits_for_testing(
+            &["src/lib.rs"],
+            ObservedTargets::from_index_keys_for_testing(
+                TEST_BRANCH_KEY,
+                TEST_PR_REVIEW_KEY,
+                TEST_CHANGE_KEY,
+            ),
+            vec![branch_commit(
+                TEST_BRANCH_KEY,
+                TEST_PR_REVIEW_KEY,
+                TEST_CHANGE_KEY,
+                "commit-before",
+                &["src/before.rs"],
+            )],
+        ),
+    );
+    let second_turn_key = write_turn_with_observation(
+        repo.path(),
+        TEST_SESSION_KEY,
+        TEST_SOURCE_KEY,
+        "Committed update",
+        EnvironmentObservation::from_branch_commits_for_testing(
+            ObservedTargets::from_index_keys_for_testing(
+                TEST_BRANCH_KEY,
+                TEST_PR_REVIEW_KEY,
+                TEST_CHANGE_KEY,
+            ),
+            vec![branch_commit(
+                TEST_BRANCH_KEY,
+                TEST_PR_REVIEW_KEY,
+                TEST_CHANGE_KEY,
+                "commit-1",
+                &["src/lib.rs"],
+            )],
+        ),
+    );
+
+    let review = only_related(repo.path(), RelatedTarget::Review(TEST_PR_REVIEW_KEY));
+    assert_eq!(
+        review.related_turn_keys,
+        [first_turn_key.clone(), second_turn_key.clone()]
+    );
+    let branch = only_related(repo.path(), RelatedTarget::Branch(TEST_BRANCH_KEY));
+    assert_eq!(branch.related_turn_keys, [first_turn_key, second_turn_key]);
+}
+
+#[test]
+fn promotion_matches_the_branch_that_received_the_files() {
+    let repo = setup_repo();
+    const OTHER_BRANCH_KEY: &str = "ref:refs/heads/other";
+    const OTHER_REVIEW_KEY: &str = "pull-request:ref:refs/heads/other#2";
+    const OTHER_CHANGE_KEY: &str = "gitbutler-change:change-2";
+    write_turn_with_observation(
+        repo.path(),
+        TEST_SESSION_KEY,
+        TEST_SOURCE_KEY,
+        "Update other branch file",
+        EnvironmentObservation::from_worktree_and_branch_commits_for_testing(
+            &["src/other.rs"],
+            ObservedTargets::default(),
+            vec![
+                branch_commit(
+                    TEST_BRANCH_KEY,
+                    TEST_PR_REVIEW_KEY,
+                    TEST_CHANGE_KEY,
+                    "commit-main-before",
+                    &["src/main-before.rs"],
+                ),
+                branch_commit(
+                    OTHER_BRANCH_KEY,
+                    OTHER_REVIEW_KEY,
+                    OTHER_CHANGE_KEY,
+                    "commit-other-before",
+                    &["src/other-before.rs"],
+                ),
+            ],
+        ),
+    );
+    write_turn_with_observation(
+        repo.path(),
+        TEST_SESSION_KEY,
+        TEST_SOURCE_KEY,
+        "Committed mixed branch state",
+        EnvironmentObservation::from_branch_commits_for_testing(
+            ObservedTargets::from_index_key_sets_for_testing(
+                &[TEST_BRANCH_KEY, OTHER_BRANCH_KEY],
+                &[TEST_PR_REVIEW_KEY, OTHER_REVIEW_KEY],
+                &[TEST_CHANGE_KEY, OTHER_CHANGE_KEY],
+            ),
+            vec![
+                branch_commit(
+                    TEST_BRANCH_KEY,
+                    TEST_PR_REVIEW_KEY,
+                    TEST_CHANGE_KEY,
+                    "commit-main",
+                    &["src/main.rs"],
+                ),
+                branch_commit(
+                    OTHER_BRANCH_KEY,
+                    OTHER_REVIEW_KEY,
+                    OTHER_CHANGE_KEY,
+                    "commit-other",
+                    &["src/other.rs"],
+                ),
+            ],
+        ),
+    );
+
+    let main_sessions =
+        find_related_sessions_limited(repo.path(), RelatedTarget::Review(TEST_PR_REVIEW_KEY), None)
+            .expect("find main review sessions");
+    assert!(main_sessions.is_empty());
+    let other = only_related(repo.path(), RelatedTarget::Review(OTHER_REVIEW_KEY));
+    assert_eq!(other.related_turn_keys.len(), 2);
+}
+
+#[test]
+fn promotion_handles_branch_that_appears_with_commit() {
+    let repo = setup_repo();
+    const OTHER_BRANCH_KEY: &str = "ref:refs/heads/other";
+    const OTHER_REVIEW_KEY: &str = "pull-request:ref:refs/heads/other#2";
+    const OTHER_CHANGE_KEY: &str = "gitbutler-change:change-2";
+    write_turn_with_observation(
+        repo.path(),
+        TEST_SESSION_KEY,
+        TEST_SOURCE_KEY,
+        "Update file before branches exist",
+        EnvironmentObservation::from_worktree_and_branch_commits_for_testing(
+            &["src/other.rs"],
+            ObservedTargets::default(),
+            Vec::new(),
+        ),
+    );
+    write_turn_with_observation(
+        repo.path(),
+        TEST_SESSION_KEY,
+        TEST_SOURCE_KEY,
+        "Branches appeared with commits",
+        EnvironmentObservation::from_branch_commits_for_testing(
+            ObservedTargets::from_index_key_sets_for_testing(
+                &[TEST_BRANCH_KEY, OTHER_BRANCH_KEY],
+                &[TEST_PR_REVIEW_KEY, OTHER_REVIEW_KEY],
+                &[TEST_CHANGE_KEY, OTHER_CHANGE_KEY],
+            ),
+            vec![
+                branch_commit(
+                    TEST_BRANCH_KEY,
+                    TEST_PR_REVIEW_KEY,
+                    TEST_CHANGE_KEY,
+                    "commit-main",
+                    &["src/main.rs"],
+                ),
+                branch_commit(
+                    OTHER_BRANCH_KEY,
+                    OTHER_REVIEW_KEY,
+                    OTHER_CHANGE_KEY,
+                    "commit-other",
+                    &["src/other.rs"],
+                ),
+            ],
+        ),
+    );
+
+    let main_sessions =
+        find_related_sessions_limited(repo.path(), RelatedTarget::Review(TEST_PR_REVIEW_KEY), None)
+            .expect("find main review sessions");
+    assert!(main_sessions.is_empty());
+    let other = only_related(repo.path(), RelatedTarget::Review(OTHER_REVIEW_KEY));
+    assert_eq!(other.related_turn_keys.len(), 2);
+}
+
+#[test]
+fn existing_branch_without_commit_snapshots_is_not_promotion_evidence() {
+    let repo = setup_repo();
+    write_turn_with_observation(
+        repo.path(),
+        TEST_SESSION_KEY,
+        TEST_SOURCE_KEY,
+        "Update file while branch is already ambient",
+        EnvironmentObservation::from_worktree_and_branch_commits_for_testing(
+            &["src/lib.rs"],
+            ObservedTargets::from_index_keys_for_testing(
+                TEST_BRANCH_KEY,
+                TEST_PR_REVIEW_KEY,
+                TEST_CHANGE_KEY,
+            ),
+            vec![branch_without_commits(
+                TEST_BRANCH_KEY,
+                TEST_PR_REVIEW_KEY,
+                TEST_CHANGE_KEY,
+            )],
+        ),
+    );
+    write_turn_with_observation(
+        repo.path(),
+        TEST_SESSION_KEY,
+        TEST_SOURCE_KEY,
+        "Later capture has commit snapshots",
+        EnvironmentObservation::from_branch_commits_for_testing(
+            ObservedTargets::from_index_keys_for_testing(
+                TEST_BRANCH_KEY,
+                TEST_PR_REVIEW_KEY,
+                TEST_CHANGE_KEY,
+            ),
+            vec![branch_commit(
+                TEST_BRANCH_KEY,
+                TEST_PR_REVIEW_KEY,
+                TEST_CHANGE_KEY,
+                "commit-1",
+                &["src/lib.rs"],
+            )],
+        ),
+    );
+
+    let sessions =
+        find_related_sessions_limited(repo.path(), RelatedTarget::Review(TEST_PR_REVIEW_KEY), None)
+            .expect("find review sessions");
+    assert!(
+        sessions.is_empty(),
+        "a legacy existing branch without commit snapshots cannot prove a new commit"
+    );
+}
+
+#[test]
+fn rewritten_commit_with_already_committed_worktree_file_is_not_promotion_evidence() {
+    let repo = setup_repo();
+    write_turn_with_observation(
+        repo.path(),
+        TEST_SESSION_KEY,
+        TEST_SOURCE_KEY,
+        "Update file already touched by branch commit",
+        EnvironmentObservation::from_worktree_and_branch_commits_for_testing(
+            &["src/lib.rs"],
+            ObservedTargets::from_index_keys_for_testing(
+                TEST_BRANCH_KEY,
+                TEST_PR_REVIEW_KEY,
+                TEST_CHANGE_KEY,
+            ),
+            vec![branch_commit(
+                TEST_BRANCH_KEY,
+                TEST_PR_REVIEW_KEY,
+                TEST_CHANGE_KEY,
+                "commit-before-rewrite",
+                &["src/lib.rs"],
+            )],
+        ),
+    );
+    write_turn_with_observation(
+        repo.path(),
+        TEST_SESSION_KEY,
+        TEST_SOURCE_KEY,
+        "Commit was rewritten but did not gain a new file",
+        EnvironmentObservation::from_branch_commits_for_testing(
+            ObservedTargets::from_index_keys_for_testing(
+                TEST_BRANCH_KEY,
+                TEST_PR_REVIEW_KEY,
+                TEST_CHANGE_KEY,
+            ),
+            vec![branch_commit(
+                TEST_BRANCH_KEY,
+                TEST_PR_REVIEW_KEY,
+                TEST_CHANGE_KEY,
+                "commit-after-rewrite",
+                &["src/lib.rs"],
+            )],
+        ),
+    );
+
+    let sessions =
+        find_related_sessions_limited(repo.path(), RelatedTarget::Review(TEST_PR_REVIEW_KEY), None)
+            .expect("find review sessions");
+    assert!(
+        sessions.is_empty(),
+        "a rewritten commit is not promotion evidence when the file was already on the branch"
+    );
+}
+
+#[test]
+fn partial_current_environment_is_not_promotion_evidence() {
+    let repo = setup_repo();
+    write_turn_with_observation(
+        repo.path(),
+        TEST_SESSION_KEY,
+        TEST_SOURCE_KEY,
+        "Update file while target branch is ambient",
+        EnvironmentObservation::from_worktree_and_branch_commits_for_testing(
+            &["src/lib.rs"],
+            ObservedTargets::from_index_keys_for_testing(
+                TEST_BRANCH_KEY,
+                TEST_PR_REVIEW_KEY,
+                TEST_CHANGE_KEY,
+            ),
+            vec![branch_commit(
+                TEST_BRANCH_KEY,
+                TEST_PR_REVIEW_KEY,
+                TEST_CHANGE_KEY,
+                "commit-before",
+                &["src/before.rs"],
+            )],
+        ),
+    );
+    write_turn_with_observation(
+        repo.path(),
+        TEST_SESSION_KEY,
+        TEST_SOURCE_KEY,
+        "Truncated capture has matching commit evidence",
+        EnvironmentObservation::from_branch_commits_for_testing(
+            ObservedTargets::from_index_keys_for_testing(
+                TEST_BRANCH_KEY,
+                TEST_PR_REVIEW_KEY,
+                TEST_CHANGE_KEY,
+            ),
+            vec![branch_commit(
+                TEST_BRANCH_KEY,
+                TEST_PR_REVIEW_KEY,
+                TEST_CHANGE_KEY,
+                "commit-1",
+                &["src/lib.rs"],
+            )],
+        )
+        .with_partial_truncated_for_testing(),
+    );
+
+    let sessions =
+        find_related_sessions_limited(repo.path(), RelatedTarget::Review(TEST_PR_REVIEW_KEY), None)
+            .expect("find review sessions");
+    assert!(
+        sessions.is_empty(),
+        "partial current captures cannot provide strong promotion evidence"
+    );
+}
+
+#[test]
+fn partial_previous_environment_is_not_promotion_evidence() {
+    let repo = setup_repo();
+    write_turn_with_observation(
+        repo.path(),
+        TEST_SESSION_KEY,
+        TEST_SOURCE_KEY,
+        "Update file while previous branch files are unknown",
+        EnvironmentObservation::from_worktree_and_branch_commits_for_testing(
+            &["src/lib.rs"],
+            ObservedTargets::from_index_keys_for_testing(
+                TEST_BRANCH_KEY,
+                TEST_PR_REVIEW_KEY,
+                TEST_CHANGE_KEY,
+            ),
+            vec![branch_commit(
+                TEST_BRANCH_KEY,
+                TEST_PR_REVIEW_KEY,
+                TEST_CHANGE_KEY,
+                "commit-with-unknown-files",
+                &[],
+            )],
+        )
+        .with_partial_diff_for_testing(),
+    );
+    write_turn_with_observation(
+        repo.path(),
+        TEST_SESSION_KEY,
+        TEST_SOURCE_KEY,
+        "Later capture has rewritten matching commit",
+        EnvironmentObservation::from_branch_commits_for_testing(
+            ObservedTargets::from_index_keys_for_testing(
+                TEST_BRANCH_KEY,
+                TEST_PR_REVIEW_KEY,
+                TEST_CHANGE_KEY,
+            ),
+            vec![branch_commit(
+                TEST_BRANCH_KEY,
+                TEST_PR_REVIEW_KEY,
+                TEST_CHANGE_KEY,
+                "commit-after-rewrite",
+                &["src/lib.rs"],
+            )],
+        ),
+    );
+
+    let sessions =
+        find_related_sessions_limited(repo.path(), RelatedTarget::Review(TEST_PR_REVIEW_KEY), None)
+            .expect("find review sessions");
+    assert!(
+        sessions.is_empty(),
+        "partial previous captures cannot prove the file was absent before"
+    );
+}
+
+#[test]
 fn project_pr_returns_public_review_projection_without_raw_storage_keys() {
     let repo = setup_repo();
-    let turn_key = write_active_turn_with_targets(
+    write_turn_with_targets(repo.path(), "Initial PR work", ObservedTargets::default());
+    let turn_key = write_turn_with_targets(
         repo.path(),
         "Related PR work",
         ObservedTargets::from_index_keys_for_testing(
@@ -646,8 +1035,8 @@ fn project_pr_returns_public_review_projection_without_raw_storage_keys() {
     assert_eq!(session.evidence_tier, ProjectionEvidenceTier::Supporting);
     assert_eq!(session.agents.len(), 1);
     assert_eq!(session.agents[0].agent.as_deref(), Some("codex"));
-    assert_eq!(session.turns.len(), 1);
-    let turn = &session.turns[0];
+    assert_eq!(session.turns.len(), 2);
+    let turn = &session.turns[1];
     assert!(turn.handle.starts_with("pt_"));
     assert_eq!(turn.evidence_tier, ProjectionEvidenceTier::Supporting);
     assert_eq!(
@@ -660,14 +1049,11 @@ fn project_pr_returns_public_review_projection_without_raw_storage_keys() {
             ProjectionMatchKind::BranchTarget
         ]
     );
-    assert_eq!(turn.records.len(), 2);
+    assert_eq!(turn.records.len(), 1);
     let message = &turn.records[0];
     assert!(message.handle.starts_with("pr_"));
     assert_eq!(message.text.as_deref(), Some("Related PR work"));
     assert_eq!(message.kind.as_deref(), Some("message"));
-    let command = &turn.records[1];
-    assert_eq!(command.kind.as_deref(), Some("tool_call"));
-    assert_eq!(command.tool_kind.as_deref(), Some("exec"));
 
     let json = serde_json::to_string(&projection).expect("projection json");
     assert!(
@@ -699,7 +1085,12 @@ fn project_pr_returns_public_review_projection_without_raw_storage_keys() {
 #[test]
 fn project_pr_marks_branch_only_matches_as_weak_evidence() {
     let repo = setup_repo();
-    write_active_turn_with_targets(
+    write_turn_with_targets(
+        repo.path(),
+        "Initial branch-only work",
+        ObservedTargets::default(),
+    );
+    write_turn_with_targets(
         repo.path(),
         "Branch-only work",
         ObservedTargets::from_index_keys_for_testing(
@@ -726,7 +1117,7 @@ fn project_pr_marks_branch_only_matches_as_weak_evidence() {
     );
     let session = &projection.sessions[0];
     assert_eq!(session.evidence_tier, ProjectionEvidenceTier::Possible);
-    let turn = &session.turns[0];
+    let turn = &session.turns[1];
     assert_eq!(turn.evidence_tier, ProjectionEvidenceTier::Possible);
     assert_eq!(turn.match_reasons.len(), 1);
     assert_eq!(
@@ -738,6 +1129,7 @@ fn project_pr_marks_branch_only_matches_as_weak_evidence() {
 #[test]
 fn project_pr_filters_hidden_prompts_and_strips_tool_payloads() {
     let repo = setup_repo();
+    write_turn_with_targets(repo.path(), "Initial prompt", ObservedTargets::default());
     let batch = TranscriptBatch::parse(
         Agent::Codex,
         jsonl([
@@ -815,12 +1207,20 @@ fn project_pr_filters_hidden_prompts_and_strips_tool_payloads() {
         TEST_SOURCE_KEY,
         batch,
         || {
-            EnvironmentObservation::from_observed_targets_for_testing(
+            EnvironmentObservation::from_worktree_and_branch_commits_for_testing(
+                &["private/secret.rs"],
                 ObservedTargets::from_index_keys_for_testing(
                     TEST_BRANCH_KEY,
                     TEST_PR_REVIEW_KEY,
                     TEST_CHANGE_KEY,
                 ),
+                vec![branch_commit(
+                    TEST_BRANCH_KEY,
+                    TEST_PR_REVIEW_KEY,
+                    TEST_CHANGE_KEY,
+                    "commit-with-private-path",
+                    &["private/secret.rs"],
+                )],
             )
         },
     )
@@ -834,7 +1234,7 @@ fn project_pr_filters_hidden_prompts_and_strips_tool_payloads() {
 
     let projection = project_pr(repo.path(), &request).expect("project PR");
 
-    let turn = &projection.sessions[0].turns[0];
+    let turn = projection.sessions[0].turns.last().expect("projected turn");
     assert_eq!(
         turn.latest_user_preview
             .as_ref()

--- a/crates/but-agentlog/src/gitmeta/tests.rs
+++ b/crates/but-agentlog/src/gitmeta/tests.rs
@@ -270,6 +270,64 @@ fn write_turn_with_targets(repo: &Path, text: &str, observed_targets: ObservedTa
     )
 }
 
+fn write_active_turn_with_targets(
+    repo: &Path,
+    text: &str,
+    observed_targets: ObservedTargets,
+) -> String {
+    write_active_turn_for_session(
+        repo,
+        TEST_SESSION_KEY,
+        TEST_SOURCE_KEY,
+        text,
+        observed_targets,
+    )
+}
+
+fn write_readonly_command_turn_with_targets(
+    repo: &Path,
+    text: &str,
+    observed_targets: ObservedTargets,
+) -> String {
+    let transcript = jsonl([
+        serde_json::json!({
+            "timestamp": "2026-05-07T09:00:00Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": text,
+            },
+        }),
+        serde_json::json!({
+            "timestamp": "2026-05-07T09:00:01Z",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "exec_command",
+                "call_id": "call-readonly",
+                "arguments": "{\"cmd\":\"git branch --show-current\"}",
+            },
+        }),
+    ]);
+    let batch =
+        TranscriptBatch::parse(Agent::Codex, transcript.as_bytes()).expect("parse transcript");
+    write_transcript_batch(
+        repo,
+        Agent::Codex,
+        TEST_SESSION_KEY,
+        TEST_SOURCE_KEY,
+        batch,
+        || EnvironmentObservation::from_observed_targets_for_testing(observed_targets),
+    )
+    .expect("write transcript batch");
+    turn_summaries(repo, TEST_SESSION_KEY)
+        .last()
+        .and_then(|turn| turn["turn_key"].as_str())
+        .expect("latest turn key")
+        .to_owned()
+}
+
 fn write_turn_for_session(
     repo: &Path,
     session_key: &str,
@@ -286,6 +344,47 @@ fn write_turn_for_session(
             "content": text,
         },
     })]);
+    let batch =
+        TranscriptBatch::parse(Agent::Codex, transcript.as_bytes()).expect("parse transcript");
+    write_transcript_batch(repo, Agent::Codex, session_key, source_key, batch, || {
+        EnvironmentObservation::from_observed_targets_for_testing(observed_targets)
+    })
+    .expect("write transcript batch");
+    turn_summaries(repo, session_key)
+        .last()
+        .and_then(|turn| turn["turn_key"].as_str())
+        .expect("latest turn key")
+        .to_owned()
+}
+
+fn write_active_turn_for_session(
+    repo: &Path,
+    session_key: &str,
+    source_key: &str,
+    text: &str,
+    observed_targets: ObservedTargets,
+) -> String {
+    let transcript = jsonl([
+        serde_json::json!({
+            "timestamp": "2026-05-07T09:00:00Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": text,
+            },
+        }),
+        serde_json::json!({
+            "timestamp": "2026-05-07T09:00:01Z",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "exec_command",
+                "call_id": "call-activity",
+                "arguments": "{\"cmd\":\"but pr new main\"}",
+            },
+        }),
+    ]);
     let batch =
         TranscriptBatch::parse(Agent::Codex, transcript.as_bytes()).expect("parse transcript");
     write_transcript_batch(repo, Agent::Codex, session_key, source_key, batch, || {
@@ -380,7 +479,7 @@ fn find_related_sessions_returns_verified_turn_keys() {
             TEST_CHANGE_KEY,
         )
     };
-    let turn_key = write_turn_with_targets(repo.path(), "Related work", observed_targets());
+    let turn_key = write_active_turn_with_targets(repo.path(), "Related work", observed_targets());
 
     let branch = only_related(repo.path(), RelatedTarget::Branch(TEST_BRANCH_KEY));
     assert_eq!(branch.session_key, TEST_SESSION_KEY);
@@ -389,7 +488,7 @@ fn find_related_sessions_returns_verified_turn_keys() {
         std::slice::from_ref(&turn_key)
     );
     assert_eq!(branch.turn_count, 1);
-    assert_eq!(branch.record_count, 1);
+    assert_eq!(branch.record_count, 2);
     assert_eq!(
         branch
             .latest_assistant_preview
@@ -409,7 +508,7 @@ fn find_related_sessions_returns_verified_turn_keys() {
         );
     }
 
-    write_turn_with_targets(repo.path(), "Related follow-up", observed_targets());
+    write_active_turn_with_targets(repo.path(), "Related follow-up", observed_targets());
     let turn_keys = turn_summaries(repo.path(), TEST_SESSION_KEY)
         .iter()
         .map(|turn| turn["turn_key"].as_str().expect("turn key").to_owned())
@@ -495,9 +594,39 @@ fn session_target_association_backfills_targetless_turns() {
 }
 
 #[test]
+fn applied_branch_targets_from_session_start_are_not_enough_evidence() {
+    let repo = setup_repo();
+    let observed_targets = || {
+        ObservedTargets::from_index_keys_for_testing(
+            TEST_BRANCH_KEY,
+            TEST_PR_REVIEW_KEY,
+            TEST_CHANGE_KEY,
+        )
+    };
+    write_readonly_command_turn_with_targets(
+        repo.path(),
+        "Unrelated investigation",
+        observed_targets(),
+    );
+    write_turn_with_targets(repo.path(), "Still unrelated", observed_targets());
+
+    let review_sessions =
+        find_related_sessions_limited(repo.path(), RelatedTarget::Review(TEST_PR_REVIEW_KEY), None)
+            .expect("find review sessions");
+    assert!(
+        review_sessions.is_empty(),
+        "an already-applied branch should not attach a passive session to its PR"
+    );
+
+    let projection = project_pr(repo.path(), &projection_request()).expect("project PR");
+    assert_eq!(projection.status, ProjectionStatus::NoMatches);
+    assert!(projection.sessions.is_empty());
+}
+
+#[test]
 fn project_pr_returns_public_review_projection_without_raw_storage_keys() {
     let repo = setup_repo();
-    let turn_key = write_turn_with_targets(
+    let turn_key = write_active_turn_with_targets(
         repo.path(),
         "Related PR work",
         ObservedTargets::from_index_keys_for_testing(
@@ -531,11 +660,14 @@ fn project_pr_returns_public_review_projection_without_raw_storage_keys() {
             ProjectionMatchKind::BranchTarget
         ]
     );
-    assert_eq!(turn.records.len(), 1);
-    let record = &turn.records[0];
-    assert!(record.handle.starts_with("pr_"));
-    assert_eq!(record.text.as_deref(), Some("Related PR work"));
-    assert_eq!(record.kind.as_deref(), Some("message"));
+    assert_eq!(turn.records.len(), 2);
+    let message = &turn.records[0];
+    assert!(message.handle.starts_with("pr_"));
+    assert_eq!(message.text.as_deref(), Some("Related PR work"));
+    assert_eq!(message.kind.as_deref(), Some("message"));
+    let command = &turn.records[1];
+    assert_eq!(command.kind.as_deref(), Some("tool_call"));
+    assert_eq!(command.tool_kind.as_deref(), Some("exec"));
 
     let json = serde_json::to_string(&projection).expect("projection json");
     assert!(
@@ -567,7 +699,7 @@ fn project_pr_returns_public_review_projection_without_raw_storage_keys() {
 #[test]
 fn project_pr_marks_branch_only_matches_as_weak_evidence() {
     let repo = setup_repo();
-    write_turn_with_targets(
+    write_active_turn_with_targets(
         repo.path(),
         "Branch-only work",
         ObservedTargets::from_index_keys_for_testing(
@@ -662,6 +794,16 @@ fn project_pr_filters_hidden_prompts_and_strips_tool_payloads() {
                     "output": "Chunk ID: abc\nWall time: 0.01s\nProcess exited with code 0\nUpdated file\n",
                 },
             }),
+            serde_json::json!({
+                "timestamp": "2026-05-07T09:00:06Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "exec_command",
+                    "call_id": "call-2",
+                    "arguments": "{\"cmd\":\"but pr new main\"}",
+                },
+            }),
         ])
         .as_bytes(),
     )
@@ -700,7 +842,7 @@ fn project_pr_filters_hidden_prompts_and_strips_tool_payloads() {
         Some("Please update src/lib.rs")
     );
     let records = &turn.records;
-    assert_eq!(records.len(), 3);
+    assert_eq!(records.len(), 4);
     assert!(
         records
             .iter()
@@ -719,6 +861,9 @@ fn project_pr_filters_hidden_prompts_and_strips_tool_payloads() {
     assert_eq!(records[2].text.as_deref(), Some("Updated file"));
     assert_eq!(records[2].exit_code, Some(0));
     assert_eq!(records[2].outcome.as_deref(), Some("succeeded"));
+    assert_eq!(records[3].kind.as_deref(), Some("tool_call"));
+    assert_eq!(records[3].tool_name.as_deref(), Some("exec_command"));
+    assert_eq!(records[3].tool_kind.as_deref(), Some("exec"));
 
     let json = serde_json::to_string(&projection).expect("projection json");
     assert!(!json.contains("# AGENTS.md instructions"));


### PR DESCRIPTION
Fixes agent trail false positives where a session was attached to a PR only because that GitButler branch was already applied.

What changed:
- Treat ambient applied branches as weak evidence unless the target appears after targetless work or stronger environment evidence exists.
- Capture bounded applied-branch commit snapshots so read-time can detect dirty-file-to-commit promotion.
- Keep the saved schema lean with key-only target refs and hashed committed file paths.
- Avoid false promotion for legacy captures without commit snapshots and rewritten commits where the file was already on the branch.

Validation:
- cargo test -p but-agentlog
- cargo clippy -p but-agentlog --all-targets --no-deps
- git diff --check
- real PR 13948 skim returns only the true session.