### PR TITLE
Discard uncommitted changes and commits with one operation in the TUI

### DIFF
--- a/crates/but-transaction/src/lib.rs
+++ b/crates/but-transaction/src/lib.rs
@@ -229,6 +229,20 @@ where
         })
     }
 
+    pub fn discard_workspace_changes(
+        &mut self,
+        changes: impl IntoIterator<Item = DiffSpec>,
+    ) -> anyhow::Result<Vec<DiffSpec>> {
+        let context_lines = self.inner.context_lines;
+        self.rebase(|editor, _, _| {
+            let dropped_changes =
+                but_workspace::discard_workspace_changes(editor.repo(), changes, context_lines)?;
+            let rebase = editor.rebase()?;
+
+            Ok((dropped_changes, rebase))
+        })
+    }
+
     pub fn remove_reference(&mut self, ref_name: &FullNameRef) -> anyhow::Result<()> {
         self.rebase(|mut editor, _, _| {
             let selector = editor.select_reference(ref_name)?;

--- a/crates/but-transaction/src/lib.rs
+++ b/crates/but-transaction/src/lib.rs
@@ -430,6 +430,7 @@ mod sealed {
     pub trait Sealed {}
     impl Sealed for () {}
     impl<T> Sealed for super::Rollback<T> {}
+    impl<T> Sealed for Option<super::Rollback<T>> {}
     impl<T, K> Sealed for super::DynamicOutcome<T, K> {}
 }
 
@@ -491,6 +492,35 @@ impl<T> TransactionOutcome for Rollback<T> {
         _dry_run: DryRun,
     ) -> anyhow::Result<Self::Outcome> {
         Ok(self.0)
+    }
+}
+
+impl<T> TransactionOutcome for Option<Rollback<T>> {
+    type Outcome = Option<T>;
+
+    fn should_rollback(&self) -> bool {
+        self.is_some()
+    }
+
+    fn maybe_commit<M: RefMetadata>(
+        self,
+        repo: &gix::Repository,
+        rebase: SuccessfulRebase<'_, '_, M>,
+        db_tx: but_db::Transaction<'_>,
+        pending_metadata_removals: Vec<FullName>,
+        dry_run: DryRun,
+    ) -> anyhow::Result<Self::Outcome> {
+        match self {
+            Some(Rollback(output)) => Ok(Some(output)),
+            None => {
+                let _workspace =
+                    workspace_state_from_rebase(rebase, repo, pending_metadata_removals, dry_run)?;
+                if dry_run == DryRun::No {
+                    db_tx.commit()?;
+                }
+                Ok(None)
+            }
+        }
     }
 }
 

--- a/crates/but-transaction/src/tests.rs
+++ b/crates/but-transaction/src/tests.rs
@@ -307,7 +307,7 @@ fn remove_references() {
 }
 
 #[test]
-fn discard_workspace_changes() {
+fn rolling_back_discard_workspace_changes() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
     env.setup_metadata(&["A"]).unwrap();
 
@@ -345,25 +345,19 @@ fn discard_workspace_changes() {
                 dropped_changes.is_empty(),
                 "all matching worktree changes should be discarded"
             );
-
-            Ok(())
+            Ok(tx.rollback(()))
         },
     )
     .unwrap();
 
-    snapbox::assert_data_eq!(env.git_status().unwrap(), snapbox::str![[r#""#]]);
-
     snapbox::assert_data_eq!(
-        env.git_log().unwrap(),
+        env.git_status().unwrap(),
         snapbox::str![[r#"
-* ebaef69 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 1e25c58 (branch) add file-three
-* 9b3b3d5 add file-two
-* dbdbcea add file-one
-* 6674d4f (origin/main, origin/HEAD, main, gitbutler/target) add random-file
+ M file-one
+?? new-file
 
 "#]]
     );
 
-    assert_num_snapshots(&ctx, 1);
+    assert_num_snapshots(&ctx, 0);
 }

--- a/crates/but-transaction/src/tests.rs
+++ b/crates/but-transaction/src/tests.rs
@@ -1,5 +1,5 @@
 use but_api::WorkspaceState;
-use but_core::DryRun;
+use but_core::{DiffSpec, DryRun};
 use but_ctx::Context;
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
 use but_testsupport::Sandbox;
@@ -24,6 +24,21 @@ fn assert_num_snapshots(ctx: &Context, expected: usize) {
             .unwrap()
             .count(),
     );
+}
+
+#[track_caller]
+fn worktree_changes_as_specs(repo: &gix::Repository) -> Vec<DiffSpec> {
+    let changes = but_core::diff::worktree_changes(repo).unwrap();
+    let specs = changes
+        .changes
+        .into_iter()
+        .map(DiffSpec::from)
+        .collect::<Vec<_>>();
+    assert!(
+        !specs.is_empty(),
+        "fixture should contain worktree changes to discard"
+    );
+    specs
 }
 
 #[test]
@@ -283,6 +298,68 @@ fn remove_references() {
         env.git_log().unwrap(),
         snapbox::str![[r#"
 * 8413d71 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 6674d4f (origin/main, origin/HEAD, main, gitbutler/target) add random-file
+
+"#]]
+    );
+
+    assert_num_snapshots(&ctx, 1);
+}
+
+#[test]
+fn discard_workspace_changes() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.append_file("file-one", "changed\n");
+    env.file("new-file", "new\n");
+
+    snapbox::assert_data_eq!(
+        env.git_status().unwrap(),
+        snapbox::str![[r#"
+ M file-one
+?? new-file
+
+"#]]
+    );
+
+    let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
+    let changes = worktree_changes_as_specs(&repo);
+    let mut ctx = Context::from_repo(repo)
+        .map(Context::with_memory_app_cache)
+        .unwrap();
+
+    assert_num_snapshots(&ctx, 0);
+
+    let mut meta = ctx.meta().unwrap();
+    let snapshot_details = SnapshotDetails::new(OperationKind::DiscardChanges);
+
+    with_transaction(
+        &mut ctx,
+        &mut meta,
+        snapshot_details,
+        DryRun::No,
+        |mut tx| {
+            let dropped_changes = tx.discard_workspace_changes(changes)?;
+            assert!(
+                dropped_changes.is_empty(),
+                "all matching worktree changes should be discarded"
+            );
+
+            Ok(())
+        },
+    )
+    .unwrap();
+
+    snapbox::assert_data_eq!(env.git_status().unwrap(), snapbox::str![[r#""#]]);
+
+    snapbox::assert_data_eq!(
+        env.git_log().unwrap(),
+        snapbox::str![[r#"
+* ebaef69 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 1e25c58 (branch) add file-three
+* 9b3b3d5 add file-two
+* dbdbcea add file-one
 * 6674d4f (origin/main, origin/HEAD, main, gitbutler/target) add random-file
 
 "#]]

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -872,7 +872,18 @@ fn print_assignments(
         };
 
         if unstaged {
-            output.unassigned_file(Vec::from([Span::raw("┊   ")]), file_line, file_cli_id)?;
+            output.unassigned_file(
+                Vec::from([
+                    Span::raw("┊"),
+                    // The way we render checkmarks next to marked uncommitted files requires there
+                    // being at least three connector spans. Therefore we bread the padding up into
+                    // separate spans.
+                    Span::raw(" "),
+                    Span::raw("  "),
+                ]),
+                file_line,
+                file_cli_id,
+            )?;
         } else {
             output.staged_file(Vec::from([Span::raw("┊  │ ")]), file_line, file_cli_id)?;
         }

--- a/crates/but/src/command/legacy/status/tui/cursor/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/mod.rs
@@ -13,6 +13,7 @@ use crate::{
             render::{commit_operation_display, move_operation_display},
         },
     },
+    id::UncommittedCliId,
 };
 
 #[cfg(test)]
@@ -92,25 +93,60 @@ impl Cursor {
         lines: &[StatusOutputLine],
         discarded_commits: &[gix::ObjectId],
     ) -> Option<SelectAfterReload> {
-        if self.0 >= lines.len() {
-            return None;
-        }
+        self.select_after_discarded_marks(lines, discarded_commits, &[])
+    }
 
-        if let Some(CliId::Commit { commit_id, .. }) = lines[self.0].data.cli_id().map(|id| &**id)
-            && !discarded_commits.contains(commit_id)
+    /// Selects what should be focused after discarding marked commits and uncommitted files.
+    pub(super) fn select_after_discarded_marks(
+        self,
+        lines: &[StatusOutputLine],
+        discarded_commits: &[gix::ObjectId],
+        discarded_uncommitted: &[UncommittedCliId],
+    ) -> Option<SelectAfterReload> {
+        let current = lines.get(self.0)?;
+
+        if let Some(cli_id) = current.data.cli_id()
+            && matches!(&**cli_id, CliId::Commit { .. } | CliId::Uncommitted(..))
+            && !is_discarded_cli_id(cli_id, discarded_commits, discarded_uncommitted)
         {
-            return Some(SelectAfterReload::Commit(*commit_id));
+            return select_after_reload_for_cli_id(cli_id);
         }
 
+        if matches!(
+            current.data.cli_id().map(|id| &**id),
+            Some(CliId::Commit { .. })
+        ) {
+            return self.select_after_discarded_marks_in_commit_section(
+                lines,
+                discarded_commits,
+                discarded_uncommitted,
+            );
+        }
+
+        self.select_after_discarded_marks_in_file_section(
+            lines,
+            discarded_commits,
+            discarded_uncommitted,
+        )
+    }
+
+    fn select_after_discarded_marks_in_commit_section(
+        self,
+        lines: &[StatusOutputLine],
+        discarded_commits: &[gix::ObjectId],
+        discarded_uncommitted: &[UncommittedCliId],
+    ) -> Option<SelectAfterReload> {
         for line in lines.iter().skip(self.0 + 1) {
             if is_discard_commit_boundary(line) {
                 break;
             }
 
-            if let Some(CliId::Commit { commit_id, .. }) = line.data.cli_id().map(|id| &**id)
-                && !discarded_commits.contains(commit_id)
+            if let Some(cli_id) = line.data.cli_id()
+                && !is_discarded_cli_id(cli_id, discarded_commits, discarded_uncommitted)
+                && let Some(target @ SelectAfterReload::Commit(_)) =
+                    select_after_reload_for_cli_id(cli_id)
             {
-                return Some(SelectAfterReload::Commit(*commit_id));
+                return Some(target);
             }
         }
 
@@ -119,10 +155,12 @@ impl Cursor {
                 break;
             }
 
-            if let Some(CliId::Commit { commit_id, .. }) = line.data.cli_id().map(|id| &**id)
-                && !discarded_commits.contains(commit_id)
+            if let Some(cli_id) = line.data.cli_id()
+                && !is_discarded_cli_id(cli_id, discarded_commits, discarded_uncommitted)
+                && let Some(target @ SelectAfterReload::Commit(_)) =
+                    select_after_reload_for_cli_id(cli_id)
             {
-                return Some(SelectAfterReload::Commit(*commit_id));
+                return Some(target);
             }
         }
 
@@ -133,6 +171,52 @@ impl Cursor {
 
             if is_discard_commit_boundary(line) {
                 break;
+            }
+        }
+
+        None
+    }
+
+    fn select_after_discarded_marks_in_file_section(
+        self,
+        lines: &[StatusOutputLine],
+        discarded_commits: &[gix::ObjectId],
+        discarded_uncommitted: &[UncommittedCliId],
+    ) -> Option<SelectAfterReload> {
+        for line in lines.iter().skip(self.0 + 1) {
+            if is_discard_file_boundary(line) {
+                break;
+            }
+
+            if let Some(cli_id) = line.data.cli_id()
+                && !is_discarded_cli_id(cli_id, discarded_commits, discarded_uncommitted)
+                && let Some(target) = select_after_reload_for_cli_id(cli_id)
+            {
+                return Some(target);
+            }
+        }
+
+        for line in lines.iter().take(self.0).rev() {
+            if is_discard_file_boundary(line) {
+                break;
+            }
+
+            if let Some(cli_id) = line.data.cli_id()
+                && !is_discarded_cli_id(cli_id, discarded_commits, discarded_uncommitted)
+                && let Some(target) = select_after_reload_for_cli_id(cli_id)
+            {
+                return Some(target);
+            }
+        }
+
+        for line in lines.iter().take(self.0 + 1).rev() {
+            match &line.data {
+                StatusOutputLineData::Branch { cli_id }
+                | StatusOutputLineData::StagedChanges { cli_id }
+                | StatusOutputLineData::UnassignedChanges { cli_id } => {
+                    return Some(SelectAfterReload::CliId(Arc::clone(cli_id)));
+                }
+                _ => {}
             }
         }
 
@@ -515,6 +599,34 @@ fn first_selectable_in_section(
         .map(|(idx, _)| idx)
 }
 
+fn select_after_reload_for_cli_id(cli_id: &Arc<CliId>) -> Option<SelectAfterReload> {
+    match &**cli_id {
+        CliId::Commit { commit_id, .. } => Some(SelectAfterReload::Commit(*commit_id)),
+        CliId::Branch { name, .. } => Some(SelectAfterReload::Branch(name.clone())),
+        CliId::Unassigned { .. } => Some(SelectAfterReload::Unassigned),
+        CliId::Stack { stack_id, .. } => Some(SelectAfterReload::Stack(*stack_id)),
+        CliId::Uncommitted(..) | CliId::PathPrefix { .. } | CliId::CommittedFile { .. } => {
+            Some(SelectAfterReload::CliId(Arc::clone(cli_id)))
+        }
+    }
+}
+
+fn is_discarded_cli_id(
+    cli_id: &CliId,
+    discarded_commits: &[gix::ObjectId],
+    discarded_uncommitted: &[UncommittedCliId],
+) -> bool {
+    match cli_id {
+        CliId::Commit { commit_id, .. } => discarded_commits.contains(commit_id),
+        CliId::Uncommitted(uncommitted) => discarded_uncommitted.contains(uncommitted),
+        CliId::PathPrefix { .. }
+        | CliId::CommittedFile { .. }
+        | CliId::Branch { .. }
+        | CliId::Unassigned { .. }
+        | CliId::Stack { .. } => false,
+    }
+}
+
 /// Returns true if a line marks the boundary of a commit list within a branch section.
 fn is_discard_commit_boundary(line: &StatusOutputLine) -> bool {
     match &line.data {
@@ -535,6 +647,18 @@ fn is_discard_commit_boundary(line: &StatusOutputLine) -> bool {
         | StatusOutputLineData::Hint
         | StatusOutputLineData::NoAssignmentsUnstaged => false,
     }
+}
+
+/// Returns true if a line marks the boundary of an uncommitted file list.
+fn is_discard_file_boundary(line: &StatusOutputLine) -> bool {
+    matches!(
+        line.data,
+        StatusOutputLineData::Branch { .. }
+            | StatusOutputLineData::StagedChanges { .. }
+            | StatusOutputLineData::UnassignedChanges { .. }
+            | StatusOutputLineData::MergeBase
+            | StatusOutputLineData::Commit { .. }
+    )
 }
 
 /// Returns true if a line is a section header row.

--- a/crates/but/src/command/legacy/status/tui/cursor/tests.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/tests.rs
@@ -1,7 +1,10 @@
 use std::sync::Arc;
 
+use bstr::BString;
 use but_core::ref_metadata::StackId;
+use but_hunk_assignment::HunkAssignment;
 use but_workspace::commit::squash_commits::MessageCombinationStrategy;
+use nonempty::NonEmpty;
 use ratatui_textarea::TextArea;
 
 use super::{Cursor, is_selectable_in_mode};
@@ -16,6 +19,7 @@ use crate::{
             mode::UnassignedCommitSource,
         },
     },
+    id::UncommittedCliId,
 };
 
 fn line(data: StatusOutputLineData) -> StatusOutputLine {
@@ -46,6 +50,30 @@ fn committed_file_cli_id(hex: &str, path: &str, id: &str) -> Arc<CliId> {
         commit_id: commit_id(hex),
         path: path.into(),
         id: id.into(),
+    })
+}
+
+fn uncommitted_cli_id(path: &str, id: &str, stack_id: Option<StackId>) -> UncommittedCliId {
+    UncommittedCliId {
+        id: id.into(),
+        hunk_assignments: NonEmpty::new(HunkAssignment {
+            id: None,
+            hunk_header: None,
+            path: path.into(),
+            path_bytes: BString::from(path),
+            stack_id,
+            branch_ref_bytes: None,
+            line_nums_added: None,
+            line_nums_removed: None,
+            diff: None,
+        }),
+        is_entire_file: true,
+    }
+}
+
+fn uncommitted_line(path: &str, id: &str, stack_id: Option<StackId>) -> StatusOutputLine {
+    line(StatusOutputLineData::File {
+        cli_id: Arc::new(CliId::Uncommitted(uncommitted_cli_id(path, id, stack_id))),
     })
 }
 
@@ -466,6 +494,121 @@ fn select_after_discarded_commits_selects_branch_when_all_commits_in_section_are
         Cursor(1).select_after_discarded_commits(&lines, &[commit_id(top), commit_id(bottom)]),
         Some(SelectAfterReload::CliId(cli_id))
             if matches!(&*cli_id, CliId::Branch { id, .. } if id == "b0")
+    ));
+}
+
+#[test]
+fn select_after_discarded_marks_selects_unmarked_uncommitted_file_below() {
+    let marked = uncommitted_cli_id("marked.txt", "u0", None);
+    let lines = vec![
+        line(StatusOutputLineData::UnassignedChanges {
+            cli_id: unassigned("zz"),
+        }),
+        uncommitted_line("marked.txt", "u0", None),
+        uncommitted_line("below.txt", "u1", None),
+    ];
+
+    assert!(matches!(
+        Cursor(1).select_after_discarded_marks(&lines, &[], &[marked]),
+        Some(SelectAfterReload::CliId(cli_id))
+            if matches!(&*cli_id, CliId::Uncommitted(uncommitted)
+                if uncommitted.hunk_assignments.first().path_bytes == "below.txt")
+    ));
+}
+
+#[test]
+fn select_after_discarded_marks_skips_marked_uncommitted_files_below() {
+    let top = uncommitted_cli_id("top.txt", "u0", None);
+    let marked = uncommitted_cli_id("marked.txt", "u1", None);
+    let lines = vec![
+        line(StatusOutputLineData::UnassignedChanges {
+            cli_id: unassigned("zz"),
+        }),
+        uncommitted_line("top.txt", "u0", None),
+        uncommitted_line("marked.txt", "u1", None),
+        uncommitted_line("below.txt", "u2", None),
+    ];
+
+    assert!(matches!(
+        Cursor(1).select_after_discarded_marks(&lines, &[], &[top, marked]),
+        Some(SelectAfterReload::CliId(cli_id))
+            if matches!(&*cli_id, CliId::Uncommitted(uncommitted)
+                if uncommitted.hunk_assignments.first().path_bytes == "below.txt")
+    ));
+}
+
+#[test]
+fn select_after_discarded_marks_selects_uncommitted_file_above_when_no_unmarked_file_below() {
+    let marked = uncommitted_cli_id("marked.txt", "u1", None);
+    let bottom = uncommitted_cli_id("bottom.txt", "u2", None);
+    let lines = vec![
+        line(StatusOutputLineData::UnassignedChanges {
+            cli_id: unassigned("zz"),
+        }),
+        uncommitted_line("above.txt", "u0", None),
+        uncommitted_line("marked.txt", "u1", None),
+        uncommitted_line("bottom.txt", "u2", None),
+    ];
+
+    assert!(matches!(
+        Cursor(2).select_after_discarded_marks(&lines, &[], &[marked, bottom]),
+        Some(SelectAfterReload::CliId(cli_id))
+            if matches!(&*cli_id, CliId::Uncommitted(uncommitted)
+                if uncommitted.hunk_assignments.first().path_bytes == "above.txt")
+    ));
+}
+
+#[test]
+fn select_after_discarded_marks_selects_section_header_when_all_uncommitted_files_discarded() {
+    let top = uncommitted_cli_id("top.txt", "u0", None);
+    let bottom = uncommitted_cli_id("bottom.txt", "u1", None);
+    let lines = vec![
+        line(StatusOutputLineData::UnassignedChanges {
+            cli_id: unassigned("zz"),
+        }),
+        uncommitted_line("top.txt", "u0", None),
+        uncommitted_line("bottom.txt", "u1", None),
+    ];
+
+    assert!(matches!(
+        Cursor(1).select_after_discarded_marks(&lines, &[], &[top, bottom]),
+        Some(SelectAfterReload::CliId(cli_id))
+            if matches!(&*cli_id, CliId::Unassigned { .. })
+    ));
+}
+
+#[test]
+fn select_after_discarded_marks_skips_mixed_discarded_items() {
+    let marked_file = uncommitted_cli_id("marked.txt", "u0", None);
+    let marked_commit = "1111111111111111111111111111111111111111";
+    let target_commit = "2222222222222222222222222222222222222222";
+    let lines = vec![
+        line(StatusOutputLineData::Branch {
+            cli_id: branch_cli_id("main", "b0", None),
+        }),
+        line(StatusOutputLineData::Commit {
+            cli_id: commit_cli_id(marked_commit, "c0"),
+            stack_id: None,
+            classification: CommitClassification::LocalOnly,
+        }),
+        line(StatusOutputLineData::Commit {
+            cli_id: commit_cli_id(target_commit, "c1"),
+            stack_id: None,
+            classification: CommitClassification::LocalOnly,
+        }),
+        line(StatusOutputLineData::UnassignedChanges {
+            cli_id: unassigned("zz"),
+        }),
+        uncommitted_line("marked.txt", "u0", None),
+    ];
+
+    assert!(matches!(
+        Cursor(1).select_after_discarded_marks(
+            &lines,
+            &[commit_id(marked_commit)],
+            &[marked_file],
+        ),
+        Some(SelectAfterReload::Commit(target)) if target == commit_id(target_commit)
     ));
 }
 

--- a/crates/but/src/command/legacy/status/tui/marking.rs
+++ b/crates/but/src/command/legacy/status/tui/marking.rs
@@ -1,15 +1,18 @@
-use std::collections::HashSet;
+use std::collections::HashMap;
 
-use crate::{CliId, id::ShortId};
+use crate::{
+    CliId,
+    id::{ShortId, UncommittedCliId},
+};
 
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone)]
 pub(super) struct Marks {
-    marks: HashSet<Markable>,
+    marks: HashMap<ShortId, Markable>,
 }
 
 impl Marks {
     pub(super) fn toggle(&mut self, markable: Markable) {
-        if self.marks.contains(&markable) {
+        if self.marks.contains_key(markable.short_id()) {
             self.remove(&markable);
         } else {
             self.insert(markable);
@@ -17,11 +20,11 @@ impl Marks {
     }
 
     pub(super) fn insert(&mut self, markable: Markable) {
-        self.marks.insert(markable);
+        self.marks.insert(markable.short_id().to_owned(), markable);
     }
 
     pub(super) fn remove(&mut self, markable: &Markable) {
-        self.marks.remove(markable);
+        self.marks.remove(markable.short_id());
     }
 
     pub(super) fn clear(&mut self) {
@@ -37,29 +40,21 @@ impl Marks {
     }
 
     pub(super) fn contains(&self, markable: &Markable) -> bool {
-        self.marks.contains(markable)
+        self.marks.contains_key(markable.short_id())
     }
 
     pub(super) fn iter(&self) -> impl Iterator<Item = &Markable> {
-        self.into_iter()
+        self.marks.values()
     }
 }
 
-impl<'a> IntoIterator for &'a Marks {
-    type Item = <&'a HashSet<Markable> as IntoIterator>::Item;
-    type IntoIter = <&'a HashSet<Markable> as IntoIterator>::IntoIter;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.marks.iter()
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq)]
 pub(super) enum Markable {
     Commit {
         commit_id: gix::ObjectId,
         id: ShortId,
     },
+    Uncommitted(UncommittedCliId),
 }
 
 impl Markable {
@@ -69,12 +64,26 @@ impl Markable {
                 commit_id: *commit_id,
                 id: id.clone(),
             }),
-            CliId::Uncommitted(..)
-            | CliId::PathPrefix { .. }
+            CliId::Uncommitted(uncommitted) => Some(Self::Uncommitted(uncommitted.clone())),
+            CliId::PathPrefix { .. }
             | CliId::CommittedFile { .. }
             | CliId::Branch { .. }
             | CliId::Unassigned { .. }
             | CliId::Stack { .. } => None,
+        }
+    }
+
+    fn short_id(&self) -> &ShortId {
+        match self {
+            Markable::Commit { id, .. } => id,
+            Markable::Uncommitted(uncommitted_cli_id) => &uncommitted_cli_id.id,
+        }
+    }
+
+    pub(super) fn into_cli_id(self) -> CliId {
+        match self {
+            Markable::Commit { commit_id, id } => CliId::Commit { commit_id, id },
+            Markable::Uncommitted(uncommitted_cli_id) => CliId::Uncommitted(uncommitted_cli_id),
         }
     }
 }

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -2874,10 +2874,15 @@ impl App {
                     handle_mark_branch(&mut normal_mode.marks, ctx, stack_id, name)?;
                 }
             }
-            CliId::PathPrefix { .. }
-            | CliId::CommittedFile { .. }
-            | CliId::Unassigned { .. }
-            | CliId::Stack { .. } => {}
+            CliId::Unassigned { .. } => {
+                if let Mode::Normal(normal_mode) = self
+                    .mode
+                    .get_mut_without_updating_backstack_and_i_promise_not_to_change_state()
+                {
+                    handle_mark_unassigned(&mut normal_mode.marks, ctx)?;
+                }
+            }
+            CliId::PathPrefix { .. } | CliId::CommittedFile { .. } | CliId::Stack { .. } => {}
         }
 
         if let Some(marks) = self.marks() {
@@ -3143,27 +3148,7 @@ fn handle_mark_branch(
         return Ok(());
     };
 
-    let (marked, unmarked) = commits
-        .into_iter()
-        .partition::<Vec<_>, _>(|commit| marks.contains(commit));
-
-    match (marked.is_empty(), unmarked.is_empty()) {
-        (true, false) => {
-            for commit in unmarked {
-                marks.insert(commit);
-            }
-        }
-        (false, true) => {
-            for commit in marked {
-                marks.remove(&commit);
-            }
-        }
-        _ => {
-            for commit in unmarked {
-                marks.insert(commit);
-            }
-        }
-    }
+    toggle_marks_section(marks, commits);
 
     Ok(())
 }
@@ -3195,6 +3180,49 @@ fn commits_on_branch(
         .collect::<Vec<_>>();
 
     Ok(commits)
+}
+
+fn handle_mark_unassigned(marks: &mut Marks, ctx: &Context) -> anyhow::Result<()> {
+    let guard = ctx.shared_worktree_access();
+    let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
+
+    let Some(ids) = id_map
+        .uncommitted_files
+        .values()
+        .filter(|uncommitted_file| uncommitted_file.stack_id().is_none())
+        .map(|uncommitted_file| Markable::try_from_cli_id(&uncommitted_file.to_id()))
+        .collect::<Option<Vec<_>>>()
+    else {
+        return Ok(());
+    };
+
+    toggle_marks_section(marks, ids);
+
+    Ok(())
+}
+
+fn toggle_marks_section(marks: &mut Marks, markables: Vec<Markable>) {
+    let (marked, unmarked) = markables
+        .into_iter()
+        .partition::<Vec<_>, _>(|mark| marks.contains(mark));
+
+    match (marked.is_empty(), unmarked.is_empty()) {
+        (true, false) => {
+            for mark in unmarked {
+                marks.insert(mark);
+            }
+        }
+        (false, true) => {
+            for mark in marked {
+                marks.remove(&mark);
+            }
+        }
+        _ => {
+            for mark in unmarked {
+                marks.insert(mark);
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, strum::EnumDiscriminants)]

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -1018,12 +1018,8 @@ impl App {
             RubSource::Marks(marks) => {
                 let marks = marks
                     .iter()
-                    .map(|mark| match mark {
-                        Markable::Commit { commit_id, id } => CliId::Commit {
-                            commit_id: *commit_id,
-                            id: id.clone(),
-                        },
-                    })
+                    .cloned()
+                    .map(|mark| mark.into_cli_id())
                     .collect::<Vec<_>>();
                 self.status_lines
                     .iter()
@@ -1058,8 +1054,8 @@ impl App {
                 }
             }
             RubSource::Marks(marks) => {
-                for mark in marks {
-                    if !rub::mark_supports_rubbing(mark) {
+                for mark in marks.iter() {
+                    if !rub::mark_supports_being_the_rub_source(mark) {
                         return;
                     }
                 }
@@ -1290,9 +1286,7 @@ impl App {
                 let sources = marks
                     .iter()
                     .cloned()
-                    .map(|markable| match markable {
-                        Markable::Commit { commit_id, id } => CliId::Commit { commit_id, id },
-                    })
+                    .map(|mark| mark.into_cli_id())
                     .filter(|source| source != &**target)
                     .collect::<Vec<_>>();
                 let mut iter = sources.iter();
@@ -1486,12 +1480,34 @@ impl App {
                         NonEmpty::new(format!("Discard {}?", uncommitted.describe()).into()),
                         self.theme,
                         move |ctx, messages| {
-                            let hunk_assignments = uncommitted
-                                .hunk_assignments
-                                .iter()
-                                .cloned()
-                                .collect::<Vec<_>>();
-                            operations::discard_uncommitted_legacy(ctx, hunk_assignments)?;
+                            let mut meta = ctx.meta()?;
+                            let snapshot_details = SnapshotDetails::new(OperationKind::Discard);
+                            but_transaction::with_transaction(
+                                ctx,
+                                &mut meta,
+                                snapshot_details,
+                                DryRun::No,
+                                |mut tx| {
+                                    let addition_or_deletion_paths = {
+                                        let repo = tx.repo();
+                                        let changes =
+                                            but_core::diff::ui::worktree_changes(repo)?.changes;
+                                        operations::addition_or_deletion_paths(&changes)
+                                    };
+                                    let maybe_rollback =
+                                        if operations::discard_uncommitted_legacy_with_paths_tx(
+                                            &mut tx,
+                                            &uncommitted.hunk_assignments,
+                                            &addition_or_deletion_paths,
+                                        )? {
+                                            None
+                                        } else {
+                                            Some(tx.rollback(()))
+                                        };
+                                    Ok(maybe_rollback)
+                                },
+                            )?;
+
                             messages.push(Message::Reload(
                                 Some(select_after_reload),
                                 ReloadCause::Mutation,
@@ -1626,42 +1642,61 @@ impl App {
         let commits = normal_mode
             .marks
             .iter()
-            .map(|mark| match mark {
-                Markable::Commit { commit_id, .. } => *commit_id,
+            .filter_map(|mark| match mark {
+                Markable::Commit { commit_id, .. } => Some(*commit_id),
+                Markable::Uncommitted(..) => None,
+            })
+            .collect::<Vec<_>>();
+
+        let uncommitted = normal_mode
+            .marks
+            .iter()
+            .filter_map(|mark| match mark {
+                Markable::Uncommitted(uncommitted) => Some(uncommitted.clone()),
+                Markable::Commit { .. } => None,
             })
             .collect::<Vec<_>>();
 
         self.to_be_discarded = normal_mode
             .marks
             .iter()
-            .map(|mark| match mark {
-                Markable::Commit { commit_id, id } => Arc::new(CliId::Commit {
-                    commit_id: *commit_id,
-                    id: id.clone(),
-                }),
-            })
+            .map(|mark| Arc::new(mark.clone().into_cli_id()))
             .collect::<Vec<_>>();
 
-        let select_after_reload = self
-            .cursor
-            .select_after_discarded_commits(&self.status_lines, &commits);
+        let select_after_reload =
+            self.cursor
+                .select_after_discarded_marks(&self.status_lines, &commits, &uncommitted);
 
         let drop_to_be_discarded =
             message_on_drop::message_on_drop(Message::DropToBeDiscarded, messages);
 
-        let confirm = Confirm::new(
-            NonEmpty::new(
-                if commits.len() == 1 {
-                    "Discard 1 commit?".to_owned()
+        let discard_message: Cow<'_, str> = match (commits.len(), uncommitted.len()) {
+            (0, 0) => {
+                return Ok(());
+            }
+            (n, 0) => {
+                if n == 1 {
+                    "Discard 1 commit?".to_owned().into()
                 } else {
-                    format!("Discard {} commits?", commits.len())
+                    format!("Discard {n} commits?").into()
                 }
-                .into(),
-            ),
+            }
+            (0, n) => {
+                if n == 1 {
+                    "Discard 1 uncommitted file?".to_owned().into()
+                } else {
+                    format!("Discard {n} uncommitted files?").into()
+                }
+            }
+            _ => "Discard?".into(),
+        };
+
+        let confirm = Confirm::new(
+            NonEmpty::new(discard_message.into()),
             self.theme,
             move |ctx, messages| {
                 let mut meta = ctx.meta()?;
-                let snapshot_details = SnapshotDetails::new(OperationKind::DiscardCommit);
+                let snapshot_details = SnapshotDetails::new(OperationKind::Discard);
                 let workspace = but_transaction::with_transaction(
                     ctx,
                     &mut meta,
@@ -1670,6 +1705,21 @@ impl App {
                     |mut tx| {
                         if !commits.is_empty() {
                             tx.discard_commits(commits)?;
+                        }
+                        if !uncommitted.is_empty() {
+                            let addition_or_deletion_paths = {
+                                let repo = tx.repo();
+                                let changes = but_core::diff::ui::worktree_changes(repo)?.changes;
+                                operations::addition_or_deletion_paths(&changes)
+                            };
+
+                            for id in uncommitted {
+                                operations::discard_uncommitted_legacy_with_paths_tx(
+                                    &mut tx,
+                                    &id.hunk_assignments,
+                                    &addition_or_deletion_paths,
+                                )?;
+                            }
                         }
                         Ok(())
                     },
@@ -2797,8 +2847,8 @@ impl App {
         };
 
         match &**selection {
-            CliId::Commit { .. } => {
-                if handle_mark_commit(
+            CliId::Commit { .. } | CliId::Uncommitted(..) => {
+                if handle_mark_cli_id(
                     selection,
                     self.mode
                         .get_mut_without_updating_backstack_and_i_promise_not_to_change_state(),
@@ -2824,8 +2874,7 @@ impl App {
                     handle_mark_branch(&mut normal_mode.marks, ctx, stack_id, name)?;
                 }
             }
-            CliId::Uncommitted(..)
-            | CliId::PathPrefix { .. }
+            CliId::PathPrefix { .. }
             | CliId::CommittedFile { .. }
             | CliId::Unassigned { .. }
             | CliId::Stack { .. } => {}
@@ -3009,7 +3058,7 @@ fn event_to_messages(
     }
 }
 
-fn handle_mark_commit(commit: &CliId, mode: &mut Mode) -> bool {
+fn handle_mark_cli_id(commit: &CliId, mode: &mut Mode) -> bool {
     let Some(markable) = Markable::try_from_cli_id(commit) else {
         return false;
     };
@@ -3047,24 +3096,13 @@ fn handle_mark_commit(commit: &CliId, mode: &mut Mode) -> bool {
                     marks.toggle(markable.clone());
 
                     match marks.len() {
-                        0 => match markable {
-                            Markable::Commit { commit_id, id } => {
-                                rub_mode.source =
-                                    RubSource::CliId(Arc::new(CliId::Commit { commit_id, id }))
-                            }
-                        },
+                        0 => {
+                            rub_mode.source = RubSource::CliId(Arc::new(markable.into_cli_id()));
+                        }
                         1 => {
                             let only_remaining_mark = marks.iter().next().cloned();
                             if let Some(mark) = only_remaining_mark {
-                                match mark {
-                                    Markable::Commit { commit_id, id } => {
-                                        rub_mode.source =
-                                            RubSource::CliId(Arc::new(CliId::Commit {
-                                                commit_id,
-                                                id,
-                                            }))
-                                    }
-                                }
+                                rub_mode.source = RubSource::CliId(Arc::new(mark.into_cli_id()));
                             }
                         }
                         _ => {

--- a/crates/but/src/command/legacy/status/tui/mode.rs
+++ b/crates/but/src/command/legacy/status/tui/mode.rs
@@ -112,7 +112,7 @@ pub(super) struct RubMode {
     pub(super) _unlock_details: Option<MessageOnDrop>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub(super) enum RubSource {
     Marks(Marks),
     CliId(Arc<CliId>),

--- a/crates/but/src/command/legacy/status/tui/operations.rs
+++ b/crates/but/src/command/legacy/status/tui/operations.rs
@@ -15,7 +15,7 @@ use but_core::{DiffSpec, DryRun, diff::CommitDetails, ref_metadata::StackId};
 use but_ctx::Context;
 use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
 use gitbutler_operating_modes::OperatingMode;
-use gitbutler_oplog::entry::Snapshot;
+use gitbutler_oplog::entry::{OperationKind, Snapshot, SnapshotDetails};
 
 use crate::{
     CliId,
@@ -467,7 +467,12 @@ fn discard_uncommitted_legacy_with_paths(
         return Ok(());
     }
 
-    but_api::legacy::workspace::discard_worktree_changes(ctx, changes_to_discard)?;
+    let mut meta = ctx.meta()?;
+    let snapshot_details = SnapshotDetails::new(OperationKind::UndoCommit);
+    but_transaction::with_transaction(ctx, &mut meta, snapshot_details, DryRun::No, |mut tx| {
+        tx.discard_workspace_changes(changes_to_discard)?;
+        Ok(())
+    })?;
 
     Ok(())
 }
@@ -513,7 +518,12 @@ pub(super) fn discard_unassigned_legacy(ctx: &mut Context) -> anyhow::Result<()>
         return Ok(());
     }
 
-    but_api::legacy::workspace::discard_worktree_changes(ctx, unassigned_changes)?;
+    let mut meta = ctx.meta()?;
+    let snapshot_details = SnapshotDetails::new(OperationKind::UndoCommit);
+    but_transaction::with_transaction(ctx, &mut meta, snapshot_details, DryRun::No, |mut tx| {
+        tx.discard_workspace_changes(unassigned_changes)?;
+        Ok(())
+    })?;
 
     Ok(())
 }

--- a/crates/but/src/command/legacy/status/tui/operations.rs
+++ b/crates/but/src/command/legacy/status/tui/operations.rs
@@ -11,7 +11,7 @@ use but_api::{
     diff::ComputeLineStats,
     legacy::oplog::RestoreKind,
 };
-use but_core::{DiffSpec, DryRun, diff::CommitDetails, ref_metadata::StackId};
+use but_core::{DiffSpec, DryRun, RefMetadata, diff::CommitDetails, ref_metadata::StackId};
 use but_ctx::Context;
 use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
 use gitbutler_operating_modes::OperatingMode;
@@ -410,7 +410,7 @@ pub(super) fn reword_branch_legacy(
 }
 
 /// Collect paths whose worktree status is either addition or deletion.
-fn addition_or_deletion_paths(
+pub(super) fn addition_or_deletion_paths(
     changes: &[but_core::ui::TreeChange],
 ) -> std::collections::HashSet<Vec<u8>> {
     changes
@@ -431,8 +431,8 @@ fn addition_or_deletion_paths(
 }
 
 /// Convert hunk assignments to diff specs, using whole-file mode for additions/deletions.
-fn diff_specs_from_assignments(
-    assignments: impl IntoIterator<Item = but_hunk_assignment::HunkAssignment>,
+pub(super) fn diff_specs_from_assignments<'a>(
+    assignments: impl IntoIterator<Item = &'a but_hunk_assignment::HunkAssignment>,
     addition_or_deletion_paths: &std::collections::HashSet<Vec<u8>>,
 ) -> Vec<DiffSpec> {
     assignments
@@ -443,7 +443,7 @@ fn diff_specs_from_assignments(
 
             DiffSpec {
                 previous_path: None,
-                path: assignment.path_bytes,
+                path: assignment.path_bytes.clone(),
                 hunk_headers: if is_addition_or_deletion {
                     Vec::new()
                 } else {
@@ -454,40 +454,21 @@ fn diff_specs_from_assignments(
         .collect()
 }
 
-/// Discard uncommitted assignments with precomputed addition/deletion paths.
-fn discard_uncommitted_legacy_with_paths(
-    ctx: &mut Context,
-    hunk_assignments: Vec<but_hunk_assignment::HunkAssignment>,
+pub(super) fn discard_uncommitted_legacy_with_paths_tx<'a>(
+    tx: &mut but_transaction::Transaction<'_, '_, impl RefMetadata>,
+    hunk_assignments: impl IntoIterator<Item = &'a but_hunk_assignment::HunkAssignment>,
     addition_or_deletion_paths: &std::collections::HashSet<Vec<u8>>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<bool> {
     let changes_to_discard =
         diff_specs_from_assignments(hunk_assignments, addition_or_deletion_paths);
 
     if changes_to_discard.is_empty() {
-        return Ok(());
+        return Ok(false);
     }
 
-    let mut meta = ctx.meta()?;
-    let snapshot_details = SnapshotDetails::new(OperationKind::UndoCommit);
-    but_transaction::with_transaction(ctx, &mut meta, snapshot_details, DryRun::No, |mut tx| {
-        tx.discard_workspace_changes(changes_to_discard)?;
-        Ok(())
-    })?;
+    tx.discard_workspace_changes(changes_to_discard)?;
 
-    Ok(())
-}
-
-pub(super) fn discard_uncommitted_legacy(
-    ctx: &mut Context,
-    hunk_assignments: Vec<but_hunk_assignment::HunkAssignment>,
-) -> anyhow::Result<()> {
-    let addition_or_deletion_paths = {
-        let repo = ctx.repo.get()?;
-        let changes = but_core::diff::ui::worktree_changes(&repo)?.changes;
-        addition_or_deletion_paths(&changes)
-    };
-
-    discard_uncommitted_legacy_with_paths(ctx, hunk_assignments, &addition_or_deletion_paths)
+    Ok(true)
 }
 
 pub(super) fn discard_unassigned_legacy(ctx: &mut Context) -> anyhow::Result<()> {
@@ -511,7 +492,7 @@ pub(super) fn discard_unassigned_legacy(ctx: &mut Context) -> anyhow::Result<()>
             .filter(|assignment| assignment.stack_id.is_none())
             .collect::<Vec<_>>();
 
-        diff_specs_from_assignments(unassigned_assignments, &addition_or_deletion_paths)
+        diff_specs_from_assignments(&unassigned_assignments, &addition_or_deletion_paths)
     };
 
     if unassigned_changes.is_empty() {
@@ -519,7 +500,7 @@ pub(super) fn discard_unassigned_legacy(ctx: &mut Context) -> anyhow::Result<()>
     }
 
     let mut meta = ctx.meta()?;
-    let snapshot_details = SnapshotDetails::new(OperationKind::UndoCommit);
+    let snapshot_details = SnapshotDetails::new(OperationKind::Discard);
     but_transaction::with_transaction(ctx, &mut meta, snapshot_details, DryRun::No, |mut tx| {
         tx.discard_workspace_changes(unassigned_changes)?;
         Ok(())
@@ -551,7 +532,21 @@ pub(super) fn discard_stack(ctx: &mut Context, stack_id: StackId) -> anyhow::Res
         (stack_changes, addition_or_deletion_paths)
     };
 
-    discard_uncommitted_legacy_with_paths(ctx, stack_changes, &addition_or_deletion_paths)
+    let mut meta = ctx.meta()?;
+    let snapshot_details = SnapshotDetails::new(OperationKind::Discard);
+    but_transaction::with_transaction(ctx, &mut meta, snapshot_details, DryRun::No, |mut tx| {
+        if discard_uncommitted_legacy_with_paths_tx(
+            &mut tx,
+            &stack_changes,
+            &addition_or_deletion_paths,
+        )? {
+            Ok(None)
+        } else {
+            Ok(Some(tx.rollback(())))
+        }
+    })?;
+
+    Ok(())
 }
 
 pub(super) fn commit_discard(

--- a/crates/but/src/command/legacy/status/tui/rub.rs
+++ b/crates/but/src/command/legacy/status/tui/rub.rs
@@ -66,9 +66,10 @@ pub(super) fn supports_rubbing(id: &CliId) -> bool {
     }
 }
 
-pub(super) fn mark_supports_rubbing(mark: &Markable) -> bool {
+pub(super) fn mark_supports_being_the_rub_source(mark: &Markable) -> bool {
     match mark {
         Markable::Commit { .. } => true,
+        Markable::Uncommitted(..) => false,
     }
 }
 

--- a/crates/but/src/command/legacy/status/tui/tests/discard_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/discard_tests.rs
@@ -304,3 +304,20 @@ fn discard_multiple_commits() {
     tui.input_then_render(None)
         .assert_rendered_term_svg_eq(file!["snapshots/discard_multiple_commits_final.svg"]);
 }
+
+#[test]
+fn discard_uncommitted_file() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
+    env.setup_metadata(&[]).unwrap();
+
+    let mut tui = test_tui(env);
+
+    tui.env().file("file", "content");
+
+    tui.input_then_render(KeyCode::Down);
+    tui.input_then_render('x');
+    tui.input_then_render('y');
+
+    tui.input_then_render(None)
+        .assert_rendered_term_svg_eq(file!["snapshots/discard_uncommitted_final.svg"]);
+}

--- a/crates/but/src/command/legacy/status/tui/tests/discard_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/discard_tests.rs
@@ -321,3 +321,43 @@ fn discard_uncommitted_file() {
     tui.input_then_render(None)
         .assert_rendered_term_svg_eq(file!["snapshots/discard_uncommitted_final.svg"]);
 }
+
+#[test]
+fn discard_commit_and_uncommitted_file() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
+    env.setup_metadata(&[]).unwrap();
+
+    let mut tui = test_tui(env);
+
+    // create file and commit it on a new branch
+    tui.env().file("file-one", "content");
+    tui.input_then_render('c');
+    tui.input_then_render('e');
+    tui.input_then_render('b');
+
+    tui.env().file("file-two", "content");
+    tui.input_then_render('g');
+
+    // mark the file
+    tui.input_then_render(KeyCode::Down);
+    tui.input_then_render(' ');
+
+    // mark the commit
+    tui.input_then_render(KeyCode::Down);
+    tui.input_then_render(KeyCode::Down);
+    tui.input_then_render(' ');
+
+    tui.input_then_render(None)
+        .assert_rendered_term_svg_eq(file![
+            "snapshots/discard_commit_and_uncommitted_file_both_marked.svg"
+        ]);
+
+    // discard both
+    tui.input_then_render('x');
+    tui.input_then_render('y');
+
+    tui.input_then_render(None)
+        .assert_rendered_term_svg_eq(file![
+            "snapshots/discard_commit_and_uncommitted_file_final.svg"
+        ]);
+}

--- a/crates/but/src/command/legacy/status/tui/tests/discard_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/discard_tests.rs
@@ -361,3 +361,17 @@ fn discard_commit_and_uncommitted_file() {
             "snapshots/discard_commit_and_uncommitted_file_final.svg"
         ]);
 }
+
+#[test]
+fn marking_all_unassigned_files() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
+    env.setup_metadata(&[]).unwrap();
+
+    let mut tui = test_tui(env);
+
+    tui.env().file("file-one", "content");
+    tui.env().file("file-two", "content");
+
+    tui.input_then_render(' ')
+        .assert_rendered_term_svg_eq(file!["snapshots/marking_all_unassigned_files_final.svg"]);
+}

--- a/crates/but/src/command/legacy/status/tui/tests/rub_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/rub_tests.rs
@@ -517,3 +517,23 @@ fn rub_api_stack_to_stack_operation() {
     tui.input_then_render('r')
         .assert_current_line_eq(str!["┊╭┄h0 [B]"]);
 }
+
+#[test]
+fn cannot_yet_rub_multiple_uncommitted_files() {
+    // some day we will allow rubbing multiple uncommitted files
+
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
+    env.setup_metadata(&[]).unwrap();
+
+    let mut tui = test_tui(env);
+
+    tui.env().file("file-one", "content");
+    tui.env().file("file-two", "content");
+
+    tui.input_then_render(KeyCode::Down);
+    tui.input_then_render(' ');
+    tui.input_then_render(' ');
+
+    tui.input_then_render('r')
+        .assert_rendered_term_svg_eq(file!["snapshots/cannot_yet_rub_multiple_files_final.svg"]);
+}

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/cannot_yet_rub_multiple_files_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/cannot_yet_rub_multiple_files_final.svg
@@ -1,0 +1,365 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
+  <rect x="0" y="0" width="820" height="380" fill="#000000" />
+  <rect x="18" y="28" width="8" height="18" fill="#0000AA" />
+  <rect x="26" y="28" width="8" height="18" fill="#0000AA" />
+  <rect x="10" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="18" y="46" width="8" height="18" fill="#0000AA" />
+  <rect x="26" y="46" width="8" height="18" fill="#0000AA" />
+  <rect x="34" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="42" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="50" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="58" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="66" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="74" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="82" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="90" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="98" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="106" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="114" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="122" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="130" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="138" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="146" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="154" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="162" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="170" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="178" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="186" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="194" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="202" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="210" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="218" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="226" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="234" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="242" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="250" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="258" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="266" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="274" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="282" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="290" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="298" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="306" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="314" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="322" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="330" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="338" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="346" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="354" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="362" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="370" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="378" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="386" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="394" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="402" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="410" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="418" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="426" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="434" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="442" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="450" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="458" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="466" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="474" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="482" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="490" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="498" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="506" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="514" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="522" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="530" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="538" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="546" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="554" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="562" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="570" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="578" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="586" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="594" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="602" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="610" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="618" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="626" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="634" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="642" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="650" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="658" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="666" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="674" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="682" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="690" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="698" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="706" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="714" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="722" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="730" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="738" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="746" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="754" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="762" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="770" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="778" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="786" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="794" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="802" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="10" y="352" width="8" height="18" fill="#555555" />
+  <rect x="18" y="352" width="8" height="18" fill="#555555" />
+  <rect x="26" y="352" width="8" height="18" fill="#555555" />
+  <rect x="34" y="352" width="8" height="18" fill="#555555" />
+  <rect x="42" y="352" width="8" height="18" fill="#555555" />
+  <rect x="50" y="352" width="8" height="18" fill="#555555" />
+  <rect x="58" y="352" width="8" height="18" fill="#555555" />
+  <rect x="66" y="352" width="8" height="18" fill="#555555" />
+  <rect x="74" y="352" width="8" height="18" fill="#555555" />
+  <rect x="82" y="352" width="8" height="18" fill="#555555" />
+  <text x="10" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
+  <text x="18" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
+  <text x="26" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="34" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="50" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="58" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="66" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="74" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="82" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="90" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="98" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="106" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="114" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="122" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="130" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="146" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="154" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="162" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="178" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="186" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="194" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="202" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="10" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="42" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">✔︎</text>
+  <text x="42" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">y</text>
+  <text x="50" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="66" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="82" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="90" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="98" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="106" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="114" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="122" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="130" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="138" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="60" style="fill:#000000;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">✔︎</text>
+  <text x="42" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="50" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="66" y="60" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="82" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="90" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="98" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="106" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="114" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="122" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="130" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="138" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="10" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="10" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┴</text>
+  <text x="26" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="34" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="42" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="50" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="58" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
+  <text x="66" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="74" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="90" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
+  <text x="98" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="106" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="114" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="122" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="130" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="138" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="154" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="162" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="178" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="186" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
+  <text x="202" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="210" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="218" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="226" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="234" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="242" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="250" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="258" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="266" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="274" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="290" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="298" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="306" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="322" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
+  <text x="10" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="18" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="34" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="42" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="50" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="58" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="66" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="74" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="82" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="90" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="98" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="106" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="114" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="122" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="130" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="138" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="146" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="154" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="162" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="170" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="178" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="186" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="194" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="202" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="210" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="218" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="226" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="234" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="242" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="250" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="258" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="266" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="274" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="282" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="290" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="298" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="306" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="314" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="322" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="330" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="338" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="346" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="354" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="362" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="370" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="378" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="386" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="394" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="402" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="410" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="418" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="426" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="434" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="442" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="450" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="458" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="466" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="474" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="482" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="490" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="498" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="506" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="514" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="522" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="530" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="538" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="546" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="554" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="562" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="570" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="578" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="586" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="594" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="602" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="610" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="618" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="626" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="634" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="642" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="650" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="658" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="666" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="674" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="682" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="690" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="698" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="706" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="714" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="722" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="730" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="738" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="746" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="754" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="762" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="770" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="778" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="786" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="794" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="802" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="34" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="42" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="50" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="58" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="66" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="98" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↑</text>
+  <text x="106" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="114" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="130" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="138" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="154" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="170" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↓</text>
+  <text x="178" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="186" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">j</text>
+  <text x="202" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="210" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="218" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="226" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="242" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="258" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="274" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="282" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="290" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="306" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="322" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="338" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="346" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="354" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="362" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="370" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="378" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="386" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="402" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="418" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="434" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="442" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="450" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="458" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="466" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="482" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="490" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="498" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="506" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="514" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="522" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="530" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="546" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="562" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="578" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="586" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="594" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="602" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="610" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="626" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="642" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">?</text>
+  <text x="658" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="666" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="674" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="682" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="698" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="714" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="730" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="738" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="746" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="754" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+</svg>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_commit_and_uncommitted_file_both_marked.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_commit_and_uncommitted_file_both_marked.svg
@@ -1,0 +1,398 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
+  <rect x="0" y="0" width="820" height="380" fill="#000000" />
+  <rect x="18" y="28" width="8" height="18" fill="#0000AA" />
+  <rect x="26" y="28" width="8" height="18" fill="#0000AA" />
+  <rect x="10" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="18" y="82" width="8" height="18" fill="#0000AA" />
+  <rect x="26" y="82" width="8" height="18" fill="#0000AA" />
+  <rect x="34" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="42" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="50" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="58" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="66" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="74" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="82" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="90" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="98" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="106" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="114" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="122" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="130" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="138" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="146" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="154" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="162" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="170" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="178" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="186" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="194" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="202" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="210" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="218" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="226" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="234" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="242" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="250" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="258" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="266" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="274" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="282" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="290" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="298" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="306" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="314" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="322" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="330" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="338" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="346" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="354" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="362" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="370" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="378" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="386" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="394" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="402" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="410" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="418" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="426" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="434" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="442" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="450" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="458" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="466" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="474" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="482" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="490" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="498" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="506" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="514" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="522" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="530" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="538" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="546" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="554" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="562" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="570" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="578" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="586" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="594" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="602" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="610" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="618" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="626" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="634" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="642" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="650" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="658" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="666" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="674" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="682" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="690" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="698" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="706" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="714" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="722" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="730" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="738" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="746" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="754" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="762" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="770" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="778" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="786" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="794" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="802" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="10" y="352" width="8" height="18" fill="#555555" />
+  <rect x="18" y="352" width="8" height="18" fill="#555555" />
+  <rect x="26" y="352" width="8" height="18" fill="#555555" />
+  <rect x="34" y="352" width="8" height="18" fill="#555555" />
+  <rect x="42" y="352" width="8" height="18" fill="#555555" />
+  <rect x="50" y="352" width="8" height="18" fill="#555555" />
+  <rect x="58" y="352" width="8" height="18" fill="#555555" />
+  <rect x="66" y="352" width="8" height="18" fill="#555555" />
+  <rect x="74" y="352" width="8" height="18" fill="#555555" />
+  <rect x="82" y="352" width="8" height="18" fill="#555555" />
+  <text x="10" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
+  <text x="18" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
+  <text x="26" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="34" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="50" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="58" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="66" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="74" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="82" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="90" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="98" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="106" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="114" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="122" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="130" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="146" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="154" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="162" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="178" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="186" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="194" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="202" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="10" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="42" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">✔︎</text>
+  <text x="42" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="50" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="66" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="82" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="90" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="98" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="106" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="114" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="122" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="130" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="138" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="10" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="10" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
+  <text x="26" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
+  <text x="34" y="78" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="42" y="78" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="58" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="66" y="78" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="74" y="78" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="82" y="78" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="90" y="78" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="98" y="78" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="106" y="78" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="114" y="78" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="122" y="78" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="130" y="78" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="138" y="78" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="146" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="10" y="96" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="96" style="fill:#000000;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">✔︎</text>
+  <text x="50" y="96" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="58" y="96" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="66" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="74" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="82" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="90" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="114" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
+  <text x="122" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="130" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="146" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="154" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="162" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="170" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="178" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="186" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="202" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="210" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="218" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="226" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="234" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="242" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="250" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="258" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
+  <text x="10" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">├</text>
+  <text x="18" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
+  <text x="10" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="10" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┴</text>
+  <text x="26" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="34" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="42" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="50" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="58" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
+  <text x="66" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="74" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="90" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
+  <text x="98" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="106" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="114" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="122" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="130" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="138" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="154" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="162" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="178" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="186" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
+  <text x="202" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="210" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="218" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="226" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="234" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="242" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="250" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="258" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="266" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="274" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="290" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="298" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="306" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="322" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
+  <text x="10" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="18" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="34" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="42" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="50" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="58" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="66" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="74" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="82" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="90" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="98" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="106" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="114" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="122" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="130" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="138" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="146" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="154" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="162" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="170" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="178" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="186" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="194" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="202" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="210" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="218" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="226" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="234" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="242" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="250" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="258" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="266" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="274" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="282" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="290" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="298" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="306" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="314" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="322" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="330" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="338" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="346" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="354" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="362" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="370" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="378" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="386" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="394" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="402" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="410" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="418" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="426" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="434" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="442" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="450" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="458" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="466" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="474" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="482" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="490" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="498" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="506" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="514" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="522" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="530" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="538" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="546" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="554" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="562" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="570" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="578" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="586" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="594" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="602" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="610" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="618" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="626" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="634" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="642" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="650" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="658" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="666" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="674" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="682" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="690" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="698" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="706" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="714" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="722" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="730" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="738" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="746" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="754" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="762" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="770" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="778" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="786" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="794" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="802" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="34" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="42" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="50" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="58" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="66" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="98" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↑</text>
+  <text x="106" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="114" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="130" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="138" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="154" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="170" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↓</text>
+  <text x="178" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="186" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">j</text>
+  <text x="202" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="210" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="218" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="226" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="242" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="258" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="274" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="282" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="290" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="306" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="322" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="338" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="346" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="354" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="362" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="370" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="378" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="386" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="402" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="418" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="434" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="442" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="450" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="458" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="466" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="482" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="490" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="498" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="506" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="514" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="522" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="530" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="546" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="562" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="578" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="586" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="594" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="602" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="610" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="626" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="642" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">?</text>
+  <text x="658" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="666" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="674" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="682" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="698" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="714" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="730" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="738" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="746" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="754" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+</svg>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_commit_and_uncommitted_file_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_commit_and_uncommitted_file_final.svg
@@ -1,0 +1,380 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
+  <rect x="0" y="0" width="820" height="380" fill="#000000" />
+  <rect x="10" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="18" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="26" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="34" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="42" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="50" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="58" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="66" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="74" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="82" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="90" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="98" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="106" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="114" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="122" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="130" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="138" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="146" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="154" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="162" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="170" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="178" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="186" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="194" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="202" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="210" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="218" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="226" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="234" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="242" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="250" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="258" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="266" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="274" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="282" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="290" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="298" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="306" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="314" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="322" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="330" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="338" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="346" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="354" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="362" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="370" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="378" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="386" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="394" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="402" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="410" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="418" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="426" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="434" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="442" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="450" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="458" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="466" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="474" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="482" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="490" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="498" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="506" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="514" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="522" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="530" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="538" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="546" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="554" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="562" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="570" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="578" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="586" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="594" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="602" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="610" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="618" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="626" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="634" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="642" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="650" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="658" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="666" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="674" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="682" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="690" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="698" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="706" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="714" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="722" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="730" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="738" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="746" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="754" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="762" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="770" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="778" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="786" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="794" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="802" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="10" y="352" width="8" height="18" fill="#555555" />
+  <rect x="18" y="352" width="8" height="18" fill="#555555" />
+  <rect x="26" y="352" width="8" height="18" fill="#555555" />
+  <rect x="34" y="352" width="8" height="18" fill="#555555" />
+  <rect x="42" y="352" width="8" height="18" fill="#555555" />
+  <rect x="50" y="352" width="8" height="18" fill="#555555" />
+  <rect x="58" y="352" width="8" height="18" fill="#555555" />
+  <rect x="66" y="352" width="8" height="18" fill="#555555" />
+  <rect x="74" y="352" width="8" height="18" fill="#555555" />
+  <rect x="82" y="352" width="8" height="18" fill="#555555" />
+  <text x="10" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
+  <text x="18" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
+  <text x="26" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="34" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="50" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="58" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="66" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="74" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="82" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="90" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="98" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="106" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="114" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="122" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="130" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="146" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="154" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="162" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="178" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="186" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="194" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="202" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="218" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
+  <text x="226" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="234" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="250" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="258" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="266" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="274" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="282" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="290" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="298" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="306" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
+  <text x="10" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="60" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
+  <text x="26" y="60" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
+  <text x="34" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="42" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="58" y="60" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="66" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="74" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="82" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="90" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="98" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="106" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="114" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="122" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="130" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="138" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="146" y="60" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="162" y="60" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
+  <text x="170" y="60" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="178" y="60" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="194" y="60" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="202" y="60" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="210" y="60" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="218" y="60" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="226" y="60" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="234" y="60" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="242" y="60" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="250" y="60" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
+  <text x="10" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">├</text>
+  <text x="18" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
+  <text x="10" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="10" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┴</text>
+  <text x="26" y="114" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="34" y="114" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="42" y="114" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="50" y="114" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="58" y="114" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
+  <text x="66" y="114" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="74" y="114" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="90" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
+  <text x="98" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="106" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="114" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="122" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="130" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="138" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="154" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="162" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="178" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="186" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
+  <text x="202" y="114" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="210" y="114" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="218" y="114" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="226" y="114" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="234" y="114" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="242" y="114" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="250" y="114" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="258" y="114" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="266" y="114" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="274" y="114" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="290" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="298" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="306" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="322" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
+  <text x="10" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="18" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="34" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="42" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="50" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="58" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="66" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="74" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="82" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="90" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="98" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="106" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="114" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="122" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="130" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="138" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="146" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="154" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="162" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="170" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="178" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="186" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="194" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="202" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="210" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="218" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="226" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="234" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="242" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="250" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="258" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="266" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="274" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="282" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="290" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="298" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="306" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="314" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="322" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="330" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="338" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="346" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="354" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="362" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="370" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="378" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="386" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="394" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="402" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="410" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="418" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="426" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="434" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="442" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="450" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="458" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="466" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="474" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="482" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="490" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="498" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="506" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="514" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="522" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="530" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="538" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="546" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="554" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="562" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="570" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="578" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="586" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="594" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="602" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="610" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="618" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="626" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="634" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="642" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="650" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="658" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="666" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="674" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="682" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="690" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="698" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="706" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="714" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="722" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="730" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="738" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="746" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="754" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="762" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="770" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="778" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="786" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="794" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="802" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="34" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="42" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="50" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="58" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="66" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="98" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↑</text>
+  <text x="106" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="114" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="130" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="138" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="154" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="170" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↓</text>
+  <text x="178" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="186" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">j</text>
+  <text x="202" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="210" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="218" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="226" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="242" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="258" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="274" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="282" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="290" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="306" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="322" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="338" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="346" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="354" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="362" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="370" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="378" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="394" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="410" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="426" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="434" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="442" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">v</text>
+  <text x="450" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="466" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="482" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="498" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="506" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="514" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="522" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="530" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="538" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="554" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="570" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="586" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="594" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="602" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="610" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="618" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="626" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="634" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="650" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="666" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">?</text>
+  <text x="682" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="690" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="698" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="706" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="722" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="738" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="754" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="762" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="770" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="778" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+</svg>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_uncommitted_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_uncommitted_final.svg
@@ -1,0 +1,349 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
+  <rect x="0" y="0" width="820" height="380" fill="#000000" />
+  <rect x="10" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="18" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="26" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="34" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="42" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="50" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="58" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="66" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="74" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="82" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="90" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="98" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="106" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="114" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="122" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="130" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="138" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="146" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="154" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="162" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="170" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="178" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="186" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="194" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="202" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="210" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="218" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="226" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="234" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="242" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="250" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="258" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="266" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="274" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="282" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="290" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="298" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="306" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="314" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="322" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="330" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="338" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="346" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="354" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="362" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="370" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="378" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="386" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="394" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="402" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="410" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="418" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="426" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="434" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="442" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="450" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="458" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="466" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="474" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="482" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="490" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="498" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="506" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="514" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="522" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="530" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="538" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="546" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="554" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="562" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="570" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="578" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="586" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="594" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="602" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="610" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="618" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="626" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="634" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="642" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="650" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="658" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="666" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="674" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="682" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="690" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="698" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="706" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="714" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="722" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="730" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="738" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="746" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="754" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="762" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="770" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="778" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="786" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="794" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="802" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="10" y="352" width="8" height="18" fill="#555555" />
+  <rect x="18" y="352" width="8" height="18" fill="#555555" />
+  <rect x="26" y="352" width="8" height="18" fill="#555555" />
+  <rect x="34" y="352" width="8" height="18" fill="#555555" />
+  <rect x="42" y="352" width="8" height="18" fill="#555555" />
+  <rect x="50" y="352" width="8" height="18" fill="#555555" />
+  <rect x="58" y="352" width="8" height="18" fill="#555555" />
+  <rect x="66" y="352" width="8" height="18" fill="#555555" />
+  <rect x="74" y="352" width="8" height="18" fill="#555555" />
+  <rect x="82" y="352" width="8" height="18" fill="#555555" />
+  <text x="10" y="24" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
+  <text x="18" y="24" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
+  <text x="26" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="34" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="50" y="24" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="58" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="66" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="74" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="82" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="90" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="98" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="106" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="114" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="122" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="130" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="146" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="154" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="162" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="178" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="186" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="194" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="202" y="24" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="218" y="24" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
+  <text x="226" y="24" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="234" y="24" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="250" y="24" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="258" y="24" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="266" y="24" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="274" y="24" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="282" y="24" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="290" y="24" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="298" y="24" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="306" y="24" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
+  <text x="10" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="10" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┴</text>
+  <text x="26" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="34" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="42" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="50" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="58" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
+  <text x="66" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="74" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="90" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
+  <text x="98" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="106" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="114" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="122" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="130" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="138" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="154" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="162" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="178" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="186" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
+  <text x="202" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="210" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="218" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="226" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="234" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="242" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="250" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="258" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="266" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="274" y="60" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="290" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="298" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="306" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="322" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
+  <text x="10" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="18" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="34" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="42" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="50" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="58" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="66" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="74" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="82" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="90" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="98" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="106" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="114" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="122" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="130" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="138" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="146" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="154" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="162" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="170" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="178" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="186" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="194" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="202" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="210" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="218" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="226" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="234" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="242" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="250" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="258" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="266" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="274" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="282" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="290" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="298" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="306" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="314" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="322" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="330" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="338" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="346" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="354" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="362" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="370" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="378" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="386" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="394" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="402" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="410" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="418" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="426" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="434" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="442" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="450" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="458" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="466" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="474" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="482" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="490" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="498" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="506" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="514" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="522" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="530" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="538" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="546" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="554" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="562" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="570" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="578" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="586" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="594" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="602" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="610" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="618" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="626" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="634" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="642" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="650" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="658" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="666" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="674" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="682" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="690" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="698" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="706" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="714" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="722" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="730" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="738" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="746" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="754" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="762" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="770" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="778" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="786" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="794" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="802" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="34" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="42" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="50" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="58" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="66" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="98" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↑</text>
+  <text x="106" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="114" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="130" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="138" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="154" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="170" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↓</text>
+  <text x="178" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="186" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">j</text>
+  <text x="202" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="210" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="218" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="226" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="242" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="258" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="274" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="282" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="290" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="306" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="322" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="338" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="346" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="354" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="362" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="370" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="378" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="394" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="410" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="426" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="434" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="442" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">v</text>
+  <text x="450" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="466" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="482" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="498" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="506" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="514" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="522" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="530" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="538" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="554" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="570" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="586" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="594" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="602" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="610" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="618" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="626" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="634" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="650" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="666" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">?</text>
+  <text x="682" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="690" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="698" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="706" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="722" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="738" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="754" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="762" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="770" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="778" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+</svg>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_unassigned_files_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_unassigned_files_final.svg
@@ -1,0 +1,367 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
+  <rect x="0" y="0" width="820" height="380" fill="#000000" />
+  <rect x="10" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="18" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="26" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="34" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="42" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="50" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="58" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="66" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="74" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="82" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="90" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="98" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="106" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="114" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="122" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="130" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="138" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="146" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="154" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="162" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="170" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="178" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="186" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="194" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="202" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="210" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="218" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="226" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="234" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="242" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="250" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="258" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="266" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="274" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="282" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="290" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="298" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="306" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="314" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="322" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="330" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="338" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="346" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="354" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="362" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="370" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="378" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="386" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="394" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="402" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="410" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="418" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="426" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="434" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="442" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="450" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="458" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="466" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="474" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="482" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="490" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="498" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="506" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="514" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="522" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="530" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="538" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="546" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="554" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="562" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="570" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="578" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="586" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="594" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="602" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="610" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="618" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="626" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="634" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="642" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="650" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="658" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="666" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="674" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="682" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="690" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="698" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="706" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="714" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="722" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="730" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="738" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="746" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="754" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="762" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="770" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="778" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="786" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="794" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="802" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="18" y="28" width="8" height="18" fill="#0000AA" />
+  <rect x="26" y="28" width="8" height="18" fill="#0000AA" />
+  <rect x="18" y="46" width="8" height="18" fill="#0000AA" />
+  <rect x="26" y="46" width="8" height="18" fill="#0000AA" />
+  <rect x="10" y="352" width="8" height="18" fill="#555555" />
+  <rect x="18" y="352" width="8" height="18" fill="#555555" />
+  <rect x="26" y="352" width="8" height="18" fill="#555555" />
+  <rect x="34" y="352" width="8" height="18" fill="#555555" />
+  <rect x="42" y="352" width="8" height="18" fill="#555555" />
+  <rect x="50" y="352" width="8" height="18" fill="#555555" />
+  <rect x="58" y="352" width="8" height="18" fill="#555555" />
+  <rect x="66" y="352" width="8" height="18" fill="#555555" />
+  <rect x="74" y="352" width="8" height="18" fill="#555555" />
+  <rect x="82" y="352" width="8" height="18" fill="#555555" />
+  <text x="10" y="24" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
+  <text x="18" y="24" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
+  <text x="26" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="34" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="50" y="24" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="58" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="66" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="74" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="82" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="90" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="98" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="106" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="114" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="122" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="130" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="146" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="154" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="162" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="178" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="186" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="194" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="202" y="24" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="10" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="42" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">✔︎</text>
+  <text x="42" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">y</text>
+  <text x="50" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="66" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="82" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="90" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="98" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="106" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="114" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="122" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="130" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="138" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="10" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="60" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">✔︎</text>
+  <text x="42" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="50" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="66" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="82" y="60" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="90" y="60" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="98" y="60" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="106" y="60" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="114" y="60" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="122" y="60" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="130" y="60" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="138" y="60" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="10" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="10" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┴</text>
+  <text x="26" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="34" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="42" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="50" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="58" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
+  <text x="66" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="74" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="90" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
+  <text x="98" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="106" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="114" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="122" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="130" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="138" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="154" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="162" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="178" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="186" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
+  <text x="202" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="210" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="218" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="226" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="234" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="242" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="250" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="258" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="266" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="274" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="290" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="298" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="306" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="322" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
+  <text x="10" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="18" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="34" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="42" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="50" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="58" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="66" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="74" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="82" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="90" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="98" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="106" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="114" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="122" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="130" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="138" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="146" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="154" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="162" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="170" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="178" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="186" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="194" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="202" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="210" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="218" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="226" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="234" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="242" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="250" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="258" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="266" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="274" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="282" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="290" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="298" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="306" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="314" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="322" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="330" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="338" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="346" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="354" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="362" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="370" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="378" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="386" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="394" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="402" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="410" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="418" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="426" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="434" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="442" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="450" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="458" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="466" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="474" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="482" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="490" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="498" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="506" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="514" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="522" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="530" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="538" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="546" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="554" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="562" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="570" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="578" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="586" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="594" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="602" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="610" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="618" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="626" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="634" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="642" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="650" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="658" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="666" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="674" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="682" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="690" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="698" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="706" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="714" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="722" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="730" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="738" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="746" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="754" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="762" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="770" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="778" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="786" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="794" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="802" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="34" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="42" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="50" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="58" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="66" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="98" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↑</text>
+  <text x="106" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="114" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="130" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="138" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="154" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="170" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↓</text>
+  <text x="178" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="186" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">j</text>
+  <text x="202" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="210" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="218" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="226" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="242" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="258" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="274" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="282" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="290" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="306" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="322" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="338" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="346" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="354" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="362" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="370" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="378" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="386" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="402" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="418" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="434" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="442" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="450" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="458" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="466" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="482" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="490" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="498" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="506" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="514" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="522" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="530" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="546" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="562" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="578" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="586" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="594" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="602" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="610" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="626" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="642" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">?</text>
+  <text x="658" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="666" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="674" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="682" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="698" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="714" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="730" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="738" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="746" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="754" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+</svg>


### PR DESCRIPTION
This extends marking in the TUI to also allow marking uncommitted files and discard them. Additionally you can mark both commits and uncommitted files and discard everything at once. This previously would require two operations.