### PR TITLE
breaking(but): improve average case performance for `but branch [list]`

### DIFF
--- a/crates/but/src/command/legacy/branch/json.rs
+++ b/crates/but/src/command/legacy/branch/json.rs
@@ -14,8 +14,7 @@ pub struct BranchNewOutput {
 pub struct BranchListOutput {
     pub applied_stacks: Vec<StackOutput>,
     pub branches: Vec<BranchOutput>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub more_branches: Option<usize>,
+    pub has_more_branches: bool,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/but/src/command/legacy/branch/list.rs
+++ b/crates/but/src/command/legacy/branch/list.rs
@@ -142,8 +142,15 @@ pub fn list(
 
     // Sort all branches by last commit date (most recent first)
     //
-    // Must happen _before any lazy filtering_
-    branches.sort_by_key(|branch| std::cmp::Reverse(branch.updated_at));
+    // Must happen _before any lazy filtering_.
+    //
+    // We use branch name as a tie breaker for stable output in tests as all timestamps are the
+    // same, but it should rarely matter in a realistic scenario.
+    branches.sort_by(|a, b| {
+        b.updated_at
+            .cmp(&a.updated_at)
+            .then_with(|| a.name.cmp(&b.name))
+    });
 
     let max_branches = if all { usize::MAX / 2 } else { 20 };
     // Take one extra branch than we want to show to check if there's more to show

--- a/crates/but/src/command/legacy/branch/list.rs
+++ b/crates/but/src/command/legacy/branch/list.rs
@@ -129,25 +129,6 @@ pub fn list(
         });
     }
 
-    // Filter out branches with no commits ahead of target unless --empty is requested.
-    // A branch has 0 commits ahead when its tip equals the target, or when it is an
-    // ancestor of the target (all its commits are already in the target).
-    if let Some(target_oid) = target_oid_for_filter {
-        let repo = ctx.repo.get()?;
-        let cache = repo.commit_graph_if_enabled()?;
-        let mut graph = repo.revision_graph(cache.as_ref());
-        branches.retain(|branch| {
-            if branch.head == target_oid {
-                return false;
-            }
-            // If the merge-base equals the branch head, the branch is already fully contained
-            // in the target and has no commits ahead to show.
-            repo.merge_base_with_graph(branch.head, target_oid, &mut graph)
-                .map(|merge_base| merge_base.detach() != branch.head)
-                .unwrap_or(true)
-        });
-    }
-
     // Filter out dependabot branches unless --all is specified
     if !all {
         branches.retain(|branch| {
@@ -160,20 +141,44 @@ pub fn list(
     }
 
     // Sort all branches by last commit date (most recent first)
+    //
+    // Must happen _before any lazy filtering_
     branches.sort_by_key(|branch| std::cmp::Reverse(branch.updated_at));
 
-    // Limit branches unless --all flag is set
-    let (branches_to_show, more_count) = if all {
-        (branches, 0)
+    let max_branches = if all { usize::MAX } else { 20 };
+    let num_branches_before_limits = branches.len();
+
+    let branches_to_show: Vec<_> = if let Some(target_oid) = target_oid_for_filter {
+        let repo = ctx.repo.get()?;
+        let cache = repo.commit_graph_if_enabled()?;
+        let mut graph = repo.revision_graph(cache.as_ref());
+
+        // Filter out branches with no commits ahead of target unless --empty is requested.
+        // A branch has 0 commits ahead when its tip equals the target, or when it is an
+        // ancestor of the target (all its commits are already in the target).
+        //
+        // This computation is _very heavy_ and can take minutes in repositories with thousands of
+        // branches (e.g. the VS Code repository), so we perform it lazily. It's therefore important
+        // that it happens after sorting.
+        branches
+            .into_iter()
+            .filter(|branch| {
+                if branch.head == target_oid {
+                    return false;
+                }
+                // If the merge-base equals the branch head, the branch is already fully contained
+                // in the target and has no commits ahead to show.
+                repo.merge_base_with_graph(branch.head, target_oid, &mut graph)
+                    .map(|merge_base| merge_base.detach() != branch.head)
+                    .unwrap_or(true)
+            })
+            .take(max_branches)
+            .collect()
     } else {
-        const MAX_BRANCHES: usize = 20;
-        if branches.len() > MAX_BRANCHES {
-            let remaining = branches.len() - MAX_BRANCHES;
-            (branches.into_iter().take(MAX_BRANCHES).collect(), remaining)
-        } else {
-            (branches, 0)
-        }
+        branches.into_iter().take(max_branches).collect()
     };
+
+    let more_count = num_branches_before_limits - branches_to_show.len();
 
     // Calculate commits ahead if requested
     let commits_ahead_map: Option<HashMap<String, usize>> = if ahead {

--- a/crates/but/src/command/legacy/branch/list.rs
+++ b/crates/but/src/command/legacy/branch/list.rs
@@ -145,8 +145,9 @@ pub fn list(
     // Must happen _before any lazy filtering_
     branches.sort_by_key(|branch| std::cmp::Reverse(branch.updated_at));
 
-    let max_branches = if all { usize::MAX } else { 20 };
-    let num_branches_before_limits = branches.len();
+    let max_branches = if all { usize::MAX / 2 } else { 20 };
+    // Take one extra branch than we want to show to check if there's more to show
+    let num_branches_to_take = max_branches + 1;
 
     let branches_to_show: Vec<_> = if let Some(target_oid) = target_oid_for_filter {
         let repo = ctx.repo.get()?;
@@ -172,13 +173,14 @@ pub fn list(
                     .map(|merge_base| merge_base.detach() != branch.head)
                     .unwrap_or(true)
             })
-            .take(max_branches)
+            .take(num_branches_to_take)
             .collect()
     } else {
-        branches.into_iter().take(max_branches).collect()
+        branches.into_iter().take(num_branches_to_take).collect()
     };
 
-    let more_count = num_branches_before_limits - branches_to_show.len();
+    let has_more_branches = branches_to_show.len() > max_branches;
+    let branches_to_show: Vec<_> = branches_to_show.into_iter().take(max_branches).collect();
 
     // Calculate commits ahead if requested
     let commits_ahead_map: Option<HashMap<String, usize>> = if ahead {
@@ -207,7 +209,7 @@ pub fn list(
         output_json(
             &applied_stacks,
             &branches_to_show,
-            more_count,
+            has_more_branches,
             &branch_review_map,
             commits_ahead_map.as_ref(),
             merge_status_map.as_ref(),
@@ -243,10 +245,11 @@ pub fn list(
             )?;
         }
 
-        if more_count > 0 {
+        if has_more_branches {
             writeln!(
                 out,
-                "\n... and {more_count} more branches (use --all to show all)"
+                "\n... result truncated to {} matching branches (use --all to show all that match filters)",
+                branches_to_show.len()
             )?;
         }
     }
@@ -257,7 +260,7 @@ pub fn list(
 fn output_json(
     applied_stacks: &[but_workspace::legacy::ui::StackEntry],
     branches: &[gitbutler_branch_actions::BranchListing],
-    more_count: usize,
+    has_more_branches: bool,
     branch_review_map: &HashMap<String, Vec<but_forge::ForgeReview>>,
     commits_ahead_map: Option<&HashMap<String, usize>>,
     merge_status_map: Option<&HashMap<String, bool>>,
@@ -334,11 +337,7 @@ fn output_json(
     let output = BranchListOutput {
         applied_stacks: applied_stacks_output,
         branches: branches_output,
-        more_branches: if more_count > 0 {
-            Some(more_count)
-        } else {
-            None
-        },
+        has_more_branches,
     };
 
     out.write_value(output)?;

--- a/crates/but/tests/but/command/branch/list.rs
+++ b/crates/but/tests/but/command/branch/list.rs
@@ -45,3 +45,85 @@ fn list_hides_empty_applied_branches_by_default() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn list_truncates_results_if_they_exceed_default_limit() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+    let default_limit = 20;
+
+    for i in 0..default_limit {
+        env.invoke_git(&format!("branch branch-{i} A"));
+    }
+
+    env.but("branch list")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Applied branches
+active  ✓ *A          26y ago    author
+
+Unapplied Branches
+local   ✓ branch-0  ↑1     26y ago    author
+local   ✓ branch-1  ↑1     26y ago    author
+local   ✓ branch-10 ↑1     26y ago    author
+local   ✓ branch-11 ↑1     26y ago    author
+local   ✓ branch-12 ↑1     26y ago    author
+local   ✓ branch-13 ↑1     26y ago    author
+local   ✓ branch-14 ↑1     26y ago    author
+local   ✓ branch-15 ↑1     26y ago    author
+local   ✓ branch-16 ↑1     26y ago    author
+local   ✓ branch-17 ↑1     26y ago    author
+local   ✓ branch-18 ↑1     26y ago    author
+local   ✓ branch-19 ↑1     26y ago    author
+local   ✓ branch-2  ↑1     26y ago    author
+local   ✓ branch-3  ↑1     26y ago    author
+local   ✓ branch-4  ↑1     26y ago    author
+local   ✓ branch-5  ↑1     26y ago    author
+local   ✓ branch-6  ↑1     26y ago    author
+local   ✓ branch-7  ↑1     26y ago    author
+local   ✓ branch-8  ↑1     26y ago    author
+local   ✓ branch-9  ↑1     26y ago    author
+
+"#]])
+        .stderr_eq(snapbox::str![[]]);
+
+    // This should be the tipping point for truncating branch results
+    env.invoke_git("branch branch-20 A");
+
+    env.but("branch list")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Applied branches
+active  ✓ *A          26y ago    author
+
+Unapplied Branches
+local   ✓ branch-0  ↑1     26y ago    author
+local   ✓ branch-1  ↑1     26y ago    author
+local   ✓ branch-10 ↑1     26y ago    author
+local   ✓ branch-11 ↑1     26y ago    author
+local   ✓ branch-12 ↑1     26y ago    author
+local   ✓ branch-13 ↑1     26y ago    author
+local   ✓ branch-14 ↑1     26y ago    author
+local   ✓ branch-15 ↑1     26y ago    author
+local   ✓ branch-16 ↑1     26y ago    author
+local   ✓ branch-17 ↑1     26y ago    author
+local   ✓ branch-18 ↑1     26y ago    author
+local   ✓ branch-19 ↑1     26y ago    author
+local   ✓ branch-2  ↑1     26y ago    author
+local   ✓ branch-20 ↑1     26y ago    author
+local   ✓ branch-3  ↑1     26y ago    author
+local   ✓ branch-4  ↑1     26y ago    author
+local   ✓ branch-5  ↑1     26y ago    author
+local   ✓ branch-6  ↑1     26y ago    author
+local   ✓ branch-7  ↑1     26y ago    author
+local   ✓ branch-8  ↑1     26y ago    author
+
+... result truncated to 20 matching branches (use --all to show all that match filters)
+
+"#]])
+        .stderr_eq(snapbox::str![[]]);
+
+    Ok(())
+}


### PR DESCRIPTION
The performance of `but branch list` without any extra options (a.k.a `but branch`) is very poor on repositories with many branches. The culprit is the "empty branch" computation where we check if the branch is ahead of the workspace or not. This computation was performed eagerly, and as the defaults include remote branches, repositories like https://github.com/microsoft/vscode with its ~4k branches made `but branch` take on the order of minutes to complete. That's even on powerful workstations.

This commit makes the computation lazy, which solves the problem for the average case. The X latest branches that satisfy the criteria of "non-empty" will always be found within the X+Y first scanned branches. In a typical repository, I've found that Y is somewhat proportional to X. For X=20, Y tends to be negligible. Hence, we solve the average case with lazy computation, while the worst case remains the same.

You can still trigger worst case performance by running with the `--all` flag, but at least then you've made an explicit choice about it. `but branch list` requires a more fundamental rewrite to address larger UX concerns, which is why this change targets this performance issue in isolation.

Performance before:

* GitButler repo: ~500ms
* VS Code repo: ~1m10s

Performance after:

* GitButler repo: ~60ms
* VS Code repo: ~160ms

## Breaking change
Output (JSON and human alike) no longer show the exact amount of branches that would be revealed with `--all`. The JSON output now has a boolean `has_more_branches` and the human output indicates more loosely that "there are more branches matching the current filter".

I think we should break this API a _lot_ more to improve it in the near future :)