### PR TITLE
Bump git-meta for agentlog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,7 +936,7 @@ dependencies = [
  "but-workspace",
  "chrono",
  "clap",
- "git-meta-lib 0.1.10 (git+https://github.com/git-meta/git-meta.git?rev=3237a6e1cad6bbd5acf348f7ed8b861b14090c69)",
+ "git-meta-lib 0.1.10 (git+https://github.com/git-meta/git-meta.git?rev=13a3a118c16c07532d84e97df43fdecd4accd6ef)",
  "gix 0.84.0",
  "hex",
  "serde",
@@ -3854,9 +3854,9 @@ dependencies = [
 [[package]]
 name = "git-meta-lib"
 version = "0.1.10"
-source = "git+https://github.com/git-meta/git-meta.git?rev=3237a6e1cad6bbd5acf348f7ed8b861b14090c69#3237a6e1cad6bbd5acf348f7ed8b861b14090c69"
+source = "git+https://github.com/git-meta/git-meta.git?rev=13a3a118c16c07532d84e97df43fdecd4accd6ef#13a3a118c16c07532d84e97df43fdecd4accd6ef"
 dependencies = [
- "gix 0.83.0",
+ "gix 0.84.0",
  "rusqlite",
  "serde",
  "serde_json",

--- a/crates/but-agentlog/Cargo.toml
+++ b/crates/but-agentlog/Cargo.toml
@@ -16,7 +16,7 @@ but-workspace.workspace = true
 chrono = { workspace = true, features = ["clock"] }
 clap.workspace = true
 gix.workspace = true
-git-meta-lib = { git = "https://github.com/git-meta/git-meta.git", rev = "3237a6e1cad6bbd5acf348f7ed8b861b14090c69" }
+git-meta-lib = { git = "https://github.com/git-meta/git-meta.git", rev = "13a3a118c16c07532d84e97df43fdecd4accd6ef" }
 hex.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
## Summary
- Bump but-agentlog git-meta-lib to git-meta main commit 13a3a118c16c07532d84e97df43fdecd4accd6ef
- Refresh Cargo.lock so the git-meta dependency now uses gix 0.84

## Validation
- cargo check --locked -p but-agentlog --all-targets
- cargo machete