### PR TITLE
Make agentlog captures local by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -201,7 +201,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -244,7 +244,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -852,7 +852,7 @@ dependencies = [
  "gitbutler-project",
  "gitbutler-repo",
  "gitbutler-watcher",
- "gix 0.84.0",
+ "gix",
  "indexmap 2.14.0",
  "insta",
  "itertools",
@@ -912,7 +912,7 @@ dependencies = [
  "gitbutler-operating-modes",
  "gitbutler-oplog",
  "gitbutler-reference",
- "gix 0.84.0",
+ "gix",
  "itertools",
  "rmcp",
  "schemars 1.2.1",
@@ -936,8 +936,8 @@ dependencies = [
  "but-workspace",
  "chrono",
  "clap",
- "git-meta-lib 0.1.10 (git+https://github.com/git-meta/git-meta.git?rev=87ddd03d7cc5ba6d7005c55263ef833ff4ff98c5)",
- "gix 0.84.0",
+ "git-meta-lib",
+ "gix",
  "hex",
  "serde",
  "serde_json",
@@ -991,7 +991,7 @@ dependencies = [
  "gitbutler-reference",
  "gitbutler-repo",
  "gitbutler-user",
- "gix 0.84.0",
+ "gix",
  "insta",
  "itertools",
  "napi",
@@ -1029,7 +1029,7 @@ dependencies = [
  "but-ctx",
  "but-error",
  "futures",
- "gix 0.84.0",
+ "gix",
  "napi",
  "napi-derive",
  "serde",
@@ -1062,7 +1062,7 @@ dependencies = [
  "but-workspace",
  "gitbutler-branch-actions",
  "gitbutler-workspace",
- "gix 0.84.0",
+ "gix",
  "serde",
 ]
 
@@ -1091,7 +1091,7 @@ dependencies = [
  "chardetng",
  "fslock",
  "git2",
- "gix 0.84.0",
+ "gix",
  "insta",
  "parking_lot",
  "rand 0.9.4",
@@ -1122,7 +1122,7 @@ dependencies = [
  "but-utils",
  "git2",
  "gitbutler-project",
- "gix 0.84.0",
+ "gix",
  "serde_json",
  "tracing",
 ]
@@ -1156,7 +1156,7 @@ dependencies = [
  "but-workspace",
  "clap",
  "gitbutler-reference",
- "gix 0.84.0",
+ "gix",
  "insta",
  "open",
  "prodash",
@@ -1190,7 +1190,7 @@ dependencies = [
  "but-ctx",
  "but-graph",
  "chrono",
- "gix 0.84.0",
+ "gix",
  "tempfile",
  "walkdir",
  "zip",
@@ -1241,7 +1241,7 @@ dependencies = [
  "but-testsupport",
  "chrono",
  "gitbutler-commit",
- "gix 0.84.0",
+ "gix",
  "schemars 1.2.1",
  "serde",
  "snapbox",
@@ -1295,7 +1295,7 @@ dependencies = [
  "but-meta",
  "but-testsupport",
  "gitbutler-reference",
- "gix 0.84.0",
+ "gix",
  "insta",
  "itertools",
  "petgraph",
@@ -1314,7 +1314,7 @@ dependencies = [
  "but-hunk-dependency",
  "but-schemars",
  "but-serde",
- "gix 0.84.0",
+ "gix",
  "itertools",
  "schemars 1.2.1",
  "serde",
@@ -1335,7 +1335,7 @@ dependencies = [
  "but-schemars",
  "but-serde",
  "but-testsupport",
- "gix 0.84.0",
+ "gix",
  "insta",
  "itertools",
  "schemars 1.2.1",
@@ -1391,7 +1391,7 @@ dependencies = [
  "but-secret",
  "but-tools",
  "futures",
- "gix 0.84.0",
+ "gix",
  "reqwest",
  "schemars 1.2.1",
  "serde",
@@ -1416,7 +1416,7 @@ dependencies = [
  "but-testsupport",
  "but-utils",
  "gitbutler-reference",
- "gix 0.84.0",
+ "gix",
  "hex",
  "insta",
  "itertools",
@@ -1453,7 +1453,7 @@ dependencies = [
  "but-core",
  "but-ctx",
  "gitbutler-oplog",
- "gix 0.84.0",
+ "gix",
  "tracing",
 ]
 
@@ -1463,7 +1463,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "git2",
- "gix 0.84.0",
+ "gix",
 ]
 
 [[package]]
@@ -1483,7 +1483,7 @@ dependencies = [
  "base64 0.22.1",
  "but-path",
  "but-testsupport",
- "gix 0.84.0",
+ "gix",
  "serde",
  "serde_json",
  "tracing",
@@ -1504,7 +1504,7 @@ dependencies = [
  "but-schemars",
  "but-testsupport",
  "gitbutler-reference",
- "gix 0.84.0",
+ "gix",
  "insta",
  "petgraph",
  "schemars 1.2.1",
@@ -1527,7 +1527,7 @@ dependencies = [
  "but-rebase",
  "but-workspace",
  "chrono",
- "gix 0.84.0",
+ "gix",
  "itertools",
  "regex",
  "serde",
@@ -1551,7 +1551,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "but-error",
- "gix 0.84.0",
+ "gix",
  "keyring",
  "serde",
  "tracing",
@@ -1563,7 +1563,7 @@ version = "0.0.0"
 dependencies = [
  "bstr",
  "git2",
- "gix 0.84.0",
+ "gix",
  "serde",
 ]
 
@@ -1624,7 +1624,7 @@ dependencies = [
  "but-graph",
  "but-meta",
  "but-settings",
- "gix 0.84.0",
+ "gix",
  "gix-testtools",
  "regex",
  "shell-words",
@@ -1641,7 +1641,7 @@ dependencies = [
  "but-core",
  "but-ctx",
  "but-workspace",
- "gix 0.84.0",
+ "gix",
  "serde",
  "serde_json",
 ]
@@ -1660,7 +1660,7 @@ dependencies = [
  "but-rebase",
  "but-testsupport",
  "but-workspace",
- "gix 0.84.0",
+ "gix",
  "snapbox",
 ]
 
@@ -1700,7 +1700,7 @@ name = "but-utils"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "gix 0.84.0",
+ "gix",
  "serde",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
@@ -1731,7 +1731,7 @@ dependencies = [
  "gitbutler-reference",
  "gitbutler-repo",
  "gitbutler-stack",
- "gix 0.84.0",
+ "gix",
  "indexmap 2.14.0",
  "insta",
  "itertools",
@@ -1759,7 +1759,7 @@ dependencies = [
  "gitbutler-branch-actions",
  "gitbutler-stack",
  "gitbutler-workspace",
- "gix 0.84.0",
+ "gix",
  "insta",
  "serde",
  "tracing",
@@ -2143,7 +2143,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2919,7 +2919,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3184,7 +3184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3839,24 +3839,9 @@ dependencies = [
 [[package]]
 name = "git-meta-lib"
 version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8d88d5f482ae39baea4b7375ccb5e99932c5f6079436530f044854763e30c1"
+source = "git+https://github.com/git-meta/git-meta?rev=b40c108514a992abea2f739889376334481af1a3#b40c108514a992abea2f739889376334481af1a3"
 dependencies = [
- "gix 0.83.0",
- "rusqlite",
- "serde",
- "serde_json",
- "sha1",
- "thiserror 2.0.18",
- "time",
-]
-
-[[package]]
-name = "git-meta-lib"
-version = "0.1.10"
-source = "git+https://github.com/git-meta/git-meta.git?rev=87ddd03d7cc5ba6d7005c55263ef833ff4ff98c5#87ddd03d7cc5ba6d7005c55263ef833ff4ff98c5"
-dependencies = [
- "gix 0.84.0",
+ "gix",
  "rusqlite",
  "serde",
  "serde_json",
@@ -3914,7 +3899,7 @@ dependencies = [
  "but-core",
  "but-schemars",
  "gitbutler-reference",
- "gix 0.84.0",
+ "gix",
  "lazy_static",
  "schemars 1.2.1",
  "serde",
@@ -3957,7 +3942,7 @@ dependencies = [
  "gitbutler-repo-actions",
  "gitbutler-stack",
  "gitbutler-workspace",
- "gix 0.84.0",
+ "gix",
  "glob",
  "insta",
  "itertools",
@@ -3977,7 +3962,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "gitbutler-commit",
- "gix 0.84.0",
+ "gix",
 ]
 
 [[package]]
@@ -3986,7 +3971,7 @@ version = "0.0.0"
 dependencies = [
  "bstr",
  "but-core",
- "gix 0.84.0",
+ "gix",
 ]
 
 [[package]]
@@ -4003,14 +3988,14 @@ dependencies = [
  "but-rebase",
  "but-schemars",
  "but-testsupport",
- "git-meta-lib 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-meta-lib",
  "git2",
  "gitbutler-cherry-pick",
  "gitbutler-commit",
  "gitbutler-operating-modes",
  "gitbutler-oplog",
  "gitbutler-workspace",
- "gix 0.84.0",
+ "gix",
  "insta",
  "schemars 1.2.1",
  "serde",
@@ -4027,7 +4012,7 @@ dependencies = [
  "but-project-handle",
  "but-testsupport",
  "gitbutler-notify-debouncer",
- "gix 0.84.0",
+ "gix",
  "insta",
  "notify",
  "tokio",
@@ -4046,7 +4031,7 @@ dependencies = [
  "but-testsupport",
  "file-id 0.2.3 (git+https://github.com/notify-rs/notify?rev=978fe719b066a8ce76b9a9d346546b1569eecfb6)",
  "futures",
- "gix 0.84.0",
+ "gix",
  "nix 0.30.1",
  "rand 0.9.4",
  "serde",
@@ -4088,7 +4073,7 @@ dependencies = [
  "but-testsupport",
  "but-utils",
  "but-workspace",
- "gix 0.84.0",
+ "gix",
  "schemars 1.2.1",
  "serde",
  "toml 0.9.12+spec-1.1.0",
@@ -4113,7 +4098,7 @@ dependencies = [
  "gitbutler-branch",
  "gitbutler-cherry-pick",
  "gitbutler-repo",
- "gix 0.84.0",
+ "gix",
  "itertools",
  "pretty_assertions",
  "schemars 1.2.1",
@@ -4138,7 +4123,7 @@ dependencies = [
  "but-serde",
  "but-testsupport",
  "but-utils",
- "gix 0.84.0",
+ "gix",
  "insta",
  "schemars 1.2.1",
  "serde",
@@ -4154,7 +4139,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "but-core",
- "gix 0.84.0",
+ "gix",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -4179,7 +4164,7 @@ dependencies = [
  "gitbutler-project",
  "gitbutler-reference",
  "gitbutler-user",
- "gix 0.84.0",
+ "gix",
  "ignore",
  "infer",
  "insta",
@@ -4201,7 +4186,7 @@ dependencies = [
  "but-ctx",
  "gitbutler-repo",
  "gitbutler-stack",
- "gix 0.84.0",
+ "gix",
 ]
 
 [[package]]
@@ -4223,7 +4208,7 @@ dependencies = [
  "gitbutler-git",
  "gitbutler-reference",
  "gitbutler-repo",
- "gix 0.84.0",
+ "gix",
  "insta",
  "itertools",
  "serde",
@@ -4254,7 +4239,7 @@ dependencies = [
  "document-features",
  "gitbutler-project",
  "gitbutler-watcher",
- "gix 0.84.0",
+ "gix",
  "notify-rust",
  "open",
  "opener",
@@ -4329,7 +4314,7 @@ dependencies = [
  "but-settings",
  "gitbutler-filemonitor",
  "gitbutler-operating-modes",
- "gix 0.84.0",
+ "gix",
  "serde-error",
  "tokio",
  "tokio-util",
@@ -4347,64 +4332,7 @@ dependencies = [
  "but-oxidize",
  "git2",
  "gitbutler-cherry-pick",
- "gix 0.84.0",
-]
-
-[[package]]
-name = "gix"
-version = "0.83.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce52001b946a6249d5d0d3011df0a042ac3f8a4d013460db6476577b0b9c567"
-dependencies = [
- "gix-actor 0.41.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-archive",
- "gix-attributes 0.33.0",
- "gix-blame",
- "gix-command 0.9.0",
- "gix-commitgraph 0.37.0",
- "gix-config 0.56.0",
- "gix-date 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-diff 0.63.0",
- "gix-dir 0.25.0",
- "gix-discover 0.51.0",
- "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-features 0.48.0",
- "gix-filter 0.30.0",
- "gix-fs 0.21.1",
- "gix-glob 0.26.0",
- "gix-hash 0.25.0",
- "gix-hashtable 0.15.0",
- "gix-ignore 0.21.0",
- "gix-index 0.51.0",
- "gix-lock 23.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-merge 0.16.0",
- "gix-negotiate 0.31.0",
- "gix-object 0.60.0",
- "gix-odb 0.80.0",
- "gix-pack 0.70.0",
- "gix-path 0.12.0",
- "gix-pathspec 0.18.0",
- "gix-protocol 0.61.0",
- "gix-ref 0.63.0",
- "gix-refspec 0.41.0",
- "gix-revision 0.45.0",
- "gix-revwalk 0.31.0",
- "gix-sec 0.14.0",
- "gix-shallow 0.12.0",
- "gix-status 0.30.0",
- "gix-submodule 0.30.0",
- "gix-tempfile 23.0.0",
- "gix-trace 0.1.19",
- "gix-traverse 0.57.0",
- "gix-url 0.36.0",
- "gix-utils 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-validate 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-worktree 0.52.0",
- "gix-worktree-state 0.30.0",
- "gix-worktree-stream 0.32.0",
- "nonempty",
- "smallvec",
- "thiserror 2.0.18",
+ "gix",
 ]
 
 [[package]]
@@ -4412,54 +4340,54 @@ name = "gix"
 version = "0.84.0"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
- "gix-actor 0.41.1 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-attributes 0.33.1",
- "gix-command 0.9.1",
- "gix-commitgraph 0.37.1",
- "gix-config 0.57.0",
+ "gix-actor",
+ "gix-attributes",
+ "gix-command",
+ "gix-commitgraph",
+ "gix-config",
  "gix-credentials",
- "gix-date 0.15.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-diff 0.64.0",
- "gix-dir 0.26.0",
- "gix-discover 0.52.0",
- "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-features 0.48.1",
- "gix-filter 0.31.0",
- "gix-fs 0.21.2",
- "gix-glob 0.26.1",
- "gix-hash 0.25.1",
- "gix-hashtable 0.15.1",
- "gix-ignore 0.21.1",
- "gix-index 0.52.0",
- "gix-lock 23.0.1 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-date",
+ "gix-diff",
+ "gix-dir",
+ "gix-discover",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-ignore",
+ "gix-index",
+ "gix-lock",
  "gix-mailmap",
- "gix-merge 0.17.0",
- "gix-negotiate 0.32.0",
- "gix-object 0.61.0",
- "gix-odb 0.81.0",
- "gix-pack 0.71.0",
+ "gix-merge",
+ "gix-negotiate",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
  "gix-path 0.12.1",
- "gix-pathspec 0.18.1",
+ "gix-pathspec",
  "gix-prompt",
- "gix-protocol 0.62.0",
- "gix-ref 0.64.0",
- "gix-refspec 0.42.0",
- "gix-revision 0.46.0",
- "gix-revwalk 0.32.0",
- "gix-sec 0.14.1",
- "gix-shallow 0.12.1",
- "gix-status 0.31.0",
- "gix-submodule 0.31.0",
- "gix-tempfile 23.0.1",
+ "gix-protocol",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-sec",
+ "gix-shallow",
+ "gix-status",
+ "gix-submodule",
+ "gix-tempfile",
  "gix-trace 0.1.20",
- "gix-transport 0.57.1",
- "gix-traverse 0.58.0",
- "gix-url 0.36.1",
- "gix-utils 0.3.3 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-validate 0.11.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-worktree 0.53.0",
- "gix-worktree-state 0.31.0",
- "gix-worktree-stream 0.33.0",
+ "gix-transport",
+ "gix-traverse",
+ "gix-url",
+ "gix-utils",
+ "gix-validate 0.11.2",
+ "gix-worktree",
+ "gix-worktree-state",
+ "gix-worktree-stream",
  "nonempty",
  "parking_lot",
  "serde",
@@ -4471,53 +4399,12 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.41.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc998b8f746dda8565450d08a63b792ced9165d8c27a1ed3f02799ec6a7820f"
-dependencies = [
- "bstr",
- "gix-date 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "gix-actor"
-version = "0.41.1"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
- "gix-date 0.15.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-date",
+ "gix-error",
  "serde",
-]
-
-[[package]]
-name = "gix-archive"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a20ec244b733338d4cb60e5e05eac700dab7fcc689647b1d1daa9396b119342"
-dependencies = [
- "bstr",
- "gix-date 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-object 0.60.0",
- "gix-worktree-stream 0.32.0",
-]
-
-[[package]]
-name = "gix-attributes"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe17c5a1c0b6f2ef1476aa1d3222ea50cdff67608016613a58bfc3e078046000"
-dependencies = [
- "bstr",
- "gix-glob 0.26.0",
- "gix-path 0.12.0",
- "gix-quote 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-trace 0.1.19",
- "kstring",
- "smallvec",
- "thiserror 2.0.18",
- "unicode-bom",
 ]
 
 [[package]]
@@ -4526,9 +4413,9 @@ version = "0.33.1"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
- "gix-glob 0.26.1",
+ "gix-glob",
  "gix-path 0.12.1",
- "gix-quote 0.7.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-quote",
  "gix-trace 0.1.20",
  "kstring",
  "serde",
@@ -4540,47 +4427,9 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ebef0c26ad305747649e727bbcd56a7b7910754eb7cea88f6dff6f93c51283"
-dependencies = [
- "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "gix-bitmap"
-version = "0.3.2"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
- "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
-]
-
-[[package]]
-name = "gix-blame"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dab9a942ab54a9661ded7397c3bf927274e7afa94494db0d75cfcbde02ca0a"
-dependencies = [
- "gix-commitgraph 0.37.0",
- "gix-date 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-diff 0.63.0",
- "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.25.0",
- "gix-object 0.60.0",
- "gix-revwalk 0.31.0",
- "gix-trace 0.1.19",
- "gix-traverse 0.57.0",
- "gix-worktree 0.52.0",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-chunk"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9faee47943b638e58ddd5e275a4906ad3e4b6c8584f1d41bd18ab9032ec52afb"
-dependencies = [
- "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-error",
 ]
 
 [[package]]
@@ -4588,20 +4437,7 @@ name = "gix-chunk"
 version = "0.7.2"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
- "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
-]
-
-[[package]]
-name = "gix-command"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86335306511abe43d75c866d4b1f3d90932fe202edcd43e1314036333e7384d8"
-dependencies = [
- "bstr",
- "gix-path 0.12.0",
- "gix-quote 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-trace 0.1.19",
- "shell-words",
+ "gix-error",
 ]
 
 [[package]]
@@ -4611,23 +4447,9 @@ source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48
 dependencies = [
  "bstr",
  "gix-path 0.12.1",
- "gix-quote 0.7.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-quote",
  "gix-trace 0.1.20",
  "shell-words",
-]
-
-[[package]]
-name = "gix-commitgraph"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3b5aa0f24e19028c261d229aeeedafcaaa52ebd71021cc15184620fc9d32eb"
-dependencies = [
- "bstr",
- "gix-chunk 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.25.0",
- "memmap2",
- "nonempty",
 ]
 
 [[package]]
@@ -4636,30 +4458,12 @@ version = "0.37.1"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
- "gix-chunk 0.7.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-hash 0.25.1",
+ "gix-chunk",
+ "gix-error",
+ "gix-hash",
  "memmap2",
  "nonempty",
  "serde",
-]
-
-[[package]]
-name = "gix-config"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c01848aebd21c67f6ba41f1de8efd46ae96df21f001954a3c9e1517e514d410"
-dependencies = [
- "bstr",
- "gix-config-value 0.18.0",
- "gix-features 0.48.0",
- "gix-glob 0.26.0",
- "gix-path 0.12.0",
- "gix-ref 0.63.0",
- "gix-sec 0.14.0",
- "smallvec",
- "thiserror 2.0.18",
- "unicode-bom",
 ]
 
 [[package]]
@@ -4668,28 +4472,15 @@ version = "0.57.0"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
- "gix-config-value 0.18.1",
- "gix-features 0.48.1",
- "gix-glob 0.26.1",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
  "gix-path 0.12.1",
- "gix-ref 0.64.0",
- "gix-sec 0.14.1",
+ "gix-ref",
+ "gix-sec",
  "smallvec",
  "thiserror 2.0.18",
  "unicode-bom",
-]
-
-[[package]]
-name = "gix-config-value"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b39ed39ee4c10a3b157f9fb94bac8098d9f8e56201f0cf7dee6c187416c4b2"
-dependencies = [
- "bitflags 2.11.1",
- "bstr",
- "gix-path 0.12.0",
- "libc",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4710,28 +4501,16 @@ version = "0.38.1"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
- "gix-command 0.9.1",
- "gix-config-value 0.18.1",
- "gix-date 0.15.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-command",
+ "gix-config-value",
+ "gix-date",
  "gix-path 0.12.1",
  "gix-prompt",
- "gix-sec 0.14.1",
+ "gix-sec",
  "gix-trace 0.1.20",
- "gix-url 0.36.1",
+ "gix-url",
  "serde",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-date"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ecab64a98bbac9f8e02990a9ea5e3c974a7d49b95f2bd70ad94ad22fa6b48c"
-dependencies = [
- "bstr",
- "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa",
- "jiff",
 ]
 
 [[package]]
@@ -4740,31 +4519,10 @@ version = "0.15.4"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
- "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-error",
  "itoa",
  "jiff",
  "serde",
-]
-
-[[package]]
-name = "gix-diff"
-version = "0.63.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc08e0fa1a91ff5f24affeab052f198056645e1de004910bde7b82b50ea5982a"
-dependencies = [
- "bstr",
- "gix-command 0.9.0",
- "gix-filter 0.30.0",
- "gix-fs 0.21.1",
- "gix-hash 0.25.0",
- "gix-imara-diff 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-object 0.60.0",
- "gix-path 0.12.0",
- "gix-tempfile 23.0.0",
- "gix-trace 0.1.19",
- "gix-traverse 0.57.0",
- "gix-worktree 0.52.0",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4773,40 +4531,20 @@ version = "0.64.0"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
- "gix-attributes 0.33.1",
- "gix-command 0.9.1",
- "gix-filter 0.31.0",
- "gix-fs 0.21.2",
- "gix-hash 0.25.1",
- "gix-imara-diff 0.2.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-index 0.52.0",
- "gix-object 0.61.0",
+ "gix-attributes",
+ "gix-command",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-imara-diff",
+ "gix-index",
+ "gix-object",
  "gix-path 0.12.1",
- "gix-pathspec 0.18.1",
- "gix-tempfile 23.0.1",
+ "gix-pathspec",
+ "gix-tempfile",
  "gix-trace 0.1.20",
- "gix-traverse 0.58.0",
- "gix-worktree 0.53.0",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-dir"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a0fc06e9e1e430cbf0a313666976d90f822f461a6525320427aa9b8af5236c"
-dependencies = [
- "bstr",
- "gix-discover 0.51.0",
- "gix-fs 0.21.1",
- "gix-ignore 0.21.0",
- "gix-index 0.51.0",
- "gix-object 0.60.0",
- "gix-path 0.12.0",
- "gix-pathspec 0.18.0",
- "gix-trace 0.1.19",
- "gix-utils 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-worktree 0.52.0",
+ "gix-traverse",
+ "gix-worktree",
  "thiserror 2.0.18",
 ]
 
@@ -4816,31 +4554,16 @@ version = "0.26.0"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
- "gix-discover 0.52.0",
- "gix-fs 0.21.2",
- "gix-ignore 0.21.1",
- "gix-index 0.52.0",
- "gix-object 0.61.0",
+ "gix-discover",
+ "gix-fs",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
  "gix-path 0.12.1",
- "gix-pathspec 0.18.1",
+ "gix-pathspec",
  "gix-trace 0.1.20",
- "gix-utils 0.3.3 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-worktree 0.53.0",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-discover"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17852e6a501e688a1702b24ebe5b3761d4719455bc869fd29f38b0b859bcad34"
-dependencies = [
- "bstr",
- "dunce",
- "gix-fs 0.21.1",
- "gix-path 0.12.0",
- "gix-ref 0.63.0",
- "gix-sec 0.14.0",
+ "gix-utils",
+ "gix-worktree",
  "thiserror 2.0.18",
 ]
 
@@ -4851,20 +4574,11 @@ source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48
 dependencies = [
  "bstr",
  "dunce",
- "gix-fs 0.21.2",
+ "gix-fs",
  "gix-path 0.12.1",
- "gix-ref 0.64.0",
- "gix-sec 0.14.1",
+ "gix-ref",
+ "gix-sec",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-error"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57831e199be480af90dcd7e459abed8a174c09ec9a6e2cc8f7ca6c54598b06b"
-dependencies = [
- "bstr",
 ]
 
 [[package]]
@@ -4873,25 +4587,6 @@ version = "0.2.4"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
-]
-
-[[package]]
-name = "gix-features"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af375693ad5333d0a2c66b4c5b2cbe9ccc38e34f8e8bf24e4ae42c12307fdc4f"
-dependencies = [
- "bytes",
- "crc32fast",
- "gix-path 0.12.0",
- "gix-trace 0.1.19",
- "gix-utils 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc",
- "once_cell",
- "prodash",
- "thiserror 2.0.18",
- "walkdir",
- "zlib-rs",
 ]
 
 [[package]]
@@ -4904,7 +4599,7 @@ dependencies = [
  "crossbeam-channel",
  "gix-path 0.12.1",
  "gix-trace 0.1.20",
- "gix-utils 0.3.3 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-utils",
  "libc",
  "once_cell",
  "parking_lot",
@@ -4916,56 +4611,21 @@ dependencies = [
 
 [[package]]
 name = "gix-filter"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac917dbe9653c9b615d248db91907a365bd779750c9e1b457a9d9fdeece3a08"
-dependencies = [
- "bstr",
- "encoding_rs",
- "gix-attributes 0.33.0",
- "gix-command 0.9.0",
- "gix-hash 0.25.0",
- "gix-object 0.60.0",
- "gix-packetline 0.21.3",
- "gix-path 0.12.0",
- "gix-quote 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-trace 0.1.19",
- "gix-utils 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-filter"
 version = "0.31.0"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
  "encoding_rs",
- "gix-attributes 0.33.1",
- "gix-command 0.9.1",
- "gix-hash 0.25.1",
- "gix-object 0.61.0",
- "gix-packetline 0.21.4",
+ "gix-attributes",
+ "gix-command",
+ "gix-hash",
+ "gix-object",
+ "gix-packetline",
  "gix-path 0.12.1",
- "gix-quote 0.7.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-quote",
  "gix-trace 0.1.20",
- "gix-utils 0.3.3 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-utils",
  "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-fs"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e1967daac9848757c47c2aef0c57bcadc1a897347f559778249bf286a536c86"
-dependencies = [
- "bstr",
- "fastrand",
- "gix-features 0.48.0",
- "gix-path 0.12.0",
- "gix-utils 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 2.0.18",
 ]
 
@@ -4976,22 +4636,10 @@ source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48
 dependencies = [
  "bstr",
  "fastrand",
- "gix-features 0.48.1",
+ "gix-features",
  "gix-path 0.12.1",
- "gix-utils 0.3.3 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-utils",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-glob"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bf29249a069bf2507f5964f80997f37b134d320ea348d66527726b9be2c38c"
-dependencies = [
- "bitflags 2.11.1",
- "bstr",
- "gix-features 0.48.0",
- "gix-path 0.12.0",
 ]
 
 [[package]]
@@ -5001,21 +4649,9 @@ source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
- "gix-features 0.48.1",
+ "gix-features",
  "gix-path 0.12.1",
  "serde",
-]
-
-[[package]]
-name = "gix-hash"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf70d1e252337eed16360f8b8ebb71865ece58eab7954b39ce38b420de703d2"
-dependencies = [
- "faster-hex",
- "gix-features 0.48.0",
- "sha1-checked",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5024,7 +4660,7 @@ version = "0.25.1"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "faster-hex",
- "gix-features 0.48.1",
+ "gix-features",
  "serde",
  "sha1-checked",
  "sha2 0.11.0",
@@ -5033,36 +4669,12 @@ dependencies = [
 
 [[package]]
 name = "gix-hashtable"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d33b455e07b3c16d3b2eeebc7b38d2dafcbf8a653de1138ef55d4c2a1fd0b08b"
-dependencies = [
- "gix-hash 0.25.0",
- "hashbrown 0.16.1",
- "parking_lot",
-]
-
-[[package]]
-name = "gix-hashtable"
 version = "0.15.1"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
- "gix-hash 0.25.1",
+ "gix-hash",
  "hashbrown 0.17.0",
  "parking_lot",
-]
-
-[[package]]
-name = "gix-ignore"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb13fbbeeafee943e52b61fcc88dfddf6a452fcaf0c4d0cdc8f218fa25bbec5"
-dependencies = [
- "bstr",
- "gix-glob 0.26.0",
- "gix-path 0.12.0",
- "gix-trace 0.1.19",
- "unicode-bom",
 ]
 
 [[package]]
@@ -5071,7 +4683,7 @@ version = "0.21.1"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
- "gix-glob 0.26.1",
+ "gix-glob",
  "gix-path 0.12.1",
  "gix-trace 0.1.20",
  "serde",
@@ -5081,48 +4693,10 @@ dependencies = [
 [[package]]
 name = "gix-imara-diff"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19"
-dependencies = [
- "bstr",
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "gix-imara-diff"
-version = "0.2.2"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
- "hashbrown 0.16.1",
-]
-
-[[package]]
-name = "gix-index"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c3ef97ad08121e4327a6226bd63fed6b9e3c6b976d48bddd4356d9d41191db"
-dependencies = [
- "bitflags 2.11.1",
- "bstr",
- "filetime",
- "fnv",
- "gix-bitmap 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-features 0.48.0",
- "gix-fs 0.21.1",
- "gix-hash 0.25.0",
- "gix-lock 23.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-object 0.60.0",
- "gix-traverse 0.57.0",
- "gix-utils 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-validate 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hashbrown 0.16.1",
- "itoa",
- "libc",
- "memmap2",
- "rustix 1.1.4",
- "smallvec",
- "thiserror 2.0.18",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -5134,15 +4708,15 @@ dependencies = [
  "bstr",
  "filetime",
  "fnv",
- "gix-bitmap 0.3.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-features 0.48.1",
- "gix-fs 0.21.2",
- "gix-hash 0.25.1",
- "gix-lock 23.0.1 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-object 0.61.0",
- "gix-traverse 0.58.0",
- "gix-utils 0.3.3 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-validate 0.11.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-bitmap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-traverse",
+ "gix-utils",
+ "gix-validate 0.11.2",
  "hashbrown 0.17.0",
  "itoa",
  "libc",
@@ -5156,21 +4730,10 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "23.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c9dedd9e90b0d47624d2ed241d394e09294118364e87b9b7e5f1fe755f3c2c"
-dependencies = [
- "gix-tempfile 23.0.0",
- "gix-utils 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-lock"
-version = "23.0.1"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
- "gix-tempfile 23.0.1",
- "gix-utils 0.3.3 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-tempfile",
+ "gix-utils",
  "thiserror 2.0.18",
 ]
 
@@ -5180,36 +4743,10 @@ version = "0.33.1"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
- "gix-actor 0.41.1 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-date 0.15.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-actor",
+ "gix-date",
+ "gix-error",
  "serde",
-]
-
-[[package]]
-name = "gix-merge"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74bbcdcc52b70a32f0a151b024dff9d0fcf56ee48f00d9503e735af9d99ea881"
-dependencies = [
- "bstr",
- "gix-command 0.9.0",
- "gix-diff 0.63.0",
- "gix-filter 0.30.0",
- "gix-fs 0.21.1",
- "gix-hash 0.25.0",
- "gix-imara-diff 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-index 0.51.0",
- "gix-object 0.60.0",
- "gix-path 0.12.0",
- "gix-quote 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-revision 0.45.0",
- "gix-revwalk 0.31.0",
- "gix-tempfile 23.0.0",
- "gix-trace 0.1.19",
- "gix-worktree 0.52.0",
- "nonempty",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5218,37 +4755,23 @@ version = "0.17.0"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
- "gix-command 0.9.1",
- "gix-diff 0.64.0",
- "gix-filter 0.31.0",
- "gix-fs 0.21.2",
- "gix-hash 0.25.1",
- "gix-imara-diff 0.2.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-index 0.52.0",
- "gix-object 0.61.0",
+ "gix-command",
+ "gix-diff",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-imara-diff",
+ "gix-index",
+ "gix-object",
  "gix-path 0.12.1",
- "gix-quote 0.7.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-revision 0.46.0",
- "gix-revwalk 0.32.0",
- "gix-tempfile 23.0.1",
+ "gix-quote",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-tempfile",
  "gix-trace 0.1.20",
- "gix-worktree 0.53.0",
+ "gix-worktree",
  "nonempty",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-negotiate"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "103d42bfade1b8a96ca5005933127bdad461ce588d92422b2c2daa3ff20d780c"
-dependencies = [
- "bitflags 2.11.1",
- "gix-commitgraph 0.37.0",
- "gix-date 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.25.0",
- "gix-object 0.60.0",
- "gix-revwalk 0.31.0",
 ]
 
 [[package]]
@@ -5257,30 +4780,11 @@ version = "0.32.0"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bitflags 2.11.1",
- "gix-commitgraph 0.37.1",
- "gix-date 0.15.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-hash 0.25.1",
- "gix-object 0.61.0",
- "gix-revwalk 0.32.0",
-]
-
-[[package]]
-name = "gix-object"
-version = "0.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38075a95d7cc5df8afd38e72c617026c1456952207a4120a7f55a3fbf93b4d7"
-dependencies = [
- "bstr",
- "gix-actor 0.41.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-date 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-features 0.48.0",
- "gix-hash 0.25.0",
- "gix-hashtable 0.15.0",
- "gix-utils 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-validate 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa",
- "smallvec",
- "thiserror 2.0.18",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
 ]
 
 [[package]]
@@ -5289,37 +4793,16 @@ version = "0.61.0"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
- "gix-actor 0.41.1 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-date 0.15.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-features 0.48.1",
- "gix-hash 0.25.1",
- "gix-hashtable 0.15.1",
- "gix-utils 0.3.3 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-validate 0.11.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-utils",
+ "gix-validate 0.11.2",
  "itoa",
  "serde",
  "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-odb"
-version = "0.80.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeeda12a9663120418735ecdc1250d06eeab0be75700e47b3402a981331716ba"
-dependencies = [
- "arc-swap",
- "gix-features 0.48.0",
- "gix-fs 0.21.1",
- "gix-hash 0.25.0",
- "gix-hashtable 0.15.0",
- "gix-object 0.60.0",
- "gix-pack 0.70.0",
- "gix-path 0.12.0",
- "gix-quote 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "memmap2",
- "parking_lot",
- "tempfile",
  "thiserror 2.0.18",
 ]
 
@@ -5329,14 +4812,14 @@ version = "0.81.0"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "arc-swap",
- "gix-features 0.48.1",
- "gix-fs 0.21.2",
- "gix-hash 0.25.1",
- "gix-hashtable 0.15.1",
- "gix-object 0.61.0",
- "gix-pack 0.71.0",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-pack",
  "gix-path 0.12.1",
- "gix-quote 0.7.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-quote",
  "memmap2",
  "parking_lot",
  "serde",
@@ -5346,55 +4829,24 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf02e6f5c8f07a069c9ea5245f40d9b14856ada4086091dc99941b49002b4fa"
-dependencies = [
- "clru",
- "gix-chunk 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-features 0.48.0",
- "gix-hash 0.25.0",
- "gix-hashtable 0.15.0",
- "gix-object 0.60.0",
- "gix-path 0.12.0",
- "memmap2",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-pack"
 version = "0.71.0"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "clru",
- "gix-chunk 0.7.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-features 0.48.1",
- "gix-hash 0.25.1",
- "gix-hashtable 0.15.1",
- "gix-object 0.61.0",
+ "gix-chunk",
+ "gix-error",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
  "gix-path 0.12.1",
- "gix-tempfile 23.0.1",
+ "gix-tempfile",
  "memmap2",
  "parking_lot",
  "serde",
  "smallvec",
  "thiserror 2.0.18",
  "uluru",
-]
-
-[[package]]
-name = "gix-packetline"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "362246df440ee691699f0664cbf7006a6ece477db6734222be95e4198e5656e6"
-dependencies = [
- "bstr",
- "faster-hex",
- "gix-trace 0.1.19",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5422,39 +4874,12 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671a6059e8a4c1b7f406e24716499cefa3926e060876fb1959ef225efeee346e"
-dependencies = [
- "bstr",
- "gix-trace 0.1.19",
- "gix-validate 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-path"
 version = "0.12.1"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
  "gix-trace 0.1.20",
- "gix-validate 0.11.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-pathspec"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a84a4f083dd70fb49f4377e13afa6d90df2daaa1c705c49d6ff1331fc7e8855"
-dependencies = [
- "bitflags 2.11.1",
- "bstr",
- "gix-attributes 0.33.0",
- "gix-config-value 0.18.0",
- "gix-glob 0.26.0",
- "gix-path 0.12.0",
+ "gix-validate 0.11.2",
  "thiserror 2.0.18",
 ]
 
@@ -5465,9 +4890,9 @@ source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
- "gix-attributes 0.33.1",
- "gix-config-value 0.18.1",
- "gix-glob 0.26.1",
+ "gix-attributes",
+ "gix-config-value",
+ "gix-glob",
  "gix-path 0.12.1",
  "thiserror 2.0.18",
 ]
@@ -5477,29 +4902,10 @@ name = "gix-prompt"
 version = "0.15.1"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
- "gix-command 0.9.1",
- "gix-config-value 0.18.1",
+ "gix-command",
+ "gix-config-value",
  "parking_lot",
  "rustix 1.1.4",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-protocol"
-version = "0.61.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4bee82db63ec635996b96efae71cf467c155fa3f34a556184373224a26c4fd"
-dependencies = [
- "bstr",
- "gix-date 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-features 0.48.0",
- "gix-hash 0.25.0",
- "gix-ref 0.63.0",
- "gix-shallow 0.12.0",
- "gix-transport 0.57.0",
- "gix-utils 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "maybe-async",
- "nonempty",
  "thiserror 2.0.18",
 ]
 
@@ -5510,19 +4916,19 @@ source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48
 dependencies = [
  "bstr",
  "gix-credentials",
- "gix-date 0.15.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-features 0.48.1",
- "gix-hash 0.25.1",
- "gix-lock 23.0.1 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-negotiate 0.32.0",
- "gix-object 0.61.0",
- "gix-ref 0.64.0",
- "gix-refspec 0.42.0",
- "gix-revwalk 0.32.0",
- "gix-shallow 0.12.1",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-lock",
+ "gix-negotiate",
+ "gix-object",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revwalk",
+ "gix-shallow",
  "gix-trace 0.1.20",
- "gix-transport 0.57.1",
- "gix-utils 0.3.3 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-transport",
+ "gix-utils",
  "maybe-async",
  "nonempty",
  "serde",
@@ -5532,42 +4938,11 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e541fc33cc2b783b7979040d445a0c86a2eca747c8faea4ca84230d06ae6ef"
-dependencies = [
- "bstr",
- "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-utils 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "gix-quote"
-version = "0.7.2"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
- "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-utils 0.3.3 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
-]
-
-[[package]]
-name = "gix-ref"
-version = "0.63.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8ba9cc15f558b274c99349b83130f5ec83459660828fde9718bbbb43a726167"
-dependencies = [
- "gix-actor 0.41.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-features 0.48.0",
- "gix-fs 0.21.1",
- "gix-hash 0.25.0",
- "gix-lock 23.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-object 0.60.0",
- "gix-path 0.12.0",
- "gix-tempfile 23.0.0",
- "gix-utils 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-validate 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "memmap2",
- "thiserror 2.0.18",
+ "gix-error",
+ "gix-utils",
 ]
 
 [[package]]
@@ -5575,34 +4950,18 @@ name = "gix-ref"
 version = "0.64.0"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
- "gix-actor 0.41.1 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-features 0.48.1",
- "gix-fs 0.21.2",
- "gix-hash 0.25.1",
- "gix-lock 23.0.1 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-object 0.61.0",
+ "gix-actor",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
  "gix-path 0.12.1",
- "gix-tempfile 23.0.1",
- "gix-utils 0.3.3 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-validate 0.11.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-tempfile",
+ "gix-utils",
+ "gix-validate 0.11.2",
  "memmap2",
  "serde",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-refspec"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61755b27d57edc8940a1b1593c8c61548ca8e4c02da1ed8d5bfeda9eb2a6b761"
-dependencies = [
- "bstr",
- "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-glob 0.26.0",
- "gix-hash 0.25.0",
- "gix-revision 0.45.0",
- "gix-validate 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec",
  "thiserror 2.0.18",
 ]
 
@@ -5612,32 +4971,13 @@ version = "0.42.0"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
- "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-glob 0.26.1",
- "gix-hash 0.25.1",
- "gix-revision 0.46.0",
- "gix-validate 0.11.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-error",
+ "gix-glob",
+ "gix-hash",
+ "gix-revision",
+ "gix-validate 0.11.2",
  "smallvec",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-revision"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb5288fac706d3ea3e4e2ba9ec38b78743b8c02f422e18cb342299cfd6ab7e8"
-dependencies = [
- "bitflags 2.11.1",
- "bstr",
- "gix-commitgraph 0.37.0",
- "gix-date 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.25.0",
- "gix-hashtable 0.15.0",
- "gix-object 0.60.0",
- "gix-revwalk 0.31.0",
- "gix-trace 0.1.19",
- "nonempty",
 ]
 
 [[package]]
@@ -5647,13 +4987,13 @@ source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
- "gix-commitgraph 0.37.1",
- "gix-date 0.15.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-hash 0.25.1",
- "gix-hashtable 0.15.1",
- "gix-object 0.61.0",
- "gix-revwalk 0.32.0",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
  "gix-trace 0.1.20",
  "nonempty",
  "serde",
@@ -5661,45 +5001,17 @@ dependencies = [
 
 [[package]]
 name = "gix-revwalk"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "313813706b073a12ff7f9b2896bf3e6504cdac7cfbc97b1920114724705069f0"
-dependencies = [
- "gix-commitgraph 0.37.0",
- "gix-date 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.25.0",
- "gix-hashtable 0.15.0",
- "gix-object 0.60.0",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-revwalk"
 version = "0.32.0"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
- "gix-commitgraph 0.37.1",
- "gix-date 0.15.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-hash 0.25.1",
- "gix-hashtable 0.15.1",
- "gix-object 0.61.0",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
  "smallvec",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-sec"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a3a2d3e504a238136751e646a6c028252286a0ea64ea9974bf0498633407c6"
-dependencies = [
- "bitflags 2.11.1",
- "gix-path 0.12.0",
- "libc",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5716,25 +5028,12 @@ dependencies = [
 
 [[package]]
 name = "gix-shallow"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29187305521bfacf4aefd284ab28dbfa9fb74abd39a5e63dd313b1baa5808c27"
-dependencies = [
- "bstr",
- "gix-hash 0.25.0",
- "gix-lock 23.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "nonempty",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-shallow"
 version = "0.12.1"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
- "gix-hash 0.25.1",
- "gix-lock 23.0.1 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-hash",
+ "gix-lock",
  "nonempty",
  "serde",
  "thiserror 2.0.18",
@@ -5742,61 +5041,23 @@ dependencies = [
 
 [[package]]
 name = "gix-status"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c6d2a8c521ffa205fe7e268c82e6d1378ba37cd826ca10ab6129fdc29a4b65"
-dependencies = [
- "bstr",
- "filetime",
- "gix-diff 0.63.0",
- "gix-dir 0.25.0",
- "gix-features 0.48.0",
- "gix-filter 0.30.0",
- "gix-fs 0.21.1",
- "gix-hash 0.25.0",
- "gix-index 0.51.0",
- "gix-object 0.60.0",
- "gix-path 0.12.0",
- "gix-pathspec 0.18.0",
- "gix-worktree 0.52.0",
- "portable-atomic",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-status"
 version = "0.31.0"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
  "filetime",
- "gix-diff 0.64.0",
- "gix-dir 0.26.0",
- "gix-features 0.48.1",
- "gix-filter 0.31.0",
- "gix-fs 0.21.2",
- "gix-hash 0.25.1",
- "gix-index 0.52.0",
- "gix-object 0.61.0",
+ "gix-diff",
+ "gix-dir",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
  "gix-path 0.12.1",
- "gix-pathspec 0.18.1",
- "gix-worktree 0.53.0",
+ "gix-pathspec",
+ "gix-worktree",
  "portable-atomic",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-submodule"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd5fc8692890bd71a596e540fd4c364f8460eaa82c4eaaedebde6e1e3eb4d91"
-dependencies = [
- "bstr",
- "gix-config 0.56.0",
- "gix-path 0.12.0",
- "gix-pathspec 0.18.0",
- "gix-refspec 0.41.0",
- "gix-url 0.36.0",
  "thiserror 2.0.18",
 ]
 
@@ -5806,25 +5067,12 @@ version = "0.31.0"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
- "gix-config 0.57.0",
+ "gix-config",
  "gix-path 0.12.1",
- "gix-pathspec 0.18.1",
- "gix-refspec 0.42.0",
- "gix-url 0.36.1",
+ "gix-pathspec",
+ "gix-refspec",
+ "gix-url",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-tempfile"
-version = "23.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "691ea1e31435c7e7d4d04705ec9d1c0d9482c46b2acf512bc723939d8f0af7fb"
-dependencies = [
- "dashmap",
- "gix-fs 0.21.1",
- "libc",
- "parking_lot",
- "tempfile",
 ]
 
 [[package]]
@@ -5833,7 +5081,7 @@ version = "23.0.1"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "dashmap",
- "gix-fs 0.21.2",
+ "gix-fs",
  "libc",
  "parking_lot",
  "signal-hook 0.4.3",
@@ -5850,12 +5098,12 @@ dependencies = [
  "crc",
  "fastrand",
  "fs_extra",
- "gix-discover 0.52.0",
- "gix-fs 0.21.2",
- "gix-hash 0.25.1",
- "gix-lock 23.0.1 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-tempfile 23.0.1",
- "gix-worktree 0.53.0",
+ "gix-discover",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-tempfile",
+ "gix-worktree",
  "io-close",
  "is_ci",
  "parking_lot",
@@ -5879,53 +5127,20 @@ dependencies = [
 
 [[package]]
 name = "gix-transport"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd6a5c676b92d4ead5f5a2b2935024415dec69edc997b6090ca9cac010a3018"
-dependencies = [
- "bstr",
- "gix-command 0.9.0",
- "gix-features 0.48.0",
- "gix-packetline 0.21.3",
- "gix-quote 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-sec 0.14.0",
- "gix-url 0.36.0",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-transport"
 version = "0.57.1"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "base64 0.22.1",
  "bstr",
- "gix-command 0.9.1",
+ "gix-command",
  "gix-credentials",
- "gix-features 0.48.1",
- "gix-packetline 0.21.4",
- "gix-quote 0.7.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-sec 0.14.1",
- "gix-url 0.36.1",
+ "gix-features",
+ "gix-packetline",
+ "gix-quote",
+ "gix-sec",
+ "gix-url",
  "reqwest",
  "serde",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-traverse"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14b7052c0786676c03e71fcfde7d7f0f8e8316e642b5cec6bb3998719b2ce5c"
-dependencies = [
- "bitflags 2.11.1",
- "gix-commitgraph 0.37.0",
- "gix-date 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.25.0",
- "gix-hashtable 0.15.0",
- "gix-object 0.60.0",
- "gix-revwalk 0.31.0",
- "smallvec",
  "thiserror 2.0.18",
 ]
 
@@ -5935,25 +5150,13 @@ version = "0.58.0"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bitflags 2.11.1",
- "gix-commitgraph 0.37.1",
- "gix-date 0.15.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-hash 0.25.1",
- "gix-hashtable 0.15.1",
- "gix-object 0.61.0",
- "gix-revwalk 0.32.0",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
  "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-url"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35842d099e813f6f6bba529e88d4670572149c3df79b7a412952259887721ece"
-dependencies = [
- "bstr",
- "gix-path 0.12.0",
- "percent-encoding",
  "thiserror 2.0.18",
 ]
 
@@ -5967,17 +5170,6 @@ dependencies = [
  "percent-encoding",
  "serde",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-utils"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c50966184123caf580ffa64e28031a878597f1c7fceb8fe19566c38eb1b771"
-dependencies = [
- "bstr",
- "fastrand",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -6003,36 +5195,9 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc6fc771c4063ba7cd2f47b91fb6076251c6a823b64b7fe7b8874b0fe4afae3"
-dependencies = [
- "bstr",
-]
-
-[[package]]
-name = "gix-validate"
-version = "0.11.2"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
-]
-
-[[package]]
-name = "gix-worktree"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69955eb5e2910832f88d041964b809eee01dadd579237e0b55efec58fd406fd"
-dependencies = [
- "bstr",
- "gix-attributes 0.33.0",
- "gix-fs 0.21.1",
- "gix-glob 0.26.0",
- "gix-hash 0.25.0",
- "gix-ignore 0.21.0",
- "gix-index 0.51.0",
- "gix-object 0.60.0",
- "gix-path 0.12.0",
- "gix-validate 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6041,34 +5206,16 @@ version = "0.53.0"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
- "gix-attributes 0.33.1",
- "gix-fs 0.21.2",
- "gix-glob 0.26.1",
- "gix-hash 0.25.1",
- "gix-ignore 0.21.1",
- "gix-index 0.52.0",
- "gix-object 0.61.0",
+ "gix-attributes",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
  "gix-path 0.12.1",
- "gix-validate 0.11.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
+ "gix-validate 0.11.2",
  "serde",
-]
-
-[[package]]
-name = "gix-worktree-state"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a96dccbcf9e8fe0291c55f06e08da93ebb2e691c1311276f541eefcc6d70800"
-dependencies = [
- "bstr",
- "gix-features 0.48.0",
- "gix-filter 0.30.0",
- "gix-fs 0.21.1",
- "gix-index 0.51.0",
- "gix-object 0.60.0",
- "gix-path 0.12.0",
- "gix-worktree 0.52.0",
- "io-close",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6077,33 +5224,15 @@ version = "0.31.0"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
  "bstr",
- "gix-features 0.48.1",
- "gix-filter 0.31.0",
- "gix-fs 0.21.2",
- "gix-index 0.52.0",
- "gix-object 0.61.0",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-index",
+ "gix-object",
  "gix-path 0.12.1",
- "gix-worktree 0.53.0",
+ "gix-worktree",
  "io-close",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-worktree-stream"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8444b8ed4662e1a0c97f3eceda29630001a1bbb2632201e50312623e594213"
-dependencies = [
- "gix-attributes 0.33.0",
- "gix-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-features 0.48.0",
- "gix-filter 0.30.0",
- "gix-fs 0.21.1",
- "gix-hash 0.25.0",
- "gix-object 0.60.0",
- "gix-path 0.12.0",
- "gix-traverse 0.57.0",
- "parking_lot",
 ]
 
 [[package]]
@@ -6111,15 +5240,15 @@ name = "gix-worktree-stream"
 version = "0.33.0"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5#b5b2d54d6a63921621d48c492eaa77faf89e8cb5"
 dependencies = [
- "gix-attributes 0.33.1",
- "gix-error 0.2.4 (git+https://github.com/GitoxideLabs/gitoxide?rev=b5b2d54d6a63921621d48c492eaa77faf89e8cb5)",
- "gix-features 0.48.1",
- "gix-filter 0.31.0",
- "gix-fs 0.21.2",
- "gix-hash 0.25.1",
- "gix-object 0.61.0",
+ "gix-attributes",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-object",
  "gix-path 0.12.1",
- "gix-traverse 0.58.0",
+ "gix-traverse",
  "parking_lot",
 ]
 
@@ -6577,7 +5706,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -6933,7 +6062,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7008,7 +6137,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7603,7 +6732,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7864,7 +6993,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8408,7 +7537,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -9123,7 +8252,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9680,7 +8809,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9693,7 +8822,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9751,7 +8880,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11301,7 +10430,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11330,7 +10459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11960,7 +11089,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12736,7 +11865,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -310,13 +310,10 @@ self_cell = "1.2.2"
 unicode-segmentation = "1.13.2"
 urlencoding = "2.1"
 inventory = "0.3"
-git-meta-lib = { version = "0.1.10" }
+git-meta-lib = { git = "https://github.com/git-meta/git-meta", rev = "b40c108514a992abea2f739889376334481af1a3" }
 
 [patch.crates-io]
 # Keep workspace crates that use the `gix 0.84` line on the same git revision.
-# Note that this does not currently eliminate duplicate `gix` versions entirely:
-# `git-meta-lib` still depends on `gix 0.83`, so Cargo will continue to pull that
-# version from crates.io until `git-meta-lib` moves to `0.84` as well.
 gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "b5b2d54d6a63921621d48c492eaa77faf89e8cb5" }
 
 [workspace.lints.clippy]

--- a/crates/but-agentlog/Cargo.toml
+++ b/crates/but-agentlog/Cargo.toml
@@ -16,7 +16,7 @@ but-workspace.workspace = true
 chrono = { workspace = true, features = ["clock"] }
 clap.workspace = true
 gix.workspace = true
-git-meta-lib = { git = "https://github.com/git-meta/git-meta.git", rev = "87ddd03d7cc5ba6d7005c55263ef833ff4ff98c5" }
+git-meta-lib.workspace = true
 hex.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/but-agentlog/src/capture.rs
+++ b/crates/but-agentlog/src/capture.rs
@@ -4,7 +4,9 @@ use anyhow::{Context as _, Result};
 use sha2::{Digest, Sha256};
 
 use crate::{
-    agent::Agent, environment::capture_environment, gitmeta::write_transcript_batch,
+    agent::Agent,
+    environment::capture_environment,
+    gitmeta::{CaptureWriteOutcome, write_transcript_batch},
     transcript::TranscriptBatch,
 };
 
@@ -23,7 +25,8 @@ pub(crate) fn record_transcript(
     let Some(transcript) = prepare_transcript(agent, transcript_path)? else {
         return Ok((0, false));
     };
-    record_prepared_transcript(repo_path, agent, transcript)
+    let write = record_prepared_transcript(repo_path, agent, transcript)?;
+    Ok((write.records_written, write.metadata_changed))
 }
 
 pub(crate) fn prepare_transcript(
@@ -60,16 +63,15 @@ pub(crate) fn record_prepared_transcript(
     repo_path: &Path,
     agent: Agent,
     transcript: PreparedTranscript,
-) -> Result<(usize, bool)> {
+) -> Result<CaptureWriteOutcome> {
     let PreparedTranscript {
         session_key,
         source_key,
         batch,
     } = transcript;
-    let write = write_transcript_batch(repo_path, agent, &session_key, &source_key, batch, || {
+    write_transcript_batch(repo_path, agent, &session_key, &source_key, batch, || {
         capture_environment(repo_path)
-    })?;
-    Ok((write.records_written, write.metadata_changed))
+    })
 }
 
 fn agent_identity_key(agent: Agent, identity: &[u8]) -> String {

--- a/crates/but-agentlog/src/cli.rs
+++ b/crates/but-agentlog/src/cli.rs
@@ -13,8 +13,9 @@ use crate::{
     capture::{prepare_transcript, record_prepared_transcript},
     capture_lock::with_capture_lock,
     gitmeta::{
-        RelatedTarget, SessionRecords, SessionTimeline, find_related_sessions_limited,
-        get_session_records, get_session_timeline_outline, sync_metadata,
+        PublicationStatus, RelatedSession, RelatedTarget, SessionRecords, SessionTimeline,
+        find_related_sessions_limited_by_statuses, find_session_status, get_session_records,
+        get_session_timeline_outline, share_sessions, sync_metadata,
     },
     skim::{self, SkimReport},
 };
@@ -51,6 +52,22 @@ pub enum Command {
         #[clap(value_name = "VALUE", value_parser = non_empty_value)]
         value: Option<String>,
     },
+    /// Share local-only agent sessions for a branch, review, or change.
+    #[clap(
+        name = "publish",
+        after_help = "Examples:\n  but agentlog publish main\n  but agentlog publish branch main\n  but agentlog publish review <id>\n  but agentlog publish change <id>"
+    )]
+    Publish {
+        /// Branch name, or `branch`, `review`, or `change` when VALUE is provided.
+        #[clap(value_name = "BRANCH_OR_TARGET", value_parser = non_empty_value)]
+        branch_or_target: String,
+        /// Target value for explicit branch, review, or change publishing.
+        #[clap(value_name = "VALUE", value_parser = non_empty_value)]
+        value: Option<String>,
+        /// Report what would be shared without changing metadata or syncing.
+        #[clap(long)]
+        dry_run: bool,
+    },
     /// Sync GitMeta metadata.
     #[clap(hide = true)]
     Sync,
@@ -63,6 +80,7 @@ enum CommandOutput {
     Timeline(SessionTimeline),
     Records(SessionRecords),
     Skim(SkimReport),
+    Publish(ShareReport),
 }
 
 impl fmt::Display for CommandOutput {
@@ -135,6 +153,7 @@ impl fmt::Display for CommandOutput {
                 Ok(())
             }
             CommandOutput::Skim(report) => report.fmt(f),
+            CommandOutput::Publish(report) => report.fmt(f),
         }
     }
 }
@@ -167,6 +186,123 @@ impl RelatedSessionTarget {
     }
 }
 
+#[derive(Debug, Serialize)]
+pub(crate) struct ShareReport {
+    target_kind: &'static str,
+    target_value: String,
+    target_key: String,
+    dry_run: bool,
+    session_count: usize,
+    turn_count: usize,
+    related_turn_count: usize,
+    latest_captured_at: Option<String>,
+    sessions: Vec<ShareSession>,
+    #[serde(skip)]
+    synced: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ShareSession {
+    session_key: String,
+    turn_count: usize,
+    related_turn_count: usize,
+    latest_captured_at: Option<String>,
+}
+
+impl ShareReport {
+    fn new(
+        target: RelatedSessionTarget,
+        target_value: String,
+        target_key: String,
+        dry_run: bool,
+        sessions: Vec<RelatedSession>,
+    ) -> Self {
+        let mut latest_captured_at = None;
+        let mut turn_count = 0;
+        let mut related_turn_count = 0;
+        let sessions = sessions
+            .into_iter()
+            .map(|session| {
+                turn_count += session.turn_count;
+                related_turn_count += session.related_turn_keys.len();
+                if let Some(latest) = session.latest_captured_at.as_ref()
+                    && latest_captured_at
+                        .as_ref()
+                        .is_none_or(|current| latest > current)
+                {
+                    latest_captured_at = Some(latest.clone());
+                }
+                ShareSession {
+                    session_key: session.session_key,
+                    turn_count: session.turn_count,
+                    related_turn_count: session.related_turn_keys.len(),
+                    latest_captured_at: session.latest_captured_at,
+                }
+            })
+            .collect::<Vec<_>>();
+        Self {
+            target_kind: target.as_str(),
+            target_value,
+            target_key,
+            dry_run,
+            session_count: sessions.len(),
+            turn_count,
+            related_turn_count,
+            latest_captured_at,
+            sessions,
+            synced: false,
+        }
+    }
+}
+
+impl fmt::Display for ShareReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let action = if self.dry_run {
+            "Would share"
+        } else {
+            "Shared"
+        };
+        writeln!(
+            f,
+            "{} {} local-only sessions for {} {}",
+            action, self.session_count, self.target_kind, self.target_key
+        )?;
+        if self.session_count == 0 {
+            if self.synced {
+                writeln!(f, "Synced GitMeta metadata.")?;
+            }
+            return Ok(());
+        }
+        writeln!(
+            f,
+            "Turns: {} total, {} directly related. Latest: {}",
+            self.turn_count,
+            self.related_turn_count,
+            self.latest_captured_at.as_deref().unwrap_or("unknown")
+        )?;
+        for (index, session) in self.sessions.iter().enumerate() {
+            writeln!(
+                f,
+                "Session #{}: {} turns, {} directly related, latest {}",
+                index + 1,
+                session.turn_count,
+                session.related_turn_count,
+                session.latest_captured_at.as_deref().unwrap_or("unknown")
+            )?;
+        }
+        if self.dry_run {
+            writeln!(
+                f,
+                "Preview with `but agentlog skim {} {}`. For exact records, rerun skim with JSON and use `but agentlog show <session> --turn <turn>`.",
+                self.target_kind, self.target_value
+            )?;
+        } else if self.synced {
+            writeln!(f, "Synced GitMeta metadata.")?;
+        }
+        Ok(())
+    }
+}
+
 pub fn run_from_dir(dir: &Path, command: Command) -> anyhow::Result<impl Serialize + fmt::Display> {
     match command {
         Command::Hook { agent } => {
@@ -189,9 +325,12 @@ pub fn run_from_dir(dir: &Path, command: Command) -> anyhow::Result<impl Seriali
             let repo_path = resolve_read_repo_path(dir)?;
             match turn {
                 Some(turn) => {
+                    let status = find_session_status(&repo_path, &session_key)?
+                        .with_context(|| format!("agent session '{session_key}' was not found"))?;
                     let records = get_session_records(
                         &repo_path,
                         &session_key,
+                        status,
                         &turn,
                         limit.unwrap_or(DEFAULT_RECORD_LIMIT),
                     )
@@ -199,9 +338,12 @@ pub fn run_from_dir(dir: &Path, command: Command) -> anyhow::Result<impl Seriali
                     Ok(CommandOutput::Records(records))
                 }
                 None => {
+                    let status = find_session_status(&repo_path, &session_key)?
+                        .with_context(|| format!("agent session '{session_key}' was not found"))?;
                     let timeline = get_session_timeline_outline(
                         &repo_path,
                         &session_key,
+                        status,
                         Some(limit.unwrap_or(DEFAULT_TIMELINE_LIMIT)),
                     )
                     .context("failed to read agent session timeline")?;
@@ -230,12 +372,69 @@ pub fn run_from_dir(dir: &Path, command: Command) -> anyhow::Result<impl Seriali
                 None => skim::resolve_default_branch_target(&repo_path)?,
             };
             let target_key = related_session_target_key(target, &value);
-            let sessions =
-                find_related_sessions_limited(&repo_path, target.related_target(&target_key), None)
-                    .context("failed to find related agent sessions")?;
+            let sessions = find_related_sessions_limited_by_statuses(
+                &repo_path,
+                target.related_target(&target_key),
+                None,
+                &[PublicationStatus::LocalOnly, PublicationStatus::Published],
+            )
+            .context("failed to find related agent sessions")?;
             let report = skim::report(&repo_path, target, target_key, sessions)
                 .context("failed to build agent skim")?;
             Ok(CommandOutput::Skim(report))
+        }
+        Command::Publish {
+            branch_or_target,
+            value,
+            dry_run,
+        } => {
+            let (target, value) = resolve_publish_target(branch_or_target, value)?;
+            let repo_path = resolve_workdir(dir)?;
+            let target_key = related_session_target_key(target, &value);
+            let report = with_capture_lock(&repo_path, || {
+                let sessions = find_related_sessions_limited_by_statuses(
+                    &repo_path,
+                    target.related_target(&target_key),
+                    None,
+                    &[PublicationStatus::LocalOnly],
+                )
+                .context("failed to find local-only agent sessions")?;
+                let mut report =
+                    ShareReport::new(target, value.clone(), target_key.clone(), dry_run, sessions);
+                if !dry_run {
+                    let session_keys = report
+                        .sessions
+                        .iter()
+                        .map(|session| session.session_key.clone())
+                        .collect::<Vec<_>>();
+                    let should_sync = if session_keys.is_empty() {
+                        !find_related_sessions_limited_by_statuses(
+                            &repo_path,
+                            target.related_target(&target_key),
+                            Some(1),
+                            &[PublicationStatus::Published],
+                        )
+                        .context("failed to find published agent sessions")?
+                        .is_empty()
+                    } else {
+                        share_sessions(&repo_path, &session_keys)
+                            .context("failed to share agent sessions")?;
+                        true
+                    };
+                    if should_sync {
+                        sync_metadata(&repo_path).with_context(|| {
+                            if session_keys.is_empty() {
+                                "failed to sync GitMeta metadata"
+                            } else {
+                                "shared agent sessions, but failed to sync GitMeta metadata"
+                            }
+                        })?;
+                        report.synced = true;
+                    }
+                }
+                Ok(report)
+            })?;
+            Ok(CommandOutput::Publish(report))
         }
         Command::Sync => {
             let workdir = resolve_workdir(dir)?;
@@ -245,6 +444,23 @@ pub fn run_from_dir(dir: &Path, command: Command) -> anyhow::Result<impl Seriali
                 message: "Synced GitMeta metadata".into(),
             })
         }
+    }
+}
+
+fn resolve_publish_target(
+    branch_or_target: String,
+    value: Option<String>,
+) -> anyhow::Result<(RelatedSessionTarget, String)> {
+    let Some(value) = value else {
+        return Ok((RelatedSessionTarget::Branch, branch_or_target));
+    };
+    match branch_or_target.as_str() {
+        "branch" => Ok((RelatedSessionTarget::Branch, value)),
+        "review" => Ok((RelatedSessionTarget::Review, value)),
+        "change" => Ok((RelatedSessionTarget::Change, value)),
+        other => anyhow::bail!(
+            "unknown publish target '{other}'. Use `but agentlog publish <branch>` or `but agentlog publish <branch|review|change> <value>`."
+        ),
     }
 }
 
@@ -303,14 +519,12 @@ fn record_agent_log(
         return Ok(None);
     };
 
-    let metadata_changed = with_capture_lock(&workdir, || {
-        let (_records_written, metadata_changed) =
-            record_prepared_transcript(&workdir, agent, transcript)?;
-
-        Ok(metadata_changed)
+    let published_metadata_changed = with_capture_lock(&workdir, || {
+        let write = record_prepared_transcript(&workdir, agent, transcript)?;
+        Ok(write.published_metadata_changed)
     })?;
 
-    Ok(metadata_changed.then_some(workdir))
+    Ok(published_metadata_changed.then_some(workdir))
 }
 
 fn resolve_workdir(dir: &Path) -> anyhow::Result<PathBuf> {
@@ -403,11 +617,12 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        Command, RelatedSessionTarget, related_session_target_key, run_from_dir, run_hook,
+        Command, RelatedSessionTarget, related_session_target_key, resolve_publish_target,
+        run_from_dir, run_hook,
     };
     use crate::Agent;
     use crate::environment::{EnvironmentObservation, ObservedTargets};
-    use crate::gitmeta::write_transcript_batch;
+    use crate::gitmeta::{share_sessions, write_transcript_batch};
     use crate::transcript::TranscriptBatch;
 
     const TEST_SESSION_KEY: &str = "sha256-11111111111111111111111111111111";
@@ -538,6 +753,59 @@ mod tests {
     }
 
     #[test]
+    fn skim_labels_local_only_and_published_sessions() {
+        let repo = setup_repo();
+        let published_session_key = TEST_SESSION_KEY.to_owned();
+        write_targetless_turn_for_session(
+            repo.path(),
+            &published_session_key,
+            TEST_SOURCE_KEY,
+            "published setup",
+            None,
+        );
+        write_turn_for_session(
+            repo.path(),
+            &published_session_key,
+            TEST_SOURCE_KEY,
+            "published",
+        );
+        share_sessions(repo.path(), std::slice::from_ref(&published_session_key))
+            .expect("share session");
+
+        let local_session_key = "sha256-33333333333333333333333333333333";
+        let local_source_key = "sha256-44444444444444444444444444444444";
+        write_targetless_turn_for_session(
+            repo.path(),
+            local_session_key,
+            local_source_key,
+            "local setup",
+            None,
+        );
+        write_turn_for_session(repo.path(), local_session_key, local_source_key, "local");
+
+        let output = run_from_dir(
+            repo.path(),
+            Command::Skim {
+                target: Some(RelatedSessionTarget::Branch),
+                value: Some("main".into()),
+            },
+        )
+        .expect("read skim");
+        let json = serde_json::to_value(&output).expect("serialize command output");
+        let statuses = json["sessions"]
+            .as_array()
+            .expect("sessions")
+            .iter()
+            .map(|session| session["status"].as_str().expect("status"))
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(statuses, BTreeSet::from(["local-only", "published"]));
+        let human = output.to_string();
+        assert!(human.contains("status: local-only"));
+        assert!(human.contains("status: published"));
+    }
+
+    #[test]
     fn explicit_skim_reads_bare_repo_metadata() {
         let repo = setup_bare_repo();
         let turn_key = write_user_session_with_targetless_prelude(repo.path());
@@ -663,6 +931,134 @@ mod tests {
     }
 
     #[test]
+    fn publish_dry_run_reports_local_sessions_without_moving_metadata() {
+        let repo = setup_repo();
+        write_user_session_with_targetless_prelude(repo.path());
+
+        let output = run_from_dir(
+            repo.path(),
+            Command::Publish {
+                branch_or_target: "main".into(),
+                value: None,
+                dry_run: true,
+            },
+        )
+        .expect("publish dry-run");
+        let json = serde_json::to_value(&output).expect("serialize command output");
+
+        assert_eq!(json["dry_run"], true);
+        assert_eq!(json["session_count"], 1);
+        assert_eq!(json["turn_count"], 2);
+        assert!(
+            output
+                .to_string()
+                .contains("Would share 1 local-only sessions")
+        );
+        assert!(
+            target_value(repo.path(), &Target::project(), "gitbutler:agent-sessions").is_none(),
+            "dry-run must not share the session index"
+        );
+        assert!(
+            target_value(
+                repo.path(),
+                &Target::project(),
+                &format!("gitbutler:agent-session:{TEST_SESSION_KEY}:schema")
+            )
+            .is_none(),
+            "dry-run must not share session payload keys"
+        );
+        assert!(
+            target_value(
+                repo.path(),
+                &Target::project(),
+                &format!("gitbutler:agent-session:{TEST_SESSION_KEY}:turns")
+            )
+            .is_none(),
+            "dry-run must not share session turns"
+        );
+        assert!(
+            target_value(
+                repo.path(),
+                &Target::project(),
+                &format!("gitbutler:agent-session:{TEST_SESSION_KEY}:transcript")
+            )
+            .is_none(),
+            "dry-run must not share transcript records"
+        );
+        assert!(
+            target_value(
+                repo.path(),
+                &Target::project(),
+                "local:gitbutler:agent-sessions"
+            )
+            .is_some(),
+            "dry-run must leave local metadata in place"
+        );
+        assert!(
+            target_value(
+                repo.path(),
+                &Target::project(),
+                &format!("local:gitbutler:agent-session:{TEST_SESSION_KEY}:schema")
+            )
+            .is_some(),
+            "dry-run must leave local session payload keys in place"
+        );
+        assert!(
+            target_value(
+                repo.path(),
+                &Target::project(),
+                &format!("local:gitbutler:agent-session:{TEST_SESSION_KEY}:turns")
+            )
+            .is_some(),
+            "dry-run must leave local session turns in place"
+        );
+        assert!(
+            target_value(
+                repo.path(),
+                &Target::project(),
+                &format!("local:gitbutler:agent-session:{TEST_SESSION_KEY}:transcript")
+            )
+            .is_some(),
+            "dry-run must leave local transcript records in place"
+        );
+    }
+
+    #[test]
+    fn publish_target_resolution_defaults_to_branch_shorthand() {
+        let (target, value) =
+            resolve_publish_target("review".to_owned(), None).expect("resolve publish target");
+
+        assert_eq!(target, RelatedSessionTarget::Branch);
+        assert_eq!(value, "review");
+    }
+
+    #[test]
+    fn publish_target_resolution_keeps_explicit_targets() {
+        for (target_name, expected_target, expected_value) in [
+            ("branch", RelatedSessionTarget::Branch, "main"),
+            ("review", RelatedSessionTarget::Review, "review-1"),
+            ("change", RelatedSessionTarget::Change, "change-1"),
+        ] {
+            let (target, value) =
+                resolve_publish_target(target_name.to_owned(), Some(expected_value.to_owned()))
+                    .expect("resolve explicit publish target");
+            assert_eq!(target, expected_target);
+            assert_eq!(value, expected_value);
+        }
+    }
+
+    #[test]
+    fn publish_target_resolution_rejects_two_value_branch_shorthand() {
+        let error = resolve_publish_target("main".to_owned(), Some("other".to_owned()))
+            .expect_err("ambiguous two-value publish target should fail");
+
+        assert!(
+            error.to_string().contains("unknown publish target 'main'"),
+            "ambiguous publish target should explain the accepted forms"
+        );
+    }
+
+    #[test]
     fn related_session_target_key_normalizes_common_inputs() {
         for (target, value, expected) in [
             (RelatedSessionTarget::Branch, "main", TEST_BRANCH_KEY),
@@ -716,15 +1112,53 @@ mod tests {
 
         let sync_dir = run_hook(Path::new("/"), Some(Agent::Codex), &payload).expect("run hook");
 
-        assert_eq!(
-            sync_dir,
-            Some(fs::canonicalize(repo.path()).expect("canonical repo"))
-        );
+        assert_eq!(sync_dir, None);
         assert_eq!(session_keys(repo.path(), &Target::project()).len(), 1);
+        assert!(
+            target_value(repo.path(), &Target::project(), "gitbutler:agent-sessions").is_none()
+        );
+        assert!(
+            target_value(
+                repo.path(),
+                &Target::project(),
+                "local:gitbutler:agent-sessions"
+            )
+            .is_some()
+        );
 
         let duplicate_sync_dir =
             run_hook(repo.path(), Some(Agent::Codex), &payload).expect("duplicate hook");
         assert_eq!(duplicate_sync_dir, None);
+    }
+
+    #[test]
+    fn hook_requests_sync_for_share_default_capture() {
+        let repo = setup_repo();
+        set_agentlog_share_default(repo.path(), true);
+        write_transcript_with_message(repo.path());
+        let payload = serde_json::json!({
+            "transcript_path": "session.jsonl",
+            "cwd": repo.path().display().to_string(),
+        })
+        .to_string();
+
+        let sync_dir = run_hook(Path::new("/"), Some(Agent::Codex), &payload).expect("run hook");
+
+        assert_eq!(
+            sync_dir,
+            Some(fs::canonicalize(repo.path()).expect("canonical repo"))
+        );
+        assert!(
+            target_value(repo.path(), &Target::project(), "gitbutler:agent-sessions").is_some()
+        );
+        assert!(
+            target_value(
+                repo.path(),
+                &Target::project(),
+                "local:gitbutler:agent-sessions"
+            )
+            .is_none()
+        );
     }
 
     #[test]
@@ -744,6 +1178,14 @@ mod tests {
         );
         assert!(
             target_value(repo.path(), &Target::project(), "gitbutler:agent-sessions").is_none()
+        );
+        assert!(
+            target_value(
+                repo.path(),
+                &Target::project(),
+                "local:gitbutler:agent-sessions"
+            )
+            .is_none()
         );
     }
 
@@ -872,8 +1314,15 @@ mod tests {
         let Some(MetaValue::List(entries)) = target_value(
             repo,
             &Target::project(),
-            &format!("gitbutler:agent-session:{session_key}:turns"),
-        ) else {
+            &format!("local:gitbutler:agent-session:{session_key}:turns"),
+        )
+        .or_else(|| {
+            target_value(
+                repo,
+                &Target::project(),
+                &format!("gitbutler:agent-session:{session_key}:turns"),
+            )
+        }) else {
             panic!("expected turn summaries");
         };
         let summary: serde_json::Value =
@@ -885,7 +1334,12 @@ mod tests {
     fn set_session_updated_at(repo: &Path, session_key: &str, updated_at: &str) {
         let session = Session::open(repo).expect("open session");
         let target = Target::project();
-        let key = format!("gitbutler:agent-session:{session_key}:updated-at");
+        let public_key = format!("gitbutler:agent-session:{session_key}:updated-at");
+        let key = if target_value(repo, &target, &public_key).is_some() {
+            public_key
+        } else {
+            format!("local:gitbutler:agent-session:{session_key}:updated-at")
+        };
         let value = MetaValue::String(updated_at.to_owned());
         session
             .target(&target)
@@ -905,6 +1359,20 @@ mod tests {
         dir
     }
 
+    fn set_agentlog_share_default(repo: &Path, value: bool) {
+        let output = std::process::Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args([
+                "config",
+                "gitbutler.agentlog-share-default",
+                if value { "true" } else { "false" },
+            ])
+            .output()
+            .expect("set git config");
+        assert!(output.status.success(), "git config should succeed");
+    }
+
     fn setup_bare_repo() -> TempDir {
         let dir = TempDir::new().expect("temp bare repo");
         gix::init_bare(dir.path()).expect("gitoxide bare repo init");
@@ -912,7 +1380,9 @@ mod tests {
     }
 
     fn session_keys(repo: &Path, target: &Target) -> BTreeSet<String> {
-        let Some(MetaValue::Set(keys)) = target_value(repo, target, "gitbutler:agent-sessions")
+        let Some(MetaValue::Set(keys)) =
+            target_value(repo, target, "local:gitbutler:agent-sessions")
+                .or_else(|| target_value(repo, target, "gitbutler:agent-sessions"))
         else {
             panic!("expected session index set");
         };

--- a/crates/but-agentlog/src/gitmeta/mod.rs
+++ b/crates/but-agentlog/src/gitmeta/mod.rs
@@ -13,6 +13,39 @@ const TRUNCATION_MARKER: &str = "\n[TRUNCATED]\n";
 
 // Index entries are rebuildable lookup data; readers verify hits against turn details.
 const INDEX_NAMESPACE: &str = "gitbutler:agentlog-index:v1";
+const LOCAL_KEY_PREFIX: &str = "local:";
+const SESSION_SET_KEY: &str = "gitbutler:agent-sessions";
+const SESSION_PREFIX: &str = "gitbutler:agent-session";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum PublicationStatus {
+    LocalOnly,
+    Published,
+}
+
+impl PublicationStatus {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            PublicationStatus::LocalOnly => "local_only",
+            PublicationStatus::Published => "published",
+        }
+    }
+
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            PublicationStatus::LocalOnly => "local-only",
+            PublicationStatus::Published => "published",
+        }
+    }
+
+    pub(crate) fn storage_key(self, key: &str) -> String {
+        match self {
+            PublicationStatus::LocalOnly => local_storage_key(key),
+            PublicationStatus::Published => key.to_owned(),
+        }
+    }
+}
 
 #[derive(Debug, Deserialize, Serialize)]
 struct AcceptedRecord {
@@ -139,6 +172,7 @@ struct StoredCommitSnapshot {
 
 struct SessionListEntry {
     session_key: String,
+    status: PublicationStatus,
     updated_at: String,
     sort_updated_at: DateTime<Utc>,
 }
@@ -153,21 +187,41 @@ mod read;
 mod read_support;
 mod records_outline;
 mod session_outline;
+mod share;
 mod timeline_outline;
 mod write;
 
 pub(crate) use read::RelatedTarget;
-pub(crate) use read::find_related_sessions_limited;
+pub(crate) use read::{
+    find_related_sessions_limited, find_related_sessions_limited_by_statuses, find_session_status,
+};
 pub(crate) use records_outline::{SessionRecords, get_session_records};
 pub(crate) use session_outline::RelatedSession;
+pub(crate) use share::share_sessions;
 pub(crate) use timeline_outline::{SessionTimeline, get_session_timeline_outline};
-pub(crate) use write::{sync_metadata, write_transcript_batch};
+pub(crate) use write::{CaptureWriteOutcome, sync_metadata, write_transcript_batch};
 
 fn index_key(kind: &str, target_key: &str) -> String {
     format!(
         "{INDEX_NAMESPACE}:{kind}:{}",
         hashed_index_target_key(target_key)
     )
+}
+
+fn local_storage_key(key: &str) -> String {
+    format!("{LOCAL_KEY_PREFIX}{key}")
+}
+
+fn strip_local_storage_prefix(key: &str) -> Option<&str> {
+    key.strip_prefix(LOCAL_KEY_PREFIX)
+}
+
+fn session_storage_prefix(status: PublicationStatus, session_key: &str) -> String {
+    status.storage_key(&format!("{SESSION_PREFIX}:{session_key}"))
+}
+
+fn status_index_key(status: PublicationStatus, kind: &str, target_key: &str) -> String {
+    status.storage_key(&index_key(kind, target_key))
 }
 
 fn hashed_index_target_key(target_key: &str) -> String {

--- a/crates/but-agentlog/src/gitmeta/read.rs
+++ b/crates/but-agentlog/src/gitmeta/read.rs
@@ -12,13 +12,14 @@ use serde_json::Value;
 use crate::environment::{is_public_repo_path, path_fingerprint};
 
 use super::{
-    IndexHit, SessionListEntry, StoredBranchSnapshot, StoredCommitSnapshot,
-    StoredEnvironmentSnapshot, StoredObservedTargets, index_key,
+    IndexHit, PublicationStatus, SESSION_PREFIX, SessionListEntry, StoredBranchSnapshot,
+    StoredCommitSnapshot, StoredEnvironmentSnapshot, StoredObservedTargets,
     read_support::{
         read_optional_turn_detail, read_transcript_entries, read_turn_detail, read_turn_summaries,
         transcript_records_by_hash, with_project_target,
     },
     session_outline::{RelatedSession, related_session_outline},
+    session_storage_prefix, status_index_key,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -48,9 +49,10 @@ impl<'a> RelatedTarget<'a> {
 
 fn session_list_entry(
     handle: &SessionTargetHandle<'_>,
+    status: PublicationStatus,
     session_key: String,
 ) -> Result<SessionListEntry> {
-    let session_prefix = format!("gitbutler:agent-session:{session_key}");
+    let session_prefix = session_storage_prefix(status, &session_key);
     let updated_at_key = format!("{session_prefix}:updated-at");
     let updated_at = match handle
         .get_value(&updated_at_key)
@@ -65,6 +67,7 @@ fn session_list_entry(
         .with_timezone(&Utc);
     Ok(SessionListEntry {
         session_key,
+        status,
         updated_at,
         sort_updated_at,
     })
@@ -75,15 +78,34 @@ pub(crate) fn find_related_sessions_limited(
     target: RelatedTarget<'_>,
     max_sessions: Option<usize>,
 ) -> Result<Vec<RelatedSession>> {
+    find_related_sessions_limited_by_statuses(
+        repo_path,
+        target,
+        max_sessions,
+        &[PublicationStatus::Published],
+    )
+}
+
+pub(crate) fn find_related_sessions_limited_by_statuses(
+    repo_path: &Path,
+    target: RelatedTarget<'_>,
+    max_sessions: Option<usize>,
+    statuses: &[PublicationStatus],
+) -> Result<Vec<RelatedSession>> {
     with_project_target(repo_path, |handle| {
         let mut matches = Vec::new();
-        for (session_key, related_turn_keys) in verified_related_turns_by_session(handle, target)? {
-            let entry = session_list_entry(handle, session_key)?;
-            matches.push((entry, related_turn_keys));
+        for &status in statuses {
+            for (session_key, related_turn_keys) in
+                verified_related_turns_by_session(handle, target, status)?
+            {
+                let entry = session_list_entry(handle, status, session_key)?;
+                matches.push((entry, related_turn_keys));
+            }
         }
         matches.sort_by(|(lhs, _), (rhs, _)| {
             rhs.sort_updated_at
                 .cmp(&lhs.sort_updated_at)
+                .then_with(|| lhs.status.as_str().cmp(rhs.status.as_str()))
                 .then_with(|| lhs.session_key.cmp(&rhs.session_key))
         });
         if let Some(max_sessions) = max_sessions {
@@ -98,17 +120,38 @@ pub(crate) fn find_related_sessions_limited(
     })
 }
 
+pub(crate) fn find_session_status(
+    repo_path: &Path,
+    session_key: &str,
+) -> Result<Option<PublicationStatus>> {
+    with_project_target(repo_path, |handle| {
+        for status in [PublicationStatus::Published, PublicationStatus::LocalOnly] {
+            let schema_key = status.storage_key(&format!("{SESSION_PREFIX}:{session_key}:schema"));
+            if handle
+                .get_value(&schema_key)
+                .with_context(|| format!("failed to read GitMeta key '{schema_key}'"))?
+                .is_some()
+            {
+                return Ok(Some(status));
+            }
+        }
+        Ok(None)
+    })
+}
+
 fn verified_related_turns_by_session(
     handle: &SessionTargetHandle<'_>,
     target: RelatedTarget<'_>,
+    status: PublicationStatus,
 ) -> Result<BTreeMap<String, Vec<String>>> {
     let mut indexed_turns = BTreeMap::<String, HashSet<String>>::new();
     let mut session_activity_matches = BTreeMap::<String, bool>::new();
-    for hit in target_index_hits(handle, target)? {
+    for hit in target_index_hits(handle, target, status)? {
         let Ok(hit) = serde_json::from_str::<IndexHit>(&hit) else {
             continue;
         };
-        if turn_detail_observes_target(handle, &hit, target, &mut session_activity_matches)? {
+        if turn_detail_observes_target(handle, &hit, target, status, &mut session_activity_matches)?
+        {
             indexed_turns
                 .entry(hit.session_key)
                 .or_default()
@@ -118,7 +161,8 @@ fn verified_related_turns_by_session(
 
     let mut by_session = BTreeMap::new();
     for (session_key, turn_keys) in indexed_turns {
-        let ordered_turn_keys = ordered_existing_turn_keys(handle, &session_key, &turn_keys)?;
+        let ordered_turn_keys =
+            ordered_existing_turn_keys(handle, &session_key, status, &turn_keys)?;
         if !ordered_turn_keys.is_empty() {
             by_session.insert(session_key, ordered_turn_keys);
         }
@@ -129,9 +173,10 @@ fn verified_related_turns_by_session(
 fn ordered_existing_turn_keys(
     handle: &SessionTargetHandle<'_>,
     session_key: &str,
+    status: PublicationStatus,
     turn_keys: &HashSet<String>,
 ) -> Result<Vec<String>> {
-    let turns_key = format!("gitbutler:agent-session:{session_key}:turns");
+    let turns_key = format!("{}:turns", session_storage_prefix(status, session_key));
     Ok(read_turn_summaries(handle, &turns_key)?
         .into_iter()
         .filter_map(|summary| {
@@ -147,8 +192,9 @@ fn ordered_existing_turn_keys(
 fn target_index_hits(
     handle: &SessionTargetHandle<'_>,
     target: RelatedTarget<'_>,
+    status: PublicationStatus,
 ) -> Result<BTreeSet<String>> {
-    let index_key = index_key(target.index_kind(), target.key());
+    let index_key = status_index_key(status, target.index_kind(), target.key());
     let Some(value) = handle
         .get_value(&index_key)
         .with_context(|| format!("failed to read GitMeta key '{index_key}'"))?
@@ -165,24 +211,26 @@ fn turn_detail_observes_target(
     handle: &SessionTargetHandle<'_>,
     hit: &IndexHit,
     target: RelatedTarget<'_>,
+    status: PublicationStatus,
     session_activity_matches: &mut BTreeMap<String, bool>,
 ) -> Result<bool> {
     let detail_key = format!(
-        "gitbutler:agent-session:{}:turn:{}",
-        hit.session_key, hit.turn_key
+        "{}:turn:{}",
+        session_storage_prefix(status, &hit.session_key),
+        hit.turn_key
     );
     let Some(detail) = read_optional_turn_detail(handle, &detail_key)? else {
         return Ok(false);
     };
     if !observed_targets_observe(&detail.observed_targets, target)
-        && !session_associations_observe_target(handle, &hit.session_key, target)?
+        && !session_associations_observe_target(handle, &hit.session_key, status, target)?
     {
         return Ok(false);
     }
     if let Some(matches) = session_activity_matches.get(&hit.session_key) {
         return Ok(*matches);
     }
-    let matches = session_has_target_activity(handle, &hit.session_key, target)?;
+    let matches = session_has_target_activity(handle, &hit.session_key, status, target)?;
     session_activity_matches.insert(hit.session_key.clone(), matches);
     Ok(matches)
 }
@@ -198,10 +246,13 @@ fn observed_targets_observe(targets: &StoredObservedTargets, target: RelatedTarg
 fn session_associations_observe_target(
     handle: &SessionTargetHandle<'_>,
     session_key: &str,
+    status: PublicationStatus,
     target: RelatedTarget<'_>,
 ) -> Result<bool> {
-    let associated_targets_key =
-        format!("gitbutler:agent-session:{session_key}:associated-targets");
+    let associated_targets_key = format!(
+        "{}:associated-targets",
+        session_storage_prefix(status, session_key)
+    );
     let Some(value) = handle
         .get_value(&associated_targets_key)
         .with_context(|| format!("failed to read GitMeta key '{associated_targets_key}'"))?
@@ -240,9 +291,10 @@ impl StoredSessionAssociations {
 fn session_has_target_activity(
     handle: &SessionTargetHandle<'_>,
     session_key: &str,
+    status: PublicationStatus,
     target: RelatedTarget<'_>,
 ) -> Result<bool> {
-    let session_prefix = format!("gitbutler:agent-session:{session_key}");
+    let session_prefix = session_storage_prefix(status, session_key);
     let summaries = read_turn_summaries(handle, &format!("{session_prefix}:turns"))?;
     let turns = read_session_turn_details(handle, &session_prefix, &summaries)?;
     let file_edit_hashes_by_turn =

--- a/crates/but-agentlog/src/gitmeta/records_outline.rs
+++ b/crates/but-agentlog/src/gitmeta/records_outline.rs
@@ -6,15 +6,17 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use super::{
-    AcceptedRecord,
+    AcceptedRecord, PublicationStatus,
     read_support::{
         read_transcript_entries, read_turn_detail, transcript_records_by_hash, with_project_target,
     },
+    session_storage_prefix,
 };
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub(crate) struct SessionRecords {
     pub(crate) session_key: String,
+    pub(crate) status: PublicationStatus,
     pub(crate) turn_key: String,
     pub(crate) coverage: RecordCoverage,
     pub(crate) records: Vec<RecordDetail>,
@@ -50,11 +52,12 @@ pub(crate) struct RecordDetail {
 pub(crate) fn get_session_records(
     repo_path: &std::path::Path,
     session_key: &str,
+    status: PublicationStatus,
     turn_key: &str,
     limit: usize,
 ) -> Result<SessionRecords> {
     with_project_target(repo_path, |handle| {
-        let session_prefix = format!("gitbutler:agent-session:{session_key}");
+        let session_prefix = session_storage_prefix(status, session_key);
         let detail_key = format!("{session_prefix}:turn:{turn_key}");
         let detail = read_turn_detail(handle, &detail_key)?;
         let total_records = detail.records.len();
@@ -85,6 +88,7 @@ pub(crate) fn get_session_records(
 
         Ok(SessionRecords {
             session_key: session_key.to_owned(),
+            status,
             turn_key: turn_key.to_owned(),
             coverage,
             records,

--- a/crates/but-agentlog/src/gitmeta/session_outline.rs
+++ b/crates/but-agentlog/src/gitmeta/session_outline.rs
@@ -6,14 +6,16 @@ use serde::Serialize;
 use serde_json::Value;
 
 use super::{
-    SessionListEntry,
+    PublicationStatus, SessionListEntry,
     outline_support::{RecordPreview, compact_preview},
     read_support::{read_turn_detail, read_turn_summaries},
+    session_storage_prefix,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct RelatedSession {
     pub(crate) session_key: String,
+    pub(crate) status: PublicationStatus,
     pub(crate) updated_at: String,
     pub(crate) started_at: Option<String>,
     pub(crate) turn_count: usize,
@@ -29,7 +31,7 @@ pub(super) fn related_session_outline(
     entry: SessionListEntry,
     related_turn_keys: Vec<String>,
 ) -> Result<RelatedSession> {
-    let session_prefix = format!("gitbutler:agent-session:{}", entry.session_key);
+    let session_prefix = session_storage_prefix(entry.status, &entry.session_key);
     let summaries = read_turn_summaries(handle, &format!("{session_prefix}:turns"))?;
     let related_turn_key_set = related_turn_keys
         .iter()
@@ -50,6 +52,7 @@ pub(super) fn related_session_outline(
     let latest = summaries.last();
     Ok(RelatedSession {
         session_key: entry.session_key,
+        status: entry.status,
         updated_at: entry.updated_at,
         started_at: summaries.first().map(|summary| summary.captured_at.clone()),
         turn_count: summaries.len(),

--- a/crates/but-agentlog/src/gitmeta/share.rs
+++ b/crates/but-agentlog/src/gitmeta/share.rs
@@ -1,0 +1,105 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::Path,
+};
+
+use anyhow::{Context as _, Result, bail};
+use git_meta_lib::{LocalPublish, MetaValue, Session, Target};
+
+use super::{
+    INDEX_NAMESPACE, IndexHit, PublicationStatus, SESSION_SET_KEY, local_storage_key,
+    session_storage_prefix, strip_local_storage_prefix,
+};
+
+struct SetMemberShare {
+    local_key: String,
+    published_key: String,
+    members: Vec<String>,
+}
+
+pub(crate) fn share_sessions(repo_path: &Path, session_keys: &[String]) -> Result<()> {
+    let session_keys = session_keys
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    if session_keys.is_empty() {
+        return Ok(());
+    }
+
+    let gitmeta = Session::open(repo_path).context("failed to open GitMeta session")?;
+    let target = Target::project();
+    let handle = gitmeta.target(&target);
+
+    let prefix_shares = session_keys
+        .iter()
+        .map(|session_key| {
+            (
+                session_storage_prefix(PublicationStatus::LocalOnly, session_key),
+                session_storage_prefix(PublicationStatus::Published, session_key),
+            )
+        })
+        .collect::<Vec<_>>();
+    let mut set_member_shares = vec![SetMemberShare {
+        local_key: local_storage_key(SESSION_SET_KEY),
+        published_key: SESSION_SET_KEY.to_owned(),
+        members: session_keys.clone(),
+    }];
+    set_member_shares.extend(index_set_member_shares(&handle, &session_keys)?);
+
+    let entries = prefix_shares
+        .iter()
+        .map(|(local, published)| LocalPublish::key_prefix(local, published))
+        .chain(set_member_shares.iter().map(|share| {
+            LocalPublish::set_members(&share.local_key, &share.published_key, &share.members)
+        }))
+        .collect::<Vec<_>>();
+    handle
+        .publish_local(entries)
+        .context("failed to share local agentlog metadata")?;
+    Ok(())
+}
+
+fn index_set_member_shares(
+    handle: &git_meta_lib::SessionTargetHandle<'_>,
+    session_keys: &[String],
+) -> Result<Vec<SetMemberShare>> {
+    let selected_sessions = session_keys
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let index_prefix = local_storage_key(INDEX_NAMESPACE);
+    let mut shares = BTreeMap::<String, SetMemberShare>::new();
+    for (local_key, value) in handle
+        .get_all_values(Some(&index_prefix))
+        .with_context(|| format!("failed to read GitMeta keys under '{index_prefix}'"))?
+    {
+        let MetaValue::Set(members) = value else {
+            bail!("existing GitMeta key '{local_key}' is not a set");
+        };
+        let Some(published_key) = strip_local_storage_prefix(&local_key) else {
+            continue;
+        };
+        let published_key = published_key.to_owned();
+        let selected_members = members
+            .into_iter()
+            .filter(|member| match serde_json::from_str::<IndexHit>(member) {
+                Ok(hit) => selected_sessions.contains(hit.session_key.as_str()),
+                Err(_) => false,
+            })
+            .collect::<Vec<_>>();
+        if selected_members.is_empty() {
+            continue;
+        }
+        shares.insert(
+            local_key.clone(),
+            SetMemberShare {
+                local_key,
+                published_key,
+                members: selected_members,
+            },
+        );
+    }
+    Ok(shares.into_values().collect())
+}

--- a/crates/but-agentlog/src/gitmeta/tests.rs
+++ b/crates/but-agentlog/src/gitmeta/tests.rs
@@ -32,7 +32,34 @@ fn setup_repo() -> TempDir {
         gix::open::Options::isolated().config_overrides(["init.defaultBranch=main"]),
     )
     .expect("gitoxide repo init");
+    set_agentlog_share_default(dir.path(), true);
     dir
+}
+
+fn setup_local_repo() -> TempDir {
+    let dir = TempDir::new().expect("temp repo");
+    gix::ThreadSafeRepository::init_opts(
+        dir.path(),
+        gix::create::Kind::WithWorktree,
+        gix::create::Options::default(),
+        gix::open::Options::isolated().config_overrides(["init.defaultBranch=main"]),
+    )
+    .expect("gitoxide repo init");
+    dir
+}
+
+fn set_agentlog_share_default(repo: &Path, value: bool) {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args([
+            "config",
+            "gitbutler.agentlog-share-default",
+            if value { "true" } else { "false" },
+        ])
+        .output()
+        .expect("set git config");
+    assert!(output.status.success(), "git config should succeed");
 }
 
 fn commit_file(repo: &Path, path: &str, body: &str) {
@@ -100,6 +127,32 @@ fn jsonl(records: impl IntoIterator<Item = serde_json::Value>) -> String {
         output.push('\n');
     }
     output
+}
+
+fn write_test_batch(repo: &Path, text: &str, observed_targets: ObservedTargets) {
+    let batch = TranscriptBatch::parse(
+        Agent::Codex,
+        jsonl([serde_json::json!({
+            "timestamp": "2026-05-07T09:00:00Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": text,
+            },
+        })])
+        .as_bytes(),
+    )
+    .expect("parse transcript");
+    write_transcript_batch(
+        repo,
+        Agent::Codex,
+        TEST_SESSION_KEY,
+        TEST_SOURCE_KEY,
+        batch,
+        || EnvironmentObservation::from_observed_targets_for_testing(observed_targets),
+    )
+    .expect("write transcript batch");
 }
 
 fn projection_request() -> ProjectionRequest {
@@ -555,6 +608,104 @@ fn codex_capture_can_be_read_back_and_is_idempotent() {
         detail["records"][0]["record_hash"],
         records[0]["record_hash"]
     );
+}
+
+#[test]
+fn capture_defaults_to_local_only_without_share_default() {
+    let repo = setup_local_repo();
+    let observed_targets = ObservedTargets::from_index_keys_for_testing(
+        TEST_BRANCH_KEY,
+        TEST_REVIEW_KEY,
+        TEST_CHANGE_KEY,
+    );
+    write_test_batch(repo.path(), "private setup", ObservedTargets::default());
+    write_test_batch(repo.path(), "private by default", observed_targets);
+
+    assert!(project_value(repo.path(), "gitbutler:agent-sessions").is_none());
+    assert!(
+        project_value(repo.path(), "local:gitbutler:agent-sessions").is_some(),
+        "new captures should stay under the local prefix by default"
+    );
+    let published =
+        find_related_sessions_limited(repo.path(), RelatedTarget::Branch(TEST_BRANCH_KEY), None)
+            .expect("find published sessions");
+    assert!(
+        published.is_empty(),
+        "published readers should not see local-only captures"
+    );
+    let local = find_related_sessions_limited_by_statuses(
+        repo.path(),
+        RelatedTarget::Branch(TEST_BRANCH_KEY),
+        None,
+        &[PublicationStatus::LocalOnly],
+    )
+    .expect("find local sessions");
+    assert_eq!(local.len(), 1);
+    assert_eq!(local[0].status, PublicationStatus::LocalOnly);
+}
+
+#[test]
+fn share_sessions_moves_whole_sessions_to_shared_keys() {
+    let repo = setup_local_repo();
+    let observed_targets = ObservedTargets::from_index_keys_for_testing(
+        TEST_BRANCH_KEY,
+        TEST_REVIEW_KEY,
+        TEST_CHANGE_KEY,
+    );
+    write_test_batch(repo.path(), "share setup", ObservedTargets::default());
+    write_test_batch(repo.path(), "share me", observed_targets);
+
+    share_sessions(repo.path(), &[TEST_SESSION_KEY.to_owned()]).expect("share sessions");
+
+    assert!(project_value(repo.path(), "local:gitbutler:agent-sessions").is_some());
+    assert!(project_value(repo.path(), "gitbutler:agent-sessions").is_some());
+    assert!(
+        project_value(
+            repo.path(),
+            &format!("local:gitbutler:agent-session:{TEST_SESSION_KEY}:schema"),
+        )
+        .is_none(),
+        "session-specific keys should move out of local storage when shared"
+    );
+    assert!(
+        project_value(
+            repo.path(),
+            &format!("gitbutler:agent-session:{TEST_SESSION_KEY}:schema"),
+        )
+        .is_some()
+    );
+    let published =
+        find_related_sessions_limited(repo.path(), RelatedTarget::Branch(TEST_BRANCH_KEY), None)
+            .expect("find published sessions");
+    assert_eq!(published.len(), 1);
+    assert_eq!(published[0].status, PublicationStatus::Published);
+    let timeline = get_session_timeline_outline(
+        repo.path(),
+        TEST_SESSION_KEY,
+        PublicationStatus::Published,
+        None,
+    )
+    .expect("read published timeline");
+    assert_eq!(timeline.coverage.total_turns, 2);
+    let latest_turn_key = timeline.turns[1].turn_key.clone();
+    let records = get_session_records(
+        repo.path(),
+        TEST_SESSION_KEY,
+        PublicationStatus::Published,
+        &latest_turn_key,
+        10,
+    )
+    .expect("read published records");
+    assert_eq!(records.coverage.total_records, 1);
+    assert_eq!(records.records[0].text.as_deref(), Some("share me"));
+    let local = find_related_sessions_limited_by_statuses(
+        repo.path(),
+        RelatedTarget::Branch(TEST_BRANCH_KEY),
+        None,
+        &[PublicationStatus::LocalOnly],
+    )
+    .expect("find local sessions");
+    assert!(local.is_empty());
 }
 
 #[test]
@@ -1431,6 +1582,34 @@ fn project_pr_returns_public_review_projection_without_raw_storage_keys() {
 }
 
 #[test]
+fn project_pr_ignores_local_only_sessions() {
+    let repo = setup_local_repo();
+    write_test_batch(repo.path(), "Private setup", ObservedTargets::default());
+    write_test_batch(
+        repo.path(),
+        "Private PR work",
+        ObservedTargets::from_index_keys_for_testing(
+            TEST_BRANCH_KEY,
+            TEST_PR_REVIEW_KEY,
+            TEST_CHANGE_KEY,
+        ),
+    );
+
+    let projection = project_pr(repo.path(), &projection_request()).expect("project PR");
+
+    assert_eq!(projection.status, ProjectionStatus::NoMatches);
+    assert!(projection.sessions.is_empty());
+    assert_eq!(
+        projection
+            .warnings
+            .iter()
+            .map(|warning| warning.kind)
+            .collect::<Vec<_>>(),
+        [ProjectionWarningKind::NoMatches]
+    );
+}
+
+#[test]
 fn project_pr_marks_branch_only_matches_as_weak_evidence() {
     let repo = setup_repo();
     write_turn_with_targets(
@@ -1761,8 +1940,13 @@ fn get_session_timeline_outline_returns_compact_bounded_turns() {
     )
     .expect("write second timeline batch");
 
-    let timeline =
-        get_session_timeline_outline(repo.path(), TEST_SESSION_KEY, None).expect("read outline");
+    let timeline = get_session_timeline_outline(
+        repo.path(),
+        TEST_SESSION_KEY,
+        PublicationStatus::Published,
+        None,
+    )
+    .expect("read outline");
 
     assert_eq!(timeline.session_key, TEST_SESSION_KEY);
     assert_eq!(timeline.coverage.showing_turns, 2);
@@ -1807,8 +1991,13 @@ fn get_session_timeline_outline_returns_compact_bounded_turns() {
         [TEST_CHANGE_KEY]
     );
 
-    let latest =
-        get_session_timeline_outline(repo.path(), TEST_SESSION_KEY, Some(1)).expect("read window");
+    let latest = get_session_timeline_outline(
+        repo.path(),
+        TEST_SESSION_KEY,
+        PublicationStatus::Published,
+        Some(1),
+    )
+    .expect("read window");
     assert_eq!(latest.coverage.showing_turns, 1);
     assert_eq!(latest.coverage.total_turns, 2);
     assert!(latest.coverage.has_more_before);
@@ -1886,8 +2075,14 @@ fn get_session_records_returns_latest_bounded_records_without_storage_keys() {
         .expect("turn key")
         .to_owned();
 
-    let records =
-        get_session_records(repo.path(), TEST_SESSION_KEY, &turn_key, 2).expect("records");
+    let records = get_session_records(
+        repo.path(),
+        TEST_SESSION_KEY,
+        PublicationStatus::Published,
+        &turn_key,
+        2,
+    )
+    .expect("records");
 
     assert_eq!(records.session_key, TEST_SESSION_KEY);
     assert_eq!(records.turn_key, turn_key);
@@ -1926,13 +2121,27 @@ fn get_session_records_returns_latest_bounded_records_without_storage_keys() {
     assert!(json["records"][0].get("source_key").is_none());
     assert_eq!(json["records"][0]["source_record_index"], 3);
 
-    let empty = get_session_records(repo.path(), TEST_SESSION_KEY, &turn_key, 0).expect("empty");
+    let empty = get_session_records(
+        repo.path(),
+        TEST_SESSION_KEY,
+        PublicationStatus::Published,
+        &turn_key,
+        0,
+    )
+    .expect("empty");
     assert_eq!(empty.coverage.showing_records, 0);
     assert_eq!(empty.coverage.total_records, 3);
     assert!(empty.coverage.has_more_before);
     assert!(empty.records.is_empty());
 
-    let all = get_session_records(repo.path(), TEST_SESSION_KEY, &turn_key, 99).expect("all");
+    let all = get_session_records(
+        repo.path(),
+        TEST_SESSION_KEY,
+        PublicationStatus::Published,
+        &turn_key,
+        99,
+    )
+    .expect("all");
     assert_eq!(all.coverage.showing_records, 3);
     assert_eq!(all.coverage.total_records, 3);
     assert!(!all.coverage.has_more_before);
@@ -2259,7 +2468,14 @@ fn transcript_records_store_prompt_source_tool_kind_and_outcome() {
         .as_str()
         .expect("turn key")
         .to_owned();
-    let records = get_session_records(repo.path(), &session_key, &turn_key, 10).expect("records");
+    let records = get_session_records(
+        repo.path(),
+        &session_key,
+        PublicationStatus::Published,
+        &turn_key,
+        10,
+    )
+    .expect("records");
     assert_eq!(
         records.records[1].prompt_source.as_deref(),
         Some("spawned_agent")
@@ -2467,8 +2683,13 @@ fn incremental_capture_links_previous_turn_by_entry_timestamp() {
     assert_eq!(third_turn["previous_turn_key"], second_turn_key);
     assert_ne!(third_turn["previous_turn_key"], first_turn_key);
 
-    let timeline =
-        get_session_timeline_outline(repo.path(), TEST_SESSION_KEY, None).expect("read timeline");
+    let timeline = get_session_timeline_outline(
+        repo.path(),
+        TEST_SESSION_KEY,
+        PublicationStatus::Published,
+        None,
+    )
+    .expect("read timeline");
     let timeline_turn_keys = timeline
         .turns
         .iter()

--- a/crates/but-agentlog/src/gitmeta/timeline_outline.rs
+++ b/crates/but-agentlog/src/gitmeta/timeline_outline.rs
@@ -5,17 +5,19 @@ use git_meta_lib::SessionTargetHandle;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    AcceptedRecord, StoredObservedTargets, StoredTurnSummary,
+    AcceptedRecord, PublicationStatus, StoredObservedTargets, StoredTurnSummary,
     outline_support::{ObservedTargetKeys, RecordPreview, compact_preview, push_unique},
     read_support::{
         read_transcript_entries, read_turn_detail, read_turn_summaries, transcript_records_by_hash,
         with_project_target,
     },
+    session_storage_prefix,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct SessionTimeline {
     pub(crate) session_key: String,
+    pub(crate) status: PublicationStatus,
     pub(crate) coverage: TimelineCoverage,
     pub(crate) turns: Vec<TimelineTurnOutline>,
 }
@@ -61,10 +63,11 @@ pub(crate) struct ToolCounts {
 pub(crate) fn get_session_timeline_outline(
     repo_path: &std::path::Path,
     session_key: &str,
+    status: PublicationStatus,
     max_turns: Option<usize>,
 ) -> Result<SessionTimeline> {
     with_project_target(repo_path, |handle| {
-        let session_prefix = format!("gitbutler:agent-session:{session_key}");
+        let session_prefix = session_storage_prefix(status, session_key);
         let turns_key = format!("{session_prefix}:turns");
         let summaries = read_turn_summaries(handle, &turns_key)?;
         let total_turns = summaries.len();
@@ -81,6 +84,7 @@ pub(crate) fn get_session_timeline_outline(
 
         Ok(SessionTimeline {
             session_key: session_key.to_owned(),
+            status,
             coverage,
             turns,
         })

--- a/crates/but-agentlog/src/gitmeta/write.rs
+++ b/crates/but-agentlog/src/gitmeta/write.rs
@@ -20,14 +20,18 @@ use crate::{
 };
 
 use super::{
-    AcceptedRecord, CaptureKind, IndexHit, TurnDetail, TurnSummary, cap_tool_result_text,
-    capture_turn_key, index_key, stored_turn_summary_entries,
+    AcceptedRecord, CaptureKind, IndexHit, PublicationStatus, SESSION_PREFIX, SESSION_SET_KEY,
+    TurnDetail, TurnSummary, cap_tool_result_text, capture_turn_key, session_storage_prefix,
+    status_index_key, stored_turn_summary_entries,
 };
 
 #[derive(Debug)]
 pub(crate) struct CaptureWriteOutcome {
+    #[allow(dead_code)]
     pub(crate) records_written: usize,
+    #[allow(dead_code)]
     pub(crate) metadata_changed: bool,
+    pub(crate) published_metadata_changed: bool,
 }
 
 pub(crate) fn write_transcript_batch(
@@ -50,10 +54,15 @@ pub(crate) fn write_transcript_batch(
         return Ok(CaptureWriteOutcome {
             records_written: 0,
             metadata_changed: false,
+            published_metadata_changed: false,
         });
     }
 
-    let session_prefix = format!("gitbutler:agent-session:{session_key}");
+    let gitmeta = Session::open(repo_path).context("failed to open GitMeta session")?;
+    let target = Target::project();
+    let handle = gitmeta.target(&target);
+    let publication_status = capture_publication_status(repo_path, &handle, session_key)?;
+    let session_prefix = session_storage_prefix(publication_status, session_key);
     let sources_key = format!("{session_prefix}:sources");
     let source_prefix = format!("{session_prefix}:source:{source_key}");
     let transcript_key = format!("{session_prefix}:transcript");
@@ -61,9 +70,6 @@ pub(crate) fn write_transcript_batch(
     let turns_key = format!("{session_prefix}:turns");
     let associated_targets_key = format!("{session_prefix}:associated-targets");
 
-    let gitmeta = Session::open(repo_path).context("failed to open GitMeta session")?;
-    let target = Target::project();
-    let handle = gitmeta.target(&target);
     let turns_value = handle
         .get_value(&turns_key)
         .with_context(|| format!("failed to read GitMeta key '{turns_key}'"))?;
@@ -102,15 +108,17 @@ pub(crate) fn write_transcript_batch(
         let metadata_changed = enrich_incomplete_turn(
             &handle,
             turns_value,
-            &session_prefix,
             session_key,
             source_key,
             &incoming_record_hashes,
+            publication_status,
             capture_environment,
         )?;
         return Ok(CaptureWriteOutcome {
             records_written: 0,
             metadata_changed,
+            published_metadata_changed: metadata_changed
+                && publication_status == PublicationStatus::Published,
         });
     }
 
@@ -217,15 +225,16 @@ pub(crate) fn write_transcript_batch(
     let mut associated_turn_keys = previous_turn_keys;
     associated_turn_keys.push(turn_key.clone());
     let index_hit_members = index_hits_for_turns(session_key, &associated_turn_keys)?;
-    let index_keys = target_associations.index_keys();
+    let index_keys = target_associations.index_keys(publication_status);
     let associated_targets_value = if target_associations != original_associations {
         target_associations.meta_value()?
     } else {
         None
     };
 
+    let session_set_key = publication_status.storage_key(SESSION_SET_KEY);
     let mut edits = vec![
-        MetaEdit::set_add("gitbutler:agent-sessions", &session_keys),
+        MetaEdit::set_add(&session_set_key, &session_keys),
         MetaEdit::set_value(&session_schema_key, &session_schema_value),
         MetaEdit::set_value(&updated_at_key, &updated_at_value),
         MetaEdit::set_add(&sources_key, &source_keys),
@@ -260,6 +269,7 @@ pub(crate) fn write_transcript_batch(
     Ok(CaptureWriteOutcome {
         records_written: records_captured,
         metadata_changed: true,
+        published_metadata_changed: publication_status == PublicationStatus::Published,
     })
 }
 
@@ -465,11 +475,23 @@ impl TargetAssociations {
         )))
     }
 
-    fn index_keys(&self) -> Vec<String> {
+    fn index_keys(&self, status: PublicationStatus) -> Vec<String> {
         let mut keys = Vec::new();
-        keys.extend(self.branches.iter().map(|key| index_key("branch", key)));
-        keys.extend(self.reviews.iter().map(|key| index_key("review", key)));
-        keys.extend(self.changes.iter().map(|key| index_key("change", key)));
+        keys.extend(
+            self.branches
+                .iter()
+                .map(|key| status_index_key(status, "branch", key)),
+        );
+        keys.extend(
+            self.reviews
+                .iter()
+                .map(|key| status_index_key(status, "review", key)),
+        );
+        keys.extend(
+            self.changes
+                .iter()
+                .map(|key| status_index_key(status, "change", key)),
+        );
         keys
     }
 }
@@ -508,22 +530,23 @@ fn index_hits_for_turns(session_key: &str, turn_keys: &[String]) -> Result<Vec<S
 fn enrich_incomplete_turn(
     handle: &SessionTargetHandle<'_>,
     turns_value: Option<MetaValue>,
-    session_prefix: &str,
     session_key: &str,
     source_key: &str,
     incoming_record_hashes: &[String],
+    publication_status: PublicationStatus,
     capture_environment: impl FnOnce() -> EnvironmentObservation,
 ) -> Result<bool> {
     let Some(MetaValue::List(mut turn_entries)) = turns_value else {
         return Ok(false);
     };
 
+    let session_prefix = session_storage_prefix(publication_status, session_key);
     let turns_key = format!("{session_prefix}:turns");
     let Some((turn_index, mut summary, turn_key, mut detail)) = incomplete_turn_matching_records(
         handle,
         &turn_entries,
         &turns_key,
-        session_prefix,
+        &session_prefix,
         source_key,
         incoming_record_hashes,
     )?
@@ -582,7 +605,7 @@ fn enrich_incomplete_turn(
         None
     };
     let index_hit_members = index_hits_for_turns(session_key, &all_turn_keys)?;
-    let index_keys = target_associations.index_keys();
+    let index_keys = target_associations.index_keys(publication_status);
 
     let mut edits = vec![MetaEdit::set_value(&updated_at_key, &updated_at_value)];
     if improves_status {
@@ -607,6 +630,43 @@ fn enrich_incomplete_turn(
         .apply_edits(edits)
         .context("failed to enrich agent session turn")?;
     Ok(true)
+}
+
+fn capture_publication_status(
+    repo_path: &Path,
+    handle: &SessionTargetHandle<'_>,
+    session_key: &str,
+) -> Result<PublicationStatus> {
+    let published_schema_key = format!("{SESSION_PREFIX}:{session_key}:schema");
+    if handle
+        .get_value(&published_schema_key)
+        .with_context(|| format!("failed to read GitMeta key '{published_schema_key}'"))?
+        .is_some()
+    {
+        return Ok(PublicationStatus::Published);
+    }
+    let local_schema_key =
+        PublicationStatus::LocalOnly.storage_key(&format!("{SESSION_PREFIX}:{session_key}:schema"));
+    if handle
+        .get_value(&local_schema_key)
+        .with_context(|| format!("failed to read GitMeta key '{local_schema_key}'"))?
+        .is_some()
+    {
+        return Ok(PublicationStatus::LocalOnly);
+    }
+    if agentlog_share_default(repo_path)? {
+        Ok(PublicationStatus::Published)
+    } else {
+        Ok(PublicationStatus::LocalOnly)
+    }
+}
+
+fn agentlog_share_default(repo_path: &Path) -> Result<bool> {
+    let repo = gix::open(repo_path).context("failed to open repository config")?;
+    Ok(repo
+        .config_snapshot()
+        .boolean("gitbutler.agentlog-share-default")
+        .unwrap_or(false))
 }
 
 fn incomplete_turn_matching_records(

--- a/crates/but-agentlog/src/projection.rs
+++ b/crates/but-agentlog/src/projection.rs
@@ -19,8 +19,8 @@ use sha2::{Digest, Sha256};
 
 use crate::environment::is_public_repo_path;
 use crate::gitmeta::{
-    RelatedSession, RelatedTarget, SessionRecords, find_related_sessions_limited,
-    get_session_records, get_session_timeline_outline,
+    PublicationStatus, RelatedSession, RelatedTarget, SessionRecords,
+    find_related_sessions_limited, get_session_records, get_session_timeline_outline,
 };
 use crate::redaction::redact_text;
 
@@ -83,10 +83,15 @@ pub fn project_pr(repo_path: &Path, request: &ProjectionRequest) -> Result<Proje
     let source_metadata = session_source_metadata(repo_path, candidates.keys())?;
     let mut turn_candidates = Vec::new();
     for (session_key, candidate) in &candidates {
-        let timeline =
-            get_session_timeline_outline(repo_path, session_key, None).with_context(|| {
-                format!("failed to read projected timeline for session '{session_key}'")
-            })?;
+        let timeline = get_session_timeline_outline(
+            repo_path,
+            session_key,
+            PublicationStatus::Published,
+            None,
+        )
+        .with_context(|| {
+            format!("failed to read projected timeline for session '{session_key}'")
+        })?;
         for turn in &timeline.turns {
             let reasons = candidate.turn_match_reasons(&turn.turn_key);
             if reasons.is_empty() {
@@ -133,6 +138,7 @@ pub fn project_pr(repo_path: &Path, request: &ProjectionRequest) -> Result<Proje
         let records = get_session_records(
             repo_path,
             &selected.session_key,
+            PublicationStatus::Published,
             &selected.turn_key,
             request.limits.max_records_per_turn,
         )

--- a/crates/but-agentlog/src/skim.rs
+++ b/crates/but-agentlog/src/skim.rs
@@ -32,6 +32,7 @@ struct SkimCoverage {
 #[derive(Debug, Serialize)]
 struct SkimSession {
     session_key: String,
+    status: &'static str,
     updated_at: String,
     latest_captured_at: Option<String>,
     turn_count: usize,
@@ -76,6 +77,7 @@ impl fmt::Display for SkimReport {
                 session.record_count,
                 session.latest_captured_at.as_deref().unwrap_or("unknown")
             )?;
+            writeln!(f, "  status: {}", session.status)?;
             for turn in &session.turns {
                 write!(f, "- #{}", turn.turn_index)?;
                 if !turn.labels.is_empty() {
@@ -135,6 +137,7 @@ pub(crate) fn report(
         let previews = session_previews(&session);
         skim_sessions.push(SkimSession {
             session_key: session.session_key,
+            status: session.status.label(),
             updated_at: session.updated_at,
             latest_captured_at: session.latest_captured_at,
             turn_count: session.turn_count,
@@ -159,8 +162,9 @@ pub(crate) fn report(
 }
 
 fn skim_session_turns(workdir: &Path, session: &RelatedSession) -> anyhow::Result<Vec<SkimTurn>> {
-    let timeline = get_session_timeline_outline(workdir, &session.session_key, None)
-        .context("failed to read agent session timeline")?;
+    let timeline =
+        get_session_timeline_outline(workdir, &session.session_key, session.status, None)
+            .context("failed to read agent session timeline")?;
     let related_turn_keys = &session.related_turn_keys;
     Ok(timeline
         .turns

--- a/crates/but/src/args/tests.rs
+++ b/crates/but/src/args/tests.rs
@@ -136,6 +136,65 @@ fn clap() {
     Args::command().debug_assert();
 }
 
+mod agentlog {
+    use clap::Parser;
+
+    use crate::args::{Args, Subcommands};
+
+    #[test]
+    fn publish_parses_branch_shorthand() {
+        let args =
+            Args::try_parse_from(["but", "agentlog", "publish", "main"]).expect("parse args");
+        let cmd = args.cmd.expect("subcommand");
+
+        match cmd {
+            Subcommands::AgentLog {
+                cmd:
+                    but_agentlog::Command::Publish {
+                        branch_or_target,
+                        value,
+                        dry_run,
+                    },
+            } => {
+                assert_eq!(branch_or_target, "main");
+                assert_eq!(value, None);
+                assert!(!dry_run);
+            }
+            _ => panic!("unexpected command shape"),
+        }
+    }
+
+    #[test]
+    fn publish_parses_explicit_review_target() {
+        let args = Args::try_parse_from([
+            "but",
+            "agentlog",
+            "publish",
+            "review",
+            "review-1",
+            "--dry-run",
+        ])
+        .expect("parse args");
+        let cmd = args.cmd.expect("subcommand");
+
+        match cmd {
+            Subcommands::AgentLog {
+                cmd:
+                    but_agentlog::Command::Publish {
+                        branch_or_target,
+                        value,
+                        dry_run,
+                    },
+            } => {
+                assert_eq!(branch_or_target, "review");
+                assert_eq!(value.as_deref(), Some("review-1"));
+                assert!(dry_run);
+            }
+            _ => panic!("unexpected command shape"),
+        }
+    }
+}
+
 #[cfg(feature = "legacy")]
 mod push {
     use clap::Parser;


### PR DESCRIPTION
## Summary
- capture new agentlog sessions under local: metadata by default, with gitbutler.agentlog-share-default preserving old share-by-default behavior
- add explicit publish flow for branch/review/change targets and keep Agent Trail projection on published metadata only
- pin git-meta-lib from the workspace by git revision only

## Validation
- cargo clippy -p but-agentlog --all-targets --no-deps --no-default-features
- cargo test -p but-agentlog --no-default-features
- cargo fmt --check -p but-agentlog
- cargo check -p gitbutler-edit-mode --no-default-features
- cargo machete
- git diff --check