### PR TITLE
Update `gix`  to latest version for bugfixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -852,7 +852,7 @@ dependencies = [
  "gitbutler-project",
  "gitbutler-repo",
  "gitbutler-watcher",
- "gix",
+ "gix 0.84.0",
  "indexmap 2.14.0",
  "insta",
  "itertools",
@@ -912,7 +912,7 @@ dependencies = [
  "gitbutler-operating-modes",
  "gitbutler-oplog",
  "gitbutler-reference",
- "gix",
+ "gix 0.84.0",
  "itertools",
  "rmcp",
  "schemars 1.2.1",
@@ -937,7 +937,7 @@ dependencies = [
  "chrono",
  "clap",
  "git-meta-lib 0.1.10 (git+https://github.com/git-meta/git-meta.git?rev=e5244374ec2bb413d5f8af28b7983ef29957a0d2)",
- "gix",
+ "gix 0.84.0",
  "hex",
  "serde",
  "serde_json",
@@ -991,7 +991,7 @@ dependencies = [
  "gitbutler-reference",
  "gitbutler-repo",
  "gitbutler-user",
- "gix",
+ "gix 0.84.0",
  "insta",
  "itertools",
  "napi",
@@ -1029,7 +1029,7 @@ dependencies = [
  "but-ctx",
  "but-error",
  "futures",
- "gix",
+ "gix 0.84.0",
  "napi",
  "napi-derive",
  "serde",
@@ -1062,7 +1062,7 @@ dependencies = [
  "but-workspace",
  "gitbutler-branch-actions",
  "gitbutler-workspace",
- "gix",
+ "gix 0.84.0",
  "serde",
 ]
 
@@ -1091,7 +1091,7 @@ dependencies = [
  "chardetng",
  "fslock",
  "git2",
- "gix",
+ "gix 0.84.0",
  "insta",
  "parking_lot",
  "rand 0.9.4",
@@ -1122,7 +1122,7 @@ dependencies = [
  "but-utils",
  "git2",
  "gitbutler-project",
- "gix",
+ "gix 0.84.0",
  "serde_json",
  "tracing",
 ]
@@ -1156,7 +1156,7 @@ dependencies = [
  "but-workspace",
  "clap",
  "gitbutler-reference",
- "gix",
+ "gix 0.84.0",
  "insta",
  "open",
  "prodash",
@@ -1190,7 +1190,7 @@ dependencies = [
  "but-ctx",
  "but-graph",
  "chrono",
- "gix",
+ "gix 0.84.0",
  "tempfile",
  "walkdir",
  "zip",
@@ -1241,7 +1241,7 @@ dependencies = [
  "but-testsupport",
  "chrono",
  "gitbutler-commit",
- "gix",
+ "gix 0.84.0",
  "schemars 1.2.1",
  "serde",
  "snapbox",
@@ -1295,7 +1295,7 @@ dependencies = [
  "but-meta",
  "but-testsupport",
  "gitbutler-reference",
- "gix",
+ "gix 0.84.0",
  "insta",
  "itertools",
  "petgraph",
@@ -1314,7 +1314,7 @@ dependencies = [
  "but-hunk-dependency",
  "but-schemars",
  "but-serde",
- "gix",
+ "gix 0.84.0",
  "itertools",
  "schemars 1.2.1",
  "serde",
@@ -1335,7 +1335,7 @@ dependencies = [
  "but-schemars",
  "but-serde",
  "but-testsupport",
- "gix",
+ "gix 0.84.0",
  "insta",
  "itertools",
  "schemars 1.2.1",
@@ -1391,7 +1391,7 @@ dependencies = [
  "but-secret",
  "but-tools",
  "futures",
- "gix",
+ "gix 0.84.0",
  "reqwest",
  "schemars 1.2.1",
  "serde",
@@ -1416,7 +1416,7 @@ dependencies = [
  "but-testsupport",
  "but-utils",
  "gitbutler-reference",
- "gix",
+ "gix 0.84.0",
  "hex",
  "insta",
  "itertools",
@@ -1453,7 +1453,7 @@ dependencies = [
  "but-core",
  "but-ctx",
  "gitbutler-oplog",
- "gix",
+ "gix 0.84.0",
  "tracing",
 ]
 
@@ -1463,7 +1463,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "git2",
- "gix",
+ "gix 0.84.0",
 ]
 
 [[package]]
@@ -1483,7 +1483,7 @@ dependencies = [
  "base64 0.22.1",
  "but-path",
  "but-testsupport",
- "gix",
+ "gix 0.84.0",
  "serde",
  "serde_json",
  "tracing",
@@ -1504,7 +1504,7 @@ dependencies = [
  "but-schemars",
  "but-testsupport",
  "gitbutler-reference",
- "gix",
+ "gix 0.84.0",
  "insta",
  "petgraph",
  "schemars 1.2.1",
@@ -1527,7 +1527,7 @@ dependencies = [
  "but-rebase",
  "but-workspace",
  "chrono",
- "gix",
+ "gix 0.84.0",
  "itertools",
  "regex",
  "serde",
@@ -1551,7 +1551,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "but-error",
- "gix",
+ "gix 0.84.0",
  "keyring",
  "serde",
  "tracing",
@@ -1563,7 +1563,7 @@ version = "0.0.0"
 dependencies = [
  "bstr",
  "git2",
- "gix",
+ "gix 0.84.0",
  "serde",
 ]
 
@@ -1624,7 +1624,7 @@ dependencies = [
  "but-graph",
  "but-meta",
  "but-settings",
- "gix",
+ "gix 0.84.0",
  "gix-testtools",
  "regex",
  "shell-words",
@@ -1641,7 +1641,7 @@ dependencies = [
  "but-core",
  "but-ctx",
  "but-workspace",
- "gix",
+ "gix 0.84.0",
  "serde",
  "serde_json",
 ]
@@ -1660,7 +1660,7 @@ dependencies = [
  "but-rebase",
  "but-testsupport",
  "but-workspace",
- "gix",
+ "gix 0.84.0",
  "snapbox",
 ]
 
@@ -1700,7 +1700,7 @@ name = "but-utils"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "gix",
+ "gix 0.84.0",
  "serde",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
@@ -1731,7 +1731,7 @@ dependencies = [
  "gitbutler-reference",
  "gitbutler-repo",
  "gitbutler-stack",
- "gix",
+ "gix 0.84.0",
  "indexmap 2.14.0",
  "insta",
  "itertools",
@@ -1759,7 +1759,7 @@ dependencies = [
  "gitbutler-branch-actions",
  "gitbutler-stack",
  "gitbutler-workspace",
- "gix",
+ "gix 0.84.0",
  "insta",
  "serde",
  "tracing",
@@ -2143,7 +2143,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2919,7 +2919,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3184,7 +3184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3842,7 +3842,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d8d88d5f482ae39baea4b7375ccb5e99932c5f6079436530f044854763e30c1"
 dependencies = [
- "gix",
+ "gix 0.83.0",
  "rusqlite",
  "serde",
  "serde_json",
@@ -3856,7 +3856,7 @@ name = "git-meta-lib"
 version = "0.1.10"
 source = "git+https://github.com/git-meta/git-meta.git?rev=e5244374ec2bb413d5f8af28b7983ef29957a0d2#e5244374ec2bb413d5f8af28b7983ef29957a0d2"
 dependencies = [
- "gix",
+ "gix 0.83.0",
  "rusqlite",
  "serde",
  "serde_json",
@@ -3914,7 +3914,7 @@ dependencies = [
  "but-core",
  "but-schemars",
  "gitbutler-reference",
- "gix",
+ "gix 0.84.0",
  "lazy_static",
  "schemars 1.2.1",
  "serde",
@@ -3957,7 +3957,7 @@ dependencies = [
  "gitbutler-repo-actions",
  "gitbutler-stack",
  "gitbutler-workspace",
- "gix",
+ "gix 0.84.0",
  "glob",
  "insta",
  "itertools",
@@ -3977,7 +3977,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "gitbutler-commit",
- "gix",
+ "gix 0.84.0",
 ]
 
 [[package]]
@@ -3986,7 +3986,7 @@ version = "0.0.0"
 dependencies = [
  "bstr",
  "but-core",
- "gix",
+ "gix 0.84.0",
 ]
 
 [[package]]
@@ -4010,7 +4010,7 @@ dependencies = [
  "gitbutler-operating-modes",
  "gitbutler-oplog",
  "gitbutler-workspace",
- "gix",
+ "gix 0.84.0",
  "insta",
  "schemars 1.2.1",
  "serde",
@@ -4027,7 +4027,7 @@ dependencies = [
  "but-project-handle",
  "but-testsupport",
  "gitbutler-notify-debouncer",
- "gix",
+ "gix 0.84.0",
  "insta",
  "notify",
  "tokio",
@@ -4046,7 +4046,7 @@ dependencies = [
  "but-testsupport",
  "file-id 0.2.3 (git+https://github.com/notify-rs/notify?rev=978fe719b066a8ce76b9a9d346546b1569eecfb6)",
  "futures",
- "gix",
+ "gix 0.84.0",
  "nix 0.30.1",
  "rand 0.9.4",
  "serde",
@@ -4088,7 +4088,7 @@ dependencies = [
  "but-testsupport",
  "but-utils",
  "but-workspace",
- "gix",
+ "gix 0.84.0",
  "schemars 1.2.1",
  "serde",
  "toml 0.9.12+spec-1.1.0",
@@ -4113,7 +4113,7 @@ dependencies = [
  "gitbutler-branch",
  "gitbutler-cherry-pick",
  "gitbutler-repo",
- "gix",
+ "gix 0.84.0",
  "itertools",
  "pretty_assertions",
  "schemars 1.2.1",
@@ -4138,7 +4138,7 @@ dependencies = [
  "but-serde",
  "but-testsupport",
  "but-utils",
- "gix",
+ "gix 0.84.0",
  "insta",
  "schemars 1.2.1",
  "serde",
@@ -4154,7 +4154,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "but-core",
- "gix",
+ "gix 0.84.0",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -4179,7 +4179,7 @@ dependencies = [
  "gitbutler-project",
  "gitbutler-reference",
  "gitbutler-user",
- "gix",
+ "gix 0.84.0",
  "ignore",
  "infer",
  "insta",
@@ -4201,7 +4201,7 @@ dependencies = [
  "but-ctx",
  "gitbutler-repo",
  "gitbutler-stack",
- "gix",
+ "gix 0.84.0",
 ]
 
 [[package]]
@@ -4223,7 +4223,7 @@ dependencies = [
  "gitbutler-git",
  "gitbutler-reference",
  "gitbutler-repo",
- "gix",
+ "gix 0.84.0",
  "insta",
  "itertools",
  "serde",
@@ -4254,7 +4254,7 @@ dependencies = [
  "document-features",
  "gitbutler-project",
  "gitbutler-watcher",
- "gix",
+ "gix 0.84.0",
  "notify-rust",
  "open",
  "opener",
@@ -4329,7 +4329,7 @@ dependencies = [
  "but-settings",
  "gitbutler-filemonitor",
  "gitbutler-operating-modes",
- "gix",
+ "gix 0.84.0",
  "serde-error",
  "tokio",
  "tokio-util",
@@ -4347,62 +4347,119 @@ dependencies = [
  "but-oxidize",
  "git2",
  "gitbutler-cherry-pick",
- "gix",
+ "gix 0.84.0",
 ]
 
 [[package]]
 name = "gix"
 version = "0.83.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce52001b946a6249d5d0d3011df0a042ac3f8a4d013460db6476577b0b9c567"
 dependencies = [
- "gix-actor",
- "gix-attributes",
- "gix-command",
- "gix-commitgraph",
- "gix-config",
- "gix-credentials",
- "gix-date",
- "gix-diff",
- "gix-dir",
- "gix-discover",
- "gix-error",
- "gix-features",
- "gix-filter",
- "gix-fs",
- "gix-glob",
- "gix-hash",
- "gix-hashtable",
- "gix-ignore",
- "gix-index",
- "gix-lock",
- "gix-mailmap",
- "gix-merge",
- "gix-negotiate",
- "gix-object",
- "gix-odb",
- "gix-pack",
+ "gix-actor 0.41.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-archive",
+ "gix-attributes 0.33.0",
+ "gix-blame",
+ "gix-command 0.9.0",
+ "gix-commitgraph 0.37.0",
+ "gix-config 0.56.0",
+ "gix-date 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-diff 0.63.0",
+ "gix-dir 0.25.0",
+ "gix-discover 0.51.0",
+ "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-features 0.48.0",
+ "gix-filter 0.30.0",
+ "gix-fs 0.21.1",
+ "gix-glob 0.26.0",
+ "gix-hash 0.25.0",
+ "gix-hashtable 0.15.0",
+ "gix-ignore 0.21.0",
+ "gix-index 0.51.0",
+ "gix-lock 23.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-merge 0.16.0",
+ "gix-negotiate 0.31.0",
+ "gix-object 0.60.0",
+ "gix-odb 0.80.0",
+ "gix-pack 0.70.0",
  "gix-path 0.12.0",
- "gix-pathspec",
+ "gix-pathspec 0.18.0",
+ "gix-protocol 0.61.0",
+ "gix-ref 0.63.0",
+ "gix-refspec 0.41.0",
+ "gix-revision 0.45.0",
+ "gix-revwalk 0.31.0",
+ "gix-sec 0.14.0",
+ "gix-shallow 0.12.0",
+ "gix-status 0.30.0",
+ "gix-submodule 0.30.0",
+ "gix-tempfile 23.0.0",
+ "gix-trace 0.1.19",
+ "gix-traverse 0.57.0",
+ "gix-url 0.36.0",
+ "gix-utils 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-validate 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-worktree 0.52.0",
+ "gix-worktree-state 0.30.0",
+ "gix-worktree-stream 0.32.0",
+ "nonempty",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix"
+version = "0.84.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "gix-actor 0.41.1 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-attributes 0.33.1",
+ "gix-command 0.9.1",
+ "gix-commitgraph 0.37.1",
+ "gix-config 0.57.0",
+ "gix-credentials",
+ "gix-date 0.15.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-diff 0.64.0",
+ "gix-dir 0.26.0",
+ "gix-discover 0.52.0",
+ "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-features 0.48.1",
+ "gix-filter 0.31.0",
+ "gix-fs 0.21.2",
+ "gix-glob 0.26.1",
+ "gix-hash 0.25.1",
+ "gix-hashtable 0.15.1",
+ "gix-ignore 0.21.1",
+ "gix-index 0.52.0",
+ "gix-lock 23.0.1 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-mailmap",
+ "gix-merge 0.17.0",
+ "gix-negotiate 0.32.0",
+ "gix-object 0.61.0",
+ "gix-odb 0.81.0",
+ "gix-pack 0.71.0",
+ "gix-path 0.12.1",
+ "gix-pathspec 0.18.1",
  "gix-prompt",
- "gix-protocol",
- "gix-ref",
- "gix-refspec",
- "gix-revision",
- "gix-revwalk",
- "gix-sec",
- "gix-shallow",
- "gix-status",
- "gix-submodule",
- "gix-tempfile",
- "gix-trace 0.1.19 (git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd)",
- "gix-transport",
- "gix-traverse",
- "gix-url",
- "gix-utils",
- "gix-validate 0.11.1",
- "gix-worktree",
- "gix-worktree-state",
- "gix-worktree-stream",
+ "gix-protocol 0.62.0",
+ "gix-ref 0.64.0",
+ "gix-refspec 0.42.0",
+ "gix-revision 0.46.0",
+ "gix-revwalk 0.32.0",
+ "gix-sec 0.14.1",
+ "gix-shallow 0.12.1",
+ "gix-status 0.31.0",
+ "gix-submodule 0.31.0",
+ "gix-tempfile 23.0.1",
+ "gix-trace 0.1.20",
+ "gix-transport 0.57.1",
+ "gix-traverse 0.58.0",
+ "gix-url 0.36.1",
+ "gix-utils 0.3.3 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-validate 0.11.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-worktree 0.53.0",
+ "gix-worktree-state 0.31.0",
+ "gix-worktree-stream 0.33.0",
  "nonempty",
  "parking_lot",
  "serde",
@@ -4413,25 +4470,66 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.41.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+version = "0.41.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bc998b8f746dda8565450d08a63b792ced9165d8c27a1ed3f02799ec6a7820f"
 dependencies = [
  "bstr",
- "gix-date",
- "gix-error",
+ "gix-date 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.41.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bstr",
+ "gix-date 0.15.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
  "serde",
+]
+
+[[package]]
+name = "gix-archive"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a20ec244b733338d4cb60e5e05eac700dab7fcc689647b1d1daa9396b119342"
+dependencies = [
+ "bstr",
+ "gix-date 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-object 0.60.0",
+ "gix-worktree-stream 0.32.0",
 ]
 
 [[package]]
 name = "gix-attributes"
 version = "0.33.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe17c5a1c0b6f2ef1476aa1d3222ea50cdff67608016613a58bfc3e078046000"
 dependencies = [
  "bstr",
- "gix-glob",
+ "gix-glob 0.26.0",
  "gix-path 0.12.0",
- "gix-quote",
- "gix-trace 0.1.19 (git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd)",
+ "gix-quote 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-trace 0.1.19",
+ "kstring",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.33.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bstr",
+ "gix-glob 0.26.1",
+ "gix-path 0.12.1",
+ "gix-quote 0.7.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-trace 0.1.20",
  "kstring",
  "serde",
  "smallvec",
@@ -4441,41 +4539,106 @@ dependencies = [
 
 [[package]]
 name = "gix-bitmap"
-version = "0.3.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ebef0c26ad305747649e727bbcd56a7b7910754eb7cea88f6dff6f93c51283"
 dependencies = [
- "gix-error",
+ "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gix-bitmap"
+version = "0.3.2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+]
+
+[[package]]
+name = "gix-blame"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dab9a942ab54a9661ded7397c3bf927274e7afa94494db0d75cfcbde02ca0a"
+dependencies = [
+ "gix-commitgraph 0.37.0",
+ "gix-date 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-diff 0.63.0",
+ "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-hash 0.25.0",
+ "gix-object 0.60.0",
+ "gix-revwalk 0.31.0",
+ "gix-trace 0.1.19",
+ "gix-traverse 0.57.0",
+ "gix-worktree 0.52.0",
+ "smallvec",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-chunk"
-version = "0.7.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9faee47943b638e58ddd5e275a4906ad3e4b6c8584f1d41bd18ab9032ec52afb"
 dependencies = [
- "gix-error",
+ "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.7.2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
 ]
 
 [[package]]
 name = "gix-command"
 version = "0.9.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86335306511abe43d75c866d4b1f3d90932fe202edcd43e1314036333e7384d8"
 dependencies = [
  "bstr",
  "gix-path 0.12.0",
- "gix-quote",
- "gix-trace 0.1.19 (git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd)",
+ "gix-quote 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-trace 0.1.19",
+ "shell-words",
+]
+
+[[package]]
+name = "gix-command"
+version = "0.9.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bstr",
+ "gix-path 0.12.1",
+ "gix-quote 0.7.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-trace 0.1.20",
  "shell-words",
 ]
 
 [[package]]
 name = "gix-commitgraph"
 version = "0.37.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe3b5aa0f24e19028c261d229aeeedafcaaa52ebd71021cc15184620fc9d32eb"
 dependencies = [
  "bstr",
- "gix-chunk",
- "gix-error",
- "gix-hash",
+ "gix-chunk 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-hash 0.25.0",
+ "memmap2",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.37.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bstr",
+ "gix-chunk 0.7.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-hash 0.25.1",
  "memmap2",
  "nonempty",
  "serde",
@@ -4484,15 +4647,33 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.56.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c01848aebd21c67f6ba41f1de8efd46ae96df21f001954a3c9e1517e514d410"
 dependencies = [
  "bstr",
- "gix-config-value",
- "gix-features",
- "gix-glob",
+ "gix-config-value 0.18.0",
+ "gix-features 0.48.0",
+ "gix-glob 0.26.0",
  "gix-path 0.12.0",
- "gix-ref",
- "gix-sec",
+ "gix-ref 0.63.0",
+ "gix-sec 0.14.0",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.57.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bstr",
+ "gix-config-value 0.18.1",
+ "gix-features 0.48.1",
+ "gix-glob 0.26.1",
+ "gix-path 0.12.1",
+ "gix-ref 0.64.0",
+ "gix-sec 0.14.1",
  "smallvec",
  "thiserror 2.0.18",
  "unicode-bom",
@@ -4501,7 +4682,8 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.18.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b39ed39ee4c10a3b157f9fb94bac8098d9f8e56201f0cf7dee6c187416c4b2"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
@@ -4511,96 +4693,184 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-config-value"
+version = "0.18.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-path 0.12.1",
+ "libc",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "gix-credentials"
-version = "0.38.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+version = "0.38.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
- "gix-command",
- "gix-config-value",
- "gix-date",
- "gix-path 0.12.0",
+ "gix-command 0.9.1",
+ "gix-config-value 0.18.1",
+ "gix-date 0.15.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-path 0.12.1",
  "gix-prompt",
- "gix-sec",
- "gix-trace 0.1.19 (git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd)",
- "gix-url",
+ "gix-sec 0.14.1",
+ "gix-trace 0.1.20",
+ "gix-url 0.36.1",
  "serde",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-date"
-version = "0.15.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ecab64a98bbac9f8e02990a9ea5e3c974a7d49b95f2bd70ad94ad22fa6b48c"
 dependencies = [
  "bstr",
- "gix-error",
+ "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa",
+ "jiff",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.15.4"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bstr",
+ "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
  "itoa",
  "jiff",
  "serde",
- "smallvec",
 ]
 
 [[package]]
 name = "gix-diff"
 version = "0.63.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc08e0fa1a91ff5f24affeab052f198056645e1de004910bde7b82b50ea5982a"
 dependencies = [
  "bstr",
- "gix-attributes",
- "gix-command",
- "gix-filter",
- "gix-fs",
- "gix-hash",
- "gix-imara-diff",
- "gix-index",
- "gix-object",
+ "gix-command 0.9.0",
+ "gix-filter 0.30.0",
+ "gix-fs 0.21.1",
+ "gix-hash 0.25.0",
+ "gix-imara-diff 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-object 0.60.0",
  "gix-path 0.12.0",
- "gix-pathspec",
- "gix-tempfile",
- "gix-trace 0.1.19 (git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd)",
- "gix-traverse",
- "gix-worktree",
+ "gix-tempfile 23.0.0",
+ "gix-trace 0.1.19",
+ "gix-traverse 0.57.0",
+ "gix-worktree 0.52.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.64.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bstr",
+ "gix-attributes 0.33.1",
+ "gix-command 0.9.1",
+ "gix-filter 0.31.0",
+ "gix-fs 0.21.2",
+ "gix-hash 0.25.1",
+ "gix-imara-diff 0.2.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-index 0.52.0",
+ "gix-object 0.61.0",
+ "gix-path 0.12.1",
+ "gix-pathspec 0.18.1",
+ "gix-tempfile 23.0.1",
+ "gix-trace 0.1.20",
+ "gix-traverse 0.58.0",
+ "gix-worktree 0.53.0",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-dir"
 version = "0.25.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a0fc06e9e1e430cbf0a313666976d90f822f461a6525320427aa9b8af5236c"
 dependencies = [
  "bstr",
- "gix-discover",
- "gix-fs",
- "gix-ignore",
- "gix-index",
- "gix-object",
+ "gix-discover 0.51.0",
+ "gix-fs 0.21.1",
+ "gix-ignore 0.21.0",
+ "gix-index 0.51.0",
+ "gix-object 0.60.0",
  "gix-path 0.12.0",
- "gix-pathspec",
- "gix-trace 0.1.19 (git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd)",
- "gix-utils",
- "gix-worktree",
+ "gix-pathspec 0.18.0",
+ "gix-trace 0.1.19",
+ "gix-utils 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-worktree 0.52.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-dir"
+version = "0.26.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bstr",
+ "gix-discover 0.52.0",
+ "gix-fs 0.21.2",
+ "gix-ignore 0.21.1",
+ "gix-index 0.52.0",
+ "gix-object 0.61.0",
+ "gix-path 0.12.1",
+ "gix-pathspec 0.18.1",
+ "gix-trace 0.1.20",
+ "gix-utils 0.3.3 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-worktree 0.53.0",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-discover"
 version = "0.51.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17852e6a501e688a1702b24ebe5b3761d4719455bc869fd29f38b0b859bcad34"
 dependencies = [
  "bstr",
  "dunce",
- "gix-fs",
+ "gix-fs 0.21.1",
  "gix-path 0.12.0",
- "gix-ref",
- "gix-sec",
+ "gix-ref 0.63.0",
+ "gix-sec 0.14.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.52.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-fs 0.21.2",
+ "gix-path 0.12.1",
+ "gix-ref 0.64.0",
+ "gix-sec 0.14.1",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-error"
-version = "0.2.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57831e199be480af90dcd7e459abed8a174c09ec9a6e2cc8f7ca6c54598b06b"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-error"
+version = "0.2.4"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
 ]
@@ -4608,14 +4878,33 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.48.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af375693ad5333d0a2c66b4c5b2cbe9ccc38e34f8e8bf24e4ae42c12307fdc4f"
+dependencies = [
+ "bytes",
+ "crc32fast",
+ "gix-path 0.12.0",
+ "gix-trace 0.1.19",
+ "gix-utils 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "once_cell",
+ "prodash",
+ "thiserror 2.0.18",
+ "walkdir",
+ "zlib-rs",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.48.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bytes",
  "crc32fast",
  "crossbeam-channel",
- "gix-path 0.12.0",
- "gix-trace 0.1.19 (git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd)",
- "gix-utils",
+ "gix-path 0.12.1",
+ "gix-trace 0.1.20",
+ "gix-utils 0.3.3 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
  "libc",
  "once_cell",
  "parking_lot",
@@ -4628,19 +4917,40 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac917dbe9653c9b615d248db91907a365bd779750c9e1b457a9d9fdeece3a08"
 dependencies = [
  "bstr",
  "encoding_rs",
- "gix-attributes",
- "gix-command",
- "gix-hash",
- "gix-object",
- "gix-packetline",
+ "gix-attributes 0.33.0",
+ "gix-command 0.9.0",
+ "gix-hash 0.25.0",
+ "gix-object 0.60.0",
+ "gix-packetline 0.21.3",
  "gix-path 0.12.0",
- "gix-quote",
- "gix-trace 0.1.19 (git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd)",
- "gix-utils",
+ "gix-quote 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-trace 0.1.19",
+ "gix-utils 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.31.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes 0.33.1",
+ "gix-command 0.9.1",
+ "gix-hash 0.25.1",
+ "gix-object 0.61.0",
+ "gix-packetline 0.21.4",
+ "gix-path 0.12.1",
+ "gix-quote 0.7.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-trace 0.1.20",
+ "gix-utils 0.3.3 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
  "smallvec",
  "thiserror 2.0.18",
 ]
@@ -4648,35 +4958,73 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.21.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e1967daac9848757c47c2aef0c57bcadc1a897347f559778249bf286a536c86"
 dependencies = [
  "bstr",
  "fastrand",
- "gix-features",
+ "gix-features 0.48.0",
  "gix-path 0.12.0",
- "gix-utils",
+ "gix-utils 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.21.2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "gix-features 0.48.1",
+ "gix-path 0.12.1",
+ "gix-utils 0.3.3 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-glob"
 version = "0.26.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bf29249a069bf2507f5964f80997f37b134d320ea348d66527726b9be2c38c"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
- "gix-features",
+ "gix-features 0.48.0",
  "gix-path 0.12.0",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.26.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-features 0.48.1",
+ "gix-path 0.12.1",
  "serde",
 ]
 
 [[package]]
 name = "gix-hash"
 version = "0.25.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf70d1e252337eed16360f8b8ebb71865ece58eab7954b39ce38b420de703d2"
 dependencies = [
  "faster-hex",
- "gix-features",
+ "gix-features 0.48.0",
+ "sha1-checked",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.25.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "faster-hex",
+ "gix-features 0.48.1",
  "serde",
  "sha1-checked",
  "sha2 0.11.0",
@@ -4686,9 +5034,20 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d33b455e07b3c16d3b2eeebc7b38d2dafcbf8a653de1138ef55d4c2a1fd0b08b"
 dependencies = [
- "gix-hash",
+ "gix-hash 0.25.0",
+ "hashbrown 0.16.1",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.15.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "gix-hash 0.25.1",
  "hashbrown 0.17.0",
  "parking_lot",
 ]
@@ -4696,43 +5055,94 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb13fbbeeafee943e52b61fcc88dfddf6a452fcaf0c4d0cdc8f218fa25bbec5"
 dependencies = [
  "bstr",
- "gix-glob",
+ "gix-glob 0.26.0",
  "gix-path 0.12.0",
- "gix-trace 0.1.19 (git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd)",
+ "gix-trace 0.1.19",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.21.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bstr",
+ "gix-glob 0.26.1",
+ "gix-path 0.12.1",
+ "gix-trace 0.1.20",
  "serde",
  "unicode-bom",
 ]
 
 [[package]]
 name = "gix-imara-diff"
-version = "0.2.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19"
 dependencies = [
  "bstr",
- "hashbrown 0.17.0",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "gix-imara-diff"
+version = "0.2.2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bstr",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
 name = "gix-index"
 version = "0.51.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54c3ef97ad08121e4327a6226bd63fed6b9e3c6b976d48bddd4356d9d41191db"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
  "filetime",
  "fnv",
- "gix-bitmap",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-lock",
- "gix-object",
- "gix-traverse",
- "gix-utils",
- "gix-validate 0.11.1",
+ "gix-bitmap 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-features 0.48.0",
+ "gix-fs 0.21.1",
+ "gix-hash 0.25.0",
+ "gix-lock 23.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-object 0.60.0",
+ "gix-traverse 0.57.0",
+ "gix-utils 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-validate 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashbrown 0.16.1",
+ "itoa",
+ "libc",
+ "memmap2",
+ "rustix 1.1.4",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.52.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "filetime",
+ "fnv",
+ "gix-bitmap 0.3.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-features 0.48.1",
+ "gix-fs 0.21.2",
+ "gix-hash 0.25.1",
+ "gix-lock 23.0.1 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-object 0.61.0",
+ "gix-traverse 0.58.0",
+ "gix-utils 0.3.3 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-validate 0.11.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
  "hashbrown 0.17.0",
  "itoa",
  "libc",
@@ -4745,47 +5155,84 @@ dependencies = [
 
 [[package]]
 name = "gix-lock"
-version = "23.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+version = "23.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c9dedd9e90b0d47624d2ed241d394e09294118364e87b9b7e5f1fe755f3c2c"
 dependencies = [
- "gix-tempfile",
- "gix-utils",
+ "gix-tempfile 23.0.0",
+ "gix-utils 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-lock"
+version = "23.0.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "gix-tempfile 23.0.1",
+ "gix-utils 0.3.3 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-mailmap"
-version = "0.33.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+version = "0.33.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
- "gix-actor",
- "gix-date",
- "gix-error",
+ "gix-actor 0.41.1 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-date 0.15.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
  "serde",
 ]
 
 [[package]]
 name = "gix-merge"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74bbcdcc52b70a32f0a151b024dff9d0fcf56ee48f00d9503e735af9d99ea881"
 dependencies = [
  "bstr",
- "gix-command",
- "gix-diff",
- "gix-filter",
- "gix-fs",
- "gix-hash",
- "gix-imara-diff",
- "gix-index",
- "gix-object",
+ "gix-command 0.9.0",
+ "gix-diff 0.63.0",
+ "gix-filter 0.30.0",
+ "gix-fs 0.21.1",
+ "gix-hash 0.25.0",
+ "gix-imara-diff 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-index 0.51.0",
+ "gix-object 0.60.0",
  "gix-path 0.12.0",
- "gix-quote",
- "gix-revision",
- "gix-revwalk",
- "gix-tempfile",
- "gix-trace 0.1.19 (git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd)",
- "gix-worktree",
+ "gix-quote 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-revision 0.45.0",
+ "gix-revwalk 0.31.0",
+ "gix-tempfile 23.0.0",
+ "gix-trace 0.1.19",
+ "gix-worktree 0.52.0",
+ "nonempty",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-merge"
+version = "0.17.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bstr",
+ "gix-command 0.9.1",
+ "gix-diff 0.64.0",
+ "gix-filter 0.31.0",
+ "gix-fs 0.21.2",
+ "gix-hash 0.25.1",
+ "gix-imara-diff 0.2.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-index 0.52.0",
+ "gix-object 0.61.0",
+ "gix-path 0.12.1",
+ "gix-quote 0.7.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-revision 0.46.0",
+ "gix-revwalk 0.32.0",
+ "gix-tempfile 23.0.1",
+ "gix-trace 0.1.20",
+ "gix-worktree 0.53.0",
  "nonempty",
  "thiserror 2.0.18",
 ]
@@ -4793,29 +5240,62 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "103d42bfade1b8a96ca5005933127bdad461ce588d92422b2c2daa3ff20d780c"
 dependencies = [
  "bitflags 2.11.1",
- "gix-commitgraph",
- "gix-date",
- "gix-hash",
- "gix-object",
- "gix-revwalk",
+ "gix-commitgraph 0.37.0",
+ "gix-date 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-hash 0.25.0",
+ "gix-object 0.60.0",
+ "gix-revwalk 0.31.0",
+]
+
+[[package]]
+name = "gix-negotiate"
+version = "0.32.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bitflags 2.11.1",
+ "gix-commitgraph 0.37.1",
+ "gix-date 0.15.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-hash 0.25.1",
+ "gix-object 0.61.0",
+ "gix-revwalk 0.32.0",
 ]
 
 [[package]]
 name = "gix-object"
 version = "0.60.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a38075a95d7cc5df8afd38e72c617026c1456952207a4120a7f55a3fbf93b4d7"
 dependencies = [
  "bstr",
- "gix-actor",
- "gix-date",
- "gix-features",
- "gix-hash",
- "gix-hashtable",
- "gix-utils",
- "gix-validate 0.11.1",
+ "gix-actor 0.41.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-date 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-features 0.48.0",
+ "gix-hash 0.25.0",
+ "gix-hashtable 0.15.0",
+ "gix-utils 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-validate 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.61.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bstr",
+ "gix-actor 0.41.1 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-date 0.15.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-features 0.48.1",
+ "gix-hash 0.25.1",
+ "gix-hashtable 0.15.1",
+ "gix-utils 0.3.3 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-validate 0.11.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
  "itoa",
  "serde",
  "smallvec",
@@ -4825,17 +5305,38 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.80.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeeda12a9663120418735ecdc1250d06eeab0be75700e47b3402a981331716ba"
 dependencies = [
  "arc-swap",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-pack",
+ "gix-features 0.48.0",
+ "gix-fs 0.21.1",
+ "gix-hash 0.25.0",
+ "gix-hashtable 0.15.0",
+ "gix-object 0.60.0",
+ "gix-pack 0.70.0",
  "gix-path 0.12.0",
- "gix-quote",
+ "gix-quote 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memmap2",
+ "parking_lot",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.81.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "arc-swap",
+ "gix-features 0.48.1",
+ "gix-fs 0.21.2",
+ "gix-hash 0.25.1",
+ "gix-hashtable 0.15.1",
+ "gix-object 0.61.0",
+ "gix-pack 0.71.0",
+ "gix-path 0.12.1",
+ "gix-quote 0.7.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
  "memmap2",
  "parking_lot",
  "serde",
@@ -4846,17 +5347,36 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.70.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf02e6f5c8f07a069c9ea5245f40d9b14856ada4086091dc99941b49002b4fa"
 dependencies = [
  "clru",
- "gix-chunk",
- "gix-error",
- "gix-features",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
+ "gix-chunk 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-features 0.48.0",
+ "gix-hash 0.25.0",
+ "gix-hashtable 0.15.0",
+ "gix-object 0.60.0",
  "gix-path 0.12.0",
- "gix-tempfile",
+ "memmap2",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.71.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "clru",
+ "gix-chunk 0.7.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-features 0.48.1",
+ "gix-hash 0.25.1",
+ "gix-hashtable 0.15.1",
+ "gix-object 0.61.0",
+ "gix-path 0.12.1",
+ "gix-tempfile 23.0.1",
  "memmap2",
  "parking_lot",
  "serde",
@@ -4868,11 +5388,23 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.21.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "362246df440ee691699f0664cbf7006a6ece477db6734222be95e4198e5656e6"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.19 (git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd)",
+ "gix-trace 0.1.19",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-packetline"
+version = "0.21.4"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace 0.1.20",
  "thiserror 2.0.18",
 ]
 
@@ -4883,7 +5415,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cb06c3e4f8eed6e24fd915fa93145e28a511f4ea0e768bae16673e05ed3f366"
 dependencies = [
  "bstr",
- "gix-trace 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-trace 0.1.19",
  "gix-validate 0.10.1",
  "thiserror 2.0.18",
 ]
@@ -4891,35 +5423,62 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671a6059e8a4c1b7f406e24716499cefa3926e060876fb1959ef225efeee346e"
 dependencies = [
  "bstr",
- "gix-trace 0.1.19 (git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd)",
- "gix-validate 0.11.1",
+ "gix-trace 0.1.19",
+ "gix-validate 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.12.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bstr",
+ "gix-trace 0.1.20",
+ "gix-validate 0.11.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-pathspec"
 version = "0.18.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a84a4f083dd70fb49f4377e13afa6d90df2daaa1c705c49d6ff1331fc7e8855"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
- "gix-attributes",
- "gix-config-value",
- "gix-glob",
+ "gix-attributes 0.33.0",
+ "gix-config-value 0.18.0",
+ "gix-glob 0.26.0",
  "gix-path 0.12.0",
  "thiserror 2.0.18",
 ]
 
 [[package]]
-name = "gix-prompt"
-version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+name = "gix-pathspec"
+version = "0.18.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
- "gix-command",
- "gix-config-value",
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-attributes 0.33.1",
+ "gix-config-value 0.18.1",
+ "gix-glob 0.26.1",
+ "gix-path 0.12.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-prompt"
+version = "0.15.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "gix-command 0.9.1",
+ "gix-config-value 0.18.1",
  "parking_lot",
  "rustix 1.1.4",
  "thiserror 2.0.18",
@@ -4928,23 +5487,42 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.61.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4bee82db63ec635996b96efae71cf467c155fa3f34a556184373224a26c4fd"
+dependencies = [
+ "bstr",
+ "gix-date 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-features 0.48.0",
+ "gix-hash 0.25.0",
+ "gix-ref 0.63.0",
+ "gix-shallow 0.12.0",
+ "gix-transport 0.57.0",
+ "gix-utils 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maybe-async",
+ "nonempty",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-protocol"
+version = "0.62.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
  "gix-credentials",
- "gix-date",
- "gix-features",
- "gix-hash",
- "gix-lock",
- "gix-negotiate",
- "gix-object",
- "gix-ref",
- "gix-refspec",
- "gix-revwalk",
- "gix-shallow",
- "gix-trace 0.1.19 (git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd)",
- "gix-transport",
- "gix-utils",
+ "gix-date 0.15.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-features 0.48.1",
+ "gix-hash 0.25.1",
+ "gix-lock 23.0.1 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-negotiate 0.32.0",
+ "gix-object 0.61.0",
+ "gix-ref 0.64.0",
+ "gix-refspec 0.42.0",
+ "gix-revwalk 0.32.0",
+ "gix-shallow 0.12.1",
+ "gix-trace 0.1.20",
+ "gix-transport 0.57.1",
+ "gix-utils 0.3.3 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
  "maybe-async",
  "nonempty",
  "serde",
@@ -4953,29 +5531,60 @@ dependencies = [
 
 [[package]]
 name = "gix-quote"
-version = "0.7.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e541fc33cc2b783b7979040d445a0c86a2eca747c8faea4ca84230d06ae6ef"
 dependencies = [
  "bstr",
- "gix-error",
- "gix-utils",
+ "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-utils 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gix-quote"
+version = "0.7.2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bstr",
+ "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-utils 0.3.3 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
 ]
 
 [[package]]
 name = "gix-ref"
 version = "0.63.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8ba9cc15f558b274c99349b83130f5ec83459660828fde9718bbbb43a726167"
 dependencies = [
- "gix-actor",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-lock",
- "gix-object",
+ "gix-actor 0.41.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-features 0.48.0",
+ "gix-fs 0.21.1",
+ "gix-hash 0.25.0",
+ "gix-lock 23.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-object 0.60.0",
  "gix-path 0.12.0",
- "gix-tempfile",
- "gix-utils",
- "gix-validate 0.11.1",
+ "gix-tempfile 23.0.0",
+ "gix-utils 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-validate 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memmap2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.64.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "gix-actor 0.41.1 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-features 0.48.1",
+ "gix-fs 0.21.2",
+ "gix-hash 0.25.1",
+ "gix-lock 23.0.1 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-object 0.61.0",
+ "gix-path 0.12.1",
+ "gix-tempfile 23.0.1",
+ "gix-utils 0.3.3 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-validate 0.11.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
  "memmap2",
  "serde",
  "thiserror 2.0.18",
@@ -4984,14 +5593,30 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.41.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61755b27d57edc8940a1b1593c8c61548ca8e4c02da1ed8d5bfeda9eb2a6b761"
 dependencies = [
  "bstr",
- "gix-error",
- "gix-glob",
- "gix-hash",
- "gix-revision",
- "gix-validate 0.11.1",
+ "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-glob 0.26.0",
+ "gix-hash 0.25.0",
+ "gix-revision 0.45.0",
+ "gix-validate 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.42.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bstr",
+ "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-glob 0.26.1",
+ "gix-hash 0.25.1",
+ "gix-revision 0.46.0",
+ "gix-validate 0.11.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
  "smallvec",
  "thiserror 2.0.18",
 ]
@@ -4999,18 +5624,37 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.45.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb5288fac706d3ea3e4e2ba9ec38b78743b8c02f422e18cb342299cfd6ab7e8"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
- "gix-commitgraph",
- "gix-date",
- "gix-error",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-revwalk",
- "gix-trace 0.1.19 (git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd)",
+ "gix-commitgraph 0.37.0",
+ "gix-date 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-hash 0.25.0",
+ "gix-hashtable 0.15.0",
+ "gix-object 0.60.0",
+ "gix-revwalk 0.31.0",
+ "gix-trace 0.1.19",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.46.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-commitgraph 0.37.1",
+ "gix-date 0.15.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-hash 0.25.1",
+ "gix-hashtable 0.15.1",
+ "gix-object 0.61.0",
+ "gix-revwalk 0.32.0",
+ "gix-trace 0.1.20",
  "nonempty",
  "serde",
 ]
@@ -5018,14 +5662,30 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "313813706b073a12ff7f9b2896bf3e6504cdac7cfbc97b1920114724705069f0"
 dependencies = [
- "gix-commitgraph",
- "gix-date",
- "gix-error",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
+ "gix-commitgraph 0.37.0",
+ "gix-date 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-hash 0.25.0",
+ "gix-hashtable 0.15.0",
+ "gix-object 0.60.0",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.32.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "gix-commitgraph 0.37.1",
+ "gix-date 0.15.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-hash 0.25.1",
+ "gix-hashtable 0.15.1",
+ "gix-object 0.61.0",
  "smallvec",
  "thiserror 2.0.18",
 ]
@@ -5033,10 +5693,22 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.14.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3a2d3e504a238136751e646a6c028252286a0ea64ea9974bf0498633407c6"
 dependencies = [
  "bitflags 2.11.1",
  "gix-path 0.12.0",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.14.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bitflags 2.11.1",
+ "gix-path 0.12.1",
  "libc",
  "serde",
  "windows-sys 0.61.2",
@@ -5045,11 +5717,24 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29187305521bfacf4aefd284ab28dbfa9fb74abd39a5e63dd313b1baa5808c27"
 dependencies = [
  "bstr",
- "gix-hash",
- "gix-lock",
+ "gix-hash 0.25.0",
+ "gix-lock 23.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nonempty",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-shallow"
+version = "0.12.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bstr",
+ "gix-hash 0.25.1",
+ "gix-lock 23.0.1 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
  "nonempty",
  "serde",
  "thiserror 2.0.18",
@@ -5058,21 +5743,44 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c6d2a8c521ffa205fe7e268c82e6d1378ba37cd826ca10ab6129fdc29a4b65"
 dependencies = [
  "bstr",
  "filetime",
- "gix-diff",
- "gix-dir",
- "gix-features",
- "gix-filter",
- "gix-fs",
- "gix-hash",
- "gix-index",
- "gix-object",
+ "gix-diff 0.63.0",
+ "gix-dir 0.25.0",
+ "gix-features 0.48.0",
+ "gix-filter 0.30.0",
+ "gix-fs 0.21.1",
+ "gix-hash 0.25.0",
+ "gix-index 0.51.0",
+ "gix-object 0.60.0",
  "gix-path 0.12.0",
- "gix-pathspec",
- "gix-worktree",
+ "gix-pathspec 0.18.0",
+ "gix-worktree 0.52.0",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-status"
+version = "0.31.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bstr",
+ "filetime",
+ "gix-diff 0.64.0",
+ "gix-dir 0.26.0",
+ "gix-features 0.48.1",
+ "gix-filter 0.31.0",
+ "gix-fs 0.21.2",
+ "gix-hash 0.25.1",
+ "gix-index 0.52.0",
+ "gix-object 0.61.0",
+ "gix-path 0.12.1",
+ "gix-pathspec 0.18.1",
+ "gix-worktree 0.53.0",
  "portable-atomic",
  "thiserror 2.0.18",
 ]
@@ -5080,24 +5788,52 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fd5fc8692890bd71a596e540fd4c364f8460eaa82c4eaaedebde6e1e3eb4d91"
 dependencies = [
  "bstr",
- "gix-config",
+ "gix-config 0.56.0",
  "gix-path 0.12.0",
- "gix-pathspec",
- "gix-refspec",
- "gix-url",
+ "gix-pathspec 0.18.0",
+ "gix-refspec 0.41.0",
+ "gix-url 0.36.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.31.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bstr",
+ "gix-config 0.57.0",
+ "gix-path 0.12.1",
+ "gix-pathspec 0.18.1",
+ "gix-refspec 0.42.0",
+ "gix-url 0.36.1",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-tempfile"
 version = "23.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "691ea1e31435c7e7d4d04705ec9d1c0d9482c46b2acf512bc723939d8f0af7fb"
 dependencies = [
  "dashmap",
- "gix-fs",
+ "gix-fs 0.21.1",
+ "libc",
+ "parking_lot",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "23.0.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "dashmap",
+ "gix-fs 0.21.2",
  "libc",
  "parking_lot",
  "signal-hook 0.4.3",
@@ -5108,18 +5844,18 @@ dependencies = [
 [[package]]
 name = "gix-testtools"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
  "crc",
  "fastrand",
  "fs_extra",
- "gix-discover",
- "gix-fs",
- "gix-hash",
- "gix-lock",
- "gix-tempfile",
- "gix-worktree",
+ "gix-discover 0.52.0",
+ "gix-fs 0.21.2",
+ "gix-hash 0.25.1",
+ "gix-lock 23.0.1 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-tempfile 23.0.1",
+ "gix-worktree 0.53.0",
  "io-close",
  "is_ci",
  "parking_lot",
@@ -5135,8 +5871,8 @@ checksum = "6f23569e55f2ffaf958617353b9734a7d52a7c19c439eeaa5e3efc217fd2270e"
 
 [[package]]
 name = "gix-trace"
-version = "0.1.19"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+version = "0.1.20"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "tracing",
 ]
@@ -5144,17 +5880,33 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.57.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd6a5c676b92d4ead5f5a2b2935024415dec69edc997b6090ca9cac010a3018"
+dependencies = [
+ "bstr",
+ "gix-command 0.9.0",
+ "gix-features 0.48.0",
+ "gix-packetline 0.21.3",
+ "gix-quote 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-sec 0.14.0",
+ "gix-url 0.36.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-transport"
+version = "0.57.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "base64 0.22.1",
  "bstr",
- "gix-command",
+ "gix-command 0.9.1",
  "gix-credentials",
- "gix-features",
- "gix-packetline",
- "gix-quote",
- "gix-sec",
- "gix-url",
+ "gix-features 0.48.1",
+ "gix-packetline 0.21.4",
+ "gix-quote 0.7.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-sec 0.14.1",
+ "gix-url 0.36.1",
  "reqwest",
  "serde",
  "thiserror 2.0.18",
@@ -5163,15 +5915,32 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.57.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a14b7052c0786676c03e71fcfde7d7f0f8e8316e642b5cec6bb3998719b2ce5c"
 dependencies = [
  "bitflags 2.11.1",
- "gix-commitgraph",
- "gix-date",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-revwalk",
+ "gix-commitgraph 0.37.0",
+ "gix-date 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-hash 0.25.0",
+ "gix-hashtable 0.15.0",
+ "gix-object 0.60.0",
+ "gix-revwalk 0.31.0",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.58.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bitflags 2.11.1",
+ "gix-commitgraph 0.37.1",
+ "gix-date 0.15.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-hash 0.25.1",
+ "gix-hashtable 0.15.1",
+ "gix-object 0.61.0",
+ "gix-revwalk 0.32.0",
  "smallvec",
  "thiserror 2.0.18",
 ]
@@ -5179,10 +5948,22 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.36.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35842d099e813f6f6bba529e88d4670572149c3df79b7a412952259887721ece"
 dependencies = [
  "bstr",
  "gix-path 0.12.0",
+ "percent-encoding",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.36.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bstr",
+ "gix-path 0.12.1",
  "percent-encoding",
  "serde",
  "thiserror 2.0.18",
@@ -5190,8 +5971,19 @@ dependencies = [
 
 [[package]]
 name = "gix-utils"
-version = "0.3.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c50966184123caf580ffa64e28031a878597f1c7fceb8fe19566c38eb1b771"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-utils"
+version = "0.3.3"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
  "fastrand",
@@ -5210,8 +6002,17 @@ dependencies = [
 
 [[package]]
 name = "gix-validate"
-version = "0.11.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bc6fc771c4063ba7cd2f47b91fb6076251c6a823b64b7fe7b8874b0fe4afae3"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.11.2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
 ]
@@ -5219,34 +6020,70 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.52.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69955eb5e2910832f88d041964b809eee01dadd579237e0b55efec58fd406fd"
 dependencies = [
  "bstr",
- "gix-attributes",
- "gix-fs",
- "gix-glob",
- "gix-hash",
- "gix-ignore",
- "gix-index",
- "gix-object",
+ "gix-attributes 0.33.0",
+ "gix-fs 0.21.1",
+ "gix-glob 0.26.0",
+ "gix-hash 0.25.0",
+ "gix-ignore 0.21.0",
+ "gix-index 0.51.0",
+ "gix-object 0.60.0",
  "gix-path 0.12.0",
- "gix-validate 0.11.1",
+ "gix-validate 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.53.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bstr",
+ "gix-attributes 0.33.1",
+ "gix-fs 0.21.2",
+ "gix-glob 0.26.1",
+ "gix-hash 0.25.1",
+ "gix-ignore 0.21.1",
+ "gix-index 0.52.0",
+ "gix-object 0.61.0",
+ "gix-path 0.12.1",
+ "gix-validate 0.11.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
  "serde",
 ]
 
 [[package]]
 name = "gix-worktree-state"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a96dccbcf9e8fe0291c55f06e08da93ebb2e691c1311276f541eefcc6d70800"
 dependencies = [
  "bstr",
- "gix-features",
- "gix-filter",
- "gix-fs",
- "gix-index",
- "gix-object",
+ "gix-features 0.48.0",
+ "gix-filter 0.30.0",
+ "gix-fs 0.21.1",
+ "gix-index 0.51.0",
+ "gix-object 0.60.0",
  "gix-path 0.12.0",
- "gix-worktree",
+ "gix-worktree 0.52.0",
+ "io-close",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-worktree-state"
+version = "0.31.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "bstr",
+ "gix-features 0.48.1",
+ "gix-filter 0.31.0",
+ "gix-fs 0.21.2",
+ "gix-index 0.52.0",
+ "gix-object 0.61.0",
+ "gix-path 0.12.1",
+ "gix-worktree 0.53.0",
  "io-close",
  "thiserror 2.0.18",
 ]
@@ -5254,17 +6091,35 @@ dependencies = [
 [[package]]
 name = "gix-worktree-stream"
 version = "0.32.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=575113dfb10b3ba12eb57f57a81b241e773968bd#575113dfb10b3ba12eb57f57a81b241e773968bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8444b8ed4662e1a0c97f3eceda29630001a1bbb2632201e50312623e594213"
 dependencies = [
- "gix-attributes",
- "gix-error",
- "gix-features",
- "gix-filter",
- "gix-fs",
- "gix-hash",
- "gix-object",
+ "gix-attributes 0.33.0",
+ "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-features 0.48.0",
+ "gix-filter 0.30.0",
+ "gix-fs 0.21.1",
+ "gix-hash 0.25.0",
+ "gix-object 0.60.0",
  "gix-path 0.12.0",
- "gix-traverse",
+ "gix-traverse 0.57.0",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-worktree-stream"
+version = "0.33.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
+dependencies = [
+ "gix-attributes 0.33.1",
+ "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-features 0.48.1",
+ "gix-filter 0.31.0",
+ "gix-fs 0.21.2",
+ "gix-hash 0.25.1",
+ "gix-object 0.61.0",
+ "gix-path 0.12.1",
+ "gix-traverse 0.58.0",
  "parking_lot",
 ]
 
@@ -6078,7 +6933,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6153,7 +7008,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7009,7 +7864,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7553,7 +8408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8268,7 +9123,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8838,7 +9693,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8896,7 +9751,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10446,7 +11301,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10475,7 +11330,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11881,7 +12736,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,10 +214,10 @@ bstr = "1.12.1"
 zip = { version = "4", default-features = false, features = ["bzip2"] }
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
 # When adjusting this, update `gix-testtools` as well!
-gix = { version = "0.83.0", default-features = false, features = [
+gix = { version = "0.84.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "b5b2d54d6a63921621d48c492eaa77faf89e8cb5", default-features = false, features = [
     "sha1", "sha256"
 ] }
-gix-testtools = { version = "0.19.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "575113dfb10b3ba12eb57f57a81b241e773968bd" }
+gix-testtools = { version = "0.19.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "b5b2d54d6a63921621d48c492eaa77faf89e8cb5" }
 
 
 insta = { version = "1.47.2", features = ["json"] }
@@ -315,7 +315,7 @@ git-meta-lib = { version = "0.1.10" }
 [patch.crates-io]
 # Make all dependencies use the same gix as our crates, so that we don't end up
 # with two versions of gix compiled in.
-gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "575113dfb10b3ba12eb57f57a81b241e773968bd" }
+gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "b5b2d54d6a63921621d48c492eaa77faf89e8cb5" }
 
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -313,8 +313,10 @@ inventory = "0.3"
 git-meta-lib = { version = "0.1.10" }
 
 [patch.crates-io]
-# Make all dependencies use the same gix as our crates, so that we don't end up
-# with two versions of gix compiled in.
+# Keep workspace crates that use the `gix 0.84` line on the same git revision.
+# Note that this does not currently eliminate duplicate `gix` versions entirely:
+# `git-meta-lib` still depends on `gix 0.83`, so Cargo will continue to pull that
+# version from crates.io until `git-meta-lib` moves to `0.84` as well.
 gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "b5b2d54d6a63921621d48c492eaa77faf89e8cb5" }
 
 [workspace.lints.clippy]


### PR DESCRIPTION
There are plenty of improvements, with one that allows relative worktrees to be handled correctly, as of Git 2.48.

This also *duplicates* dependencies until `git-meta-lib` also uses v0.84.
That's a bit of a pitty, but probably our life every month if we want to stay up-to-date.
After all, the patch section in `Cargo.toml` can only compensate for different versions
from one source, it won't allow to change 'breaking' versions.

Related PR: https://github.com/git-meta/git-meta/pull/85
