### PR TITLE
fix(tui): fix full screen details off-by-one

### DIFF
--- a/crates/but/src/command/legacy/status/tui/render.rs
+++ b/crates/but/src/command/legacy/status/tui/render.rs
@@ -1053,7 +1053,7 @@ pub(super) fn details_viewport(app: &App, terminal_area: Rect) -> Rect {
     status_layout(app, content_area)
         .details_area
         .map(|details_area| details_content_area(app, details_area))
-        .unwrap_or(content_area)
+        .unwrap_or_else(|| pane_block(app, true, Borders::BOTTOM).inner(content_area))
 }
 
 /// Returns the number of terminal rows available for rendering the status list.

--- a/crates/but/src/command/legacy/status/tui/tests/details_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/details_tests.rs
@@ -352,6 +352,32 @@ fn toggle_full_screen_details_view() {
 }
 
 #[test]
+fn full_screen_details_scrolls_selected_hunk_to_include_final_line() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    let first_file_contents = (1..=4)
+        .map(|line| format!("first-{line:02}\n"))
+        .collect::<String>();
+    let second_file_contents = (1..=4)
+        .map(|line| format!("second-{line:02}\n"))
+        .collect::<String>();
+    env.file("first-added.txt", first_file_contents);
+    env.file("second-added.txt", second_file_contents);
+
+    let mut tui = test_tui_with_size(env, 100, 12);
+
+    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('D')));
+    tui.render_with_messages(None, Vec::new());
+
+    let output = tui.render_with_messages('j', Vec::new()).output();
+    assert!(
+        output.contains("second-04"),
+        "selected second hunk should include its final line, got:\n{output}"
+    );
+}
+
+#[test]
 fn rubbing_from_full_screen_details() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
     env.setup_metadata(&["A"]).unwrap();


### PR DESCRIPTION
We we're missing one line of context when scrolling to a hunk.