### PR TITLE
Bump git-meta for but-agentlog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,7 +936,7 @@ dependencies = [
  "but-workspace",
  "chrono",
  "clap",
- "git-meta-lib 0.1.10 (git+https://github.com/git-meta/git-meta.git?rev=e5244374ec2bb413d5f8af28b7983ef29957a0d2)",
+ "git-meta-lib 0.1.10 (git+https://github.com/git-meta/git-meta.git?rev=3237a6e1cad6bbd5acf348f7ed8b861b14090c69)",
  "gix 0.84.0",
  "hex",
  "serde",
@@ -3854,7 +3854,7 @@ dependencies = [
 [[package]]
 name = "git-meta-lib"
 version = "0.1.10"
-source = "git+https://github.com/git-meta/git-meta.git?rev=e5244374ec2bb413d5f8af28b7983ef29957a0d2#e5244374ec2bb413d5f8af28b7983ef29957a0d2"
+source = "git+https://github.com/git-meta/git-meta.git?rev=3237a6e1cad6bbd5acf348f7ed8b861b14090c69#3237a6e1cad6bbd5acf348f7ed8b861b14090c69"
 dependencies = [
  "gix 0.83.0",
  "rusqlite",

--- a/crates/but-agentlog/Cargo.toml
+++ b/crates/but-agentlog/Cargo.toml
@@ -16,7 +16,7 @@ but-workspace.workspace = true
 chrono = { workspace = true, features = ["clock"] }
 clap.workspace = true
 gix.workspace = true
-git-meta-lib = { git = "https://github.com/git-meta/git-meta.git", rev = "e5244374ec2bb413d5f8af28b7983ef29957a0d2" }
+git-meta-lib = { git = "https://github.com/git-meta/git-meta.git", rev = "3237a6e1cad6bbd5acf348f7ed8b861b14090c69" }
 hex.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
## Summary
- Update but-agentlog's git-meta-lib revision to 3237a6e1cad6bbd5acf348f7ed8b861b14090c69
- Refresh Cargo.lock for the pinned Git dependency

## Test
- cargo check -p but-agentlog --all-targets --locked