### PR TITLE
Fix agentlog PR session association

### DIFF
--- a/crates/but-agentlog/src/environment.rs
+++ b/crates/but-agentlog/src/environment.rs
@@ -571,6 +571,20 @@ pub(crate) fn path_fingerprint(path: &str) -> String {
     hex::encode(&hasher.finalize()[..16])
 }
 
+pub(crate) fn is_public_repo_path(path: &str) -> bool {
+    !path.is_empty()
+        && !path.starts_with('/')
+        && !path.starts_with('~')
+        && !path.contains('\\')
+        && !path.contains(':')
+        && !path.contains("[local path]")
+        && !path.contains("[REDACTED")
+        && !path.contains('‹')
+        && path
+            .split('/')
+            .all(|component| !matches!(component, "" | "." | ".."))
+}
+
 #[cfg(test)]
 impl PathList {
     fn empty() -> Self {

--- a/crates/but-agentlog/src/gitmeta/read.rs
+++ b/crates/but-agentlog/src/gitmeta/read.rs
@@ -7,14 +7,16 @@ use anyhow::{Context as _, Result, bail};
 use chrono::{DateTime, Utc};
 use git_meta_lib::{MetaValue, SessionTargetHandle};
 use serde::Deserialize;
+use serde_json::Value;
 
-use crate::environment::path_fingerprint;
+use crate::environment::{is_public_repo_path, path_fingerprint};
 
 use super::{
     IndexHit, SessionListEntry, StoredBranchSnapshot, StoredCommitSnapshot,
     StoredEnvironmentSnapshot, StoredObservedTargets, index_key,
     read_support::{
-        read_optional_turn_detail, read_turn_detail, read_turn_summaries, with_project_target,
+        read_optional_turn_detail, read_transcript_entries, read_turn_detail, read_turn_summaries,
+        transcript_records_by_hash, with_project_target,
     },
     session_outline::{RelatedSession, related_session_outline},
 };
@@ -242,19 +244,67 @@ fn session_has_target_activity(
 ) -> Result<bool> {
     let session_prefix = format!("gitbutler:agent-session:{session_key}");
     let summaries = read_turn_summaries(handle, &format!("{session_prefix}:turns"))?;
+    let turns = read_session_turn_details(handle, &session_prefix, &summaries)?;
+    let file_edit_hashes_by_turn =
+        session_file_edit_hashes_by_turn(handle, &session_prefix, &turns)?;
+    session_has_target_activity_from_turns(target, &turns, &file_edit_hashes_by_turn)
+}
+
+struct SessionTurnDetail {
+    turn_key: String,
+    detail: super::StoredTurnDetail,
+}
+
+fn read_session_turn_details(
+    handle: &SessionTargetHandle<'_>,
+    session_prefix: &str,
+    summaries: &[super::StoredTurnSummary],
+) -> Result<Vec<SessionTurnDetail>> {
+    summaries
+        .iter()
+        .map(|summary| {
+            let detail_key = format!("{session_prefix}:turn:{}", summary.turn_key);
+            Ok(SessionTurnDetail {
+                turn_key: summary.turn_key.clone(),
+                detail: read_turn_detail(handle, &detail_key)?,
+            })
+        })
+        .collect()
+}
+
+fn session_has_target_activity_from_turns(
+    target: RelatedTarget<'_>,
+    turns: &[SessionTurnDetail],
+    file_edit_hashes_by_turn: &BTreeMap<String, BTreeSet<String>>,
+) -> Result<bool> {
+    if let RelatedTarget::Review(review_key) = target
+        && let Some(branch_key) = pull_request_review_branch_key(review_key)
+        && session_has_target_activity_from_turns(
+            RelatedTarget::Branch(branch_key),
+            turns,
+            file_edit_hashes_by_turn,
+        )?
+    {
+        return Ok(true);
+    }
+
     let mut saw_turn_before_target = false;
-    let mut previous_detail: Option<super::StoredTurnDetail> = None;
-    for summary in summaries {
-        let detail_key = format!("{session_prefix}:turn:{}", summary.turn_key);
-        let detail = read_turn_detail(handle, &detail_key)?;
+    let mut previous_detail: Option<&super::StoredTurnDetail> = None;
+    let mut session_file_edit_hashes = BTreeSet::new();
+    for turn in turns {
+        let detail = &turn.detail;
         if previous_detail.as_ref().is_some_and(|previous| {
             environment_promotes_worktree_to_target(
                 &previous.environment,
                 &detail.environment,
                 target,
+                &session_file_edit_hashes,
             )
         }) {
             return Ok(true);
+        }
+        if let Some(file_edit_hashes) = file_edit_hashes_by_turn.get(&turn.turn_key) {
+            session_file_edit_hashes.extend(file_edit_hashes.iter().cloned());
         }
         if observed_targets_observe(&detail.observed_targets, target) {
             if saw_turn_before_target
@@ -268,6 +318,137 @@ fn session_has_target_activity(
         previous_detail = Some(detail);
     }
     Ok(false)
+}
+
+fn pull_request_review_branch_key(review_key: &str) -> Option<&str> {
+    review_key
+        .strip_prefix("pull-request:")
+        .and_then(|review| review.rsplit_once('#').map(|(branch_key, _)| branch_key))
+}
+
+#[derive(Deserialize)]
+struct StoredTranscriptActivityRecord {
+    record_hash: String,
+    #[serde(default)]
+    tool_name: Option<String>,
+    #[serde(default)]
+    tool_kind: Option<String>,
+    #[serde(default)]
+    file_path_hashes: BTreeSet<String>,
+    #[serde(default)]
+    tool_input: Option<Value>,
+}
+
+impl StoredTranscriptActivityRecord {
+    fn is_file_edit(&self) -> bool {
+        self.tool_kind.as_deref() == Some("file_edit")
+            || matches!(
+                self.tool_name.as_deref(),
+                Some(
+                    "apply_patch"
+                        | "edit_file"
+                        | "write_file"
+                        | "str_replace"
+                        | "Edit"
+                        | "MultiEdit"
+                        | "Write"
+                )
+            )
+    }
+}
+
+fn session_file_edit_hashes_by_turn(
+    handle: &SessionTargetHandle<'_>,
+    session_prefix: &str,
+    turns: &[SessionTurnDetail],
+) -> Result<BTreeMap<String, BTreeSet<String>>> {
+    let mut needed_hashes = HashSet::new();
+    let mut turn_record_hashes = Vec::new();
+    for turn in turns {
+        let record_hashes = turn
+            .detail
+            .records
+            .iter()
+            .map(|record| record.record_hash.clone())
+            .collect::<Vec<_>>();
+        needed_hashes.extend(record_hashes.iter().cloned());
+        turn_record_hashes.push((turn.turn_key.clone(), record_hashes));
+    }
+    if needed_hashes.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+
+    let transcript_key = format!("{session_prefix}:transcript");
+    let records = transcript_records_by_hash(
+        read_transcript_entries(handle, &transcript_key)?,
+        &needed_hashes,
+        parse_activity_record,
+    );
+
+    let mut file_edit_hashes_by_turn = BTreeMap::new();
+    for (turn_key, record_hashes) in turn_record_hashes {
+        let mut file_edit_hashes = BTreeSet::new();
+        for record_hash in record_hashes {
+            let Some(record) = records.get(&record_hash) else {
+                continue;
+            };
+            if record.is_file_edit() {
+                file_edit_hashes.extend(record.file_path_hashes.iter().cloned());
+                file_edit_hashes.extend(file_edit_path_hashes(record.tool_input.as_ref()));
+            }
+        }
+        if !file_edit_hashes.is_empty() {
+            file_edit_hashes_by_turn.insert(turn_key, file_edit_hashes);
+        }
+    }
+    Ok(file_edit_hashes_by_turn)
+}
+
+fn parse_activity_record(raw: &str) -> Option<(String, StoredTranscriptActivityRecord)> {
+    let record = serde_json::from_str::<StoredTranscriptActivityRecord>(raw).ok()?;
+    Some((record.record_hash.clone(), record))
+}
+
+fn file_edit_path_hashes(input: Option<&Value>) -> BTreeSet<String> {
+    let mut hashes = BTreeSet::new();
+    let Some(input) = input else {
+        return hashes;
+    };
+
+    for field in ["path", "file_path", "filename"] {
+        if let Some(path) = input.get(field).and_then(Value::as_str) {
+            insert_public_path_hash(&mut hashes, path);
+        }
+    }
+
+    let patch = input
+        .get("patch")
+        .or_else(|| input.get("input"))
+        .or_else(|| input.get("content"))
+        .and_then(Value::as_str)
+        .or_else(|| input.as_str())
+        .unwrap_or_default();
+    for line in patch.lines().map(str::trim) {
+        for marker in [
+            "*** Update File: ",
+            "*** Add File: ",
+            "*** Delete File: ",
+            "*** Move to: ",
+        ] {
+            if let Some(path) = line.strip_prefix(marker) {
+                insert_public_path_hash(&mut hashes, path);
+            }
+        }
+    }
+
+    hashes
+}
+
+fn insert_public_path_hash(hashes: &mut BTreeSet<String>, path: &str) {
+    let path = path.trim();
+    if is_public_repo_path(path) {
+        hashes.insert(path_fingerprint(path));
+    }
 }
 
 fn target_appearance_is_specific(
@@ -285,9 +466,12 @@ fn environment_promotes_worktree_to_target(
     previous: &StoredEnvironmentSnapshot,
     current: &StoredEnvironmentSnapshot,
     target: RelatedTarget<'_>,
+    session_file_edit_hashes: &BTreeSet<String>,
 ) -> bool {
     // Strong association: files dirty in one turn show up in a new commit on the
-    // target in the next turn. Ambient applied branches stay weak.
+    // target in the next turn. In multi-branch workspaces, the dirty file must
+    // also have been edited by this session; otherwise shared worktree dirtiness
+    // can be credited to the wrong concurrent session.
     if !environment_is_complete(previous) || !environment_is_complete(current) {
         return false;
     }
@@ -306,6 +490,7 @@ fn environment_promotes_worktree_to_target(
         .iter()
         .map(|file| path_fingerprint(file))
         .collect::<BTreeSet<_>>();
+    let requires_session_file_edit = environment_branches(current).count() > 1;
 
     environment_branches(current).any(|branch| {
         let previous_branch = match previous_branch_snapshot(previous, &branch.key) {
@@ -322,6 +507,8 @@ fn environment_promotes_worktree_to_target(
                         &previous_worktree_files,
                         &previous_worktree_file_hashes,
                         &previous_branch,
+                        session_file_edit_hashes,
+                        requires_session_file_edit,
                     )
             })
     })
@@ -349,15 +536,19 @@ fn commit_contains_worktree_file(
     previous_worktree_files: &BTreeSet<&str>,
     previous_worktree_file_hashes: &BTreeSet<String>,
     previous_branch: &KnownPreviousBranch,
+    session_file_edit_hashes: &BTreeSet<String>,
+    requires_session_file_edit: bool,
 ) -> bool {
     commit.file_hashes.iter().any(|hash| {
-        previous_worktree_file_hashes.contains(hash) && !previous_branch.file_hashes.contains(hash)
+        previous_worktree_file_hashes.contains(hash)
+            && !previous_branch.file_hashes.contains(hash)
+            && (!requires_session_file_edit || session_file_edit_hashes.contains(hash))
     }) || commit.files.iter().any(|file| {
+        let path_fingerprint = path_fingerprint(file);
         previous_worktree_files.contains(file.as_str())
             && !previous_branch.files.contains(file)
-            && !previous_branch
-                .file_hashes
-                .contains(&path_fingerprint(file))
+            && !previous_branch.file_hashes.contains(&path_fingerprint)
+            && (!requires_session_file_edit || session_file_edit_hashes.contains(&path_fingerprint))
     })
 }
 

--- a/crates/but-agentlog/src/gitmeta/tests.rs
+++ b/crates/but-agentlog/src/gitmeta/tests.rs
@@ -316,6 +316,101 @@ fn write_readonly_command_turn_with_targets(
         .to_owned()
 }
 
+fn write_file_edit_turn_with_observation(
+    repo: &Path,
+    session_key: &str,
+    source_key: &str,
+    text: &str,
+    edited_path: &str,
+    observation: EnvironmentObservation,
+) -> String {
+    let patch =
+        format!("*** Begin Patch\n*** Update File: {edited_path}\n@@\n-old\n+new\n*** End Patch\n");
+    let arguments =
+        serde_json::to_string(&serde_json::json!({ "patch": patch })).expect("tool arguments");
+    let transcript = jsonl([
+        serde_json::json!({
+            "timestamp": "2026-05-07T09:00:00Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": text,
+            },
+        }),
+        serde_json::json!({
+            "timestamp": "2026-05-07T09:00:01Z",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "apply_patch",
+                "call_id": "call-edit",
+                "arguments": arguments,
+            },
+        }),
+    ]);
+    let batch =
+        TranscriptBatch::parse(Agent::Codex, transcript.as_bytes()).expect("parse transcript");
+    write_transcript_batch(repo, Agent::Codex, session_key, source_key, batch, || {
+        observation
+    })
+    .expect("write transcript batch");
+    turn_summaries(repo, session_key)
+        .last()
+        .and_then(|turn| turn["turn_key"].as_str())
+        .expect("latest turn key")
+        .to_owned()
+}
+
+fn write_structured_file_edit_turn_with_observation(
+    repo: &Path,
+    session_key: &str,
+    source_key: &str,
+    text: &str,
+    edited_path: &str,
+    observation: EnvironmentObservation,
+) -> String {
+    let file_path = repo.join(edited_path).to_string_lossy().to_string();
+    let arguments = serde_json::to_string(&serde_json::json!({
+        "file_path": file_path,
+        "old_string": "old",
+        "new_string": "new",
+    }))
+    .expect("tool arguments");
+    let transcript = jsonl([
+        serde_json::json!({
+            "timestamp": "2026-05-07T09:00:00Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": text,
+            },
+        }),
+        serde_json::json!({
+            "timestamp": "2026-05-07T09:00:01Z",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "Edit",
+                "call_id": "call-edit",
+                "arguments": arguments,
+            },
+        }),
+    ]);
+    let batch =
+        TranscriptBatch::parse(Agent::Codex, transcript.as_bytes()).expect("parse transcript");
+    write_transcript_batch(repo, Agent::Codex, session_key, source_key, batch, || {
+        observation
+    })
+    .expect("write transcript batch");
+    turn_summaries(repo, session_key)
+        .last()
+        .and_then(|turn| turn["turn_key"].as_str())
+        .expect("latest turn key")
+        .to_owned()
+}
+
 fn write_turn_for_session(
     repo: &Path,
     session_key: &str,
@@ -671,16 +766,268 @@ fn worktree_files_promoted_to_target_commit_are_strong_evidence() {
 }
 
 #[test]
+fn shared_worktree_files_from_another_session_do_not_promote_to_target() {
+    let repo = setup_repo();
+    const SESSION_A: &str = "sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const SOURCE_A: &str = "sha256-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const SESSION_B: &str = "sha256-cccccccccccccccccccccccccccccccc";
+    const SOURCE_B: &str = "sha256-dddddddddddddddddddddddddddddddd";
+    const BRANCH_A: &str = "ref:refs/heads/agent-status-after-default";
+    const REVIEW_A: &str = "pull-request:ref:refs/heads/agent-status-after-default#13995";
+    const CHANGE_A: &str = "gitbutler-change:change-a";
+    const BRANCH_B: &str = "ref:refs/heads/unapply-v3-settings-toggle";
+    const REVIEW_B: &str = "pull-request:ref:refs/heads/unapply-v3-settings-toggle#13996";
+    const CHANGE_B: &str = "gitbutler-change:change-b";
+    const FILE_A: &str = "crates/but/src/lib.rs";
+    const FILE_B: &str = "apps/desktop/src/components/settings/ExperimentalSettings.svelte";
+
+    let branch_b_without_review = || TestBranchCommitSnapshot {
+        branch_key: BRANCH_B.to_owned(),
+        review_keys: Vec::new(),
+        change_key: Some(CHANGE_B.to_owned()),
+        commit_id: Some("commit-b".to_owned()),
+        files: vec![FILE_B.to_owned()],
+    };
+
+    write_file_edit_turn_with_observation(
+        repo.path(),
+        SESSION_A,
+        SOURCE_A,
+        "Session A edits its own file",
+        FILE_A,
+        EnvironmentObservation::from_worktree_and_branch_commits_for_testing(
+            &[FILE_A],
+            ObservedTargets::default(),
+            Vec::new(),
+        ),
+    );
+    write_turn_with_observation(
+        repo.path(),
+        SESSION_A,
+        SOURCE_A,
+        "Session A commits its own file",
+        EnvironmentObservation::from_branch_commits_for_testing(
+            ObservedTargets::from_index_keys_for_testing(BRANCH_A, REVIEW_A, CHANGE_A),
+            vec![branch_commit(
+                BRANCH_A,
+                REVIEW_A,
+                CHANGE_A,
+                "commit-a",
+                &[FILE_A],
+            )],
+        ),
+    );
+    write_turn_with_observation(
+        repo.path(),
+        SESSION_A,
+        SOURCE_A,
+        "Session A sees session B's dirty workspace file",
+        EnvironmentObservation::from_worktree_and_branch_commits_for_testing(
+            &[FILE_B],
+            ObservedTargets::from_index_keys_for_testing(BRANCH_A, REVIEW_A, CHANGE_A),
+            vec![branch_commit(
+                BRANCH_A,
+                REVIEW_A,
+                CHANGE_A,
+                "commit-a",
+                &[FILE_A],
+            )],
+        ),
+    );
+    write_file_edit_turn_with_observation(
+        repo.path(),
+        SESSION_B,
+        SOURCE_B,
+        "Session B edits its own file",
+        FILE_B,
+        EnvironmentObservation::from_worktree_and_branch_commits_for_testing(
+            &[FILE_B],
+            ObservedTargets::from_index_keys_for_testing(BRANCH_A, REVIEW_A, CHANGE_A),
+            vec![branch_commit(
+                BRANCH_A,
+                REVIEW_A,
+                CHANGE_A,
+                "commit-a",
+                &[FILE_A],
+            )],
+        ),
+    );
+    write_turn_with_observation(
+        repo.path(),
+        SESSION_B,
+        SOURCE_B,
+        "Session B commits its file before the review exists",
+        EnvironmentObservation::from_branch_commits_for_testing(
+            ObservedTargets::from_index_key_sets_for_testing(
+                &[BRANCH_A, BRANCH_B],
+                &[REVIEW_A],
+                &[CHANGE_A, CHANGE_B],
+            ),
+            vec![
+                branch_commit(BRANCH_A, REVIEW_A, CHANGE_A, "commit-a", &[FILE_A]),
+                branch_b_without_review(),
+            ],
+        ),
+    );
+    write_turn_with_observation(
+        repo.path(),
+        SESSION_A,
+        SOURCE_A,
+        "Session A later sees both branches and reviews",
+        EnvironmentObservation::from_branch_commits_for_testing(
+            ObservedTargets::from_index_key_sets_for_testing(
+                &[BRANCH_A, BRANCH_B],
+                &[REVIEW_A, REVIEW_B],
+                &[CHANGE_A, CHANGE_B],
+            ),
+            vec![
+                branch_commit(BRANCH_A, REVIEW_A, CHANGE_A, "commit-a", &[FILE_A]),
+                branch_commit(BRANCH_B, REVIEW_B, CHANGE_B, "commit-b", &[FILE_B]),
+            ],
+        ),
+    );
+    write_turn_with_observation(
+        repo.path(),
+        SESSION_B,
+        SOURCE_B,
+        "Session B later sees its review",
+        EnvironmentObservation::from_branch_commits_for_testing(
+            ObservedTargets::from_index_key_sets_for_testing(
+                &[BRANCH_A, BRANCH_B],
+                &[REVIEW_A, REVIEW_B],
+                &[CHANGE_A, CHANGE_B],
+            ),
+            vec![
+                branch_commit(BRANCH_A, REVIEW_A, CHANGE_A, "commit-a", &[FILE_A]),
+                branch_commit(BRANCH_B, REVIEW_B, CHANGE_B, "commit-b", &[FILE_B]),
+            ],
+        ),
+    );
+
+    let branch_b_sessions =
+        find_related_sessions_limited(repo.path(), RelatedTarget::Branch(BRANCH_B), None)
+            .expect("find branch B sessions");
+    assert_eq!(
+        branch_b_sessions
+            .iter()
+            .map(|session| session.session_key.as_str())
+            .collect::<Vec<_>>(),
+        [SESSION_B],
+        "only the session that edited the promoted worktree file should match branch B"
+    );
+
+    let review_b_sessions =
+        find_related_sessions_limited(repo.path(), RelatedTarget::Review(REVIEW_B), None)
+            .expect("find review B sessions");
+    assert_eq!(
+        review_b_sessions
+            .iter()
+            .map(|session| session.session_key.as_str())
+            .collect::<Vec<_>>(),
+        [SESSION_B],
+        "branch-proven work should carry to the review once the review target is known"
+    );
+
+    let review_a_sessions =
+        find_related_sessions_limited(repo.path(), RelatedTarget::Review(REVIEW_A), None)
+            .expect("find review A sessions");
+    assert_eq!(
+        review_a_sessions
+            .iter()
+            .map(|session| session.session_key.as_str())
+            .collect::<Vec<_>>(),
+        [SESSION_A],
+        "session B's worktree file must not attach it to review A"
+    );
+}
+
+#[test]
+fn structured_file_edit_paths_are_hashed_before_redaction_for_promotion() {
+    let repo = setup_repo();
+    const OTHER_BRANCH_KEY: &str = "ref:refs/heads/other";
+    const OTHER_REVIEW_KEY: &str = "pull-request:ref:refs/heads/other#2";
+    const OTHER_CHANGE_KEY: &str = "gitbutler-change:change-2";
+    const FILE: &str = "src/structured.rs";
+
+    write_structured_file_edit_turn_with_observation(
+        repo.path(),
+        TEST_SESSION_KEY,
+        TEST_SOURCE_KEY,
+        "Update structured file",
+        FILE,
+        EnvironmentObservation::from_worktree_and_branch_commits_for_testing(
+            &[FILE],
+            ObservedTargets::default(),
+            Vec::new(),
+        ),
+    );
+    write_turn_with_observation(
+        repo.path(),
+        TEST_SESSION_KEY,
+        TEST_SOURCE_KEY,
+        "Branches appeared with commits",
+        EnvironmentObservation::from_branch_commits_for_testing(
+            ObservedTargets::from_index_key_sets_for_testing(
+                &[TEST_BRANCH_KEY, OTHER_BRANCH_KEY],
+                &[TEST_PR_REVIEW_KEY, OTHER_REVIEW_KEY],
+                &[TEST_CHANGE_KEY, OTHER_CHANGE_KEY],
+            ),
+            vec![
+                branch_commit(
+                    TEST_BRANCH_KEY,
+                    TEST_PR_REVIEW_KEY,
+                    TEST_CHANGE_KEY,
+                    "commit-main",
+                    &["src/main.rs"],
+                ),
+                branch_commit(
+                    OTHER_BRANCH_KEY,
+                    OTHER_REVIEW_KEY,
+                    OTHER_CHANGE_KEY,
+                    "commit-other",
+                    &[FILE],
+                ),
+            ],
+        ),
+    );
+
+    let main_sessions =
+        find_related_sessions_limited(repo.path(), RelatedTarget::Review(TEST_PR_REVIEW_KEY), None)
+            .expect("find main review sessions");
+    assert!(main_sessions.is_empty());
+    let other = only_related(repo.path(), RelatedTarget::Review(OTHER_REVIEW_KEY));
+    assert_eq!(other.related_turn_keys.len(), 2);
+
+    let records = transcript_entries(repo.path(), TEST_SESSION_KEY)
+        .into_iter()
+        .map(|entry| {
+            serde_json::from_str::<serde_json::Value>(&entry).expect("transcript record json")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(records[1]["tool_input"]["file_path"], "[REDACTED:entropy]");
+    assert_eq!(
+        records[1]["file_path_hashes"]
+            .as_array()
+            .expect("file path hashes")
+            .len(),
+        1
+    );
+    let json = serde_json::to_string(&records).expect("records json");
+    assert!(!json.contains(FILE));
+}
+
+#[test]
 fn promotion_matches_the_branch_that_received_the_files() {
     let repo = setup_repo();
     const OTHER_BRANCH_KEY: &str = "ref:refs/heads/other";
     const OTHER_REVIEW_KEY: &str = "pull-request:ref:refs/heads/other#2";
     const OTHER_CHANGE_KEY: &str = "gitbutler-change:change-2";
-    write_turn_with_observation(
+    write_file_edit_turn_with_observation(
         repo.path(),
         TEST_SESSION_KEY,
         TEST_SOURCE_KEY,
         "Update other branch file",
+        "src/other.rs",
         EnvironmentObservation::from_worktree_and_branch_commits_for_testing(
             &["src/other.rs"],
             ObservedTargets::default(),
@@ -746,11 +1093,12 @@ fn promotion_handles_branch_that_appears_with_commit() {
     const OTHER_BRANCH_KEY: &str = "ref:refs/heads/other";
     const OTHER_REVIEW_KEY: &str = "pull-request:ref:refs/heads/other#2";
     const OTHER_CHANGE_KEY: &str = "gitbutler-change:change-2";
-    write_turn_with_observation(
+    write_file_edit_turn_with_observation(
         repo.path(),
         TEST_SESSION_KEY,
         TEST_SOURCE_KEY,
         "Update file before branches exist",
+        "src/other.rs",
         EnvironmentObservation::from_worktree_and_branch_commits_for_testing(
             &["src/other.rs"],
             ObservedTargets::default(),

--- a/crates/but-agentlog/src/gitmeta/write.rs
+++ b/crates/but-agentlog/src/gitmeta/write.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{BTreeSet, HashSet},
-    path::Path,
+    path::{Component, Path, PathBuf},
 };
 
 use anyhow::{Context as _, Result, bail};
@@ -11,7 +11,10 @@ use serde_json::Value;
 
 use crate::{
     agent::Agent,
-    environment::{EnvironmentObservation, ObservedTargets, SnapshotStatus},
+    environment::{
+        EnvironmentObservation, ObservedTargets, SnapshotStatus, is_public_repo_path,
+        path_fingerprint,
+    },
     redaction::{redact_text, redact_value},
     transcript::{PromptSource, RecordKind, ToolKind, ToolOutcome, TranscriptBatch},
 };
@@ -117,6 +120,9 @@ pub(crate) fn write_transcript_batch(
     } else {
         CaptureKind::Backfill
     };
+    let repo_root = repo_path
+        .canonicalize()
+        .unwrap_or_else(|_| repo_path.to_owned());
     let mut record_hashes = Vec::with_capacity(records_captured);
     let mut transcript_entries = Vec::with_capacity(records_captured);
     let mut accepted_records = Vec::with_capacity(records_captured);
@@ -138,6 +144,11 @@ pub(crate) fn write_transcript_batch(
             prompt_source: record.prompt_source,
             tool_name: record.tool_name.as_deref().map(redact_text),
             tool_kind: record.tool_kind,
+            file_path_hashes: file_path_hashes_for_record(
+                &repo_root,
+                record.tool_kind,
+                record.tool_input.as_ref(),
+            ),
             tool_input: record.tool_input.map(redact_value),
             exit_code: record.exit_code,
             outcome: record.tool_outcome,
@@ -291,6 +302,101 @@ fn stored_text(kind: RecordKind, text: Option<&str>) -> Option<String> {
         RecordKind::ToolResult => redact_text(cap_tool_result_text(text).as_ref()),
         _ => redact_text(text),
     })
+}
+
+fn file_path_hashes_for_record(
+    repo_root: &Path,
+    tool_kind: Option<ToolKind>,
+    input: Option<&Value>,
+) -> Vec<String> {
+    if tool_kind != Some(ToolKind::FileEdit) {
+        return Vec::new();
+    }
+    let Some(input) = input else {
+        return Vec::new();
+    };
+
+    let mut hashes = BTreeSet::new();
+    for field in ["path", "file_path", "filename"] {
+        if let Some(path) = input.get(field).and_then(Value::as_str) {
+            insert_file_path_hash(&mut hashes, repo_root, path);
+        }
+    }
+
+    let patch = input
+        .get("patch")
+        .or_else(|| input.get("input"))
+        .or_else(|| input.get("content"))
+        .and_then(Value::as_str)
+        .or_else(|| input.as_str())
+        .unwrap_or_default();
+    for line in patch.lines().map(str::trim) {
+        for marker in [
+            "*** Update File: ",
+            "*** Add File: ",
+            "*** Delete File: ",
+            "*** Move to: ",
+        ] {
+            if let Some(path) = line.strip_prefix(marker) {
+                insert_file_path_hash(&mut hashes, repo_root, path);
+            }
+        }
+    }
+
+    hashes.into_iter().collect()
+}
+
+fn insert_file_path_hash(hashes: &mut BTreeSet<String>, repo_root: &Path, path: &str) {
+    if let Some(path) = repo_relative_file_path(repo_root, path.trim()) {
+        hashes.insert(path_fingerprint(&path));
+    }
+}
+
+fn repo_relative_file_path(repo_root: &Path, path: &str) -> Option<String> {
+    if path.is_empty()
+        || path.contains("[local path]")
+        || path.contains("[REDACTED")
+        || path.contains('‹')
+    {
+        return None;
+    }
+
+    let candidate = Path::new(path);
+    if candidate.is_absolute() {
+        if let Ok(relative_path) = candidate.strip_prefix(repo_root) {
+            return path_to_repo_string(relative_path);
+        }
+        let normalized = normalize_absolute_path(candidate)?;
+        return path_to_repo_string(normalized.strip_prefix(repo_root).ok()?);
+    }
+
+    is_public_repo_path(path).then(|| path.to_owned())
+}
+
+fn normalize_absolute_path(path: &Path) -> Option<PathBuf> {
+    let mut missing_components = Vec::new();
+    let mut existing_prefix = path;
+    while !existing_prefix.exists() {
+        missing_components.push(existing_prefix.file_name()?.to_owned());
+        existing_prefix = existing_prefix.parent()?;
+    }
+
+    let mut normalized = existing_prefix.canonicalize().ok()?;
+    for component in missing_components.iter().rev() {
+        normalized.push(component);
+    }
+    Some(normalized)
+}
+
+fn path_to_repo_string(path: &Path) -> Option<String> {
+    let mut components = Vec::new();
+    for component in path.components() {
+        let Component::Normal(component) = component else {
+            return None;
+        };
+        components.push(component.to_str()?);
+    }
+    (!components.is_empty()).then(|| components.join("/"))
 }
 
 fn source_metadata_fields(
@@ -585,6 +691,8 @@ struct TranscriptRecord<'a> {
     tool_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tool_kind: Option<ToolKind>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    file_path_hashes: Vec<String>,
     tool_input: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     exit_code: Option<i32>,

--- a/crates/but-agentlog/src/projection.rs
+++ b/crates/but-agentlog/src/projection.rs
@@ -17,6 +17,7 @@ use serde::Serialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
+use crate::environment::is_public_repo_path;
 use crate::gitmeta::{
     RelatedSession, RelatedTarget, SessionRecords, find_related_sessions_limited,
     get_session_records, get_session_timeline_outline,
@@ -652,20 +653,6 @@ fn file_paths_of(input: Option<&Value>) -> Vec<String> {
         }
     }
     paths
-}
-
-fn is_public_repo_path(path: &str) -> bool {
-    !path.is_empty()
-        && !path.starts_with('/')
-        && !path.starts_with('~')
-        && !path.contains('\\')
-        && !path.contains(':')
-        && !path.contains("[local path]")
-        && !path.contains("[REDACTED")
-        && !path.contains('‹')
-        && path
-            .split('/')
-            .all(|component| !matches!(component, "" | "." | ".."))
 }
 
 fn bounded_text(text: &str, max_chars: usize) -> (Option<String>, bool) {


### PR DESCRIPTION
Agent Trail could attach a session from a neighboring PR when concurrent branches shared dirty worktree state. This makes multi-branch promotion require session-owned file edit evidence, while still carrying branch-proven work to its PR review.

New captures store hashed edit-path evidence before redaction, and old patch-based recordings still work through the read-time fallback.

Validation:
- cargo test -p but-agentlog
- checked PR 13995 and 13996 skim output against local GitMeta