### PR TITLE
but-rebase: cherry pick writes out gb merge conflicts

### DIFF
--- a/crates/but-rebase/src/graph_rebase/cherry_pick.rs
+++ b/crates/but-rebase/src/graph_rebase/cherry_pick.rs
@@ -80,9 +80,28 @@ pub enum PickMode {
 /// Except in the case where X is conflicted. In that case we then make use of
 /// X's "base" sub-tree as the base.
 ///
-/// `pick_mode` - controls how to determine if a commit should be cherry-picked.
-/// `tree_merge_mode` - controls how parent trees are merged for merge commits.
-/// `sign_commit` - controls how the resulting commit is signed.
+/// Special case: when a synthetic merge template has no original parents, an
+/// empty tree, and exactly two new parents whose trees conflict with each
+/// other, we materialize that conflict as a GitButler conflicted merge commit
+/// instead of returning [`CherryPickOutcome::FailedToMergeBases`].
+///
+/// `repo`
+/// The repository that owns `target`, `ontos`, and any newly written commit or tree objects.
+///
+/// `target`
+/// The commit to cherry-pick, possibly including conflicted-tree metadata or a synthetic merge template.
+///
+/// `ontos`
+/// The parent commits that `target` should be replayed onto in the result graph.
+///
+/// `pick_mode`
+/// Controls whether the cherry-pick may short-circuit to identity or must recreate the commit.
+///
+/// `tree_merge_mode`
+/// Controls how parent trees are merged while constructing merge-commit bases and ontos.
+///
+/// `sign_commit`
+/// Controls whether the newly written commit should be signed.
 pub fn cherry_pick(
     repo: &gix::Repository,
     target: gix::ObjectId,
@@ -123,11 +142,6 @@ pub fn cherry_pick(
             // by the ontos & parents comparison or the PickMode::Force case.
             Ok(CherryPickOutcome::Identity(target.id.detach()))
         }
-        // TODO(cto): We can handle the specific case where (the base is
-        // _not_ conflicted & the ontos _is_ conflicted & the target == base
-        // & ontos.len() == 2) by writing out the ontos conflict as a
-        // conflicted merge commit, without expanding our conflict
-        // representation.
         (MergeOutcome::Conflict { commits: bases }, MergeOutcome::Conflict { commits: ontos }) => {
             Ok(CherryPickOutcome::FailedToMergeBases {
                 base_merge_failed: true,
@@ -142,12 +156,26 @@ pub fn cherry_pick(
             onto_merge_failed: false,
             ontos: None,
         }),
-        (_, MergeOutcome::Conflict { commits }) => Ok(CherryPickOutcome::FailedToMergeBases {
-            base_merge_failed: false,
-            bases: None,
-            onto_merge_failed: true,
-            ontos: Some(commits.to_vec()),
-        }),
+        (_, MergeOutcome::Conflict { commits }) => {
+            if let Some(outcome) = maybe_materialize_conflicted_onto_merge(
+                repo,
+                &target,
+                ontos,
+                &base_t,
+                target_t.detach(),
+                tree_merge_mode,
+                sign_commit,
+            )? {
+                Ok(outcome)
+            } else {
+                Ok(CherryPickOutcome::FailedToMergeBases {
+                    base_merge_failed: false,
+                    bases: None,
+                    onto_merge_failed: true,
+                    ontos: Some(commits.to_vec()),
+                })
+            }
+        }
         (
             MergeOutcome::Success(_) | MergeOutcome::NoCommit,
             MergeOutcome::Success(_) | MergeOutcome::NoCommit,
@@ -188,6 +216,93 @@ pub fn cherry_pick(
             }
         }
     }
+}
+
+/// Materialize the narrow synthetic-merge case where building the merged
+/// `onto` tree conflicts before the normal final cherry-pick merge can run.
+///
+/// This helper only handles parentless, non-conflicted, empty-tree templates
+/// that are being replayed onto exactly two commits with rename detection
+/// enabled. In that situation we can treat the conflicting `onto` merge itself
+/// as the desired result and wrap it in GitButler's conflicted-commit format.
+///
+/// `repo`
+/// The repository that owns all commits and trees involved in the merge attempt.
+///
+/// `target`
+/// The synthetic merge template commit that is being replayed onto `ontos`.
+///
+/// `ontos`
+/// The two commits whose full trees should become the merge parents of the result.
+///
+/// `base_t`
+/// The already-computed original-base merge outcome for `target`, used to confirm this is the parentless template case.
+///
+/// `target_tree_id`
+/// The resolved tree of `target`, used to confirm the template starts from the empty tree.
+///
+/// `tree_merge_mode`
+/// The merge mode requested by the caller; only `TreeMergeMode::WithRenames` is handled here.
+///
+/// `sign_commit`
+/// Controls whether the conflicted or clean merge commit written by this helper should be signed.
+fn maybe_materialize_conflicted_onto_merge(
+    repo: &gix::Repository,
+    target: &but_core::Commit<'_>,
+    ontos: &[gix::ObjectId],
+    base_t: &MergeOutcome,
+    target_tree_id: gix::ObjectId,
+    tree_merge_mode: TreeMergeMode,
+    sign_commit: SignCommit,
+) -> Result<Option<CherryPickOutcome>> {
+    let empty_tree = gix::ObjectId::empty_tree(repo.object_hash());
+    if !matches!(base_t, MergeOutcome::NoCommit)
+        || target.is_conflicted()
+        || !target.parents.is_empty()
+        || target_tree_id != empty_tree
+        || ontos.len() != 2
+        || tree_merge_mode != TreeMergeMode::WithRenames
+    {
+        return Ok(None);
+    }
+
+    let base_tree_id = peel_to_tree_or_empty(repo, merge_base(repo, ontos[0], ontos[1])?)?.detach();
+    let ours_tree_id = but_core::Commit::from_id(ontos[0].attach(repo))?
+        .tree_id_or_auto_resolution()?
+        .detach();
+    let theirs_tree_id = but_core::Commit::from_id(ontos[1].attach(repo))?
+        .tree_id_or_auto_resolution()?
+        .detach();
+
+    let mut outcome = repo.merge_trees(
+        base_tree_id,
+        ours_tree_id,
+        theirs_tree_id,
+        repo.default_merge_labels(),
+        repo.merge_options_force_ours()?,
+    )?;
+    let tree_id = outcome.tree.write()?;
+    let conflict_kind = gix::merge::tree::TreatAsUnresolved::forced_resolution();
+    if !outcome.has_unresolved_conflicts(conflict_kind) {
+        return Ok(Some(CherryPickOutcome::Commit(
+            commit_from_unconflicted_tree(ontos, target.clone(), tree_id, sign_commit)?.detach(),
+        )));
+    }
+
+    let conflicted_commit = commit_from_conflicted_tree(
+        ontos,
+        target.clone(),
+        tree_id,
+        outcome,
+        conflict_kind,
+        base_tree_id,
+        ours_tree_id,
+        theirs_tree_id,
+        sign_commit,
+    )?;
+    Ok(Some(CherryPickOutcome::ConflictedCommit(
+        conflicted_commit.detach(),
+    )))
 }
 
 #[derive(Debug, Clone)]
@@ -295,7 +410,8 @@ fn merge_base(
         // It's very possible we'll see scenarios where there are two parents
         // that have no common ancestor. We should handle that well by using the
         // empty tree as the base.
-        Err(gix::repository::merge_base::Error::FindMergeBase(_)) => Ok(None),
+        Err(gix::repository::merge_base::Error::FindMergeBase(_))
+        | Err(gix::repository::merge_base::Error::NotFound { .. }) => Ok(None),
         Err(e) => bail!(e),
     }
 }

--- a/crates/but-rebase/tests/rebase/graph_rebase/cherry_pick.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/cherry_pick.rs
@@ -1,4 +1,5 @@
 use anyhow::{Result, bail};
+use bstr::ByteSlice;
 use but_core::commit::SignCommit;
 use but_rebase::graph_rebase::cherry_pick::{
     CherryPickOutcome, PickMode, TreeMergeMode, cherry_pick,
@@ -257,6 +258,132 @@ fn single_parent_to_multiple_parents_parents_conflict() -> Result<()> {
         ),
     }
     ");
+
+    Ok(())
+}
+
+#[test]
+fn synthetic_empty_merge_template_with_conflicting_new_parents_materializes_conflicted_merge_commit()
+-> Result<()> {
+    let (repo, _tmpdir, _meta) = fixture_writable("cherry-pick")?;
+
+    let template_source = repo.rev_parse_single("base")?.object()?.peel_to_commit()?;
+    let mut template_commit: gix::objs::Commit = template_source.decode()?.try_into()?;
+    template_commit.tree = gix::ObjectId::empty_tree(repo.object_hash());
+    template_commit.parents.clear();
+    template_commit.message = b"synthetic merge template".into();
+    let target = repo.write_object(template_commit)?.detach();
+
+    let onto = repo.rev_parse_single("single-target")?.detach();
+    let onto2 = repo.rev_parse_single("second-conflicting-target")?.detach();
+
+    let result = cherry_pick(
+        &repo,
+        target,
+        &[onto, onto2],
+        PickMode::IfChanged,
+        TreeMergeMode::WithRenames,
+        SignCommit::IfSignCommitsEnabled,
+    )?;
+
+    insta::assert_debug_snapshot!(result, @"
+    ConflictedCommit(
+        Sha1(009287dffe7bc486ed6e08ce70ac55f291b15354),
+    )
+    ");
+
+    let CherryPickOutcome::ConflictedCommit(id) = result else {
+        bail!("synthetic merge template should materialize a conflicted merge commit");
+    };
+
+    assert_eq!(
+        &get_parents(&id.attach(&repo))?,
+        &[onto, onto2],
+        "synthetic merge template should keep the conflicting new parents",
+    );
+
+    let commit = id.attach(&repo).object()?.peel_to_commit()?;
+    insta::assert_snapshot!(commit.message_raw()?.as_bstr(), @r#"
+    [conflict] synthetic merge template
+
+    GitButler-Conflict: This is a GitButler-managed conflicted commit. Files are auto-resolved
+       using the "ours" side. The commit tree contains additional directories:
+         .conflict-side-0  — our tree
+         .conflict-side-1  — their tree
+         .conflict-base-0  — the merge base tree
+         .auto-resolution  — the auto-resolved tree
+         .conflict-files   — metadata about conflicted files
+       To manually resolve, check out this commit, remove the directories
+       listed above, resolve the conflicts, and amend the commit.
+    "#);
+
+    insta::assert_snapshot!(visualize_tree(id.attach(&repo)), @r#"
+    7e70098
+    ├── .auto-resolution:aa3d213 
+    │   ├── base-f:100644:7898192 "a\n"
+    │   └── target-f:100644:eb5a316 "target\n"
+    ├── .conflict-base-0:964aa4d 
+    │   └── base-f:100644:7898192 "a\n"
+    ├── .conflict-files:100644:68fb397 "ancestorEntries = []\nourEntries = [\"target-f\"]\ntheirEntries = [\"target-f\"]\n"
+    ├── .conflict-side-0:aa3d213 
+    │   ├── base-f:100644:7898192 "a\n"
+    │   └── target-f:100644:eb5a316 "target\n"
+    ├── .conflict-side-1:e6ffce2 
+    │   ├── base-f:100644:7898192 "a\n"
+    │   └── target-f:100644:caac8f9 "target 2\n"
+    ├── base-f:100644:7898192 "a\n"
+    └── target-f:100644:eb5a316 "target\n"
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn synthetic_empty_merge_template_with_unrelated_new_parents_uses_empty_base_tree() -> Result<()> {
+    let (repo, _tmpdir, _meta) = fixture_writable("disjoint-orphan-branches")?;
+
+    let template_source = repo.rev_parse_single("main")?.object()?.peel_to_commit()?;
+    let mut template_commit: gix::objs::Commit = template_source.decode()?.try_into()?;
+    template_commit.tree = gix::ObjectId::empty_tree(repo.object_hash());
+    template_commit.parents.clear();
+    template_commit.message = b"synthetic unrelated merge template".into();
+    let target = repo.write_object(template_commit)?.detach();
+
+    let onto = repo.rev_parse_single("main")?.detach();
+    let onto2 = repo.rev_parse_single("orphan")?.detach();
+
+    let result = cherry_pick(
+        &repo,
+        target,
+        &[onto, onto2],
+        PickMode::IfChanged,
+        TreeMergeMode::WithRenames,
+        SignCommit::IfSignCommitsEnabled,
+    )?;
+
+    insta::assert_debug_snapshot!(result, @"
+    Commit(
+        Sha1(8deb9d849412560636bc9dce3a82392324467c0b),
+    )
+    ");
+
+    let CherryPickOutcome::Commit(id) = result else {
+        bail!("unrelated synthetic merge template should merge from the empty tree base");
+    };
+
+    assert_eq!(
+        &get_parents(&id.attach(&repo))?,
+        &[onto, onto2],
+        "unrelated synthetic merge template should keep both new parents",
+    );
+
+    insta::assert_snapshot!(visualize_tree(id.attach(&repo)), @r#"
+    9418a9b
+    ├── base:100644:df967b9 "base\n"
+    ├── main-1:100644:114be18 "main-1\n"
+    ├── orphan-base:100644:0b12d02 "orphan-base\n"
+    └── orphan-tip:100644:1647ebd "orphan-tip\n"
+    "#);
 
     Ok(())
 }

--- a/crates/but-workspace/tests/fixtures/scenario/remote-diverged-with-workspace-conflicting.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/remote-diverged-with-workspace-conflicting.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git init
+
+tick
+echo base >shared.txt
+git add shared.txt
+git commit -m "init-integration"
+setup_target_to_match_main
+
+git checkout -b A main
+remote_tracking_caught_up A
+
+tick
+echo local >shared.txt
+git add shared.txt
+git commit -m "local change in A 1"
+
+git checkout -b new-origin main
+
+tick
+echo remote >shared.txt
+git add shared.txt
+git commit -m "remote change in A 1"
+setup_remote_tracking new-origin A
+
+git checkout A
+
+create_workspace_commit_once A

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -1,9 +1,11 @@
 use anyhow::Result;
+use but_core::Commit;
 use but_graph::init::Options;
 use but_meta::virtual_branches_legacy_types::Target;
 use but_rebase::graph_rebase::mutate::RelativeTo;
 use but_testsupport::{graph_workspace, visualize_commit_graph_all};
 use but_workspace::{BottomUpdate, BottomUpdateKind, integrate_upstream};
+use gix::prelude::ObjectIdExt;
 
 use crate::ref_info::with_workspace_commit::utils::{
     StackState, add_stack, named_writable_scenario_with_description,
@@ -318,6 +320,94 @@ fn diamond_partially_content_integrated_merge() -> Result<()> {
     |/  
     * 85aa44b (o1) o1
     ");
+
+    Ok(())
+}
+
+#[test]
+fn merge_upstream_with_conflicting_target_materializes_conflicted_merge_commit() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("remote-diverged-with-workspace-conflicting")?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "A"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    add_stack(&mut meta, 1, "A", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * 8fd8fb6 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 61c4a24 (A) local change in A 1
+    | * f03fc2c (origin/A, new-origin) remote change in A 1
+    |/  
+    * 2b73dee (origin/main, main) init-integration
+    ");
+
+    let mut workspace = graph.into_workspace()?;
+    let but_workspace::IntegrateUpstreamOutcome { rebase, .. } = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Merge,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A")?.detach()),
+        }],
+    )?;
+
+    rebase.materialize()?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 379fa91 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   9b4efdf (A) [conflict] Merge refs/remotes/origin/A into merge
+    |\  
+    | * f03fc2c (origin/A, new-origin) remote change in A 1
+    * | 61c4a24 local change in A 1
+    |/  
+    * 2b73dee (origin/main, main) init-integration
+    ");
+
+    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?.detach())?;
+    assert!(
+        Commit::from_id(branch_tip.id.attach(&repo))?.is_conflicted(),
+        "upstream integration merge should materialize a conflicted commit when target and stack changes conflict",
+    );
+
+    let parents = branch_tip.parent_ids().collect::<Vec<_>>();
+    assert_eq!(
+        parents.len(),
+        2,
+        "upstream integration merge should preserve merge ancestry in conflicted cases",
+    );
+    assert_eq!(
+        parents[1].detach(),
+        repo.rev_parse_single("origin/A")?.detach(),
+        "upstream integration merge should keep the target branch tip as second parent",
+    );
+
+    insta::assert_snapshot!(branch_tip.message_raw()?, @r#"
+    [conflict] Merge refs/remotes/origin/A into merge
+
+    GitButler-Conflict: This is a GitButler-managed conflicted commit. Files are auto-resolved
+       using the "ours" side. The commit tree contains additional directories:
+         .conflict-side-0  — our tree
+         .conflict-side-1  — their tree
+         .conflict-base-0  — the merge base tree
+         .auto-resolution  — the auto-resolved tree
+         .conflict-files   — metadata about conflicted files
+       To manually resolve, check out this commit, remove the directories
+       listed above, resolve the conflicts, and amend the commit.
+    "#);
 
     Ok(())
 }


### PR DESCRIPTION
`cherry_pick` writes out a GitButler conflicted-trees commit under the circumstance of it being a ‘conventional merge commit':
- Having exactly two parents
- Being empty
  
This allows us to use the existing representation of conflicted commits.

---

### Notes for the reviewer

I encountered this while testing remote-branch integration strategies in which merging the remote into the local branch would result in a conflict.
As it was, this would result in an error instead of a gb-managed conflict:
```
Failed to merge bases while cherry picking commit ...
Encountered a conflict while merging the commit's new bases: local, remote.
```

### Root cause

Given a commit X with initial parents Y,Z and a destination parents A,B (we want to rebase X on top of A,B).
What `cherry_pick` does is to calculate the merge tree of Y+Z = N and the merge tree of A+B = M, so that we can use N as the 'base' M as the 'ours' side and X as the 'theirs' side for merging.

The issue was that if the destination parents (A + B) resulted on a conflict, we would raise an error.
What we'd want to happen is to write the auto-resolution tree into that commit instead.
The only **caveat** is that we can only do that for the specific case of a 'classic' merge commit: 
The tree of X must be the empty tree and the destination parents must be exactly 2.

### Things to consider
This makes the PR a bit more *magical* in that we handle a very specific scenario in a special way.
I think this is ok since the merge-commit scenario itself is special and should be handled that way.

The *more-correct* way of solving this would be to extend the way we represent conflicts to support N-sides of conflicts.

### Effects of this PR

Integrating the latest target into a stack, that results in a conflict doesn't fail, but it writes a conflicted commit that we can later resolve.