### PR TITLE
Fix discarding conflicted commits

### DIFF
--- a/crates/but-workspace/src/commit/discard_commit.rs
+++ b/crates/but-workspace/src/commit/discard_commit.rs
@@ -23,14 +23,7 @@ pub fn discard_commits<'ws, 'meta, M: RefMetadata>(
             continue;
         }
         count += 1;
-        let (selector, commit) = editor.find_selectable_commit(commit_id)?;
-
-        if commit.clone().attach(editor.repo()).is_conflicted() {
-            bail!(
-                "Cannot discard conflicted commit {}",
-                commit_id.to_hex_with_len(7)
-            )
-        }
+        let (selector, _commit) = editor.find_selectable_commit(commit_id)?;
 
         let delimiter = SegmentDelimiter {
             child: selector,

--- a/crates/but-workspace/tests/workspace/commit/discard_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/discard_commit.rs
@@ -208,7 +208,7 @@ fn discard_bottom_commit_in_workspace_stack() -> Result<()> {
 }
 
 #[test]
-fn cannot_discard_conflicted_commit() -> Result<()> {
+fn can_discard_conflicted_commit() -> Result<()> {
     let (_tmp, graph, repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph("with-conflict", |_| {})?;
 
@@ -221,17 +221,13 @@ fn cannot_discard_conflicted_commit() -> Result<()> {
 
     let mut ws = graph.into_workspace()?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
-    let result = discard_commits(editor, [conflicted.detach()]);
+    let outcome = discard_commits(editor, [conflicted.detach()])?;
 
-    let err = result.expect_err("Discarding a conflicted commit must fail");
-    assert!(
-        err.to_string().contains("Cannot discard conflicted commit"),
-        "unexpected error: {err}"
-    );
+    outcome.materialize()?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * 8450331 (HEAD -> main, tag: conflicted) GitButler WIP Commit
-    * a047f81 (tag: normal) init
+    * 8450331 (tag: conflicted) GitButler WIP Commit
+    * a047f81 (HEAD -> main, tag: normal) init
     ");
 
     Ok(())


### PR DESCRIPTION
There is no reason why we shouldn’t be able to?