### PR TITLE
fix(desktop): wrap Tauri IPC errors at the boundary, stop double capture

### DIFF
--- a/apps/desktop/src/lib/analytics/sentry.ts
+++ b/apps/desktop/src/lib/analytics/sentry.ts
@@ -2,7 +2,7 @@ import { dev } from "$app/environment";
 import * as Sentry from "@sentry/sveltekit";
 import { PUBLIC_SENTRY_ENVIRONMENT } from "$env/static/public";
 
-const { setUser, init } = Sentry;
+const { setUser, init, globalHandlersIntegration } = Sentry;
 
 export function initSentry() {
 	init({
@@ -11,6 +11,20 @@ export function initSentry() {
 		environment: PUBLIC_SENTRY_ENVIRONMENT,
 		tracesSampleRate: 0,
 		tracePropagationTargets: ["localhost", /gitbutler\.com/i],
+		// `hooks.client.ts` installs a `window.onunhandledrejection` handler
+		// that routes through `logError`, which wraps Tauri-shaped
+		// `{name, message, code}` rejections into proper `Error` instances
+		// before capture. Sentry's default `GlobalHandlers` integration adds
+		// its own `addEventListener('unhandledrejection', ...)` that fires in
+		// parallel and captures the raw object, producing a duplicate event
+		// that all bucket into one generic "Object captured as promise
+		// rejection" issue. Disable that half of the integration; keep
+		// `onerror` as a safety net for sync errors that escape SvelteKit's
+		// `handleError`.
+		integrations: (defaults) => [
+			...defaults.filter((i) => i.name !== "GlobalHandlers"),
+			globalHandlersIntegration({ onerror: true, onunhandledrejection: false }),
+		],
 	});
 }
 

--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -1,4 +1,4 @@
-import { isReduxError } from "$lib/error/reduxError";
+import { IpcError, isReduxError } from "$lib/error/reduxError";
 import { getName, getVersion, getVersion as tauriGetVersion } from "@tauri-apps/api/app";
 import { invoke as invokeTauri } from "@tauri-apps/api/core";
 import { documentDir as documentDirTauri } from "@tauri-apps/api/path";
@@ -239,6 +239,10 @@ async function tauriInvoke<T>(command: string, params: Record<string, unknown> =
 	} catch (error: unknown) {
 		if (isReduxError(error)) {
 			console.error(`ipc->${command}: ${JSON.stringify(params)}`, error);
+			// Re-throw as a proper Error subclass so the stack points at the
+			// caller and Sentry can fingerprint by name + message instead of
+			// bucketing every raw `{name, message, code}` rejection together.
+			throw new IpcError(error, command);
 		}
 		throw error;
 	}

--- a/apps/desktop/src/lib/backend/web.ts
+++ b/apps/desktop/src/lib/backend/web.ts
@@ -1,4 +1,4 @@
-import { isReduxError } from "$lib/error/reduxError";
+import { IpcError, isReduxError } from "$lib/error/reduxError";
 import { getCookie } from "$lib/utils/cookies";
 import ReconnectingWebSocket from "reconnecting-websocket";
 import { readable } from "svelte/store";
@@ -198,12 +198,16 @@ async function webInvoke<T>(command: string, params: Record<string, unknown> = {
 		} else {
 			if (isReduxError(out.subject)) {
 				console.error(`ipc->${command}: ${JSON.stringify(params)}`, out.subject);
+				throw new IpcError(out.subject, command);
 			}
 			throw out.subject;
 		}
 	} catch (error: unknown) {
-		if (isReduxError(error)) {
+		// Already wrapped on the explicit-throw path above; only the network
+		// / parse failure path lands here with a raw redux-shaped error.
+		if (isReduxError(error) && !(error instanceof IpcError)) {
 			console.error(`ipc->${command}: ${JSON.stringify(params)}`, error);
+			throw new IpcError(error, command);
 		}
 		throw error;
 	}

--- a/apps/desktop/src/lib/error/reduxError.ts
+++ b/apps/desktop/src/lib/error/reduxError.ts
@@ -15,3 +15,34 @@ export function isReduxError(something: unknown): something is ReduxError {
 		(r.code === undefined || typeof r.code === "string")
 	);
 }
+
+/**
+ * Proper Error subclass for backend IPC failures.
+ *
+ * The Tauri (and web fallback) backend returns failures as plain
+ * `{name?, message, code?}` objects. Throwing those raw means: no stack
+ * trace, Sentry can't extract a fingerprint, and every variant collapses
+ * into one generic "Object captured as promise rejection" bucket.
+ *
+ * Wrapping at the IPC boundary gives us a real Error instance with a
+ * stack pointing at the actual caller, while still satisfying the
+ * `ReduxError` duck-typed shape that downstream consumers (parser,
+ * customHooks, backendQuery, baseBranchService) rely on.
+ */
+export class IpcError extends Error implements ReduxError {
+	override readonly name: string;
+	override readonly message: string;
+	readonly code?: Code;
+
+	constructor(raw: ReduxError, command: string) {
+		super(raw.message);
+		this.name = raw.name ?? `API error: (${command})`;
+		// `Error.prototype.message` set via `super()` is a non-enumerable own
+		// property, so `JSON.stringify(err)` would drop it — and any consumer
+		// that captures `{error: ipcError}` to PostHog or similar would lose
+		// the message. Redefine as enumerable to match the plain-object
+		// `ReduxError` shape callers used to see.
+		this.message = raw.message;
+		this.code = raw.code;
+	}
+}


### PR DESCRIPTION
Tauri's backend rejects IPC calls with plain `{name?, message, code?}`
objects — no stack, no Error subclass — so Sentry groups every variant
into one generic "Object captured as promise rejection" bucket (the
largest issue on 0.19.13).

Wrap at the source: `IpcError extends Error` thrown from `tauriInvoke`
and `webInvoke`. Stack now points at the caller, Sentry groups by
command, and `IpcError` keeps the `ReduxError` duck-typed shape so
existing `isReduxError` consumers work unchanged. `message` is
redefined as an own enumerable property — `Error.message` set via
`super()` is non-enumerable, so `JSON.stringify(err)` would drop it
and `{error}` captures (e.g. PostHog) would silently lose the message.

Also disable Sentry's `onunhandledrejection` integration. Our
`hooks.client.ts` handler already routes rejections through `logError`;
without the disable, Sentry's auto-handler fires in parallel —
duplicating every event and bypassing `logError`'s `SilentError` and
E2E ignore filters.