### PR TITLE
Lite: remove resizable panels for now

### DIFF
--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -480,9 +480,6 @@ void app.whenReady().then(async () => {
 			"script-src 'self' 'wasm-unsafe-eval';" +
 			// Hash is for inline style in index.html
 			"style-src 'self' 'sha256-XBXaUBQCe+0UGd1QCfoPFCc7UsLKd8xrn9oXNYqjFog=';" +
-			// react-resizable-panels has inline styles in elements. `style-src-attr 'unsafe-inline'` is slightly more narrow
-			// than just `style-src 'unsafe-inline'`, but we should still try to get rid of this.
-			"style-src-attr 'unsafe-inline';" +
 			"font-src 'self';" +
 			"connect-src 'self';" +
 			"object-src 'none';" +

--- a/apps/lite/package.json
+++ b/apps/lite/package.json
@@ -136,8 +136,7 @@
 		"electron-updater": "^6.8.4",
 		"react": "^19.2.4",
 		"react-dom": "^19.2.4",
-		"react-redux": "^9.2.0",
-		"react-resizable-panels": "^4.7.3"
+		"react-redux": "^9.2.0"
 	},
 	"devDependencies": {
 		"@storybook/addon-designs": "^11.1.3",

--- a/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.module.css
@@ -18,7 +18,7 @@
 	}
 }
 
-.panes {
+.panels {
 	--resize-spacing: 6px;
 	min-height: 0;
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.module.css
@@ -76,7 +76,6 @@
 }
 
 .detailsVirtualizer {
-	min-height: 0;
 	overflow: auto;
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.module.css
@@ -6,6 +6,8 @@
 	display: grid;
 	grid-template-rows: auto minmax(0, 1fr);
 
+	row-gap: 12px;
+
 	padding: var(--panel-padding);
 }
 
@@ -40,7 +42,6 @@
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	margin-block: 16px;
 	gap: 10px;
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.module.css
@@ -20,31 +20,27 @@
 
 .panels {
 	--resize-spacing: 6px;
-	min-height: 0;
+
+	display: grid;
+	grid-template-rows: minmax(0, 1fr);
+	grid-template-columns: 1fr;
+}
+
+.panelsWithFiles {
+	grid-template-columns: 300px 1fr;
 }
 
 .filesPanel {
 	padding-inline: var(--panel-padding) var(--resize-spacing);
+	overflow: auto;
 }
 
 .detailsContentPanel {
 	display: grid;
-	grid-template-rows: minmax(0, 1fr);
 	padding-inline: var(--panel-padding);
 
 	&.alongsideFiles {
 		padding-inline-start: var(--resize-spacing);
-	}
-}
-
-.panelResizeHandle {
-	width: 1px;
-	margin-block-start: var(--panel-padding);
-	transition: background-color 0.2s;
-
-	&[data-separator="hover"],
-	&[data-separator="active"] {
-		background-color: var(--border-3);
 	}
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.module.css
@@ -5,12 +5,11 @@
 .panel {
 	display: grid;
 	grid-template-rows: auto minmax(0, 1fr);
+
+	padding: var(--panel-padding);
 }
 
 .headerWrap {
-	padding-inline: var(--panel-padding);
-	padding-block-start: calc(var(--panel-padding) + 4px);
-
 	& header {
 		display: flex;
 		align-items: center;
@@ -19,11 +18,10 @@
 }
 
 .panels {
-	--resize-spacing: 6px;
-
 	display: grid;
 	grid-template-rows: minmax(0, 1fr);
 	grid-template-columns: 1fr;
+	column-gap: 12px;
 }
 
 .panelsWithFiles {
@@ -31,17 +29,11 @@
 }
 
 .filesPanel {
-	padding-inline: var(--panel-padding) var(--resize-spacing);
 	overflow: auto;
 }
 
 .detailsContentPanel {
 	display: grid;
-	padding-inline: var(--panel-padding);
-
-	&.alongsideFiles {
-		padding-inline-start: var(--resize-spacing);
-	}
 }
 
 .headerActions {
@@ -143,11 +135,6 @@
 
 .emptyFileHunks {
 	margin: 8px;
-}
-
-.commitDetailsWrapper {
-	padding: 0 var(--panel-padding) var(--panel-padding);
-	overflow: auto;
 }
 
 .commitDetailsContent {

--- a/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.tsx
@@ -43,14 +43,14 @@ import { PatchDiff, Virtualizer } from "@pierre/diffs/react";
 import { useSuspenseQueries } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
 import { Array, Match, pipe } from "effect";
-import { FC, Suspense, useDeferredValue, useState } from "react";
-import { Group, Panel, PanelProps, Separator, useDefaultLayout } from "react-resizable-panels";
+import { ComponentProps, FC, Suspense, useDeferredValue, useState } from "react";
 import { DiffStat } from "#ui/components/DiffStat.tsx";
 import { DependencyIndicatorButton } from "./DependencyIndicatorButton.tsx";
 import { FilesPanel } from "./FilesPanel.tsx";
 import styles from "./DetailsPanel.module.css";
 import { workspaceHotkeys } from "#ui/hotkeys.ts";
 import { ToggleGroupStyles, ToggleStyles } from "#ui/components/ToggleGroup.tsx";
+import { Panel } from "#ui/panels.ts";
 
 const lineEndingForDiff = (diff: string): string => (diff.includes("\r\n") ? "\r\n" : "\n");
 
@@ -574,7 +574,7 @@ const DiffContents: FC<{
 		}),
 	);
 
-export const DetailsPanel: FC<PanelProps> = (panelProps) => {
+export const DetailsPanel: FC<ComponentProps<"div">> = (panelProps) => {
 	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
 	const panelsState = useAppSelector((state) => selectProjectPanelsState(state, projectId));
 	const urgentSelection = useAppSelector((state) => selectProjectSelectionFiles(state, projectId));
@@ -582,13 +582,9 @@ export const DetailsPanel: FC<PanelProps> = (panelProps) => {
 	const detailsOpacity = urgentSelection !== selection ? 0.5 : 1;
 	const [commitView, setCommitView] = useState<CommitView>("diff");
 	const showDiff = selection._tag !== "Commit" || commitView === "diff";
-	const { defaultLayout, onLayoutChanged } = useDefaultLayout({
-		id: `project:${projectId}:details`,
-		panelIds: panelsState.filesVisible ? ["files", "details"] : ["details"],
-	});
 
 	return (
-		<Panel {...panelProps} className={classes(panelProps.className, styles.panel)}>
+		<div {...panelProps} className={classes(panelProps.className, styles.panel)}>
 			<div className={styles.headerWrap} style={{ opacity: detailsOpacity }}>
 				<Suspense fallback={<p className="text-13">Loading details…</p>}>
 					<Header
@@ -609,28 +605,20 @@ export const DetailsPanel: FC<PanelProps> = (panelProps) => {
 			)}
 
 			{showDiff && (
-				<Group
-					className={styles.panels}
-					defaultLayout={defaultLayout}
-					onLayoutChange={onLayoutChanged}
-				>
+				<div className={classes(styles.panels, panelsState.filesVisible && styles.panelsWithFiles)}>
 					{panelsState.filesVisible && (
-						<>
-							<FilesPanel
-								id="files"
-								minSize={250}
-								defaultSize={400}
-								groupResizeBehavior="preserve-pixel-size"
-								tabIndex={0}
-								className={styles.filesPanel}
-							/>
-							<Separator className={styles.panelResizeHandle} />
-						</>
+						<FilesPanel
+							id={"files" satisfies Panel}
+							data-panel
+							tabIndex={0}
+							className={styles.filesPanel}
+						/>
 					)}
 
-					<Panel
-						id="details"
-						minSize={400}
+					<div
+						id={"details" satisfies Panel}
+						data-panel
+						// oxlint-disable-next-line jsx_a11y/no-noninteractive-tabindex -- Revisit this when we add hunk/line selection.
 						tabIndex={0}
 						className={classes(
 							styles.detailsContentPanel,
@@ -643,9 +631,9 @@ export const DetailsPanel: FC<PanelProps> = (panelProps) => {
 								<DiffContents projectId={projectId} selection={selection} />
 							</Suspense>
 						</Virtualizer>
-					</Panel>
-				</Group>
+					</div>
+				</div>
 			)}
-		</Panel>
+		</div>
 	);
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.tsx
@@ -622,7 +622,7 @@ export const DetailsPanel: FC<PanelProps> = (panelProps) => {
 								defaultSize={400}
 								groupResizeBehavior="preserve-pixel-size"
 								tabIndex={0}
-								className={classes(styles.filesPanel)}
+								className={styles.filesPanel}
 							/>
 							<Separator className={styles.panelResizeHandle} />
 						</>

--- a/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.tsx
@@ -610,7 +610,7 @@ export const DetailsPanel: FC<PanelProps> = (panelProps) => {
 
 			{showDiff && (
 				<Group
-					className={styles.panes}
+					className={styles.panels}
 					defaultLayout={defaultLayout}
 					onLayoutChange={onLayoutChanged}
 				>

--- a/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.tsx
@@ -597,11 +597,9 @@ export const DetailsPanel: FC<ComponentProps<"div">> = (panelProps) => {
 			</div>
 
 			{selection._tag === "Commit" && commitView === "details" && (
-				<div className={styles.commitDetailsWrapper}>
-					<Suspense>
-						<CommitDetailsContent projectId={projectId} commitId={selection.commitId} />
-					</Suspense>
-				</div>
+				<Suspense>
+					<CommitDetailsContent projectId={projectId} commitId={selection.commitId} />
+				</Suspense>
 			)}
 
 			{showDiff && (
@@ -620,10 +618,7 @@ export const DetailsPanel: FC<ComponentProps<"div">> = (panelProps) => {
 						data-panel
 						// oxlint-disable-next-line jsx_a11y/no-noninteractive-tabindex -- Revisit this when we add hunk/line selection.
 						tabIndex={0}
-						className={classes(
-							styles.detailsContentPanel,
-							panelsState.filesVisible && styles.alongsideFiles,
-						)}
+						className={styles.detailsContentPanel}
 						style={{ opacity: detailsOpacity }}
 					>
 						<Virtualizer className={styles.detailsVirtualizer}>

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesPanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesPanel.module.css
@@ -2,6 +2,11 @@
 	display: flex;
 	row-gap: 24px;
 	flex-direction: column;
+
+	&:focus {
+		/* The focus state is displayed on the item row instead. */
+		outline: none;
+	}
 }
 
 .item,

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesPanel.tsx
@@ -42,7 +42,6 @@ import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
 import { Array, Match } from "effect";
 import { ComponentProps, createContext, FC, ReactNode, Suspense, use, useEffect } from "react";
-import { Panel, PanelProps } from "react-resizable-panels";
 import styles from "./FilesPanel.module.css";
 import workspaceItemRowStyles from "./WorkspaceItemRow.module.css";
 import { WorkspaceItemRow, WorkspaceItemRowToolbar } from "./WorkspaceItemRow.tsx";
@@ -153,11 +152,9 @@ const useFilesTreeHotkeys = ({
 	});
 };
 
-const CommitFilesTreePanel: FC<{ projectId: string; commit: CommitOperand } & PanelProps> = ({
-	projectId,
-	commit,
-	...panelProps
-}) => {
+const CommitFilesTreePanel: FC<
+	{ projectId: string; commit: CommitOperand } & ComponentProps<"div">
+> = ({ projectId, commit, ...panelProps }) => {
 	const { data } = useSuspenseQuery(
 		commitDetailsWithLineStatsQueryOptions({ projectId, commitId: commit.commitId }),
 	);
@@ -232,7 +229,7 @@ const CommitFilesTreePanel: FC<{ projectId: string; commit: CommitOperand } & Pa
 const ChangesFilesTreePanel: FC<
 	{
 		projectId: string;
-	} & PanelProps
+	} & ComponentProps<"div">
 > = ({ projectId, ...panelProps }) => {
 	const { data: worktreeChanges } = useSuspenseQuery(changesInWorktreeQueryOptions(projectId));
 
@@ -278,7 +275,7 @@ const BranchFilesTreePanel: FC<
 		projectId: string;
 		stackId: string;
 		branchRef: Array<number>;
-	} & PanelProps
+	} & ComponentProps<"div">
 > = ({ projectId, stackId, branchRef, ...panelProps }) => {
 	const decodedBranchRef = decodeRefName(branchRef);
 	const { data: branchDiff } = useSuspenseQuery(
@@ -317,7 +314,7 @@ const BranchFilesTreePanel: FC<
 	);
 };
 
-export const FilesPanel: FC<PanelProps> = (panelProps) => {
+export const FilesPanel: FC<ComponentProps<"div">> = (panelProps) => {
 	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
 
 	const outlineSelection = useAppSelector((state) =>
@@ -327,9 +324,9 @@ export const FilesPanel: FC<PanelProps> = (panelProps) => {
 	return (
 		<Suspense
 			fallback={
-				<Panel {...panelProps} className={classes(panelProps.className, styles.loading)}>
+				<div {...panelProps} className={classes(panelProps.className, styles.loading)}>
 					Loading files…
-				</Panel>
+				</div>
 			}
 		>
 			{Match.value(outlineSelection).pipe(
@@ -347,13 +344,13 @@ export const FilesPanel: FC<PanelProps> = (panelProps) => {
 						branchRef={branchRef}
 					/>
 				)),
-				Match.orElse(() => <Panel {...panelProps} />),
+				Match.orElse(() => <div {...panelProps} />),
 			)}
 		</Suspense>
 	);
 };
 
-const FilesTreePanel: FC<{ parent: Operand; files: Array<Operand> } & PanelProps> = ({
+const FilesTreePanel: FC<{ parent: Operand; files: Array<Operand> } & ComponentProps<"div">> = ({
 	className,
 	children,
 	parent,
@@ -372,7 +369,7 @@ const FilesTreePanel: FC<{ parent: Operand; files: Array<Operand> } & PanelProps
 
 	return (
 		<NavigationIndexContext value={navigationIndex}>
-			<Panel
+			<div
 				{...panelProps}
 				tabIndex={0}
 				role="tree"
@@ -400,7 +397,7 @@ const FilesTreePanel: FC<{ parent: Operand; files: Array<Operand> } & PanelProps
 
 					{children}
 				</TreeItem>
-			</Panel>
+			</div>
 		</NavigationIndexContext>
 	);
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesPanel.tsx
@@ -317,7 +317,7 @@ const BranchFilesTreePanel: FC<
 	);
 };
 
-export const FilesPanel: FC<PanelProps> = ({ ...panelProps }) => {
+export const FilesPanel: FC<PanelProps> = (panelProps) => {
 	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
 
 	const outlineSelection = useAppSelector((state) =>

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationTarget.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationTarget.module.css
@@ -2,7 +2,6 @@
 	display: flex;
 	position: relative;
 	flex-direction: column;
-	min-width: 0;
 }
 
 .activeTarget {

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.module.css
@@ -31,9 +31,19 @@
 
 .panel {
 	display: grid;
+
+	/* `operationSourcePreview` is relative to this. */
+	position: relative;
 	grid-template-rows: auto auto minmax(0, 1fr);
+	grid-template-columns: minmax(0, 1fr);
 	padding-inline: var(--panel-padding);
 	gap: 12px;
+	border-right: 1px solid var(--border-3);
+
+	&:focus {
+		/* The focus state is displayed on the item row instead. */
+		outline: none;
+	}
 }
 
 .headInfo {

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.module.css
@@ -2,7 +2,6 @@
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	margin-block-start: var(--panel-padding);
 	margin-block-end: 4px;
 	overflow: hidden;
 	gap: 6px;
@@ -36,7 +35,7 @@
 	position: relative;
 	grid-template-rows: auto auto minmax(0, 1fr);
 	grid-template-columns: minmax(0, 1fr);
-	padding-inline: var(--panel-padding);
+	padding: var(--panel-padding);
 	gap: 12px;
 	border-right: 1px solid var(--border-3);
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.tsx
@@ -98,7 +98,6 @@ import {
 	useState,
 	useTransition,
 } from "react";
-import { Panel, PanelProps } from "react-resizable-panels";
 import styles from "./OutlinePanel.module.css";
 import workspaceItemRowStyles from "./WorkspaceItemRow.module.css";
 import { WorkspaceItemRow, WorkspaceItemRowToolbar } from "./WorkspaceItemRow.tsx";
@@ -625,7 +624,7 @@ const ActivitySpinner: FC = () => {
 	return status !== null && <Icon name="spinner" aria-label={status} />;
 };
 
-export const OutlinePanel: FC<PanelProps> = (panelProps) => {
+export const OutlinePanel: FC<ComponentProps<"div">> = (panelProps) => {
 	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
 
 	const selection = useAppSelector((state) => selectProjectSelectionOutline(state, projectId));
@@ -693,7 +692,7 @@ export const OutlinePanel: FC<PanelProps> = (panelProps) => {
 		<NavigationIndexContext value={navigationIndex}>
 			<AbsorptionTargetKeysContext value={absorptionTargetKeys}>
 				<DryRunWorkspaceContext value={dryRunWorkspace}>
-					<Panel
+					<div
 						{...panelProps}
 						tabIndex={0}
 						role="tree"
@@ -750,7 +749,7 @@ export const OutlinePanel: FC<PanelProps> = (panelProps) => {
 								)}
 							</div>
 						)}
-					</Panel>
+					</div>
 				</DryRunWorkspaceContext>
 			</AbsorptionTargetKeysContext>
 		</NavigationIndexContext>

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlinePanel.tsx
@@ -625,7 +625,7 @@ const ActivitySpinner: FC = () => {
 	return status !== null && <Icon name="spinner" aria-label={status} />;
 };
 
-export const OutlinePanel: FC<PanelProps> = ({ ...panelProps }) => {
+export const OutlinePanel: FC<PanelProps> = (panelProps) => {
 	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
 
 	const selection = useAppSelector((state) => selectProjectSelectionOutline(state, projectId));

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.module.css
@@ -1,20 +1,9 @@
 .page {
+	display: grid;
+	grid-template-rows: minmax(0, 1fr);
+	grid-template-columns: 400px 1fr;
 	flex-grow: 1;
-}
-
-[data-panel] {
-	/* `operationSourcePreview` is relative to this. */
-	position: relative;
-
-	&:focus {
-		/* The focus state is displayed on the item row instead. */
-		outline: none;
-	}
-}
-
-.panelResizeHandle {
-	width: 1px;
-	background-color: var(--border-3);
+	min-height: 0;
 }
 
 .notFound {

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -37,7 +37,6 @@ import {
 import { useParams } from "@tanstack/react-router";
 import { Match, Order } from "effect";
 import { type FC, Component, ReactNode } from "react";
-import { Group, Separator, useDefaultLayout } from "react-resizable-panels";
 import { branchOperand, type BranchOperand } from "#ui/operands.ts";
 import { PickerDialog, type PickerDialogGroup } from "#ui/components/PickerDialog.tsx";
 import { DetailsPanel } from "./DetailsPanel.tsx";
@@ -440,15 +439,9 @@ const WorkspacePage: FC = () => {
 	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
 
 	const dialog = useAppSelector((state) => selectProjectDialogState(state, projectId));
-	const panelsState = useAppSelector((state) => selectProjectPanelsState(state, projectId));
 	const focusedPanel = useFocusedProjectPanel(projectId);
 
 	useWorkspaceHotkeys(projectId);
-
-	const { defaultLayout, onLayoutChanged } = useDefaultLayout({
-		id: `project:${projectId}:workspace`,
-		panelIds: ["outline", "details-files-container"],
-	});
 
 	const selectBranch = (branch: BranchOperand) => {
 		dispatch(
@@ -477,20 +470,16 @@ const WorkspacePage: FC = () => {
 
 	return (
 		<>
-			<Group className={styles.page} defaultLayout={defaultLayout} onLayoutChange={onLayoutChanged}>
+			<div className={styles.page}>
 				<OutlinePanel
 					id={"outline" satisfies PanelType}
-					minSize={300}
-					defaultSize={500}
-					groupResizeBehavior="preserve-pixel-size"
+					data-panel
 					tabIndex={0}
-					elementRef={(el) => el?.focus({ focusVisible: false })}
+					ref={(el) => el?.focus({ focusVisible: false })}
 				/>
 
-				<Separator className={styles.panelResizeHandle} />
-
-				<DetailsPanel id="details-files-container" minSize={panelsState.filesVisible ? 650 : 400} />
-			</Group>
+				<DetailsPanel />
+			</div>
 
 			{Match.value(dialog).pipe(
 				Match.tagsExhaustive({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -458,9 +458,6 @@ importers:
       react-redux:
         specifier: ^9.2.0
         version: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
-      react-resizable-panels:
-        specifier: ^4.7.3
-        version: 4.7.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
       '@storybook/addon-designs':
         specifier: ^11.1.3
@@ -8363,12 +8360,6 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
-  react-resizable-panels@4.7.3:
-    resolution: {integrity: sha512-PYcYMLtvJD+Pr0TQNeMvddcnLOwUa/Yb4iNwU7ThNLlHaQYEEC9MIBWHaBGODzYuXIkPRZ/OWe5sbzG1Rzq5ew==}
-    peerDependencies:
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
@@ -13766,7 +13757,7 @@ snapshots:
       magic-string: 0.30.21
       sirv: 3.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.7.0)(jsdom@26.1.0)(sass-embedded@1.98.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.7.0)(jsdom@28.1.0)(sass-embedded@1.98.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.2)
       ws: 8.19.0
     optionalDependencies:
       playwright: 1.58.2
@@ -13872,7 +13863,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.7.0)(jsdom@26.1.0)(sass-embedded@1.98.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.7.0)(jsdom@28.1.0)(sass-embedded@1.98.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -17955,11 +17946,6 @@ snapshots:
       redux: 5.0.1
 
   react-refresh@0.18.0: {}
-
-  react-resizable-panels@4.7.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
-    dependencies:
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
 
   react@19.2.4: {}
 


### PR DESCRIPTION
This was adding a lot of complexity and bugs. Let's go without resizing for now and revisit later on once we've locked in the overall UX .