### PR TITLE
feat(cli): beginnings of cli revamp (commit2/move2/squash2)

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -300,6 +300,8 @@ jobs:
           rm cargo-nextest.tar.gz
       - name: Run workspace tests
         run: cargo nextest run --workspace --exclude gitbutler-tauri --exclude but-api-macros-tests --profile ci
+      - name: Run experimental cli command tests
+        run: make test-but-2
       - name: Run doctests
         run: cargo test --doc --workspace --exclude gitbutler-tauri --exclude but-api-macros-tests
       - name: Upload results to Buildkite Test Engine

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,16 @@ check-modern-but:
 test-modern-but:
 	cargo test -p but --no-default-features
 
+# Lint: `but` with new experimental commands.
+.PHONY: clippy-but-2
+clippy-but-2:
+	cargo clippy -p but --features but-2 -- -D warnings
+
+# CI executes this to test a version of `but` with new experimental commands.
+.PHONY: test-but-2
+test-but-2:
+	cargo test -p but --features but-2
+
 # Run all tests in the entire workspace and show all failures in the end.
 .PHONY: nextest
 nextest:

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -41,6 +41,8 @@ legacy = [
 ]
 # Feature that enables profiling related features of the TUI.
 tui-profiling = []
+# Enables new experimental CLI commands that'll eventually replace old commands
+but-2 = []
 
 [dependencies]
 but-core.workspace = true

--- a/crates/but/but-cli-revamp/branch-new.md
+++ b/crates/but/but-cli-revamp/branch-new.md
@@ -1,0 +1,170 @@
+```
+but branch new <name>?
+but branch new -A/--above <commit or branch>
+but branch new -B/--below <commit or branch>
+but branch new --format human/json/shell
+```
+
+Example baseline
+```
+┊╭┄op [top]
+┊●   20e235d six
+┊●   e28a167 five
+┊│
+┊├┄mi [middle]
+┊●   58410cd four
+┊●   5a08eb5 three
+┊│
+┊├┄bo [bottom]
+┊●   87a11e5 two
+┊●   28e6961 one
+├╯
+```
+
+# Above/below branches
+but branch new
+```
+┊╭┄op [top]
+┊●   20e235d six
+┊●   e28a167 five
+┊│
+┊├┄mi [middle]
+┊●   58410cd four
+┊●   5a08eb5 three
+┊│
+┊├┄bo [bottom]
+┊●   87a11e5 two
+┊●   28e6961 one
+├╯
+┊
+┊╭┄dp [canned]
+├╯
+```
+
+but branch new foo
+```
+┊╭┄op [top]
+┊●   20e235d six
+┊●   e28a167 five
+┊│
+┊├┄mi [middle]
+┊●   58410cd four
+┊●   5a08eb5 three
+┊│
+┊├┄bo [bottom]
+┊●   87a11e5 two
+┊●   28e6961 one
+├╯
+┊
+┊╭┄dp [foo]
+├╯
+```
+
+but branch new --above bottom
+```
+┊╭┄op [top]
+┊●   20e235d six
+┊●   e28a167 five
+┊│
+┊├┄mi [middle]
+┊●   58410cd four
+┊●   5a08eb5 three
+┊│
+┊├┄mi [canned]
+┊│
+┊├┄bo [bottom]
+┊●   87a11e5 two
+┊●   28e6961 one
+├╯
+```
+
+but branch new --below bottom
+```
+┊╭┄op [top]
+┊●   20e235d six
+┊●   e28a167 five
+┊│
+┊├┄mi [middle]
+┊●   58410cd four
+┊●   5a08eb5 three
+┊│
+┊├┄bo [bottom]
+┊●   87a11e5 two
+┊●   28e6961 one
+┊│
+┊├┄bo [canned]
+├╯
+```
+
+but branch new --above top
+```
+┊╭┄op [canned]
+┊│
+┊├┄op [top]
+┊●   20e235d six
+┊●   e28a167 five
+┊│
+┊├┄mi [middle]
+┊●   58410cd four
+┊●   5a08eb5 three
+┊│
+┊├┄bo [bottom]
+┊●   87a11e5 two
+┊●   28e6961 one
+├╯
+```
+
+# Above/below commits
+but branch new --above 5a08eb5
+```
+┊╭┄op [top]
+┊●   20e235d six
+┊●   e28a167 five
+┊│
+┊├┄mi [middle]
+┊●   58410cd four
+┊│
+┊├┄mi [canned]
+┊●   5a08eb5 three
+┊│
+┊├┄bo [bottom]
+┊●   87a11e5 two
+┊●   28e6961 one
+├╯
+```
+
+but branch new --below 5a08eb5
+```
+┊╭┄op [top]
+┊●   20e235d six
+┊●   e28a167 five
+┊│
+┊├┄mi [middle]
+┊●   58410cd four
+┊●   5a08eb5 three
+┊│
+┊├┄mi [canned]
+┊│
+┊├┄bo [bottom]
+┊●   87a11e5 two
+┊●   28e6961 one
+├╯
+```
+
+but branch new --above 58410cd
+```
+┊╭┄op [top]
+┊●   20e235d six
+┊●   e28a167 five
+┊│
+┊├┄mi [middle]
+┊│
+┊├┄mi [canned]
+┊●   58410cd four
+┊●   5a08eb5 three
+┊│
+┊├┄bo [bottom]
+┊●   87a11e5 two
+┊●   28e6961 one
+├╯
+```

--- a/crates/but/but-cli-revamp/commit.md
+++ b/crates/but/but-cli-revamp/commit.md
@@ -1,0 +1,239 @@
+```
+but commit
+but commit <uncommitted file>*
+but commit -i/--interactive
+but commit --empty
+but commit -b/--branch
+but commit -A/--above <commit or branch>
+but commit -B/--below <commit or branch>
+but commit -m/--message <message> (can be repeated)
+but commit --message-file <path>
+but commit --no-message
+but commit --format human/json/shell
+but commit --abort-on-conflicts
+```
+
+We assume that we remove staging/assigments. The rational is that if deciding
+what to commit is easy and commits are easy to mutate, then you don’t need
+staging
+
+We expect most people will just run `but commit` to commit everything to
+whatever branch they're working on. With no branches `but commit` will also
+create a branch and when run again will commit to that same branch, since there
+is only one branch in the workspace.
+
+`but commit -b foo` can also be repeated in the same way to keep committing to
+the same branch.
+
+# Questions
+
+Q: Are commit messages required?
+A: No and saving the editor without a commit message still creates the commit without a message
+
+Q: Can you do `but commit --above middle -b`?
+A: No. Mixing --above/--below with -b is not allowed
+
+# What to commit
+```
+but commit
+```
+commit everything unassigned
+
+```
+but commit -i/--interactive
+```
+opens the tui where you can mark changes
+confirming will exit the tui and commit
+
+```
+but commit cli-id-1 cli-id-2
+```
+for agents picking what to commit
+
+# Where to commit
+Examples below assume this baseline
+```
+┊╭┄h0 [top]
+┊●   f3e56a9 some commit (no changes)
+┊│
+┊├┄i0 [middle]
+┊●   b440dea add bar-1.txt
+┊│
+┊├┄fo [bottom]
+┊●   9cd3abf add foo.txt
+├╯
+```
+
+## Without above/below
+```
+but commit
+```
+Will try and figure out where to commit. If thats not obvious it'll show a picker
+
+```
+but commit -b
+```
+Commit to a new branch with a canned name
+
+```
+but commit -b new-branch
+```
+Commit to a new branch with a given name. Creates a new stack
+
+```
+but commit -b existing-branch
+```
+Commit to an existing branch
+
+```
+but commit --above foo
+```
+Creates a new branch above foo and commits there
+Mixing --above/--below with -b is not allowed
+
+```
+but commit --below foo
+```
+Same idea as `--above foo`, i.e. creates a new branch below foo and commits there
+
+```
+but commit --above/--below f3e56a9
+```
+Will create a commit above/below f3e56a9 but wont create a new branch
+
+## above/below branches
+### top
+#### above
+but commit --above top
+```
+┊╭┄h0 [canned]
+┊●   NEW COMMIT GOES HERE
+┊│
+┊├┄h0 [top]
+┊●   f3e56a9 some commit (no changes)
+┊│
+┊├┄i0 [middle]
+┊●   b440dea add bar-1.txt
+┊│
+┊├┄fo [bottom]
+┊●   9cd3abf add foo.txt
+├╯
+```
+
+#### below
+but commit --below top
+```
+┊╭┄h0 [top]
+┊●   f3e56a9 some commit (no changes)
+┊│
+┊├┄i0 [canned]
+┊●   NEW COMMIT GOES HERE
+┊│
+┊├┄i0 [middle]
+┊●   b440dea add bar-1.txt
+┊│
+┊├┄fo [bottom]
+┊●   9cd3abf add foo.txt
+├╯
+```
+
+### middle
+#### above
+but commit --above middle
+```
+┊╭┄h0 [top]
+┊●   f3e56a9 some commit (no changes)
+┊│
+┊├┄i0 [canned]
+┊●   NEW COMMIT GOES HERE
+┊│
+┊├┄i0 [middle]
+┊●   b440dea add bar-1.txt
+┊│
+┊├┄fo [bottom]
+┊●   9cd3abf add foo.txt
+├╯
+```
+
+#### below
+but commit --below middle
+```
+┊╭┄h0 [top]
+┊●   f3e56a9 some commit (no changes)
+┊│
+┊├┄i0 [middle]
+┊●   b440dea add bar-1.txt
+┊│
+┊├┄i0 [canned]
+┊●   NEW COMMIT GOES HERE
+┊│
+┊├┄fo [bottom]
+┊●   9cd3abf add foo.txt
+├╯
+```
+
+### bottom
+#### above
+but commit --above bottom
+```
+┊╭┄h0 [top]
+┊●   f3e56a9 some commit (no changes)
+┊│
+┊├┄i0 [middle]
+┊●   b440dea add bar-1.txt
+┊│
+┊├┄i0 [canned]
+┊●   NEW COMMIT GOES HERE
+┊│
+┊├┄fo [bottom]
+┊●   9cd3abf add foo.txt
+├╯
+```
+
+#### below
+but commit --below bottom
+```
+┊╭┄h0 [top]
+┊●   f3e56a9 some commit (no changes)
+┊│
+┊├┄i0 [middle]
+┊●   b440dea add bar-1.txt
+┊│
+┊├┄fo [bottom]
+┊●   9cd3abf add foo.txt
+┊│
+┊├┄i0 [canned]
+┊●   NEW COMMIT GOES HERE
+├╯
+```
+
+## above/below commits
+### above
+but commit --above b440dea
+```
+┊╭┄h0 [top]
+┊●   f3e56a9 some commit (no changes)
+┊│
+┊├┄i0 [middle]
+┊●   NEW COMMIT GOES HERE
+┊●   b440dea add bar-1.txt
+┊│
+┊├┄fo [bottom]
+┊●   9cd3abf add foo.txt
+├╯
+```
+
+### below
+but commit --below b440dea
+```
+┊╭┄h0 [top]
+┊●   f3e56a9 some commit (no changes)
+┊│
+┊├┄i0 [middle]
+┊●   b440dea add bar-1.txt
+┊●   NEW COMMIT GOES HERE
+┊│
+┊├┄fo [bottom]
+┊●   9cd3abf add foo.txt
+├╯
+```

--- a/crates/but/but-cli-revamp/move.md
+++ b/crates/but/but-cli-revamp/move.md
@@ -1,0 +1,283 @@
+```
+but move <source>+
+but move -b/--branch <branch>
+but move -A/--above <commit or branch>
+but move -B/--below <commit or branch>
+but move <commit or branch>+ --unstack
+but move -i/--interactive
+but move --format human/json/shell
+but move --abort-on-conflicts
+```
+
+`but move f3e56a9 --branch existing-branch` moves the commit to the top of the branch
+
+`but move f3e56a9 --branch non-existing-branch` creates the branch and moves the commit there
+`but move f3e56a9 --branch` creates the branch, with a canned name, and moves the commit there
+
+`but move some-branch --unstack` to unstack a branch because you cannot target zz/common base. This solution isn't great but we couldn't think of something nicer.
+
+The order of the sources dont matter. We'll do a sort internally
+
+`but move b440dea --above 20e235d --interactive` will open the TUI where you can pick the hunks to move
+
+# Questions
+
+Q: Can you do `but move zz` to create a commit?
+A: No. Move doesn't create new commits. The number of commits doesn't change when moving
+
+Q: Can you do `but move f3e56a9 --target zz` to create a uncommit?
+A: No. `--target` isn't a thing and move doesn't uncommit/remove commits. The number of commits doesn't change when moving
+
+Q: Can you move all the commits on a branch, without moving the branch itself?
+A: Not for now. You can specify multiple sources so maybe we'll have ranges in the future or something specific to moving all commits on a branch
+
+Q: Can you specify commit ranges?
+A: Not for now.
+
+Q: Can you do `but move f3e56a9 --after top --branch bar` to create a new branch?
+A: Yes!
+
+Q: Can you mix sources like `but move f3e56a9 middle --after top`?
+A: No
+
+Q: Can you do `but move top --below b440dea`?
+A: No. The available targets for each source is
+  - Branch: Branches
+  - Commit: Branches + commits
+  - File: Branches + commits
+  - Hunk: Branches + commits
+
+Q: Can you do `but move top -b`
+A: No. You cannot use `-b` when the source is a branch. Use `--unstack`
+
+Q: Moving commits to new unstacked branches
+A: `but move b440dea -b`
+
+Q: Can you specify both --above and --below
+A: Not for now but someday maybe
+
+# Examples
+Examples below assume this baseline
+```
+┊╭┄h0 [top]
+┊●   f3e56a9 six
+┊●   ed663c1 five
+┊│
+┊├┄i0 [middle]
+┊●   b440dea four
+┊●   0db9c35 three
+┊│
+┊├┄fo [bottom]
+┊●   9cd3abf two
+┊●   58f9cc1 one
+├╯
+```
+
+## Moving commits
+but move 0db9c35 --branch top
+```
+┊╭┄h0 [top]
+┊●   0db9c35 three <- to here
+┊●   f3e56a9 six
+┊●   ed663c1 five
+┊│
+┊├┄i0 [middle]
+┊●   b440dea four
+┊●   0db9c35 three <- from here
+┊│
+┊├┄fo [bottom]
+┊●   9cd3abf two
+┊●   58f9cc1 one
+├╯
+```
+
+but move 9cd3abf --above 0db9c35
+```
+┊╭┄h0 [top]
+┊●   f3e56a9 six
+┊●   ed663c1 five
+┊│
+┊├┄i0 [middle]
+┊●   b440dea four
+┊●   9cd3abf two <- to here
+┊●   0db9c35 three
+┊│
+┊├┄fo [bottom]
+┊●   9cd3abf two <- from here
+┊●   58f9cc1 one
+├╯
+```
+
+but move ed663c1 --above middle
+but move ed663c1 --above middle -b (isn't necessary, it means the same thing)
+```
+┊╭┄h0 [top]
+┊●   f3e56a9 six
+┊│
+┊├┄i0 [canned]
+┊●   ed663c1 five <- to here
+┊│
+┊├┄i0 [middle]
+┊●   b440dea four
+┊●   0db9c35 three
+┊●   ed663c1 five <- from here
+┊│
+┊├┄fo [bottom]
+┊●   9cd3abf two
+┊●   58f9cc1 one
+├╯
+```
+
+but move ed663c1 --below middle
+```
+┊╭┄h0 [top]
+┊●   f3e56a9 six
+┊│
+┊├┄i0 [middle]
+┊●   b440dea four
+┊●   0db9c35 three
+┊●   ed663c1 five <- to here
+┊│
+┊├┄i0 [canned]
+┊●   ed663c1 five <- from here
+┊│
+┊├┄fo [bottom]
+┊●   9cd3abf two
+┊●   58f9cc1 one
+├╯
+```
+
+but move 58f9cc1 9cd3abf --above 0db9c35
+```
+┊╭┄h0 [top]
+┊●   f3e56a9 six
+┊●   ed663c1 five
+┊│
+┊├┄i0 [middle]
+┊●   b440dea four
+┊●   9cd3abf two <- to here
+┊●   58f9cc1 one <- to here
+┊●   0db9c35 three
+┊│
+┊├┄fo [bottom]
+┊●   9cd3abf two <- from here
+┊●   58f9cc1 one <- from here
+├╯
+```
+
+but move f3e56a9 --unstack
+but move f3e56a9 --unstack -b foo
+```
+┊╭┄h0 [top]
+┊●   f3e56a9 six <- from here
+┊●   ed663c1 five
+┊│
+┊├┄i0 [middle]
+┊●   b440dea four
+┊●   0db9c35 three
+┊│
+┊├┄fo [bottom]
+┊●   9cd3abf two
+┊●   58f9cc1 one
+├╯
+┊
+┊╭┄fo [canned]
+┊●   f3e56a9 six  <- to here
+├╯
+```
+
+## Moving branches
+but move middle --above top
+```
+┊╭┄i0 [middle]     <- to here
+┊●   b440dea four  <- to here
+┊●   0db9c35 three <- to here
+┊│
+┊├┄h0 [top]
+┊●   f3e56a9 six
+┊●   ed663c1 five
+┊│
+┊├ <- from here
+┊│
+┊├┄fo [bottom]
+┊●   9cd3abf two
+┊●   58f9cc1 one
+├╯
+```
+
+but move middle --unstack
+```
+┊╭┄h0 [top]
+┊●   f3e56a9 six
+┊●   ed663c1 five
+┊│
+┊├ <- from here
+┊│
+┊├┄fo [bottom]
+┊●   9cd3abf two
+┊●   58f9cc1 one
+├╯
+┊
+┊╭┄fo [middle]     <- to here
+┊●   b440dea four  <- to here
+┊●   0db9c35 three <- to here
+├╯
+```
+
+## Moving files
+Baseline
+```
+┊╭┄h0 [top]
+┊●   f3e56a9 six
+┊│     f3:xv A six.txt
+┊●   ed663c1 five
+┊│
+┊├┄i0 [middle]
+┊●   b440dea four
+┊●   0db9c35 three
+┊│
+┊├┄fo [bottom]
+┊●   9cd3abf two
+┊●   58f9cc1 one
+├╯
+```
+
+but move f3:xv --above top
+```
+┊╭┄h0 [canned]
+┊●   1dabfe5 (no commit message)
+┊│     1d:xv A six.txt <- to here
+┊│
+┊├┄i0 [top]
+┊●   f3e56a9 six
+┊│     f3:xv A six.txt <- from here
+┊●   ed663c1 five
+┊│
+┊├┄i0 [middle]
+┊●   b440dea four
+┊●   0db9c35 three
+┊│
+┊├┄fo [bottom]
+┊●   9cd3abf two
+┊●   58f9cc1 one
+├╯
+```
+
+but move f3:xv --below b440dea
+```
+┊╭┄h0 [top]
+┊●   f3e56a9 six
+┊│     f3:xv A six.txt <- from here
+┊●   ed663c1 five
+┊│
+┊├┄i0 [middle]
+┊●   b440dea four
+┊●   1dabfe5 (no commit message)
+┊│     1d:xv A six.txt <- to here
+┊●   0db9c35 three
+┊│
+┊├┄fo [bottom]
+┊●   9cd3abf two
+┊●   58f9cc1 one
+├╯
+```

--- a/crates/but/but-cli-revamp/squash.md
+++ b/crates/but/but-cli-revamp/squash.md
@@ -1,0 +1,205 @@
+```
+but squash <source>+
+but squash -t/--target <target>
+but squash -m/--message <message> (can be repeated)
+but squash --message-file <path>
+but squash --no-message
+but squash --use-source-message
+but squash -u/--use-target-message
+but squash -i/--interactive
+but squash --format human/json/shell
+but squash --abort-on-conflicts
+```
+
+# Questions
+
+Q: `but squash branch`
+A: Will squash all commits on the branch and keep the reference
+
+Q: Can you squash a branch into another commit
+A: Yes. That'll squash all the commits in the branch and remove the reference
+
+Q: Can you squash into branches
+A: No
+
+Q: Does the editor open to edit the squashed messages
+A: Yes
+
+Q: Can you mix source types?
+A: No but except you can mix files and hunks
+
+Q: Does squash open the editor to edit the commit message
+
+# Examples
+Examples below assume this baseline
+```
+╭┄zz [unassigned changes]
+┊   ur M flake.nix
+┊
+┊╭┄op [top]
+┊●   20e235d six
+┊●   e28a167 five
+┊│
+┊├┄mi [middle]
+┊●   58410cd four
+┊●   5a08eb5 three
+┊│
+┊├┄bo [bottom]
+┊●   87a11e5 two
+┊●   28e6961 one
+├╯
+┊
+┴ ed7c1f1 (common base) 2026-06-01 add flake.lock
+```
+
+but squash e28a167 -t 20e235d
+but squash top
+```
+╭┄zz [unassigned changes]
+┊   ur M flake.nix
+┊
+┊╭┄op [top]
+┊●   21ec00c six+five
+┊│
+┊├┄mi [middle]
+┊●   58410cd four
+┊●   5a08eb5 three
+┊│
+┊├┄bo [bottom]
+┊●   87a11e5 two
+┊●   28e6961 one
+├╯
+┊
+┴ ed7c1f1 (common base) 2026-06-01 add flake.lock
+```
+
+but squash 58410cd 5a08eb5 -t 20e235d
+```
+╭┄zz [unassigned changes]
+┊   ur M flake.nix
+┊
+┊╭┄op [top]
+┊●   21ec00c six+four+three
+┊●   e28a167 five
+┊│
+┊├┄mi [middle]
+┊│
+┊├┄bo [bottom]
+┊●   87a11e5 two
+┊●   28e6961 one
+├╯
+┊
+┴ ed7c1f1 (common base) 2026-06-01 add flake.lock
+```
+
+but squash middle -t e28a167
+```
+╭┄zz [unassigned changes]
+┊   ur M flake.nix
+┊
+┊╭┄op [top]
+┊●   20e235d six
+┊●   e28a167 five+four+three
+┊│
+┊├┄bo [bottom]
+┊●   87a11e5 two
+┊●   28e6961 one
+├╯
+┊
+┴ ed7c1f1 (common base) 2026-06-01 add flake.lock
+```
+
+but squash 20e235d -t zz
+```
+╭┄zz [unassigned changes]
+┊   ur M flake.nix
+┊   ab M six
+┊
+┊╭┄op [top]
+┊●   e28a167 five
+┊│
+┊├┄mi [middle]
+┊●   58410cd four
+┊●   5a08eb5 three
+┊│
+┊├┄bo [bottom]
+┊●   87a11e5 two
+┊●   28e6961 one
+├╯
+┊
+┴ ed7c1f1 (common base) 2026-06-01 add flake.lock
+```
+
+but squash zz -t 20e235d
+```
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄op [top]
+┊●   20e235d six+flake.nix
+┊●   e28a167 five
+┊│
+┊├┄mi [middle]
+┊●   58410cd four
+┊●   5a08eb5 three
+┊│
+┊├┄bo [bottom]
+┊●   87a11e5 two
+┊●   28e6961 one
+├╯
+┊
+┴ ed7c1f1 (common base) 2026-06-01 add flake.lock
+```
+
+but squash middle -t zz
+```
+╭┄zz [unassigned changes]
+┊   ur M flake.nix
+┊   ur M four
+┊   ur M three
+┊
+┊╭┄op [top]
+┊●   20e235d six
+┊●   e28a167 five
+┊│
+┊├┄bo [bottom]
+┊●   87a11e5 two
+┊●   28e6961 one
+├╯
+┊
+┴ ed7c1f1 (common base) 2026-06-01 add flake.lock
+```
+
+## Squashing hunks
+Baseline
+```
+┊╭┄h0 [top]
+┊●   f3e56a9 six
+┊│     f3:xv A six.txt
+┊●   ed663c1 five
+┊│
+┊├┄i0 [middle]
+┊●   b440dea four
+┊●   0db9c35 three
+┊│
+┊├┄fo [bottom]
+┊●   9cd3abf two
+┊●   58f9cc1 one
+├╯
+```
+
+but squash f3:xv -t b440dea
+```
+┊╭┄h0 [top]
+┊●   f3e56a9 six (no changes)
+┊●   ed663c1 five
+┊│
+┊├┄i0 [middle]
+┊●   b440dea four
+┊│     b4:xv A six.txt
+┊●   0db9c35 three
+┊│
+┊├┄fo [bottom]
+┊●   9cd3abf two
+┊●   58f9cc1 one
+├╯
+```

--- a/crates/but/src/args/commit2.rs
+++ b/crates/but/src/args/commit2.rs
@@ -1,0 +1,2 @@
+#[derive(Debug, clap::Parser)]
+pub struct Platform {}

--- a/crates/but/src/args/metrics.rs
+++ b/crates/but/src/args/metrics.rs
@@ -21,6 +21,7 @@ pub enum CommandName {
     Show,
     Commit,
     CommitEmpty,
+    Commit2,
     Push,
     Reword,
     OplogList,

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -223,6 +223,11 @@ pub enum Subcommands {
     #[clap(verbatim_doc_comment)]
     Commit(commit::Platform),
 
+    #[cfg(all(feature = "legacy", feature = "but-2"))]
+    #[clap(verbatim_doc_comment)]
+    #[clap(hide = true)]
+    Commit2(commit2::Platform),
+
     /// Stages a file or hunk to a specific branch.
     ///
     /// Without arguments, opens an interactive TUI for selecting files and hunks to stage.
@@ -1223,6 +1228,8 @@ pub enum Subcommands {
 pub mod alias;
 #[cfg(feature = "legacy")]
 pub mod commit;
+#[cfg(feature = "legacy")]
+pub mod commit2;
 pub mod config;
 pub mod skill;
 pub mod update;

--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -74,6 +74,8 @@ pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
 
                 #[cfg(feature = "legacy")]
                 SubcommandDiscriminant::Commit => Group::BranchingAndCommitting,
+                #[cfg(all(feature = "legacy", feature = "but-2"))]
+                SubcommandDiscriminant::Commit2 => Group::BranchingAndCommitting,
                 #[cfg(feature = "legacy")]
                 SubcommandDiscriminant::Stage => Group::BranchingAndCommitting,
                 SubcommandDiscriminant::Branch => Group::BranchingAndCommitting,

--- a/crates/but/src/command/legacy/commit2.rs
+++ b/crates/but/src/command/legacy/commit2.rs
@@ -1,0 +1,37 @@
+use serde::Serialize;
+
+use crate::{
+    CliResult,
+    args::commit2::Platform,
+    theme::Theme,
+    utils::{CliOutput, CliOutputHuman, IntermediateChannel, WriteWithUtils},
+};
+
+#[derive(Serialize)]
+#[must_use]
+pub struct CommitOutcome {}
+
+impl CliOutputHuman for CommitOutcome {
+    fn on_human(self, _out: &mut dyn WriteWithUtils, _theme: &Theme) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+impl CliOutput for CommitOutcome {
+    fn on_shell(self, _out: &mut dyn WriteWithUtils) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn on_json(self) -> impl serde::Serialize {
+        self
+    }
+}
+
+pub fn commit(
+    _ctx: &mut but_ctx::Context,
+    _out: IntermediateChannel<'_>,
+    args: Platform,
+) -> CliResult<CommitOutcome> {
+    let Platform {} = args;
+    Ok(CommitOutcome {})
+}

--- a/crates/but/src/command/legacy/mod.rs
+++ b/crates/but/src/command/legacy/mod.rs
@@ -10,6 +10,8 @@ pub mod ai;
 pub mod branch;
 pub mod clean;
 pub mod commit;
+#[cfg(all(feature = "legacy", feature = "but-2"))]
+pub mod commit2;
 pub mod commit_message_prep;
 pub mod diff;
 pub mod discard;

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -979,6 +979,30 @@ async fn match_subcommand(
             maybe_run_status_after(status_after, &result, &mut ctx, out).await;
             result
         }
+        #[cfg(all(feature = "legacy", feature = "but-2"))]
+        Subcommands::Commit2(commit_args) => {
+            use crate::utils::{IntermediateChannel, OutputChannelExt};
+
+            let status_after = args.status_after;
+            let mut ctx = setup::init_ctx(
+                &args,
+                InitCtxOptions {
+                    background_sync: BackgroundSync::Enabled { silent: false },
+                    ..Default::default()
+                },
+                out,
+            )?;
+            out.begin_status_after(status_after);
+
+            let outcome = command::legacy::commit2::commit(
+                &mut ctx,
+                IntermediateChannel::new(out),
+                commit_args,
+            )
+            .emit_metrics(metrics_ctx)?;
+            out.print_cli_output(outcome)?;
+            Ok(())
+        }
         #[cfg(feature = "legacy")]
         Subcommands::Push(push_args) => {
             let mut ctx = setup::init_ctx(&args, InitCtxOptions::default(), out)?;

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -126,6 +126,8 @@ impl Subcommands {
                 None => Commit,
                 Some(crate::args::commit::Subcommands::Empty { .. }) => CommitEmpty,
             },
+            #[cfg(all(feature = "legacy", feature = "but-2"))]
+            Subcommands::Commit2(..) => Commit2,
             #[cfg(feature = "legacy")]
             Subcommands::Push(_) => Push,
             #[cfg(feature = "legacy")]

--- a/crates/but/src/utils/mod.rs
+++ b/crates/but/src/utils/mod.rs
@@ -1,6 +1,8 @@
 use std::io::Write;
 
 mod output_channel;
+#[cfg(all(feature = "legacy", feature = "but-2"))]
+pub use output_channel::experimental::*;
 pub use output_channel::{
     Confirm, ConfirmDefault, ConfirmOrEmpty, InputOutputChannel, OutputChannel, WriteWithUtils,
 };

--- a/crates/but/src/utils/output_channel.rs
+++ b/crates/but/src/utils/output_channel.rs
@@ -11,6 +11,9 @@ use crate::{
     },
 };
 
+#[cfg(all(feature = "legacy", feature = "but-2"))]
+pub mod experimental;
+
 /// Default value for a confirmation prompt.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConfirmDefault {

--- a/crates/but/src/utils/output_channel/experimental.rs
+++ b/crates/but/src/utils/output_channel/experimental.rs
@@ -1,0 +1,80 @@
+//! Experimental output used by new (but-2) CLI commands.
+//!
+//! Still very much in flux and will change as we implement and dog food the new commands.
+
+use crate::{
+    args::OutputFormat,
+    theme::Theme,
+    utils::{OutputChannel, WriteWithUtils},
+};
+
+pub struct IntermediateChannel<'out> {
+    out: &'out mut OutputChannel,
+}
+
+impl std::fmt::Write for IntermediateChannel<'_> {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        self.out.progress_channel().write_str(s)
+    }
+}
+
+impl<'out> IntermediateChannel<'out> {
+    pub fn new(out: &'out mut OutputChannel) -> Self {
+        Self { out }
+    }
+
+    // TODO: some functions for prompting the user
+    // pub fn can_prompt(&self) -> bool {
+    //     self.out.can_prompt()
+    // }
+
+    // pub fn prompt(&self) -> anyhow::Result<()> {
+    //     if !self.can_prompt() {
+    //         anyhow::bail!("BUG: attempted to prompt when prompting is not allowed")
+    //     } else {
+    //         Ok(())
+    //     }
+    // }
+}
+
+pub trait CliOutputHuman {
+    fn on_human(self, out: &mut dyn WriteWithUtils, theme: &Theme) -> anyhow::Result<()>;
+}
+
+pub trait CliOutput: CliOutputHuman {
+    fn on_shell(self, out: &mut dyn WriteWithUtils) -> anyhow::Result<()>;
+
+    fn on_json(self) -> impl serde::Serialize;
+}
+
+pub trait OutputChannelExt {
+    fn print_cli_output(&mut self, output: impl CliOutput) -> anyhow::Result<()>;
+
+    #[expect(dead_code)]
+    fn print_cli_output_human(&mut self, output: impl CliOutputHuman) -> anyhow::Result<()>;
+}
+
+impl OutputChannelExt for OutputChannel {
+    fn print_cli_output(&mut self, output: impl CliOutput) -> anyhow::Result<()> {
+        match self.format {
+            OutputFormat::Human => output.on_human(self, crate::theme::get()),
+            OutputFormat::Shell => output.on_shell(self),
+            OutputFormat::Json => {
+                let value = output.on_json();
+                Ok(self.write_value(value)?)
+            }
+            OutputFormat::None => Ok(()),
+        }
+    }
+
+    fn print_cli_output_human(&mut self, output: impl CliOutputHuman) -> anyhow::Result<()> {
+        if let Some(for_human) = self.for_human() {
+            output.on_human(for_human, crate::theme::get())
+        } else {
+            anyhow::bail!(
+                "BUG: attempted to write human output when requested format is {:?}",
+                self.format
+            )
+        }
+    }
+}

--- a/crates/but/tests/but/command/commit2.rs
+++ b/crates/but/tests/but/command/commit2.rs
@@ -1,0 +1,36 @@
+use crate::utils::Sandbox;
+
+#[test]
+fn commit2_help() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata_at_target(&["A"], "origin/main").unwrap();
+
+    env.but("commit2 --help")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Usage: but commit2 [OPTIONS]
+
+Options:
+      --format <FORMAT>
+          Explicitly control how output should be formatted.
+          
+          If unset and from a terminal, it defaults to human output, when redirected it's for
+          shells.
+
+          Possible values:
+          - human: The output to write is supposed to be for human consumption, and can be more
+            verbose
+          - shell: The output should be suitable for shells, and assigning the major result to
+            variables so that it can be reused in subsequent CLI invocations
+          - json:  Output detailed information as JSON for tool consumption
+          - none:  Do not output anything, like redirecting to /dev/null
+          
+          [env: BUT_OUTPUT_FORMAT=]
+          [default: human]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+"#]]);
+}

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -11,6 +11,8 @@ mod branch;
 mod clean;
 #[cfg(feature = "legacy")]
 mod commit;
+#[cfg(all(feature = "legacy", feature = "but-2"))]
+mod commit2;
 mod config;
 #[cfg(feature = "legacy")]
 mod diff;


### PR DESCRIPTION
This adds documentation for the revamped CLI commands that @slarse and I are working on.

It also adds a POC `but commit2` command with a test. The new commands are hidden and requires building but with `--features but-2`. We'll do that in nightly but not in stable releases. This required a few CI tweaks.