### PR TITLE
feat(cli)!: remove `--json` in favor of `--format json`

### DIFF
--- a/apps/web/src/routes/cli/scripts.json
+++ b/apps/web/src/routes/cli/scripts.json
@@ -230,11 +230,11 @@
 		"script": [
 			{
 				"type": "input",
-				"lines": ["# Everything takes --json"]
+				"lines": ["# Everything takes --format json"]
 			},
 			{
 				"type": "input",
-				"lines": ["$ but --json branch new feature/ai-integration | jq ."]
+				"lines": ["$ but --format json branch new feature/ai-integration | jq ."]
 			},
 			{
 				"type": "output",
@@ -247,7 +247,7 @@
 			},
 			{
 				"type": "input",
-				"lines": ["$ but show -j 90fe | jq ."]
+				"lines": ["$ but show --format json 90fe | jq ."]
 			},
 			{
 				"type": "output",
@@ -265,7 +265,7 @@
 			},
 			{
 				"type": "input",
-				"lines": ["$ but --json status | jq '.stacks[].branches[].commits[]'"]
+				"lines": ["$ but --format json status | jq '.stacks[].branches[].commits[]'"]
 			},
 			{
 				"type": "output",

--- a/crates/but-agentlog/skill/SKILL.md
+++ b/crates/but-agentlog/skill/SKILL.md
@@ -54,7 +54,7 @@ Pass an explicit target only when the user gives one.
 Use JSON only when you need exact handles for drill-down:
 
 ```sh
-but --json agentlog skim
+but --format json agentlog skim
 ```
 
 1. Start with `skim` for a clean orientation.
@@ -63,8 +63,8 @@ but --json agentlog skim
 3. If `skim` is enough for a lightweight status answer, summarize it and stop.
 4. Drill down only when `skim` is ambiguous, misses the rationale, or you need
    exact evidence.
-5. To drill down, rerun `skim` with `--json` to get the relevant `session_key`
-   and `turn_key`, then use `show`.
+5. To drill down, rerun `skim` with `--format json` to get the relevant
+   `session_key` and `turn_key`, then use `show`.
 6. Use `show <session-key>` for turn-level context.
 7. Use `show <session-key> --turn <turn-key>` only for turns that need exact detail.
 
@@ -91,8 +91,8 @@ Do not use plain Git's `gitbutler/workspace` branch as an agentlog target.
 - Prefer `skim` for turn-history recovery.
 - Treat `skim` as complete but abbreviated. It includes every related session
   and every turn in those sessions, not every record or the full transcript.
-- Prefer human `skim` output first. Use `--json` only for drill-down handles
-  or exact evidence.
+- Prefer human `skim` output first. Use `--format json` only for drill-down
+  handles or exact evidence.
 - Run `show` when `skim` is thin, ambiguous, missing the why, or when the user
   is asking you to make or verify a consequential claim.
 - Do not dump records for every candidate session.

--- a/crates/but-agentlog/skill/agents/openai.yaml
+++ b/crates/but-agentlog/skill/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "But Agentlog"
   short_description: "Get context for a GitButler branch from prior agent work"
-  default_prompt: "Use $but-agentlog for requests like \"get context for branch\", \"catch up on this branch\", or \"recover branch context\". Do not start with generic git branch/diff inspection; run `but agentlog skim` first. Use `but --json agentlog skim` plus `but agentlog show` only if exact drill-down is needed."
+  default_prompt: "Use $but-agentlog for requests like \"get context for branch\", \"catch up on this branch\", or \"recover branch context\". Do not start with generic git branch/diff inspection; run `but agentlog skim` first. Use `but --format json agentlog skim` plus `but agentlog show` only if exact drill-down is needed."

--- a/crates/but-agentlog/src/cli.rs
+++ b/crates/but-agentlog/src/cli.rs
@@ -33,7 +33,7 @@ pub enum Command {
     /// Show a session, or one turn in detail.
     #[clap(name = "show")]
     Show {
-        /// Session key from `skim --json`.
+        /// Session key from `skim --format json`.
         #[clap(value_name = "SESSION", value_parser = non_empty_value)]
         session_key: String,
         /// Show detailed records for this turn key.

--- a/crates/but-agentlog/src/skim.rs
+++ b/crates/but-agentlog/src/skim.rs
@@ -346,16 +346,18 @@ fn applied_gitbutler_branch(workdir: &Path) -> anyhow::Result<String> {
     let output = ProcessCommand::new(&but_path)
         .arg("-C")
         .arg(workdir)
-        .args(["--json", "status"])
+        .args(["--format", "json", "status"])
         .stdin(Stdio::null())
         .output()
-        .context("failed to run 'but --json status' for agentlog skim target discovery")?;
+        .context("failed to run 'but --format json status' for agentlog skim target discovery")?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("failed to discover GitButler branch with 'but --json status': {stderr}");
+        anyhow::bail!(
+            "failed to discover GitButler branch with 'but --format json status': {stderr}"
+        );
     }
-    let status: StatusReport =
-        serde_json::from_slice(&output.stdout).context("failed to parse 'but --json status'")?;
+    let status: StatusReport = serde_json::from_slice(&output.stdout)
+        .context("failed to parse 'but --format json status'")?;
     status
         .stacks
         .into_iter()

--- a/crates/but/skill/RESEARCH.md
+++ b/crates/but/skill/RESEARCH.md
@@ -52,9 +52,9 @@ Evaluation structure they suggest:
   "query": "Commit the auth changes to the feature branch",
   "files": ["src/auth.rs"],
   "expected_behavior": [
-    "Runs but status --json to check workspace state",
+    "Runs but status --format json to check workspace state",
     "Uses but commit with --changes flag for specific files",
-    "Includes --json and --status-after flags"
+    "Includes --format json and --status-after flags"
   ]
 }
 ```
@@ -101,7 +101,7 @@ tests:
       - type: javascript
         value: |
           const text = String(output).toLowerCase();
-          return text.includes('--json') && text.includes('--status-after');
+          return text.includes('--format json') && text.includes('--status-after');
 ```
 
 ## Metrics That Matter
@@ -113,10 +113,10 @@ Based on industry standards and our specific skill file, here are the metrics to
 | Metric | What It Measures | Target | How to Score |
 |--------|-----------------|--------|-------------|
 | **Tool routing accuracy** | Uses `but` instead of `git` for write ops | 100% | Binary per command |
-| **`--json` compliance** | All `but` commands include `--json` | 100% | Count across all commands in response |
+| **`--format json` compliance** | All `but` commands include `--format json` | 100% | Count across all commands in response |
 | **`--status-after` compliance** | Mutation commands include `--status-after` | 100% | Check commit/absorb/rub/stage/squash/move/uncommit |
 | **`--changes` specificity** | `but commit` uses `--changes` with explicit IDs (`a1,b2` or repeated flag), not bare commit | >90% | Binary per commit command |
-| **Workflow ordering** | Runs `but status --json` before mutations | 100% | Check command sequence |
+| **Workflow ordering** | Runs `but status --format json` before mutations | 100% | Check command sequence |
 | **Unnecessary round-trips** | No `but status` after commands with `--status-after` | 0 | Count redundant status calls |
 | **Task completion** | End-to-end task succeeds | >80% | Binary per scenario |
 
@@ -149,7 +149,7 @@ Validate skill file structure without calling any LLM. Run as part of `cargo tes
 **What to check:**
 - YAML frontmatter is valid and meets Anthropic's constraints (name <=64 chars, description <=1024 chars)
 - All referenced files exist (`references/reference.md`, etc.)
-- Code examples are internally consistent (every mutation command example includes `--json --status-after`)
+- Code examples are internally consistent (every mutation command example includes `--format json --status-after`)
 - No contradictions between SKILL.md and reference files
 - Translation table covers all commands mentioned in reference.md
 - Line count stays under 250 (our budget)
@@ -171,13 +171,13 @@ Score: Does the tool call match expectations?
 
 | User Prompt | Expected First Command | Assertions |
 |------------|----------------------|------------|
-| "What files have I changed?" | `but status --json` | contains `but status`, contains `--json` |
-| "Commit my auth changes" | `but status --json` | status first, then commit with `--changes` |
+| "What files have I changed?" | `but status --format json` | contains `but status`, contains `--format json` |
+| "Commit my auth changes" | `but status --format json` | status first, then commit with `--changes` |
 | "Create a new branch for auth" | `but branch new auth` | contains `but branch new` |
 | "Push my changes" | `but push` | NOT `git push` |
 | "Squash my last 3 commits" | `but squash` | NOT `git rebase -i` |
 | "Can you do a git push?" | `but push` | uses `but` not `git` |
-| "Check what's changed" | `but status --json` | NOT `git status`, NOT `git diff` |
+| "Check what's changed" | `but status --format json` | NOT `git status`, NOT `git diff` |
 | "Undo my last commit" | some `but` command | NOT `git reset` |
 
 **Implementation options:**
@@ -206,12 +206,12 @@ Test complete workflows with mock tool execution. This is the highest-signal tie
 ```
 User: "I just finished implementing auth. Commit it."
 Expected sequence:
-  1. but status --json           (check state)
-  2. but commit <branch> -m "..." --changes <id>,<id> --json --status-after  (commit)
+  1. but status --format json           (check state)
+  2. but commit <branch> -m "..." --changes <id>,<id> --format json --status-after  (commit)
 Assertions:
   - Step 1 happens before step 2
   - Commit includes --changes (not bare commit)
-  - Commit includes --json --status-after
+  - Commit includes --format json --status-after
   - No git commands used
 ```
 
@@ -219,10 +219,10 @@ Assertions:
 ```
 User: "Add a dark mode feature"
 Expected sequence:
-  1. but status --json           (check state)
+  1. but status --format json           (check state)
   2. but branch new dark-mode    (create branch)
   3. [file edits happen]
-  4. but commit ... --changes ... --json --status-after
+  4. but commit ... --changes ... --format json --status-after
 Assertions:
   - Branch created before any commits
   - Commit targets the new branch
@@ -243,7 +243,7 @@ The key insight from the research: you don't need to run real commands. Mock the
 
 ```python
 def mock_bash(command: str) -> str:
-    if "but status --json" in command:
+    if "but status --format json" in command:
         return json.dumps({
             "unassignedChanges": [
                 {"cliId": "a1", "filePath": "src/auth.rs", "changeType": "modified"}
@@ -261,20 +261,20 @@ This gives full control, deterministic scoring, and low cost (can use Sonnet/Hai
 
 #### Tier 3 Implementation Notes
 
-**Key insight: Tier 3 tests the skill file, not the `but` CLI.** No `but` binary runs. No git repo exists. The mock handlers return canned JSON that looks like `but status --json` output. You're measuring whether SKILL.md *teaches the model correctly* — complementary to Tier 1's structural validation.
+**Key insight: Tier 3 tests the skill file, not the `but` CLI.** No `but` binary runs. No git repo exists. The mock handlers return canned JSON that looks like `but status --format json` output. You're measuring whether SKILL.md *teaches the model correctly* — complementary to Tier 1's structural validation.
 
 ```
                     ┌─────────────┐
   SKILL.md ───────► │  LLM (API)  │ ◄──── user prompt
   (system context)  └──────┬──────┘
                            │
-                      tool_use: "but status --json"
+                      tool_use: "but status --format json"
                            │
                     ┌──────▼──────┐
                     │ Mock handler │ ──► canned JSON
                     └──────┬──────┘
                            │
-                      tool_use: "but commit ... --changes a1 --json --status-after"
+                      tool_use: "but commit ... --changes a1 --format json --status-after"
                            │
                     Score: did the command sequence follow SKILL.md rules?
 ```
@@ -285,13 +285,13 @@ Tier 3 remains useful for cheap, deterministic diagnostics, but this project gat
 
 | # | Scenario | Key assertions |
 |---|----------|----------------|
-| 1 | Basic commit flow | `status --json` before `commit`; commit has `--changes`, `--json`, `--status-after`; no git write commands |
+| 1 | Basic commit flow | `status --format json` before `commit`; commit has `--changes`, `--format json`, `--status-after`; no git write commands |
 | 2 | Branch workflow | Create branch (`but branch new` or `but commit <branch> -c`) before committing |
 | 3 | Git synonym redirect | User says "git push", model uses `but push` and not `git push` |
-| 4 | Ordering flow | `but status --json` occurs before `but commit` |
+| 4 | Ordering flow | `but status --format json` occurs before `but commit` |
 | 5 | Specificity flow | Single-file commit uses `--changes`; non-target file remains unassigned in repo state |
-| 6 | Amend flow | Use `but amend` with `--json --status-after`; no git write fallback |
-| 7 | Reorder flow | Use `but move`/`but rub` with `--json --status-after`; no `git rebase`/checkout fallback; repo reflects target order |
+| 6 | Amend flow | Use `but amend` with `--format json --status-after`; no git write fallback |
+| 7 | Reorder flow | Use `but move`/`but rub` with `--format json --status-after`; no `git rebase`/checkout fallback; repo reflects target order |
 
 ### Tier 4: Integration (High-cost, realistic)
 
@@ -304,7 +304,7 @@ Run Claude Code against a real test repository with the latest `but` binary and 
 | Runs `but` binary | No | Yes — freshly built from source |
 | Real git repo | No | Yes — disposable fixture |
 | Command trace | From mock loop | From SDK hooks or output parsing |
-| Asserts on repo state | No | Yes — `but status --json` after |
+| Asserts on repo state | No | Yes — `but status --format json` after |
 | Cost per scenario | ~$0.02 | ~$0.10-0.50 |
 | Speed | ~5 sec | ~30-120 sec |
 | Catches real bugs | Skill file only | Skill + CLI interaction |
@@ -361,7 +361,7 @@ Running the real Tier 4 harness surfaced a few practical issues that are not obv
    - Fix: normalize fixture path with `pwd -P` in `setup-fixture.sh`.
 
 4. **Keep fixture support files out of Git status.**
-   - `.but-data/` and installed `.claude/skills/` content polluted `but status --json` and changed CLI IDs.
+   - `.but-data/` and installed `.claude/skills/` content polluted `but status --format json` and changed CLI IDs.
    - Fix: add `.but-data/`, `.claude/`, `.tmp/` to `.git/info/exclude` in each fixture.
 
 5. **Fixture cleanup should be best-effort.**
@@ -398,7 +398,7 @@ For **Tier 3** (mock tool execution), Rust is viable since it just calls the Ant
 1. **Keep Tier 4 as the default evaluator** for skill changes.
 2. **Treat a 7-scenario Tier 4 smoke run (`--repeat 1`) as the PR gate** for changes under `crates/but/skill/`.
 3. **Run repeated Tier 4 (`--repeat 3+`) nightly or pre-release** to catch stochastic regressions.
-4. **Track the key Tier 4 metrics over time**: pass rate, git-command leakage rate, `--json` and `--status-after` compliance, and cost per scenario.
+4. **Track the key Tier 4 metrics over time**: pass rate, git-command leakage rate, `--format json` and `--status-after` compliance, and cost per scenario.
 
 ### Supplemental Layers (Optional)
 

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -325,7 +325,7 @@ Reword commit message or rename branch.
 ```bash
 but reword <id>               # Interactive editor
 but reword <id> -m "new"      # Non-interactive
-but reword <id> --format      # Format to 72-char wrapping
+but reword <id> --fix-formatting  # Format to 72-char wrapping
 ```
 
 ### `but discard <id>`

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -36,20 +36,8 @@ pub struct Args {
     /// Run as if but was started in PATH instead of the current working directory.
     #[clap(short = 'C', long, default_value = ".", value_name = "PATH")]
     pub current_dir: PathBuf,
-    /// Explicitly control how output should be formatted.
-    ///
-    /// If unset and from a terminal, it defaults to human output, when redirected it's for shells.
-    #[clap(
-        long,
-        short = 'f',
-        env = "BUT_OUTPUT_FORMAT",
-        conflicts_with = "json",
-        default_value = "human"
-    )]
-    pub format: OutputFormat,
-    /// Whether to use JSON output format.
-    #[clap(long, short = 'j', global = true)]
-    pub json: bool,
+    #[clap(flatten)]
+    pub format: OutputFormatArg,
     /// Whether mutation commands should append workspace status.
     #[clap(skip)]
     pub status_after: bool,
@@ -64,6 +52,20 @@ pub struct Args {
     /// is executed with the remaining arguments (`but <COMMAND> [ARGS]`).
     #[clap(subcommand)]
     pub cmd: Option<Subcommands>,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct OutputFormatArg {
+    /// Explicitly control how output should be formatted.
+    ///
+    /// If unset and from a terminal, it defaults to human output, when redirected it's for shells.
+    #[clap(
+        long,
+        env = "BUT_OUTPUT_FORMAT",
+        default_value = "human",
+        global = true
+    )]
+    pub format: OutputFormat,
 }
 
 /// How we should format anything written to [`std::io::stdout()`].
@@ -573,19 +575,24 @@ pub enum Subcommands {
         /// Commit ID to edit the message for, or branch ID to rename
         target: CliIdArg,
         /// The new commit message or branch name. If not provided, opens an editor.
-        #[clap(short = 'm', long = "message", conflicts_with = "format")]
+        #[clap(short = 'm', long = "message", conflicts_with = "fix_formatting")]
         message: Option<String>,
         /// Format the existing commit message to 72-char line wrapping without opening an editor
-        #[clap(short = 'f', long = "format", conflicts_with = "message")]
+        #[clap(
+            id = "fix_formatting",
+            short = 'f',
+            long = "fix-formatting",
+            conflicts_with = "message"
+        )]
         format: bool,
         /// Always show diff inside the editor.
         ///
         /// By default the diff will be shown unless it's large. The diff will always be shown if
         /// `--diff` is passed, regardless of the size of the diff.
-        #[clap(long = "diff", default_value_t, conflicts_with_all = &["no_diff", "format"])]
+        #[clap(long = "diff", default_value_t, conflicts_with_all = &["no_diff", "fix_formatting"])]
         diff: bool,
         /// Never show the diff inside the editor.
-        #[clap(long = "no-diff", default_value_t, conflicts_with_all = &["diff", "format"])]
+        #[clap(long = "no-diff", default_value_t, conflicts_with_all = &["diff", "fix_formatting"])]
         no_diff: bool,
     },
 

--- a/crates/but/src/args/tests.rs
+++ b/crates/but/src/args/tests.rs
@@ -145,12 +145,13 @@ fn status_after_is_hidden_noop_compatibility_flag() {
         "move",
         "source",
         "target",
-        "--json",
+        "--format",
+        "json",
         "--status-after",
     ])
     .expect("parse legacy status-after flag");
 
-    assert!(args.json);
+    assert!(matches!(dbg!(args.format.format), OutputFormat::Json));
     assert!(args.legacy_status_after);
     assert!(!args.status_after);
 }

--- a/crates/but/src/args/tests/reword.rs
+++ b/crates/but/src/args/tests/reword.rs
@@ -3,6 +3,18 @@ use clap::Parser as _;
 use crate::args::{Args, Subcommands};
 
 #[test]
+fn fix_formatting() {
+    let args = Args::try_parse_from(["but", "reword", "a", "--fix-formatting"]).unwrap();
+    let cmd = args.cmd.unwrap();
+
+    let Subcommands::Reword { format, .. } = cmd else {
+        panic!("expected reword command. Got {cmd:?}");
+    };
+
+    assert!(format);
+}
+
+#[test]
 fn always_show_diff() {
     let args = Args::try_parse_from(["but", "reword", "a", "--diff"]).unwrap();
     let cmd = args.cmd.unwrap();

--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -248,8 +248,11 @@ pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
             "  -C, --current-dir <PATH>",
             "Run as if but was started in PATH instead of the current working directory [default: .]",
         ),
-        ("  -j, --json", "Whether to use JSON output format"),
-        ("  -h, --help", "Print help"),
+        (
+            "      --format <FORMAT>",
+            "   Explicitly control how output should be formatted [possible values: human, shell, json, none]",
+        ),
+        ("  -h, --help", "              Print help"),
     ];
 
     for (flag, desc) in option_descriptions {
@@ -352,8 +355,8 @@ To use the GitButler CLI with coding agents (Claude Code hooks, Cursor hooks, MC
 
 Options:
   -C, --current-dir <PATH>  Run as if but was started in PATH instead of the cu…
-  -j, --json  Whether to use JSON output format
-  -h, --help  Print help
+      --format <FORMAT>     Explicitly control how output should be formatted […
+  -h, --help                Print help
 
 Environment variables:
   BUT_PAGER  Sets the pager for large outputs. [default: less]
@@ -404,8 +407,8 @@ To use the GitButler CLI with coding agents (Claude Code hooks, Cursor hooks, MC
 
 Options:
   -C, --current-dir <PATH>  Run as if but was started in PATH instead of the cu…
-  -j, --json  Whether to use JSON output format
-  -h, --help  Print help
+      --format <FORMAT>     Explicitly control how output should be formatted […
+  -h, --help                Print help
 
 Environment variables:
   BUT_PAGER  Sets the pager for large outputs. [default: less]

--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -36,7 +36,7 @@ pub(crate) fn reword_target(
         BranchOrCommit::Branch(BranchArg(name)) => {
             if format {
                 return Err(anyhow::anyhow!(
-                    "--format flag can only be used with commits, not branches"
+                    "--fix-formatting flag can only be used with commits, not branches"
                 )
                 .into());
             }
@@ -177,7 +177,7 @@ fn edit_commit_message_by_id_and_reword_commit(
     // Get new message from provided argument, format flag, or editor
     let new_message = if format {
         if message.is_some() {
-            bail!("Cannot use both --format and --message flags together");
+            bail!("Cannot use both --fix-formatting and --message flags together");
         }
         // Format the current message without opening an editor
         Some(but_action::commit_format::format_commit_message(

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -1554,8 +1554,9 @@ pub(crate) fn stage_cli_error(err: anyhow::Error) -> CliError {
     }
 }
 
-const STAGE_FILE_OR_HUNK_HINT: &str = "Run `but status --json -f` to refresh CLI IDs, then retry with a file or hunk cliId from the output";
-const STAGE_BRANCH_HINT: &str = "Use a branch name or branch cliId from `but status --json -f`";
+const STAGE_FILE_OR_HUNK_HINT: &str = "Run `but status --format json -f` to refresh CLI IDs, then retry with a file or hunk cliId from the output";
+const STAGE_BRANCH_HINT: &str =
+    "Use a branch name or branch cliId from `but status --format json -f`";
 
 #[derive(Debug)]
 struct StageBadInput {

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -133,11 +133,6 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
 
     let mut args: Args = Args::parse_from(args);
     args.status_after = utils::detect_agent::detect().is_some();
-    let output_format = if args.json {
-        OutputFormat::Json
-    } else {
-        args.format
-    };
     // Determine if pager should be used based on the command
     let use_pager = match args.cmd {
         #[cfg(feature = "legacy")]
@@ -162,7 +157,7 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     let namespace = option_env!("IDENTIFIER").unwrap_or("com.gitbutler.app");
     but_secret::secret::set_application_namespace(namespace);
 
-    let mut out = OutputChannel::new_with_optional_pager(output_format, use_pager);
+    let mut out = OutputChannel::new_with_optional_pager(args.format.format, use_pager);
 
     if let (Err(theme_preset_err), Some(out)) = (theme_preset_from_env, out.for_human()) {
         writeln!(
@@ -204,15 +199,8 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
             if args.current_dir != std::path::Path::new(".") {
                 default_alias_args.current_dir = args.current_dir.clone();
             }
-            if !matches!(args.format, OutputFormat::Human) {
-                default_alias_args.format = args.format;
-            }
-            if args.json {
-                default_alias_args.json = true;
-            }
-            if args.status_after {
-                default_alias_args.status_after = true;
-            }
+            default_alias_args.format = args.format;
+            default_alias_args.status_after = args.status_after;
 
             match default_alias_args.cmd.take() {
                 Some(cmd) => match_subcommand(cmd, default_alias_args, app_settings, out).await,
@@ -950,7 +938,7 @@ async fn match_subcommand(
                     // Handle the regular `but commit` command
 
                     // In JSON mode, require either -m, --message-file, or --ai to be specified
-                    if args.json
+                    if matches!(args.format.format, OutputFormat::Json)
                         && commit_args.message.is_none()
                         && commit_args.message_file.is_none()
                         && commit_args.ai.is_none()

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -21,7 +21,7 @@ fn uncommitted_file() -> anyhow::Result<()> {
     env.setup_metadata_at_target(&["A", "B"], "origin/main")?;
     commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
 
-    env.but("--json status -f")
+    env.but("--format json status -f")
         .allow_json()
         .assert()
         .success()
@@ -71,7 +71,7 @@ Hint: you can run `but undo` to undo these changes
     ");
 
     // Status is clean
-    env.but("--json status -f")
+    env.but("--format json status -f")
         .allow_json()
         .assert()
         .success()
@@ -149,7 +149,7 @@ Hint: you can run `but undo` to undo these changes
     ");
 
     // Status is not clean
-    env.but("--json status -f")
+    env.but("--format json status -f")
         .allow_json()
         .assert()
         .success()
@@ -444,7 +444,11 @@ fn dry_run_shows_plan_without_changes() -> anyhow::Result<()> {
     commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
 
     // Get initial status
-    let initial_status = env.but("--json status -f").allow_json().output()?.stdout;
+    let initial_status = env
+        .but("--format json status -f")
+        .allow_json()
+        .output()?
+        .stdout;
 
     // Run absorb with dry-run flag
     env.but("absorb i0 --dry-run")
@@ -464,7 +468,11 @@ Dry run complete. No changes were made.
         .stderr_eq(str![""]);
 
     // Verify that no changes were actually made - status should be unchanged
-    let post_dry_run_status = env.but("--json status -f").allow_json().output()?.stdout;
+    let post_dry_run_status = env
+        .but("--format json status -f")
+        .allow_json()
+        .output()?
+        .stdout;
     assert_eq!(
         initial_status, post_dry_run_status,
         "Status should be unchanged after dry-run"
@@ -494,7 +502,7 @@ Dry run complete. No changes were made.
     ");
 
     // Verify there are still uncommitted changes
-    env.but("--json status -f")
+    env.but("--format json status -f")
         .allow_json()
         .assert()
         .success()

--- a/crates/but/tests/but/command/branch/apply.rs
+++ b/crates/but/tests/but/command/branch/apply.rs
@@ -112,7 +112,7 @@ Applied branch 'feature-branch' to workspace
 
 "#]]);
     // It's idempotent and can produce a shell value.
-    env.but("-f shell apply feature-branch")
+    env.but("--format shell apply feature-branch")
         .allow_json()
         .assert()
         .success()
@@ -149,7 +149,7 @@ fn local_branch_with_json_output() -> anyhow::Result<()> {
     create_local_branch_with_commit(&env, "feature-branch");
 
     // Apply with JSON output
-    env.but("--json apply feature-branch")
+    env.but("--format json apply feature-branch")
         .allow_json()
         .assert()
         .success()
@@ -400,7 +400,7 @@ fn nonexistent_branch_with_json() -> anyhow::Result<()> {
     let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
 
     // Try to apply a branch that doesn't exist with JSON output
-    env.but("--json apply nonexistent-branch")
+    env.but("--format json apply nonexistent-branch")
         .allow_json()
         .assert()
         .failure()

--- a/crates/but/tests/but/command/branch/list.rs
+++ b/crates/but/tests/but/command/branch/list.rs
@@ -6,7 +6,7 @@ fn list_hides_empty_applied_branches_by_default() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks-one-empty")?;
     env.setup_metadata(&["A", "B"])?;
 
-    let result = env.but("--json branch list").allow_json().output()?;
+    let result = env.but("--format json branch list").allow_json().output()?;
     assert!(result.status.success());
     let stdout = String::from_utf8_lossy(&result.stdout);
     let json: serde_json::Value = serde_json::from_str(stdout.trim())?;
@@ -25,7 +25,7 @@ fn list_hides_empty_applied_branches_by_default() -> anyhow::Result<()> {
     assert!(json["branches"].as_array().unwrap().is_empty());
 
     let result = env
-        .but("--json branch list --empty")
+        .but("--format json branch list --empty")
         .allow_json()
         .output()?;
     assert!(result.status.success());

--- a/crates/but/tests/but/command/branch/new.rs
+++ b/crates/but/tests/but/command/branch/new.rs
@@ -134,7 +134,7 @@ fn with_json_output() -> anyhow::Result<()> {
     env.setup_metadata(&["A"])?;
 
     // Test JSON output without anchor
-    env.but("--json branch new my-feature")
+    env.but("--format json branch new my-feature")
         .allow_json()
         .assert()
         .success()
@@ -147,7 +147,7 @@ fn with_json_output() -> anyhow::Result<()> {
 "#]]);
 
     // Test JSON output with anchor
-    env.but("branch new --json --anchor 9477ae7 my-anchored-feature")
+    env.but("branch new --format json --anchor 9477ae7 my-anchored-feature")
         .allow_json()
         .assert()
         .success()

--- a/crates/but/tests/but/command/branch/show.rs
+++ b/crates/but/tests/but/command/branch/show.rs
@@ -7,7 +7,7 @@ fn show_lists_commits_ahead_for_applied_branch() -> anyhow::Result<()> {
     env.setup_metadata(&["applied-branch"])?;
 
     let result = env
-        .but("--json branch show applied-branch")
+        .but("--format json branch show applied-branch")
         .allow_json()
         .output()?;
 
@@ -30,7 +30,7 @@ fn show_check_reports_clean_merge_for_applied_branch() -> anyhow::Result<()> {
     env.setup_metadata(&["applied-branch"])?;
 
     let result = env
-        .but("--json branch show applied-branch --check")
+        .but("--format json branch show applied-branch --check")
         .allow_json()
         .output()?;
 

--- a/crates/but/tests/but/command/branch/unapply.rs
+++ b/crates/but/tests/but/command/branch/unapply.rs
@@ -74,7 +74,7 @@ fn unapply_with_json_output() -> anyhow::Result<()> {
     env.but("apply").arg(branch_name).assert().success();
 
     // Unapply with JSON output using the new `but unapply` command
-    env.but("--json unapply")
+    env.but("--format json unapply")
         .arg(branch_name)
         .allow_json()
         .assert()
@@ -132,7 +132,7 @@ fn unapply_shell_format() -> anyhow::Result<()> {
 
     // Unapply with shell format using the new `but unapply` command
     // Shell format outputs one branch name per line
-    env.but("-f shell unapply")
+    env.but("--format shell unapply")
         .arg(branch_name)
         .allow_json()
         .assert()
@@ -168,7 +168,7 @@ fn unapply_nonexistent_branch_with_json() -> anyhow::Result<()> {
     let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
 
     // Try to unapply a branch that doesn't exist with JSON output - should fail
-    env.but("--json unapply nonexistent-branch")
+    env.but("--format json unapply nonexistent-branch")
         .allow_json()
         .assert()
         .failure();
@@ -303,8 +303,8 @@ fn unapply_using_cli_branch_id() -> anyhow::Result<()> {
     // Apply the branch
     env.but("apply").arg(branch_name).assert().success();
 
-    // Get the CLI ID from status --json
-    let status_output = env.but("status --json").allow_json().output()?;
+    // Get the CLI ID from status --format json
+    let status_output = env.but("status --format json").allow_json().output()?;
     let status: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
 
     // Find the branch's CLI ID - JSON uses camelCase and "branches" not "heads"
@@ -336,7 +336,7 @@ Unapplied stack with branches 'feature-branch' from workspace
 "#]]);
 
     // Verify the branch is no longer in workspace
-    let status_output = env.but("status --json").allow_json().output()?;
+    let status_output = env.but("status --format json").allow_json().output()?;
     let status: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
     let stacks = status["stacks"]
         .as_array()
@@ -369,8 +369,8 @@ fn unapply_using_cli_stack_id() -> anyhow::Result<()> {
     // Apply the branch
     env.but("apply").arg(branch_name).assert().success();
 
-    // Get the stack CLI ID from status --json
-    let status_output = env.but("status --json").allow_json().output()?;
+    // Get the stack CLI ID from status --format json
+    let status_output = env.but("status --format json").allow_json().output()?;
     let status: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
 
     // Find the stack's CLI ID for the feature-branch - JSON uses camelCase and "branches" not "heads"
@@ -417,7 +417,7 @@ fn unapply_json_output_validation() -> anyhow::Result<()> {
 
     // Unapply with JSON output and validate structure
     let output = env
-        .but("--json unapply")
+        .but("--format json unapply")
         .arg(branch_name)
         .allow_json()
         .output()?;

--- a/crates/but/tests/but/command/clean.rs
+++ b/crates/but/tests/but/command/clean.rs
@@ -86,7 +86,7 @@ fn json_output() -> anyhow::Result<()> {
 
     env.but("branch new empty-branch").assert().success();
 
-    env.but("--json clean")
+    env.but("--format json clean")
         .allow_json()
         .assert()
         .success()
@@ -112,7 +112,7 @@ fn json_output_dry_run() -> anyhow::Result<()> {
 
     env.but("branch new empty-branch").assert().success();
 
-    env.but("--json clean --dry-run")
+    env.but("--format json clean --dry-run")
         .allow_json()
         .assert()
         .success()
@@ -136,7 +136,7 @@ fn json_output_no_empty_branches() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
     env.setup_metadata_at_target(&["A"], "origin/main")?;
 
-    env.but("--json clean")
+    env.but("--format json clean")
         .allow_json()
         .assert()
         .success()

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -752,7 +752,7 @@ fn commit_json_mode_requires_message_or_file() -> anyhow::Result<()> {
     env.file("new-file.txt", "test content");
 
     // Try to commit in JSON mode without -m or --message-file
-    env.but("commit --json")
+    env.but("commit --format json")
         .assert()
         .failure()
         .stderr_eq(str![[r#"
@@ -772,7 +772,10 @@ fn commit_json_mode_with_message_succeeds() -> anyhow::Result<()> {
     env.file("new-file.txt", "test content");
 
     // Commit in JSON mode with -m
-    let output = env.but("commit --json -m 'Test commit'").assert().success();
+    let output = env
+        .but("commit --format json -m 'Test commit'")
+        .assert()
+        .success();
 
     // Parse JSON output
     let stdout = std::str::from_utf8(&output.get_output().stdout)?;
@@ -802,7 +805,7 @@ fn commit_json_mode_with_file_succeeds() -> anyhow::Result<()> {
 
     // Commit in JSON mode with --message-file
     let output = env
-        .but("commit --json --message-file commit-msg.txt")
+        .but("commit --format json --message-file commit-msg.txt")
         .assert()
         .success();
 
@@ -830,7 +833,7 @@ fn commit_json_mode_multiple_branches_requires_branch() -> anyhow::Result<()> {
     env.file("new-file.txt", "test content");
 
     // Try to commit in JSON mode without specifying a branch
-    env.but("commit --json -m 'Test commit'")
+    env.but("commit --format json -m 'Test commit'")
         .assert()
         .failure()
         .stderr_eq(str![[r#"
@@ -851,7 +854,7 @@ fn commit_json_mode_multiple_branches_with_branch_succeeds() -> anyhow::Result<(
 
     // Commit in JSON mode with branch specified
     let output = env
-        .but("commit --json -m 'Test commit' B")
+        .but("commit --format json -m 'Test commit' B")
         .assert()
         .success();
 
@@ -880,7 +883,7 @@ fn commit_with_specific_file_ids() -> anyhow::Result<()> {
     env.file("file2.txt", "content 2");
 
     // Get file IDs from status
-    let status_output = env.but("status --json").assert().success();
+    let status_output = env.but("status --format json").assert().success();
     let stdout = std::str::from_utf8(&status_output.get_output().stdout)?;
     let status: serde_json::Value = serde_json::from_str(stdout)?;
 
@@ -912,7 +915,7 @@ fn commit_with_specific_file_ids() -> anyhow::Result<()> {
     assert!(log.contains("Add file1 only"));
 
     // Verify file2 is still uncommitted
-    let status_after = env.but("status --json").assert().success();
+    let status_after = env.but("status --format json").assert().success();
     let stdout_after = std::str::from_utf8(&status_after.get_output().stdout)?;
     let status_after: serde_json::Value = serde_json::from_str(stdout_after)?;
 
@@ -940,7 +943,7 @@ fn commit_with_multiple_file_ids() -> anyhow::Result<()> {
     env.file("file3.txt", "content 3");
 
     // Get file IDs from status
-    let status_output = env.but("status --json").assert().success();
+    let status_output = env.but("status --format json").assert().success();
     let stdout = std::str::from_utf8(&status_output.get_output().stdout)?;
     let status: serde_json::Value = serde_json::from_str(stdout)?;
 
@@ -967,7 +970,7 @@ fn commit_with_multiple_file_ids() -> anyhow::Result<()> {
     .success();
 
     // Verify file3 is still uncommitted
-    let status_after = env.but("status --json").assert().success();
+    let status_after = env.but("status --format json").assert().success();
     let stdout_after = std::str::from_utf8(&status_after.get_output().stdout)?;
     let status_after: serde_json::Value = serde_json::from_str(stdout_after)?;
 
@@ -1000,7 +1003,7 @@ fn commit_with_short_changes_flag() -> anyhow::Result<()> {
     env.file("file2.txt", "content 2");
 
     // Get file ID from status
-    let status_output = env.but("status --json").assert().success();
+    let status_output = env.but("status --format json").assert().success();
     let stdout = std::str::from_utf8(&status_output.get_output().stdout)?;
     let status: serde_json::Value = serde_json::from_str(stdout)?;
 
@@ -1027,7 +1030,7 @@ fn commit_with_short_changes_flag() -> anyhow::Result<()> {
 "#]]);
 
     // Verify file2 is still uncommitted
-    let status_after = env.but("status --json").assert().success();
+    let status_after = env.but("status --format json").assert().success();
     let stdout_after = std::str::from_utf8(&status_after.get_output().stdout)?;
     let status_after: serde_json::Value = serde_json::from_str(stdout_after)?;
 
@@ -1139,7 +1142,7 @@ fn commit_with_empty_file_list_uses_all_files() -> anyhow::Result<()> {
 "#]]);
 
     // Verify both files were committed (no uncommitted files left)
-    let status_after = env.but("status --json").assert().success();
+    let status_after = env.but("status --format json").assert().success();
     let stdout_after = std::str::from_utf8(&status_after.get_output().stdout)?;
     let status_after: serde_json::Value = serde_json::from_str(stdout_after)?;
 
@@ -1173,7 +1176,7 @@ fn commit_with_multiple_hunk_ids_from_same_file() -> anyhow::Result<()> {
     );
 
     // Get hunk IDs from status
-    let status_output = env.but("status --json -f").assert().success();
+    let status_output = env.but("status --format json -f").assert().success();
     let stdout = std::str::from_utf8(&status_output.get_output().stdout)?;
     let status: serde_json::Value = serde_json::from_str(stdout)?;
 
@@ -1197,7 +1200,7 @@ fn commit_with_multiple_hunk_ids_from_same_file() -> anyhow::Result<()> {
             .success();
 
         // Verify no uncommitted changes left
-        let status_after = env.but("status --json").assert().success();
+        let status_after = env.but("status --format json").assert().success();
         let stdout_after = std::str::from_utf8(&status_after.get_output().stdout)?;
         let status_after: serde_json::Value = serde_json::from_str(stdout_after)?;
 
@@ -1247,7 +1250,7 @@ fn commit_single_hunk_leaves_other_hunks_uncommitted() -> anyhow::Result<()> {
     );
 
     // Get hunk IDs from diff (which shows individual hunks)
-    let diff_output = env.but("diff --json").assert().success();
+    let diff_output = env.but("diff --format json").assert().success();
     let stdout = std::str::from_utf8(&diff_output.get_output().stdout)?;
     let diff: serde_json::Value = serde_json::from_str(stdout)?;
 
@@ -1274,7 +1277,7 @@ fn commit_single_hunk_leaves_other_hunks_uncommitted() -> anyhow::Result<()> {
         .success();
 
         // Verify there are still uncommitted changes (the second hunk)
-        let diff_after = env.but("diff --json").assert().success();
+        let diff_after = env.but("diff --format json").assert().success();
         let stdout_after = std::str::from_utf8(&diff_after.get_output().stdout)?;
         let diff_after: serde_json::Value = serde_json::from_str(stdout_after)?;
 
@@ -1354,7 +1357,6 @@ fn but_std_cmd(env: &Sandbox, args: &str) -> std::process::Command {
     cmd.current_dir(env.projects_root());
     cmd.env("E2E_TEST_APP_DATA_DIR", env.app_data_dir());
     cmd.env("GITBUTLER_CHANGE_ID", "42");
-    cmd.env("BUT_OUTPUT_FORMAT", "human");
     cmd.env("NOPAGER", "1");
     cmd.stdin(std::process::Stdio::null());
     cmd.stdout(std::process::Stdio::piped());
@@ -1377,7 +1379,7 @@ fn find_unassigned_cli_id(status: &serde_json::Value, path_contains: &str) -> Op
         .and_then(|c| c["cliId"].as_str().map(|s| s.to_string()))
 }
 
-/// Helper: parse `--json status` and find a branch by name, returning its commit messages.
+/// Helper: parse `--format json status` and find a branch by name, returning its commit messages.
 fn branch_commit_messages(env: &Sandbox, branch_name: &str) -> Vec<String> {
     let status = util::status_json(env).expect("status should be valid JSON");
     let branch = util::find_branch(&status, branch_name).expect("branch should exist in status");
@@ -1389,7 +1391,7 @@ fn branch_commit_messages(env: &Sandbox, branch_name: &str) -> Vec<String> {
         .collect()
 }
 
-/// Helper: count unassigned (uncommitted) changes in `--json status`.
+/// Helper: count unassigned (uncommitted) changes in `--format json status`.
 fn unassigned_file_count(env: &Sandbox) -> usize {
     util::status_json(env).expect("status should be valid JSON")["unassignedChanges"]
         .as_array()

--- a/crates/but/tests/but/command/config.rs
+++ b/crates/but/tests/but/command/config.rs
@@ -97,7 +97,7 @@ fn ai_show_outputs_current_global_configuration_json() -> anyhow::Result<()> {
         .success();
 
     let output = env
-        .but("--json config ai show")
+        .but("--format json config ai show")
         .env("GIT_CONFIG_GLOBAL", &global_config)
         .allow_json()
         .output()?;
@@ -122,7 +122,7 @@ fn ai_show_outputs_current_local_configuration_json() -> anyhow::Result<()> {
         .success();
 
     let output = env
-        .but("-C repo --json config ai --local show")
+        .but("-C repo --format json config ai --local show")
         .allow_json()
         .output()?;
     let json: serde_json::Value = serde_json::from_slice(&output.stdout)?;

--- a/crates/but/tests/but/command/format.rs
+++ b/crates/but/tests/but/command/format.rs
@@ -6,10 +6,14 @@ fn json_flag_can_be_placed_before_or_after_subcommand() -> anyhow::Result<()> {
     //       so everything fails anyway.
     let env = Sandbox::empty()?;
 
-    // Test that --json flag works in both positions with help command (doesn't need a valid repo)
-    env.but("--json completions --help").assert().success();
+    // Test that --format json flag works in both positions with help command (doesn't need a valid repo)
+    env.but("--format json completions --help")
+        .assert()
+        .success();
 
-    env.but("completions --help --json").assert().success();
+    env.but("completions --help --format json")
+        .assert()
+        .success();
 
     #[cfg(feature = "legacy")]
     {
@@ -18,7 +22,7 @@ fn json_flag_can_be_placed_before_or_after_subcommand() -> anyhow::Result<()> {
         use crate::utils::CommandExt;
         // Test with actual commands that need a repo (they'll fail but should accept the flag)
         // Before subcommand
-        env.but("--json status")
+        env.but("--format json status")
             .allow_json()
             .assert()
             .failure()
@@ -29,7 +33,7 @@ Please run 'but setup' to initialize the project.
 "#]]);
 
         // After subcommand
-        env.but("status --json")
+        env.but("status --format json")
             .allow_json()
             .assert()
             .failure()

--- a/crates/but/tests/but/command/help.rs
+++ b/crates/but/tests/but/command/help.rs
@@ -70,8 +70,22 @@ Arguments:
           The target entity to combine with the source
 
 Options:
-  -j, --json
-          Whether to use JSON output format
+      --format <FORMAT>
+          Explicitly control how output should be formatted.
+          
+          If unset and from a terminal, it defaults to human output, when redirected it's for
+          shells.
+
+          Possible values:
+          - human: The output to write is supposed to be for human consumption, and can be more
+            verbose
+          - shell: The output should be suitable for shells, and assigning the major result to
+            variables so that it can be reused in subsequent CLI invocations
+          - json:  Output detailed information as JSON for tool consumption
+          - none:  Do not output anything, like redirecting to /dev/null
+          
+          [env: BUT_OUTPUT_FORMAT=]
+          [default: human]
 
   -h, --help
           Print help (see a summary with '-h')
@@ -87,8 +101,9 @@ Arguments:
   <TARGET>  The target entity to combine with the source
 
 Options:
-  -j, --json  Whether to use JSON output format
-  -h, --help  Print help (see more with '--help')
+      --format <FORMAT>  Explicitly control how output should be formatted [env: BUT_OUTPUT_FORMAT=]
+                         [default: human] [possible values: human, shell, json, none]
+  -h, --help             Print help (see more with '--help')
 
 "#]]);
     Ok(())

--- a/crates/but/tests/but/command/merge.rs
+++ b/crates/but/tests/but/command/merge.rs
@@ -91,7 +91,7 @@ To undo this operation:
 
     // Verify that only the second branch remains in the workspace
     let status_after = env
-        .but("status --json")
+        .but("status --format json")
         .allow_json()
         .assert()
         .success()
@@ -183,7 +183,7 @@ To undo this operation:
     );
 
     let status_after = env
-        .but("status --json")
+        .but("status --format json")
         .allow_json()
         .assert()
         .success()

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -107,13 +107,13 @@ mod util {
 
     /// Return `but status` JSON output as a parsed value.
     pub fn status_json(env: &Sandbox) -> anyhow::Result<serde_json::Value> {
-        let output = env.but("--json status").allow_json().output()?;
+        let output = env.but("--format json status").allow_json().output()?;
         serde_json::from_slice(&output.stdout).context("status output should be valid JSON")
     }
 
     /// Return `but status -f` JSON output as a parsed value.
     pub fn status_json_with_files(env: &Sandbox) -> anyhow::Result<serde_json::Value> {
-        let output = env.but("--json status -f").allow_json().output()?;
+        let output = env.but("--format json status -f").allow_json().output()?;
         serde_json::from_slice(&output.stdout).context("status output should be valid JSON")
     }
 
@@ -168,7 +168,6 @@ mod util {
         cmd.current_dir(env.projects_root());
         cmd.env("E2E_TEST_APP_DATA_DIR", env.app_data_dir());
         cmd.env("GITBUTLER_CHANGE_ID", "42");
-        cmd.env("BUT_OUTPUT_FORMAT", "human");
         cmd.env("NOPAGER", "1");
         cmd.stdin(std::process::Stdio::null());
         cmd.stdout(std::process::Stdio::piped());

--- a/crates/but/tests/but/command/move.rs
+++ b/crates/but/tests/but/command/move.rs
@@ -18,7 +18,7 @@ fn move_commit_before_another_commit() -> anyhow::Result<()> {
     commit_two_files_as_two_hunks_each(&env, "A", "e.txt", "f.txt", "third commit");
 
     // Get commit IDs from status
-    let status_output = env.but("--json status").allow_json().output()?;
+    let status_output = env.but("--format json status").allow_json().output()?;
     let status_json: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
     let commits = &status_json["stacks"][0]["branches"][0]["commits"];
 
@@ -42,7 +42,7 @@ Moved 23e1bf8 → before fce8ecc
 
     // Verify the move was successful by checking that we still have the right number of commits
     // (The actual reordering is tested in unit tests, here we just verify the command executed)
-    let status_output = env.but("--json status").allow_json().output()?;
+    let status_output = env.but("--format json status").allow_json().output()?;
     let status_json: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
     let commits_after = &status_json["stacks"][0]["branches"][0]["commits"];
 
@@ -64,7 +64,7 @@ fn move_commit_after_another_commit() -> anyhow::Result<()> {
     commit_two_files_as_two_hunks_each(&env, "A", "e.txt", "f.txt", "third commit");
 
     // Get commit IDs
-    let status_output = env.but("--json status").allow_json().output()?;
+    let status_output = env.but("--format json status").allow_json().output()?;
     let status_json: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
     let commits = &status_json["stacks"][0]["branches"][0]["commits"];
 
@@ -81,7 +81,7 @@ Moved fce8ecc → after 23e1bf8
 "#]]);
 
     // Verify the move was successful by checking that we still have the right number of commits
-    let status_output = env.but("--json status").allow_json().output()?;
+    let status_output = env.but("--format json status").allow_json().output()?;
     let status_json: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
     let commits_after = &status_json["stacks"][0]["branches"][0]["commits"];
 
@@ -122,7 +122,7 @@ Hint: run `but help` for all commands
 
 "#]]);
     // Commits are ordered newest first.
-    let status_output = env.but("--json status").allow_json().output()?;
+    let status_output = env.but("--format json status").allow_json().output()?;
     let status_json: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
     let commits = &status_json["stacks"][0]["branches"][0]["commits"];
 
@@ -140,7 +140,7 @@ Moved 2 commits → before fce8ecc
 
 "#]]);
 
-    let status_output = env.but("--json status").allow_json().output()?;
+    let status_output = env.but("--format json status").allow_json().output()?;
     let status_json: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
     let commits_after = &status_json["stacks"][0]["branches"][0]["commits"];
 
@@ -200,7 +200,7 @@ Hint: run `but help` for all commands
 
 "#]]);
     // Commits are ordered newest first.
-    let status_output = env.but("--json status").allow_json().output()?;
+    let status_output = env.but("--format json status").allow_json().output()?;
     let status_json: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
     let commits = &status_json["stacks"][0]["branches"][0]["commits"];
 
@@ -218,7 +218,7 @@ Moved 2 commits → after 23e1bf8
 
 "#]]);
 
-    let status_output = env.but("--json status").allow_json().output()?;
+    let status_output = env.but("--format json status").allow_json().output()?;
     let status_json: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
     let commits_after = &status_json["stacks"][0]["branches"][0]["commits"];
 
@@ -545,7 +545,7 @@ fn move_commit_to_branch() -> anyhow::Result<()> {
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "commit on A");
 
     // Get commit ID
-    let status_output = env.but("--json status").allow_json().output()?;
+    let status_output = env.but("--format json status").allow_json().output()?;
     let status_json: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
     let commit_id = status_json["stacks"][0]["branches"][0]["commits"][0]["cliId"]
         .as_str()
@@ -561,7 +561,7 @@ Moved [..] → [B]
 "#]]);
 
     // Verify commit is now on branch B
-    let status_output = env.but("--json status").allow_json().output()?;
+    let status_output = env.but("--format json status").allow_json().output()?;
     let status_json: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
 
     // Branch A should have no commits (except the initial one)
@@ -603,7 +603,7 @@ fn move_commit_with_after_flag_and_branch_target() -> anyhow::Result<()> {
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "commit on A");
 
     // Get commit ID
-    let status_output = env.but("--json status").allow_json().output()?;
+    let status_output = env.but("--format json status").allow_json().output()?;
     let status_json: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
     let commit_id = status_json["stacks"][0]["branches"][0]["commits"][0]["cliId"]
         .as_str()
@@ -631,7 +631,7 @@ fn move_same_commit_to_itself() -> anyhow::Result<()> {
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
 
     // Get commit ID
-    let status_output = env.but("--json status").allow_json().output()?;
+    let status_output = env.but("--format json status").allow_json().output()?;
     let status_json: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
     let commit_id = status_json["stacks"][0]["branches"][0]["commits"][0]["cliId"]
         .as_str()
@@ -658,7 +658,7 @@ fn move_commit_with_invalid_target() -> anyhow::Result<()> {
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
 
     // Get commit ID
-    let status_output = env.but("--json status").allow_json().output()?;
+    let status_output = env.but("--format json status").allow_json().output()?;
     let status_json: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
     let commit_id = status_json["stacks"][0]["branches"][0]["commits"][0]["cliId"]
         .as_str()
@@ -686,7 +686,7 @@ fn move_cross_stack_works_yay() -> anyhow::Result<()> {
     commit_two_files_as_two_hunks_each(&env, "B", "c.txt", "d.txt", "commit on B");
 
     // Get commit IDs
-    let status_output = env.but("--json status").allow_json().output()?;
+    let status_output = env.but("--format json status").allow_json().output()?;
     let status_json: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
 
     let commit_a_id = status_json["stacks"][0]["branches"][0]["commits"][0]["cliId"]
@@ -719,7 +719,7 @@ fn move_committed_file_to_another_commit() -> anyhow::Result<()> {
     commit_two_files_as_two_hunks_each(&env, "A", "c.txt", "d.txt", "second commit");
 
     // Get commit IDs and file IDs from status with files (-f flag)
-    let status_output = env.but("--json status -f").allow_json().output()?;
+    let status_output = env.but("--format json status -f").allow_json().output()?;
     let status_json: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
     let commits = &status_json["stacks"][0]["branches"][0]["commits"];
 
@@ -749,7 +749,7 @@ Moved files between commits!
 "#]]);
 
     // Verify the file was moved by checking status again
-    let status_output = env.but("--json status -f").allow_json().output()?;
+    let status_output = env.but("--format json status -f").allow_json().output()?;
     let status_json: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
     let commits = &status_json["stacks"][0]["branches"][0]["commits"];
 
@@ -1075,7 +1075,7 @@ Hint: run `but help` for all commands
 }
 
 fn status_json(env: &Sandbox) -> anyhow::Result<serde_json::Value> {
-    let output = env.but("--json status").allow_json().output()?;
+    let output = env.but("--format json status").allow_json().output()?;
     Ok(serde_json::from_slice(&output.stdout)?)
 }
 

--- a/crates/but/tests/but/command/onboarding.rs
+++ b/crates/but/tests/but/command/onboarding.rs
@@ -56,7 +56,7 @@ fn json_mode_is_silent_but_marks_complete() -> anyhow::Result<()> {
     std::fs::remove_file(&settings_path)?;
 
     // JSON mode should produce no output even on first run
-    env.but("--json onboarding")
+    env.but("--format json onboarding")
         .allow_json()
         .assert()
         .success()

--- a/crates/but/tests/but/command/pick.rs
+++ b/crates/but/tests/but/command/pick.rs
@@ -9,7 +9,7 @@ fn get_commit_sha(env: &Sandbox, git_ref: &str) -> String {
 
 /// Check if a branch contains a commit with the given message substring
 fn branch_has_commit_message(env: &Sandbox, branch_name: &str, message_contains: &str) -> bool {
-    let result = env.but("status --json").assert().success();
+    let result = env.but("status --format json").assert().success();
     let stdout = String::from_utf8_lossy(&result.get_output().stdout);
     let status: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
 
@@ -119,7 +119,7 @@ fn pick_json_output() -> anyhow::Result<()> {
 
     let sha = get_commit_sha(&env, "refs/gitbutler/pickable-first");
     let result = env
-        .but(format!("--json pick {sha} applied-branch"))
+        .but(format!("--format json pick {sha} applied-branch"))
         .allow_json()
         .output()?;
 

--- a/crates/but/tests/but/command/push.rs
+++ b/crates/but/tests/but/command/push.rs
@@ -23,12 +23,12 @@ fn push_dry_run_json_reports_remote_and_remote_ref() -> anyhow::Result<()> {
         .success();
 
     let output = env
-        .but("push --dry-run --json branchB")
+        .but("push --dry-run --format json branchB")
         .allow_json()
         .output()?;
     assert!(
         output.status.success(),
-        "push --dry-run --json branchB failed: {}",
+        "push --dry-run --format json branchB failed: {}",
         String::from_utf8_lossy(&output.stderr)
     );
     let json: serde_json::Value = serde_json::from_slice(&output.stdout)?;
@@ -91,7 +91,7 @@ fn push_refuses_conflicted_commits() -> anyhow::Result<()> {
 
     // Make origin a writable local repository for the push attempt.
     // Get the first commit's CLI ID from status
-    let status_output = env.but("--json status").allow_json().output()?;
+    let status_output = env.but("--format json status").allow_json().output()?;
     let status_json: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
     let branch = find_branch(&status_json, "branchB")?;
     let first_commit_id = branch["commits"]

--- a/crates/but/tests/but/command/reword.rs
+++ b/crates/but/tests/but/command/reword.rs
@@ -212,7 +212,7 @@ fn reword_commit_with_json_flag() -> anyhow::Result<()> {
     env.setup_metadata(&["A"])?;
 
     // Use reword with -m flag to change commit message (using commit ID)
-    env.but("reword 9477ae7 -m 'Updated commit message' --json")
+    env.but("reword 9477ae7 -m 'Updated commit message' --format json")
         .assert()
         .success()
         .stdout_eq(str![[r#"{

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -192,7 +192,7 @@ fn committed_file_to_unassigned() -> anyhow::Result<()> {
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "second commit");
 
-    env.but("--json status -f")
+    env.but("--format json status -f")
         .allow_json()
         .assert()
         .success()
@@ -264,7 +264,7 @@ Uncommitted changes
         .stderr_eq(str![""]);
 
     // Verify that `status` reflects the move.
-    env.but("--json status -f")
+    env.but("--format json status -f")
         .allow_json()
         .assert()
         .success()
@@ -387,7 +387,7 @@ Unstaged a hunk in a.txt in a stack
 
     // Verify that only one hunk moved back to unassigned ("a.txt" appears both in the
     // unassigned area and in a stack).
-    env.but("--json status -f")
+    env.but("--format json status -f")
         .allow_json()
         .assert()
         .success()
@@ -466,7 +466,7 @@ Staged a hunk in a.txt in the unassigned area → [A].
 
     // Verify that only one hunk was assigned ("a.txt" appears both in the
     // unassigned area and in a stack).
-    env.but("--json status -f")
+    env.but("--format json status -f")
         .allow_json()
         .assert()
         .success()
@@ -534,7 +534,7 @@ fn uncommit_command_on_commit() -> anyhow::Result<()> {
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
 
     // Get the commit ID from status
-    let status_output = env.but("--json status").allow_json().output()?;
+    let status_output = env.but("--format json status").allow_json().output()?;
     let status_json: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
     let commit_id = status_json["stacks"][0]["branches"][0]["commits"][0]["cliId"]
         .as_str()
@@ -544,7 +544,7 @@ fn uncommit_command_on_commit() -> anyhow::Result<()> {
     env.but(format!("uncommit {commit_id}")).assert().success();
 
     // Verify the files are now unassigned
-    env.but("--json status -f")
+    env.but("--format json status -f")
         .allow_json()
         .assert()
         .success()
@@ -799,7 +799,7 @@ fn agent_uncommit_discard_multiple_sources_writes_single_json_with_status() -> a
     let sources = format!("{},{}", commits_before[0], commits_before[1]);
 
     let output = env
-        .but(format!("--json uncommit {sources} --discard"))
+        .but(format!("--format json uncommit {sources} --discard"))
         .env("AI_AGENT", "codex")
         .allow_json()
         .output()?;
@@ -839,7 +839,7 @@ fn stage_command() -> anyhow::Result<()> {
     env.but("stage a.txt A").assert().success();
 
     // Verify the file is assigned to A
-    env.but("--json status -f")
+    env.but("--format json status -f")
         .allow_json()
         .assert()
         .success()
@@ -893,7 +893,7 @@ Error: Bad input 'missing-file' for '<FILE_OR_HUNK>'
 
 Source 'missing-file' not found. If you just performed a Git operation (squash, rebase, etc.), try running 'but status' to refresh the current state.
 
-Hint: Run `but status --json -f` to refresh CLI IDs, then retry with a file or hunk cliId from the output
+Hint: Run `but status --format json -f` to refresh CLI IDs, then retry with a file or hunk cliId from the output
 
 "#]]);
 
@@ -915,7 +915,7 @@ Error: Bad input 'missing-branch' for '<BRANCH>'
 
 Branch 'missing-branch' not found. If you just performed a Git operation (squash, rebase, etc.), try running 'but status' to refresh the current state.
 
-Hint: Use a branch name or branch cliId from `but status --json -f`
+Hint: Use a branch name or branch cliId from `but status --format json -f`
 
 "#]]);
 
@@ -937,7 +937,7 @@ Error: Bad input 'zz' for '<BRANCH>'
 
 Cannot stage to zz - it is the unassigned area. Target must be a branch.
 
-Hint: Use a branch name or branch cliId from `but status --json -f`
+Hint: Use a branch name or branch cliId from `but status --format json -f`
 
 "#]]);
 
@@ -955,7 +955,7 @@ fn unstage_command() -> anyhow::Result<()> {
     env.but("stage a.txt A").assert().success();
 
     // Verify it's assigned
-    env.but("--json status -f")
+    env.but("--format json status -f")
         .allow_json()
         .assert()
         .success()
@@ -980,7 +980,7 @@ fn unstage_command() -> anyhow::Result<()> {
     env.but("unstage A@{stack}:a.txt").assert().success();
 
     // Verify it's now unassigned
-    env.but("--json status -f")
+    env.but("--format json status -f")
         .allow_json()
         .assert()
         .success()
@@ -1040,7 +1040,7 @@ fn unstage_command_with_branch() -> anyhow::Result<()> {
     env.but("unstage A@{stack}:a.txt A").assert().success();
 
     // Verify it's unassigned
-    env.but("--json status -f")
+    env.but("--format json status -f")
         .allow_json()
         .assert()
         .success()
@@ -1068,7 +1068,7 @@ fn unstage_command_validation() -> anyhow::Result<()> {
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
 
     // Get the commit ID from status
-    let status_output = env.but("--json status").allow_json().output()?;
+    let status_output = env.but("--format json status").allow_json().output()?;
     let status_json: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
     let commit_id = status_json["stacks"][0]["branches"][0]["commits"][0]["cliId"]
         .as_str()
@@ -2022,7 +2022,7 @@ fn agent_json_wraps_mutation_and_status() -> anyhow::Result<()> {
     env.file("a.txt", "arbitrary text\n");
 
     let output = env
-        .but("--json stage a.txt A")
+        .but("--format json stage a.txt A")
         .env("AI_AGENT", "codex")
         .allow_json()
         .output()?;
@@ -2067,7 +2067,7 @@ fn agent_invocation_enables_status_after_for_mutations() -> anyhow::Result<()> {
     env.file("agent.txt", "content\n");
 
     let output = env
-        .but("--json stage agent.txt A")
+        .but("--format json stage agent.txt A")
         .env("AI_AGENT", "codex")
         .allow_json()
         .output()?;
@@ -2096,7 +2096,7 @@ fn agent_json_success_has_no_status_error_field() -> anyhow::Result<()> {
     env.file("b.txt", "content\n");
 
     let output = env
-        .but("--json stage b.txt A")
+        .but("--format json stage b.txt A")
         .env("AI_AGENT", "codex")
         .allow_json()
         .output()?;

--- a/crates/but/tests/but/command/setup.rs
+++ b/crates/but/tests/but/command/setup.rs
@@ -342,7 +342,7 @@ Learn more at https://docs.gitbutler.com/cli-overview
 fn json_output_new_setup() -> anyhow::Result<()> {
     let env = Sandbox::open_with_default_settings("repo-with-remote-and-head")?;
 
-    env.but("--json setup")
+    env.but("--format json setup")
         .allow_json()
         .assert()
         .success()
@@ -371,7 +371,7 @@ fn json_output_already_setup() -> anyhow::Result<()> {
     env.but("setup").assert().success();
 
     // Run again with JSON output
-    env.but("--json setup")
+    env.but("--format json setup")
         .allow_json()
         .assert()
         .success()
@@ -396,7 +396,7 @@ fn json_output_already_setup() -> anyhow::Result<()> {
 fn json_output_gb_local() -> anyhow::Result<()> {
     let env = Sandbox::open_with_default_settings("repo-no-remote")?;
 
-    env.but("--json setup")
+    env.but("--format json setup")
         .allow_json()
         .assert()
         .success()
@@ -421,7 +421,7 @@ fn json_output_gb_local() -> anyhow::Result<()> {
 fn json_output_non_standard_branch() -> anyhow::Result<()> {
     let env = Sandbox::open_with_default_settings("repo-no-remote-no-main-or-master")?;
 
-    env.but("--json setup")
+    env.but("--format json setup")
         .allow_json()
         .assert()
         .success()
@@ -446,7 +446,7 @@ fn json_output_non_standard_branch() -> anyhow::Result<()> {
 fn json_output_remote_no_head_fallback() -> anyhow::Result<()> {
     let env = Sandbox::open_with_default_settings("repo-with-remote-no-head")?;
 
-    env.but("--json setup")
+    env.but("--format json setup")
         .allow_json()
         .assert()
         .success()
@@ -471,7 +471,7 @@ fn json_output_remote_no_head_fallback() -> anyhow::Result<()> {
 fn json_output_not_a_git_repo() -> anyhow::Result<()> {
     let env = Sandbox::empty()?;
 
-    env.but("--json setup")
+    env.but("--format json setup")
         .allow_json()
         .assert()
         .failure()
@@ -568,7 +568,7 @@ Learn more at https://docs.gitbutler.com/cli-overview
 fn init_flag_json_output() -> anyhow::Result<()> {
     let env = Sandbox::empty()?;
 
-    env.but("--json setup --init")
+    env.but("--format json setup --init")
         .allow_json()
         .assert()
         .success()

--- a/crates/but/tests/but/command/skill.rs
+++ b/crates/but/tests/but/command/skill.rs
@@ -37,7 +37,7 @@ fn skill_check_json_output_is_valid() -> anyhow::Result<()> {
     // Check with --global to avoid needing a repo context
     // The JSON output should always be valid even if no skills are found
     let output = env
-        .but("skill check --global --json")
+        .but("skill check --global --format json")
         .allow_json()
         .assert()
         .success()
@@ -63,7 +63,7 @@ fn skill_check_json_output_is_valid() -> anyhow::Result<()> {
 fn skill_install_json_outside_repo_requires_path_instead_of_repo_context() -> anyhow::Result<()> {
     let env = Sandbox::empty()?;
 
-    env.but("skill install --json")
+    env.but("skill install --format json")
         .allow_json()
         .assert()
         .failure()
@@ -84,7 +84,7 @@ fn skill_install_path_outside_repo_requires_global() -> anyhow::Result<()> {
     env.but("")
         .arg("skill")
         .arg("install")
-        .arg("--json")
+        .args(["--format", "json"])
         .arg("--path")
         .arg(&install_path)
         .allow_json()
@@ -109,7 +109,7 @@ fn skill_install_absolute_path_outside_repo_does_not_require_global() -> anyhow:
         .but("")
         .arg("skill")
         .arg("install")
-        .arg("--json")
+        .args(["--format", "json"])
         .arg("--path")
         .arg(&install_dir)
         .allow_json()
@@ -138,7 +138,7 @@ fn skill_check_detects_agent_skills_installation_in_repo() -> anyhow::Result<()>
     env.but("")
         .arg("skill")
         .arg("install")
-        .arg("--json")
+        .args(["--format", "json"])
         .arg("--path")
         .arg(&install_path)
         .allow_json()
@@ -146,7 +146,7 @@ fn skill_check_detects_agent_skills_installation_in_repo() -> anyhow::Result<()>
         .success();
 
     let output = env
-        .but("skill check --local --json")
+        .but("skill check --local --format json")
         .allow_json()
         .assert()
         .success()
@@ -183,7 +183,7 @@ fn skill_install_detect_finds_agent_skills_installation_in_repo() -> anyhow::Res
     env.but("")
         .arg("skill")
         .arg("install")
-        .arg("--json")
+        .args(["--format", "json"])
         .arg("--path")
         .arg(&install_path)
         .allow_json()
@@ -191,7 +191,7 @@ fn skill_install_detect_finds_agent_skills_installation_in_repo() -> anyhow::Res
         .success();
 
     let output = env
-        .but("skill install --json --detect")
+        .but("skill install --format json --detect")
         .allow_json()
         .assert()
         .success()
@@ -222,7 +222,7 @@ fn skill_install_surfaces_non_repo_discovery_errors() -> anyhow::Result<()> {
         .arg(&invalid_dir)
         .arg("skill")
         .arg("install")
-        .arg("--json")
+        .args(["--format", "json"])
         .allow_json()
         .assert()
         .failure();

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -105,7 +105,7 @@ fn json_shows_paths_as_strings() -> anyhow::Result<()> {
     // Create a new file to ensure we have file assignments
     env.file("test-file.txt", "test content");
 
-    env.but("--json status")
+    env.but("--format json status")
         .allow_json()
         .assert()
         .success()
@@ -228,7 +228,7 @@ fn uncommitted_and_committed_file_cli_ids() -> anyhow::Result<()> {
     env.file("a.txt", format!("firstb\n{}lastb\n", "line\n".repeat(100)));
     env.file("b.txt", "onlyb\n");
 
-    env.but("--json status -f")
+    env.but("--format json status -f")
         .allow_json()
         .assert()
         .success()
@@ -339,7 +339,7 @@ fn long_cli_ids_json() -> anyhow::Result<()> {
 
     // Assert a handful of commits to show that the commit CLI IDs become longer
     // if a short ID would be ambiguous, but remain at 2 characters otherwise.
-    env.but("--json status -f")
+    env.but("--format json status -f")
         .allow_json()
         .with_assert(env.assert_with_uuid_and_timestamp_redactions())
         .assert()

--- a/crates/but/tests/but/command/teardown.rs
+++ b/crates/but/tests/but/command/teardown.rs
@@ -354,7 +354,7 @@ fn json_output_single_branch() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
     env.setup_metadata(&["A"])?;
 
-    env.but("--json teardown")
+    env.but("--format json teardown")
         .allow_json()
         .assert()
         .success()
@@ -381,7 +381,7 @@ fn json_output_with_dangling_commits() -> anyhow::Result<()> {
         Sandbox::init_scenario_with_target_and_default_settings("teardown-dangling-single-commit")?;
     env.setup_metadata(&["A"])?;
 
-    env.but("--json teardown")
+    env.but("--format json teardown")
         .allow_json()
         .assert()
         .success()
@@ -424,7 +424,7 @@ fn teardown_checks_out_to_branch_override() -> anyhow::Result<()> {
     env.setup_metadata(&["A"])?;
     env.but("unapply A").assert().success();
 
-    env.but("--json teardown")
+    env.but("--format json teardown")
         .arg("--checkout-to")
         .arg("A")
         .allow_json()
@@ -457,7 +457,7 @@ fn teardown_checks_out_to_branch_override_with_qualified_ref_name() -> anyhow::R
     env.setup_metadata(&["A"])?;
     env.but("unapply A").assert().success();
 
-    env.but("--json teardown")
+    env.but("--format json teardown")
         .arg("--checkout-to")
         .arg("refs/heads/A")
         .allow_json()

--- a/crates/but/tests/but/command/undo/undo_commit.rs
+++ b/crates/but/tests/but/command/undo/undo_commit.rs
@@ -12,7 +12,7 @@ pub(super) fn commit_empty_with_message(env: &Sandbox, message: &str) -> String 
         new_commit_id: String,
     }
 
-    let output = env.but("commit empty A --json").assert().success();
+    let output = env.but("commit empty A --format json").assert().success();
     let output = output.get_output();
     let commit_id = serde_json::from_slice::<CommitEmptyJson>(&output.stdout)
         .unwrap()
@@ -20,7 +20,7 @@ pub(super) fn commit_empty_with_message(env: &Sandbox, message: &str) -> String 
 
     let output = env
         .but("reword")
-        .args([&commit_id, "-m", message, "--json"])
+        .args([&commit_id, "-m", message, "--format", "json"])
         .assert()
         .success();
     let output = output.get_output();

--- a/crates/but/tests/but/command/undo/undo_redo.rs
+++ b/crates/but/tests/but/command/undo/undo_redo.rs
@@ -11,7 +11,7 @@ fn reword(env: &Sandbox, commit_before: &str, new_message: &str) -> (std::proces
 
     let reword_output = env
         .but("reword")
-        .args([commit_before, "-m", new_message, "--json"])
+        .args([commit_before, "-m", new_message, "--format", "json"])
         .assert()
         .success();
 

--- a/crates/but/tests/but/utils.rs
+++ b/crates/but/tests/but/utils.rs
@@ -131,7 +131,6 @@ impl Sandbox {
         }
         self.with_updated_env(cmd)
             .env("GITBUTLER_CHANGE_ID", "42")
-            .env("BUT_OUTPUT_FORMAT", "human")
             .env("NOPAGER", "1")
     }
 
@@ -147,7 +146,7 @@ pub trait CommandExt {
     /// asserting with [snapbox::cmd::OutputAssert::stdout_eq] against an SVG
     /// file.
     fn with_color_for_svg(self) -> Self;
-    /// Change the environment to allow passing `--json`.
+    /// Change the environment to allow passing `--format json`.
     fn allow_json(self) -> Self;
 }
 


### PR DESCRIPTION
Removes the global `--json` flag in favor of using `--format json`. That way, there is only one way to specify the format.

@slarse and I think not having `--format` as a global flag is good since it might not make sense for all commands. Instead, the commands that support format should handle it specifically. This PR doesn't change that; `--format` is still global, but we'll look into it later. But to move in that direction, I added

```rust
#[derive(clap::Args)]
pub struct OutputFormatArg {
    #[clap(...)]
    pub format: OutputFormat,
}
```

which can be `#[clap(flatten)]`'ed into other arg structs later. Currently, it's just used in the top-level `Args` type.