### PR TITLE
Improve error message for git command failed

### DIFF
--- a/crates/gitbutler-git/src/repository.rs
+++ b/crates/gitbutler-git/src/repository.rs
@@ -31,7 +31,7 @@ pub enum RepositoryError<
     #[error("i/o error communicating with askpass utility: {0}")]
     AskpassIo(Esocket),
     #[error(
-        "git command exited with non-zero exit code {status}: {args:?}\n\nSTDOUT:\n{stdout}\n\nSTDERR:\n{stderr}"
+        "git command exited with non-zero exit code {status}:\n\nARGS:\n{args:?}\n\nSTDOUT:\n{stdout}\n\nSTDERR:\n{stderr}"
     )]
     Failed {
         status: usize,


### PR DESCRIPTION
Having a newline after the error code enables better grouping