### PR TITLE
Add undo/redo to Lite native menu

### DIFF
--- a/apps/lite/electron/src/ipc.ts
+++ b/apps/lite/electron/src/ipc.ts
@@ -243,6 +243,8 @@ export interface ShowNativeMenuParams {
 	position: NativeMenuPosition;
 }
 
+export type NativeMenuCommand = "redo" | "undo";
+
 export interface LiteElectronApi {
 	absorptionPlan: (params: AbsorptionPlanParams) => Promise<Array<CommitAbsorption>>;
 	absorb: (params: AbsorbParams) => Promise<number>;
@@ -287,6 +289,7 @@ export interface LiteElectronApi {
 	watcherSubscribe: (projectId: string, callback: (event: WatcherEvent) => void) => Promise<string>;
 	watcherUnsubscribe: (subscriptionId: string) => Promise<boolean>;
 	watcherStopAll: () => Promise<number>;
+	onNativeMenuCommand: (callback: (command: NativeMenuCommand) => void) => () => void;
 	onUpdateDownloaded: (callback: (info: UpdateDownloadedEvent) => void) => () => void;
 	quitAndInstallUpdate: () => Promise<void>;
 	platform: string;
@@ -327,6 +330,7 @@ export const liteIpcChannels = {
 	removeBranch: "workspace:remove-branch",
 	restoreSnapshotWithKind: "workspace:restore-snapshot-with-kind",
 	showNativeMenu: "lite:show-native-menu",
+	nativeMenuCommand: "lite:native-menu-command",
 	treeChangeDiffs: "workspace:tree-change-diffs",
 	unapplyStack: "workspace:unapply-stack",
 	workspaceIntegrateUpstream: "workspace:integrate-upstream",

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -29,6 +29,7 @@ import {
 	type WatcherSubscribeParams,
 	type WatcherUnsubscribeParams,
 	type NativeMenuPopupItem,
+	type NativeMenuCommand,
 	type CommitUncommitParams,
 	type RestoreSnapshotWithKindParams,
 	type PeelRestoreSnapshotParams,
@@ -73,6 +74,7 @@ import {
 import {
 	app,
 	BrowserWindow,
+	type BaseWindow,
 	clipboard,
 	ipcMain,
 	Menu,
@@ -199,6 +201,69 @@ function getMacDockIcon(): string | undefined {
 
 	return candidates.find((c) => fs.existsSync(c));
 }
+
+const sendNativeMenuCommand = (
+	window: BaseWindow | undefined,
+	command: NativeMenuCommand,
+): void => {
+	const targetWindow = window instanceof BrowserWindow ? window : BrowserWindow.getFocusedWindow();
+	targetWindow?.webContents.send(liteIpcChannels.nativeMenuCommand, command);
+};
+
+const createApplicationMenu = (): void => {
+	const editSubmenu: Array<MenuItemConstructorOptions> = [
+		{
+			label: "Undo",
+			accelerator: "CommandOrControl+Z",
+			click: (_item, window) => sendNativeMenuCommand(window, "undo"),
+		},
+		{
+			label: "Redo",
+			accelerator: "Shift+CommandOrControl+Z",
+			click: (_item, window) => sendNativeMenuCommand(window, "redo"),
+		},
+		{ type: "separator" },
+		{ role: "cut" },
+		{ role: "copy" },
+		{ role: "paste" },
+		{ role: "pasteAndMatchStyle" },
+		{ role: "delete" },
+		{ role: "selectAll" },
+	];
+
+	const template: Array<MenuItemConstructorOptions> = [
+		...(process.platform === "darwin"
+			? ([
+					{
+						label: app.name,
+						submenu: [
+							{ role: "about" },
+							{ type: "separator" },
+							{ role: "services" },
+							{ type: "separator" },
+							{ role: "hide" },
+							{ role: "hideOthers" },
+							{ role: "unhide" },
+							{ type: "separator" },
+							{ role: "quit" },
+						],
+					},
+				] satisfies Array<MenuItemConstructorOptions>)
+			: []),
+		{
+			label: "File",
+			submenu: [process.platform === "darwin" ? { role: "close" } : { role: "quit" }],
+		},
+		{
+			label: "Edit",
+			submenu: editSubmenu,
+		},
+		{ role: "viewMenu" },
+		{ role: "windowMenu" },
+	];
+
+	Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+};
 
 const buildNativeMenuTemplate = (
 	items: Array<NativeMenuPopupItem>,
@@ -556,6 +621,7 @@ void app.whenReady().then(async () => {
 		return callback(false);
 	});
 
+	createApplicationMenu();
 	registerIpcHandlers();
 	await createMainWindow();
 

--- a/apps/lite/electron/src/preload.cts
+++ b/apps/lite/electron/src/preload.cts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from "electron";
-import type { LiteElectronApi, WatcherSubscribeResult } from "./ipc";
+import type { LiteElectronApi, NativeMenuCommand, WatcherSubscribeResult } from "./ipc";
 import type { UpdateDownloadedEvent } from "electron-updater";
 import type {
 	CommitAbsorption,
@@ -171,6 +171,12 @@ const api: LiteElectronApi = {
 
 		watcherListenerBySubscription.clear();
 		return ipcRenderer.invoke("workspace:watcher-stop-all") as Promise<number>;
+	},
+	onNativeMenuCommand: (callback) => {
+		const listener = (_event: Electron.IpcRendererEvent, command: NativeMenuCommand) =>
+			callback(command);
+		ipcRenderer.on("lite:native-menu-command", listener);
+		return () => ipcRenderer.removeListener("lite:native-menu-command", listener);
 	},
 	onUpdateDownloaded: (callback) => {
 		const listener = (_event: Electron.IpcRendererEvent, info: UpdateDownloadedEvent) =>

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -39,7 +39,7 @@ import {
 } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
 import { Match, Order } from "effect";
-import { type FC, Component, ReactNode } from "react";
+import { type FC, Component, ReactNode, useEffect } from "react";
 import { branchOperand, type BranchOperand } from "#ui/operands.ts";
 import { PickerDialog, type PickerDialogGroup } from "#ui/components/PickerDialog.tsx";
 import { Details } from "./Details.tsx";
@@ -361,6 +361,13 @@ const ApplyBranchPicker: FC<{
 	);
 };
 
+const isEditableElement = (element: Element | null): boolean => {
+	if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement)
+		return !element.disabled && !element.readOnly;
+
+	return element instanceof HTMLElement && element.isContentEditable;
+};
+
 const useRestoreSnapshot = ({ projectId }: { projectId: string }) => {
 	const toastManager = Toast.useToastManager();
 
@@ -431,6 +438,21 @@ const useWorkspaceHotkeys = (projectId: string) => {
 	const outlineMode = useAppSelector((state) => selectProjectOutlineModeState(state, projectId));
 
 	const restoreSnapshotMutation = useRestoreSnapshot({ projectId });
+
+	useEffect(
+		() =>
+			window.lite.onNativeMenuCommand((command) => {
+				if (isEditableElement(document.activeElement)) {
+					document.execCommand(command);
+					return;
+				}
+
+				if (outlineMode._tag !== "Default" || restoreSnapshotMutation.isPending) return;
+
+				restoreSnapshotMutation.mutate(command);
+			}),
+		[outlineMode._tag, restoreSnapshotMutation],
+	);
 
 	useHotkeys([
 		{


### PR DESCRIPTION
### Motivation
- Provide visible, mouse-accessible Undo/Redo in the native application menu for Lite so undo/redo is discoverable for non-keyboard users.
- Deliver a typed IPC path for native menu commands so the renderer can respond to menu clicks consistently.

### Description
- Add `NativeMenuCommand` and `liteIpcChannels.nativeMenuCommand` to `apps/lite/electron/src/ipc.ts` and expose `onNativeMenuCommand` via the preload bridge in `apps/lite/electron/src/preload.cts`.
- Add `createApplicationMenu` and `sendNativeMenuCommand` to `apps/lite/electron/src/main.ts` and wire an Edit menu with `Undo` and `Redo` items (plus standard edit roles) to send typed commands to the focused window.
- Handle native menu commands in `apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx` by delegating to `document.execCommand` when an editable element is focused, otherwise invoking the existing workspace snapshot `undo`/`redo` flow (`restoreSnapshotMutation.mutate`).
- Adjusted typing/instance checks to correctly target the focused `BrowserWindow` when sending IPC and fixed related TypeScript issues.

### Testing
- Ran TypeScript checks with `pnpm -F @gitbutler/lite check` which completed successfully after fixes.
- Formatting/lint: ran `pnpm oxlint:fix && pnpm exec prettier --write apps/lite` which completed successfully.
- Dependency analysis: ran `pnpm knip:prod` and `pnpm knip:non-prod` which completed with the repository checks.
- Attempted `nix develop -c pnpm -F @gitbutler/lite check` and `nix develop -c bash -c "pnpm oxlint:fix ..."` but those failed in this environment because `nix` is not installed (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f5f48b25c8326bc6b4cf7c8abc777)