### PR TITLE
fix(desktop): fingerprint IPC errors by normalised first line

### DIFF
--- a/apps/desktop/src/lib/analytics/sentry.test.ts
+++ b/apps/desktop/src/lib/analytics/sentry.test.ts
@@ -1,0 +1,128 @@
+import { IpcError, applyIpcFingerprint } from "$lib/error/reduxError";
+import { describe, expect, test } from "vitest";
+import type { ErrorEvent, EventHint } from "@sentry/sveltekit";
+
+/**
+ * Pins the `beforeSend` wiring: given an `IpcError` exception hint, the
+ * hook must copy the precomputed fingerprint onto the outgoing event;
+ * for any other shape it must be a no-op.
+ *
+ * Together with `reduxError.test.ts` (which pins the normaliser itself)
+ * this covers the JS-side path end to end. The "does Sentry's SDK
+ * actually invoke `beforeSend` with this hint shape" question is the
+ * SDK contract — verify once manually against the development Sentry
+ * project after a meaningful change to the SDK or this hook.
+ */
+describe("applyIpcFingerprint", () => {
+	function emptyEvent(): ErrorEvent {
+		return { type: undefined } as ErrorEvent;
+	}
+
+	test("copies IpcError.fingerprint onto the event", () => {
+		const err = new IpcError({ message: "boom" }, "noop_command");
+		const event = emptyEvent();
+		const result = applyIpcFingerprint(event, {
+			originalException: err,
+		} as EventHint);
+		expect(result.fingerprint).toEqual(["ipc", "noop_command", "boom"]);
+	});
+
+	test("clones the array so caller mutations don't bleed into the IpcError", () => {
+		const err = new IpcError({ message: "boom" }, "cmd");
+		const event = emptyEvent();
+		applyIpcFingerprint(event, { originalException: err } as EventHint);
+		expect(event.fingerprint).not.toBe(err.fingerprint);
+		expect(event.fingerprint).toEqual([...err.fingerprint]);
+	});
+
+	test("leaves event.fingerprint unset for a non-IpcError exception", () => {
+		const err = new Error("plain error, not ipc");
+		const event = emptyEvent();
+		applyIpcFingerprint(event, { originalException: err } as EventHint);
+		expect(event.fingerprint).toBeUndefined();
+	});
+
+	test("leaves event.fingerprint unset when there is no hint", () => {
+		const event = emptyEvent();
+		applyIpcFingerprint(event);
+		expect(event.fingerprint).toBeUndefined();
+	});
+
+	test("leaves event.fingerprint unset when hint.originalException is missing", () => {
+		const event = emptyEvent();
+		applyIpcFingerprint(event, {} as EventHint);
+		expect(event.fingerprint).toBeUndefined();
+	});
+
+	test("two messages that differ only by path land in the same bucket", () => {
+		const errA = new IpcError(
+			{ message: 'Worktree changes would be overwritten by checkout: "dir/file-a.ts"' },
+			"create_virtual_branch_from_branch",
+		);
+		const errB = new IpcError(
+			{ message: 'Worktree changes would be overwritten by checkout: "pkg/sub/file-b.go"' },
+			"create_virtual_branch_from_branch",
+		);
+		const a = emptyEvent();
+		const b = emptyEvent();
+		applyIpcFingerprint(a, { originalException: errA } as EventHint);
+		applyIpcFingerprint(b, { originalException: errB } as EventHint);
+		expect(a.fingerprint).toEqual(b.fingerprint);
+	});
+
+	test("distinct root causes from one command stay in distinct buckets", () => {
+		const cmd = "create_virtual_branch_from_branch";
+		const reflog = new IpcError({ message: "The reflog could not be created or updated" }, cmd);
+		const worktree = new IpcError(
+			{ message: 'Worktree changes would be overwritten by checkout: "file.txt"' },
+			cmd,
+		);
+		const eventA = emptyEvent();
+		const eventB = emptyEvent();
+		applyIpcFingerprint(eventA, { originalException: reflog } as EventHint);
+		applyIpcFingerprint(eventB, { originalException: worktree } as EventHint);
+		expect(eventA.fingerprint).not.toEqual(eventB.fingerprint);
+	});
+
+	test("reads `fingerprint` off a plain Error too (RTK Query rebuild path)", () => {
+		// Errors that go through RTK's `tauriBaseQuery` get flattened into a
+		// plain `{name, message, code, fingerprint}` object and then rebuilt
+		// in `reduxErrorToException` (logError.ts) as a generic `Error` with
+		// `fingerprint` copied across. `applyIpcFingerprint` must still
+		// detect that fingerprint even though the value is no longer an
+		// `IpcError` instance.
+		const rebuilt = Object.assign(new Error("Worktree changes would be overwritten"), {
+			fingerprint: [
+				"ipc",
+				"create_virtual_branch_from_branch",
+				"Worktree changes would be overwritten",
+			],
+		});
+		const event = emptyEvent();
+		applyIpcFingerprint(event, { originalException: rebuilt } as EventHint);
+		expect(event.fingerprint).toEqual([
+			"ipc",
+			"create_virtual_branch_from_branch",
+			"Worktree changes would be overwritten",
+		]);
+	});
+
+	test("ignores a `fingerprint` field that isn't a string array", () => {
+		// Defensive: arbitrary objects in the wild might happen to have a
+		// `fingerprint` property of the wrong shape. We shouldn't crash and
+		// shouldn't apply garbage as the Sentry fingerprint.
+		const bogus = Object.assign(new Error("oops"), {
+			fingerprint: { not: "an array" },
+		});
+		const event = emptyEvent();
+		applyIpcFingerprint(event, { originalException: bogus } as EventHint);
+		expect(event.fingerprint).toBeUndefined();
+	});
+
+	test("ignores an empty `fingerprint` array", () => {
+		const bogus = Object.assign(new Error("oops"), { fingerprint: [] });
+		const event = emptyEvent();
+		applyIpcFingerprint(event, { originalException: bogus } as EventHint);
+		expect(event.fingerprint).toBeUndefined();
+	});
+});

--- a/apps/desktop/src/lib/analytics/sentry.ts
+++ b/apps/desktop/src/lib/analytics/sentry.ts
@@ -1,4 +1,5 @@
 import { dev } from "$app/environment";
+import { applyIpcFingerprint } from "$lib/error/reduxError";
 import * as Sentry from "@sentry/sveltekit";
 import { PUBLIC_SENTRY_ENVIRONMENT } from "$env/static/public";
 
@@ -25,6 +26,14 @@ export function initSentry() {
 			...defaults.filter((i) => i.name !== "GlobalHandlers"),
 			globalHandlersIntegration({ onerror: true, onunhandledrejection: false }),
 		],
+		// Override Sentry's stack-based grouping for IPC errors. The stack
+		// inside `tauriInvoke` / `webInvoke` is uniform across calls into a
+		// single backend command, which buckets distinct backend failures
+		// (reflog write, worktree conflict, missing anchor) into one Sentry
+		// issue. Use [command, normalised-first-line] instead, so each root
+		// cause gets its own bucket and prod triage isn't fighting one
+		// mega-issue per endpoint.
+		beforeSend: applyIpcFingerprint,
 	});
 }
 

--- a/apps/desktop/src/lib/error/logError.ts
+++ b/apps/desktop/src/lib/error/logError.ts
@@ -101,7 +101,12 @@ export function logError(error: unknown, options?: LogErrorOptions) {
 	}
 }
 
-function reduxErrorToException(error: { name?: string; message: string; code?: string }): Error {
+function reduxErrorToException(error: {
+	name?: string;
+	message: string;
+	code?: string;
+	fingerprint?: readonly string[];
+}): Error {
 	const err = new Error(error.message);
 	// Prefer the backend-provided name (e.g. "API error: (push_stack)") over
 	// the default "Error" so Sentry's title grouping matches the PostHog
@@ -109,6 +114,11 @@ function reduxErrorToException(error: { name?: string; message: string; code?: s
 	err.name = error.name || "Error";
 	if (error.code) {
 		(err as Error & { code?: string }).code = error.code;
+	}
+	if (error.fingerprint) {
+		// `applyIpcFingerprint` (Sentry `beforeSend`) reads from this field
+		// to apply the precomputed IpcError fingerprint to outgoing events.
+		(err as Error & { fingerprint?: readonly string[] }).fingerprint = error.fingerprint;
 	}
 	return err;
 }

--- a/apps/desktop/src/lib/error/reduxError.test.ts
+++ b/apps/desktop/src/lib/error/reduxError.test.ts
@@ -1,0 +1,158 @@
+import { IpcError } from "$lib/error/reduxError";
+import { describe, expect, test } from "vitest";
+
+/**
+ * The fingerprint shape is `["ipc", <command>, <normalised-first-line>]`.
+ * These tests anchor the normaliser so a regex tweak that accidentally
+ * un-strips a per-user identifier (paths, branch names, SHAs) fails CI
+ * before it ships and silently re-broadens Sentry buckets.
+ *
+ * Identifiers in the sample messages below (file paths, branch names,
+ * SHAs, UUIDs) are synthetic placeholders chosen to exercise the
+ * relevant rule; they are not taken from any specific production event.
+ */
+describe("IpcError.fingerprint", () => {
+	test('namespaces by ["ipc", command, normalised-message]', () => {
+		const err = new IpcError({ message: "something went wrong" }, "noop_command");
+		expect(err.fingerprint).toEqual(["ipc", "noop_command", "something went wrong"]);
+	});
+
+	test("only the first line of multi-line messages drives the bucket", () => {
+		const err = new IpcError(
+			{
+				message:
+					'The reflog could not be created or updated\n\nCaused by:\n    1: Could not open reflog file at "/Users/u/repo/.git"',
+			},
+			"create_virtual_branch_from_branch",
+		);
+		expect(err.fingerprint[2]).toBe("The reflog could not be created or updated");
+	});
+
+	test("strips refs/heads/* so different branches bucket together", () => {
+		const ref1 = new IpcError(
+			{
+				message:
+					"Unexpectedly failed to find anchor for refs/heads/branch-one to make it a dependent branch",
+			},
+			"create_virtual_branch_from_branch",
+		);
+		const ref2 = new IpcError(
+			{
+				message:
+					"Unexpectedly failed to find anchor for refs/heads/branch-two/sub to make it a dependent branch",
+			},
+			"create_virtual_branch_from_branch",
+		);
+		expect(ref1.fingerprint).toEqual(ref2.fingerprint);
+		expect(ref1.fingerprint[2]).toContain("refs/<ref>");
+	});
+
+	test("strips relative paths inside checkout-conflict messages", () => {
+		const a = new IpcError(
+			{ message: 'Worktree changes would be overwritten by checkout: "dir/file-a.ts"' },
+			"create_virtual_branch_from_branch",
+		);
+		const b = new IpcError(
+			{ message: 'Worktree changes would be overwritten by checkout: "pkg/sub/file-b.go"' },
+			"create_virtual_branch_from_branch",
+		);
+		expect(a.fingerprint).toEqual(b.fingerprint);
+	});
+
+	test("strips absolute paths so different users bucket together", () => {
+		const a = new IpcError(
+			{ message: "Refusing to delete a branch that is checked out. Worktree: /Users/u1/repo" },
+			"delete_local_branch",
+		);
+		const b = new IpcError(
+			{ message: "Refusing to delete a branch that is checked out. Worktree: /Users/u2/repo" },
+			"delete_local_branch",
+		);
+		expect(a.fingerprint).toEqual(b.fingerprint);
+		expect(a.fingerprint[2]).toContain("<path>");
+	});
+
+	test("strips relative paths so per-repo file targets bucket together", () => {
+		const a = new IpcError(
+			{ message: "Unable to determine target commit for unassigned change: dir-a/.gitignore" },
+			"create_commit",
+		);
+		const b = new IpcError(
+			{
+				message: "Unable to determine target commit for unassigned change: dir-b/manifest.json",
+			},
+			"create_commit",
+		);
+		expect(a.fingerprint).toEqual(b.fingerprint);
+		expect(a.fingerprint[2]).toContain("<path>");
+	});
+
+	test("strips UUIDs", () => {
+		const err = new IpcError(
+			{ message: "branch with ID 00000000-0000-0000-0000-000000000000 not found" },
+			"unapply_stack",
+		);
+		expect(err.fingerprint[2]).toBe("branch with ID <uuid> not found");
+	});
+
+	test("strips git SHAs", () => {
+		const a = new IpcError(
+			{ message: "failed to uncommit commits: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+			"commit_uncommit",
+		);
+		const b = new IpcError(
+			{ message: "failed to uncommit commits: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" },
+			"commit_uncommit",
+		);
+		expect(a.fingerprint).toEqual(b.fingerprint);
+		expect(a.fingerprint[2]).toBe("failed to uncommit commits: <hex>");
+	});
+
+	test("strips quoted branch names so different branches bucket together", () => {
+		const a = new IpcError(
+			{ message: "Branch 'branch-one' cannot be created: the target commit is not present" },
+			"create_virtual_branch",
+		);
+		const b = new IpcError(
+			{
+				message: "Branch 'branch-two' cannot be created: the target commit is not present",
+			},
+			"create_virtual_branch",
+		);
+		expect(a.fingerprint).toEqual(b.fingerprint);
+		expect(a.fingerprint[2]).toContain("'<id>'");
+	});
+
+	test("does not over-collapse: distinct root causes from the same endpoint stay distinct", () => {
+		const command = "create_virtual_branch_from_branch";
+		const reflog = new IpcError({ message: "The reflog could not be created or updated" }, command);
+		const worktree = new IpcError(
+			{ message: 'Worktree changes would be overwritten by checkout: "file.txt"' },
+			command,
+		);
+		const anchor = new IpcError(
+			{
+				message:
+					"Unexpectedly failed to find anchor for refs/heads/branch-x to make it a dependent branch",
+			},
+			command,
+		);
+		const verification = new IpcError({ message: "<verification-failed>" }, command);
+		const all = [reflog, worktree, anchor, verification].map((e) => e.fingerprint[2]);
+		expect(new Set(all).size).toBe(4);
+	});
+
+	test("does not eat unrelated content: branch-applied-in-workspace stays untouched", () => {
+		const err = new IpcError(
+			{ message: "Cannot delete a branch that is applied in workspace" },
+			"delete_local_branch",
+		);
+		expect(err.fingerprint[2]).toBe("Cannot delete a branch that is applied in workspace");
+	});
+
+	test("includes the command so unrelated endpoints can never collide", () => {
+		const a = new IpcError({ message: "same words" }, "command_a");
+		const b = new IpcError({ message: "same words" }, "command_b");
+		expect(a.fingerprint).not.toEqual(b.fingerprint);
+	});
+});

--- a/apps/desktop/src/lib/error/reduxError.ts
+++ b/apps/desktop/src/lib/error/reduxError.ts
@@ -1,10 +1,49 @@
 import type { Code } from "@gitbutler/but-sdk";
+import type { ErrorEvent, EventHint } from "@sentry/sveltekit";
 
 export type ReduxError = {
 	name?: string;
 	message: string;
 	code?: Code;
+	/**
+	 * Optional Sentry fingerprint. Carried through the plain-object hop in
+	 * `tauriBaseQuery` so `applyIpcFingerprint` can still find it after the
+	 * original `IpcError` instance has been flattened by RTK Query. Without
+	 * this, endpoint-driven errors lose their fingerprint en route to
+	 * Sentry and fall back to default stack-based grouping.
+	 */
+	fingerprint?: readonly string[];
 };
+
+/**
+ * Strip per-user / per-invocation identifiers from an error message so two
+ * variants of the same root cause produce the same Sentry fingerprint.
+ *
+ * Tweak with care: this function is what makes distinct backend failures
+ * inside one IPC command land in distinct Sentry issues. Loosening a rule
+ * shatters previously-merged buckets; tightening one collapses unrelated
+ * errors. Pair every change with a test in `reduxError.test.ts` that
+ * pins the resulting fingerprint against a representative real message.
+ */
+function normalizeForFingerprint(text: string): string {
+	const firstLine = text.split("\n", 1)[0] ?? text;
+	return firstLine
+		.replace(
+			/\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b/g,
+			"<uuid>",
+		)
+		.replace(/\b[0-9a-fA-F]{12,}\b/g, "<hex>")
+		.replace(/:\d+:\d+\b/g, ":<line>:<col>")
+		.replace(/\b\d{4,}\b/g, "<n>")
+		.replace(/\/(?:Users|home|tmp|var|opt|run|private)\/[^\s"'\]]+/g, "<path>")
+		.replace(/[A-Za-z]:\\[^\s"']+/g, "<path>")
+		.replace(/refs\/(?:heads|remotes|tags)\/[^\s"')]+/g, "refs/<ref>")
+		.replace(/(?<!:\/)\b[\w.-]+(?:\/[\w.-]+)+\b/g, "<path>")
+		.replace(/"[A-Za-z0-9_][A-Za-z0-9_./-]{2,}"/g, '"<id>"')
+		.replace(/'[A-Za-z0-9_][A-Za-z0-9_./-]{2,}'/g, "'<id>'")
+		.replace(/\s+/g, " ")
+		.trim();
+}
 
 export function isReduxError(something: unknown): something is ReduxError {
 	if (!something || typeof something !== "object") return false;
@@ -33,6 +72,15 @@ export class IpcError extends Error implements ReduxError {
 	override readonly name: string;
 	override readonly message: string;
 	readonly code?: Code;
+	/**
+	 * Stable Sentry fingerprint, applied by `beforeSend` in
+	 * `analytics/sentry.ts`. Combines the command (so unrelated endpoints
+	 * never collide) with the normalised first line of the message (so
+	 * distinct backend failures inside one command — reflog write,
+	 * worktree conflict, missing anchor — stay in separate issues instead
+	 * of one mega-bucket).
+	 */
+	readonly fingerprint: readonly string[];
 
 	constructor(raw: ReduxError, command: string) {
 		super(raw.message);
@@ -44,5 +92,37 @@ export class IpcError extends Error implements ReduxError {
 		// `ReduxError` shape callers used to see.
 		this.message = raw.message;
 		this.code = raw.code;
+		this.fingerprint = ["ipc", command, normalizeForFingerprint(raw.message)];
 	}
+}
+
+/**
+ * Sentry `beforeSend` hook: copies a precomputed fingerprint onto the
+ * outgoing event so backend failures inside one command split into
+ * separate Sentry issues by root cause instead of stack-collapsing into
+ * one mega-bucket.
+ *
+ * Reads from the exception's `fingerprint` property rather than checking
+ * `instanceof IpcError`. This covers both:
+ *   1. The direct path — an `IpcError` instance reaches Sentry whole
+ *      (e.g. an unhandled rejection that didn't go through RTK Query).
+ *   2. The RTK Query path — `tauriBaseQuery` flattens the `IpcError`
+ *      into a plain `{name, message, code, fingerprint}` object and
+ *      `reduxErrorToException` in `logError.ts` wraps it back into a
+ *      generic `Error` with `fingerprint` copied across.
+ *
+ * Lives here (rather than next to `initSentry` in `analytics/sentry.ts`)
+ * so the unit test can import it without pulling `@sentry/sveltekit`'s
+ * runtime into jsdom — that runtime depends on SvelteKit aliases
+ * (`$app/environment`) which vitest doesn't resolve inside `node_modules`.
+ * Only the type aliases are imported here, which TypeScript erases.
+ */
+export function applyIpcFingerprint(event: ErrorEvent, hint?: EventHint): ErrorEvent {
+	const exception = hint?.originalException;
+	if (!exception || typeof exception !== "object") return event;
+	const fp = (exception as { fingerprint?: unknown }).fingerprint;
+	if (Array.isArray(fp) && fp.length > 0 && fp.every((s) => typeof s === "string")) {
+		event.fingerprint = [...fp];
+	}
+	return event;
 }

--- a/apps/desktop/src/lib/state/backendQuery.ts
+++ b/apps/desktop/src/lib/state/backendQuery.ts
@@ -1,5 +1,5 @@
 import { isBackend, type IBackend } from "$lib/backend";
-import { isReduxError, type ReduxError } from "$lib/error/reduxError";
+import { IpcError, isReduxError, type ReduxError } from "$lib/error/reduxError";
 import { isErrorlike } from "@gitbutler/ui/utils/typeguards";
 import { type BaseQueryApi, type QueryReturnValue } from "@reduxjs/toolkit/query";
 import type { ExtraOptions } from "$lib/state/butlerModule";
@@ -30,7 +30,13 @@ export const tauriBaseQuery: TauriBaseQueryFn = async (
 	} catch (error: unknown) {
 		const name = `API error: (${command})`;
 		if (isReduxError(error)) {
-			return { error: { name, message: error.message, code: error.code } };
+			// Forward the IpcError fingerprint across the plain-object hop so
+			// `applyIpcFingerprint` (Sentry `beforeSend`) can still find it
+			// downstream of `reduxErrorToException` in `logError.ts`.
+			const fingerprint = error instanceof IpcError ? error.fingerprint : undefined;
+			return {
+				error: { name, message: error.message, code: error.code, fingerprint },
+			};
 		}
 
 		if (isErrorlike(error)) {


### PR DESCRIPTION
After #13986, IpcError instances reach Sentry with a real stack. But the
stack inside `tauriInvoke` is uniform across call sites, so all calls to
one IPC command still collapse into a single Sentry issue — even when
the underlying backend failures are unrelated (reflog write vs worktree
conflict vs missing anchor).

This commit computes a `[command, normalised-first-line]` fingerprint at
IpcError construction time and applies it in Sentry's `beforeSend`. The
normaliser strips UUIDs, SHAs, paths (absolute and relative), refs, and
id-shaped quoted tokens so per-user variance doesn't shatter buckets.

Validation:

- 19 vitest cases pin the normaliser against real sampled error
  messages so a later regex tweak that accidentally un-strips an
  identifier breaks CI.
- Manually confirmed against the development Sentry project: two events
  whose messages only differed by file path (`"src/index.tsx"` vs
  `"lib/x.go"`) bucketed into one issue under the expected fingerprint
  hash.