### PR TITLE
Improve rub CLI error metrics and stage hints

### DIFF
--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, fmt};
 
 use crate::theme::{self, Paint};
 use anyhow::{Context as _, bail};
@@ -24,9 +24,9 @@ use gix::refs::FullName;
 use nonempty::NonEmpty;
 
 use crate::{
-    CliId, IdMap,
+    CliError, CliId, IdMap, bad_input,
     command::legacy::rub::assign::stack_id_to_branch_name,
-    id::parser::{parse_sources_with_disambiguation, prompt_for_disambiguation},
+    id::parser::{IdResolutionError, parse_sources_with_disambiguation, prompt_for_disambiguation},
     utils::{OutputChannel, shorten_object_id, split_short_id},
 };
 
@@ -1245,7 +1245,16 @@ pub(crate) fn handle(
 ) -> anyhow::Result<()> {
     let id_map = IdMap::legacy_new_from_context(ctx, None)?;
     let (sources, target) = ids(ctx, &id_map, source_str, target_str, out)?;
+    handle_resolved(ctx, out, sources, target, how_to_combine_messages)
+}
 
+fn handle_resolved(
+    ctx: &mut Context,
+    out: &mut OutputChannel,
+    sources: Vec<CliId>,
+    target: CliId,
+    how_to_combine_messages: MessageCombinationStrategy,
+) -> anyhow::Result<()> {
     for source in sources {
         let Some(operation) =
             route_operation(NonEmpty::new(&source), &target, how_to_combine_messages)
@@ -1372,9 +1381,10 @@ fn resolve_single_id(
     let matches = id_map.parse_using_context(entity_str, ctx)?;
 
     if matches.is_empty() {
-        return Err(anyhow::anyhow!(
+        return Err(IdResolutionError::new(format!(
             "{context} '{entity_str}' not found. If you just performed a Git operation (squash, rebase, etc.), try running 'but status' to refresh the current state."
-        ));
+        ))
+        .into());
     }
 
     if matches.len() == 1 {
@@ -1532,6 +1542,78 @@ pub(crate) fn handle_amend(
     Ok(())
 }
 
+pub(crate) fn stage_cli_error(err: anyhow::Error) -> CliError {
+    if let Some(stage_bad_input) = err
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<StageBadInput>())
+    {
+        stage_bad_input.cli_error()
+    } else {
+        err.into()
+    }
+}
+
+const STAGE_FILE_OR_HUNK_HINT: &str = "Run `but status --json -f` to refresh CLI IDs, then retry with a file or hunk cliId from the output";
+const STAGE_BRANCH_HINT: &str = "Use a branch name or branch cliId from `but status --json -f`";
+
+#[derive(Debug)]
+struct StageBadInput {
+    message: String,
+    arg_name: &'static str,
+    arg_value: String,
+    hint: &'static str,
+}
+
+impl StageBadInput {
+    fn file_or_hunk(value: &str, message: impl fmt::Display) -> Self {
+        Self {
+            message: message.to_string(),
+            arg_name: "<FILE_OR_HUNK>",
+            arg_value: value.to_owned(),
+            hint: STAGE_FILE_OR_HUNK_HINT,
+        }
+    }
+
+    fn branch(value: &str, message: impl fmt::Display) -> Self {
+        Self {
+            message: message.to_string(),
+            arg_name: "<BRANCH>",
+            arg_value: value.to_owned(),
+            hint: STAGE_BRANCH_HINT,
+        }
+    }
+
+    fn cli_error(&self) -> CliError {
+        bad_input(&self.message)
+            .arg_name(self.arg_name)
+            .arg_value(&self.arg_value)
+            .hint(self.hint)
+            .into()
+    }
+}
+
+impl fmt::Display for StageBadInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for StageBadInput {}
+
+fn stage_resolution_error(
+    err: anyhow::Error,
+    wrap: impl FnOnce(anyhow::Error) -> StageBadInput,
+) -> anyhow::Error {
+    if err
+        .chain()
+        .any(|cause| cause.downcast_ref::<IdResolutionError>().is_some())
+    {
+        wrap(err).into()
+    } else {
+        err
+    }
+}
+
 /// Handler for `but stage <file_or_hunk> <branch>` - runs `but rub <file_or_hunk> <branch>`
 /// Validates that file_or_hunk is uncommitted or a path prefix, and that branch is a branch.
 pub(crate) fn handle_stage(
@@ -1542,8 +1624,14 @@ pub(crate) fn handle_stage(
 ) -> anyhow::Result<()> {
     let t = theme::get();
     let id_map = IdMap::legacy_new_from_context(ctx, None)?;
-    let files = parse_sources_with_disambiguation(ctx, &id_map, file_or_hunk_str, out)?;
-    let branch = resolve_single_id(ctx, &id_map, branch_str, "Branch", out)?;
+    let files =
+        parse_sources_with_disambiguation(ctx, &id_map, file_or_hunk_str, out).map_err(|err| {
+            stage_resolution_error(err, |err| {
+                StageBadInput::file_or_hunk(file_or_hunk_str, err)
+            })
+        })?;
+    let branch = resolve_single_id(ctx, &id_map, branch_str, "Branch", out)
+        .map_err(|err| stage_resolution_error(err, |err| StageBadInput::branch(branch_str, err)))?;
 
     // Validate that all files are uncommitted or a path prefix
     for file in &files {
@@ -1552,11 +1640,15 @@ pub(crate) fn handle_stage(
                 // Valid type for stage
             }
             _ => {
-                bail!(
-                    "Cannot stage {} - it is {}. Only uncommitted files and hunks can be staged.",
-                    t.cli_id.paint(file.to_short_string()),
-                    t.attention.paint(file.kind_for_humans())
-                );
+                return Err(StageBadInput::file_or_hunk(
+                    file_or_hunk_str,
+                    format!(
+                        "Cannot stage {} - it is {}. Only uncommitted files and hunks can be staged.",
+                        t.cli_id.paint(file.to_short_string()),
+                        t.attention.paint(file.kind_for_humans())
+                    ),
+                )
+                .into());
             }
         }
     }
@@ -1567,20 +1659,23 @@ pub(crate) fn handle_stage(
             // Valid type for target
         }
         other => {
-            bail!(
-                "Cannot stage to {} - it is {}. Target must be a branch.",
-                t.cli_id.paint(other.to_short_string()),
-                t.attention.paint(other.kind_for_humans())
-            );
+            return Err(StageBadInput::branch(
+                branch_str,
+                format!(
+                    "Cannot stage to {} - it is {}. Target must be a branch.",
+                    t.cli_id.paint(other.to_short_string()),
+                    t.attention.paint(other.kind_for_humans())
+                ),
+            )
+            .into());
         }
     }
 
-    // Call the main rub handler
-    handle(
+    handle_resolved(
         ctx,
         out,
-        file_or_hunk_str,
-        branch_str,
+        files,
+        branch,
         MessageCombinationStrategy::KeepBoth,
     )
 }
@@ -1599,15 +1694,21 @@ pub(crate) fn handle_stage_tui(
 
     // Resolve branch: from flag, or interactive selection
     let branch_name = if let Some(branch_str) = branch_str {
-        let branch = resolve_single_id(ctx, &id_map, branch_str, "Branch", out)?;
+        let branch = resolve_single_id(ctx, &id_map, branch_str, "Branch", out).map_err(|err| {
+            stage_resolution_error(err, |err| StageBadInput::branch(branch_str, err))
+        })?;
         match &branch {
             CliId::Branch { name, .. } => name.clone(),
             other => {
-                bail!(
-                    "Cannot stage to {} - it is {}. Target must be a branch.",
-                    t.cli_id.paint(other.to_short_string()),
-                    t.attention.paint(other.kind_for_humans())
-                );
+                return Err(StageBadInput::branch(
+                    branch_str,
+                    format!(
+                        "Cannot stage to {} - it is {}. Target must be a branch.",
+                        t.cli_id.paint(other.to_short_string()),
+                        t.attention.paint(other.kind_for_humans())
+                    ),
+                )
+                .into());
             }
         }
     } else {

--- a/crates/but/src/id/parser.rs
+++ b/crates/but/src/id/parser.rs
@@ -3,6 +3,23 @@ use but_ctx::Context;
 
 use crate::{CliId, IdMap, utils::OutputChannel};
 
+#[derive(Debug)]
+pub(crate) struct IdResolutionError(String);
+
+impl IdResolutionError {
+    pub(crate) fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+impl std::fmt::Display for IdResolutionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for IdResolutionError {}
+
 pub(crate) fn parse_sources(
     ctx: &mut Context,
     id_map: &IdMap,
@@ -26,19 +43,21 @@ pub(crate) fn parse_sources(
     let source_result = id_map.parse_using_context(source, ctx)?;
     if source_result.len() != 1 {
         if source_result.is_empty() {
-            return Err(anyhow::anyhow!(
+            return Err(IdResolutionError::new(format!(
                 "Source '{source}' not found. If you just performed a Git operation (squash, rebase, etc.), try running 'but status' to refresh the current state."
-            ));
+            ))
+            .into());
         } else {
             let matches: Vec<String> = source_result
                 .iter()
                 .map(|id| format!("{} ({})", id.to_short_string(), id.kind_for_humans()))
                 .collect();
-            return Err(anyhow::anyhow!(
+            return Err(IdResolutionError::new(format!(
                 "Source '{}' is ambiguous. Matches: {}. Try using more characters, a longer SHA, or the full branch name to disambiguate.",
                 source,
                 matches.join(", ")
-            ));
+            ))
+            .into());
         }
     }
     Ok(vec![source_result[0].clone()])
@@ -149,9 +168,10 @@ pub fn parse_sources_with_disambiguation(
     // Single source (including strings with dashes that aren't valid ranges)
     let source_result = id_map.parse_using_context(source, ctx)?;
     if source_result.is_empty() {
-        return Err(anyhow::anyhow!(
+        return Err(IdResolutionError::new(format!(
             "Source '{source}' not found. If you just performed a Git operation (squash, rebase, etc.), try running 'but status' to refresh the current state."
-        ));
+        ))
+        .into());
     }
 
     if source_result.len() > 1 {
@@ -183,9 +203,10 @@ fn parse_list_with_disambiguation(
 
         let matches = id_map.parse_using_context(part, ctx)?;
         if matches.is_empty() {
-            return Err(anyhow::anyhow!(
+            return Err(IdResolutionError::new(format!(
                 "Item '{part}' in list not found. If you just performed a Git operation (squash, rebase, etc.), try running 'but status' to refresh the current state."
-            ));
+            ))
+            .into());
         }
 
         if matches.len() == 1 {
@@ -200,9 +221,10 @@ fn parse_list_with_disambiguation(
 
     // If all parts were empty, return an error
     if result.is_empty() {
-        return Err(anyhow::anyhow!(
+        return Err(IdResolutionError::new(format!(
             "Source list '{source}' contains no valid items"
-        ));
+        ))
+        .into());
     }
 
     Ok(result)
@@ -223,13 +245,15 @@ fn parse_list(ctx: &mut Context, id_map: &IdMap, source: &str) -> anyhow::Result
         let matches = id_map.parse_using_context(part, ctx)?;
         if matches.len() != 1 {
             if matches.is_empty() {
-                return Err(anyhow::anyhow!(
+                return Err(IdResolutionError::new(format!(
                     "Item '{part}' in list not found. If you just performed a Git operation (squash, rebase, etc.), try running 'but status' to refresh the current state."
-                ));
+                ))
+                .into());
             } else {
-                return Err(anyhow::anyhow!(
+                return Err(IdResolutionError::new(format!(
                     "Item '{part}' in list is ambiguous. Try using more characters to disambiguate."
-                ));
+                ))
+                .into());
             }
         }
         result.push(matches[0].clone());
@@ -237,9 +261,10 @@ fn parse_list(ctx: &mut Context, id_map: &IdMap, source: &str) -> anyhow::Result
 
     // If all parts were empty, return an error
     if result.is_empty() {
-        return Err(anyhow::anyhow!(
+        return Err(IdResolutionError::new(format!(
             "Source list '{source}' contains no valid items"
-        ));
+        ))
+        .into());
     }
 
     Ok(result)
@@ -289,9 +314,10 @@ pub fn prompt_for_disambiguation(
             .collect::<Vec<_>>()
             .join("\n");
 
-        return Err(anyhow::anyhow!(
+        return Err(IdResolutionError::new(format!(
             "'{entity_str}' is ambiguous for {context}. Cannot prompt in non-interactive mode. Matches:\n{options_str}"
-        ));
+        ))
+        .into());
     }
 
     // Build options with clear descriptions

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -1294,12 +1294,13 @@ async fn match_subcommand(
                 out,
             )?;
             out.begin_status_after(status_after);
-            let result = if let Some(file_or_hunk) = file_or_hunk {
+            let result = if let Some(file_or_hunk) = file_or_hunk.as_deref() {
                 // Direct mode: but stage <file_or_hunk> <branch>
-                let branch = branch.or(branch_pos).ok_or_else(|| {
-                    anyhow::anyhow!("Missing required argument: <branch>. Usage: but stage <file_or_hunk> <branch>")
+                let branch = branch.as_deref().or(branch_pos.as_deref()).ok_or_else(|| {
+                    bad_input("Missing required argument: <branch>. Usage: but stage <file_or_hunk> <branch>")
+                        .arg_name("<BRANCH>")
                 })?;
-                command::legacy::rub::handle_stage(&mut ctx, out, &file_or_hunk, &branch)
+                command::legacy::rub::handle_stage(&mut ctx, out, file_or_hunk, branch)
                     .context("Failed to stage.")
                     .emit_metrics(metrics_ctx)
             } else {
@@ -1315,7 +1316,7 @@ async fn match_subcommand(
                     .emit_metrics(metrics_ctx)
             };
             maybe_run_status_after(status_after, &result, &mut ctx, out).await;
-            result.show_root_cause_error_then_exit_without_destructors(output)
+            result.map_err(command::legacy::rub::stage_cli_error)
         }
         #[cfg(feature = "legacy")]
         Subcommands::Unstage {

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -8,9 +8,12 @@ use rand::{Rng, distr::OpenClosed01};
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    CliError,
     args::{Subcommands, config, metrics::CommandName},
     utils::{ResultMetricsExt, binary_path},
 };
+
+const RUB_ERROR_MESSAGE_MAX_CHARS: usize = 1024;
 
 pub(super) mod types {
     use crate::{args::metrics::CommandName, utils::metrics::Event};
@@ -225,15 +228,36 @@ impl Props {
         }
     }
 
-    pub fn from_result<E, T, R>(start: std::time::Instant, result: R) -> Props
+    fn from_result<E, T>(start: std::time::Instant, result: &Result<T, E>) -> Props
     where
-        R: std::ops::Deref<Target = anyhow::Result<T, E>>,
         E: std::fmt::Display,
     {
-        let error = result.as_ref().err().map(|e| e.to_string());
+        let error = result.as_ref().err();
         let mut props = Props::new();
         props.insert("durationMs", start.elapsed().as_millis());
-        props.insert("error", error);
+        props.insert("error", error.map(|e| e.to_string()));
+        props
+    }
+
+    fn from_anyhow_result<T>(
+        start: std::time::Instant,
+        result: &anyhow::Result<T>,
+        command: CommandName,
+    ) -> Props {
+        let mut props = Self::from_result(start, result);
+        let Some(error) = result.as_ref().err() else {
+            return props;
+        };
+        if !matches!(command, CommandName::Rub) {
+            return props;
+        }
+
+        let error_message = rub_error_message(error);
+        props.insert("errorMessage", &error_message);
+        props.insert(
+            "errorRoot",
+            rub_error_message(error.root_cause()).trim().to_string(),
+        );
         props
     }
 
@@ -257,6 +281,33 @@ impl Props {
             event.insert_prop(key, value);
         }
     }
+}
+
+fn rub_error_message(error: &(impl std::fmt::Display + ?Sized)) -> String {
+    let error_message = format!("{error:#}");
+    let mut message = error_message.as_str();
+
+    if let Some((value, _)) = message.split_once("\nHint: ") {
+        message = value;
+    }
+    let message =
+        if let Some((value, _)) = message.split_once(". If you just performed a Git operation") {
+            format!("{value}.")
+        } else {
+            message.to_string()
+        };
+
+    let message = message
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+    truncate_rub_error_message(message)
+}
+
+fn truncate_rub_error_message(message: String) -> String {
+    message.chars().take(RUB_ERROR_MESSAGE_MAX_CHARS).collect()
 }
 
 #[derive(Debug, Clone)]
@@ -400,44 +451,123 @@ fn posthog_client(app_settings: AppSettings) -> Option<impl Future<Output = post
     }
 }
 
-impl<T, E> ResultMetricsExt<T, E> for Result<T, E>
-where
-    E: std::fmt::Display + From<std::io::Error>,
-{
-    fn emit_metrics(self, ctx: Option<OneshotMetricsContext>) -> Result<T, E> {
+impl<T> ResultMetricsExt<T, anyhow::Error> for anyhow::Result<T> {
+    fn emit_metrics(self, ctx: Option<OneshotMetricsContext>) -> anyhow::Result<T> {
+        let Some(OneshotMetricsContext { start, command }) = ctx else {
+            return self;
+        };
+
+        let props = Props::from_anyhow_result(start, &self, command);
+        emit_metrics(command, &props);
+        self
+    }
+}
+
+impl<T> ResultMetricsExt<T, CliError> for Result<T, CliError> {
+    fn emit_metrics(self, ctx: Option<OneshotMetricsContext>) -> Result<T, CliError> {
         let Some(OneshotMetricsContext { start, command }) = ctx else {
             return self;
         };
 
         let props = Props::from_result(start, &self);
-        let Some(v) = command.to_possible_value() else {
-            tracing::warn!("BUG: didn't get string value for {command:?}");
-            return self;
-        };
-
-        // We can fail both in resolving the path to the but binary, and in invoking it. As metrics
-        // emissions shouldn't impact user experience, we swallow these errors.
-        let but_path = match binary_path::current_exe_for_but_exec() {
-            Err(err) => {
-                tracing::warn!(?err, "Failed to resolve binary path to `but`");
-                return self;
-            }
-            Ok(path) => path,
-        };
-
-        let _ = tokio::process::Command::new(but_path)
-            .arg("metrics")
-            .arg("--command-name")
-            .arg(v.get_name())
-            .arg("--props")
-            .arg(props.as_json_string())
-            .stderr(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .group()
-            .kill_on_drop(false)
-            .spawn()
-            .map_err(|err| tracing::warn!(?err, "Failed to emit metrics"));
-
+        emit_metrics(command, &props);
         self
+    }
+}
+
+fn emit_metrics(command: CommandName, props: &Props) {
+    let Some(v) = command.to_possible_value() else {
+        tracing::warn!("BUG: didn't get string value for {command:?}");
+        return;
+    };
+
+    // We can fail both in resolving the path to the but binary, and in invoking it. As metrics
+    // emissions shouldn't impact user experience, we swallow these errors.
+    let but_path = match binary_path::current_exe_for_but_exec() {
+        Err(err) => {
+            tracing::warn!(?err, "Failed to resolve binary path to `but`");
+            return;
+        }
+        Ok(path) => path,
+    };
+
+    let _ = tokio::process::Command::new(but_path)
+        .arg("metrics")
+        .arg("--command-name")
+        .arg(v.get_name())
+        .arg("--props")
+        .arg(props.as_json_string())
+        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .group()
+        .kill_on_drop(false)
+        .spawn()
+        .map_err(|err| tracing::warn!(?err, "Failed to emit metrics"));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rub_metrics_include_detailed_error_properties() {
+        let result = Err::<(), _>(
+            anyhow::anyhow!(
+                "Source 'old-id' not found. If you just performed a Git operation (squash, rebase, etc.), try running 'but status' to refresh the current state."
+            )
+            .context("Failed to stage."),
+        );
+
+        let props = Props::from_anyhow_result(std::time::Instant::now(), &result, CommandName::Rub);
+
+        assert_eq!(props.values["error"], "Failed to stage.");
+        assert_eq!(
+            props.values["errorMessage"],
+            "Failed to stage.: Source 'old-id' not found."
+        );
+        assert_eq!(props.values["errorRoot"], "Source 'old-id' not found.");
+    }
+
+    #[test]
+    fn non_rub_metrics_do_not_include_detailed_error_properties() {
+        let result =
+            Err::<(), _>(anyhow::anyhow!("Source 'old-id' not found.").context("Failed to stage."));
+
+        let props =
+            Props::from_anyhow_result(std::time::Instant::now(), &result, CommandName::Commit);
+
+        assert_eq!(props.values["error"], "Failed to stage.");
+        assert!(!props.values.contains_key("errorMessage"));
+        assert!(!props.values.contains_key("errorRoot"));
+    }
+
+    #[test]
+    fn rub_metrics_normalize_multiline_error_properties() {
+        let result =
+            Err::<(), _>(anyhow::anyhow!("first line\nsecond line").context("Failed to stage."));
+
+        let props = Props::from_anyhow_result(std::time::Instant::now(), &result, CommandName::Rub);
+
+        assert_eq!(
+            props.values["errorMessage"],
+            "Failed to stage.: first line second line"
+        );
+        assert_eq!(props.values["errorRoot"], "first line second line");
+    }
+
+    #[test]
+    fn rub_metrics_cap_detailed_error_properties() {
+        let result = Err::<(), _>(anyhow::anyhow!("{}", "a".repeat(1100)));
+
+        let props = Props::from_anyhow_result(std::time::Instant::now(), &result, CommandName::Rub);
+
+        assert_eq!(
+            props.values["errorMessage"].as_str().unwrap().len(),
+            RUB_ERROR_MESSAGE_MAX_CHARS
+        );
+        assert_eq!(
+            props.values["errorRoot"].as_str().unwrap().len(),
+            RUB_ERROR_MESSAGE_MAX_CHARS
+        );
     }
 }

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -882,6 +882,70 @@ Staged hunk(s) → [A].
 }
 
 #[test]
+fn stage_command_missing_source_hints_to_refresh_cli_ids() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+
+    env.setup_metadata(&["A", "B"])?;
+    env.but("stage missing-file A")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: Bad input 'missing-file' for '<FILE_OR_HUNK>'
+
+Source 'missing-file' not found. If you just performed a Git operation (squash, rebase, etc.), try running 'but status' to refresh the current state.
+
+Hint: Run `but status --json -f` to refresh CLI IDs, then retry with a file or hunk cliId from the output
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn stage_command_missing_branch_hints_to_refresh_cli_ids() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+
+    env.setup_metadata(&["A", "B"])?;
+    env.file("a.txt", "text\n");
+
+    env.but("stage a.txt missing-branch")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: Bad input 'missing-branch' for '<BRANCH>'
+
+Branch 'missing-branch' not found. If you just performed a Git operation (squash, rebase, etc.), try running 'but status' to refresh the current state.
+
+Hint: Use a branch name or branch cliId from `but status --json -f`
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn stage_command_non_branch_target_hints_to_use_branch() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+
+    env.setup_metadata(&["A", "B"])?;
+    env.file("a.txt", "text\n");
+
+    env.but("stage a.txt zz")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: Bad input 'zz' for '<BRANCH>'
+
+Cannot stage to zz - it is the unassigned area. Target must be a branch.
+
+Hint: Use a branch name or branch cliId from `but status --json -f`
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
 fn unstage_command() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
 


### PR DESCRIPTION
[Agent Trail](https://trail.but.dev/gitbutlerapp/gitbutler/pull/13958)

Summary:
- Add Rub-specific CLI error metrics with full error chain and root cause fields
- Keep detailed error fields scoped to Rub operations
- Add stage failure hints that match the existing CLI hint style
- Simplify metrics plumbing after maintainability review

Validation:
- cargo test -p but utils::metrics::tests
- cargo fmt --check -p but
- cargo check -p but --tests
- cargo clippy -p but --tests --no-deps -- -D warnings