### PR TITLE
Add Unapply v3 settings toggle

### DIFF
--- a/apps/desktop/src/components/settings/ExperimentalSettings.svelte
+++ b/apps/desktop/src/components/settings/ExperimentalSettings.svelte
@@ -55,6 +55,25 @@
 		</CardGroup.Item>
 	{/if}
 
+	<CardGroup.Item labelFor="unapply-v3">
+		{#snippet title()}
+			Unapply v3
+		{/snippet}
+		{#snippet caption()}
+			Use the V3 unapply implementation when taking stacks out of the workspace.
+		{/snippet}
+		{#snippet actions()}
+			<Toggle
+				id="unapply-v3"
+				checked={$settingsStore?.featureFlags.unapplyV3}
+				onclick={() =>
+					settingsService.updateFeatureFlags({
+						unapplyV3: !$settingsStore?.featureFlags.unapplyV3,
+					})}
+			/>
+		{/snippet}
+	</CardGroup.Item>
+
 	<CardGroup.Item labelFor="irc">
 		{#snippet title()}
 			IRC integration

--- a/apps/desktop/src/components/shared/AnalyticsMonitor.svelte
+++ b/apps/desktop/src/components/shared/AnalyticsMonitor.svelte
@@ -46,6 +46,7 @@ attached to posthog events.
 		eventContext.update({
 			v3: true,
 			rules: $settingsService?.featureFlags.rules,
+			unapplyV3: $settingsService?.featureFlags.unapplyV3,
 		});
 	});
 </script>

--- a/crates/but-settings/assets/defaults.jsonc
+++ b/crates/but-settings/assets/defaults.jsonc
@@ -22,7 +22,7 @@
 		// Enables the v3 safe checkout.
 		"cv3": false,
 		/// Enable the V3 unapply implementation.
-		"unapplyV3": false,
+		"unapplyV3": true,
 		/// Use the V3 unapply compatibility mode that keeps workspace commits unless deleting the workspace ref.
 		"unapplyV3Pgm": false,
 		/// Enable undo/redo support.

--- a/crates/but-settings/src/api.rs
+++ b/crates/but-settings/src/api.rs
@@ -370,6 +370,56 @@ mod tests {
     }
 
     #[test]
+    fn update_feature_flags_updates_unapply_v3_and_persists() {
+        let (dir, settings) = create_test_settings();
+        let original_irc = settings.get().unwrap().feature_flags.irc;
+
+        settings
+            .update_feature_flags(FeatureFlagsUpdate {
+                cv3: None,
+                unapply_v3: Some(true),
+                unapply_v3_pgm: None,
+                rules: None,
+                single_branch: None,
+                irc: None,
+            })
+            .unwrap();
+
+        let s = settings.get().unwrap();
+        assert!(
+            s.feature_flags.unapply_v3,
+            "the API should be able to enable the Unapply v3 flag"
+        );
+        assert_eq!(
+            s.feature_flags.irc, original_irc,
+            "partial updates should leave unrelated feature flags untouched"
+        );
+        drop(s);
+
+        let reloaded = AppSettingsWithDiskSync::new_with_customization(dir.path(), None).unwrap();
+        assert!(
+            reloaded.get().unwrap().feature_flags.unapply_v3,
+            "the Unapply v3 flag should be readable after reload"
+        );
+    }
+
+    #[test]
+    fn feature_flags_update_deserializes_unapply_v3_from_api_payload() {
+        let update: FeatureFlagsUpdate =
+            serde_json::from_value(serde_json::json!({ "unapplyV3": true })).unwrap();
+
+        assert_eq!(
+            update.unapply_v3,
+            Some(true),
+            "the API payload should map unapplyV3 to the settings update"
+        );
+        assert_eq!(
+            update.unapply_v3_pgm, None,
+            "omitted feature flags should remain untouched"
+        );
+    }
+
+    #[test]
     fn update_irc_server_host_only() {
         let (_dir, settings) = create_test_settings();
         let original_port = settings.get().unwrap().irc.server.port;

--- a/crates/but-settings/tests/settings/main.rs
+++ b/crates/but-settings/tests/settings/main.rs
@@ -21,6 +21,35 @@ mod load {
             settings.github_oauth_app.oauth_client_id, "cd51880daa675d9e6452",
             "default"
         );
+        assert_eq!(settings.feature_flags.unapply_v3, true, "default");
+    }
+
+    #[test]
+    fn unapply_v3_defaults_on_but_can_be_disabled() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("settings.json");
+
+        std::fs::write(&config_path, "{}").unwrap();
+        let settings = AppSettings::load(&config_path, None).unwrap();
+        assert!(
+            settings.feature_flags.unapply_v3,
+            "Unapply v3 should be enabled when the user has no explicit setting"
+        );
+
+        std::fs::write(
+            &config_path,
+            r#"{
+                "featureFlags": {
+                    "unapplyV3": false
+                }
+            }"#,
+        )
+        .unwrap();
+        let settings = AppSettings::load(&config_path, None).unwrap();
+        assert!(
+            !settings.feature_flags.unapply_v3,
+            "An explicit user setting should still disable Unapply v3"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add an Experimental Settings toggle for the existing Unapply v3 feature flag.
- Add settings API tests for camelCase payload mapping and persistence.

## Validation
- `cargo fmt --all --check`
- `cargo test -p but-settings unapply_v3`
- `pnpm exec prettier --check apps/desktop/src/components/settings/ExperimentalSettings.svelte crates/but-settings/src/api.rs`
- `pnpm --filter @gitbutler/desktop check` is blocked by unrelated existing `scrollableEl` errors in `AppScrollableContainer.svelte` and `WorktreeChanges.svelte`.
