### PR TITLE
Use CodeView

### DIFF
--- a/apps/lite/package.json
+++ b/apps/lite/package.json
@@ -124,7 +124,7 @@
 		"@base-ui/utils": "^0.2.9",
 		"@gitbutler/but-sdk": "workspace:*",
 		"@gitbutler/design-core": "3.4.3",
-		"@pierre/diffs": "^1.1.3",
+		"@pierre/diffs": "^1.2.4",
 		"@reduxjs/toolkit": "catalog:redux",
 		"@suspensive/react-query": "npm:@suspensive/react-query-5@^3.21.2",
 		"@tanstack/react-hotkeys": "^0.10.0",

--- a/apps/lite/ui/src/hunk.ts
+++ b/apps/lite/ui/src/hunk.ts
@@ -1,7 +1,7 @@
 import { DiffHunk, HunkDependencies, HunkHeader } from "@gitbutler/but-sdk";
 import { Array } from "effect";
 
-export type HunkDependencyDiff = HunkDependencies["diffs"][number];
+type HunkDependencyDiff = HunkDependencies["diffs"][number];
 
 export const formatHunkHeader = (hunk: HunkHeader): string =>
 	`-${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines}`;

--- a/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.tsx
@@ -30,7 +30,7 @@ import { OperationSourceC } from "#ui/routes/project/$id/workspace/OperationSour
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { classes } from "#ui/components/classes.ts";
 import { Tooltip } from "@base-ui/react";
-import { DiffHunk, HunkHeader, TreeChange, UnifiedPatch } from "@gitbutler/but-sdk";
+import { HunkHeader, TreeChange, UnifiedPatch } from "@gitbutler/but-sdk";
 import { PatchDiff, Virtualizer } from "@pierre/diffs/react";
 import { useSuspenseQueries } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
@@ -64,23 +64,6 @@ const patchHeaderForChange = (change: TreeChange, lineEnding: string): string =>
 		Match.exhaustive,
 	);
 
-const hunkKey = (hunk: HunkHeader): string =>
-	`${hunk.oldStart}:${hunk.oldLines}:${hunk.newStart}:${hunk.newLines}`;
-
-const Hunk: FC<{
-	change: TreeChange;
-	hunk: DiffHunk;
-}> = ({ change, hunk }) => (
-	<PatchDiff
-		patch={`${patchHeaderForChange(change, lineEndingForDiff(hunk.diff))}${hunk.diff}`}
-		options={{
-			diffStyle: "unified",
-			themeType: "system",
-			disableFileHeader: true,
-		}}
-	/>
-);
-
 const FileDiff: FC<{
 	change: TreeChange;
 	diff: UnifiedPatch | null;
@@ -99,8 +82,15 @@ const FileDiff: FC<{
 			return (
 				<ul>
 					{hunks.map((hunk) => (
-						<li key={hunkKey(hunk)}>
-							<Hunk change={change} hunk={hunk} />
+						<li key={`${hunk.oldStart}:${hunk.oldLines}:${hunk.newStart}:${hunk.newLines}`}>
+							<PatchDiff
+								patch={`${patchHeaderForChange(change, lineEndingForDiff(hunk.diff))}${hunk.diff}`}
+								options={{
+									diffStyle: "unified",
+									themeType: "system",
+									disableFileHeader: true,
+								}}
+							/>
 						</li>
 					))}
 				</ul>

--- a/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.tsx
@@ -40,30 +40,68 @@ const patchHeaderForChange = (change: TreeChange, lineEnding: string): string =>
 	Match.value(change.status).pipe(
 		Match.when(
 			{ type: "Addition" },
-			() => `--- /dev/null${lineEnding}+++ ${change.path}${lineEnding}`,
+			() =>
+				[
+					`diff --git a/${change.path} b/${change.path}`,
+					"new file mode 100644",
+					"--- /dev/null",
+					`+++ b/${change.path}`,
+				].join(lineEnding) + lineEnding,
 		),
+
 		Match.when(
 			{ type: "Deletion" },
-			() => `--- ${change.path}${lineEnding}+++ /dev/null${lineEnding}`,
+			() =>
+				[
+					`diff --git a/${change.path} b/${change.path}`,
+					"deleted file mode 100644",
+					`--- a/${change.path}`,
+					"+++ /dev/null",
+				].join(lineEnding) + lineEnding,
 		),
+
 		Match.when(
 			{ type: "Modification" },
-			() => `--- ${change.path}${lineEnding}+++ ${change.path}${lineEnding}`,
+			() =>
+				[
+					`diff --git a/${change.path} b/${change.path}`,
+					`--- a/${change.path}`,
+					`+++ b/${change.path}`,
+				].join(lineEnding) + lineEnding,
 		),
+
 		Match.when(
 			{ type: "Rename" },
-			({ subject }) => `--- ${subject.previousPath}${lineEnding}+++ ${change.path}${lineEnding}`,
+			({ subject }) =>
+				[
+					`diff --git a/${subject.previousPath} b/${change.path}`,
+					"similarity index 99%",
+					`rename from ${subject.previousPath}`,
+					`rename to ${change.path}`,
+					`--- a/${subject.previousPath}`,
+					`+++ b/${change.path}`,
+				].join(lineEnding) + lineEnding,
 		),
+
 		Match.exhaustive,
 	);
 
-const mkCodeViewItem = (change: TreeChange, hunk: DiffHunk): CodeViewDiffItem => {
-	const header = patchHeaderForChange(change, lineEndingForDiff(hunk.diff));
-	const parsed = parsePatchFiles(`${header}${hunk.diff}`);
+const mkCodeViewItem = (
+	change: TreeChange,
+	changesetKey: string,
+	hunks: Array<DiffHunk>,
+): CodeViewDiffItem | null => {
+	const fst = hunks[0];
+	if (!fst) return null;
+
+	const lineEnding = lineEndingForDiff(fst.diff);
+	const header = patchHeaderForChange(change, lineEnding);
+	const combinedFilePatch = [header, ...hunks.map((hunk) => hunk.diff)].join(lineEnding);
+	const parsed = parsePatchFiles(combinedFilePatch);
 
 	return {
 		type: "diff",
-		id: `${change.path}-${hunk.oldStart}:${hunk.oldLines}:${hunk.newStart}:${hunk.newLines}`,
+		id: `${changesetKey}:${change.path}`,
 		// oxlint-disable-next-line typescript/no-non-null-assertion: There should always be exactly one result given our one parsed hunk.
 		fileDiff: parsed[0]!.files[0]!,
 	};
@@ -71,19 +109,17 @@ const mkCodeViewItem = (change: TreeChange, hunk: DiffHunk): CodeViewDiffItem =>
 
 const ChangesFileDiffList: FC<{
 	changes: Array<TreeChange>;
+	changesetKey: string;
 	projectId: string;
-}> = ({ changes, projectId }) => {
+}> = ({ changes, changesetKey, projectId }) => {
 	const treeChangeDiffs = useSuspenseQueries({
 		queries: changes.map((change) => treeChangeDiffsQueryOptions({ projectId, change })),
 	}).map((result) => result.data);
-	const items = Array.zip(changes, treeChangeDiffs).flatMap(([change, mdiff]) =>
-		Match.value(mdiff).pipe(
-			Match.when({ type: "Patch" }, (patch) =>
-				patch.subject.hunks.map((hunk) => mkCodeViewItem(change, hunk)),
-			),
-			Match.orElse(() => []),
-		),
-	);
+	const items = Array.zip(changes, treeChangeDiffs).flatMap(([change, mdiff]) => {
+		if (mdiff?.type !== "Patch") return [];
+
+		return mkCodeViewItem(change, changesetKey, mdiff.subject.hunks) ?? [];
+	});
 
 	return items.length === 0 ? (
 		<p className="text-13">No changes.</p>
@@ -250,18 +286,25 @@ const DiffContents: FC<{
 			Branch: ({ branchRef }) => (
 				<SuspenseQuery {...branchDiffQueryOptions({ projectId, branch: decodeRefName(branchRef) })}>
 					{({ data: branchDiff }) => (
-						<ChangesFileDiffList changes={branchDiff.changes} projectId={projectId} />
+						<ChangesFileDiffList
+							changes={branchDiff.changes}
+							changesetKey={decodeRefName(branchRef)}
+							projectId={projectId}
+						/>
 					)}
 				</SuspenseQuery>
 			),
 			ChangesSection: () => (
 				<SuspenseQuery {...changesInWorktreeQueryOptions(projectId)}>
 					{({ data: worktreeChanges }) => (
-						<ChangesFileDiffList changes={worktreeChanges.changes} projectId={projectId} />
+						<ChangesFileDiffList
+							changes={worktreeChanges.changes}
+							changesetKey="changes"
+							projectId={projectId}
+						/>
 					)}
 				</SuspenseQuery>
 			),
-
 			File: ({ parent, path }) =>
 				Match.value(parent).pipe(
 					Match.tagsExhaustive({
@@ -275,6 +318,7 @@ const DiffContents: FC<{
 									return (
 										<ChangesFileDiffList
 											changes={selectedChange ? [selectedChange] : worktreeChanges.changes}
+											changesetKey="changes"
 											projectId={projectId}
 										/>
 									);
@@ -297,6 +341,7 @@ const DiffContents: FC<{
 									return (
 										<ChangesFileDiffList
 											changes={selectedChange ? [selectedChange] : branchDiff.changes}
+											changesetKey={decodeRefName(branchRef)}
 											projectId={projectId}
 										/>
 									);
@@ -311,7 +356,13 @@ const DiffContents: FC<{
 									);
 									if (!selectedChange) return null;
 
-									return <ChangesFileDiffList changes={[selectedChange]} projectId={projectId} />;
+									return (
+										<ChangesFileDiffList
+											changes={[selectedChange]}
+											changesetKey={commitId}
+											projectId={projectId}
+										/>
+									);
 								}}
 							</SuspenseQuery>
 						),
@@ -320,7 +371,11 @@ const DiffContents: FC<{
 			Commit: ({ commitId }) => (
 				<SuspenseQuery {...commitDetailsWithLineStatsQueryOptions({ projectId, commitId })}>
 					{({ data: commitDetails }) => (
-						<ChangesFileDiffList changes={commitDetails.changes} projectId={projectId} />
+						<ChangesFileDiffList
+							changes={commitDetails.changes}
+							changesetKey={commitId}
+							projectId={projectId}
+						/>
 					)}
 				</SuspenseQuery>
 			),

--- a/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.tsx
@@ -27,7 +27,7 @@ import { parsePatchFiles } from "@pierre/diffs";
 import { CodeView, type CodeViewDiffItem } from "@pierre/diffs/react";
 import { useSuspenseQueries } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
-import { Array, Match } from "effect";
+import { Array, Hash, Match } from "effect";
 import { ComponentProps, FC, Suspense, useDeferredValue } from "react";
 import { FilesPanel } from "./FilesPanel.tsx";
 import styles from "./DetailsPanel.module.css";
@@ -99,6 +99,7 @@ const mkCodeViewItem = (
 	return {
 		type: "diff",
 		id: `${changesetKey}:${change.path}`,
+		version: Hash.string(combinedFilePatch),
 		// oxlint-disable-next-line typescript/no-non-null-assertion: There should always be exactly one result given our one parsed hunk.
 		fileDiff: parsed[0]!.files[0]!,
 	};

--- a/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.tsx
@@ -91,10 +91,7 @@ const mkCodeViewItem = (
 	changesetKey: string,
 	hunks: Array<DiffHunk>,
 ): CodeViewDiffItem | null => {
-	const fst = hunks[0];
-	if (!fst) return null;
-
-	const lineEnding = lineEndingForDiff(fst.diff);
+	const lineEnding = lineEndingForDiff(hunks[0]?.diff ?? "");
 	const header = patchHeaderForChange(change, lineEnding);
 	const combinedFilePatch = [header, ...hunks.map((hunk) => hunk.diff)].join(lineEnding);
 	const parsed = parsePatchFiles(combinedFilePatch);

--- a/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.tsx
@@ -113,11 +113,17 @@ const ChangesFileDiffList: FC<{
 	const treeChangeDiffs = useSuspenseQueries({
 		queries: changes.map((change) => treeChangeDiffsQueryOptions({ projectId, change })),
 	}).map((result) => result.data);
-	const items = Array.zip(changes, treeChangeDiffs).flatMap(([change, mdiff]) => {
-		if (mdiff?.type !== "Patch") return [];
-
-		return mkCodeViewItem(change, changesetKey, mdiff.subject.hunks) ?? [];
-	});
+	const items = Array.zip(changes, treeChangeDiffs).flatMap(
+		([change, mdiff]) =>
+			Match.value(mdiff).pipe(
+				Match.when(
+					{ type: "Patch" },
+					(patch) => mkCodeViewItem(change, changesetKey, patch.subject.hunks) ?? [],
+				),
+				Match.when({ type: "Binary" }, () => mkCodeViewItem(change, changesetKey, [])),
+				Match.orElse(() => []),
+			) ?? [],
+	);
 
 	return items.length === 0 ? (
 		<p className="text-13">No changes.</p>

--- a/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.tsx
@@ -8,15 +8,7 @@ import {
 } from "#ui/api/queries.ts";
 import { decodeRefName } from "#ui/api/ref-name.ts";
 import { commitBody, commitTitle, shortCommitId } from "#ui/commit.ts";
-import {
-	branchFileParent,
-	changesFileParent,
-	commitFileParent,
-	commitOperand,
-	fileOperand,
-	type FileParent,
-	type Operand,
-} from "#ui/operands.ts";
+import { commitOperand, type Operand } from "#ui/operands.ts";
 import {
 	projectActions,
 	selectProjectPanelsState,
@@ -30,11 +22,12 @@ import { OperationSourceC } from "#ui/routes/project/$id/workspace/OperationSour
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { classes } from "#ui/components/classes.ts";
 import { Tooltip } from "@base-ui/react";
-import { HunkHeader, TreeChange, UnifiedPatch } from "@gitbutler/but-sdk";
-import { PatchDiff, Virtualizer } from "@pierre/diffs/react";
+import type { DiffHunk, TreeChange } from "@gitbutler/but-sdk";
+import { parsePatchFiles } from "@pierre/diffs";
+import { CodeView, type CodeViewDiffItem } from "@pierre/diffs/react";
 import { useSuspenseQueries } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
-import { Array, Match, pipe } from "effect";
+import { Array, Match } from "effect";
 import { ComponentProps, FC, Suspense, useDeferredValue } from "react";
 import { FilesPanel } from "./FilesPanel.tsx";
 import styles from "./DetailsPanel.module.css";
@@ -64,77 +57,50 @@ const patchHeaderForChange = (change: TreeChange, lineEnding: string): string =>
 		Match.exhaustive,
 	);
 
-const FileDiff: FC<{
-	change: TreeChange;
-	diff: UnifiedPatch | null;
-}> = ({ change, diff }) =>
-	Match.value(diff).pipe(
-		Match.when(null, () => <div>No diff available for this file.</div>),
-		Match.when({ type: "Binary" }, () => <div>Binary file (diff not available).</div>),
-		Match.when({ type: "TooLarge" }, ({ subject }) => (
-			<div>Diff too large ({subject.sizeInBytes} bytes).</div>
-		)),
-		Match.when({ type: "Patch" }, (patch) => {
-			const { hunks } = patch.subject;
-			if (hunks.length === 0)
-				return <p className={classes("text-13", styles.emptyFileHunks)}>No hunks.</p>;
+const mkCodeViewItem = (change: TreeChange, hunk: DiffHunk): CodeViewDiffItem => {
+	const header = patchHeaderForChange(change, lineEndingForDiff(hunk.diff));
+	const parsed = parsePatchFiles(`${header}${hunk.diff}`);
 
-			return (
-				<ul>
-					{hunks.map((hunk) => (
-						<li key={`${hunk.oldStart}:${hunk.oldLines}:${hunk.newStart}:${hunk.newLines}`}>
-							<PatchDiff
-								patch={`${patchHeaderForChange(change, lineEndingForDiff(hunk.diff))}${hunk.diff}`}
-								options={{
-									diffStyle: "unified",
-									themeType: "system",
-									disableFileHeader: true,
-								}}
-							/>
-						</li>
-					))}
-				</ul>
-			);
-		}),
-		Match.exhaustive,
-	);
+	return {
+		type: "diff",
+		id: `${change.path}-${hunk.oldStart}:${hunk.oldLines}:${hunk.newStart}:${hunk.newLines}`,
+		// oxlint-disable-next-line typescript/no-non-null-assertion: There should always be exactly one result given our one parsed hunk.
+		fileDiff: parsed[0]!.files[0]!,
+	};
+};
 
 const ChangesFileDiffList: FC<{
 	changes: Array<TreeChange>;
 	projectId: string;
-	fileParent: FileParent;
-}> = ({ changes, projectId, fileParent }) => {
+}> = ({ changes, projectId }) => {
 	const treeChangeDiffs = useSuspenseQueries({
 		queries: changes.map((change) => treeChangeDiffsQueryOptions({ projectId, change })),
 	}).map((result) => result.data);
-	const changesWithDiffs = pipe(changes, Array.zip(treeChangeDiffs));
+	const items = Array.zip(changes, treeChangeDiffs).flatMap(([change, mdiff]) =>
+		Match.value(mdiff).pipe(
+			Match.when({ type: "Patch" }, (patch) =>
+				patch.subject.hunks.map((hunk) => mkCodeViewItem(change, hunk)),
+			),
+			Match.orElse(() => []),
+		),
+	);
 
-	return changesWithDiffs.length === 0 ? (
+	return items.length === 0 ? (
 		<p className="text-13">No changes.</p>
 	) : (
-		<ul className={styles.fileDiffsList}>
-			{changesWithDiffs.map(([change, diff]) => {
-				const source = fileOperand({ parent: fileParent, path: change.path });
-
-				const lastSepIdx = change.path.lastIndexOf("/");
-				const mpathInit = lastSepIdx !== -1 ? change.path.slice(0, lastSepIdx + 1) : null;
-				const pathLast = lastSepIdx !== -1 ? change.path.slice(lastSepIdx + 1) : change.path;
-
-				return (
-					<li key={change.path} className={styles.fileDiff}>
-						<OperationSourceC projectId={projectId} source={source}>
-							<header className={styles.fileHeader}>
-								<h4 className={classes("text-13", styles.filePath)}>
-									{mpathInit !== null && <span className={styles.pathInit}>{mpathInit}</span>}
-									<span className={styles.pathLast}>{pathLast}</span>
-								</h4>
-							</header>
-						</OperationSourceC>
-						<FileDiff change={change} diff={diff} />
-					</li>
-				);
-			})}
-		</ul>
+		<CodeView
+			className={styles.detailsVirtualizer}
+			items={items}
+			options={{
+				diffStyle: "unified",
+				themeType: "system",
+				layout: {
+					paddingTop: 0,
+					paddingBottom: 0,
+					gap: 10,
+				},
+			}}
+		/>
 	);
 };
 
@@ -281,25 +247,17 @@ const DiffContents: FC<{
 	Match.value(selection).pipe(
 		Match.tagsExhaustive({
 			Stack: () => null,
-			Branch: ({ branchRef, stackId }) => (
+			Branch: ({ branchRef }) => (
 				<SuspenseQuery {...branchDiffQueryOptions({ projectId, branch: decodeRefName(branchRef) })}>
 					{({ data: branchDiff }) => (
-						<ChangesFileDiffList
-							changes={branchDiff.changes}
-							projectId={projectId}
-							fileParent={branchFileParent({ stackId, branchRef })}
-						/>
+						<ChangesFileDiffList changes={branchDiff.changes} projectId={projectId} />
 					)}
 				</SuspenseQuery>
 			),
 			ChangesSection: () => (
 				<SuspenseQuery {...changesInWorktreeQueryOptions(projectId)}>
 					{({ data: worktreeChanges }) => (
-						<ChangesFileDiffList
-							changes={worktreeChanges.changes}
-							fileParent={changesFileParent}
-							projectId={projectId}
-						/>
+						<ChangesFileDiffList changes={worktreeChanges.changes} projectId={projectId} />
 					)}
 				</SuspenseQuery>
 			),
@@ -317,7 +275,6 @@ const DiffContents: FC<{
 									return (
 										<ChangesFileDiffList
 											changes={selectedChange ? [selectedChange] : worktreeChanges.changes}
-											fileParent={changesFileParent}
 											projectId={projectId}
 										/>
 									);
@@ -325,7 +282,7 @@ const DiffContents: FC<{
 							</SuspenseQuery>
 						),
 
-						Branch: ({ branchRef, stackId }) => (
+						Branch: ({ branchRef }) => (
 							<SuspenseQuery
 								{...branchDiffQueryOptions({
 									projectId,
@@ -341,41 +298,29 @@ const DiffContents: FC<{
 										<ChangesFileDiffList
 											changes={selectedChange ? [selectedChange] : branchDiff.changes}
 											projectId={projectId}
-											fileParent={branchFileParent({ stackId, branchRef })}
 										/>
 									);
 								}}
 							</SuspenseQuery>
 						),
-						Commit: ({ commitId, stackId }) => (
+						Commit: ({ commitId }) => (
 							<SuspenseQuery {...commitDetailsWithLineStatsQueryOptions({ projectId, commitId })}>
 								{({ data: commitDetails }) => {
-									const fileParent = commitFileParent({ stackId, commitId });
 									const selectedChange = commitDetails.changes.find(
 										(candidate) => candidate.path === path,
 									);
 									if (!selectedChange) return null;
 
-									return (
-										<ChangesFileDiffList
-											changes={[selectedChange]}
-											fileParent={fileParent}
-											projectId={projectId}
-										/>
-									);
+									return <ChangesFileDiffList changes={[selectedChange]} projectId={projectId} />;
 								}}
 							</SuspenseQuery>
 						),
 					}),
 				),
-			Commit: ({ commitId, stackId }) => (
+			Commit: ({ commitId }) => (
 				<SuspenseQuery {...commitDetailsWithLineStatsQueryOptions({ projectId, commitId })}>
 					{({ data: commitDetails }) => (
-						<ChangesFileDiffList
-							changes={commitDetails.changes}
-							fileParent={commitFileParent({ stackId, commitId })}
-							projectId={projectId}
-						/>
+						<ChangesFileDiffList changes={commitDetails.changes} projectId={projectId} />
 					)}
 				</SuspenseQuery>
 			),
@@ -436,9 +381,7 @@ export const DetailsPanel: FC<ComponentProps<"div">> = (panelProps) => {
 					style={{ opacity: urgentFilesSelection !== filesSelection ? 0.5 : 1 }}
 				>
 					<Suspense fallback={<p className="text-13">Loading diff…</p>}>
-						<Virtualizer className={styles.detailsVirtualizer}>
-							<DiffContents projectId={projectId} selection={filesSelection} />
-						</Virtualizer>
+						<DiffContents projectId={projectId} selection={filesSelection} />
 					</Suspense>
 				</div>
 			</div>

--- a/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DetailsPanel.tsx
@@ -9,18 +9,11 @@ import {
 import { decodeRefName } from "#ui/api/ref-name.ts";
 import { commitBody, commitTitle, shortCommitId } from "#ui/commit.ts";
 import {
-	formatHunkHeader,
-	getDependencyCommitIds,
-	getHunkDependencyDiffsByPath,
-	type HunkDependencyDiff,
-} from "#ui/hunk.ts";
-import {
 	branchFileParent,
 	changesFileParent,
 	commitFileParent,
 	commitOperand,
 	fileOperand,
-	hunkOperand,
 	type FileParent,
 	type Operand,
 } from "#ui/operands.ts";
@@ -43,7 +36,6 @@ import { useSuspenseQueries } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
 import { Array, Match, pipe } from "effect";
 import { ComponentProps, FC, Suspense, useDeferredValue } from "react";
-import { DependencyIndicator } from "./DependencyIndicator.tsx";
 import { FilesPanel } from "./FilesPanel.tsx";
 import styles from "./DetailsPanel.module.css";
 import { workspaceHotkeys } from "#ui/hotkeys.ts";
@@ -76,65 +68,23 @@ const hunkKey = (hunk: HunkHeader): string =>
 	`${hunk.oldStart}:${hunk.oldLines}:${hunk.newStart}:${hunk.newLines}`;
 
 const Hunk: FC<{
-	isResultOfBinaryToTextConversion: boolean;
-	projectId: string;
-	fileParent: FileParent;
 	change: TreeChange;
 	hunk: DiffHunk;
-	hunkDependencyDiffs?: Array<HunkDependencyDiff>;
-}> = ({
-	isResultOfBinaryToTextConversion,
-	projectId,
-	fileParent,
-	change,
-	hunk,
-	hunkDependencyDiffs,
-}) => {
-	const dependencyCommitIds =
-		fileParent._tag === "Changes" && hunkDependencyDiffs
-			? getDependencyCommitIds({ hunk, hunkDependencyDiffs })
-			: undefined;
-
-	const operand = hunkOperand({
-		parent: { parent: fileParent, path: change.path },
-		hunkHeader: hunk,
-		isResultOfBinaryToTextConversion,
-	});
-
-	return (
-		<div>
-			<OperationSourceC projectId={projectId} source={operand}>
-				<div className={styles.hunkHeaderRow}>
-					{dependencyCommitIds && (
-						<DependencyIndicator projectId={projectId} commitIds={dependencyCommitIds}>
-							<Icon name="link" />
-						</DependencyIndicator>
-					)}
-					<div className={classes("text-11", "text-monospace", styles.hunkHeader)}>
-						{formatHunkHeader(hunk)}
-					</div>
-				</div>
-			</OperationSourceC>
-
-			<PatchDiff
-				patch={`${patchHeaderForChange(change, lineEndingForDiff(hunk.diff))}${hunk.diff}`}
-				options={{
-					diffStyle: "unified",
-					themeType: "system",
-					disableFileHeader: true,
-				}}
-			/>
-		</div>
-	);
-};
+}> = ({ change, hunk }) => (
+	<PatchDiff
+		patch={`${patchHeaderForChange(change, lineEndingForDiff(hunk.diff))}${hunk.diff}`}
+		options={{
+			diffStyle: "unified",
+			themeType: "system",
+			disableFileHeader: true,
+		}}
+	/>
+);
 
 const FileDiff: FC<{
-	projectId: string;
 	change: TreeChange;
-	fileParent: FileParent;
-	hunkDependencyDiffs?: Array<HunkDependencyDiff>;
 	diff: UnifiedPatch | null;
-}> = ({ projectId, change, fileParent, hunkDependencyDiffs, diff }) =>
+}> = ({ change, diff }) =>
 	Match.value(diff).pipe(
 		Match.when(null, () => <div>No diff available for this file.</div>),
 		Match.when({ type: "Binary" }, () => <div>Binary file (diff not available).</div>),
@@ -150,14 +100,7 @@ const FileDiff: FC<{
 				<ul>
 					{hunks.map((hunk) => (
 						<li key={hunkKey(hunk)}>
-							<Hunk
-								isResultOfBinaryToTextConversion={patch.subject.isResultOfBinaryToTextConversion}
-								projectId={projectId}
-								fileParent={fileParent}
-								change={change}
-								hunk={hunk}
-								hunkDependencyDiffs={hunkDependencyDiffs}
-							/>
+							<Hunk change={change} hunk={hunk} />
 						</li>
 					))}
 				</ul>
@@ -170,8 +113,7 @@ const ChangesFileDiffList: FC<{
 	changes: Array<TreeChange>;
 	projectId: string;
 	fileParent: FileParent;
-	hunkDependencyDiffsByPath?: Map<string, Array<HunkDependencyDiff>>;
-}> = ({ changes, projectId, fileParent, hunkDependencyDiffsByPath }) => {
+}> = ({ changes, projectId, fileParent }) => {
 	const treeChangeDiffs = useSuspenseQueries({
 		queries: changes.map((change) => treeChangeDiffsQueryOptions({ projectId, change })),
 	}).map((result) => result.data);
@@ -198,13 +140,7 @@ const ChangesFileDiffList: FC<{
 								</h4>
 							</header>
 						</OperationSourceC>
-						<FileDiff
-							projectId={projectId}
-							change={change}
-							fileParent={fileParent}
-							hunkDependencyDiffs={hunkDependencyDiffsByPath?.get(change.path)}
-							diff={diff}
-						/>
+						<FileDiff change={change} diff={diff} />
 					</li>
 				);
 			})}
@@ -372,9 +308,6 @@ const DiffContents: FC<{
 						<ChangesFileDiffList
 							changes={worktreeChanges.changes}
 							fileParent={changesFileParent}
-							hunkDependencyDiffsByPath={getHunkDependencyDiffsByPath(
-								worktreeChanges.dependencies?.diffs ?? [],
-							)}
 							projectId={projectId}
 						/>
 					)}
@@ -395,9 +328,6 @@ const DiffContents: FC<{
 										<ChangesFileDiffList
 											changes={selectedChange ? [selectedChange] : worktreeChanges.changes}
 											fileParent={changesFileParent}
-											hunkDependencyDiffsByPath={getHunkDependencyDiffsByPath(
-												worktreeChanges.dependencies?.diffs ?? [],
-											)}
 											projectId={projectId}
 										/>
 									);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -420,8 +420,8 @@ importers:
         specifier: 3.4.3
         version: 3.4.3
       '@pierre/diffs':
-        specifier: ^1.1.3
-        version: 1.1.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^1.2.4
+        version: 1.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@reduxjs/toolkit':
         specifier: catalog:redux
         version: 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)
@@ -3517,14 +3517,14 @@ packages:
     resolution: {integrity: sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==}
     engines: {node: '>= 10.0.0'}
 
-  '@pierre/diffs@1.1.3':
-    resolution: {integrity: sha512-sV6G1FL0L4UtequXi+50Uge4QVsouo5vgJx7pCawQ4+ctFglh03zIsB81W8PNheh3coIlVzLzFgB9kI7X4eyjw==}
+  '@pierre/diffs@1.2.4':
+    resolution: {integrity: sha512-SEuYxGpSCHVvfoLly/Q/OYpJSBLWaVLV3M3wI/VBW7aZmzYenNe4aXjOf5sIKJMWW5gbZe9WdLvtKUt6cQ1k1A==}
     peerDependencies:
       react: ^18.3.1 || ^19.0.0
       react-dom: ^18.3.1 || ^19.0.0
 
-  '@pierre/theme@0.0.22':
-    resolution: {integrity: sha512-ePUIdQRNGjrveELTU7fY89Xa7YGHHEy5Po5jQy/18lm32eRn96+tnYJEtFooGdffrx55KBUtOXfvVy/7LDFFhA==}
+  '@pierre/theme@1.0.3':
+    resolution: {integrity: sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA==}
     engines: {vscode: ^1.0.0}
 
   '@pkgjs/parseargs@0.11.0':
@@ -4795,9 +4795,8 @@ packages:
     resolution: {integrity: sha512-j1nJzzUovuy7LJmJk87OqwVIPZIdZysdMBabPBGxIXT+kHltdzc+019G2CtNtGAKV6sxHM6pbxMYi0cI6wZ20g==}
     hasBin: true
 
-  '@ungap/structured-clone@1.3.0':
-    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
-    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
+  '@ungap/structured-clone@1.3.1':
+    resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -7697,8 +7696,14 @@ packages:
   oniguruma-parser@0.12.1:
     resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
 
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
   oniguruma-to-es@4.3.4:
     resolution: {integrity: sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
   open@10.2.0:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
@@ -9328,8 +9333,8 @@ packages:
   unist-util-visit-parents@6.0.2:
     resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
 
-  unist-util-visit@5.0.0:
-    resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   universal-user-agent@6.0.1:
     resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
@@ -12214,9 +12219,9 @@ snapshots:
       '@parcel/watcher-win32-x64': 2.5.1
     optional: true
 
-  '@pierre/diffs@1.1.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@pierre/diffs@1.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@pierre/theme': 0.0.22
+      '@pierre/theme': 1.0.3
       '@shikijs/transformers': 3.23.0
       diff: 8.0.3
       hast-util-to-html: 9.0.5
@@ -12225,7 +12230,7 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       shiki: 3.23.0
 
-  '@pierre/theme@0.0.22': {}
+  '@pierre/theme@1.0.3': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -12664,7 +12669,7 @@ snapshots:
     dependencies:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
-      oniguruma-to-es: 4.3.4
+      oniguruma-to-es: 4.3.6
 
   '@shikijs/engine-javascript@4.0.2':
     dependencies:
@@ -13656,7 +13661,7 @@ snapshots:
       '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260421.1
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20260421.1
 
-  '@ungap/structured-clone@1.3.0': {}
+  '@ungap/structured-clone@1.3.1': {}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     optional: true
@@ -16832,12 +16837,12 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      '@ungap/structured-clone': 1.3.0
+      '@ungap/structured-clone': 1.3.1
       devlop: 1.1.0
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
       unist-util-position: 5.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
 
   mdast-util-to-markdown@2.1.2:
@@ -16849,7 +16854,7 @@ snapshots:
       mdast-util-to-string: 4.0.0
       micromark-util-classify-character: 2.0.1
       micromark-util-decode-string: 2.0.1
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       zwitch: 2.0.4
 
   mdast-util-to-string@4.0.0:
@@ -17252,9 +17257,17 @@ snapshots:
 
   oniguruma-parser@0.12.1: {}
 
+  oniguruma-parser@0.12.2: {}
+
   oniguruma-to-es@4.3.4:
     dependencies:
       oniguruma-parser: 0.12.1
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
       regex: 6.1.0
       regex-recursion: 6.0.2
 
@@ -19008,7 +19021,7 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
 
-  unist-util-visit@5.0.0:
+  unist-util-visit@5.1.0:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1


### PR DESCRIPTION
https://diffs.com/docs#codeview

This performs substantially better with large diffs. At this point our biggest performance bottleneck is our unvirtualised files list, as per the speedup when it’s toggled closed.

If we’re using Pierre then this is very likely how we’ll want to consume the library. I'd rather adopt it earlier than later as it may have implications for how we approach implementation, UX tradeoffs, etc.

This change drops the minimal custom styling we had for file headers (I haven't bothered removing the CSS). We can reintroduce that later when the design is more settled.