### PR TITLE
fix id_for_tree_diff: Don't deref the in-memory

### DIFF
--- a/crates/but-workspace/src/changeset.rs
+++ b/crates/but-workspace/src/changeset.rs
@@ -7,7 +7,6 @@
 use std::{
     borrow::Borrow,
     collections::{HashMap, HashSet, VecDeque, hash_map::Entry},
-    ops::Deref,
     time::Duration,
 };
 
@@ -723,7 +722,7 @@ fn id_for_tree_diff(
         ),
         gix::objs::TreeRefIter::from_bytes(&rhs_tree.data, repo.object_hash()),
         &mut state,
-        repo.objects.deref(),
+        &repo.objects,
         &mut delegate,
     )?;
     let Some(hasher) = delegate.hash.take() else {


### PR DESCRIPTION
Changing that argument to &repo.objects keeps the full object proxy in
use. That means `gix::diff::tree()` can resolve both persisted objects
and dry-run overlay objects, so workspace preview generation can diff
conflicted commits without requiring preview-only trees to be
materialized into the real repository.

--- 

This fixes an issue in which merge-conflict trees written in dry-run are found even if they don't reference an existing tree already

