### PR TITLE
Enable automatic status output for agents

### DIFF
--- a/crates/but-testsupport/src/prepare_cmd_env.rs
+++ b/crates/but-testsupport/src/prepare_cmd_env.rs
@@ -57,6 +57,25 @@ fn updates() -> Vec<EnvOp> {
         EnvOp::Remove("GIT_EDITOR"),
         EnvOp::Remove("VISUAL"),
         EnvOp::Remove("EDITOR"),
+        // Keep ambient agent environments from changing default CLI test output.
+        EnvOp::Remove("AI_AGENT"),
+        EnvOp::Remove("CLAUDE_CODE_IS_COWORK"),
+        EnvOp::Remove("CLAUDE_CODE"),
+        EnvOp::Remove("CLAUDECODE"),
+        EnvOp::Remove("CURSOR_AGENT"),
+        EnvOp::Remove("CURSOR_TRACE_ID"),
+        EnvOp::Remove("CODEX_SANDBOX"),
+        EnvOp::Remove("CODEX_CI"),
+        EnvOp::Remove("CODEX_THREAD_ID"),
+        EnvOp::Remove("CODEX_SHELL"),
+        EnvOp::Remove("GEMINI_CLI"),
+        EnvOp::Remove("COPILOT_MODEL"),
+        EnvOp::Remove("COPILOT_ALLOW_ALL"),
+        EnvOp::Remove("COPILOT_GITHUB_TOKEN"),
+        EnvOp::Remove("OPENCODE_CLIENT"),
+        EnvOp::Remove("AUGMENT_AGENT"),
+        EnvOp::Remove("ANTIGRAVITY_AGENT"),
+        EnvOp::Remove("REPL_ID"),
     ]
     .into_iter()
     .chain(

--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: but
 version: 0.0.0
-description: "Commit, push, branch, and manage version control with GitButler. Use for: commit my changes, check what changed, create a PR, push my branch, view diff, create branches, stage files, edit commit history, squash commits, amend commits, undo commits, pull requests, merge, stash work. Replaces git - use 'but' instead of git commit, git status, git push, git checkout, git add, git diff, git branch, git rebase, git stash, git merge. Covers all git, version control, and source control operations."
+description: "Commit, push, branch, and manage version control with GitButler. Use for: commit my changes, check what changed, create a PR, push my branch, view diff, create branches, stage files, edit commit history, squash commits, amend commits, undo commits, pull requests, merge, apply and unapply branches. Replaces git - use 'but' instead of git commit, git status, git push, git checkout, git add, git diff, git branch, git rebase, git merge. Covers all git, version control, and source control operations."
 author: GitButler Team
 ---
 
@@ -12,7 +12,7 @@ Use GitButler CLI (`but`) as the default version-control interface.
 ## Non-Negotiable Rules
 
 1. Use `but` for all write operations. Never run `git add`, `git commit`, `git push`, `git checkout`, `git merge`, `git rebase`, `git stash`, or `git cherry-pick`. If the user says a `git` write command, translate it to `but` and run that.
-2. Always add `--status-after` to mutation commands.
+2. After mutations, read the returned output for the updated workspace state.
 3. Use CLI IDs from `but status -fv` / `but diff` / `but show`; never hardcode IDs.
 4. Start with `but status -fv` before mutations so IDs and stack state are current.
 5. Create a branch for new work with `but branch new <name>` when needed.
@@ -34,20 +34,20 @@ but branch new <name>
 but status -fv
 
 # 5. Perform mutation with IDs from status/diff/show
-but <mutation> ... --status-after
+but <mutation> ...
 ```
 
 ## Command Patterns
 
-- Commit: `but commit <branch> -m "<msg>" --changes <id>,<id> --status-after`
-- `but commit -a` is accepted as a no-op compatibility flag; GitButler already includes unstaged changes by default.
-- Commit + create branch: `but commit <branch> -c -m "<msg>" --changes <id> --status-after`
-- Amend: `but amend <file-id> <commit-id> --status-after`
-- Reorder commits: `but move <source-commit-id> <target-commit-id> --status-after` (**commit IDs**, not branch names)
-- Stack branches: `but move <branch-name-or-id> <target-branch-name-or-id> --status-after` (**branch names or branch CLI IDs**)
-- Tear off a branch: `but move <branch-name-or-id> zz --status-after` (`zz` = unassigned; branch name or branch CLI ID)
+- Commit: `but commit <branch> -m "<msg>" --changes <id>,<id>`
+- `but commit -a` is accepted as a no-op compatibility flag; GitButler already includes uncommitted changes by default.
+- Commit + create branch: `but commit <branch> -c -m "<msg>" --changes <id>`
+- Amend: `but amend <file-id> <commit-id>`
+- Reorder commits: `but move <source-commit-id> <target-commit-id>` (**commit IDs**, not branch names)
+- Stack branches: `but move <branch-name-or-id> <target-branch-name-or-id>` (**branch names or branch CLI IDs**)
+- Tear off a branch: `but move <branch-name-or-id> zz` (`zz` = unassigned; branch name or branch CLI ID)
 - Push: `but push` or `but push <branch-id>`
-- Pull: `but pull --check` then `but pull --status-after`
+- Pull: `but pull --check` then `but pull`
 
 ## Task Recipes
 
@@ -55,23 +55,23 @@ but <mutation> ... --status-after
 
 1. `but status -fv`
 2. Find the CLI ID for each file you want to commit.
-3. `but commit <branch> -m "<msg>" --changes <id1>,<id2> --status-after`
+3. `but commit <branch> -m "<msg>" --changes <id1>,<id2>`
    Use `-c` to create the branch if it doesn't exist. Omit IDs you don't want committed.
-4. **Check the `--status-after` output** for remaining uncommitted changes. If the file still appears as unassigned or assigned to another branch after commit, it may be dependency-locked. See "Stacked dependency / commit-lock recovery" below.
+4. **Check the returned status** for remaining uncommitted changes. If the file still appears as unassigned or assigned to another branch after commit, it may be dependency-locked. See "Stacked dependency / commit-lock recovery" below.
 
 ### Amend into existing commit
 
 1. `but status -fv` (or `but show <branch-id>`)
 2. Locate file ID and target commit ID.
-3. `but amend <file-id> <commit-id> --status-after`
+3. `but amend <file-id> <commit-id>`
 
 ### Reorder commits
 
 `but move` supports both commit reordering and branch stack operations. Use commit IDs when reordering commits.
 
 1. `but status -fv`
-2. `but move <commit-a> <commit-b> --status-after` — uses commit IDs like `c3`, `c5`
-3. Refresh IDs from the returned status, then run the inverse: `but move <commit-b> <commit-a> --status-after`
+2. `but move <commit-a> <commit-b>` — uses commit IDs like `c3`, `c5`
+3. Refresh IDs from the returned status if you need to keep editing history.
 
 ### Stack existing branches
 
@@ -96,7 +96,7 @@ but move feature/logging zz
 ### Stacked dependency / commit-lock recovery
 
 A **dependency lock** occurs when a file was originally committed on branch A, but you're trying to commit changes to it on branch B. Symptoms:
-- `but commit` succeeds but the file still appears in `unassignedChanges` in the `--status-after` output
+- `but commit` succeeds but the file still appears in `unassignedChanges` in the returned status
 - The file shows as "unassigned" instead of being staged to any branch
 
 **Recovery:** Stack your branch on the dependency branch, then commit:
@@ -104,7 +104,7 @@ A **dependency lock** occurs when a file was originally committed on branch A, b
 1. `but status -fv` — identify which branch originally owns the file (check commit history).
 2. `but move <your-branch-name> <dependency-branch-name>` — stack your branch on the dependency. Uses full branch **names**, not CLI IDs.
 3. `but status -fv` — the file should now be assignable. Commit it.
-4. `but commit <branch> -m "<msg>" --changes <id> --status-after`
+4. `but commit <branch> -m "<msg>" --changes <id>`
 
 **If `but move <branch> <target-branch>` fails:** Do NOT try `uncommit`, `squash`, or `undo` to work around it — these will leave the workspace in a worse state. Instead, re-run `but status -fv` to confirm both branches still exist and are applied, then retry with exact branch names from the status output.
 
@@ -140,7 +140,7 @@ If `but move` causes conflicts (conflicted commits in status):
 - Prefer explicit IDs over file paths for mutations.
 - `--changes` accepts comma-separated values (`--changes a1,b2`) or repeated flags (`--changes a1 --changes b2`), not space-separated.
 - Read-only git inspection (`git log`, `git blame`, `git show --stat`) is allowed.
-- After a successful `--status-after`, don't run a redundant `but status -fv` unless you need new IDs.
+- After a mutation returns status, don't run a redundant `but status -fv` unless you need new IDs.
 - Use `but show <branch-id>` to see commit details for a branch, including per-commit file changes and line counts.
 - **Per-commit file counts**: `but status` does NOT include per-commit file counts. Use `but show <branch-id>` or `git show --stat <commit-hash>` to get them.
 - Avoid `--help` probes; use this skill and `references/reference.md` first. Only use `--help` after a failed attempt.

--- a/crates/but/skill/references/concepts.md
+++ b/crates/but/skill/references/concepts.md
@@ -60,7 +60,7 @@ Stacks:     m0, n0          (auto-generated, 2–3 chars)
 
 ```bash
 but commit <branch-id> -m "message"      # Commit to branch
-but stage <file-id> <branch-id>          # Stage file to branch
+but stage <file-or-hunk-id> <branch-id>  # Stage file or hunk to branch
 but rub <commit-id> <commit-id>          # Squash commits
 ```
 
@@ -135,7 +135,7 @@ but commit api-branch -m "..."   # Commit from api-branch's staging area
 but commit ui-branch -m "..."    # Commit from ui-branch's staging area
 ```
 
-**Unstaged changes:** Files not staged to any branch yet. Use `but status` to see them, then `but stage` to assign them.
+**Unassigned changes:** Files not assigned to any branch yet. Use `but status` to see them, then `but stage` to assign them.
 
 **Auto-assignment:** If only one branch is applied, changes may auto-assign to it.
 
@@ -176,7 +176,7 @@ File-in-Commit       │ Uncommit        │ Move       │ Uncommit & assign �
 
 These commands are wrappers around `but rub`:
 
-- `but stage <file> <branch>` = `but rub <file> <branch>`
+- `but stage <file-or-hunk> <branch>` = `but rub <file-or-hunk> <branch>`
 - `but amend <file> <commit>` = `but rub <file> <commit>`
 - `but squash` = Multiple `but rub <commit> <commit>` operations
 - `but move` = commit move/reorder with position control, plus branch stack/tear-off (`<branch> <target-branch>` and `<branch> zz`)
@@ -229,7 +229,8 @@ but commit empty --after c3
 Example workflow:
 
 ```bash
-but commit empty -m "TODO: Add error handling" --before c5
+but commit empty --before c5
+but reword <empty-commit-id> -m "TODO: Add error handling"
 but mark <empty-commit-id>
 # Now work on error handling, changes auto-amend into the placeholder
 ```
@@ -244,7 +245,7 @@ Set a "mark" on a branch or commit to automatically organize new changes.
 but mark <branch-id>
 ```
 
-New unstaged changes automatically stage to this branch. Useful when focused on one feature.
+New unassigned changes automatically stage to this branch. Useful when focused on one feature.
 
 ### Mark a Commit
 
@@ -287,6 +288,10 @@ Every operation in GitButler is recorded in the oplog (operation log).
 ```bash
 but oplog                      # View history
 but undo                       # Undo last operation
+but redo                       # Redo last undone operation
+but oplog list --since <snapshot-id>
+but oplog list --snapshot
+but oplog snapshot -m "known good"
 but oplog restore <snapshot-id>  # Restore to specific point
 ```
 
@@ -315,7 +320,7 @@ Branches can be in two states:
 ### Controlling State
 
 ```bash
-but apply <id>             # Make branch active
+but apply <branch-name>    # Make branch active
 but unapply <id>           # Make branch inactive
 ```
 

--- a/crates/but/skill/references/examples.md
+++ b/crates/but/skill/references/examples.md
@@ -19,19 +19,19 @@ but branch new ui-styling
 # 3. Make changes to multiple files
 # (edit api/users.js and components/Button.svelte)
 
-# 4. Check what's unstaged
+# 4. Check what's unassigned
 but status -fv
 
 # 5. Commit specific files directly using --changes (recommended for agents)
 # Use CLI ID values from but status -fv output (e.g., branch IDs and file IDs)
 # For multiple IDs, use one comma-separated argument or repeat --changes.
-but commit <api-branch-id> -m "Add user details endpoint" --changes <api-file-id> --status-after
-but commit <ui-branch-id> -m "Update button hover styles" --changes <ui-file-id> --status-after
+but commit <api-branch-id> -m "Add user details endpoint" --changes <api-file-id>
+but commit <ui-branch-id> -m "Update button hover styles" --changes <ui-file-id>
 
 # Alternative: stage first, then commit with --only
 # but stage <api-file-id> <api-branch-id> && but stage <ui-file-id> <ui-branch-id>
-# but commit <api-branch-id> --only -m "Add user details endpoint" --status-after
-# but commit <ui-branch-id> --only -m "Update button hover styles" --status-after
+# but commit <api-branch-id> --only -m "Add user details endpoint"
+# but commit <ui-branch-id> --only -m "Update button hover styles"
 
 # 6. Push branches independently (optional, can skip if using pr new)
 but push <api-branch-id>
@@ -59,8 +59,8 @@ but branch new add-authentication
 # 3. Implement auth and commit
 # (edit auth/login.js, auth/middleware.js)
 but status -fv
-but stage <file-ids> bu --status-after  # Stage changes to auth branch
-but commit bu --only -m "Add JWT authentication" --status-after
+but stage <file-ids> bu  # Stage changes to auth branch
+but commit bu --only -m "Add JWT authentication"
 
 # 4. Create stacked branch anchored on authentication
 but branch new user-profile -a bu
@@ -68,8 +68,8 @@ but branch new user-profile -a bu
 # 5. Implement profile page (depends on auth)
 # (edit pages/profile.js)
 but status -fv
-but stage <file-ids> bv --status-after  # Stage changes to profile branch
-but commit bv --only -m "Add user profile page" --status-after
+but stage <file-ids> bv  # Stage changes to profile branch
+but commit bv --only -m "Add user profile page"
 
 # 6. Push both branches (maintains stack relationship)
 but push
@@ -82,7 +82,7 @@ but push
 **Scenario:** Made a small typo fix that should be part of the last commit, not a new commit.
 
 ```bash
-# 1. Check current commits and unstaged changes
+# 1. Check current commits and unassigned changes
 but status -fv
 
 # Output shows:
@@ -97,7 +97,7 @@ but status -fv
 but absorb a1 --dry-run    # Shows where a1 would be absorbed
 
 # 3. Absorb the specific file into appropriate commit
-but absorb a1 --status-after    # Absorb just this file + get updated status
+but absorb a1    # Absorb just this file + get updated status
 
 # GitButler analyzes the change and amends it into c3
 # (because the typo is in code from c3)
@@ -106,9 +106,9 @@ but absorb a1 --status-after    # Absorb just this file + get updated status
 **Targeted vs blanket absorb:**
 
 ```bash
-but absorb a1 --status-after    # Absorb specific file (recommended)
-but absorb bu --status-after    # Absorb all changes staged to branch bu
-but absorb --status-after       # Absorb ALL uncommitted changes (use with caution)
+but absorb a1    # Absorb specific file (recommended)
+but absorb bu    # Absorb all changes staged to branch bu
+but absorb       # Absorb ALL uncommitted changes (use with caution)
 ```
 
 **Why absorb?** Keeps history clean. Small fixes belong in the commits they fix, not as separate "fix typo" commits.
@@ -128,13 +128,13 @@ but absorb --status-after       # Absorb ALL uncommitted changes (use with cauti
 # c1: Initial implementation
 
 # Squash all commits in branch
-but squash bu --status-after
+but squash bu
 
 # Or squash specific range
-but squash c2..c5 --status-after    # Squashes c2, c3, c4, c5 into one
+but squash c2..c5    # Squashes c2, c3, c4, c5 into one
 
 # Or squash specific commits
-but squash c2 c3 c4 --status-after    # Squashes these three
+but squash c2 c3 c4    # Squashes these three
 ```
 
 ### Scenario B: Moving Files Between Commits
@@ -150,7 +150,7 @@ but status -fv
 # c2: config.js
 
 # 2. Move utils.js from c3 to c2
-but rub a2 c2 --status-after    # File a2 (utils.js) → commit c2 + get updated status
+but rub a2 c2    # File a2 (utils.js) → commit c2 + get updated status
 ```
 
 ### Scenario C: Moving Commit to Different Branch
@@ -170,7 +170,7 @@ but status -fv
 but branch new feature-b    # Creates branch bv
 
 # 3. Move the commit
-but move c3 bv --status-after    # Move c3 to top of branch bv
+but move c3 bv    # Move c3 to top of branch bv
 ```
 
 ## Example 5: Stacking Existing Branches
@@ -194,8 +194,8 @@ but move feature/frontend feature/backend
 
 # 3. Continue working — commits go to the right branch
 but status -fv
-but commit bu -m "Add caching layer" --changes <id> --status-after   # To backend
-but commit bv -m "Add dialog component" --changes <id> --status-after # To frontend
+but commit bu -m "Add caching layer" --changes <id>   # To backend
+but commit bv -m "Add dialog component" --changes <id> # To frontend
 ```
 
 **Key point:** branch stack moves use branch **names** (like `feature/frontend`) or branch CLI IDs. Commit reordering still uses commit IDs.
@@ -218,7 +218,7 @@ but mark bu    # Branch bu (refactor) is now marked
 but status -fv  # Shows all changes staged to bu
 
 # 5. Commit the staged changes
-but commit bu --only -m "Refactor error handling across app" --status-after
+but commit bu --only -m "Refactor error handling across app"
 
 # 6. Remove mark
 but unmark
@@ -228,7 +228,8 @@ but unmark
 
 ```bash
 # 1. Create empty commit as placeholder
-but commit empty -m "TODO: Add error handling"
+but commit empty
+but reword <empty-commit-id> -m "TODO: Add error handling"
 
 # 2. Mark it
 but mark c5    # Commit c5 is now marked
@@ -306,24 +307,24 @@ but branch new user-dashboard
 
 # 4. Check and stage
 but status -fv
-but stage <file-ids> bu --status-after  # Stage changes to dashboard branch
+but stage <file-ids> bu  # Stage changes to dashboard branch
 
 # 5. First commit
-but commit bu --only -m "Add dashboard route and basic layout" --status-after
+but commit bu --only -m "Add dashboard route and basic layout"
 
 # 6. Continue iterating
 # (add widgets, styling)
-but stage <file-ids> bu --status-after
-but commit bu --only -m "Add dashboard widgets" --status-after
-but stage <file-ids> bu --status-after
-but commit bu --only -m "Style dashboard components" --status-after
+but stage <file-ids> bu
+but commit bu --only -m "Add dashboard widgets"
+but stage <file-ids> bu
+but commit bu --only -m "Style dashboard components"
 
 # 7. Make small fix
 # (fix typo in widget)
-but absorb a1 --status-after    # Absorb specific file into appropriate commit
+but absorb a1    # Absorb specific file into appropriate commit
 
 # 8. Clean up if needed
-but squash bu --status-after    # Combine all commits (optional)
+but squash bu    # Combine all commits (optional)
 
 # 9. Push to remote (can also skip - pr new auto-pushes)
 but push bu
@@ -359,15 +360,15 @@ but unapply bw
 
 # 3. Focus on feature-a
 # (make changes, stage, commit)
-but stage <file-ids> bu --status-after
-but commit bu --only -m "Complete feature-a" --status-after
+but stage <file-ids> bu
+but commit bu --only -m "Complete feature-a"
 
 # 4. Create PR for feature-a (auto-pushes)
 but pr new bu
 
 # 5. Reapply other branches
-but apply bv
-but apply bw
+but apply feature-b
+but apply feature-c
 
 # 6. Deal with their conflicts now
 but resolve ...
@@ -395,10 +396,10 @@ but reword c3 -m "Fix edge case in parser"
 but reword c2 -m "Update error messages"
 
 # 3. Move c5 to be earlier
-but move c5 c3 --status-after    # Move c5 before c3
+but move c5 c3    # Move c5 before c3
 
 # 4. Squash similar commits
-but squash c2 c3 --status-after    # Combine error handling commits
+but squash c2 c3    # Combine error handling commits
 
 # Output:
 # Branch: feature-x (bu)
@@ -417,44 +418,44 @@ but push bu
 
 ```bash
 # Morning: Start day
-but pull                   # Get latest from team
+but pull    # Get latest from team
 
 # Start new task
-but branch new fix-auth-bug       # Create branch for today's work
+but branch new fix-auth-bug  # Create branch for today's work
 
 # Work and commit iteratively
 # (make changes)
 but status -fv              # Check changes
-but stage <file-ids> bu --status-after    # Stage to branch
-but commit bu --only -m "Identify auth bug source" --status-after
+but stage <file-ids> bu    # Stage to branch
+but commit bu --only -m "Identify auth bug source"
 # (make more changes)
-but stage <file-ids> bu --status-after    # Stage to branch
-but commit bu --only -m "Fix token expiration handling" --status-after
+but stage <file-ids> bu    # Stage to branch
+but commit bu --only -m "Fix token expiration handling"
 # (small fix to existing code)
-but absorb a1 --status-after              # Absorb specific fix into appropriate commit
+but absorb a1              # Absorb specific fix into appropriate commit
 
 # Mid-day: Start urgent fix on different branch
-but branch new hotfix-login       # Parallel branch for urgent work
+but branch new hotfix-login  # Parallel branch for urgent work
 # (make fix)
-but stage <file-ids> bv --status-after    # Stage to hotfix branch
-but commit bv --only -m "Fix login redirect loop" --status-after
-but pr new bv              # Push and create PR immediately
+but stage <file-ids> bv    # Stage to hotfix branch
+but commit bv --only -m "Fix login redirect loop"
+but pr new bv      # Push and create PR immediately
 
 # Back to original work
 # (continue working on bu, auth bug fix)
-but stage <file-ids> bu --status-after    # Stage to auth branch
-but commit bu --only -m "Add tests for token handling" --status-after
+but stage <file-ids> bu    # Stage to auth branch
+but commit bu --only -m "Add tests for token handling"
 
 # End of day: Clean up and create PR
-but squash bu --status-after    # Combine into clean history
-but pr new bu              # Push and create PR
+but squash bu    # Combine into clean history
+but pr new bu      # Push and create PR
 
 # After PR review: Make requested changes
 # (make changes based on feedback)
-but absorb <file-id> --status-after    # Absorb specific changes into commits
+but absorb <file-id>    # Absorb specific changes into commits
 # Or absorb all changes for this branch:
-but absorb bu --status-after          # Absorb all changes staged to bu
-but push bu --with-force   # Force push updated history
+but absorb bu          # Absorb all changes staged to bu
+but push bu        # Push updated history
 ```
 
 ## Example 12: Recovering from Mistakes
@@ -495,7 +496,7 @@ but oplog restore s4
 but status -fv
 
 # Output:
-# Unstaged:
+# Unassigned:
 #   a1: bad-changes.js
 
 # Discard it

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -1,6 +1,6 @@
 # GitButler CLI Command Reference
 
-Comprehensive reference for all `but` commands.
+Agent-focused reference for useful `but` commands.
 
 ## Contents
 
@@ -14,8 +14,8 @@ Comprehensive reference for all `but` commands.
 - [Automation](#automation) - `mark`, `unmark`
 - [Workspace Maintenance](#workspace-maintenance) - `clean`
 - [History & Undo](#history--undo) - `undo`, `oplog`
-- [Setup & Configuration](#setup--configuration) - `setup`, `teardown`, `config`, `gui`, `update`, `alias`
-- [Global Options](#global-options)
+- [Setup & Configuration](#setup--configuration) - `setup`, `teardown`, `config`, `update`, `skill`
+- [Selected Options](#selected-options)
 
 ## Inspection (Understanding State)
 
@@ -33,7 +33,7 @@ but status --upstream   # Show upstream relationship
 Shows:
 
 - Applied/unapplied branches in workspace
-- Uncommitted changes (unstaged files)
+- Unassigned and assigned changes
 - Commits on each stack
 - CLI IDs to use in other commands
 
@@ -73,26 +73,28 @@ but branch list --no-check  # Skip clean-merge check (faster)
 but branch list -r      # Show only remote branches
 but branch list -l      # Show only local branches
 but branch list -a      # Show all branches (not just active + 20 most recent)
-but branch list --review  # Fetch and display PR/MR information
+but branch list --empty  # Include empty branches
+but branch list --review  # Fetch and display review information
 ```
 
-### `but branch new <name>`
+### `but branch new [name]`
 
 Create a new branch.
 
 ```bash
+but branch new                      # Generated branch name
 but branch new feature              # Independent branch (parallel work)
 but branch new feature -a <anchor>  # Stacked branch (dependent work)
 ```
 
 Use parallel branches for independent tasks. Use stacked branches when work depends on another branch.
 
-### `but apply <id>`
+### `but apply <branch-name>`
 
 Activate a branch in the workspace.
 
 ```bash
-but apply <id>           # Activate branch in workspace
+but apply feature-branch  # Activate branch in workspace
 ```
 
 Applied branches are merged into `gitbutler/workspace` and visible in working directory.
@@ -125,7 +127,7 @@ but branch show <id>
 but branch show <id> -f       # Show files modified in each commit with line counts
 but branch show <id> --ai     # Generate AI summary of branch changes
 but branch show <id> --check  # Check if branch merges cleanly into upstream
-but branch show <id> -r       # Fetch and display review information (PRs/MRs)
+but branch show <id> -r       # Fetch and display review information
 ```
 
 ### `but pick <source> [target]`
@@ -150,16 +152,15 @@ If no target is specified and multiple branches exist, prompts for selection int
 
 GitButler has multiple staging areas - one per stack.
 
-### `but stage <file> <branch>`
+### `but stage <file-or-hunk> <branch>`
 
-Stage file to a specific branch.
+Stage file or hunk to a specific branch.
 
 ```bash
-but stage <file-id> <branch-id>
-but stage <file-id> <branch-id> --status-after  # Stage then show workspace status
+but stage <file-or-hunk-id> <branch-id>
 ```
 
-Alias for `but rub <file> <branch>`. You can't stage changes that depend on branch A to branch B.
+Alias for `but rub <file-or-hunk> <branch>`. You can't stage changes that depend on branch A to branch B.
 
 ### `but rub <file> <branch>`
 
@@ -182,11 +183,10 @@ but commit <branch> -am "message"        # Accepted Git muscle-memory form; -a i
 but commit <branch> -m "message" --changes <id>,<id>  # Commit specific files or hunks by CLI ID
 but commit <branch> -m "message" --changes <id> --changes <id>  # Alternative: repeat flag
 but commit <branch> --message-file msg.txt  # Read commit message from file
-but commit <branch> -i                   # AI-generated commit message
-but commit <branch> -i="fix the auth bug"  # AI-generated with instructions (equals sign required)
-but commit <branch> -m "message" --status-after  # Commit then show workspace status
 but commit <branch> -c -m "message"      # Create new branch (or use existing) and commit
 but commit <branch> -n -m "message"      # Bypass git commit hooks (pre-commit, commit-msg, post-commit)
+but commit empty                         # Insert empty commit at top of first branch
+but commit empty <target>                # Insert empty commit before target
 but commit empty --before <target>       # Insert empty commit before target
 but commit empty --after <target>        # Insert empty commit after target
 ```
@@ -199,8 +199,6 @@ but commit empty --after <target>        # Insert empty commit after target
 - `--changes` takes one argument per flag. Use `--changes a1,b2` or `--changes a1 --changes b2`, not `--changes a1 b2`.
 
 **Note:** `--changes` and `--only` are mutually exclusive.
-
-**AI commit messages:** Use `-i` / `--ai` by itself for auto-generated messages, or `--ai="your instructions"` (equals sign required) to provide guidance.
 
 **Creating branches on commit:** Use `-c` / `--create` to create a new branch for the commit. If the branch name matches an existing branch, that branch is used instead.
 
@@ -220,7 +218,6 @@ but absorb <branch-id>        # Absorb all changes staged to this branch
 but absorb                    # Absorb ALL uncommitted changes (use with caution)
 but absorb --dry-run          # Preview without making changes
 but absorb <file-id> --dry-run  # Preview specific file absorption
-but absorb --status-after     # Absorb then show workspace status
 ```
 
 **Recommendation:** Prefer targeted absorb (`but absorb <file-id>`) over absorbing everything. Running `but absorb` without arguments absorbs ALL uncommitted changes across all branches, which may not be what you want.
@@ -242,14 +239,13 @@ but rub <file> <branch>      # Stage file to branch
 but rub <file> <commit>      # Amend file into commit
 but rub <commit> <commit>    # Squash commits together
 but rub <commit> <branch>    # Move commit to branch
-but rub <file> zz            # Unstage file (back to unassigned)
-but rub <commit> zz          # Undo commit (uncommit to unstaged)
+but rub <file> zz            # Move file back to unassigned
+but rub <commit> zz          # Undo commit to unassigned
 but rub zz <branch>          # Stage all unassigned changes to branch
 but rub zz <commit>          # Amend all unassigned changes into commit
 but rub <file-in-commit> zz  # Uncommit specific file from its commit
 but rub <file-in-commit> <commit>  # Move file from one commit to another
 but rub <branch> <branch>    # Reassign all uncommitted changes between branches
-but rub <file> <commit> --status-after  # Amend then show workspace status
 ```
 
 The core "rub two things together" operation.
@@ -280,7 +276,6 @@ but squash <branch>          # Squash all commits in branch into bottom-most
 but squash <branch> -d       # Squash and drop source commit messages (keep target's)
 but squash <branch> -m "msg" # Squash with a new commit message
 but squash <branch> -i       # Squash with AI-generated commit message
-but squash <branch> --status-after  # Squash then show workspace status
 ```
 
 ### `but amend <file> <commit>`
@@ -289,7 +284,6 @@ Amend file into a specific commit. Use when you know exactly which commit the ch
 
 ```bash
 but amend <file-id> <commit-id>                  # Amend file into specific commit
-but amend <file-id> <commit-id> --status-after   # Amend then show workspace status
 ```
 
 **When to use `amend` vs `absorb`:**
@@ -304,25 +298,24 @@ Move commits or branches to a different location.
 
 ```bash
 but move <commit> <target-commit>            # Move before target commit
+but move <commit>,<commit> <target-commit>   # Move multiple commits before target
 but move <commit> <target-commit> --after    # Move after target commit
 but move <commit> <branch>                   # Move commit to top of branch
 but move <branch> <target-branch>            # Stack branch on top of target branch
 but move <branch> zz                          # Tear off (unstack) branch
-but move <source> <target> --status-after    # Move then show workspace status
 ```
 
 `--after` is valid only for commit-to-commit moves.
 
 ### `but uncommit <source>`
 
-Uncommit changes back to unstaged area.
+Uncommit changes back to unassigned changes.
 
 ```bash
 but uncommit <commit-id>      # Uncommit entire commit
 but uncommit <file-id>        # Uncommit specific file from its commit
 but uncommit <commit-id> -d   # Discard committed changes instead of moving to unassigned
 but uncommit <file-id> --discard  # Discard committed file changes completely
-but uncommit <commit-id> --status-after  # Uncommit then show workspace status
 ```
 
 ### `but reword <id>`
@@ -378,6 +371,7 @@ Cancel conflict resolution and return to workspace mode.
 
 ```bash
 but resolve cancel
+but resolve cancel --force
 ```
 
 **Workflow:**
@@ -401,10 +395,11 @@ Push branches to remote.
 but push                      # Push all branches with unpushed commits
 but push <branch-id>          # Push specific branch
 but push --dry-run            # Preview what would be pushed
-but push --with-force         # Force push (use carefully!)
 but push -s                   # Skip force push protection checks
-but push --no-hooks           # Bypass pre-push hooks
+but push --no-hooks           # Bypass pre-push hooks (--no-verify also works)
 ```
+
+Force push is enabled by default with protection checks. Use `-s` only when intentionally skipping those checks.
 
 ### `but pull`
 
@@ -426,13 +421,19 @@ but pr new <branch-id>        # Push branch and create PR (recommended)
 but pr new <branch-id> -F pr_message.txt    # Use file: first line is title, rest is description
 but pr new <branch-id> -m "Title..."        # Inline message: first line is title, rest is description
 but pr new <branch-id> -t     # Use default content (commit message), skip prompts
-but pr new <branch-id> --no-hooks  # Bypass pre-push hooks
-but pr                        # Create PR (prompts for branch)
-but pr template               # Configure PR description template
+but pr new <branch-id> --draft  # Create as draft
+but pr new <branch-id> --no-hooks  # Bypass pre-push hooks (--no-verify also works)
+but pr new <branch-id> -s     # Skip force-push protection checks
+but pr --draft                # Top-level draft flag
+but pr auto-merge <selector>  # Enable auto-merge
+but pr set-draft <selector>   # Mark review as draft
+but pr set-ready <selector>   # Mark review as ready
 ```
 
-**Key behavior:** `but pr new` automatically pushes the branch to remote before creating the PR. No need to run `but push` first. Force push (`--with-force`) and pre-push hooks run by default.
+**Key behavior:** `but pr new` automatically pushes the branch to remote before creating the PR. No need to run `but push` first. Force push and pre-push hooks run by default.
 Use `--no-hooks` to bypass pre-push hooks when needed.
+
+Selectors for `auto-merge`, `set-draft`, and `set-ready` can be branch names, branch IDs, stack IDs, or numeric review IDs, comma-separated.
 
 In non-interactive environments, use `--message (-m)`, `--file (-F)`, or `--default (-t)` to avoid editor prompts. The `-t` flag uses the commit message as title/description for single-commit branches; for multi-commit branches it falls back to the branch name as the title.
 
@@ -457,7 +458,7 @@ Merges into local target branch, then runs `but pull` to update.
 Auto-stage or auto-commit new changes.
 
 ```bash
-but mark <branch-id>          # New unstaged changes auto-stage to this branch
+but mark <branch-id>          # New unassigned changes auto-stage to this branch
 but mark <commit-id>          # New changes auto-amend into this commit
 but mark <id> --delete        # Remove the mark
 ```
@@ -491,15 +492,14 @@ The entire operation is a single oplog entry — use `but undo` to restore all d
 
 ## History & Undo
 
-### `but undo`
+### `but undo` / `but redo`
 
-Undo last operation.
+Undo or redo operations.
 
 ```bash
 but undo
+but redo
 ```
-
-Reverts to previous oplog snapshot.
 
 ### `but oplog`
 
@@ -507,6 +507,9 @@ View operation history.
 
 ```bash
 but oplog
+but oplog list --since <snapshot-id>
+but oplog list --snapshot
+but oplog snapshot -m "known good"
 ```
 
 Shows all operations with snapshot IDs.
@@ -546,37 +549,34 @@ View and manage GitButler configuration.
 
 ```bash
 but config
+but config user               # Also: forge, target, metrics, ui, ai
+but config ai openai          # Also: anthropic, ollama, lmstudio, openrouter
 ```
 
-### `but gui`
-
-Open GitButler GUI for current project.
-
-```bash
-but gui
-```
-
-### `but update`
+### `but update check`
 
 Manage GitButler CLI and app updates.
 
 ```bash
-but update
+but update check
+but update install
+but update install [nightly|release|0.18.7]
 ```
 
-### `but alias`
+### `but skill`
 
-Manage command aliases.
+Manage installed GitButler skill files.
 
 ```bash
-but alias
+but skill check
+but skill check --update
+but skill install --detect
 ```
 
-## Global Options
+## Selected Options
 
-Available on most commands:
+Useful to agents:
 
-- `--status-after` - After a mutation command, also output workspace status. Supported on: `rub`, `commit`, `stage`, `amend`, `absorb`, `squash`, `move`, `uncommit`.
 - `-C, --current-dir <PATH>` - Run as if started in different directory
 - `-h, --help` - Show help for command
 

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -50,12 +50,8 @@ pub struct Args {
     /// Whether to use JSON output format.
     #[clap(long, short = 'j', global = true)]
     pub json: bool,
-    /// After a mutation command completes, also output workspace status.
-    ///
-    /// In human mode, prints status after the command output.
-    /// In JSON mode, wraps both in {"result": ..., "status": ...} on success, or
-    /// {"result": ..., "status_error": ...} if the status query fails (in which case "status" is absent).
-    #[clap(long = "status-after", global = true)]
+    /// Whether mutation commands should append workspace status.
+    #[clap(skip)]
     pub status_after: bool,
     /// Subcommand to run (`but <COMMAND>`).
     ///

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -132,6 +132,8 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     }
 
     let mut args: Args = Args::parse_from(args);
+    // If this was invoked by an agent, always set the status after flag since it's helpful to the agent
+    args.status_after |= utils::detect_agent::detect().is_some();
     let output_format = if args.json {
         OutputFormat::Json
     } else {

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -132,8 +132,7 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     }
 
     let mut args: Args = Args::parse_from(args);
-    // If this was invoked by an agent, always set the status after flag since it's helpful to the agent
-    args.status_after |= utils::detect_agent::detect().is_some();
+    args.status_after = utils::detect_agent::detect().is_some();
     let output_format = if args.json {
         OutputFormat::Json
     } else {
@@ -1570,7 +1569,7 @@ fn is_not_in_git_repository_error(err: &anyhow::Error) -> bool {
     )
 }
 
-/// If `--status-after` was requested, appends workspace status to the output.
+/// If requested, appends workspace status to the output.
 ///
 /// Call `out.begin_status_after(status_after)` *before* the mutation to set up
 /// JSON buffering, then call this *after* to conditionally emit the combined output.
@@ -1600,7 +1599,7 @@ async fn maybe_run_status_after<T, E>(
     }
 }
 
-/// Ignore `--status-after` in non-legacy builds until a non-legacy status command exists.
+/// Ignore mutation status output in non-legacy builds until a non-legacy status command exists.
 #[cfg(not(feature = "legacy"))]
 async fn maybe_run_status_after(
     _status_after: bool,
@@ -1645,7 +1644,7 @@ async fn run_status_after(
             }),
             Err(err) => {
                 eprintln!(
-                    "warning: --status-after failed: {err:#}. Run 'but status' separately to check workspace state."
+                    "warning: status after mutation failed: {err:#}. Run 'but status' separately to check workspace state."
                 );
                 serde_json::json!({
                     "result": mutation_json.unwrap_or(serde_json::Value::Null),
@@ -1654,7 +1653,7 @@ async fn run_status_after(
             }
         };
         if let Err(err) = out.write_value(combined) {
-            eprintln!("warning: failed to write --status-after output: {err}");
+            eprintln!("warning: failed to write status after mutation: {err}");
         }
     } else {
         if let Some(human) = out.for_human() {
@@ -1674,7 +1673,7 @@ async fn run_status_after(
         .await
         {
             eprintln!(
-                "warning: --status-after failed: {err:#}. Run 'but status' separately to check workspace state."
+                "warning: status after mutation failed: {err:#}. Run 'but status' separately to check workspace state."
             );
         }
     }

--- a/crates/but/src/utils/output_channel.rs
+++ b/crates/but/src/utils/output_channel.rs
@@ -43,7 +43,7 @@ pub struct OutputChannel {
     /// Possibly a pager we are using. If `Some`, the pager itself is used for output instead of `stdout`.
     pager: Option<Pager>,
     /// When `Some`, JSON values written via `write_value` are captured here instead of going to stdout.
-    /// Used by `--status-after` to buffer mutation JSON before combining with status JSON.
+    /// Used to buffer mutation JSON before combining with status JSON.
     json_buffer: Option<serde_json::Value>,
 }
 
@@ -231,7 +231,7 @@ impl OutputChannel {
         self.json_buffer = Some(serde_json::Value::Null);
     }
 
-    /// Conditionally start JSON buffering for `--status-after` mode.
+    /// Conditionally start JSON buffering for mutation status output.
     ///
     /// If `status_after` is `true` and the output is in JSON mode,
     /// begins buffering so mutation output can be captured and later
@@ -635,7 +635,7 @@ impl OutputChannel {
 impl Drop for OutputChannel {
     fn drop(&mut self) {
         // Flush any buffered JSON that was never consumed — this means
-        // the status-after path did not complete, but we should still
+        // the combined status path did not complete, but we should still
         // emit the mutation result rather than silently discarding it.
         if let Some(buffer) = self.json_buffer.take()
             && buffer != serde_json::Value::Null

--- a/crates/but/tests/but/command/help.rs
+++ b/crates/but/tests/but/command/help.rs
@@ -73,13 +73,6 @@ Options:
   -j, --json
           Whether to use JSON output format
 
-      --status-after
-          After a mutation command completes, also output workspace status.
-          
-          In human mode, prints status after the command output. In JSON mode, wraps both in
-          {"result": ..., "status": ...} on success, or {"result": ..., "status_error": ...} if the
-          status query fails (in which case "status" is absent).
-
   -h, --help
           Print help (see a summary with '-h')
 
@@ -94,9 +87,8 @@ Arguments:
   <TARGET>  The target entity to combine with the source
 
 Options:
-  -j, --json          Whether to use JSON output format
-      --status-after  After a mutation command completes, also output workspace status
-  -h, --help          Print help (see more with '--help')
+  -j, --json  Whether to use JSON output format
+  -h, --help  Print help (see more with '--help')
 
 "#]]);
     Ok(())

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -2061,6 +2061,33 @@ fn status_after_json_wraps_mutation_and_status() -> anyhow::Result<()> {
 }
 
 #[test]
+fn agent_invocation_enables_status_after_for_mutations() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+
+    env.setup_metadata(&["A", "B"])?;
+    env.file("agent.txt", "content\n");
+
+    let output = env
+        .but("--json stage agent.txt A")
+        .env("AI_AGENT", "codex")
+        .allow_json()
+        .output()?;
+    assert!(output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+    assert!(
+        json.get("result").is_some(),
+        "agent mutation output should include the command result"
+    );
+    assert!(
+        json.get("status").is_some(),
+        "agent mutation output should include workspace status"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn status_after_json_success_has_no_status_error_field() -> anyhow::Result<()> {
     // Verifies that on a successful mutation with --status-after, the combined
     // JSON output contains {result, status} but NOT status_error.

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -787,7 +787,7 @@ fn uncommit_help_mentions_discard_flag() -> anyhow::Result<()> {
 }
 
 #[test]
-fn uncommit_discard_multiple_sources_writes_single_json_with_status_after() -> anyhow::Result<()> {
+fn agent_uncommit_discard_multiple_sources_writes_single_json_with_status() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
 
     env.setup_metadata(&["A", "B"])?;
@@ -799,9 +799,8 @@ fn uncommit_discard_multiple_sources_writes_single_json_with_status_after() -> a
     let sources = format!("{},{}", commits_before[0], commits_before[1]);
 
     let output = env
-        .but(format!(
-            "--json --status-after uncommit {sources} --discard"
-        ))
+        .but(format!("--json uncommit {sources} --discard"))
+        .env("AI_AGENT", "codex")
         .allow_json()
         .output()?;
     assert!(output.status.success());
@@ -810,7 +809,7 @@ fn uncommit_discard_multiple_sources_writes_single_json_with_status_after() -> a
     assert_eq!(parsed["result"]["ok"], serde_json::json!(true));
     assert!(
         parsed.get("status").is_some(),
-        "--status-after JSON wrapper should include status"
+        "agent JSON wrapper should include status"
     );
 
     let after = status_json(&env)?;
@@ -2016,15 +2015,15 @@ Rubbed the wrong way. Operation doesn't make sense.[..]
 }
 
 #[test]
-fn status_after_json_wraps_mutation_and_status() -> anyhow::Result<()> {
+fn agent_json_wraps_mutation_and_status() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
 
     env.setup_metadata(&["A", "B"])?;
     env.file("a.txt", "arbitrary text\n");
 
-    // Use --json --status-after with a stage operation
     let output = env
-        .but("--json --status-after stage a.txt A")
+        .but("--json stage a.txt A")
+        .env("AI_AGENT", "codex")
         .allow_json()
         .output()?;
     assert!(output.status.success());
@@ -2088,16 +2087,17 @@ fn agent_invocation_enables_status_after_for_mutations() -> anyhow::Result<()> {
 }
 
 #[test]
-fn status_after_json_success_has_no_status_error_field() -> anyhow::Result<()> {
-    // Verifies that on a successful mutation with --status-after, the combined
-    // JSON output contains {result, status} but NOT status_error.
+fn agent_json_success_has_no_status_error_field() -> anyhow::Result<()> {
+    // Verifies that on a successful agent mutation, the combined JSON output
+    // contains {result, status} but NOT status_error.
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
 
     env.setup_metadata(&["A", "B"])?;
     env.file("b.txt", "content\n");
 
     let output = env
-        .but("--json --status-after stage b.txt A")
+        .but("--json stage b.txt A")
+        .env("AI_AGENT", "codex")
         .allow_json()
         .output()?;
     assert!(output.status.success());


### PR DESCRIPTION
Summary:
- Enable detected agent CLI invocations to receive mutation status output automatically.
- Update packaged GitButler skill guidance for the current CLI.

Tests:
- cargo test -p but agent_invocation_enables_status_after_for_mutations
- cargo test -p but status_after_json