### PR TITLE
Expose undo/redo hotkeys globally

### DIFF
--- a/apps/lite/ui/src/hotkeys.ts
+++ b/apps/lite/ui/src/hotkeys.ts
@@ -73,9 +73,17 @@ export const globalHotkeys = {
 		hotkey: "Mod+K",
 		meta: { group: "Global", name: "Command palette" },
 	},
+	redo: {
+		hotkey: "Mod+Shift+Z",
+		meta: { group: "Outline", name: "Redo" },
+	},
 	selectProject: {
 		hotkey: "Mod+Shift+P",
 		meta: { group: "Global", name: "Select project" },
+	},
+	undo: {
+		hotkey: "Mod+Z",
+		meta: { group: "Outline", name: "Undo" },
 	},
 } satisfies Record<string, HotkeyWithMeta>;
 
@@ -127,10 +135,6 @@ export const outlineHotkeys = {
 		hotkey: "Alt+ArrowUp",
 		meta: { group: "Commit", name: "Move commit up" },
 	},
-	redo: {
-		hotkey: "Mod+Shift+Z",
-		meta: { group: "Outline", name: "Redo" },
-	},
 	renameBranch: {
 		hotkey: "Enter",
 		meta: { group: "Branch", name: "Rename branch" },
@@ -146,10 +150,6 @@ export const outlineHotkeys = {
 	selectChanges: {
 		hotkey: "Z",
 		meta: { group: "Outline", name: "Select changes" },
-	},
-	undo: {
-		hotkey: "Mod+Z",
-		meta: { group: "Outline", name: "Undo" },
 	},
 } satisfies Record<string, HotkeyWithMeta>;
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.tsx
@@ -7,7 +7,7 @@ import {
 } from "#ui/api/queries.ts";
 import { findCommit, renameBranchInHeadInfo, resolveRelativeTo } from "#ui/api/ref-info.ts";
 import { decodeRefName, encodeRefName } from "#ui/api/ref-name.ts";
-import { commitIsDiverged, commitTitle, shortCommitId } from "#ui/commit.ts";
+import { commitIsDiverged, commitTitle } from "#ui/commit.ts";
 import {
 	nativeMenuItem,
 	nativeMenuSeparator,
@@ -63,7 +63,6 @@ import {
 	RefInfo,
 	RelativeTo,
 	Segment,
-	Snapshot,
 	Stack,
 	TreeChange,
 	WorkspaceState,
@@ -319,63 +318,6 @@ const useOutlineTreeHotkeys = ({
 		});
 	};
 
-	const restoreSnapshotMutation = useMutation({
-		mutationFn: async (direction: "redo" | "undo"): Promise<Snapshot | null> => {
-			const snapshot =
-				direction === "redo"
-					? await window.lite.getRedoTargetSnapshot(projectId)
-					: await window.lite.getUndoTargetSnapshot(projectId);
-			if (!snapshot) return null;
-
-			const [peeled] = await Promise.all([
-				window.lite.peelRestoreSnapshot({ projectId, sha: snapshot.commitId }),
-
-				window.lite.restoreSnapshotWithKind({
-					projectId,
-					restoreKind:
-						direction === "redo" ? "RestoreFromSnapshotViaRedo" : "RestoreFromSnapshotViaUndo",
-					sha: snapshot.commitId,
-				}),
-			]);
-
-			return peeled ?? snapshot;
-		},
-		onSuccess: (snapshot, direction) => {
-			const title = direction === "redo" ? "Redo" : "Undo";
-
-			if (!snapshot) {
-				toastManager.add({ type: "warning", title, description: `Nothing to ${direction}` });
-				return;
-			}
-
-			// TODO: We should map this to something user-friendly.
-			const op = snapshot.details?.operation;
-
-			// TODO: We should use dynamic units.
-			const minsAgo = new Intl.RelativeTimeFormat(undefined, { style: "short" }).format(
-				Math.ceil((snapshot.createdAt - Date.now()) / 1000 / 60),
-				"minutes",
-			);
-
-			toastManager.add({
-				type: "info",
-				title,
-				description: `Restored to ${shortCommitId(snapshot.commitId)} (${op !== undefined ? `${op}, ` : ""}${minsAgo})`,
-			});
-		},
-		onError: (error, direction) => {
-			// oxlint-disable-next-line no-console
-			console.error(error);
-
-			toastManager.add({
-				type: "error",
-				title: `Failed to ${direction}`,
-				description: errorMessageForToast(error),
-				priority: "high",
-			});
-		},
-	});
-
 	const defaultOutlineHotkeysEnabled = focusedPanel === "outline" && outlineMode._tag === "Default";
 	const isSelectedCommit = selection._tag === "Commit";
 	const isSelectedChanges = selection._tag === "ChangesSection";
@@ -526,24 +468,6 @@ const useOutlineTreeHotkeys = ({
 					worktreeChanges &&
 					worktreeChanges.changes.length > 0,
 				meta: outlineHotkeys.absorb.meta,
-			},
-		},
-		{
-			hotkey: outlineHotkeys.redo.hotkey,
-			callback: () => restoreSnapshotMutation.mutate("redo"),
-			options: {
-				enabled: defaultOutlineHotkeysEnabled && !restoreSnapshotMutation.isPending,
-				meta: outlineHotkeys.redo.meta,
-				ignoreInputs: true,
-			},
-		},
-		{
-			hotkey: outlineHotkeys.undo.hotkey,
-			callback: () => restoreSnapshotMutation.mutate("undo"),
-			options: {
-				enabled: defaultOutlineHotkeysEnabled && !restoreSnapshotMutation.isPending,
-				meta: outlineHotkeys.undo.meta,
-				ignoreInputs: true,
 			},
 		},
 	]);

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -12,13 +12,14 @@ import {
 import {
 	projectActions,
 	selectProjectDialogState,
+	selectProjectOutlineModeState,
 	selectProjectPanelsState,
 } from "#ui/projects/state.ts";
 import { Button } from "#ui/components/Button.tsx";
 import { Kbd } from "#ui/components/Kbd.tsx";
 import { globalHotkeys, workspaceHotkeys, type CommandGroup } from "#ui/hotkeys.ts";
 import { type AppThunk, useAppDispatch, useAppSelector } from "#ui/store.ts";
-import { BranchListing, Segment, Stack } from "@gitbutler/but-sdk";
+import { BranchListing, Segment, Snapshot, Stack } from "@gitbutler/but-sdk";
 import {
 	getHotkeyManager,
 	getSequenceManager,
@@ -44,6 +45,7 @@ import styles from "./WorkspacePage.module.css";
 import { OutlinePanel } from "#ui/routes/project/$id/workspace/OutlinePanel.tsx";
 import { Toast } from "@base-ui/react";
 import { errorMessageForToast } from "#ui/errors.ts";
+import { shortCommitId } from "#ui/commit.ts";
 
 type CommandPaletteItem = {
 	group: CommandGroup;
@@ -289,8 +291,85 @@ const useWorkspaceHotkeys = (projectId: string) => {
 	const dialog = useAppSelector((state) => selectProjectDialogState(state, projectId));
 	const panelsState = useAppSelector((state) => selectProjectPanelsState(state, projectId));
 	const focusedPanel = useFocusedProjectPanel(projectId);
+	const toastManager = Toast.useToastManager();
+	const outlineMode = useAppSelector((state) => selectProjectOutlineModeState(state, projectId));
+
+	const restoreSnapshotMutation = useMutation({
+		mutationFn: async (direction: "redo" | "undo"): Promise<Snapshot | null> => {
+			const snapshot =
+				direction === "redo"
+					? await window.lite.getRedoTargetSnapshot(projectId)
+					: await window.lite.getUndoTargetSnapshot(projectId);
+			if (!snapshot) return null;
+
+			const [peeled] = await Promise.all([
+				window.lite.peelRestoreSnapshot({ projectId, sha: snapshot.commitId }),
+
+				window.lite.restoreSnapshotWithKind({
+					projectId,
+					restoreKind:
+						direction === "redo" ? "RestoreFromSnapshotViaRedo" : "RestoreFromSnapshotViaUndo",
+					sha: snapshot.commitId,
+				}),
+			]);
+
+			return peeled ?? snapshot;
+		},
+		onSuccess: (snapshot, direction) => {
+			const title = direction === "redo" ? "Redo" : "Undo";
+
+			if (!snapshot) {
+				toastManager.add({ type: "warning", title, description: `Nothing to ${direction}` });
+				return;
+			}
+
+			// TODO: We should map this to something user-friendly.
+			const op = snapshot.details?.operation;
+
+			// TODO: We should use dynamic units.
+			const minsAgo = new Intl.RelativeTimeFormat(undefined, { style: "short" }).format(
+				Math.ceil((snapshot.createdAt - Date.now()) / 1000 / 60),
+				"minutes",
+			);
+
+			toastManager.add({
+				type: "info",
+				title,
+				description: `Restored to ${shortCommitId(snapshot.commitId)} (${op !== undefined ? `${op}, ` : ""}${minsAgo})`,
+			});
+		},
+		onError: (error, direction) => {
+			// oxlint-disable-next-line no-console
+			console.error(error);
+
+			toastManager.add({
+				type: "error",
+				title: `Failed to ${direction}`,
+				description: errorMessageForToast(error),
+				priority: "high",
+			});
+		},
+	});
 
 	useHotkeys([
+		{
+			hotkey: globalHotkeys.redo.hotkey,
+			callback: () => restoreSnapshotMutation.mutate("redo"),
+			options: {
+				enabled: outlineMode._tag === "Default" && !restoreSnapshotMutation.isPending,
+				meta: globalHotkeys.redo.meta,
+				ignoreInputs: true,
+			},
+		},
+		{
+			hotkey: globalHotkeys.undo.hotkey,
+			callback: () => restoreSnapshotMutation.mutate("undo"),
+			options: {
+				enabled: outlineMode._tag === "Default" && !restoreSnapshotMutation.isPending,
+				meta: globalHotkeys.undo.meta,
+				ignoreInputs: true,
+			},
+		},
 		{
 			hotkey: globalHotkeys.commandPalette.hotkey,
 			callback: () => {


### PR DESCRIPTION
I don't see a reason why they should only be exposed in the outline panel.