### PR TITLE
fix(but): make root flags work for aliases

### DIFF
--- a/crates/but/src/alias.rs
+++ b/crates/but/src/alias.rs
@@ -4,20 +4,6 @@
 //! similar to how `git` handles aliases like `git co` -> `git checkout`.
 //!
 //! Aliases are read from git config under the `but.alias.<name>` key.
-//!
-//! ## Examples
-//!
-//! ```bash
-//! # Set up aliases
-//! git config but.alias.st status
-//! git config but.alias.stv "status --verbose"
-//! git config but.alias.co "commit --only"
-//!
-//! # Use them
-//! but st           # Expands to: but status
-//! but stv          # Expands to: but status --verbose
-//! but co -m "fix"  # Expands to: but commit --only -m "fix"
-//! ```
 
 use std::ffi::OsString;
 
@@ -30,36 +16,27 @@ const DEFAULT_ALIASES: &[(&str, &str)] = &[
     ("stf", "status --files"),
 ];
 
-/// Expands command aliases before argument parsing.
+/// Attempts to expand `potential_alias`.
 ///
-/// If the first argument after "but" is an alias defined in git config
-/// (under `but.alias.<name>`), it will be expanded to its definition.
-/// Additional arguments are preserved and appended after the expansion.
+/// This function is naive, and does not take the broader program into consideration. If you pass a
+/// `potential_alias` that clashes with a built-in command, it'll happily try to expand it for you.
+///
+/// It is up to the caller to ensure that `potential_alias` is a reasonable target for alias
+/// expansion.
+///
+/// Note that at present, aliases are resolved from the real working directory (".").
 ///
 /// # Arguments
 ///
-/// * `args` - The raw command-line arguments including the program name
+/// * `potential_alias` - A potential alias that we try to expand
 ///
 /// # Returns
 ///
-/// The expanded arguments, or the original arguments if no alias was found
-pub fn expand_aliases(args: Vec<OsString>) -> Result<Vec<OsString>> {
-    // Skip if no subcommand (just "but" or "but --help", etc.)
-    if args.len() < 2 {
-        return Ok(args);
-    }
-
-    // Check if the first argument (after "but") might be an alias
-    let potential_alias = match args[1].to_str() {
-        Some(s) => s,
-        None => return Ok(args), // Non-UTF8, not an alias
-    };
-
-    // Skip if it's a flag or a known subcommand
-    if potential_alias.starts_with('-') || is_known_subcommand(potential_alias) {
-        return Ok(args);
-    }
-
+/// The expanded alias, or a vector consisting only of `expanded_alias` if there is no known alias
+/// associated with it.
+///
+/// An `Ok()` value doe _not_ indicate that an alias was found!
+pub fn expand_alias(potential_alias: &str) -> Result<Vec<OsString>> {
     // Try to read from git config: but.alias.<name>
     // And try to discover a git repository from the current directory, way before we have a context.
     let repo = gix::discover(".").ok();
@@ -72,7 +49,7 @@ pub fn expand_aliases(args: Vec<OsString>) -> Result<Vec<OsString>> {
             // Check for default aliases that can be overridden
             match get_default_alias(potential_alias) {
                 Some(default) => default,
-                None => return Ok(args), // No alias found
+                None => return Ok(vec![potential_alias.into()]), // No alias found
             }
         }
     };
@@ -83,12 +60,7 @@ pub fn expand_aliases(args: Vec<OsString>) -> Result<Vec<OsString>> {
         .map(OsString::from)
         .collect();
 
-    // Reconstruct args: [but, ...alias_parts, ...remaining_args]
-    let mut expanded = vec![args[0].clone()]; // Keep "but"
-    expanded.extend(alias_parts);
-    expanded.extend(args[2..].iter().cloned()); // Remaining args after the alias
-
-    Ok(expanded)
+    Ok(alias_parts)
 }
 
 /// Checks if a command is a known subcommand (not an alias).
@@ -171,64 +143,8 @@ mod tests {
     }
 
     #[test]
-    fn expand_no_args() {
-        let args = vec![OsString::from("but")];
-        let result = expand_aliases(args.clone()).unwrap();
-        assert_eq!(result, args);
-    }
-
-    #[test]
-    fn expand_known_command() {
-        let args = vec![OsString::from("but"), OsString::from("status")];
-        let result = expand_aliases(args.clone()).unwrap();
-        assert_eq!(result, args);
-    }
-
-    #[test]
-    fn expand_with_flag() {
-        let args = vec![OsString::from("but"), OsString::from("--help")];
-        let result = expand_aliases(args.clone()).unwrap();
-        assert_eq!(result, args);
-    }
-
-    #[test]
-    fn expand_unknown_alias_no_config() {
-        // This test will pass through since there's no git config set
-        let args = vec![OsString::from("but"), OsString::from("unknownalias")];
-        let result = expand_aliases(args.clone()).unwrap();
-        assert_eq!(result, args);
-    }
-
-    #[test]
     fn default_alias_stf() {
         assert_eq!(get_default_alias("stf"), Some("status --files".to_string()));
         assert_eq!(get_default_alias("other"), None);
-    }
-
-    #[test]
-    fn expand_default_alias() {
-        // Test that the default stf alias expands correctly
-        // Note: This test is sensitive to git config overrides
-        let args = vec![
-            OsString::from("but"),
-            OsString::from("stf"),
-            OsString::from("--verbose"),
-        ];
-        let result = expand_aliases(args).unwrap();
-
-        // Git config may override the default alias, so we just check:
-        // 1. That expansion happened (length > 3)
-        // 2. That "but" is still first
-        // 3. That "status" is the command
-        // 4. That --verbose is preserved at the end
-        assert!(
-            result.len() >= 4,
-            "Expected at least 4 args, got {}: {:?}",
-            result.len(),
-            result
-        );
-        assert_eq!(result[0], OsString::from("but"));
-        assert_eq!(result[1], OsString::from("status"));
-        assert_eq!(result[result.len() - 1], OsString::from("--verbose"));
     }
 }

--- a/crates/but/src/alias.rs
+++ b/crates/but/src/alias.rs
@@ -32,10 +32,10 @@ const DEFAULT_ALIASES: &[(&str, &str)] = &[
 ///
 /// # Returns
 ///
-/// The expanded alias, or a vector consisting only of `expanded_alias` if there is no known alias
-/// associated with it.
+/// A vector containing the expansion of `potential_alias`. If `potential_alias` did not match any
+/// existing alias, it simply expands into itself (i.e. `vec![potential_alias]`).
 ///
-/// An `Ok()` value doe _not_ indicate that an alias was found!
+/// An `Ok(..)` value does _not_ indicate that an alias was found!
 pub fn expand_alias(potential_alias: &str) -> Result<Vec<OsString>> {
     // Try to read from git config: but.alias.<name>
     // And try to discover a git repository from the current directory, way before we have a context.

--- a/crates/but/src/alias.rs
+++ b/crates/but/src/alias.rs
@@ -18,11 +18,7 @@ const DEFAULT_ALIASES: &[(&str, &str)] = &[
 
 /// Attempts to expand `potential_alias`.
 ///
-/// This function is naive, and does not take the broader program into consideration. If you pass a
-/// `potential_alias` that clashes with a built-in command, it'll happily try to expand it for you.
-///
-/// It is up to the caller to ensure that `potential_alias` is a reasonable target for alias
-/// expansion.
+/// Passing a known subcommand is considered an error.
 ///
 /// Note that at present, aliases are resolved from the real working directory (".").
 ///
@@ -33,10 +29,16 @@ const DEFAULT_ALIASES: &[(&str, &str)] = &[
 /// # Returns
 ///
 /// A vector containing the expansion of `potential_alias`. If `potential_alias` did not match any
-/// existing alias, it simply expands into itself (i.e. `vec![potential_alias]`).
+/// existing alias, it expands into itself (i.e. `vec![potential_alias]`).
 ///
 /// An `Ok(..)` value does _not_ indicate that an alias was found!
 pub fn expand_alias(potential_alias: &str) -> Result<Vec<OsString>> {
+    if is_known_subcommand(potential_alias) {
+        anyhow::bail!(
+            "BUG: Tried to expand known subcommand {potential_alias} as an alias - parsing order should not allow this!"
+        )
+    }
+
     // Try to read from git config: but.alias.<name>
     // And try to discover a git repository from the current directory, way before we have a context.
     let repo = gix::discover(".").ok();

--- a/crates/but/src/args/metrics.rs
+++ b/crates/but/src/args/metrics.rs
@@ -59,10 +59,9 @@ pub enum CommandName {
     SkillCheck,
     Pick,
     Clean,
+    External,
     #[default]
     Unknown,
-    #[cfg(unix)]
-    External,
 }
 
 impl CommandName {

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -6,7 +6,6 @@
 ///
 /// Nearly all documentation for the CLI is defined here using `clap` attributes,
 /// which are then used to generate help messages and online documentation.
-#[cfg(unix)]
 use std::ffi::OsString;
 use std::path::PathBuf;
 
@@ -1201,7 +1200,10 @@ pub enum Subcommands {
     #[clap(verbatim_doc_comment)]
     EvalHook,
 
-    #[cfg(unix)]
+    /// External commands and aliases are resolved to this variant.
+    ///
+    /// External commands are currently only supported on UNIX platforms, but this is available on
+    /// Windows for alias resolution.
     #[strum(disabled)]
     #[clap(hide = true, external_subcommand)]
     External(Vec<OsString>),

--- a/crates/but/src/command/external.rs
+++ b/crates/but/src/command/external.rs
@@ -1,18 +1,24 @@
 //! Run `but-{name}` executables discovered on [`std::env::var_os`]("PATH"), akin to Git's `git-send-email`-style helpers.
 
+use std::{ffi::OsString, path::Path};
+
+#[cfg(unix)]
 use std::{
-    ffi::{OsStr, OsString},
+    ffi::OsStr,
     io::ErrorKind,
     os::unix::ffi::OsStrExt,
-    path::Path,
     process::{Command, Stdio},
 };
 
+#[cfg(unix)]
 use anyhow::Context;
 
-use crate::{CliError, CliResult, bad_input};
+#[cfg(unix)]
+use crate::bad_input;
 
-pub(crate) fn dispatch(current_dir: &Path, extra: &[std::ffi::OsString]) -> CliResult<()> {
+use crate::{CliError, CliResult};
+
+pub(crate) fn dispatch(current_dir: &Path, extra: &[OsString]) -> CliResult<()> {
     let subcommand_name = match extra {
         [head, ..] => head,
         _ => {
@@ -22,41 +28,52 @@ pub(crate) fn dispatch(current_dir: &Path, extra: &[std::ffi::OsString]) -> CliR
         }
     };
 
-    if !is_allowed_command_name(subcommand_name) {
-        return Err(bad_input("Subcommand contains illegal characters")
-            .arg_value(subcommand_name.to_string_lossy())
-            .hint("Are you trying to write an extension command 'but-<command>'? Make sure that '<command>' only contains characters in the set [a-zA-Z_-]")
-            .into());
+    #[cfg(windows)]
+    {
+        // External commands not yet supported on Windows
+        return Err(CliError::ExternalCommandNotFound(
+            subcommand_name.to_owned(),
+        ));
     }
 
-    let mut prefixed = OsString::from("but-");
-    prefixed.push(subcommand_name);
-
-    let status = match Command::new(&prefixed)
-        .args(&extra[1..])
-        .current_dir(current_dir)
-        .stdin(Stdio::inherit())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .status()
+    #[cfg(unix)]
     {
-        Ok(status) => status,
-        Err(e) if e.kind() == ErrorKind::NotFound => {
-            return Err(CliError::ExternalCommandNotFound(
-                subcommand_name.to_owned(),
-            ));
+        if !is_allowed_command_name(subcommand_name) {
+            return Err(bad_input("Subcommand contains illegal characters")
+                .arg_value(subcommand_name.to_string_lossy())
+                .hint("Are you trying to write an extension command 'but-<command>'? Make sure that '<command>' only contains characters in the set [a-zA-Z_-]")
+                .into());
         }
-        Err(e) => {
-            return Err(e)
-                .with_context(|| format!("could not invoke `{prefixed:?}` from PATH"))
-                .map_err(CliError::from);
-        }
-    };
 
-    if status.success() {
-        Ok(())
-    } else {
-        std::process::exit(status.code().unwrap_or(1));
+        let mut prefixed = OsString::from("but-");
+        prefixed.push(subcommand_name);
+
+        let status = match Command::new(&prefixed)
+            .args(&extra[1..])
+            .current_dir(current_dir)
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status()
+        {
+            Ok(status) => status,
+            Err(e) if e.kind() == ErrorKind::NotFound => {
+                return Err(CliError::ExternalCommandNotFound(
+                    subcommand_name.to_owned(),
+                ));
+            }
+            Err(e) => {
+                return Err(e)
+                    .with_context(|| format!("could not invoke `{prefixed:?}` from PATH"))
+                    .map_err(CliError::from);
+            }
+        };
+
+        if status.success() {
+            Ok(())
+        } else {
+            std::process::exit(status.code().unwrap_or(1));
+        }
     }
 }
 
@@ -64,6 +81,7 @@ pub(crate) fn dispatch(current_dir: &Path, extra: &[std::ffi::OsString]) -> CliR
 ///
 /// This is overly restrictive, but I just want to prevent people from doing anything funny here. We
 /// can loosen this as we need to in the future.
+#[cfg(unix)]
 fn is_allowed_command_name(command_name: &OsStr) -> bool {
     command_name
         .as_bytes()

--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -44,10 +44,14 @@ pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
         .collect::<IndexMap<_, Vec<_>>>();
 
     for subcommand_variant in SubcommandDiscriminant::iter() {
+        if matches!(subcommand_variant, SubcommandDiscriminant::External) {
+            // There is no explicit subcommand that corresponds to External
+            continue;
+        }
+
         if let Some(clap_subcommand) = clap_subcommands.iter().find(|clap_subcommand| {
             clap_subcommand.get_name().to_lowercase().replace('-', "")
                 == subcommand_variant.as_ref().to_lowercase()
-                || matches!(subcommand_variant, SubcommandDiscriminant::External)
         }) {
             if clap_subcommand.is_hide_set() {
                 continue;

--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -44,14 +44,10 @@ pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
         .collect::<IndexMap<_, Vec<_>>>();
 
     for subcommand_variant in SubcommandDiscriminant::iter() {
-        #[cfg(unix)]
-        if matches!(subcommand_variant, SubcommandDiscriminant::External) {
-            continue;
-        }
-
         if let Some(clap_subcommand) = clap_subcommands.iter().find(|clap_subcommand| {
             clap_subcommand.get_name().to_lowercase().replace('-', "")
                 == subcommand_variant.as_ref().to_lowercase()
+                || matches!(subcommand_variant, SubcommandDiscriminant::External)
         }) {
             if clap_subcommand.is_hide_set() {
                 continue;
@@ -146,7 +142,6 @@ pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
                 SubcommandDiscriminant::Completions => continue,
                 SubcommandDiscriminant::Onboarding => continue,
                 SubcommandDiscriminant::EvalHook => continue,
-                #[cfg(unix)]
                 SubcommandDiscriminant::External => continue,
 
                 #[cfg(feature = "legacy")]

--- a/crates/but/src/command/mod.rs
+++ b/crates/but/src/command/mod.rs
@@ -8,7 +8,6 @@ pub mod commit;
 pub mod completions;
 pub mod config;
 pub mod eval_hook;
-#[cfg(unix)]
 pub(crate) mod external;
 pub(crate) mod git_config;
 pub mod gui;

--- a/crates/but/src/error.rs
+++ b/crates/but/src/error.rs
@@ -1,9 +1,7 @@
 //! Utilities for communicating user errors (i.e. the equivalent of 4xx HTTP responses) to the user.
 
-use std::fmt::Display;
-
-#[cfg(unix)]
 use std::ffi::OsString;
+use std::fmt::Display;
 
 use crate::theme::{self, Paint};
 
@@ -119,7 +117,6 @@ impl CliError {
     {
         match self {
             Self::BadInput(value) => Self::BadInput(value),
-            #[cfg(unix)]
             Self::ExternalCommandNotFound(command_name) => {
                 Self::ExternalCommandNotFound(command_name)
             }
@@ -132,7 +129,6 @@ impl Display for CliError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::BadInput(value) => value.fmt(f),
-            #[cfg(unix)]
             Self::ExternalCommandNotFound(command_name) => {
                 writeln!(
                     f,
@@ -150,7 +146,6 @@ pub enum CliError {
     /// User provided bad input.
     BadInput(BadInput),
     /// We tried to execute the subcommand as an external command, but that command was not found.
-    #[cfg(unix)]
     ExternalCommandNotFound(OsString),
     /// Something went wrong internally.
     Internal(anyhow::Error),

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -282,8 +282,18 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
 /// ```
 ///
 fn expand_aliases(args: Vec<OsString>) -> Result<Vec<OsString>, anyhow::Error> {
-    let args = {
-        match &Args::parse_from(&args).cmd {
+    let parsed_args = match Args::try_parse_from(&args) {
+        Ok(parsed) => parsed,
+        Err(_) => {
+            // We let the core parsing logic handle hard parse errors as there is special handling
+            // of e.g. help output. If we get rid of that bespoke parsing we can also get rid of
+            // this early return and let Clap handle parse errors with [`Args::parse_from`].
+            return Ok(args);
+        }
+    };
+
+    let expanded_args = {
+        match &parsed_args.cmd {
             Some(Subcommands::External(subcommand_args))
                 if let Some(command_name) = subcommand_args.first() =>
             {
@@ -304,7 +314,7 @@ fn expand_aliases(args: Vec<OsString>) -> Result<Vec<OsString>, anyhow::Error> {
             _ => args,
         }
     };
-    Ok(args)
+    Ok(expanded_args)
 }
 
 fn print_and_exit_non_zero<T: std::fmt::Display>(err: T) -> ! {

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -110,8 +110,7 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
         return Ok(());
     }
 
-    // Expand aliases before parsing arguments
-    let args = alias::expand_aliases(args)?;
+    let args = expand_aliases(args)?;
 
     // The `but push --help` output is different if gerrit mode is enabled, hence the special handling
     let args_vec: Vec<String> = std::env::args().collect();
@@ -189,9 +188,10 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
         None => {
             // No arguments means run the default alias
             // The default alias expands to "status" which provides a helpful entry point
-            let default_args = vec![OsString::from("but"), OsString::from("default")];
-            let expanded = alias::expand_aliases(default_args)?;
-            let mut default_alias_args: Args = clap::Parser::parse_from(expanded);
+            let mut default_args: Vec<OsString> = vec!["but".into()];
+            let expanded_alias = alias::expand_alias("default")?;
+            default_args.extend_from_slice(&expanded_alias);
+            let mut default_alias_args: Args = clap::Parser::parse_from(default_args);
 
             // Preserve globals from the default alias, while letting explicit user globals
             // take precedence (e.g. `but -C <dir>` without a subcommand).
@@ -246,6 +246,67 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
         }
         Ok(()) => Ok(()),
     }
+}
+
+/// Expand aliases in the argument list.
+///
+/// The parser treats aliases in the same way as external subcommands, so they end up inside of
+/// [`Subcommands::External`]. Anytime we find an external subcommand, we attempt to expand the
+/// first word in the command string as an alias.
+///
+/// Note that root options are consumed by the parser separatly from [`Subcommands::External`], so
+/// e.g.
+///
+/// This also has the intended effect of allowing aliases to shadow external commands. For example,
+/// if there is an external command `but-b` on the PATH and an alias `b=branch`, then `but b` will
+/// expand to `but branch` rather than be executid as `but-b`.
+///
+/// Cargo considers this shadowing behavior to be a security concern due to the fact that Cargo
+/// aliases can be defined in the worktree of a repository (see
+/// https://github.com/rust-lang/cargo/issues/10049). We don't have that problem as `but` aliases
+/// can only ever be defined in Git config, which is trusted and does not follow with clones.
+///
+/// Note that at present, aliases are resolved from the real working directory ("."). If you pass
+/// `-C /repo`, aliases from `/repo` are _not_ resolved.
+///
+/// # Examples
+///
+/// ```bash
+/// # Set up aliases
+/// but alias add b branch
+/// but alias add bl 'branch list --local'
+///
+/// # Use them
+/// but b                       # Expands to: but branch
+/// but bl                      # Expands to: but branch list --local
+/// but bl --review             # Expands to: but branch list --local --review
+/// but -C /repo bl --review    # Expands to: but branch -C /repo list --local --review
+/// ```
+///
+fn expand_aliases(args: Vec<OsString>) -> Result<Vec<OsString>, anyhow::Error> {
+    let args = {
+        match &Args::parse_from(&args).cmd {
+            Some(Subcommands::External(subcommand_args))
+                if let Some(command_name) = subcommand_args.first() =>
+            {
+                if let Some(command_name) = command_name.to_str() {
+                    let subcommand_start = args.len() - subcommand_args.len();
+                    let expanded = alias::expand_alias(command_name)?;
+                    Vec::<OsString>::new()
+                        .iter()
+                        .chain(args[..subcommand_start].iter())
+                        .chain(expanded.iter())
+                        .chain(args[subcommand_start + 1..].iter())
+                        .cloned()
+                        .collect()
+                } else {
+                    args
+                }
+            }
+            _ => args,
+        }
+    };
+    Ok(args)
 }
 
 fn print_and_exit_non_zero<T: std::fmt::Display>(err: T) -> ! {

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -26,7 +26,6 @@ use std::ffi::OsString;
 
 use anyhow::{Context as _, Result};
 use cfg_if::cfg_if;
-#[cfg(unix)]
 use clap::CommandFactory;
 use clap::Parser;
 
@@ -181,7 +180,6 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     let app_settings = AppSettings::load_from_default_path_creating_without_customization()?;
 
     let result = match args.cmd.take() {
-        #[cfg(unix)]
         Some(Subcommands::External(extra)) => {
             command::external::dispatch(&args.current_dir, &extra)
         }
@@ -226,7 +224,6 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     match result {
         Err(CliError::Internal(err)) => Err(err),
         Err(CliError::BadInput(bad_input)) => print_and_exit_non_zero(bad_input),
-        #[cfg(unix)]
         Err(CliError::ExternalCommandNotFound(command_name)) => {
             // We reparse without external subcommands allowed, which _should_ result in a proper
             // clap error, including suggestions for "near matches". This gives richer error
@@ -1461,7 +1458,6 @@ async fn match_subcommand(
         Subcommands::AgentLog { .. } => {
             unreachable!("agentlog command is handled before metrics setup")
         }
-        #[cfg(unix)]
         Subcommands::External(_) => {
             unreachable!("external commands are delegated before reaching match_subcommand")
         }

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -251,17 +251,18 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
 /// [`Subcommands::External`]. Anytime we find an external subcommand, we attempt to expand the
 /// first word in the command string as an alias.
 ///
-/// Note that root options are consumed by the parser separatly from [`Subcommands::External`], so
-/// e.g.
-///
 /// This also has the intended effect of allowing aliases to shadow external commands. For example,
 /// if there is an external command `but-b` on the PATH and an alias `b=branch`, then `but b` will
-/// expand to `but branch` rather than be executid as `but-b`.
+/// expand to `but branch` rather than be executed as `but-b`.
 ///
 /// Cargo considers this shadowing behavior to be a security concern due to the fact that Cargo
 /// aliases can be defined in the worktree of a repository (see
 /// https://github.com/rust-lang/cargo/issues/10049). We don't have that problem as `but` aliases
 /// can only ever be defined in Git config, which is trusted and does not follow with clones.
+///
+/// Root options are consumed by the parser separately from [`Subcommands::External`], so e.g. `but
+/// -C some-alias a -b c` resolves into `External(["some-alias", "a", "-b", "c"])`, and the root
+/// options are correctly parsed into the [`Args`] struct.
 ///
 /// Note that at present, aliases are resolved from the real working directory ("."). If you pass
 /// `-C /repo`, aliases from `/repo` are _not_ resolved.
@@ -277,7 +278,7 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
 /// but b                       # Expands to: but branch
 /// but bl                      # Expands to: but branch list --local
 /// but bl --review             # Expands to: but branch list --local --review
-/// but -C /repo bl --review    # Expands to: but branch -C /repo list --local --review
+/// but -C /repo bl --review    # Expands to: but -C /repo branch list --local --review
 /// ```
 ///
 fn expand_aliases(args: Vec<OsString>) -> Result<Vec<OsString>, anyhow::Error> {

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -109,7 +109,7 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
         return Ok(());
     }
 
-    let args = expand_aliases(args)?;
+    let args = expand_aliases(args);
 
     // The `but push --help` output is different if gerrit mode is enabled, hence the special handling
     let args_vec: Vec<String> = std::env::args().collect();
@@ -281,46 +281,60 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
 /// but -C /repo bl --review    # Expands to: but -C /repo branch list --local --review
 /// ```
 ///
-fn expand_aliases(args: Vec<OsString>) -> Result<Vec<OsString>, anyhow::Error> {
+/// This function never fails - any unexpected situation leads to the original args being returned.
+fn expand_aliases(args: Vec<OsString>) -> Vec<OsString> {
     let parsed_args = match Args::try_parse_from(&args) {
         Ok(parsed) => parsed,
         Err(_) => {
             // We let the core parsing logic handle hard parse errors as there is special handling
             // of e.g. help output. If we get rid of that bespoke parsing we can also get rid of
             // this early return and let Clap handle parse errors with [`Args::parse_from`].
-            return Ok(args);
+            return args;
         }
     };
 
-    let expanded_args = {
-        match &parsed_args.cmd {
-            Some(Subcommands::External(subcommand_args))
-                if let Some(command_name) = subcommand_args.first() =>
-            {
-                if let Some(command_name) = command_name.to_str() {
-                    let subcommand_start = args.len() - subcommand_args.len();
-                    let expanded = alias::expand_alias(command_name)?;
-                    Vec::<OsString>::new()
-                        .iter()
-                        .chain(args[..subcommand_start].iter())
-                        .chain(expanded.iter())
-                        .chain(args[subcommand_start + 1..].iter())
-                        .cloned()
-                        .collect()
-                } else {
-                    args
-                }
+    match &parsed_args.cmd {
+        Some(Subcommands::External(subcommand_args))
+            if let Some(command_name) = subcommand_args.first() =>
+        {
+            if let Some(command_name) = command_name.to_str() {
+                let subcommand_start = args.len() - subcommand_args.len();
+
+                let expanded = match alias::expand_alias(command_name) {
+                    Ok(expanded) => expanded,
+                    Err(err) => {
+                        print_err_infallible(theme::get().attention.paint(format!(
+                            "Failed to expand alias '{command_name}': {err}\nSkipping alias expansion\n",
+                        )));
+                        return args;
+                    }
+                };
+
+                Vec::<OsString>::new()
+                    .iter()
+                    .chain(args[..subcommand_start].iter())
+                    .chain(expanded.iter())
+                    .chain(args[subcommand_start + 1..].iter())
+                    .cloned()
+                    .collect()
+            } else {
+                args
             }
-            _ => args,
         }
-    };
-    Ok(expanded_args)
+        _ => args,
+    }
 }
 
-fn print_and_exit_non_zero<T: std::fmt::Display>(err: T) -> ! {
+/// Print to stderr, ignoring any errors in printing. Use this when printing to stderr is the only
+/// reasonable thing to do and there are no other options left.
+fn print_err_infallible<T: std::fmt::Display>(err: T) {
     use std::io::Write;
     // We swallow this error, there is nothing more to do at this point
     let _ = write!(std::io::stderr(), "{err}");
+}
+
+fn print_and_exit_non_zero<T: std::fmt::Display>(err: T) -> ! {
+    print_err_infallible(err);
     std::process::exit(1)
 }
 

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -207,7 +207,6 @@ impl Subcommands {
             Subcommands::Clean { .. } => Clean,
             Subcommands::Onboarding | Subcommands::EvalHook => Unknown,
             Subcommands::AgentLog { .. } => Unknown,
-            #[cfg(unix)]
             Subcommands::External(_) => External,
         }
     }

--- a/crates/but/tests/but/command/alias.rs
+++ b/crates/but/tests/but/command/alias.rs
@@ -1,4 +1,5 @@
 use crate::utils::Sandbox;
+use snapbox::str;
 
 #[test]
 fn local_alias_roundtrip_uses_repo_config() -> anyhow::Result<()> {
@@ -51,6 +52,96 @@ fn global_alias_roundtrip_uses_global_config() -> anyhow::Result<()> {
         "config --file global.gitconfig --get but.alias.st",
         "global alias should be removed from the configured global file",
     );
+
+    Ok(())
+}
+
+#[test]
+fn can_invoke_alias() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("alias add b branch").assert().success();
+
+    env.but("b")
+        .assert()
+        .stdout_eq(str![[r#"
+Applied branches
+active  ✓ *A          26y ago    author
+
+"#]])
+        .stderr_eq(str![[]]);
+
+    Ok(())
+}
+
+#[test]
+fn can_invoke_alias_with_root_flags() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("alias add b branch").assert().success();
+
+    env.but("-t b")
+        .assert()
+        .stdout_eq(str![[r#"
+Applied branches
+active  ✓ *A          26y ago    author
+
+"#]])
+        .stderr_eq(str![[r#"
+INFO [..]
+INFO [..]
+INFO [..]
+"#]]);
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+/// We allow aliases to shadow external commands. This is mostly for the sake of simplicity. There's
+/// no particular security concern with this as aliases can only be defined in trusted files, so
+/// there's no risk that you'd for example clone a repository with a malicious alias (as is the case
+/// with Cargo, see https://github.com/rust-lang/cargo/issues/10049).
+fn can_invoke_alias_that_shadows_external_command() -> anyhow::Result<()> {
+    use std::{fs, os::unix::fs::PermissionsExt};
+
+    use tempfile::tempdir;
+
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    let bin = tempdir()?;
+    let helper = bin.path().join("but-b");
+    fs::write(&helper, "#!/bin/sh\necho 'called but-b'\n")?;
+    let mut perms = fs::metadata(&helper)?.permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&helper, perms)?;
+
+    let path = std::env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{path}", bin.path().display());
+
+    env.but("b")
+        .env("PATH", &new_path)
+        .assert()
+        .stdout_eq(str![[r#"
+called but-b
+
+"#]])
+        .stderr_eq(str![[]]);
+
+    // Alias should shadow external command
+    env.but("alias add b branch").assert().success();
+    env.but("b")
+        .env("PATH", &new_path)
+        .assert()
+        .stdout_eq(str![[r#"
+Applied branches
+active  ✓ *A          26y ago    author
+
+"#]])
+        .stderr_eq(str![[]]);
 
     Ok(())
 }

--- a/crates/but/tests/but/command/alias.rs
+++ b/crates/but/tests/but/command/alias.rs
@@ -1,4 +1,6 @@
 use crate::utils::Sandbox;
+
+#[cfg(feature = "legacy")]
 use snapbox::str;
 
 #[test]
@@ -96,6 +98,32 @@ INFO [..]
 INFO [..]
 INFO [..]
 "#]]);
+
+    Ok(())
+}
+
+#[cfg(feature = "legacy")]
+#[test]
+fn can_invoke_alias_with_root_flags_with_args() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("alias add b branch").assert().success();
+    let log_file_path = env.projects_root().join("log_file.txt");
+
+    env.but("-t --log-file")
+        .arg(&log_file_path)
+        .arg("b")
+        .assert()
+        .stdout_eq(str![[r#"
+Applied branches
+active  ✓ *A          26y ago    author
+
+"#]])
+        .stderr_eq(str![[]]);
+
+    let log_file_content = std::fs::read_to_string(&log_file_path)?;
+    assert!(!log_file_content.is_empty(), "Log file must be non-empty");
 
     Ok(())
 }

--- a/crates/but/tests/but/command/alias.rs
+++ b/crates/but/tests/but/command/alias.rs
@@ -176,3 +176,30 @@ active  ✓ *A          26y ago    author
 
     Ok(())
 }
+
+#[cfg(unix)]
+#[cfg(feature = "legacy")]
+#[test]
+fn alias_expansion_failure_falls_back_to_original_args() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+
+    env.but("alias add bad").arg("'").assert().success();
+
+    env.but("bad")
+        .assert()
+        .stdout_eq(str![[]])
+        .stderr_eq(str![[r#"
+Failed to expand alias 'bad': missing closing quote
+Skipping alias expansion
+error: unrecognized subcommand 'bad'
+
+  tip: a similar subcommand exists: 'onboarding'
+
+Usage: but [OPTIONS] [COMMAND]
+
+For more information, try '--help'.
+
+"#]]);
+
+    Ok(())
+}

--- a/crates/but/tests/but/command/alias.rs
+++ b/crates/but/tests/but/command/alias.rs
@@ -203,3 +203,30 @@ For more information, try '--help'.
 
     Ok(())
 }
+
+#[cfg(unix)]
+#[cfg(feature = "legacy")]
+#[test]
+/// `but alias add branch help` rejects aliases that conflict with known commands, but a user
+/// can still write such an alias into git config directly. Known subcommands must not expand!
+///
+/// There are multiple layers of protection in the application against this. The parsing should make
+/// it impossible as known subcommands should not be parsed as external commands, and the alias
+/// expansion itself should bail if a known subcommand is passed in.
+fn alias_of_known_subcommand_is_not_expanded() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.invoke_git("config --local but.alias.branch help");
+
+    env.but("branch")
+        .assert()
+        .stdout_eq(str![[r#"
+Applied branches
+active  ✓ *A          26y ago    author
+
+"#]])
+        .stderr_eq(str![[]]);
+
+    Ok(())
+}

--- a/crates/but/tests/but/command/alias.rs
+++ b/crates/but/tests/but/command/alias.rs
@@ -56,6 +56,7 @@ fn global_alias_roundtrip_uses_global_config() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "legacy")]
 #[test]
 fn can_invoke_alias() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
@@ -75,6 +76,7 @@ active  ✓ *A          26y ago    author
     Ok(())
 }
 
+#[cfg(feature = "legacy")]
 #[test]
 fn can_invoke_alias_with_root_flags() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
@@ -99,6 +101,7 @@ INFO [..]
 }
 
 #[cfg(unix)]
+#[cfg(feature = "legacy")]
 #[test]
 /// We allow aliases to shadow external commands. This is mostly for the sake of simplicity. There's
 /// no particular security concern with this as aliases can only be defined in trusted files, so

--- a/crates/but/tests/but/command/help.rs
+++ b/crates/but/tests/but/command/help.rs
@@ -1,3 +1,4 @@
+use bstr::ByteSlice;
 use snapbox::str;
 
 use crate::utils::Sandbox;
@@ -117,6 +118,20 @@ Usage: but [OPTIONS] [COMMAND]
 For more information, try '--help'.
 
 "#]]);
+
+    Ok(())
+}
+
+#[test]
+/// We want the output of `help --help` to be the same as `help`.
+fn help_help_should_be_help() -> anyhow::Result<()> {
+    let env = Sandbox::empty()?;
+
+    let help = env.but("help").output()?.stdout;
+    env.but("help --help")
+        .assert()
+        .success()
+        .stdout_eq(help.to_str_lossy().to_string());
 
     Ok(())
 }


### PR DESCRIPTION
## 🧢 Changes
Makes root flags (e.g. `-C` or `-ttt`) work together with aliases. The prior implementation naively tries to expand the first argument, which fails if that argument happens to be a flag.

This solution utilizes the new external commands parser (which catches aliases as they are not recognized as known subcommands), and should be robust.

Note that as a consequence of the implementation, user aliases take precedence over external commands. This was already the case and is not a change in this PR, but this PR does make that fact more explicit and adds tests for it. I think it's fine to have it that way.

New to this implementation is that if alias expansion fails for _whatever reason_, we'll simply let the original args pass through unchanged. We don't hard fail on alias expansion failure anymore, we just emit a warning.

Draws some inspiration from [Cargo's implementation](https://github.com/rust-lang/cargo/blob/master/src/bin/cargo/cli.rs#L274), but as their parsing setup is quite different from ours I didn't go all in on it and chose a simpler solution.

Fixes #12697

Replaces #12909