### PR TITLE
fix(tui): dont allow selecting lines you cannot mark

### DIFF
--- a/crates/but/src/command/legacy/status/tui/cursor/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/mod.rs
@@ -10,6 +10,7 @@ use crate::{
         output::StatusOutputLineData,
         tui::{
             Mode, MoveSource, SelectAfterReload,
+            marking::MarkClasses,
             render::{commit_operation_display, move_operation_display},
         },
     },
@@ -696,6 +697,38 @@ pub(super) fn is_selectable_in_mode(
             }
         }
         Mode::Command(..) | Mode::InlineReword(..) | Mode::Normal(..) | Mode::Details => {}
+    }
+
+    if let Mode::Normal(normal_mode) = mode
+        && !normal_mode.marks.is_empty()
+    {
+        let MarkClasses { marked_commits } = normal_mode.marks.classify();
+
+        match &line.data {
+            StatusOutputLineData::Branch { .. } | StatusOutputLineData::Commit { .. } => {
+                // you're allowed to select branches and commits regardless of markings
+            }
+            StatusOutputLineData::UpdateNotice
+            | StatusOutputLineData::Connector
+            | StatusOutputLineData::StagedChanges { .. }
+            | StatusOutputLineData::StagedFile { .. }
+            | StatusOutputLineData::UnassignedChanges { .. }
+            | StatusOutputLineData::UnassignedFile { .. }
+            | StatusOutputLineData::CommitMessage
+            | StatusOutputLineData::EmptyCommitMessage
+            | StatusOutputLineData::File { .. }
+            | StatusOutputLineData::MergeBase
+            | StatusOutputLineData::UpstreamChanges
+            | StatusOutputLineData::Warning
+            | StatusOutputLineData::Hint
+            | StatusOutputLineData::NoAssignmentsUnstaged => {
+                // we currently don't allow mixing marks, i.e., you cannot mark both commits and
+                // files, so don't allow selecting them
+                if marked_commits {
+                    return false;
+                }
+            }
+        }
     }
 
     match mode {

--- a/crates/but/src/command/legacy/status/tui/marking.rs
+++ b/crates/but/src/command/legacy/status/tui/marking.rs
@@ -43,6 +43,16 @@ impl Marks {
     pub(super) fn iter(&self) -> impl Iterator<Item = &Markable> {
         self.into_iter()
     }
+
+    pub(super) fn classify(&self) -> MarkClasses {
+        let mut marked_commits = false;
+        for mark in &self.marks {
+            match mark {
+                Markable::Commit { .. } => marked_commits = true,
+            }
+        }
+        MarkClasses { marked_commits }
+    }
 }
 
 impl<'a> IntoIterator for &'a Marks {
@@ -77,4 +87,9 @@ impl Markable {
             | CliId::Stack { .. } => None,
         }
     }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct MarkClasses {
+    pub marked_commits: bool,
 }

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -52,7 +52,7 @@ use crate::{
                     KeyBinds, branch_picker_key_binds, confirm_key_binds, default_key_binds,
                     help_key_binds, normal_with_marks_key_binds,
                 },
-                marking::{Markable, Marks},
+                marking::{MarkClasses, Markable, Marks},
                 message_on_drop::MessageOnDrop,
                 mode::{
                     CommandMode, CommandModeKind, CommitMessageComposer, CommitMode, CommitSource,
@@ -1183,6 +1183,26 @@ impl App {
         ctx: &mut Context,
         messages: &mut Vec<Message>,
     ) -> anyhow::Result<()> {
+        if let Mode::Normal(normal_mode) = &*self.mode
+            && !normal_mode.marks.is_empty()
+        {
+            let MarkClasses { marked_commits } = normal_mode.marks.classify();
+            if marked_commits {
+                match self.flags.show_files {
+                    FilesStatusFlag::None => {
+                        return Ok(());
+                    }
+                    FilesStatusFlag::Commit(_) => {}
+                    FilesStatusFlag::All => {
+                        self.flags.show_files = FilesStatusFlag::None;
+                        self.backstack.remove_show_file_list();
+                        messages.push(Message::Reload(None, ReloadCause::ViewOnly));
+                        return Ok(());
+                    }
+                }
+            }
+        }
+
         if let Some(selection) = self.cursor.selected_line(&self.status_lines)
             && let Some(cli_id) = selection.data.cli_id()
             && let CliId::Commit { commit_id, .. } = &**cli_id

--- a/crates/but/src/command/legacy/status/tui/tests/commit_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/commit_tests.rs
@@ -531,3 +531,77 @@ fn commit_moved_and_modified_file() {
     tui.input_then_render(None)
         .assert_rendered_contains("zz [unassigned changes] (no changes)");
 }
+
+#[test]
+fn cannot_select_unassigned_files_with_commits_marked() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    let mut tui = test_tui(env);
+
+    tui.env().file("test.txt", "content");
+
+    // mark the commit
+    tui.input_then_render('j');
+    tui.input_then_render('j');
+    tui.input_then_render('j');
+    tui.input_then_render(' ')
+        .assert_current_line_eq(str![["┊✔︎   [..] add A"]]);
+
+    // moving up selects the branch
+    tui.input_then_render('k')
+        .assert_current_line_eq(str![["┊╭┄g0 [A]"]]);
+
+    // cannot move further up, stays on the branch
+    tui.input_then_render('k')
+        .assert_current_line_eq(str![["┊╭┄g0 [A]"]]);
+}
+
+#[test]
+fn cannot_select_committed_files_with_commits_marked() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    let mut tui = test_tui(env);
+
+    tui.env().file("test.txt", "content");
+
+    // mark the commit
+    tui.input_then_render('j');
+    tui.input_then_render('j');
+    tui.input_then_render('j');
+    tui.input_then_render(' ')
+        .assert_current_line_eq(str![["┊✔︎   [..] add A"]]);
+
+    // cannot open the file list with marked commits
+    tui.input_then_render('f')
+        .assert_current_line_eq(str![["┊✔︎   [..] add A"]]);
+}
+
+#[test]
+fn cannot_select_committed_files_from_global_listing_with_commits_marked() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    let mut tui = test_tui(env);
+
+    tui.env().file("test.txt", "content");
+
+    // mark the commit
+    tui.input_then_render('j');
+    tui.input_then_render('j');
+    tui.input_then_render('j');
+    tui.input_then_render(' ')
+        .assert_current_line_eq(str![["┊✔︎   [..] add A"]]);
+
+    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('F')))
+        .assert_current_line_eq(str![["┊✔︎   [..] add A"]]);
+
+    tui.input_then_render('j')
+        .assert_current_line_eq(str![["┊✔︎   [..] add A"]])
+        .assert_rendered_term_svg_eq(file!["snapshots/cannot_select_committed_files_from_global_listing_with_commits_marked_showing_global_file_list.svg"]);
+
+    // the global file list can be closed with f
+    tui.input_then_render('f')
+        .assert_rendered_term_svg_eq(file!["snapshots/cannot_select_committed_files_from_global_listing_with_commits_marked_final.svg"]);
+}

--- a/crates/but/src/command/legacy/status/tui/tests/marking_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/marking_tests.rs
@@ -45,44 +45,6 @@ fn marking_branch_toggles_all_commits_in_that_branch() {
 }
 
 #[test]
-fn multi_squash_multiple_marked_sources_into_unmarked_target() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
-
-    let mut tui = test_tui(env);
-
-    tui.input_then_render(KeyCode::Down)
-        .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
-
-    tui.input_then_render('n')
-        .assert_current_line_eq(str!["┊●   [..] (no commit message) (no changes)"]);
-
-    tui.input_then_render('n')
-        .assert_current_line_eq(str!["┊●   [..] (no commit message) (no changes)"]);
-
-    tui.input_then_render(' ')
-        .assert_current_line_eq(str!["┊●   [..] (no commit message) (no changes)"]);
-
-    tui.input_then_render(KeyCode::Down)
-        .assert_current_line_eq(str!["┊●   9477ae7 add A"]);
-
-    tui.input_then_render(' ')
-        .assert_current_line_eq(str!["┊✔︎   9477ae7 add A"]);
-
-    tui.input_then_render(KeyCode::Down)
-        .assert_current_line_eq(str!["┴ 0dc3733 (common base) 2000-01-02 add M"]);
-
-    tui.input_then_render('r')
-        .assert_current_line_eq(str!["┴ 0dc3733 (common base) 2000-01-02 add M"]);
-
-    tui.input_then_render(KeyCode::Enter)
-        .assert_current_line_eq(str!["┴ 0dc3733 (common base) 2000-01-02 add M"])
-        .assert_rendered_term_svg_eq(file![
-            "snapshots/multi_squash_multiple_marked_sources_into_unmarked_target_final.svg"
-        ]);
-}
-
-#[test]
 fn multi_squash_marked_commits_into_selected_marked_target() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
     env.setup_metadata(&["A", "B"]).unwrap();

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/cannot_select_committed_files_from_global_listing_with_commits_marked_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/cannot_select_committed_files_from_global_listing_with_commits_marked_final.svg
@@ -1,105 +1,105 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
   <rect x="0" y="0" width="820" height="380" fill="#000000" />
-  <rect x="10" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="18" y="64" width="8" height="18" fill="#0000AA" />
-  <rect x="26" y="64" width="8" height="18" fill="#0000AA" />
-  <rect x="34" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="42" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="50" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="58" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="66" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="74" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="82" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="90" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="98" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="106" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="114" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="122" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="130" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="138" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="146" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="154" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="162" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="170" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="178" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="186" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="194" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="202" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="210" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="218" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="226" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="234" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="242" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="250" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="258" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="266" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="274" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="282" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="290" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="298" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="306" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="314" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="322" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="330" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="338" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="346" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="354" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="362" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="370" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="378" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="386" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="394" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="402" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="410" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="418" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="426" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="434" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="442" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="450" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="458" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="466" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="474" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="482" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="490" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="498" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="506" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="514" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="522" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="530" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="538" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="546" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="554" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="562" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="570" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="578" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="586" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="594" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="602" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="610" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="618" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="626" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="634" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="642" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="650" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="658" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="666" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="674" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="682" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="690" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="698" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="706" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="714" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="722" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="730" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="738" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="746" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="754" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="762" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="770" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="778" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="786" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="794" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="802" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="10" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="18" y="82" width="8" height="18" fill="#0000AA" />
+  <rect x="26" y="82" width="8" height="18" fill="#0000AA" />
+  <rect x="34" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="42" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="50" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="58" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="66" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="74" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="82" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="90" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="98" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="106" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="114" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="122" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="130" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="138" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="146" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="154" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="162" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="170" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="178" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="186" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="194" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="202" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="210" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="218" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="226" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="234" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="242" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="250" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="258" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="266" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="274" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="282" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="290" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="298" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="306" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="314" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="322" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="330" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="338" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="346" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="354" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="362" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="370" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="378" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="386" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="394" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="402" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="410" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="418" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="426" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="434" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="442" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="450" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="458" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="466" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="474" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="482" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="490" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="498" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="506" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="514" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="522" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="530" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="538" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="546" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="554" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="562" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="570" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="578" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="586" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="594" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="602" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="610" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="618" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="626" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="634" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="642" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="650" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="658" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="666" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="674" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="682" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="690" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="698" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="706" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="714" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="722" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="730" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="738" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="746" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="754" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="762" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="770" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="778" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="786" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="794" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="802" y="82" width="8" height="18" fill="#45475A" />
   <rect x="10" y="352" width="8" height="18" fill="#555555" />
   <rect x="18" y="352" width="8" height="18" fill="#555555" />
   <rect x="26" y="352" width="8" height="18" fill="#555555" />
@@ -133,100 +133,77 @@
   <text x="186" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
   <text x="194" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
   <text x="202" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
-  <text x="218" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
-  <text x="226" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
-  <text x="234" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
-  <text x="250" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
-  <text x="258" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
-  <text x="266" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="274" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
-  <text x="282" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
-  <text x="290" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
-  <text x="298" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
-  <text x="306" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
   <text x="10" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="42" y="42" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">v</text>
+  <text x="50" y="42" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="66" y="42" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="82" y="42" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="90" y="42" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="98" y="42" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="106" y="42" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="114" y="42" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">.</text>
+  <text x="122" y="42" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="130" y="42" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">x</text>
+  <text x="138" y="42" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
   <text x="10" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="18" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
-  <text x="26" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
-  <text x="34" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
-  <text x="42" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="58" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
-  <text x="66" y="60" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
-  <text x="74" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
-  <text x="10" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="18" y="78" style="fill:#000000;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">✔︎</text>
-  <text x="50" y="78" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="58" y="78" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="74" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="82" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="90" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="98" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="114" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="122" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="130" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="146" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
-  <text x="10" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">├</text>
-  <text x="18" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
-  <text x="10" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="10" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
+  <text x="26" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
+  <text x="34" y="78" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="42" y="78" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="58" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="66" y="78" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="74" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="10" y="96" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="96" style="fill:#000000;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">✔︎</text>
+  <text x="50" y="96" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="58" y="96" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="66" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="74" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="82" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="90" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="114" y="96" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="122" y="96" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="130" y="96" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="146" y="96" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="10" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">├</text>
+  <text x="18" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
   <text x="10" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="18" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
-  <text x="26" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
-  <text x="34" y="132" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
-  <text x="42" y="132" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="58" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
-  <text x="66" y="132" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">B</text>
-  <text x="74" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
-  <text x="10" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="18" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">●</text>
-  <text x="50" y="150" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="58" y="150" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="66" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="74" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="82" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="90" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="98" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="114" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="122" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="130" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="146" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">B</text>
-  <text x="10" y="168" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">├</text>
-  <text x="18" y="168" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
-  <text x="10" y="186" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="10" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┴</text>
-  <text x="26" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="34" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="42" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
-  <text x="50" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
-  <text x="58" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
-  <text x="66" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
-  <text x="74" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
-  <text x="90" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
-  <text x="98" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
-  <text x="106" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
-  <text x="114" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
-  <text x="122" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
-  <text x="130" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
-  <text x="138" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
-  <text x="154" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
-  <text x="162" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="170" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
-  <text x="178" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
-  <text x="186" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
-  <text x="202" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
-  <text x="210" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="218" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="226" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="234" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
-  <text x="242" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="250" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
-  <text x="258" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
-  <text x="266" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="274" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
-  <text x="290" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="298" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="306" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="322" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
+  <text x="10" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┴</text>
+  <text x="26" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="34" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="42" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="50" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="58" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
+  <text x="66" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="74" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="90" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
+  <text x="98" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="106" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="114" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="122" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="130" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="138" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="154" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="162" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="178" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="186" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
+  <text x="202" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="210" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="218" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="226" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="234" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="242" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="250" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="258" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="266" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="274" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="290" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="298" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="306" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="322" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
   <text x="10" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
   <text x="18" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
   <text x="26" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/cannot_select_committed_files_from_global_listing_with_commits_marked_showing_global_file_list.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/cannot_select_committed_files_from_global_listing_with_commits_marked_showing_global_file_list.svg
@@ -1,105 +1,105 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
   <rect x="0" y="0" width="820" height="380" fill="#000000" />
-  <rect x="10" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="18" y="64" width="8" height="18" fill="#0000AA" />
-  <rect x="26" y="64" width="8" height="18" fill="#0000AA" />
-  <rect x="34" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="42" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="50" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="58" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="66" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="74" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="82" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="90" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="98" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="106" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="114" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="122" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="130" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="138" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="146" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="154" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="162" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="170" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="178" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="186" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="194" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="202" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="210" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="218" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="226" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="234" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="242" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="250" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="258" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="266" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="274" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="282" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="290" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="298" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="306" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="314" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="322" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="330" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="338" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="346" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="354" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="362" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="370" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="378" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="386" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="394" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="402" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="410" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="418" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="426" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="434" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="442" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="450" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="458" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="466" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="474" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="482" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="490" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="498" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="506" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="514" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="522" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="530" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="538" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="546" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="554" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="562" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="570" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="578" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="586" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="594" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="602" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="610" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="618" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="626" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="634" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="642" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="650" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="658" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="666" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="674" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="682" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="690" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="698" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="706" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="714" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="722" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="730" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="738" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="746" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="754" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="762" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="770" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="778" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="786" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="794" y="64" width="8" height="18" fill="#45475A" />
-  <rect x="802" y="64" width="8" height="18" fill="#45475A" />
+  <rect x="10" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="18" y="82" width="8" height="18" fill="#0000AA" />
+  <rect x="26" y="82" width="8" height="18" fill="#0000AA" />
+  <rect x="34" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="42" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="50" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="58" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="66" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="74" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="82" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="90" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="98" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="106" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="114" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="122" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="130" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="138" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="146" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="154" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="162" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="170" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="178" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="186" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="194" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="202" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="210" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="218" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="226" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="234" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="242" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="250" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="258" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="266" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="274" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="282" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="290" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="298" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="306" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="314" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="322" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="330" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="338" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="346" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="354" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="362" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="370" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="378" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="386" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="394" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="402" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="410" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="418" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="426" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="434" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="442" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="450" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="458" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="466" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="474" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="482" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="490" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="498" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="506" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="514" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="522" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="530" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="538" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="546" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="554" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="562" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="570" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="578" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="586" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="594" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="602" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="610" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="618" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="626" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="634" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="642" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="650" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="658" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="666" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="674" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="682" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="690" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="698" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="706" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="714" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="722" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="730" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="738" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="746" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="754" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="762" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="770" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="778" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="786" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="794" y="82" width="8" height="18" fill="#45475A" />
+  <rect x="802" y="82" width="8" height="18" fill="#45475A" />
   <rect x="10" y="352" width="8" height="18" fill="#555555" />
   <rect x="18" y="352" width="8" height="18" fill="#555555" />
   <rect x="26" y="352" width="8" height="18" fill="#555555" />
@@ -133,100 +133,86 @@
   <text x="186" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
   <text x="194" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
   <text x="202" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
-  <text x="218" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
-  <text x="226" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
-  <text x="234" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
-  <text x="250" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
-  <text x="258" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
-  <text x="266" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="274" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
-  <text x="282" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
-  <text x="290" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
-  <text x="298" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
-  <text x="306" y="24" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
   <text x="10" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="42" y="42" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">v</text>
+  <text x="50" y="42" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="66" y="42" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="82" y="42" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="90" y="42" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="98" y="42" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="106" y="42" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="114" y="42" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">.</text>
+  <text x="122" y="42" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="130" y="42" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">x</text>
+  <text x="138" y="42" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
   <text x="10" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="18" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
-  <text x="26" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
-  <text x="34" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
-  <text x="42" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="58" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
-  <text x="66" y="60" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
-  <text x="74" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
-  <text x="10" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="18" y="78" style="fill:#000000;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">✔︎</text>
-  <text x="50" y="78" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="58" y="78" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="74" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="82" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="90" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="98" y="78" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="114" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="122" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="130" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="146" y="78" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
-  <text x="10" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">├</text>
-  <text x="18" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
+  <text x="10" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
+  <text x="26" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
+  <text x="34" y="78" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="42" y="78" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="58" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="66" y="78" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="74" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="10" y="96" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="96" style="fill:#000000;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">✔︎</text>
+  <text x="50" y="96" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="58" y="96" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="66" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="74" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="82" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="90" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="114" y="96" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="122" y="96" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="130" y="96" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="146" y="96" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
   <text x="10" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="10" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="18" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
-  <text x="26" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
-  <text x="34" y="132" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
-  <text x="42" y="132" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="58" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
-  <text x="66" y="132" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">B</text>
-  <text x="74" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="18" y="114" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="66" y="114" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">9</text>
+  <text x="74" y="114" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">4</text>
+  <text x="82" y="114" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">:</text>
+  <text x="90" y="114" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="98" y="114" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="114" y="114" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="130" y="114" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="10" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">├</text>
+  <text x="18" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
   <text x="10" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="18" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">●</text>
-  <text x="50" y="150" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="58" y="150" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="66" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="74" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="82" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="90" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="98" y="150" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="114" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="122" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="130" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="146" y="150" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">B</text>
-  <text x="10" y="168" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">├</text>
-  <text x="18" y="168" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
-  <text x="10" y="186" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
-  <text x="10" y="204" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┴</text>
-  <text x="26" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="34" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="42" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
-  <text x="50" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
-  <text x="58" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
-  <text x="66" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
-  <text x="74" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
-  <text x="90" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
-  <text x="98" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
-  <text x="106" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
-  <text x="114" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
-  <text x="122" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
-  <text x="130" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
-  <text x="138" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
-  <text x="154" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
-  <text x="162" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="170" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
-  <text x="178" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
-  <text x="186" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
-  <text x="202" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
-  <text x="210" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="218" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="226" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="234" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
-  <text x="242" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="250" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
-  <text x="258" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
-  <text x="266" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
-  <text x="274" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
-  <text x="290" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
-  <text x="298" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="306" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
-  <text x="322" y="204" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
+  <text x="10" y="168" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┴</text>
+  <text x="26" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="34" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="42" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="50" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="58" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
+  <text x="66" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="74" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="90" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
+  <text x="98" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="106" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="114" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="122" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="130" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="138" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="154" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="162" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="178" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="186" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
+  <text x="202" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="210" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="218" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="226" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="234" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="242" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="250" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="258" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="266" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="274" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="290" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="298" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="306" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="322" y="168" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
   <text x="10" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
   <text x="18" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
   <text x="26" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>


### PR DESCRIPTION
Marking and operating on different items like commits, committed files, and
uncommitted files all at once is something we might wanna support one day but
not now. So this disables moving the cursor to lines you cannot mark.