### PR TITLE
Accept legacy status-after flag

### DIFF
--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -53,6 +53,11 @@ pub struct Args {
     /// Whether mutation commands should append workspace status.
     #[clap(skip)]
     pub status_after: bool,
+    // Keep accepting the removed flag so agents with older skills do not start
+    // erroring after the `but` CLI is updated. It is intentionally ignored;
+    // agent detection controls the current status-after behavior.
+    #[clap(long = "status-after", global = true, hide = true)]
+    pub legacy_status_after: bool,
     /// Subcommand to run (`but <COMMAND>`).
     ///
     /// On UNIX, if `<COMMAND>` is not built in and `but-<COMMAND>` exists on the PATH, that program

--- a/crates/but/src/args/tests.rs
+++ b/crates/but/src/args/tests.rs
@@ -136,6 +136,37 @@ fn clap() {
     Args::command().debug_assert();
 }
 
+#[test]
+fn status_after_is_hidden_noop_compatibility_flag() {
+    use clap::Parser;
+
+    let args = Args::try_parse_from([
+        "but",
+        "move",
+        "source",
+        "target",
+        "--json",
+        "--status-after",
+    ])
+    .expect("parse legacy status-after flag");
+
+    assert!(args.json);
+    assert!(args.legacy_status_after);
+    assert!(!args.status_after);
+}
+
+#[test]
+fn status_after_is_not_shown_in_help() {
+    use clap::CommandFactory;
+
+    let help = Args::command().render_long_help().to_string();
+
+    assert!(
+        !help.contains("--status-after"),
+        "compatibility-only flag should stay hidden from help"
+    );
+}
+
 mod agentlog {
     use clap::Parser;
 


### PR DESCRIPTION
## Summary

Accept the removed `--status-after` flag as a hidden, compatibility-only CLI option so agents with older skills do not start erroring after the `but` CLI is updated.

The flag is intentionally ignored; current status-after behavior remains controlled by agent detection.

## Validation

- `cargo fmt -p but`
- `cargo test -p but args::`
- `cargo test -p but status_after`