### PR TITLE
but gui: open project in a new window

### DIFF
--- a/apps/desktop/src/lib/backend/backend.ts
+++ b/apps/desktop/src/lib/backend/backend.ts
@@ -2,7 +2,7 @@ import type { UnlistenFn } from "@tauri-apps/api/event";
 import type { Readable } from "svelte/store";
 
 export type DeepLinkHandlers = {
-	open: (path: string) => void;
+	open: (path: string, newWindow: boolean) => void;
 	login: (accesToken: string) => void;
 };
 export interface IBackend {

--- a/apps/desktop/src/lib/backend/tauri.test.ts
+++ b/apps/desktop/src/lib/backend/tauri.test.ts
@@ -63,6 +63,14 @@ describe("parseDeepLinkUrl", () => {
 		expect(result![1].get("other")).toBe("value");
 	});
 
+	test("parses open URLs with new-window query parameter", () => {
+		const result = parseDeepLinkUrl("but://open?path=/some/path&new_window=1" as any);
+		expect(result).not.toBeNull();
+		expect(result![0]).toBe("open");
+		expect(result![1].get("path")).toBe("/some/path");
+		expect(result![1].get("new_window")).toBe("1");
+	});
+
 	test("handles URL-encoded query parameters", () => {
 		const result = parseDeepLinkUrl("but://open?path=%2Fsome%2Fpath" as any);
 		expect(result).not.toBeNull();

--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -125,7 +125,7 @@ function handleTopLevel(
 		case "open": {
 			const filePath = params.get("path");
 			if (filePath) {
-				handlers.open(filePath);
+				handlers.open(filePath, params.get("new_window") === "1");
 			}
 			return true;
 		}

--- a/apps/desktop/src/lib/project/projectsService.ts
+++ b/apps/desktop/src/lib/project/projectsService.ts
@@ -105,7 +105,6 @@ export class ProjectsService {
 		}
 	}
 
-	// TODO: Reinstate the ability to open a project in a new window.
 	async openProjectInNewWindow(projectId: string) {
 		await this.backendApi.endpoints.openProjectInWindow.mutate({ id: projectId });
 	}
@@ -141,13 +140,17 @@ export class ProjectsService {
 		return await this.backendApi.endpoints.addProject.mutate({ path });
 	}
 
-	async handleDeepLinkOpen(path: string) {
+	async handleDeepLinkOpen(path: string, newWindow = false) {
 		const outcome = await this.backendApi.endpoints.addProjectWithBestEffort.mutate({ path });
 		if (outcome) {
 			switch (outcome.type) {
 				case "added":
 				case "alreadyExists":
-					goto(projectPath(outcome.subject.id));
+					if (newWindow) {
+						await this.openProjectInNewWindow(outcome.subject.id);
+					} else {
+						goto(projectPath(outcome.subject.id));
+					}
 					break;
 				default:
 					handleAddProjectOutcome(outcome);

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -70,8 +70,8 @@
 		if (coldstartLinks !== undefined) {
 			backend.initDeepLinking(
 				{
-					open: (path: string) => {
-						projectsService.handleDeepLinkOpen(path);
+					open: (path: string, newWindow: boolean) => {
+						projectsService.handleDeepLinkOpen(path, newWindow);
 					},
 					login: (accessToken: string) => {
 						userService.setUserAccessToken(accessToken);

--- a/crates/but-path/src/lib.rs
+++ b/crates/but-path/src/lib.rs
@@ -195,7 +195,11 @@ impl AppChannel {
     ///
     /// Note: On Linux, we don't have a good way of distinguishing between channels in the installed
     /// binaries, so we always just resolve `gitbutler-tauri`.
-    pub fn open(&self, possibly_project_dir: &std::path::Path) -> anyhow::Result<()> {
+    pub fn open(
+        &self,
+        possibly_project_dir: &std::path::Path,
+        new_window: bool,
+    ) -> anyhow::Result<()> {
         let scheme = match self {
             AppChannel::Nightly => "but-nightly",
             AppChannel::Release => "but",
@@ -210,10 +214,11 @@ impl AppChannel {
             .as_millis();
 
         let url = format!(
-            "{}://open?path={}&t={}",
+            "{}://open?path={}&t={}&new_window={}",
             scheme,
             possibly_project_dir.display(),
-            timestamp
+            timestamp,
+            if new_window { 1 } else { 0 }
         );
 
         let cleaned_vars: Vec<(&str, String)> = clean_env_vars(&[

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -14,7 +14,7 @@ Agent-focused reference for useful `but` commands.
 - [Automation](#automation) - `mark`, `unmark`
 - [Workspace Maintenance](#workspace-maintenance) - `clean`
 - [History & Undo](#history--undo) - `undo`, `oplog`
-- [Setup & Configuration](#setup--configuration) - `setup`, `teardown`, `config`, `update`, `skill`
+- [Setup & Configuration](#setup--configuration) - `setup`, `teardown`, `config`, `update`, `skill`, `gui`
 - [Selected Options](#selected-options)
 
 ## Inspection (Understanding State)
@@ -573,6 +573,17 @@ Manage installed GitButler skill files.
 but skill check
 but skill check --update
 but skill install --detect
+```
+
+### `but gui [path]`
+
+Open the GitButler desktop app for a project directory.
+
+```bash
+but gui                     # Open the current directory in the app
+but gui ../other-repo       # Open a specific project directory
+but gui --new-window        # Open the current project in a new app window
+but gui -n ../other-repo    # Short flag for opening another project in a new window
 ```
 
 ## Selected Options

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -802,6 +802,9 @@ pub enum Subcommands {
     #[clap(visible_alias = ".")]
     #[clap(verbatim_doc_comment)]
     Gui {
+        /// Open the project in a new application window.
+        #[clap(long, short = 'n', default_value_t = false)]
+        new_window: bool,
         /// Path to the directory to open as a GitButler project. Defaults to the current directory.
         path: Option<PathBuf>,
     },

--- a/crates/but/src/command/gui.rs
+++ b/crates/but/src/command/gui.rs
@@ -6,7 +6,7 @@ use but_path::AppChannel;
 ///
 /// This expects that the GUI application is present and has correctly registered URL
 /// schemes for the different channels.
-pub fn open(possibly_project_dir: &std::path::Path) -> Result<()> {
+pub fn open(possibly_project_dir: &std::path::Path, new_window: bool) -> Result<()> {
     if !possibly_project_dir.is_dir() {
         anyhow::bail!(
             "Can only open the GUI on directories: '{not_dir}'",
@@ -21,6 +21,6 @@ pub fn open(possibly_project_dir: &std::path::Path) -> Result<()> {
             possibly_project_dir.display()
         )
     })?;
-    channel.open(&absolute_path)?;
+    channel.open(&absolute_path, new_window)?;
     Ok(())
 }

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -368,12 +368,12 @@ async fn match_subcommand(
             utils::metrics::capture_event_blocking(&app_settings, event).await;
             Ok(())
         }
-        Subcommands::Gui { path } => {
+        Subcommands::Gui { new_window, path } => {
             let path = path
                 .as_ref()
                 .map(|path| args.current_dir.join(path))
                 .unwrap_or_else(|| args.current_dir.clone());
-            command::gui::open(&path)
+            command::gui::open(&path, new_window)
                 .emit_metrics(metrics_ctx)
                 .map_err(CliError::from)
         }


### PR DESCRIPTION
Add the ability to open a project in a new window from the but CLI.

Usage:
```
but gui -n [path/to/my/project]
but gui --new-window [path/to/my/project]
```
