### PR TITLE
fix problem with `commit already belongs to another branch`

### DIFF
--- a/crates/but-workspace/src/branch/create_reference.rs
+++ b/crates/but-workspace/src/branch/create_reference.rs
@@ -193,7 +193,12 @@ pub(super) mod function {
                             instruction,
                         )
                     } else {
-                        let base = workspace
+                        // The target tip (e.g. `origin/main`) can be advanced *past* the
+                        // workspace, i.e. outside it. Anchoring a new independent branch there
+                        // would stop re-projection from surfacing it as a standalone segment.
+                        // Anchor at the merge-base of the target tip and the workspace commit
+                        // instead — the fork point, always inside the workspace.
+                        let target_tip = workspace
                             .resolved_target_commit_id()
                             .or(ws_base)
                             .with_context(|| {
@@ -202,8 +207,25 @@ pub(super) mod function {
                                     workspace.ref_name_display()
                                 )
                             })?;
+                        // The merge-base needs the workspace commit. Without it (e.g. a headless,
+                        // unmanaged workspace) there is no fork point and thus no insertion point
+                        // inside the workspace, so refuse rather than silently anchor at the
+                        // target tip — the very commit we know may sit outside the workspace.
+                        let ws_commit_id = workspace
+                            .ref_name()
+                            .and_then(|ws_ref| repo.try_find_reference(ws_ref).ok().flatten())
+                            .and_then(|mut ws_ref| ws_ref.peel_to_id().ok())
+                            .map(|id| id.detach())
+                            .with_context(|| {
+                                format!(
+                                    "Cannot create independent branch: workspace at {} has no commit to anchor against",
+                                    workspace.ref_name_display()
+                                )
+                            })?;
+                        let base = repo.merge_base(target_tip, ws_commit_id)?.detach();
                         (
-                            // do not validate, as the base is expectedly outside of workspace
+                            // Don't validate: the merge-base is the workspace's lower bound (the
+                            // fork point), not a commit owned by any segment.
                             false,
                             base,
                             Some(Instruction::Independent),

--- a/crates/but-workspace/tests/fixtures/scenario/stack-below-advanced-target.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/stack-below-advanced-target.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A single applied stack 'A' based at M1, while the target branch (origin/main)
+# is advanced by one commit (M2). The target tip therefore sits OUTSIDE the
+# workspace. This mirrors the `but branch new` / create_virtual_branch repro:
+# creating a no-anchor branch picks base = resolved_target_commit_id() == the
+# origin/main tip (M2), which isn't part of the workspace.
+git init
+echo "A single applied stack below an advanced target branch" >.git/description
+
+commit M1
+git checkout -b A
+  commit A1
+git checkout main
+  commit M2
+  setup_target_to_match_main
+git checkout A
+create_workspace_commit_once A

--- a/crates/but-workspace/tests/workspace/branch/create_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/create_reference.rs
@@ -1226,6 +1226,79 @@ mod with_workspace {
         );
         Ok(())
     }
+
+    /// Regression: `but branch new <name>` and `create_virtual_branch` both go through
+    /// `create_reference(.., None, ..)`. When the target (`origin/main`) is advanced past the
+    /// workspace, its tip sits OUTSIDE the workspace. The no-anchor path used to anchor the new
+    /// ref at that tip and bail with "the target commit ... already belongs to another branch".
+    /// It must instead anchor at `merge_base(target_tip, ws-commit)` (here M1), inside the
+    /// workspace, so the branch emerges cleanly as its own stack.
+    #[test]
+    fn no_anchor_branch_with_target_tip_outside_workspace() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta) = named_writable_scenario("stack-below-advanced-target")?;
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+        * 1021d74 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+        * 49d4b34 (A) A1
+        | * bce0c5e (origin/main, main) M2
+        |/  
+        * 3183e43 M1
+        ");
+
+        // `A` is applied (in the workspace), based at M1.
+        add_stack_with_segments(&mut meta, 0, "A", StackState::InWorkspace, &[]);
+
+        let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
+        let ws = graph.into_workspace()?;
+        insta::assert_snapshot!(graph_workspace(&ws), @"
+        📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+        └── ≡📙:3:A on 3183e43 {0}
+            └── 📙:3:A
+                └── ·49d4b34 (🏘️)
+        ");
+
+        // Precondition (see `⇣1` above): the target tip (M2) is one commit ahead of A's base,
+        // so it sits OUTSIDE the workspace — the situation the no-anchor path mishandled.
+        let target_id = ws
+            .resolved_target_commit_id()
+            .expect("the scenario sets a default target");
+        assert!(
+            ws.find_owner_indexes_by_commit_id(target_id).is_none(),
+            "the target tip must be outside the workspace for this repro"
+        );
+
+        // Creating the no-anchor branch now succeeds (it used to bail).
+        let new_name = rc("refs/heads/new-branch");
+        let new_ref = new_name.as_ref();
+        let updated_ws = but_workspace::branch::create_reference(
+            new_ref,
+            None,
+            &repo,
+            &ws,
+            &mut meta,
+            stack_id_for_name,
+            None,
+        )?;
+
+        // `new-branch` emerges as its own standalone stack/segment, based at M1.
+        insta::assert_snapshot!(graph_workspace(&updated_ws), @"
+        📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+        ├── ≡📙:3:A on 3183e43 {0}
+        │   └── 📙:3:A
+        │       └── ·49d4b34 (🏘️)
+        └── ≡📙:5:new-branch on 3183e43 {3e5}
+            └── 📙:5:new-branch
+        ");
+
+        // `new-branch` was written at M1 (== merge_base(target, ws-commit)), the commit just
+        // below the advanced target — inside the workspace, not at the out-of-workspace tip.
+        let new_tip = repo.find_reference(new_ref)?.peel_to_id()?.detach();
+        assert_eq!(
+            new_tip,
+            repo.rev_parse_single("main~1")?.detach(),
+            "the new branch must be anchored at M1, inside the workspace"
+        );
+        Ok(())
+    }
 }
 
 #[test]


### PR DESCRIPTION
## 🧢 Changes

`but branch new <name>` — and the modern `create_virtual_branch`, which takes the same path — failed to create a branch whenever the target branch (`origin/main`) had advanced past the applied workspace:

```
Error: Branch '<name>' cannot be created: the target commit (<sha>) already
belongs to another branch in the workspace. Each commit can only belong to
one branch at a time.
```

Both go through `create_reference(.., None, ..)`. This PR:

- **Anchors** a no-anchor ("independent") branch at `merge_base(target_tip, workspace_commit)` — the fork point, always *inside* the workspace — instead of `resolved_target_commit_id()` (the target tip, which can sit *outside* it).
- **Errors clearly** when there is no resolvable workspace commit (a headless / unmanaged workspace), rather than silently falling back to the out-of-workspace target tip.
- Adds a deterministic test scenario (`stack-below-advanced-target`) and a regression test.

## ☕️ Reasoning

### When it happens

A stack is applied below a target that has since moved ahead:

```
* 1021d74 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
* 49d4b34 (A) A1
| * bce0c5e (origin/main, main) M2
|/
* 3183e43 M1
```

`A` forks from `M1`; `origin/main` advanced to `M2` (a sibling of `A1`). So the target tip `M2` sits **outside** the workspace — note `⇣1` (target is one commit ahead) and `on 3183e43` (the workspace base is `M1`):

```
📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
└── ≡📙:3:A on 3183e43 {0}
    └── 📙:3:A
        └── ·49d4b34 (🏘️)
```

### Before — the bug

The no-anchor path anchored the new ref at `resolved_target_commit_id()` = `M2`. Because `M2` isn't in the workspace, re-projection can't surface the new ref as its own segment, so creation bailed:

```
Error: Branch 'new-branch' cannot be created: the target commit (bce0c5e…)
already belongs to another branch in the workspace.
```

### After — the fix

Anchoring at `merge_base(M2, ws-commit)` = `M1` (inside the workspace), `new-branch` emerges cleanly as its own stack, based at `M1`:

```
📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
├── ≡📙:3:A on 3183e43 {0}
│   └── 📙:3:A
│       └── ·49d4b34 (🏘️)
└── ≡📙:5:new-branch on 3183e43 {3e5}
    └── 📙:5:new-branch
```

### Verification

End-to-end via `repro.sh` (`but apply foo` below an advanced `origin/main`, then `but branch new bar`), run from an **empty** directory:

| `but` binary | `but branch new bar` |
| --- | --- |
| nightly `0.5.2047` | ❌ errors |
| this branch | ✅ creates the branch |

- Library regression test `no_anchor_branch_with_target_tip_outside_workspace` pins both graphs above.