### PR TITLE
Isolate sidebar folder as a component and add scrolling

### DIFF
--- a/apps/lite/electron/src/ipc.ts
+++ b/apps/lite/electron/src/ipc.ts
@@ -280,6 +280,7 @@ export interface LiteElectronApi {
 	watcherStopAll: () => Promise<number>;
 	onUpdateDownloaded: (callback: (info: UpdateDownloadedEvent) => void) => () => void;
 	quitAndInstallUpdate: () => Promise<void>;
+	platform: string;
 }
 
 export const liteIpcChannels = {

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -448,6 +448,8 @@ const createMainWindow = async (): Promise<void> => {
 		width: 1024,
 		height: 768,
 		icon,
+		titleBarStyle: process.platform === "darwin" ? "hidden" : "default",
+		trafficLightPosition: process.platform === "darwin" ? { x: 8, y: 8 } : undefined,
 		webPreferences: {
 			contextIsolation: true,
 			nodeIntegration: false,

--- a/apps/lite/electron/src/preload.cts
+++ b/apps/lite/electron/src/preload.cts
@@ -176,6 +176,7 @@ const api: LiteElectronApi = {
 		return () => ipcRenderer.removeListener("updater:update-downloaded", listener);
 	},
 	quitAndInstallUpdate: () => ipcRenderer.invoke("updater:quit-and-install") as Promise<void>,
+	platform: process.platform,
 };
 
 contextBridge.exposeInMainWorld("lite", api);

--- a/apps/lite/ui/src/components/ProjectButton.module.css
+++ b/apps/lite/ui/src/components/ProjectButton.module.css
@@ -1,0 +1,39 @@
+.project {
+	/* position: relative; */
+	width: 40px;
+	height: 31px;
+	padding: 8px;
+	/* Override ui button. */
+	border: none;
+	border-radius: 8px;
+	background-color: oklch(90% 0.1 var(--hue));
+	color: oklch(30% 0.1 var(--hue));
+	font-weight: 700;
+	font-size: 10px;
+	text-transform: uppercase;
+
+	&:disabled:hover {
+		/* Override ui button. */
+		background-color: oklch(90% 0.1 var(--hue));
+	}
+
+	&:not(:disabled):hover {
+		/* Override ui button. */
+		background-color: oklch(88% 0.12 var(--hue));
+	}
+
+	&.selected {
+		/* Override ui button. */
+		opacity: unset;
+
+		&::before {
+			position: absolute;
+			left: 2px;
+			width: 4px;
+			height: 22px;
+			border-radius: 10px;
+			background-color: var(--fill-gray-bg);
+			content: "";
+		}
+	}
+}

--- a/apps/lite/ui/src/components/ProjectButton.module.css
+++ b/apps/lite/ui/src/components/ProjectButton.module.css
@@ -1,26 +1,6 @@
 .project {
-	/* position: relative; */
-	width: 40px;
-	height: 31px;
-	padding: 8px;
-	/* Override ui button. */
-	border: none;
-	border-radius: 8px;
-	background-color: oklch(90% 0.1 var(--hue));
-	color: oklch(30% 0.1 var(--hue));
-	font-weight: 700;
-	font-size: 10px;
-	text-transform: uppercase;
-
-	&:disabled:hover {
-		/* Override ui button. */
-		background-color: oklch(90% 0.1 var(--hue));
-	}
-
-	&:not(:disabled):hover {
-		/* Override ui button. */
-		background-color: oklch(88% 0.12 var(--hue));
-	}
+	position: relative;
+	scroll-snap-align: center;
 
 	&.selected {
 		/* Override ui button. */
@@ -28,7 +8,8 @@
 
 		&::before {
 			position: absolute;
-			left: 2px;
+			bottom: 4px;
+			left: -15px;
 			width: 4px;
 			height: 22px;
 			border-radius: 10px;
@@ -36,4 +17,24 @@
 			content: "";
 		}
 	}
+}
+
+.folderFront {
+	position: relative;
+	width: 44px;
+	height: 35px;
+	background: linear-gradient(to bottom, oklch(90% 0.05 var(--hue)), oklch(80% 0.1 var(--hue)));
+	mask-image: url("data:image/svg+xml,%3Csvg width='44' height='35' viewBox='0 0 44 35' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M38 35H6C2.68629 35 0 32.3137 0 29V6C0 2.68629 2.68629 0 6 0H12.3647C14.2645 0 16.052 0.899672 17.1837 2.42547L18.2009 3.79675C19.3327 5.32255 21.1202 6.22222 23.0199 6.22222H38C41.3137 6.22222 44 8.90851 44 12.2222V29C44 32.3137 41.3137 35 38 35Z' fill='black'/%3E%3C/svg%3E");
+	mask-repeat: no-repeat;
+	mask-size: contain;
+}
+
+.folderFrontText {
+	display: flex;
+	position: absolute;
+	bottom: 6px;
+	left: 6px;
+	color: oklch(38% 0.12 var(--hue));
+	font-size: 11px;
+	text-transform: uppercase;
 }

--- a/apps/lite/ui/src/components/ProjectButton.tsx
+++ b/apps/lite/ui/src/components/ProjectButton.tsx
@@ -1,0 +1,30 @@
+import { Tooltip } from "#ui/components/Tooltip.tsx";
+import { classes } from "#ui/components/classes.ts";
+import { FC } from "react";
+import styles from "./ProjectButton.module.css";
+
+type Props = {
+	title: string;
+	hue: number;
+	isSelected: boolean;
+	onClick: () => void;
+};
+
+export const ProjectButton: FC<Props> = ({ title, hue, isSelected, onClick }) => (
+	<Tooltip
+		trigger={
+			<button
+				type="button"
+				aria-label={`Select project ${title}`}
+				className={classes(styles.project, isSelected && styles.selected)}
+				onClick={onClick}
+				style={{ "--hue": hue }}
+				disabled={isSelected}
+			>
+				{title.slice(0, 2)}
+			</button>
+		}
+		content={title}
+		positionerProps={{ side: "right" }}
+	/>
+);

--- a/apps/lite/ui/src/components/ProjectButton.tsx
+++ b/apps/lite/ui/src/components/ProjectButton.tsx
@@ -1,30 +1,39 @@
 import { Tooltip } from "#ui/components/Tooltip.tsx";
 import { classes } from "#ui/components/classes.ts";
+import { Hash } from "effect";
 import { FC } from "react";
 import styles from "./ProjectButton.module.css";
 
 type Props = {
 	title: string;
-	hue: number;
+	id: string;
 	isSelected: boolean;
 	onClick: () => void;
 };
 
-export const ProjectButton: FC<Props> = ({ title, hue, isSelected, onClick }) => (
-	<Tooltip
-		trigger={
-			<button
-				type="button"
-				aria-label={`Select project ${title}`}
-				className={classes(styles.project, isSelected && styles.selected)}
-				onClick={onClick}
-				style={{ "--hue": hue }}
-				disabled={isSelected}
-			>
-				{title.slice(0, 2)}
-			</button>
-		}
-		content={title}
-		positionerProps={{ side: "right" }}
-	/>
-);
+export const ProjectButton: FC<Props> = ({ title, id, isSelected, onClick }) => {
+	const hue = ((Hash.string(id) % 360) + 360) % 360;
+	return (
+		<Tooltip
+			trigger={
+				<button
+					type="button"
+					aria-label={`Select project ${title}`}
+					className={classes(styles.project, isSelected && styles.selected)}
+					onClick={onClick}
+					style={{ "--hue": hue }}
+					disabled={isSelected}
+				>
+					<div className={styles.folderFront}>
+						<span className={classes("text-bold", styles.folderFrontText)}>
+							{" "}
+							{title.slice(0, 2)}
+						</span>
+					</div>
+				</button>
+			}
+			content={title}
+			positionerProps={{ side: "right" }}
+		/>
+	);
+};

--- a/apps/lite/ui/src/routes/RootLayout.module.css
+++ b/apps/lite/ui/src/routes/RootLayout.module.css
@@ -2,6 +2,7 @@
 	display: grid;
 	grid-template-columns: auto minmax(0, 1fr);
 	height: 100dvh;
+	overflow: hidden;
 	background-color: var(--bg-2);
 }
 
@@ -20,20 +21,45 @@
 	display: flex;
 	position: relative;
 	flex-direction: column;
-	align-items: center;
-	justify-content: space-between;
 	width: 76px;
-	padding-block: 18px;
+	height: 100%;
+	min-height: 0;
 }
 
-.sidebarMac {
-	padding-block-start: 36px;
+.sidebarMacSpacer {
+	z-index: 1;
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 40px;
+	background: linear-gradient(to bottom, var(--bg-2) 70%, transparent);
+}
+
+.sidebarScroll {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	align-items: center;
+	justify-content: space-between;
+	padding-block: 18px;
+	overflow-y: auto;
+	scrollbar-width: none;
+}
+
+.sidebarScrollMac {
+	padding-block-start: 38px;
+}
+
+/* Temporary fix. Design is being updated, so we can remove this once it's done. */
+.sidebarScroll::-webkit-scrollbar {
+	display: none;
 }
 
 .projects {
 	display: flex;
 	flex-direction: column;
-	gap: 8px;
+	gap: 10px;
 }
 
 .content {
@@ -44,4 +70,9 @@
 	border-start-start-radius: 14px;
 	border-end-start-radius: 14px;
 	background: var(--bg-1);
+}
+
+.addProjectButton {
+	width: 100%;
+	padding-block: 16px;
 }

--- a/apps/lite/ui/src/routes/RootLayout.module.css
+++ b/apps/lite/ui/src/routes/RootLayout.module.css
@@ -5,66 +5,35 @@
 	background-color: var(--bg-2);
 }
 
+.dragRegion {
+	position: absolute;
+	top: 0;
+	left: 0;
+	grid-column: 1 / -1;
+	width: 100%;
+	height: 12px;
+	-webkit-app-region: drag;
+	app-region: drag;
+}
+
 .sidebar {
 	display: flex;
+	position: relative;
 	flex-direction: column;
 	align-items: center;
 	justify-content: space-between;
-	width: 64px;
-	padding-inline: 12px;
+	width: 76px;
 	padding-block: 18px;
+}
+
+.sidebarMac {
+	padding-block-start: 36px;
 }
 
 .projects {
 	display: flex;
 	flex-direction: column;
 	gap: 8px;
-}
-
-.project {
-	display: grid;
-	position: relative;
-	width: 40px;
-	height: 31px;
-	padding: 8px;
-	/* Override ui button. */
-	border: none;
-	border-radius: 8px;
-	background-color: oklch(90% 0.1 var(--hue));
-	color: oklch(30% 0.1 var(--hue));
-	font-weight: 700;
-	font-size: 10px;
-	text-transform: uppercase;
-
-	&:disabled:hover {
-		/* Override ui button. */
-		background-color: oklch(90% 0.1 var(--hue));
-	}
-
-	&:not(:disabled) {
-		cursor: pointer;
-
-		&:hover {
-			/* Override ui button. */
-			background-color: oklch(88% 0.12 var(--hue));
-		}
-	}
-
-	&.selected {
-		/* Override ui button. */
-		opacity: unset;
-
-		&::before {
-			position: absolute;
-			left: -10px;
-			align-self: center;
-			width: 4px;
-			height: calc(100% - 10px);
-			border-radius: 10px;
-			background-color: var(--fill-gray-bg);
-			content: "";
-		}
-	}
 }
 
 .content {

--- a/apps/lite/ui/src/routes/RootLayout.tsx
+++ b/apps/lite/ui/src/routes/RootLayout.tsx
@@ -11,7 +11,6 @@ import { Outlet, useMatch, useNavigate } from "@tanstack/react-router";
 import { FC, useState } from "react";
 import styles from "./RootLayout.module.css";
 import { ProjectForFrontend } from "@gitbutler/but-sdk";
-import { Hash } from "effect";
 
 const ProjectSelect: FC = () => {
 	const { data: projects } = useSuspenseQuery(listProjectsQueryOptions);
@@ -42,8 +41,6 @@ const ProjectSelect: FC = () => {
 		window.localStorage.setItem(lastOpenedProjectKey, project.id);
 	};
 
-	const hue = (id: string): number => ((Hash.string(id) % 360) + 360) % 360;
-
 	return (
 		<div className={styles.projects}>
 			{projects.map((project) => {
@@ -53,7 +50,7 @@ const ProjectSelect: FC = () => {
 					<ProjectButton
 						key={project.id}
 						title={project.title}
-						hue={hue(project.id)}
+						id={project.id}
 						isSelected={isSelected}
 						onClick={() => selectProject(project)}
 					/>
@@ -64,6 +61,7 @@ const ProjectSelect: FC = () => {
 				aria-label="Select project"
 				variant="ghost"
 				hotkey={globalHotkeys.selectProject.hotkey}
+				className={styles.addProjectButton}
 				hotkeyOptions={{ meta: globalHotkeys.selectProject.meta }}
 				onClick={openProjectPicker}
 				positionerProps={{ side: "right" }}
@@ -100,8 +98,15 @@ export const RootLayout: FC = () => (
 	<HotkeysProvider>
 		<div className={styles.layout}>
 			<div className={styles.dragRegion} />
-			<nav className={`${styles.sidebar}${isMac ? ` ${styles.sidebarMac}` : ""}`}>
-				<ProjectSelect />
+			<nav className={styles.sidebar}>
+				{isMac && <div className={styles.sidebarMacSpacer} />}
+				<div
+					className={[styles.sidebarScroll, isMac ? styles.sidebarScrollMac : undefined]
+						.filter(Boolean)
+						.join(" ")}
+				>
+					<ProjectSelect />
+				</div>
 			</nav>
 			<main className={styles.content}>
 				<Outlet />

--- a/apps/lite/ui/src/routes/RootLayout.tsx
+++ b/apps/lite/ui/src/routes/RootLayout.tsx
@@ -2,6 +2,7 @@ import { listProjectsQueryOptions } from "#ui/api/queries.ts";
 import { Icon } from "#ui/components/Icon.tsx";
 import { lastOpenedProjectKey } from "#ui/projects/last-opened.ts";
 import { PickerDialog } from "#ui/components/PickerDialog/PickerDialog.tsx";
+import { ProjectButton } from "#ui/components/ProjectButton.tsx";
 import { ShortcutButton } from "#ui/components/ShortcutButton.tsx";
 import { globalHotkeys } from "#ui/hotkeys.ts";
 import { HotkeysProvider, useHotkey } from "@tanstack/react-hotkeys";
@@ -10,9 +11,7 @@ import { Outlet, useMatch, useNavigate } from "@tanstack/react-router";
 import { FC, useState } from "react";
 import styles from "./RootLayout.module.css";
 import { ProjectForFrontend } from "@gitbutler/but-sdk";
-import { classes } from "#ui/components/classes.ts";
 import { Hash } from "effect";
-import { Tooltip } from "#ui/components/Tooltip.tsx";
 
 const ProjectSelect: FC = () => {
 	const { data: projects } = useSuspenseQuery(listProjectsQueryOptions);
@@ -51,22 +50,12 @@ const ProjectSelect: FC = () => {
 				const isSelected = selectedProject?.id === project.id;
 
 				return (
-					<Tooltip
+					<ProjectButton
 						key={project.id}
-						trigger={
-							<button
-								type="button"
-								aria-label={`Select project ${project.title}`}
-								className={classes(styles.project, isSelected && styles.selected)}
-								onClick={() => selectProject(project)}
-								style={{ "--hue": hue(project.id) }}
-								disabled={isSelected}
-							>
-								{project.title.slice(0, 2)}
-							</button>
-						}
-						content={project.title}
-						positionerProps={{ side: "right" }}
+						title={project.title}
+						hue={hue(project.id)}
+						isSelected={isSelected}
+						onClick={() => selectProject(project)}
 					/>
 				);
 			})}
@@ -105,10 +94,13 @@ const ProjectSelect: FC = () => {
 	);
 };
 
+const isMac = window.lite.platform === "darwin";
+
 export const RootLayout: FC = () => (
 	<HotkeysProvider>
 		<div className={styles.layout}>
-			<nav className={styles.sidebar}>
+			<div className={styles.dragRegion} />
+			<nav className={`${styles.sidebar}${isMac ? ` ${styles.sidebarMac}` : ""}`}>
 				<ProjectSelect />
 			</nav>
 			<main className={styles.content}>


### PR DESCRIPTION
Isolate sidebar folder button and fix sidebar scrolling. Held off on further UI/UX design changes until the final design is approved.

- Extracted the folder button into its own component to improve maintainability.
- Fixed an issue where the entire page scrolled; scrolling is now contained to the sidebar.

Before:

<img width="1112" height="468" alt="image" src="https://github.com/user-attachments/assets/1ba8e258-a4af-4edc-b1bc-908daba674a9" />

After:


https://github.com/user-attachments/assets/a763048b-e60d-4948-b7e8-cba2126539e1

