### PR TITLE
Clean up head info detail helper

### DIFF
--- a/crates/but/src/command/legacy/clean.rs
+++ b/crates/but/src/command/legacy/clean.rs
@@ -182,7 +182,7 @@ fn find_empty_branches(
     // Get the set of stack IDs that have worktree changes assigned to them.
     let stacks_with_changes = stacks_with_assigned_changes(ctx)?;
 
-    let stacks = crate::legacy::workspace::applied_stacks_with_expensive_commit_info(ctx)?;
+    let stacks = crate::legacy::workspace::applied_stacks_detailed(ctx)?;
 
     let mut empty_branches = Vec::new();
 

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -956,9 +956,9 @@ fn branch_commits(
     branch_name: &str,
 ) -> anyhow::Result<Vec<Commit>> {
     let stacks = stack_id.map_or_else(
-        || crate::legacy::workspace::applied_stacks_with_expensive_commit_info(ctx),
+        || crate::legacy::workspace::applied_stacks_detailed(ctx),
         |stack_id| {
-            crate::legacy::workspace::applied_stack_with_expensive_commit_info(ctx, Some(stack_id))
+            crate::legacy::workspace::applied_stack_detailed(ctx, Some(stack_id))
                 .map(|stack| vec![stack])
         },
     )?;

--- a/crates/but/src/command/legacy/pull/mod.rs
+++ b/crates/but/src/command/legacy/pull/mod.rs
@@ -524,18 +524,15 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
 
                                 // Also check if any commits in the branch have conflicts
                                 let has_conflicted_commits =
-                                    crate::legacy::workspace::applied_stack_with_expensive_commit_info(
+                                    crate::legacy::workspace::applied_stack_detailed(
                                         ctx,
                                         Some(*stack_id),
                                     )
                                     .ok()
                                     .map(|stack| {
-                                            stack.branches.iter().any(|branch| {
-                                                branch
-                                                    .commits
-                                                    .iter()
-                                                    .any(|commit| commit.has_conflicts)
-                                            })
+                                        stack.branches.iter().any(|branch| {
+                                            branch.commits.iter().any(|commit| commit.has_conflicts)
+                                        })
                                     })
                                     .unwrap_or(false);
 

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -186,7 +186,7 @@ fn handle_dry_run(
     // Get detailed information for each branch
     let mut dry_run_infos = Vec::new();
 
-    let stacks = crate::legacy::workspace::applied_stacks_with_expensive_commit_info(ctx)?;
+    let stacks = crate::legacy::workspace::applied_stacks_detailed(ctx)?;
 
     // Limit the shared lock to target resolution before continuing with dry-run analysis.
     let remote = {
@@ -868,7 +868,7 @@ fn handle_no_branch_specified(
 }
 
 fn get_branches_with_unpushed_info(ctx: &Context) -> anyhow::Result<Vec<(String, usize, String)>> {
-    let stacks = crate::legacy::workspace::applied_stacks_with_expensive_commit_info(ctx)?;
+    let stacks = crate::legacy::workspace::applied_stacks_detailed(ctx)?;
 
     let mut branches_info = Vec::new();
 
@@ -1147,7 +1147,7 @@ async fn update_review_targets_for_stacks(ctx: &Context, perm: &RepoShared) -> a
 /// Check if a branch contains any conflicted commits
 /// Returns an error if conflicted commits are found
 fn check_for_conflicted_commits(ctx: &Context, branch_name: &str) -> anyhow::Result<()> {
-    let stacks = crate::legacy::workspace::applied_stacks_with_expensive_commit_info(ctx)?;
+    let stacks = crate::legacy::workspace::applied_stacks_detailed(ctx)?;
 
     let repo = ctx.repo.get()?.clone().for_commit_shortening();
     // Find the stack containing this branch.

--- a/crates/but/src/command/legacy/rub/undo.rs
+++ b/crates/but/src/command/legacy/rub/undo.rs
@@ -2,7 +2,7 @@ use but_core::ref_metadata::StackId;
 use but_ctx::Context;
 
 pub(crate) fn stack_id_by_commit_id(ctx: &Context, oid: gix::ObjectId) -> anyhow::Result<StackId> {
-    for stack in crate::legacy::workspace::applied_stacks_with_expensive_commit_info(ctx)? {
+    for stack in crate::legacy::workspace::applied_stacks_detailed(ctx)? {
         let Some(id) = stack.id else {
             continue;
         };

--- a/crates/but/src/legacy/workspace.rs
+++ b/crates/but/src/legacy/workspace.rs
@@ -103,9 +103,7 @@ pub fn applied_stacks(ctx: &Context) -> anyhow::Result<Vec<HeadInfoStack>> {
     applied_stacks_with_options(ctx, false)
 }
 
-pub fn applied_stacks_with_expensive_commit_info(
-    ctx: &Context,
-) -> anyhow::Result<Vec<HeadInfoStack>> {
+pub fn applied_stacks_detailed(ctx: &Context) -> anyhow::Result<Vec<HeadInfoStack>> {
     applied_stacks_with_options(ctx, true)
 }
 
@@ -127,11 +125,11 @@ pub fn applied_stack(ctx: &Context, stack_id: Option<StackId>) -> anyhow::Result
     applied_stack_from_stacks(stacks, stack_id)
 }
 
-pub fn applied_stack_with_expensive_commit_info(
+pub fn applied_stack_detailed(
     ctx: &Context,
     stack_id: Option<StackId>,
 ) -> anyhow::Result<HeadInfoStack> {
-    let stacks = applied_stacks_with_expensive_commit_info(ctx)?;
+    let stacks = applied_stacks_detailed(ctx)?;
     applied_stack_from_stacks(stacks, stack_id)
 }
 


### PR DESCRIPTION
## Summary
- rename the explicit expensive head-info stack helpers to concise detailed variants
- keep the cheap applied_stacks default and the same opt-in detailed callers

## Validation
- cargo check -p but --all-targets
- cargo test -p but command::alias::can_invoke_alias_with_root_flags -- --nocapture
- git diff --check -- crates/but/src/legacy/workspace.rs crates/but/src/command/legacy/clean.rs crates/but/src/command/legacy/forge/review.rs crates/but/src/command/legacy/pull/mod.rs crates/but/src/command/legacy/push.rs crates/but/src/command/legacy/rub/undo.rs