### PR TITLE
fix(but): make name validation in `but reword <branch>` strict

### DIFF
--- a/crates/but/src/args/atoms/branch_arg.rs
+++ b/crates/but/src/args/atoms/branch_arg.rs
@@ -107,7 +107,6 @@ fn check_can_create_branch_with_user_provided_name(
         but_core::branch::normalize_short_name(user_provided_branch_name).map_err(|err| {
             CliError::from(
                 bad_input(format!("Invalid branch name: {err}"))
-                    .arg_name("<BRANCH_NAME>")
                     .arg_value(user_provided_branch_name),
             )
         })?;
@@ -115,7 +114,6 @@ fn check_can_create_branch_with_user_provided_name(
     let user_name_bstr: &BStr = user_provided_branch_name.into();
     if normalized != user_name_bstr {
         return Err(bad_input("Invalid branch name")
-            .arg_name("<BRANCH_NAME>")
             .arg_value(user_provided_branch_name)
             .hint(format!("Try '{normalized}' instead"))
             .into());

--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -15,7 +15,7 @@ use super::{
 use crate::{
     CliResult, IdMap,
     args::atoms::{BranchArg, BranchOrCommit, CliIdArg, Purpose},
-    tui,
+    bad_input, tui,
     utils::OutputChannel,
 };
 
@@ -70,7 +70,7 @@ fn edit_branch_name(
     out: &mut OutputChannel,
     message: Option<&str>,
     perm: &mut RepoExclusive,
-) -> Result<()> {
+) -> CliResult<()> {
     // Find which stack this branch belongs to
     let stacks = but_api::legacy::workspace::stacks(
         ctx,
@@ -83,23 +83,30 @@ fn edit_branch_name(
         }
 
         if let Some(sid) = stack_entry.id {
-            let new_name = prepare_provided_message(message, "branch name")
+            let non_validated_new_name = prepare_provided_message(message, "branch name")
                 .unwrap_or_else(|| get_branch_name_from_editor(branch_name))?;
+            let new_branch_name = {
+                let repo = ctx.repo.get()?;
+                BranchArg(non_validated_new_name).resolve_for_creation(&repo)?
+            };
             but_api::legacy::stack::update_branch_name_with_perm(
                 ctx,
                 sid,
                 branch_name.to_owned(),
-                new_name.clone(),
+                new_branch_name.clone(),
                 perm,
             )?;
             if let Some(out) = out.for_human() {
-                writeln!(out, "Renamed branch '{branch_name}' to '{new_name}'")?;
+                writeln!(out, "Renamed branch '{branch_name}' to '{new_branch_name}'")?;
             }
             return Ok(());
         }
     }
 
-    bail!("Branch '{branch_name}' not found in any stack")
+    Err(bad_input("Branch not found in workspace")
+        .arg_value(branch_name)
+        .hint("You can only reword applied branches")
+        .into())
 }
 
 fn prepare_provided_message(msg: Option<&str>, entity: &str) -> Option<Result<String>> {

--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -85,6 +85,14 @@ fn edit_branch_name(
         if let Some(sid) = stack_entry.id {
             let non_validated_new_name = prepare_provided_message(message, "branch name")
                 .unwrap_or_else(|| get_branch_name_from_editor(branch_name))?;
+
+            if non_validated_new_name == branch_name {
+                if let Some(out) = out.for_human() {
+                    writeln!(out, "Branch already named '{branch_name}' - nothing to do")?;
+                };
+                return Ok(());
+            };
+
             let new_branch_name = {
                 let repo = ctx.repo.get()?;
                 BranchArg(non_validated_new_name).resolve_for_creation(&repo)?

--- a/crates/but/tests/but/command/branch/new.rs
+++ b/crates/but/tests/but/command/branch/new.rs
@@ -42,7 +42,7 @@ fn rejects_head() -> anyhow::Result<()> {
         .assert()
         .failure()
         .stderr_eq(str![[r#"
-Error: Bad input 'HEAD' for '<BRANCH_NAME>'
+Error: Bad input 'HEAD'
 
 Invalid branch name: Could not turn "HEAD" into a valid reference name
 
@@ -60,7 +60,7 @@ fn rejects_name_that_normalizes_to_head() -> anyhow::Result<()> {
         .assert()
         .failure()
         .stderr_eq(str![[r#"
-Error: Bad input 'HEAD-' for '<BRANCH_NAME>'
+Error: Bad input 'HEAD-'
 
 Invalid branch name: Could not turn "HEAD-" into a valid reference name
 
@@ -78,7 +78,7 @@ fn rejects_name_that_normalizes_to_something_else_and_suggests_alternative() -> 
         .assert()
         .failure()
         .stderr_eq(str![[r#"
-Error: Bad input 'my branch' for '<BRANCH_NAME>'
+Error: Bad input 'my branch'
 
 Invalid branch name
 

--- a/crates/but/tests/but/command/reword.rs
+++ b/crates/but/tests/but/command/reword.rs
@@ -111,7 +111,49 @@ fn reword_branch_rejects_head() -> anyhow::Result<()> {
         .assert()
         .failure()
         .stderr_eq(str![[r#"
-Error: Could not turn "HEAD" into a valid reference name
+Error: Bad input 'HEAD'
+
+Invalid branch name: Could not turn "HEAD" into a valid reference name
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn reword_branch_rejects_non_normalized_name() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("reword A -m /B")
+        .assert()
+        .failure()
+        .stdout_eq(str![[]])
+        .stderr_eq(str![[r#"
+Error: Bad input '/B'
+
+Invalid branch name
+
+Hint: Try 'B' instead
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn reword_branch_rejects_branch_name_that_already_exists() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("branch new existing").assert().success();
+
+    env.but("reword A -m existing")
+        .assert()
+        .failure()
+        .stdout_eq(str![[]])
+        .stderr_eq(str![[r#"
+Error: A branch named 'existing' already exists
 
 "#]]);
 

--- a/crates/but/tests/but/command/reword.rs
+++ b/crates/but/tests/but/command/reword.rs
@@ -161,6 +161,23 @@ Error: A branch named 'existing' already exists
 }
 
 #[test]
+fn reword_branch_allows_rewording_to_same_name() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("reword A -m A")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Branch already named 'A' - nothing to do
+
+"#]])
+        .stderr_eq(str![[]]);
+
+    Ok(())
+}
+
+#[test]
 fn reword_commit_with_same_message_succeeds_as_noop() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
     insta::assert_snapshot!(env.git_log()?, @"


### PR DESCRIPTION
## 🧢 Changes
Imposes the same name validation when renaming a branch as when creating a new
one using `but branch new`.

See commit d70a059d15 for justification.

Replaces #13160