### PR TITLE
Skip credential cleanup in getLoginUrl when no user is signed in

### DIFF
--- a/apps/desktop/src/lib/user/userService.svelte.ts
+++ b/apps/desktop/src/lib/user/userService.svelte.ts
@@ -112,7 +112,14 @@ export class UserService {
 	}
 
 	private async getLoginUrl(): Promise<string> {
-		await this.forgetUserCredentials();
+		// Only clear existing credentials when a user is actually signed in.
+		// forgetUserCredentials() has side effects (backend deleteUser call,
+		// telemetry/observability state resets) that should not fire when no
+		// user exists -- the normal case when invoked from the onboarding
+		// "Log in / Sign up" button.
+		if (this.user) {
+			await this.forgetUserCredentials();
+		}
 		try {
 			const loginToken = await this.backendApi.endpoints.getLoginToken.fetch(undefined, {
 				forceRefetch: true,


### PR DESCRIPTION
getLoginUrl() calls forgetUserCredentials() before fetching a new login
URL. This was a defensive measure for the "signing in again while
already signed in" edge case, but the call runs unconditionally.

When a user clicks "Log in / Sign up" without being signed in -- the
normal flow during onboarding -- the cleanup still runs and produces
unwanted side effects:

  - A deleteUser backend call is issued for a non-existent user.
  - Telemetry and observability state (Sentry user context, distinct
    identifiers) is reset for a session that never had any user state.
  - A "logout" capture is emitted suggesting a session ended even
    though none had begun, splitting the user's pre- and post-OAuth
    activity across unrelated identifiers in any downstream consumer.

Guard the cleanup so it only runs when this.user is defined. Direct
callers of forgetUserCredentials (e.g. the GeneralSettings logout
button) are unaffected.