### PR TITLE
feat(cli): remove confirmation prompt from `oplog restore` and `branch delete`

### DIFF
--- a/crates/but/src/args/branch.rs
+++ b/crates/but/src/args/branch.rs
@@ -37,9 +37,6 @@ pub enum Subcommands {
     Delete {
         /// Name of the branch to delete
         branch_name: String,
-        /// Force deletion without confirmation
-        #[clap(long, short = 'f')]
-        force: bool,
     },
 
     /// List the branches in the repository

--- a/crates/but/src/args/oplog.rs
+++ b/crates/but/src/args/oplog.rs
@@ -54,8 +54,5 @@ pub enum Subcommands {
     Restore {
         /// Oplog SHA to restore to
         oplog_sha: String,
-        /// Skip confirmation prompt
-        #[clap(short = 'f', long = "force")]
-        force: bool,
     },
 }

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -7,7 +7,7 @@ use gix::refs::Category;
 use crate::{
     CliError, CliId, CliResult, IdMap, bad_input,
     theme::{self, Paint},
-    utils::{Confirm, ConfirmDefault, OutputChannel, shorten_object_id},
+    utils::{OutputChannel, shorten_object_id},
 };
 
 mod json;
@@ -18,7 +18,6 @@ pub fn delete(
     ctx: &mut but_ctx::Context,
     out: &mut OutputChannel,
     branch_name: String,
-    force: bool,
 ) -> CliResult<()> {
     let t = theme::get();
 
@@ -40,19 +39,6 @@ pub fn delete(
     let Some(segment) = segment else {
         return Err(bad_input(format!("Branch '{branch_name}' not found in any stack")).into());
     };
-
-    if !force
-        && let Some(mut inout) = out.prepare_for_terminal_input()
-        && inout.confirm(
-            format!(
-                "Are you sure you want to delete branch {}?",
-                t.local_branch.paint(&branch_name)
-            ),
-            ConfirmDefault::No,
-        )? == Confirm::No
-    {
-        return Err(anyhow::anyhow!("Aborted branch deletion.").into());
-    }
 
     let mut meta = ctx.meta()?;
     let snapshot_details = SnapshotDetails::new(OperationKind::DeleteBranch);

--- a/crates/but/src/command/legacy/oplog.rs
+++ b/crates/but/src/command/legacy/oplog.rs
@@ -5,7 +5,7 @@ use gix::{date::time::CustomFormat, prelude::ObjectIdExt};
 
 use crate::{
     theme::{self, Paint},
-    utils::{Confirm, ConfirmDefault, OutputChannel, shorten_object_id},
+    utils::{OutputChannel, shorten_object_id},
 };
 
 pub const ISO8601_NO_TZ: CustomFormat = CustomFormat::new("%Y-%m-%d %H:%M:%S");
@@ -267,7 +267,6 @@ pub(crate) fn restore_to_oplog(
     ctx: &mut but_ctx::Context,
     out: &mut OutputChannel,
     oplog_sha: &str,
-    force: bool,
 ) -> anyhow::Result<()> {
     let commit_id = ctx.repo.get()?.rev_parse_single(oplog_sha)?.detach();
     let target_snapshot = &but_api::legacy::oplog::get_snapshot(ctx, commit_id)?;
@@ -299,19 +298,6 @@ pub(crate) fn restore_to_oplog(
             t.time.paint(&target_time)
         )?;
         writeln!(out, "  Snapshot: {}", t.commit_id.paint(&commit_short))?;
-
-        // Confirm the restoration (safety check)
-        if !force {
-            writeln!(
-                out,
-                "\n{}",
-                t.attention
-                    .paint("⚠️  This will overwrite your current workspace state.")
-            )?;
-            if out.confirm("Continue with restore?", ConfirmDefault::No)? == Confirm::No {
-                return Ok(());
-            }
-        }
     }
 
     // Restore to the target snapshot using the but-api crate

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -446,7 +446,7 @@ async fn match_subcommand(
                     command::legacy::branch::new(&mut ctx, out, branch_name, anchor)
                 }
                 #[cfg(feature = "legacy")]
-                Some(branch::Subcommands::Delete { branch_name, force }) => {
+                Some(branch::Subcommands::Delete { branch_name }) => {
                     let mut ctx = setup::init_ctx(
                         &args,
                         InitCtxOptions {
@@ -455,7 +455,7 @@ async fn match_subcommand(
                         },
                         out,
                     )?;
-                    command::legacy::branch::delete(&mut ctx, out, branch_name, force)
+                    command::legacy::branch::delete(&mut ctx, out, branch_name)
                 }
                 #[cfg(not(feature = "legacy"))]
                 Some(branch::Subcommands::Apply { branch_name }) => {
@@ -998,8 +998,8 @@ async fn match_subcommand(
                         .emit_metrics(metrics_ctx)
                         .map_err(CliError::from)
                 }
-                Some(args::oplog::Subcommands::Restore { oplog_sha, force }) => {
-                    command::legacy::oplog::restore_to_oplog(&mut ctx, out, &oplog_sha, force)
+                Some(args::oplog::Subcommands::Restore { oplog_sha }) => {
+                    command::legacy::oplog::restore_to_oplog(&mut ctx, out, &oplog_sha)
                         .emit_metrics(metrics_ctx)
                         .map_err(CliError::from)
                 }

--- a/crates/but/src/utils/output_channel.rs
+++ b/crates/but/src/utils/output_channel.rs
@@ -15,6 +15,7 @@ use crate::{
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConfirmDefault {
     Yes,
+    #[expect(dead_code)]
     No,
 }
 


### PR DESCRIPTION
`but undo` supports both of these so don't think we need a confirmation.