### PR TITLE
Clarify comment regarding `remove_branch` restrictions

### DIFF
--- a/crates/but-api/src/legacy/stack.rs
+++ b/crates/but-api/src/legacy/stack.rs
@@ -243,7 +243,7 @@ pub fn remove_branch_only(
 /// This acquires exclusive worktree access from `ctx` before creating the
 /// removal snapshot and detaching the branch.
 ///
-/// This can only be called on a branch that's inside of a stack of multiple branches and is not the top branch,
+/// This can only be called on a branch that's inside of a stack of multiple branches,
 /// or on a branch that's empty.
 #[but_api(napi)]
 #[instrument(err(Debug))]

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -272,7 +272,7 @@ export declare function pushStack(projectId: string, stackId: string, withForce:
  * This acquires exclusive worktree access from `ctx` before creating the
  * removal snapshot and detaching the branch.
  *
- * This can only be called on a branch that's inside of a stack of multiple branches and is not the top branch,
+ * This can only be called on a branch that's inside of a stack of multiple branches,
  * or on a branch that's empty.
  */
 export declare function removeBranch(projectId: string, stackId: string, branchName: string): Promise<void>


### PR DESCRIPTION
As far as I can see the "not the top branch" part of this comment is incorrect. @estib-vega Can you confirm? The comment originates from 232cb1fe7b9a264f9cc5be9f3afbc11591a3a4d2.