### PR TITLE
[codex] Bump git-meta for agentlog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,7 +936,7 @@ dependencies = [
  "but-workspace",
  "chrono",
  "clap",
- "git-meta-lib 0.1.10 (git+https://github.com/git-meta/git-meta.git?rev=13a3a118c16c07532d84e97df43fdecd4accd6ef)",
+ "git-meta-lib 0.1.10 (git+https://github.com/git-meta/git-meta.git?rev=87ddd03d7cc5ba6d7005c55263ef833ff4ff98c5)",
  "gix 0.84.0",
  "hex",
  "serde",
@@ -3854,7 +3854,7 @@ dependencies = [
 [[package]]
 name = "git-meta-lib"
 version = "0.1.10"
-source = "git+https://github.com/git-meta/git-meta.git?rev=13a3a118c16c07532d84e97df43fdecd4accd6ef#13a3a118c16c07532d84e97df43fdecd4accd6ef"
+source = "git+https://github.com/git-meta/git-meta.git?rev=87ddd03d7cc5ba6d7005c55263ef833ff4ff98c5#87ddd03d7cc5ba6d7005c55263ef833ff4ff98c5"
 dependencies = [
  "gix 0.84.0",
  "rusqlite",

--- a/crates/but-agentlog/Cargo.toml
+++ b/crates/but-agentlog/Cargo.toml
@@ -16,7 +16,7 @@ but-workspace.workspace = true
 chrono = { workspace = true, features = ["clock"] }
 clap.workspace = true
 gix.workspace = true
-git-meta-lib = { git = "https://github.com/git-meta/git-meta.git", rev = "13a3a118c16c07532d84e97df43fdecd4accd6ef" }
+git-meta-lib = { git = "https://github.com/git-meta/git-meta.git", rev = "87ddd03d7cc5ba6d7005c55263ef833ff4ff98c5" }
 hex.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
## What changed

Bumped the `git-meta-lib` Git revision used by `but-agentlog` from `13a3a118c16c07532d84e97df43fdecd4accd6ef` to `87ddd03d7cc5ba6d7005c55263ef833ff4ff98c5` and refreshed `Cargo.lock`.

## Impact

Keeps `but-agentlog` on the latest upstream `git-meta` revision while preserving the existing `0.1.10` crate version.

## Validation

- `cargo check -p but-agentlog --all-targets`
- `cargo test -p but-agentlog --all-targets`
- `cargo machete`