### PR TITLE
fix: Re-add the deletion guard in the top-most branch

### DIFF
--- a/apps/desktop/src/components/branch/BranchHeaderContextMenu.svelte
+++ b/apps/desktop/src/components/branch/BranchHeaderContextMenu.svelte
@@ -291,7 +291,7 @@
 						}}
 					/>
 				{/if}
-				{#if branchName && stackLength && (stackLength > 1 || (stackLength === 1 && branchCommits.length === 0))}
+				{#if branchName && stackLength && ((stackLength > 1 && (!first || !hasCommits)) || (stackLength === 1 && branchCommits.length === 0))}
 					<ContextMenuItem
 						label="Delete"
 						icon="bin"


### PR DESCRIPTION
If a branch is at the top of a multi-branch stack, and it has commits in
it, its reference can’t be deleted.