### PR TITLE
Fix analytics confirmation race condition

### DIFF
--- a/apps/desktop/src/components/onboarding/AnalyticsConfirmation.svelte
+++ b/apps/desktop/src/components/onboarding/AnalyticsConfirmation.svelte
@@ -4,7 +4,7 @@
 	import { SETTINGS_SERVICE } from "$lib/settings/appSettings";
 	import { OnboardingEvent, POSTHOG_WRAPPER } from "$lib/telemetry/posthog";
 	import { inject } from "@gitbutler/core/context";
-	import { Button, TestId } from "@gitbutler/ui";
+	import { AsyncButton, TestId } from "@gitbutler/ui";
 
 	const settingsService = inject(SETTINGS_SERVICE);
 	const appSettings = $derived(settingsService.appSettings);
@@ -17,12 +17,12 @@
 
 	{#if $appSettings !== undefined}
 		<div class="analytics-confirmation__actions">
-			<Button
+			<AsyncButton
 				style="pop"
 				testId={TestId.OnboardingPageAnalyticsSettingsContinueButton}
 				icon="chevron-right"
-				onclick={() => {
-					settingsService.updateOnboardingComplete(true);
+				action={async () => {
+					await settingsService.updateOnboardingComplete(true);
 					initAnalyticsIfEnabled($appSettings, posthog, true).then(() => {
 						// Await the initialization before logging the event to ensure PostHog is ready
 						posthog.captureOnboarding(OnboardingEvent.ConfirmedAnalytics);
@@ -30,7 +30,7 @@
 				}}
 			>
 				Continue
-			</Button>
+			</AsyncButton>
 		</div>
 	{/if}
 </div>


### PR DESCRIPTION
We should await updating the settings before checking if we can init
analytics.