### PR TITLE
Rename CLI OS event property to $os

### DIFF
--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -336,7 +336,7 @@ impl Event {
         event.insert_prop("appVersion", option_env!("VERSION").unwrap_or_default());
         event.insert_prop("releaseChannel", option_env!("CHANNEL").unwrap_or_default());
         event.insert_prop("appName", option_env!("CARGO_BIN_NAME").unwrap_or_default());
-        event.insert_prop("OS", Event::normalize_os(env::consts::OS));
+        event.insert_prop("$os", Event::normalize_os(env::consts::OS));
         event.insert_prop("Arch", env::consts::ARCH);
         if let Some(agent) = super::detect_agent::detect() {
             event.insert_prop("agent", agent.name());


### PR DESCRIPTION
Matches the JS SDK convention so OS-segmented charts include CLI events.