### PR TITLE
edit-mode: label "New base" with parent message

### DIFF
--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -34,6 +34,8 @@ fn commit_title_to_merge_conflict_label(commit: &gix::Commit<'_>) -> String {
         but_core::commit::strip_conflict_markers(commit.message_bstr()).as_ref(),
     )
     .title
+    // For some reason, the title sometimes contains newlines at the end, so trim it.
+    .trim_ascii_end()
     .to_str_lossy()
     .chars()
     .take(80)
@@ -143,12 +145,12 @@ fn checkout_edit_branch(ctx: &Context, commit_id: gix::ObjectId) -> Result<()> {
     let commit = commit_id.attach(repo).object()?.try_into_commit()?;
 
     // Checkout commits's parent
-    let commit_parent_id = find_or_create_base_commit(repo, commit_id)?;
-    let commit_parent = commit_parent_id.attach(repo).object()?.try_into_commit()?;
+    let base_commit_id = find_or_create_base_commit(repo, commit_id)?;
+    let base_commit = base_commit_id.attach(repo).object()?.try_into_commit()?;
     let edit_branch_ref: gix::refs::FullName = EDIT_BRANCH_REF.try_into()?;
     repo.reference(
         edit_branch_ref.as_ref(),
-        commit_parent_id,
+        base_commit_id,
         gix::refs::transaction::PreviousValue::Any,
         "enter edit mode",
     )?;
@@ -168,8 +170,14 @@ fn checkout_edit_branch(ctx: &Context, commit_id: gix::ObjectId) -> Result<()> {
     let their_commit_msg = commit_title_to_merge_conflict_label(&commit);
     let their_label = format!("Current commit: {their_commit_msg}");
 
-    let our_commit_msg = commit_title_to_merge_conflict_label(&commit_parent);
-    let our_label = format!("New base: {our_commit_msg}");
+    let commit_parent_id = base_commit.parent_ids().next();
+    let our_label = if let Some(commit_parent_id) = commit_parent_id {
+        let our_commit_msg =
+            commit_title_to_merge_conflict_label(&commit_parent_id.object()?.try_into_commit()?);
+        format!("New base: {our_commit_msg}")
+    } else {
+        "New base: (no commit)".to_string()
+    };
 
     git2_repo.checkout_index(
         Some(&mut index),

--- a/crates/gitbutler-edit-mode/tests/edit_mode.rs
+++ b/crates/gitbutler-edit-mode/tests/edit_mode.rs
@@ -442,7 +442,7 @@ fn enter_edit_mode_checks_out_conflicted_commit() -> Result<()> {
     insta::assert_snapshot!(
         std::fs::read_to_string(repo.path().parent().unwrap().join("conflict"))?,
         @r"
-    <<<<<<< New base: Changes to make millions
+    <<<<<<< New base: foobar
     left
     ||||||| Common ancestor
     base

--- a/e2e/playwright/tests/branches.spec.ts
+++ b/e2e/playwright/tests/branches.spec.ts
@@ -156,7 +156,7 @@ baz
 branch1 commit 1
 branch1 commit 2
 <<<<<` +
-			`<< New base: Conflicting change commit
+			`<< New base: branch1: third commit
 branch1 commit 3
 ||||||| Common ancestor
 =======


### PR DESCRIPTION
Commit 2bf9813087 (gitbutler-edit-mode: edit edited commit directly, 2026-03-19) indirectly changed how conflicts were represented in the working tree when entering edit mode. Prior to that commit, the checked-out commit is the parent of the edited commit, and the "New base" conflict marker takes its description from the checked-out commit (i.e. the parent of the edited commit). That commit changed it such that the checked-out commit is the edited commit itself; the "New base" conflict marker still takes its description from the checked-out commit (now, the edited commit itself).

However, this results in both the "Current commit" and "New base" conflict markers taking their descriptions from the same commit, resulting in end-user confusion. The "New base" should actually take its description from the parent of the edited commit; it should not take it from what is checked out (the fact that the checked-out commit prior to commit 2bf9813087 was the parent of the edited commit is a coincidence). Restore this behavior.
