### PR TITLE
Refactor frontend to accommodate plain git mode

### DIFF
--- a/apps/desktop/src/components/branch/BranchCard.svelte
+++ b/apps/desktop/src/components/branch/BranchCard.svelte
@@ -21,7 +21,7 @@
 	import { isDefined } from "@gitbutler/ui/utils/typeguards";
 	import type { BranchIconName } from "$lib/branches/branchIcon";
 	import type { DropzoneHandler } from "$lib/dragging/handler";
-	import type { PushStatus } from "@gitbutler/but-sdk";
+	import type { PushStatus, Segment } from "@gitbutler/but-sdk";
 	import type { Snippet } from "svelte";
 
 	interface BranchCardProps {
@@ -67,6 +67,11 @@
 		numberOfCommits: number;
 		numberOfUpstreamCommits: number;
 		numberOfBranchesInStack: number;
+		segment: Segment;
+		branchIndex: number;
+		parent: Segment | undefined;
+		withForce: boolean;
+		stackPrNumbers: (number | undefined)[];
 		baseCommit?: string;
 		onclick: () => void;
 		disableClick?: boolean;
@@ -277,6 +282,12 @@
 							{projectId}
 							{branchName}
 							stackId={args.stackId}
+							segment={args.segment}
+							branchIndex={args.branchIndex}
+							parent={args.parent}
+							withForce={args.withForce}
+							stackPrNumbers={args.stackPrNumbers}
+							prNumber={args.prNumber}
 							oncancel={() => {
 								projectState.exclusiveAction.set(undefined);
 							}}

--- a/apps/desktop/src/components/branch/BranchHeaderContextMenu.svelte
+++ b/apps/desktop/src/components/branch/BranchHeaderContextMenu.svelte
@@ -2,7 +2,7 @@
 	import type { Segment } from "@gitbutler/but-sdk";
 
 	export type BranchHeaderContextData = {
-		branch: Segment;
+		segment: Segment;
 		prNumber?: number;
 		first?: boolean;
 		stackLength: number;
@@ -68,34 +68,18 @@
 	const isReadOnly = $derived(!stackId);
 
 	const aiGenEnabled = $derived(projectAiGenEnabled(projectId));
-	const branchName = $derived(contextData.branch.refName?.displayName);
+	const branchName = $derived(contextData.segment.refName?.displayName);
 	const branchReference = $derived(
-		contextData.branch.refName
-			? new TextDecoder().decode(new Uint8Array(contextData.branch.refName.fullNameBytes))
+		contextData.segment.refName
+			? new TextDecoder().decode(new Uint8Array(contextData.segment.refName.fullNameBytes))
 			: undefined,
 	);
-	const remoteTrackingBranch = $derived(contextData.branch.remoteTrackingRefName);
-	const branchCommits = $derived(contextData.branch.commits);
+	const remoteTrackingBranch = $derived(contextData.segment.remoteTrackingRefName);
+	const branchCommits = $derived(contextData.segment.commits);
 
-	const allCommits = $derived.by(() => {
-		if (!branchName) return;
-		return stackId
-			? stackService.commits(projectId, stackId, branchName)
-			: stackService.unstackedCommits(projectId, branchName);
-	});
-
-	async function getAllCommits() {
-		if (!branchName) return [];
-		if (stackId) {
-			return stackService.fetchCommits(projectId, stackId, branchName);
-		}
-		return stackService.fetchUnstackedCommits(projectId, branchName);
-	}
-
-	const commits = $derived(allCommits?.response);
-	const branchType = $derived(commits?.at(0)?.state.type || "LocalOnly");
-	const isConflicted = $derived(commits?.some((commit) => commit.hasConflicts) ?? false);
-	const hasCommits = $derived((commits?.length ?? 0) > 0);
+	const branchType = $derived(branchCommits.at(0)?.state.type || "LocalOnly");
+	const isConflicted = $derived(branchCommits.some((commit) => commit.hasConflicts));
+	const hasCommits = $derived(branchCommits.length > 0);
 
 	let aiConfigurationValid = $state(false);
 
@@ -111,12 +95,10 @@
 	async function generateBranchName(stackId: string, branchName: string) {
 		if (!$aiGenEnabled || !aiConfigurationValid) return;
 
-		const commits = await getAllCommits();
-		const commitMessages = commits?.map((commit) => commit.message) ?? [];
+		const commitMessages = branchCommits.map((commit) => commit.message);
 		// The context-menu entry is disabled via `hasCommits` when there are
-		// no commits yet. Guard defensively against a race (freshly-fetched
-		// commits may lag the reactive query) — silently no-op rather than
-		// raising an error toast.
+		// no commits yet. Guard defensively against an empty list — silently
+		// no-op rather than raising an error toast.
 		if (commitMessages.length === 0) return;
 
 		const prompt = promptService.selectedBranchPrompt(projectId);

--- a/apps/desktop/src/components/commit/CommitContextMenu.svelte
+++ b/apps/desktop/src/components/commit/CommitContextMenu.svelte
@@ -59,7 +59,6 @@
 	import { MODE_SERVICE } from "$lib/mode/modeService";
 	import { PROJECTS_SERVICE } from "$lib/project/projectsService";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
-	import { ensureValue } from "$lib/utils/validation";
 	import { inject, injectOptional } from "@gitbutler/core/context";
 	import {
 		ContextMenuItem,
@@ -108,11 +107,7 @@
 			: false,
 	);
 
-	async function insertBlankCommit(
-		stackId: string,
-		commitId: string,
-		location: "above" | "below" = "below",
-	) {
+	async function insertBlankCommit(commitId: string, location: "above" | "below" = "below") {
 		await insertBlankCommitInBranch({
 			projectId,
 			relativeTo: { type: "commit", subject: commitId },
@@ -121,7 +116,11 @@
 		});
 	}
 
-	async function handleCreateNewRef(stackId: string, commitId: string, position: AnchorPosition) {
+	async function handleCreateNewRef(
+		stackId: string | undefined,
+		commitId: string,
+		position: AnchorPosition,
+	) {
 		const newName = await stackService.fetchNewBranchName(projectId);
 		await createRef({
 			projectId,
@@ -320,7 +319,7 @@
 										label="Add empty commit above"
 										disabled={isReadOnly || commitInsertion.current.isLoading}
 										onclick={() => {
-											insertBlankCommit(ensureValue(stackId), commitId, "above");
+											insertBlankCommit(commitId, "above");
 											closeSubmenu();
 											close();
 										}}
@@ -329,7 +328,7 @@
 										label="Add empty commit below"
 										disabled={isReadOnly || commitInsertion.current.isLoading}
 										onclick={() => {
-											insertBlankCommit(ensureValue(stackId), commitId, "below");
+											insertBlankCommit(commitId, "below");
 											closeSubmenu();
 											close();
 										}}
@@ -345,7 +344,7 @@
 										disabled={isReadOnly || refCreation.current.isLoading}
 										onclick={async () => {
 											if (!isReadOnly) {
-												await handleCreateNewRef(ensureValue(stackId), commitId, "Above");
+												await handleCreateNewRef(stackId, commitId, "Above");
 												closeSubmenu();
 												close();
 											}
@@ -356,7 +355,7 @@
 										disabled={isReadOnly || refCreation.current.isLoading}
 										onclick={async () => {
 											if (!isReadOnly) {
-												await handleCreateNewRef(ensureValue(stackId), commitId, "Below");
+												await handleCreateNewRef(stackId, commitId, "Below");
 												closeSubmenu();
 												close();
 											}

--- a/apps/desktop/src/components/commit/CommitView.svelte
+++ b/apps/desktop/src/components/commit/CommitView.svelte
@@ -5,8 +5,6 @@
 	import CommitTitle from "$components/commit/CommitTitle.svelte";
 	import { isLocalAndRemoteCommit } from "$components/lib";
 	import Drawer from "$components/shared/Drawer.svelte";
-	import ReduxResult from "$components/shared/ReduxResult.svelte";
-	import { type CommitKey } from "$lib/commits/commit";
 	import { splitMessage } from "$lib/commits/commitMessage";
 	import { rewrapCommitMessage } from "$lib/config/uiFeatureFlags";
 	import { DEFAULT_FORGE_FACTORY } from "$lib/forge/forgeFactory.svelte";
@@ -14,22 +12,21 @@
 	import { showToast } from "$lib/notifications/toasts";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { UI_STATE, withStackBusy } from "$lib/state/uiState.svelte";
-	import { ensureValue } from "$lib/utils/validation";
 	import { inject, injectOptional } from "@gitbutler/core/context";
 	import { Button, TestId } from "@gitbutler/ui";
+	import type { Commit, UpstreamCommit } from "@gitbutler/but-sdk";
 
 	type Props = {
 		projectId: string;
 		stackId?: string;
 		laneId: string;
-		commitKey: CommitKey;
+		commit: Commit | UpstreamCommit;
 		active?: boolean;
 		draggableFiles: boolean;
 		grow?: boolean;
 		clientHeight?: number;
 		rounded?: boolean;
 		ontoggle?: (collapsed: boolean) => void;
-		onerror: (err: unknown) => void;
 		onclose?: () => void;
 		onpopout?: () => void;
 	};
@@ -38,12 +35,11 @@
 		projectId,
 		stackId,
 		laneId,
-		commitKey,
+		commit,
 		grow,
 		clientHeight = $bindable(),
 		rounded,
 		ontoggle,
-		onerror,
 		onclose,
 		onpopout,
 	}: Props & { isInEditMessageMode?: boolean } = $props();
@@ -61,10 +57,6 @@
 	const selected = $derived(laneState.selection);
 	const branchName = $derived(selected.current?.branchName);
 
-	const commitQuery = $derived(
-		stackService.commitById(projectId, commitKey.stackId, commitKey.commitId),
-	);
-
 	const [updateCommitMessage, messageUpdateQuery] = stackService.updateCommitMessage;
 
 	type Mode = "view" | "edit";
@@ -75,8 +67,8 @@
 				projectState.exclusiveAction.set({
 					type: "edit-commit-message",
 					stackId,
-					branchName: commitKey.branchName,
-					commitId: commitKey.commitId,
+					branchName,
+					commitId: commit.id,
 				});
 				break;
 			case "view":
@@ -85,9 +77,7 @@
 		}
 	}
 
-	const parsedMessage = $derived(
-		commitQuery.response ? splitMessage(commitQuery.response.message) : undefined,
-	);
+	const parsedMessage = $derived(splitMessage(commit.message));
 
 	function combineParts(title?: string, description?: string): string {
 		if (!title) {
@@ -111,30 +101,29 @@
 
 		const newCommitId = await updateCommitMessage({
 			projectId,
-			stackId: ensureValue(stackId),
-			commitId: commitKey.commitId,
+			stackId,
+			commitId: commit.id,
 			message: commitMessage,
 			dryRun: false,
 		});
 
-		uiState
-			.lane(ensureValue(stackId))
-			.selection.set({ branchName, commitId: newCommitId, previewOpen: true });
+		if (stackId) {
+			uiState.lane(stackId).selection.set({ branchName, commitId: newCommitId, previewOpen: true });
+		}
 		setMode("view");
 	}
 
 	async function handleUncommit() {
 		if (!branchName) return;
-		const targetStackId = ensureValue(stackId);
 		await withStackBusy(
 			uiState,
 			projectId,
-			{ commitId: commitKey.commitId, stackIds: [targetStackId] },
+			{ commitId: commit.id, stackIds: stackId ? [stackId] : undefined },
 			async () => {
 				await stackService.uncommit({
 					projectId,
-					stackId: targetStackId,
-					commitIds: [commitKey.commitId],
+					stackId,
+					commitIds: [commit.id],
 				});
 			},
 		);
@@ -151,112 +140,108 @@
 	}
 </script>
 
-<ReduxResult {stackId} {projectId} result={commitQuery.result} {onerror}>
-	{#snippet children(commit, env)}
-		<Drawer
-			bind:this={drawer}
-			bind:clientHeight
-			testId={TestId.CommitDrawer}
-			persistId="commit-view-drawer-{projectId}-{stackId}-{commitKey.commitId}"
-			{grow}
-			{rounded}
-			{ontoggle}
-			onclose={() => {
-				// When the commit view is closed, we also want to unset the
-				// relevant uiState so things like commit buttons are usable.
+<Drawer
+	bind:this={drawer}
+	bind:clientHeight
+	testId={TestId.CommitDrawer}
+	persistId="commit-view-drawer-{projectId}-{stackId}-{commit.id}"
+	{grow}
+	{rounded}
+	{ontoggle}
+	onclose={() => {
+		// When the commit view is closed, we also want to unset the
+		// relevant uiState so things like commit buttons are usable.
 
-				// TODO: We should consider having a modal to confirm the cancel
-				cancelEdit();
-				onclose?.();
-			}}
-			bottomBorder={false}
-			noshrink
-		>
-			{#snippet closeActions()}
-				{#if onpopout}
-					<Button
-						kind="ghost"
-						icon="pop-out-bottom-right"
-						size="tag"
-						tooltip="Pop out diff view"
-						onclick={onpopout}
-					/>
-				{/if}
-			{/snippet}
-			{#snippet header()}
-				<CommitTitle
-					truncate
-					commitMessage={commit.message}
-					className="text-14 text-semibold text-body"
-					editable={!isReadOnly}
-				/>
-			{/snippet}
-
-			{#snippet actions()}
-				{#if canEdit()}
-					{@const isEditingMessage =
-						projectState.exclusiveAction.current?.type === "edit-commit-message" &&
-						projectState.exclusiveAction.current.commitId === commit.id}
-					<Button
-						testId={TestId.CommitDrawerActionEditMessage}
-						size="tag"
-						kind="ghost"
-						icon="edit"
-						onclick={() => {
-							drawer?.open();
-							setMode("edit");
-						}}
-						tooltip={isReadOnly ? "Read-only mode" : "Reword commit"}
-						disabled={isReadOnly || isEditingMessage}
-					/>
-				{/if}
-				{@const data = isLocalAndRemoteCommit(commit)
-					? {
-							stackId,
-							commitId: commit.id,
-							commitMessage: commit.message,
-							commitStatus: commit.state.type,
-							commitUrl: forge.current.commitUrl(commit.id),
-							onUncommitClick: () => handleUncommit(),
-							onEditMessageClick: () => {
-								drawer?.open();
-								setMode("edit");
-							},
-						}
-					: undefined}
-				{#if data}
-					<CommitContextMenu {projectId} contextData={data} />
-				{/if}
-			{/snippet}
-
-			<div class="commit-view">
-				{#if projectState.exclusiveAction.current?.type === "edit-commit-message" && projectState.exclusiveAction.current.commitId === commit.id}
-					<div
-						class="edit-commit-view"
-						data-testid={TestId.EditCommitMessageBox}
-						class:no-paddings={uiState.global.useFloatingBox.current}
-					>
-						<CommitMessageEditor
-							noPadding
-							projectId={env.projectId}
-							stackId={env.stackId}
-							action={({ title, description }) => saveCommitMessage(title, description)}
-							actionLabel="Save changes"
-							onCancel={cancelEdit}
-							floatingBoxHeader="Reword commit"
-							loading={messageUpdateQuery.current.isLoading}
-							existingCommitId={commit.id}
-							title={parsedMessage?.title || ""}
-							description={parsedMessage?.description || ""}
-						/>
-					</div>
-				{:else}
-					<CommitDetails {commit} rewrap={$rewrapCommitMessage} />
-				{/if}
-			</div>
-		</Drawer>
+		// TODO: We should consider having a modal to confirm the cancel
+		cancelEdit();
+		onclose?.();
+	}}
+	bottomBorder={false}
+	noshrink
+>
+	{#snippet closeActions()}
+		{#if onpopout}
+			<Button
+				kind="ghost"
+				icon="pop-out-bottom-right"
+				size="tag"
+				tooltip="Pop out diff view"
+				onclick={onpopout}
+			/>
+		{/if}
 	{/snippet}
-</ReduxResult>
+	{#snippet header()}
+		<CommitTitle
+			truncate
+			commitMessage={commit.message}
+			className="text-14 text-semibold text-body"
+			editable={!isReadOnly}
+		/>
+	{/snippet}
+
+	{#snippet actions()}
+		{#if canEdit()}
+			{@const isEditingMessage =
+				projectState.exclusiveAction.current?.type === "edit-commit-message" &&
+				projectState.exclusiveAction.current.commitId === commit.id}
+			<Button
+				testId={TestId.CommitDrawerActionEditMessage}
+				size="tag"
+				kind="ghost"
+				icon="edit"
+				onclick={() => {
+					drawer?.open();
+					setMode("edit");
+				}}
+				tooltip={isReadOnly ? "Read-only mode" : "Reword commit"}
+				disabled={isReadOnly || isEditingMessage}
+			/>
+		{/if}
+		{@const data = isLocalAndRemoteCommit(commit)
+			? {
+					stackId,
+					commitId: commit.id,
+					commitMessage: commit.message,
+					commitStatus: commit.state.type,
+					commitUrl: forge.current.commitUrl(commit.id),
+					onUncommitClick: () => handleUncommit(),
+					onEditMessageClick: () => {
+						drawer?.open();
+						setMode("edit");
+					},
+				}
+			: undefined}
+		{#if data}
+			<CommitContextMenu {projectId} contextData={data} />
+		{/if}
+	{/snippet}
+
+	<div class="commit-view">
+		{#if projectState.exclusiveAction.current?.type === "edit-commit-message" && projectState.exclusiveAction.current.commitId === commit.id}
+			<div
+				class="edit-commit-view"
+				data-testid={TestId.EditCommitMessageBox}
+				class:no-paddings={uiState.global.useFloatingBox.current}
+			>
+				<CommitMessageEditor
+					noPadding
+					{projectId}
+					{stackId}
+					action={({ title, description }) => saveCommitMessage(title, description)}
+					actionLabel="Save changes"
+					onCancel={cancelEdit}
+					floatingBoxHeader="Reword commit"
+					loading={messageUpdateQuery.current.isLoading}
+					existingCommitId={commit.id}
+					title={parsedMessage?.title || ""}
+					description={parsedMessage?.description || ""}
+				/>
+			</div>
+		{:else}
+			<CommitDetails {commit} rewrap={$rewrapCommitMessage} />
+		{/if}
+	</div>
+</Drawer>
 
 <style>
 	.commit-view {

--- a/apps/desktop/src/components/commit/NewCommitView.svelte
+++ b/apps/desktop/src/components/commit/NewCommitView.svelte
@@ -122,7 +122,6 @@
 					projectId,
 					parentId,
 					insertBelow,
-					stackId: finalStackId,
 					message: finalMessage,
 					stackBranchName: finalBranchName,
 					worktreeChanges,

--- a/apps/desktop/src/components/forge/BranchReview.svelte
+++ b/apps/desktop/src/components/forge/BranchReview.svelte
@@ -7,6 +7,7 @@
 	import { DEFAULT_FORGE_FACTORY } from "$lib/forge/forgeFactory.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import { Button, Modal } from "@gitbutler/ui";
+	import type { Segment } from "@gitbutler/but-sdk";
 	import type { Snippet } from "svelte";
 
 	// TODO: This and the SeriesHeader should have a wholistic refactor to
@@ -17,11 +18,30 @@
 		projectId: string;
 		stackId?: string;
 		branchName: string;
+		segment: Segment;
+		branchIndex: number;
+		parent: Segment | undefined;
+		child: Segment | undefined;
+		withForce: boolean;
+		stackPrNumbers: (number | undefined)[];
 		prNumber?: number;
 		reviewId?: string;
 	};
 
-	const { branchStatus, projectId, stackId, branchName, prNumber, reviewId }: Props = $props();
+	const {
+		branchStatus,
+		projectId,
+		stackId,
+		branchName,
+		segment,
+		branchIndex,
+		parent,
+		child,
+		withForce,
+		stackPrNumbers,
+		prNumber,
+		reviewId,
+	}: Props = $props();
 
 	let canPublishReviewPlugin = $state<ReturnType<typeof CanPublishReviewPlugin>>();
 
@@ -38,9 +58,7 @@
 
 <CanPublishReviewPlugin
 	bind:this={canPublishReviewPlugin}
-	{projectId}
-	{stackId}
-	{branchName}
+	commits={segment.commits}
 	{prNumber}
 	{reviewId}
 />
@@ -73,6 +91,11 @@
 			{projectId}
 			{stackId}
 			{branchName}
+			{segment}
+			{branchIndex}
+			{parent}
+			{withForce}
+			{stackPrNumbers}
 			onClose={() => modal?.close()}
 		/>
 
@@ -96,7 +119,16 @@
 		{#if prNumber}
 			<div class="status-cards">
 				{#if prNumber && stackId}
-					<StackedPullRequestCard {projectId} {stackId} {branchName} {prNumber} poll />
+					<StackedPullRequestCard
+						{projectId}
+						{stackId}
+						{branchName}
+						{parent}
+						{child}
+						isPushed={segment.pushStatus !== "completelyUnpushed"}
+						{prNumber}
+						poll
+					/>
 				{:else if prNumber}
 					<PullRequestCard {projectId} {branchName} {prNumber} poll />
 				{/if}

--- a/apps/desktop/src/components/forge/CanPublishReviewPlugin.svelte
+++ b/apps/desktop/src/components/forge/CanPublishReviewPlugin.svelte
@@ -1,25 +1,19 @@
 <script lang="ts">
 	import { DEFAULT_FORGE_FACTORY } from "$lib/forge/forgeFactory.svelte";
-	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { inject } from "@gitbutler/core/context";
+	import type { Commit } from "@gitbutler/but-sdk";
 
 	type Props = {
-		projectId: string;
-		stackId?: string;
-		branchName: string | undefined;
+		commits: Commit[];
 		prNumber: number | undefined;
 		reviewId: string | undefined;
 	};
 
-	const { projectId, stackId, branchName, prNumber, reviewId }: Props = $props();
+	const { commits, prNumber, reviewId }: Props = $props();
 
 	const forge = inject(DEFAULT_FORGE_FACTORY);
-	const stackService = inject(STACK_SERVICE);
 
-	const commits = $derived(
-		stackId && branchName ? stackService.commits(projectId, stackId, branchName) : undefined,
-	);
-	const branchEmpty = $derived(commits?.response ? commits.response.length === 0 : false);
+	const branchEmpty = $derived(commits.length === 0);
 	const prService = $derived(forge.current.prService);
 	const prQuery = $derived(prNumber ? prService?.get(prNumber) : undefined);
 	const pr = $derived(prQuery?.response);
@@ -36,7 +30,7 @@
 			return branchEmpty;
 		},
 		get branchIsConflicted() {
-			return commits?.response?.some((commit) => commit.hasConflicts) || false;
+			return commits.some((commit) => commit.hasConflicts);
 		},
 		get prNumber() {
 			return prNumber;

--- a/apps/desktop/src/components/forge/CreateReviewBox.svelte
+++ b/apps/desktop/src/components/forge/CreateReviewBox.svelte
@@ -3,19 +3,36 @@
 	import ReviewCreation from "$components/forge/ReviewCreation.svelte";
 	import ReviewCreationControls from "$components/forge/ReviewCreationControls.svelte";
 	import { DEFAULT_FORGE_FACTORY } from "$lib/forge/forgeFactory.svelte";
-	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { UI_STATE } from "$lib/state/uiState.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import { TestId } from "@gitbutler/ui";
+	import type { Segment } from "@gitbutler/but-sdk";
 
 	type Props = {
 		projectId: string;
 		stackId?: string;
 		branchName: string;
+		segment: Segment;
+		branchIndex: number;
+		parent: Segment | undefined;
+		withForce: boolean;
+		stackPrNumbers: (number | undefined)[];
+		prNumber?: number;
 		oncancel?: () => void;
 	};
 
-	const { projectId, stackId, branchName, oncancel }: Props = $props();
+	const {
+		projectId,
+		stackId,
+		branchName,
+		segment,
+		branchIndex,
+		parent,
+		withForce,
+		stackPrNumbers,
+		prNumber,
+		oncancel,
+	}: Props = $props();
 
 	const uiState = inject(UI_STATE);
 	const useFloatingBox = uiState.global.useFloatingBox;
@@ -26,13 +43,8 @@
 		uiState.project(projectId).exclusiveAction.set(undefined);
 	}
 
-	const stackService = inject(STACK_SERVICE);
-
 	const forge = inject(DEFAULT_FORGE_FACTORY);
 
-	const branch = $derived(stackService.branchDetails(projectId, stackId, branchName));
-
-	const prNumber = $derived(branch.response?.metadata?.review.pullRequest ?? undefined);
 	const prService = $derived(forge.current.prService);
 	const reviewUnit = $derived(prService?.unit.abbr ?? "PR");
 	const prQuery = $derived(prNumber ? prService?.get(prNumber) : undefined);
@@ -43,7 +55,18 @@
 
 {#snippet editor()}
 	<div class="create-review-box" data-testid={TestId.CreateReviewBox}>
-		<ReviewCreation bind:this={reviewCreation} {projectId} {stackId} {branchName} onClose={close} />
+		<ReviewCreation
+			bind:this={reviewCreation}
+			{projectId}
+			{stackId}
+			{branchName}
+			{segment}
+			{branchIndex}
+			{parent}
+			{withForce}
+			{stackPrNumbers}
+			onClose={close}
+		/>
 		<ReviewCreationControls
 			isCreatingPR={!!reviewCreation?.imports.isLoading}
 			isFormBusy={!!reviewCreation?.imports.isExecuting}

--- a/apps/desktop/src/components/forge/PushButton.svelte
+++ b/apps/desktop/src/components/forge/PushButton.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import GerritPushModal from "$components/forge/GerritPushModal.svelte";
-	import ReduxResult from "$components/shared/ReduxResult.svelte";
 	import { CLIPBOARD_SERVICE } from "$lib/backend/clipboard";
 	import { URL_SERVICE } from "$lib/backend/url";
 	import { getBranchNameFromRef } from "$lib/branches/branchUtils";
@@ -9,13 +8,8 @@
 	import { projectRunCommitHooks } from "$lib/config/config";
 	import { DEFAULT_FORGE_FACTORY } from "$lib/forge/forgeFactory.svelte";
 	import { PROJECTS_SERVICE } from "$lib/project/projectsService";
-	import {
-		branchHasConflicts,
-		branchHasUnpushedCommits,
-		partialStackRequestsForcePush,
-	} from "$lib/stacks/stack";
+	import { branchHasConflicts, branchHasUnpushedCommits } from "$lib/stacks/stack";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
-	import { combineResults } from "$lib/state/helpers";
 	import { UI_STATE } from "$lib/state/uiState.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import { persisted } from "@gitbutler/shared/persisted";
@@ -30,11 +24,14 @@
 	} from "@gitbutler/ui";
 	import { isDefined } from "@gitbutler/ui/utils/typeguards";
 	import type { GerritPushFlag } from "$lib/stacks/stack";
+	import type { Segment } from "@gitbutler/but-sdk";
 
 	type Props = {
 		projectId: string;
 		stackId?: string;
 		branchName: string;
+		segment: Segment;
+		withForce: boolean;
 		multipleBranches: boolean;
 		isLastBranchInStack?: boolean;
 		isFirstBranchInStack?: boolean;
@@ -44,6 +41,8 @@
 		projectId,
 		branchName,
 		stackId,
+		segment,
+		withForce,
 		multipleBranches,
 		isFirstBranchInStack,
 		isLastBranchInStack,
@@ -64,9 +63,17 @@
 	// Component is read-only when stackId is undefined
 	const isReadOnly = $derived(!stackId);
 
-	const branchDetails = $derived(stackService.branchDetails(projectId, stackId, branchName));
-	const branchesQuery = $derived(stackService.branches(projectId, stackId));
 	const [pushStack, pushQuery] = stackService.pushStack;
+
+	const hasThingsToPush = $derived(branchHasUnpushedCommits(segment));
+	const hasConflicts = $derived(branchHasConflicts(segment));
+	const upstreamCommits = $derived(segment.commitsOnRemote);
+	const remoteTrackingBranch = $derived(
+		segment.remoteTrackingRefName
+			? new TextDecoder().decode(new Uint8Array(segment.remoteTrackingRefName.fullNameBytes))
+			: null,
+	);
+	const buttonDisabled = $derived(isReadOnly || !hasThingsToPush || hasConflicts);
 
 	function handleClick(args: {
 		withForce: boolean;
@@ -168,144 +175,131 @@
 	let pendingGerritFlags = $state<GerritPushFlag[]>([]);
 </script>
 
-<ReduxResult {projectId} result={combineResults(branchDetails.result, branchesQuery.result)}>
-	{#snippet children([branchDetails, branches])}
-		{@const withForce = partialStackRequestsForcePush(branchName, branches)}
-		{@const hasThingsToPush = branchHasUnpushedCommits(branchDetails)}
-		{@const hasConflicts = branchHasConflicts(branchDetails)}
-		{@const upstreamCommits = branchDetails.commitsOnRemote}
-		{@const remoteTrackingBranch = branchDetails.remoteTrackingRefName
-			? new TextDecoder().decode(new Uint8Array(branchDetails.remoteTrackingRefName.fullNameBytes))
-			: null}
-		{@const buttonDisabled = isReadOnly || !hasThingsToPush || hasConflicts}
+<Button
+	testId={TestId.StackPushButton}
+	kind={isFirstBranchInStack ? "solid" : "outline"}
+	size="tag"
+	style="gray"
+	{loading}
+	disabled={buttonDisabled}
+	tooltip={getButtonTooltip(hasThingsToPush, hasConflicts, withForce, remoteTrackingBranch)}
+	onclick={() => handleClick({ withForce, skipForcePushProtection: false, gerritFlags: [] })}
+	icon={multipleBranches && !isLastBranchInStack ? "push-all" : "push"}
+>
+	{isGerritMode ? "Push" : withForce ? "Force push" : "Push"}
+</Button>
 
-		<Button
-			testId={TestId.StackPushButton}
-			kind={isFirstBranchInStack ? "solid" : "outline"}
-			size="tag"
-			style="gray"
-			{loading}
-			disabled={buttonDisabled}
-			tooltip={getButtonTooltip(hasThingsToPush, hasConflicts, withForce, remoteTrackingBranch)}
-			onclick={() => handleClick({ withForce, skipForcePushProtection: false, gerritFlags: [] })}
-			icon={multipleBranches && !isLastBranchInStack ? "push-all" : "push"}
-		>
-			{isGerritMode ? "Push" : withForce ? "Force push" : "Push"}
-		</Button>
+<Modal
+	title="Push with dependencies"
+	width="small"
+	bind:this={confirmationModal}
+	onSubmit={async (close) => {
+		close();
+		push({
+			withForce,
+			skipForcePushProtection: false,
+			gerritFlags: pendingGerritFlags,
+		});
+		pendingGerritFlags = [];
+	}}
+>
+	<p>
+		You're about to push <span class="text-bold">{branchName}</span>. To maintain the correct
+		history, GitButler will also push all branches below this branch in the stack.
+	</p>
 
-		<Modal
-			title="Push with dependencies"
-			width="small"
-			bind:this={confirmationModal}
-			onSubmit={async (close) => {
-				close();
-				push({
-					withForce,
-					skipForcePushProtection: false,
-					gerritFlags: pendingGerritFlags,
-				});
-				pendingGerritFlags = [];
-			}}
-		>
-			<p>
-				You're about to push <span class="text-bold">{branchName}</span>. To maintain the correct
-				history, GitButler will also push all branches below this branch in the stack.
-			</p>
-
-			{#snippet controls(close)}
-				<div class="modal-footer">
-					<div class="flex flex-1">
-						<label for="dont-show-again" class="modal-footer__checkbox">
-							<Checkbox name="dont-show-again" small bind:checked={$doNotShowPushBelowWarning} />
-							<span class="text-12"> Don’t show again</span>
-						</label>
-					</div>
-					<Button
-						kind="outline"
-						onclick={() => {
-							$doNotShowPushBelowWarning = false;
-							close();
-						}}
-					>
-						Cancel
-					</Button>
-					<Button testId={TestId.StackConfirmPushModalButton} style="pop" type="submit" width={90}>
-						Push
-					</Button>
-				</div>
-			{/snippet}
-		</Modal>
-
-		<Modal
-			title="Protected force push"
-			width={480}
-			type="warning"
-			bind:this={forcePushProtectionModal}
-			onSubmit={async (close) => {
-				close();
-				push({
-					withForce,
-					skipForcePushProtection: true,
-					gerritFlags: pendingGerritFlags,
-				});
-				pendingGerritFlags = [];
-			}}
-		>
-			<p class="description">
-				Your force push was blocked because the remote branch contains <span
-					class="text-bold text-nowrap"
-					>{upstreamCommits?.length === 1 ? "1 commit" : `${upstreamCommits?.length} commits`}</span
-				>
-				your local branch doesn’t include. To prevent overwriting history,
-				<span class="text-bold">cancel and pull & integrate</span> the changes.
-			</p>
-			{#if upstreamCommits}
-				<div class="scroll-wrap">
-					<ScrollableContainer maxHeight="16.5rem">
-						{#each upstreamCommits as commit}
-							{@const commitUrl = forge.current.commitUrl(commit.id)}
-							<SimpleCommitRow
-								title={splitMessage(commit.message).title ?? ""}
-								sha={commit.id}
-								date={commitCreatedAtDate(commit)}
-								author={commit.author.name}
-								url={commitUrl}
-								onOpen={(url) => urlService.openExternalUrl(url)}
-								onCopy={() => clipboardService.write(commit.id, { message: "Commit hash copied" })}
-							/>
-						{/each}
-					</ScrollableContainer>
-				</div>
-			{/if}
-
-			{#snippet controls(close)}
-				<div class="controls">
-					<Button kind="outline" type="submit">Force push anyway</Button>
-					<Button wide style="pop" onclick={close}>Cancel</Button>
-				</div>
-			{/snippet}
-		</Modal>
-
-		<GerritPushModal
-			bind:this={gerritModal}
-			{projectId}
-			{stackId}
-			{branchName}
-			{multipleBranches}
-			{isFirstBranchInStack}
-			{isLastBranchInStack}
-			onPush={(gerritFlags) => {
-				if (multipleBranches && !isLastBranchInStack && !$doNotShowPushBelowWarning) {
-					// Store all gerrit flags for later use when confirmation modal completes
-					pendingGerritFlags = gerritFlags;
-					confirmationModal?.show();
-				} else {
-					push({ withForce, skipForcePushProtection: false, gerritFlags });
-				}
-			}}
-		/>
+	{#snippet controls(close)}
+		<div class="modal-footer">
+			<div class="flex flex-1">
+				<label for="dont-show-again" class="modal-footer__checkbox">
+					<Checkbox name="dont-show-again" small bind:checked={$doNotShowPushBelowWarning} />
+					<span class="text-12"> Don’t show again</span>
+				</label>
+			</div>
+			<Button
+				kind="outline"
+				onclick={() => {
+					$doNotShowPushBelowWarning = false;
+					close();
+				}}
+			>
+				Cancel
+			</Button>
+			<Button testId={TestId.StackConfirmPushModalButton} style="pop" type="submit" width={90}>
+				Push
+			</Button>
+		</div>
 	{/snippet}
-</ReduxResult>
+</Modal>
+
+<Modal
+	title="Protected force push"
+	width={480}
+	type="warning"
+	bind:this={forcePushProtectionModal}
+	onSubmit={async (close) => {
+		close();
+		push({
+			withForce,
+			skipForcePushProtection: true,
+			gerritFlags: pendingGerritFlags,
+		});
+		pendingGerritFlags = [];
+	}}
+>
+	<p class="description">
+		Your force push was blocked because the remote branch contains <span
+			class="text-bold text-nowrap"
+			>{upstreamCommits?.length === 1 ? "1 commit" : `${upstreamCommits?.length} commits`}</span
+		>
+		your local branch doesn’t include. To prevent overwriting history,
+		<span class="text-bold">cancel and pull & integrate</span> the changes.
+	</p>
+	{#if upstreamCommits}
+		<div class="scroll-wrap">
+			<ScrollableContainer maxHeight="16.5rem">
+				{#each upstreamCommits as commit}
+					{@const commitUrl = forge.current.commitUrl(commit.id)}
+					<SimpleCommitRow
+						title={splitMessage(commit.message).title ?? ""}
+						sha={commit.id}
+						date={commitCreatedAtDate(commit)}
+						author={commit.author.name}
+						url={commitUrl}
+						onOpen={(url) => urlService.openExternalUrl(url)}
+						onCopy={() => clipboardService.write(commit.id, { message: "Commit hash copied" })}
+					/>
+				{/each}
+			</ScrollableContainer>
+		</div>
+	{/if}
+
+	{#snippet controls(close)}
+		<div class="controls">
+			<Button kind="outline" type="submit">Force push anyway</Button>
+			<Button wide style="pop" onclick={close}>Cancel</Button>
+		</div>
+	{/snippet}
+</Modal>
+
+<GerritPushModal
+	bind:this={gerritModal}
+	{projectId}
+	{stackId}
+	{branchName}
+	{multipleBranches}
+	{isFirstBranchInStack}
+	{isLastBranchInStack}
+	onPush={(gerritFlags) => {
+		if (multipleBranches && !isLastBranchInStack && !$doNotShowPushBelowWarning) {
+			// Store all gerrit flags for later use when confirmation modal completes
+			pendingGerritFlags = gerritFlags;
+			confirmationModal?.show();
+		} else {
+			push({ withForce, skipForcePushProtection: false, gerritFlags });
+		}
+	}}
+/>
 
 <style>
 	/* MODAL */

--- a/apps/desktop/src/components/forge/ReviewCreation.svelte
+++ b/apps/desktop/src/components/forge/ReviewCreation.svelte
@@ -29,7 +29,7 @@
 	import { REMOTES_SERVICE } from "$lib/git/remotesService";
 	import { showToast } from "$lib/notifications/toasts";
 	import { SETTINGS_SERVICE } from "$lib/settings/appSettings";
-	import { partialStackRequestsForcePush, requiresPush } from "$lib/stacks/stack";
+	import { requiresPush } from "$lib/stacks/stack";
 	import { type BranchPushResult } from "$lib/stacks/stackEndpoints";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { UI_STATE } from "$lib/state/uiState.svelte";
@@ -40,17 +40,32 @@
 	import { IME_COMPOSITION_HANDLER } from "@gitbutler/ui/utils/imeHandling";
 	import { isDefined } from "@gitbutler/ui/utils/typeguards";
 	import { tick, untrack } from "svelte";
-	import type { Commit } from "@gitbutler/but-sdk";
+	import type { Commit, Segment } from "@gitbutler/but-sdk";
 
 	type Props = {
 		projectId: string;
 		stackId?: string;
 		branchName: string;
+		segment: Segment;
+		branchIndex: number;
+		parent: Segment | undefined;
+		withForce: boolean;
+		stackPrNumbers: (number | undefined)[];
 		reviewId?: string;
 		onClose: () => void;
 	};
 
-	const { projectId, stackId, branchName, onClose }: Props = $props();
+	const {
+		projectId,
+		stackId,
+		branchName,
+		segment,
+		branchIndex,
+		parent,
+		withForce,
+		stackPrNumbers,
+		onClose,
+	}: Props = $props();
 
 	const baseBranchService = inject(BASE_BRANCH_SERVICE);
 	const baseBranchQuery = $derived(baseBranchService.baseBranch(projectId));
@@ -67,22 +82,11 @@
 
 	const [pushStack, stackPush] = stackService.pushStack;
 
-	const branchesQuery = $derived(stackService.branches(projectId, stackId));
-	const branches = $derived(branchesQuery.response || []);
-	const branchParentQuery = $derived(
-		stackService.branchParentByName(projectId, stackId, branchName),
-	);
-	const branchParent = $derived(branchParentQuery.response);
-	const branchParentName = $derived(branchParent?.refName?.displayName);
-	const branchParentPrNumber = $derived(branchParent?.metadata?.review.pullRequest);
-	const branchParentDetailsQuery = $derived(
-		branchParentName ? stackService.branchDetails(projectId, stackId, branchParentName) : undefined,
-	);
-	const branchParentDetails = $derived(branchParentDetailsQuery?.response);
-	const branchDetailsQuery = $derived(stackService.branchDetails(projectId, stackId, branchName));
-	const branchDetails = $derived(branchDetailsQuery.response);
-	const commitsQuery = $derived(stackService.commits(projectId, stackId, branchName));
-	const commits = $derived(commitsQuery.response || []);
+	const branchParentName = $derived(parent?.refName?.displayName);
+	const branchParentPrNumber = $derived(parent?.metadata?.review.pullRequest);
+	const branchParentDetails = $derived(parent);
+	const branchDetails = $derived(segment);
+	const commits = $derived(segment.commits);
 	const runHooks = $derived(projectRunCommitHooks(projectId));
 
 	const forgeBranch = $derived(branchName ? forge.current.branch(branchName) : undefined);
@@ -168,7 +172,6 @@
 
 		if (pushBeforeCreate) {
 			const firstPush = branchDetails?.pushStatus === "completelyUnpushed";
-			const withForce = partialStackRequestsForcePush(branchName, branches);
 			const pushQuery = await pushStack({
 				projectId,
 				stackId,
@@ -246,8 +249,9 @@
 			return;
 		}
 
-		// All ids that existed prior to creating a new one (including archived).
-		const prNumbers = branches.map((branch) => branch.metadata?.review.pullRequest);
+		// Local mutable copy of pre-computed pr numbers so we can splice in
+		// the newly-created pr number below.
+		const prNumbers = [...stackPrNumbers];
 
 		try {
 			if (!baseBranchName) {
@@ -265,8 +269,7 @@
 				return;
 			}
 
-			// Find the index of the current branch so we know where we want to point the pr.
-			const currentIndex = branches.findIndex((b) => b.refName?.displayName === params.branchName);
+			const currentIndex = branchIndex;
 			if (currentIndex === -1) {
 				throw new Error("Branch index not found.");
 			}

--- a/apps/desktop/src/components/forge/StackedPullRequestCard.svelte
+++ b/apps/desktop/src/components/forge/StackedPullRequestCard.svelte
@@ -3,51 +3,37 @@
 	import PullRequestCard from "$components/forge/PullRequestCard.svelte";
 	import { BASE_BRANCH_SERVICE } from "$lib/baseBranch/baseBranchService.svelte";
 	import { DEFAULT_FORGE_FACTORY } from "$lib/forge/forgeFactory.svelte";
-	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import { AsyncButton, TestId } from "@gitbutler/ui";
 
 	import type { MergeMethod } from "$lib/forge/interface/types";
+	import type { Segment } from "@gitbutler/but-sdk";
 
 	interface Props {
 		projectId: string;
 		stackId: string;
 		branchName: string;
+		parent: Segment | undefined;
+		child: Segment | undefined;
+		isPushed: boolean;
 		poll: boolean;
 		prNumber: number;
 	}
 
-	const { projectId, stackId, branchName, prNumber }: Props = $props();
+	const { projectId, branchName, parent, child, isPushed, prNumber }: Props = $props();
 
 	const baseBranchService = inject(BASE_BRANCH_SERVICE);
 	const forge = inject(DEFAULT_FORGE_FACTORY);
-	const stackService = inject(STACK_SERVICE);
 
 	// TODO: Make these props so we don't need `!`.
 	const repoService = $derived(forge.current.repoService);
 	const prService = $derived(forge.current.prService);
 
-	const branchDetailsQuery = $derived(stackService.branchDetails(projectId, stackId, branchName));
-	const branchDetails = $derived(branchDetailsQuery.response);
-	const isPushed = $derived(branchDetails?.pushStatus !== "completelyUnpushed");
-	const prQuery = $derived(
-		branchDetails?.metadata?.review.pullRequest
-			? prService?.get(branchDetails.metadata.review.pullRequest)
-			: undefined,
-	);
+	const prQuery = $derived(prNumber ? prService?.get(prNumber) : undefined);
 	const pr = $derived(prQuery?.response);
 
-	const parentQuery = $derived(stackService.branchParentByName(projectId, stackId, branchName));
-	const parent = $derived(parentQuery.response);
 	const hasParent = $derived(!!parent);
-	const parentName = $derived(parent?.refName?.displayName);
-	const parentBranchDetailsQuery = $derived(
-		parentName ? stackService.branchDetails(projectId, stackId, parentName) : undefined,
-	);
-	const parentBranchDetails = $derived(parentBranchDetailsQuery?.response);
-	const parentIsPushed = $derived(parentBranchDetails?.pushStatus !== "completelyUnpushed");
-	const childQuery = $derived(stackService.branchChildByName(projectId, stackId, branchName));
-	const child = $derived(childQuery.response);
+	const parentIsPushed = $derived(parent?.pushStatus !== "completelyUnpushed");
 	const childPrNumber = $derived(child?.metadata?.review.pullRequest);
 
 	const baseBranchQuery = $derived(baseBranchService.baseBranch(projectId));

--- a/apps/desktop/src/components/views/BranchCommitList.svelte
+++ b/apps/desktop/src/components/views/BranchCommitList.svelte
@@ -36,7 +36,6 @@
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 
 	import { UI_STATE, withStackBusy } from "$lib/state/uiState.svelte";
-	import { ensureValue } from "$lib/utils/validation";
 	import { inject } from "@gitbutler/core/context";
 	import { TestId } from "@gitbutler/ui";
 	import { DRAG_STATE_SERVICE } from "@gitbutler/ui/drag/dragStateService.svelte";
@@ -177,18 +176,21 @@
 	}
 
 	async function handleUncommit(commitId: string) {
-		const targetStackId = ensureValue(stackId);
-		await withStackBusy(uiState, projectId, { commitId, stackIds: [targetStackId] }, async () => {
-			await stackService.uncommit({
-				projectId,
-				stackId: targetStackId,
-				commitIds: [commitId],
-			});
-		});
+		await withStackBusy(
+			uiState,
+			projectId,
+			{ commitId, stackIds: stackId ? [stackId] : undefined },
+			async () => {
+				await stackService.uncommit({
+					projectId,
+					stackId,
+					commitIds: [commitId],
+				});
+			},
+		);
 	}
 
 	async function handleUncommitSelected(selectedIds?: string[]) {
-		const targetStackId = ensureValue(stackId);
 		const commitIds = selectedIds ?? controller.selectedCommitIds;
 		if (commitIds.length === 0) return;
 
@@ -197,18 +199,22 @@
 		const filtered = commitIds.filter((id) => allIds.includes(id));
 		if (filtered.length === 0) return;
 
-		await withStackBusy(uiState, projectId, { stackIds: [targetStackId] }, async () => {
-			await stackService.uncommit({
-				projectId,
-				stackId: targetStackId,
-				commitIds: filtered,
-			});
-		});
+		await withStackBusy(
+			uiState,
+			projectId,
+			{ stackIds: stackId ? [stackId] : undefined },
+			async () => {
+				await stackService.uncommit({
+					projectId,
+					stackId,
+					commitIds: filtered,
+				});
+			},
+		);
 		controller.selection.set(undefined);
 	}
 
 	async function handleSquashSelected(selectedIds?: string[]) {
-		const targetStackId = ensureValue(stackId);
 		const commitIds = selectedIds ?? controller.selectedCommitIds;
 
 		// Filter to only IDs present in this branch to avoid invalid operations.
@@ -220,14 +226,18 @@
 		const targetCommitId = sorted[sorted.length - 1]!;
 		const sourceCommitIds = sorted.slice(0, -1);
 
-		await withStackBusy(uiState, projectId, { stackIds: [targetStackId] }, async () => {
-			await stackService.squashCommits({
-				projectId,
-				stackId: targetStackId,
-				sourceCommitIds,
-				targetCommitId,
-			});
-		});
+		await withStackBusy(
+			uiState,
+			projectId,
+			{ stackIds: stackId ? [stackId] : undefined },
+			async () => {
+				await stackService.squashCommits({
+					projectId,
+					sourceCommitIds,
+					targetCommitId,
+				});
+			},
+		);
 		controller.selection.set(undefined);
 	}
 

--- a/apps/desktop/src/components/views/BranchList.svelte
+++ b/apps/desktop/src/components/views/BranchList.svelte
@@ -17,6 +17,7 @@
 	import { REORDER_DROPZONE_FACTORY } from "$lib/dragging/stackingReorderDropzoneManager";
 	import { DEFAULT_FORGE_FACTORY } from "$lib/forge/forgeFactory.svelte";
 	import { createBranchSelection } from "$lib/selection/key";
+	import { segmentContext } from "$lib/stacks/segmentContext";
 	import { getStackContext } from "$lib/stacks/stackController.svelte";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { ensureValue } from "$lib/utils/validation";
@@ -27,10 +28,10 @@
 	import type { Segment } from "@gitbutler/but-sdk";
 
 	type Props = {
-		branches: Segment[];
+		segments: Segment[];
 	};
 
-	const { branches }: Props = $props();
+	const { segments }: Props = $props();
 
 	const controller = getStackContext();
 	const stackService = inject(STACK_SERVICE);
@@ -64,7 +65,7 @@
 		stackingReorderDropzoneManagerFactory.build(
 			projectId,
 			laneId,
-			branches
+			segments
 				.map((s) =>
 					s.refName
 						? { name: s.refName.displayName, commitIds: s.commits.map((p) => p.id) }
@@ -80,21 +81,22 @@
 </script>
 
 <div class="branches-wrapper">
-	{#each branches as branch, i}
-		{@const branchName = branch.refName?.displayName}
+	{#each segments as segment, i}
+		{@const ctx = segmentContext(segments, i)}
+		{@const branchName = segment.refName?.displayName}
 		{@const branchLabel = branchName ?? "Unnamed segment"}
-		{@const remoteTrackingBranch = branch.remoteTrackingRefName
-			? new TextDecoder().decode(new Uint8Array(branch.remoteTrackingRefName.fullNameBytes))
+		{@const remoteTrackingBranch = segment.remoteTrackingRefName
+			? new TextDecoder().decode(new Uint8Array(segment.remoteTrackingRefName.fullNameBytes))
 			: undefined}
-		{@const prNumber = branch.metadata?.review.pullRequest ?? undefined}
-		{@const reviewId = branch.metadata?.review.reviewId ?? undefined}
+		{@const prNumber = segment.metadata?.review.pullRequest ?? undefined}
+		{@const reviewId = segment.metadata?.review.reviewId ?? undefined}
 		{@const prQuery = prNumber ? forge.current.prService?.get(prNumber) : undefined}
-		{@const commit = branch.commits.at(0)}
+		{@const commit = segment.commits.at(0)}
 
 		{@const first = i === 0}
 
 		{@const firstBranch = i === 0}
-		{@const lastBranch = i === branches.length - 1}
+		{@const lastBranch = i === segments.length - 1}
 		{@const iconName = getIconFromCommitState(commit?.id, commit?.state)}
 		{@const lineColor = commit
 			? getColorFromCommitState(
@@ -102,14 +104,14 @@
 					commit.state.type === "LocalAndRemote" && commit.id !== commit.state.subject,
 				)
 			: "var(--commit-local)"}
-		{@const isNewBranch = branch.commitsOnRemote.length === 0 && branch.commits.length === 0}
+		{@const isNewBranch = segment.commitsOnRemote.length === 0 && segment.commits.length === 0}
 		{@const selected =
 			selection?.current?.branchName === branchName && selection?.current?.commitId === undefined}
-		{@const allOtherPrNumbersInStack = branches
-			.filter((b) => b.refName?.displayName !== branchName)
-			.map((b) => b.metadata?.review.pullRequest)
+		{@const allOtherPrNumbersInStack = segments
+			.filter((s) => s.refName?.displayName !== branchName)
+			.map((s) => s.metadata?.review.pullRequest)
 			.filter((n): n is number => n !== undefined && n !== null)}
-		{@const isConflicted = branch.commits.some((commit) => commit.hasConflicts)}
+		{@const isConflicted = segment.commits.some((commit) => commit.hasConflicts)}
 		{@const startCommittingDz = branchName
 			? new StartCommitDzHandler(projectId, stackId, branchName)
 			: undefined}
@@ -137,7 +139,6 @@
 			{#if selected && branchName}
 				{@const changesQuery = stackService.branchChanges({
 					projectId,
-					stackId,
 					branch: branchName,
 				})}
 				<ReduxResult {projectId} {stackId} result={changesQuery.result}>
@@ -239,7 +240,9 @@
 					{branchName}
 					{projectId}
 					{stackId}
-					multipleBranches={branches.length > 1}
+					{segment}
+					withForce={ctx.withForce}
+					multipleBranches={segments.length > 1}
 					isFirstBranchInStack={firstBranch}
 					isLastBranchInStack={lastBranch}
 				/>
@@ -249,10 +252,10 @@
 		{#snippet menu({ rightClickTrigger }: { rightClickTrigger?: HTMLElement })}
 			{#if branchName}
 				{@const data = {
-					branch,
+					segment,
 					prNumber,
 					first,
-					stackLength: branches.length,
+					stackLength: segments.length,
 				}}
 				<BranchHeaderContextMenu
 					{projectId}
@@ -276,15 +279,20 @@
 			{iconName}
 			{selected}
 			{isNewBranch}
-			pushStatus={branch.pushStatus}
+			pushStatus={segment.pushStatus}
 			{isConflicted}
 			{reviewId}
 			{prNumber}
 			{allOtherPrNumbersInStack}
-			numberOfCommits={branch.commits.length}
-			numberOfUpstreamCommits={branch.commitsOnRemote.length}
-			numberOfBranchesInStack={branches.length}
-			baseCommit={branch.base ?? undefined}
+			numberOfCommits={segment.commits.length}
+			numberOfUpstreamCommits={segment.commitsOnRemote.length}
+			numberOfBranchesInStack={segments.length}
+			{segment}
+			branchIndex={ctx.branchIndex}
+			parent={ctx.parent}
+			withForce={ctx.withForce}
+			stackPrNumbers={ctx.stackPrNumbers}
+			baseCommit={segment.base ?? undefined}
 			dropzones={branchName && startCommittingDz
 				? [stackingReorderDropzoneManager.top(branchName), startCommittingDz]
 				: []}
@@ -302,17 +310,12 @@
 				}
 				controller.clearWorktreeSelection();
 			}}
-			changedFiles={branch.refName ? changedFiles : undefined}
-			buttons={branch.refName ? buttons : undefined}
-			menu={branch.refName ? menu : undefined}
+			changedFiles={segment.refName ? changedFiles : undefined}
+			buttons={segment.refName ? buttons : undefined}
+			menu={segment.refName ? menu : undefined}
 		>
 			{#snippet branchContent()}
-				<BranchCommitList
-					{lastBranch}
-					{branchName}
-					segment={branch}
-					{stackingReorderDropzoneManager}
-				/>
+				<BranchCommitList {lastBranch} {branchName} {segment} {stackingReorderDropzoneManager} />
 			{/snippet}
 		</BranchCard>
 	{/each}

--- a/apps/desktop/src/components/views/BranchView.svelte
+++ b/apps/desktop/src/components/views/BranchView.svelte
@@ -6,29 +6,33 @@
 	import CommitListItem from "$components/commit/CommitListItem.svelte";
 	import BranchReview from "$components/forge/BranchReview.svelte";
 	import Drawer from "$components/shared/Drawer.svelte";
-	import ReduxResult from "$components/shared/ReduxResult.svelte";
 	import newBranchSmolSVG from "$lib/assets/empty-state/new-branch-smol.svg?raw";
 	import { commitCreatedAt, commitStateSubject } from "$lib/branches/v3";
 	import { findEarliestConflict } from "$lib/commits/utils";
 	import { editPatch } from "$lib/mode/editPatchUtils";
 	import { MODE_SERVICE } from "$lib/mode/modeService";
-	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
-	import { combineResults } from "$lib/state/helpers";
 	import { UI_STATE } from "$lib/state/uiState.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import { Icon, TestId, Tooltip, Button } from "@gitbutler/ui";
+	import type { Segment } from "@gitbutler/but-sdk";
 
 	interface Props {
 		stackId?: string;
 		laneId: string;
 		projectId: string;
 		branchName: string;
+		segment: Segment;
+		branchIndex: number;
+		parent: Segment | undefined;
+		child: Segment | undefined;
+		withForce: boolean;
+		stackPrNumbers: (number | undefined)[];
+		stackLength: number;
 		active?: boolean;
 		grow?: boolean;
 		clientHeight?: number;
 		rounded?: boolean;
 		ontoggle?: (collapsed: boolean) => void;
-		onerror?: (err: unknown) => void;
 		onclose?: () => void;
 		onpopout?: () => void;
 	}
@@ -38,25 +42,48 @@
 		laneId,
 		projectId,
 		branchName,
+		segment,
+		branchIndex,
+		parent,
+		child,
+		withForce,
+		stackPrNumbers,
+		stackLength,
 		grow,
 		clientHeight = $bindable(),
 		rounded,
 		ontoggle,
-		onerror,
 		onclose,
 		onpopout,
 	}: Props = $props();
 
-	const stackService = inject(STACK_SERVICE);
 	const uiState = inject(UI_STATE);
 	const modeService = inject(MODE_SERVICE);
 
-	const branchQuery = $derived(stackService.branchDetails(projectId, stackId, branchName));
-	const branchesQuery = $derived(stackService.branches(projectId, stackId));
+	const topCommit = $derived(segment.commits.at(0));
+	const hasCommits = $derived(!!topCommit || segment.commitsOnRemote.length > 0);
+	const remoteTrackingBranch = $derived(
+		segment.remoteTrackingRefName
+			? new TextDecoder().decode(new Uint8Array(segment.remoteTrackingRefName.fullNameBytes))
+			: undefined,
+	);
+	const prNumber = $derived(segment.metadata?.review.pullRequest ?? undefined);
+	const reviewId = $derived(segment.metadata?.review.reviewId ?? undefined);
+	const authors = $derived(
+		Array.from(
+			new Map(
+				[...segment.commits, ...segment.commitsOnRemote].map((commit) => [
+					JSON.stringify(commit.author),
+					commit.author,
+				]),
+			).values(),
+		),
+	);
+	const isConflicted = $derived(segment.commits.some((commit) => commit.hasConflicts));
 
 	// Get conflicted commits for this branch
 	const conflictedCommitsInBranch = $derived(
-		branchQuery.response?.commits.filter((commit) => commit.hasConflicts) || [],
+		segment.commits.filter((commit) => commit.hasConflicts),
 	);
 
 	let renameBranchModal = $state<BranchRenameModal>();
@@ -79,143 +106,128 @@
 	}
 </script>
 
-<ReduxResult
-	{stackId}
-	{projectId}
-	{onerror}
-	result={combineResults(branchesQuery.result, branchQuery.result)}
+<Drawer
+	bind:clientHeight
+	persistId="branch-view-drawer-{projectId}-{stackId}-{branchName}"
+	testId={TestId.BranchView}
+	{grow}
+	{onclose}
+	{ontoggle}
+	{rounded}
+	noshrink
 >
-	{#snippet children([branches, branch], { stackId, projectId })}
-		{@const topCommit = branch.commits.at(0)}
-		{@const hasCommits = !!topCommit || branch.commitsOnRemote.length > 0}
-		{@const remoteTrackingBranch = branch.remoteTrackingRefName
-			? new TextDecoder().decode(new Uint8Array(branch.remoteTrackingRefName.fullNameBytes))
-			: undefined}
-		{@const prNumber = branch.metadata?.review.pullRequest ?? undefined}
-		{@const reviewId = branch.metadata?.review.reviewId ?? undefined}
-		{@const authors = Array.from(
-			new Map(
-				[...branch.commits, ...branch.commitsOnRemote].map((commit) => [
-					JSON.stringify(commit.author),
-					commit.author,
-				]),
-			).values(),
-		)}
-		{@const isConflicted = branch.commits.some((commit) => commit.hasConflicts)}
-		<Drawer
-			bind:clientHeight
-			persistId="branch-view-drawer-{projectId}-{stackId}-{branchName}"
-			testId={TestId.BranchView}
-			{grow}
-			{onclose}
-			{ontoggle}
-			{rounded}
-			noshrink
-		>
-			{#snippet closeActions()}
-				{#if onpopout}
-					<Button
-						kind="ghost"
-						icon="pop-out-bottom-right"
-						size="tag"
-						tooltip="Pop out diff view"
-						onclick={onpopout}
-					/>
-				{/if}
-			{/snippet}
-			{#snippet header()}
-				<div class="branch__header">
-					{#if hasCommits}
-						<Tooltip
-							text={remoteTrackingBranch
-								? `Remote tracking branch:\n${remoteTrackingBranch}`
-								: "No remote tracking branch"}
-						>
-							<div class="remote-tracking-branch-icon" class:disabled={!remoteTrackingBranch}>
-								<Icon name={remoteTrackingBranch ? "target-branch" : "target-cross"} />
-							</div>
-						</Tooltip>
-					{/if}
-					<h3 class="text-15 text-bold truncate">{branchName}</h3>
-				</div>
-			{/snippet}
-
-			{#snippet actions()}
-				{@const data = {
-					branch,
-					prNumber,
-					stackLength: branches.length,
-				}}
-				<BranchHeaderContextMenu {projectId} {stackId} {laneId} contextData={data} />
-			{/snippet}
-
-			{#if hasCommits}
-				<div class="branch-view">
-					<BranchDetails
-						pushStatus={branch.pushStatus}
-						{authors}
-						{isConflicted}
-						onResolveConflicts={handleResolveConflicts}
-					>
-						<BranchReview {stackId} {projectId} {branchName} {prNumber} {reviewId} />
-
-						{#snippet conflictedCommits()}
-							{#if conflictedCommitsInBranch.length > 0}
-								{#each conflictedCommitsInBranch as commit}
-									{@const isLocalAndRemote = commit.state.type === "LocalAndRemote"}
-									<CommitListItem
-										type={commit.state.type}
-										{branchName}
-										commitId={commit.id}
-										commitMessage={commit.message}
-										gerritReviewUrl={commit.gerritReviewUrl ?? undefined}
-										createdAt={commitCreatedAt(commit)}
-										hasConflicts={true}
-										disableCommitActions={true}
-										diverged={isLocalAndRemote && commit.id !== commitStateSubject(commit)}
-										active
-										onclick={() => {
-											// Open commit preview by setting selection
-											const laneState = uiState.lane(laneId);
-											laneState.selection.set({
-												branchName,
-												commitId: commit.id,
-												previewOpen: true,
-											});
-										}}
-									/>
-								{/each}
-							{/if}
-						{/snippet}
-					</BranchDetails>
-				</div>
-			{:else}
-				<div class="branch-view__empty-state">
-					<div class="branch-view__empty-state__image">
-						{@html newBranchSmolSVG}
-					</div>
-					<h3 class="text-16 text-semibold branch-view__empty-state__title">
-						This is a new branch
-					</h3>
-					<p class="text-13 text-body branch-view__empty-state__description">
-						Commit your changes here. You can stack additional branches or apply them independently.
-						You can also drag and drop files to start a new commit.
-					</p>
-				</div>
-			{/if}
-		</Drawer>
-
-		<BranchRenameModal
-			{projectId}
-			{stackId}
-			{laneId}
-			{branchName}
-			bind:this={renameBranchModal}
-			isPushed={!!remoteTrackingBranch}
-		/>
-		<DeleteBranchModal {projectId} {stackId} {branchName} bind:this={deleteBranchModal} />
+	{#snippet closeActions()}
+		{#if onpopout}
+			<Button
+				kind="ghost"
+				icon="pop-out-bottom-right"
+				size="tag"
+				tooltip="Pop out diff view"
+				onclick={onpopout}
+			/>
+		{/if}
 	{/snippet}
-</ReduxResult>
+	{#snippet header()}
+		<div class="branch__header">
+			{#if hasCommits}
+				<Tooltip
+					text={remoteTrackingBranch
+						? `Remote tracking branch:\n${remoteTrackingBranch}`
+						: "No remote tracking branch"}
+				>
+					<div class="remote-tracking-branch-icon" class:disabled={!remoteTrackingBranch}>
+						<Icon name={remoteTrackingBranch ? "target-branch" : "target-cross"} />
+					</div>
+				</Tooltip>
+			{/if}
+			<h3 class="text-15 text-bold truncate">{branchName}</h3>
+		</div>
+	{/snippet}
+
+	{#snippet actions()}
+		{@const data = {
+			segment,
+			prNumber,
+			stackLength,
+		}}
+		<BranchHeaderContextMenu {projectId} {stackId} {laneId} contextData={data} />
+	{/snippet}
+
+	{#if hasCommits}
+		<div class="branch-view">
+			<BranchDetails
+				pushStatus={segment.pushStatus}
+				{authors}
+				{isConflicted}
+				onResolveConflicts={handleResolveConflicts}
+			>
+				<BranchReview
+					{stackId}
+					{projectId}
+					{branchName}
+					{segment}
+					{branchIndex}
+					{parent}
+					{child}
+					{withForce}
+					{stackPrNumbers}
+					{prNumber}
+					{reviewId}
+				/>
+
+				{#snippet conflictedCommits()}
+					{#if conflictedCommitsInBranch.length > 0}
+						{#each conflictedCommitsInBranch as commit}
+							{@const isLocalAndRemote = commit.state.type === "LocalAndRemote"}
+							<CommitListItem
+								type={commit.state.type}
+								{branchName}
+								commitId={commit.id}
+								commitMessage={commit.message}
+								gerritReviewUrl={commit.gerritReviewUrl ?? undefined}
+								createdAt={commitCreatedAt(commit)}
+								hasConflicts={true}
+								disableCommitActions={true}
+								diverged={isLocalAndRemote && commit.id !== commitStateSubject(commit)}
+								active
+								onclick={() => {
+									// Open commit preview by setting selection
+									const laneState = uiState.lane(laneId);
+									laneState.selection.set({
+										branchName,
+										commitId: commit.id,
+										previewOpen: true,
+									});
+								}}
+							/>
+						{/each}
+					{/if}
+				{/snippet}
+			</BranchDetails>
+		</div>
+	{:else}
+		<div class="branch-view__empty-state">
+			<div class="branch-view__empty-state__image">
+				{@html newBranchSmolSVG}
+			</div>
+			<h3 class="text-16 text-semibold branch-view__empty-state__title">This is a new branch</h3>
+			<p class="text-13 text-body branch-view__empty-state__description">
+				Commit your changes here. You can stack additional branches or apply them independently. You
+				can also drag and drop files to start a new commit.
+			</p>
+		</div>
+	{/if}
+</Drawer>
+
+<BranchRenameModal
+	{projectId}
+	{stackId}
+	{laneId}
+	{branchName}
+	bind:this={renameBranchModal}
+	isPushed={!!remoteTrackingBranch}
+/>
+<DeleteBranchModal {projectId} {stackId} {branchName} bind:this={deleteBranchModal} />
 
 <style>
 	.branch__header {

--- a/apps/desktop/src/components/views/MultiStackView.svelte
+++ b/apps/desktop/src/components/views/MultiStackView.svelte
@@ -270,10 +270,9 @@
 						<ErrorBoundary title="Something went wrong in this stack">
 							<StackView
 								{projectId}
+								{stack}
 								laneId={stack.id || "banana"}
-								stackId={stack.id ?? undefined}
 								onFoldStack={() => foldStack(stack.id)}
-								topBranchName={stack.segments.at(0)?.refName?.displayName}
 								bind:clientWidth={laneWidths[i]}
 								bind:clientHeight={lineHeights[i]}
 								onVisible={(visible) => {

--- a/apps/desktop/src/components/views/StackDetails.svelte
+++ b/apps/desktop/src/components/views/StackDetails.svelte
@@ -29,9 +29,9 @@
 		createCommitDropHandlers,
 		type DzCommitData,
 	} from "$lib/dragging/dropHandlers/commitDropHandler";
-	import { isParsedError } from "$lib/error/parser";
 
 	import { UNCOMMITTED_SERVICE } from "$lib/selection/uncommittedService.svelte";
+	import { segmentContext } from "$lib/stacks/segmentContext";
 	import { getStackContext } from "$lib/stacks/stackController.svelte";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { inject } from "@gitbutler/core/context";
@@ -40,12 +40,14 @@
 	import { isDefined } from "@gitbutler/ui/utils/typeguards";
 	import { get } from "svelte/store";
 	import { fly } from "svelte/transition";
+	import type { Segment } from "@gitbutler/but-sdk";
 	type Props = {
 		ircChannel?: string;
+		segments: Segment[];
 		onWidthChange: (width: number) => void;
 	};
 
-	const { ircChannel, onWidthChange }: Props = $props();
+	const { ircChannel, segments, onWidthChange }: Props = $props();
 
 	const controller = getStackContext();
 
@@ -60,11 +62,17 @@
 	};
 	const DETAILS_RIGHT_PADDING_REM = 1;
 
-	const commitQuery = $derived(
-		controller.commitId
-			? stackService.commitById(controller.projectId, controller.stackId, controller.commitId)
-			: undefined,
-	);
+	const selectedCommit = $derived.by(() => {
+		const id = controller.commitId;
+		if (!id) return undefined;
+		for (const segment of segments) {
+			const c = segment.commits.find((c) => c.id === id);
+			if (c) return c;
+			const uc = segment.commitsOnRemote.find((c) => c.id === id);
+			if (uc) return uc;
+		}
+		return undefined;
+	});
 	const runHooks = $derived(projectRunCommitHooks(controller.projectId));
 	const commitFiles = $derived(
 		controller.commitId
@@ -74,13 +82,6 @@
 	const assignedFiles = $derived(
 		uncommittedService.getChangesByStackId(controller.stackId || null),
 	);
-
-	function onerror(err: unknown) {
-		if (isParsedError(err) && err.code === "BranchNotFound") {
-			controller.selection.set(undefined);
-			console.warn("Workspace selection cleared");
-		}
-	}
 
 	let multiDiffView = $state<MultiDiffView>();
 
@@ -105,9 +106,24 @@
 	const laneId = $derived(controller.laneId);
 	const branchName = $derived(controller.branchName);
 	const commitId = $derived(controller.commitId);
-	const upstream = $derived(controller.upstream);
 	const focusedFileStore = $derived(controller.focusedFileStore);
 	const selection = $derived(controller.laneState.selection.current);
+	const selectedIndex = $derived(
+		branchName ? segments.findIndex((s) => s.refName?.displayName === branchName) : -1,
+	);
+	const selectedSegment = $derived(selectedIndex >= 0 ? segments[selectedIndex] : undefined);
+	const selectedContext = $derived(
+		selectedIndex >= 0 ? segmentContext(segments, selectedIndex) : undefined,
+	);
+
+	// If the selected branch is no longer in the stack (e.g. it was renamed
+	// or deleted), clear the selection. This replaces the BranchNotFound
+	// handling that used to live in BranchView's ReduxResult onerror.
+	$effect(() => {
+		if (branchName && !selectedSegment) {
+			controller.selection.set(undefined);
+		}
+	});
 </script>
 
 <div
@@ -123,7 +139,7 @@
 	{#if stackId && selection?.irc && ircChannel}
 		<IrcChannel projectId={controller.projectId} type="group" channel={ircChannel} autojoin />
 	{:else}
-		{@const commit = commitQuery?.response}
+		{@const commit = selectedCommit}
 		{@const dzCommit: DzCommitData | undefined = commit
 			? {
 					id: commit.id,
@@ -153,7 +169,7 @@
 						},
 					})
 				: { amendHandler: undefined, squashHandler: undefined, hunkHandler: undefined }}
-		{#if branchName && commitId}
+		{#if commitId}
 			<Dropzone
 				handlers={[amendHandler, squashHandler, hunkHandler].filter(isDefined)}
 				fillHeight
@@ -168,22 +184,18 @@
 					<DropzoneOverlay {hovered} {activated} {label} />
 				{/snippet}
 				<div class="details-view__inner">
-					<CommitView
-						{projectId}
-						{stackId}
-						{laneId}
-						commitKey={{
-							stackId,
-							branchName,
-							commitId,
-							upstream: !!upstream,
-						}}
-						draggableFiles
-						rounded
-						{onerror}
-						onclose={() => controller.closePreview()}
-						onpopout={() => controller.openFloatingDiff()}
-					/>
+					{#if commit}
+						<CommitView
+							{projectId}
+							{stackId}
+							{laneId}
+							{commit}
+							draggableFiles
+							rounded
+							onclose={() => controller.closePreview()}
+							onpopout={() => controller.openFloatingDiff()}
+						/>
+					{/if}
 					{#if commitFiles}
 						{@const commitResult = commitFiles?.result}
 						{#if commitResult}
@@ -206,10 +218,9 @@
 					{/if}
 				</div>
 			</Dropzone>
-		{:else if branchName}
+		{:else if branchName && selectedSegment && selectedContext}
 			{@const changesQuery = stackService.branchChanges({
 				projectId: controller.projectId,
-				stackId: controller.stackId,
 				branch: branchName,
 			})}
 			<div class="details-view__inner">
@@ -218,7 +229,13 @@
 					{laneId}
 					{projectId}
 					{branchName}
-					{onerror}
+					segment={selectedSegment}
+					branchIndex={selectedContext.branchIndex}
+					parent={selectedContext.parent}
+					child={selectedContext.child}
+					withForce={selectedContext.withForce}
+					stackPrNumbers={selectedContext.stackPrNumbers}
+					stackLength={segments.length}
 					onclose={() => controller.closePreview()}
 					rounded
 					onpopout={() => controller.openFloatingDiff()}

--- a/apps/desktop/src/components/views/StackPanel.svelte
+++ b/apps/desktop/src/components/views/StackPanel.svelte
@@ -5,7 +5,7 @@
 
 	Usage:
 	```svelte
-	<StackPanel {branches} {topBranchName} {onFoldStack} {ircEnabled} {ircChannel} />
+	<StackPanel {segments} {topBranchName} {onFoldStack} {ircEnabled} {ircChannel} />
 	```
 -->
 <script lang="ts">
@@ -21,32 +21,26 @@
 	import { createWorktreeSelection, type SelectionId } from "$lib/selection/key";
 	import { UNCOMMITTED_SERVICE } from "$lib/selection/uncommittedService.svelte";
 	import { getStackContext } from "$lib/stacks/stackController.svelte";
-	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import { Button, TestId } from "@gitbutler/ui";
 	import type { Segment } from "@gitbutler/but-sdk";
 
 	type Props = {
-		branches: Segment[];
+		segments: Segment[];
 		topBranchName?: string;
 		onFoldStack?: () => void;
 		ircEnabled: boolean;
 		ircChannel?: string;
 	};
 
-	const { branches, topBranchName, onFoldStack, ircEnabled, ircChannel }: Props = $props();
+	const { segments, topBranchName, onFoldStack, ircEnabled, ircChannel }: Props = $props();
 
 	const controller = getStackContext();
-	const stackService = inject(STACK_SERVICE);
 	const uncommittedService = inject(UNCOMMITTED_SERVICE);
 	const idSelection = inject(FILE_SELECTION_MANAGER);
 
 	const changes = $derived(uncommittedService.changesByStackId(controller.stackId || null));
 	const startCommitVisible = $derived(uncommittedService.startCommitVisible(controller.stackId));
-	const defaultBranchQuery = $derived(
-		stackService.defaultBranch(controller.projectId, controller.stackId),
-	);
-	const defaultBranch = $derived(defaultBranchQuery?.response);
 
 	let dropzoneActivated = $state(false);
 	let dropzoneHovered = $state(false);
@@ -215,12 +209,10 @@
 						style={changes.current.length > 0 ? "pop" : "gray"}
 						type="button"
 						wide
-						disabled={controller.isReadOnly ||
-							defaultBranch === null ||
-							!!controller.exclusiveAction}
+						disabled={controller.isReadOnly || !topBranchName || !!controller.exclusiveAction}
 						tooltip={controller.isReadOnly ? "Read-only mode" : undefined}
 						onclick={() => {
-							if (defaultBranch) startCommit(defaultBranch);
+							if (topBranchName) startCommit(topBranchName);
 						}}
 					>
 						Start a commit…
@@ -236,7 +228,7 @@
 		<IrcRow stackId={controller.stackId} channel={ircChannel} selected={controller.ircPanelOpen} />
 	{/if}
 
-	<BranchList {branches} />
+	<BranchList {segments} />
 </div>
 
 <style lang="postcss">

--- a/apps/desktop/src/components/views/StackView.svelte
+++ b/apps/desktop/src/components/views/StackView.svelte
@@ -1,16 +1,13 @@
 <script lang="ts">
 	import AppScrollableContainer from "$components/shared/AppScrollableContainer.svelte";
-	import FullviewLoading from "$components/shared/FullviewLoading.svelte";
-	import ReduxResult from "$components/shared/ReduxResult.svelte";
 	import Resizer from "$components/shared/Resizer.svelte";
 	import StackDetails from "$components/views/StackDetails.svelte";
 	import StackPanel from "$components/views/StackPanel.svelte";
 	import { IRC_API_SERVICE } from "$lib/irc/ircApiService";
 	import { sessionChannel } from "$lib/irc/protocol";
 	import { SETTINGS_SERVICE } from "$lib/settings/appSettings";
+	import { type Stack } from "$lib/stacks/stack";
 	import { StackController, setStackContext } from "$lib/stacks/stackController.svelte";
-	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
-	import { combineResults } from "$lib/state/helpers";
 	import { inject } from "@gitbutler/core/context";
 	import { persistWithExpiration } from "@gitbutler/shared/persisted";
 	import { TestId } from "@gitbutler/ui";
@@ -19,10 +16,9 @@
 
 	type Props = {
 		projectId: string;
-		stackId: string | undefined;
+		stack: Stack;
 		laneId: string;
 		onFoldStack?: () => void;
-		topBranchName?: string;
 		onVisible: (visible: boolean) => void;
 		clientWidth?: number;
 		clientHeight?: number;
@@ -30,14 +26,17 @@
 
 	let {
 		projectId,
-		stackId,
+		stack,
 		laneId,
 		onFoldStack,
-		topBranchName,
 		clientHeight = $bindable(),
 		clientWidth = $bindable(),
 		onVisible,
 	}: Props = $props();
+
+	const stackId = $derived(stack.id ?? undefined);
+	const topBranchName = $derived(stack.segments.at(0)?.refName?.displayName);
+	const segments = $derived(stack.segments);
 
 	const controller = new StackController({
 		projectId: () => projectId,
@@ -46,11 +45,9 @@
 	});
 	setStackContext(controller);
 
-	const stackService = inject(STACK_SERVICE);
 	const settingsService = inject(SETTINGS_SERVICE);
 	const ircApiService = inject(IRC_API_SERVICE);
 
-	const branchesQuery = $derived(stackService.branches(controller.projectId, controller.stackId));
 	const PANEL1_RESIZER = {
 		minWidth: 20,
 		maxWidth: 64,
@@ -140,52 +137,43 @@
 		},
 	}}
 >
-	<ReduxResult projectId={controller.projectId} result={combineResults(branchesQuery.result)}>
-		{#snippet loading()}
-			<div style:width="{$persistedStackWidth}rem" class="lane-skeleton">
-				<FullviewLoading />
-			</div>
-		{/snippet}
-		{#snippet children([branches])}
-			<AppScrollableContainer childrenWrapHeight="100%" enableDragScroll>
-				<div
-					class="stack-view"
-					class:details-open={isDetailsOpen}
-					style:width="{$persistedStackWidth}rem"
-					data-fade-on-reorder
-					use:focusable={{
-						vertical: true,
-						onActive: (value) => (controller.active = value),
+	<AppScrollableContainer childrenWrapHeight="100%" enableDragScroll>
+		<div
+			class="stack-view"
+			class:details-open={isDetailsOpen}
+			style:width="{$persistedStackWidth}rem"
+			data-fade-on-reorder
+			use:focusable={{
+				vertical: true,
+				onActive: (value) => (controller.active = value),
+			}}
+			bind:this={stackViewEl}
+		>
+			<StackPanel {segments} {topBranchName} {onFoldStack} {ircEnabled} {ircChannel} />
+
+			<!-- RESIZE PANEL 1 -->
+			{#if stackViewEl}
+				<Resizer
+					persistId="ui-stack-width-${controller.stackId}"
+					viewport={stackViewEl}
+					zIndex="var(--z-lifted)"
+					direction="right"
+					minWidth={PANEL1_RESIZER.minWidth}
+					maxWidth={PANEL1_RESIZER.maxWidth}
+					defaultValue={$persistedStackWidth ?? PANEL1_RESIZER.defaultValue}
+					syncName="panel1"
+					onWidth={(newWidth) => {
+						persistedStackWidth.set(newWidth);
 					}}
-					bind:this={stackViewEl}
-				>
-					<StackPanel {branches} {topBranchName} {onFoldStack} {ircEnabled} {ircChannel} />
-
-					<!-- RESIZE PANEL 1 -->
-					{#if stackViewEl}
-						<Resizer
-							persistId="ui-stack-width-${controller.stackId}"
-							viewport={stackViewEl}
-							zIndex="var(--z-lifted)"
-							direction="right"
-							minWidth={PANEL1_RESIZER.minWidth}
-							maxWidth={PANEL1_RESIZER.maxWidth}
-							defaultValue={$persistedStackWidth ?? PANEL1_RESIZER.defaultValue}
-							syncName="panel1"
-							onWidth={(newWidth) => {
-								persistedStackWidth.set(newWidth);
-							}}
-						/>
-					{/if}
-				</div>
-			</AppScrollableContainer>
-
-			<!-- DETAILS PANEL -->
-			{#if isDetailsOpen}
-				<StackDetails {ircChannel} onWidthChange={updateDetailsViewWidth} />
+				/>
 			{/if}
-		{/snippet}
-	</ReduxResult>
+		</div>
+	</AppScrollableContainer>
+
+	<!-- DETAILS PANEL -->
+	{#if isDetailsOpen}
+		<StackDetails {ircChannel} {segments} onWidthChange={updateDetailsViewWidth} />
+	{/if}
 </div>
 
 <style lang="postcss">
@@ -223,11 +211,5 @@
 	.dimmed .stack-view,
 	.stack-busy .stack-view {
 		pointer-events: none;
-	}
-
-	.lane-skeleton {
-		display: flex;
-		flex-direction: column;
-		height: 100%;
 	}
 </style>

--- a/apps/desktop/src/lib/commits/commit.ts
+++ b/apps/desktop/src/lib/commits/commit.ts
@@ -1,13 +1,6 @@
 import { splitMessage } from "$lib/commits/commitMessage";
 import type { RemoteCommit } from "@gitbutler/but-sdk";
 
-export type CommitKey = {
-	stackId?: string;
-	branchName: string;
-	commitId: string;
-	upstream: boolean;
-};
-
 export function descriptionTitle(commit: { description: string }): string | undefined {
 	return splitMessage(commit.description).title || undefined;
 }

--- a/apps/desktop/src/lib/dragging/dropHandlers/commitDropHandler.ts
+++ b/apps/desktop/src/lib/dragging/dropHandlers/commitDropHandler.ts
@@ -484,7 +484,6 @@ export class SquashCommitDzHandler implements DropzoneHandler {
 				async () => {
 					await this.stackService.squashCommits({
 						projectId,
-						stackId,
 						sourceCommitIds,
 						targetCommitId: commit.id,
 					});

--- a/apps/desktop/src/lib/selection/fileSelectionManager.svelte.ts
+++ b/apps/desktop/src/lib/selection/fileSelectionManager.svelte.ts
@@ -182,7 +182,6 @@ export class FileSelectionManager {
 				const branch = createBranchRef(branchName, remote);
 				return await this.stackService.branchChangesByPaths({
 					projectId,
-					stackId: params.stackId,
 					branch,
 					paths: paths,
 				});
@@ -283,7 +282,6 @@ export class FileSelectionManager {
 				const branch = createBranchRef(branchName, remote);
 				return this.stackService.branchChange({
 					projectId,
-					stackId: selectedFile.stackId,
 					branch,
 					path: selectedFile.path,
 				});

--- a/apps/desktop/src/lib/stacks/macros.ts
+++ b/apps/desktop/src/lib/stacks/macros.ts
@@ -58,7 +58,6 @@ export default class StackMacros {
 		const branchName = ensureValue(stack.heads.at(0)?.name);
 		const outcome = await this.stackService.createCommitMutation({
 			projectId: this.projectId,
-			stackId: ensureValue(stack.id),
 			stackBranchName: branchName,
 			parentId: undefined,
 			message: message ?? STUB_COMMIT_MESSAGE,

--- a/apps/desktop/src/lib/stacks/segmentContext.ts
+++ b/apps/desktop/src/lib/stacks/segmentContext.ts
@@ -1,0 +1,26 @@
+import { partialStackRequestsForcePush } from "$lib/stacks/stack";
+import type { Segment } from "@gitbutler/but-sdk";
+
+/**
+ * Values derived from a segment's position in a stack. Pre-computed by
+ * parent components (BranchList iteration, StackDetails selection) so
+ * that leaves can take narrow props instead of the whole segments array.
+ */
+export interface SegmentContext {
+	branchIndex: number;
+	parent: Segment | undefined;
+	child: Segment | undefined;
+	withForce: boolean;
+	stackPrNumbers: (number | undefined)[];
+}
+
+export function segmentContext(segments: Segment[], index: number): SegmentContext {
+	const branchName = segments[index]?.refName?.displayName;
+	return {
+		branchIndex: index,
+		parent: segments[index + 1],
+		child: segments[index - 1],
+		withForce: branchName ? partialStackRequestsForcePush(branchName, segments) : false,
+		stackPrNumbers: segments.map((s) => s.metadata?.review.pullRequest ?? undefined),
+	};
+}

--- a/apps/desktop/src/lib/stacks/stackController.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackController.svelte.ts
@@ -141,7 +141,7 @@ export class StackController {
 	}
 
 	get isCommitView(): boolean {
-		return !!(this.branchName && this.commitId);
+		return !!this.commitId;
 	}
 
 	get projectState() {

--- a/apps/desktop/src/lib/stacks/stackEndpoints.test.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.test.ts
@@ -46,7 +46,6 @@ describe("buildStackEndpoints", () => {
 		expect(
 			query?.({
 				projectId: "project-1",
-				stackId: "stack-1",
 				sourceCommitIds: ["commit-1", "commit-2"],
 				targetCommitId: "commit-3",
 			}),
@@ -152,8 +151,8 @@ describe("buildStackEndpoints", () => {
 			invalidatesList(ReduxTag.HeadSha),
 			invalidatesList(ReduxTag.WorktreeChanges),
 			invalidatesList(ReduxTag.Stacks),
+			invalidatesList(ReduxTag.BranchChanges),
 			invalidatesItem(ReduxTag.StackDetails, "stack-1"),
-			invalidatesItem(ReduxTag.BranchChanges, "stack-1"),
 		]);
 	});
 });

--- a/apps/desktop/src/lib/stacks/stackEndpoints.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.ts
@@ -54,7 +54,6 @@ export type BranchParams = {
 };
 
 export type CreateCommitRequest = {
-	stackId: string;
 	message: string;
 	/** Undefined means that the backend will infer the parent to be the current head of stackBranchName */
 	parentId: string | undefined;
@@ -364,12 +363,11 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 		}),
 		branchChanges: build.query<
 			{ changes: EntityState<TreeChange, string>; stats: TreeStats },
-			{ projectId: string; stackId?: string; branch: string }
+			{ projectId: string; branch: string }
 		>({
 			extraOptions: { command: "branch_diff" },
 			query: (args) => args,
-			providesTags: (_result, _error, { stackId }) =>
-				stackId ? providesItem(ReduxTag.BranchChanges, stackId) : [],
+			providesTags: (_result, _error, { branch }) => providesItem(ReduxTag.BranchChanges, branch),
 			transformResponse(rsp: TreeChanges) {
 				return {
 					changes: changesAdapter.addMany(changesAdapter.getInitialState(), rsp.changes),
@@ -379,15 +377,14 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 		}),
 		updateCommitMessage: build.mutation<
 			string,
-			{ projectId: string; stackId: string; commitId: string; message: string; dryRun: boolean }
+			{ projectId: string; stackId?: string; commitId: string; message: string; dryRun: boolean }
 		>({
 			extraOptions: {
 				command: "commit_reword",
 				actionName: "Update Commit Message",
 			},
-			query: ({ projectId, stackId, commitId, message, dryRun }) => ({
+			query: ({ projectId, commitId, message, dryRun }) => ({
 				projectId,
-				stackId,
 				commitId,
 				message,
 				dryRun,
@@ -395,7 +392,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 			transformResponse: (response: CommitRewordResult) => response.newCommit,
 			invalidatesTags: (_result, _error, { stackId }) => [
 				invalidatesList(ReduxTag.HeadSha),
-				invalidatesItem(ReduxTag.StackDetails, stackId),
+				...(stackId ? [invalidatesItem(ReduxTag.StackDetails, stackId)] : []),
 			],
 		}),
 		newBranch: build.mutation<
@@ -415,7 +412,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 		}),
 		uncommit: build.mutation<
 			UncommitResult,
-			{ projectId: string; stackId: string; commitIds: string[] }
+			{ projectId: string; stackId?: string; commitIds: string[] }
 		>({
 			extraOptions: {
 				command: "commit_uncommit",
@@ -424,11 +421,11 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 			query: ({ projectId, stackId, commitIds }) => ({
 				projectId,
 				subjectCommitIds: commitIds,
-				assignTo: stackId,
+				assignTo: stackId ?? null,
 				dryRun: false,
 			}),
-			invalidatesTags: (_result, _error, args) => [
-				invalidatesItem(ReduxTag.BranchChanges, args.stackId),
+			invalidatesTags: [
+				invalidatesList(ReduxTag.BranchChanges),
 				invalidatesList(ReduxTag.WorktreeChanges),
 				invalidatesList(ReduxTag.HeadSha),
 			],
@@ -707,7 +704,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 			MoveBranchResult,
 			{
 				projectId: string;
-				sourceStackId: string;
+				sourceStackId?: string;
 				subjectBranchName: string;
 			}
 		>({
@@ -720,15 +717,13 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 				subjectBranch: normalizeReferenceSubject(subjectBranchName),
 				dryRun: false,
 			}),
-			invalidatesTags: (_result, _error, args) => {
-				return [
-					invalidatesList(ReduxTag.HeadSha),
-					invalidatesList(ReduxTag.WorktreeChanges), // Moving commits can cause conflicts
-					invalidatesList(ReduxTag.Stacks),
-					invalidatesItem(ReduxTag.StackDetails, args.sourceStackId),
-					invalidatesItem(ReduxTag.BranchChanges, args.sourceStackId), // Affects source stack, new stack is new
-				];
-			},
+			invalidatesTags: (_result, _error, args) => [
+				invalidatesList(ReduxTag.HeadSha),
+				invalidatesList(ReduxTag.WorktreeChanges), // Moving commits can cause conflicts
+				invalidatesList(ReduxTag.Stacks),
+				invalidatesList(ReduxTag.BranchChanges),
+				...(args.sourceStackId ? [invalidatesItem(ReduxTag.StackDetails, args.sourceStackId)] : []),
+			],
 		}),
 		integrateUpstreamCommits: build.mutation<
 			void,
@@ -748,7 +743,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 				invalidatesList(ReduxTag.HeadSha),
 				invalidatesList(ReduxTag.WorktreeChanges),
 				invalidatesItem(ReduxTag.StackDetails, args.stackId),
-				invalidatesItem(ReduxTag.BranchChanges, args.stackId),
+				invalidatesItem(ReduxTag.BranchChanges, args.seriesName),
 			],
 		}),
 		getInitialIntegrationSteps: build.query<
@@ -779,7 +774,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 				invalidatesItem(ReduxTag.StackDetails, args.stackId),
 				invalidatesItem(ReduxTag.IntegrationSteps, args.stackId + args.branchName),
 				invalidatesItem(ReduxTag.BranchDetails, args.branchName),
-				invalidatesItem(ReduxTag.BranchChanges, args.stackId),
+				invalidatesItem(ReduxTag.BranchChanges, args.branchName),
 			],
 		}),
 		createVirtualBranchFromBranch: build.mutation<
@@ -809,7 +804,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 		}),
 		squashCommits: build.mutation<
 			CommitSquashResult,
-			{ projectId: string; stackId: string; sourceCommitIds: string[]; targetCommitId: string }
+			{ projectId: string; sourceCommitIds: string[]; targetCommitId: string }
 		>({
 			extraOptions: {
 				command: "commit_squash",
@@ -860,22 +855,15 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 		}),
 		createReference: build.mutation<
 			void,
-			{ projectId: string; stackId: string; request: CreateRefRequest }
+			{ projectId: string; stackId?: string; request: CreateRefRequest }
 		>({
 			extraOptions: {
 				command: "create_reference",
 				actionName: "Create Reference",
 			},
-			query: (args) => {
-				// TODO: Remove the stack ID from the request args.
-				// The backend doesn't need it, but the frontend does to invalidate the right tags.
-				// We should move away from using the stack ID as the cache key, an move towards some form of branch name instead.
-
-				return { projectId: args.projectId, request: args.request };
-			},
-			invalidatesTags: (_result, _error, args) => [
-				invalidatesItem(ReduxTag.StackDetails, args.stackId), // This is probably still needed. Adding a ref won't change the workspace commit, right?
-			],
+			query: (args) => ({ projectId: args.projectId, request: args.request }),
+			invalidatesTags: (_result, _error, args) =>
+				args.stackId ? [invalidatesItem(ReduxTag.StackDetails, args.stackId)] : [],
 		}),
 		templates: build.query<string[], { projectId: string; forge: string }>({
 			extraOptions: { command: "pr_templates" },

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -497,12 +497,11 @@ export class StackService {
 	/**
 	 * Gets the changes for a given branch.
 	 */
-	branchChanges(args: { projectId: string; stackId?: string; branch: string }) {
+	branchChanges(args: { projectId: string; branch: string }) {
 		return this.backendApi.endpoints.branchChanges.useQuery(
 			{
 				projectId: args.projectId,
 				branch: args.branch,
-				stackId: args.stackId,
 			},
 			{
 				transform: (result) => ({
@@ -513,27 +512,20 @@ export class StackService {
 		);
 	}
 
-	branchChange(args: { projectId: string; stackId?: string; branch: string; path: string }) {
+	branchChange(args: { projectId: string; branch: string; path: string }) {
 		return this.backendApi.endpoints.branchChanges.useQuery(
 			{
 				projectId: args.projectId,
-				stackId: args.stackId,
 				branch: args.branch,
 			},
 			{ transform: (result) => changesSelectors.selectById(result.changes, args.path) },
 		);
 	}
 
-	async branchChangesByPaths(args: {
-		projectId: string;
-		stackId?: string;
-		branch: string;
-		paths: string[];
-	}) {
+	async branchChangesByPaths(args: { projectId: string; branch: string; paths: string[] }) {
 		const result = await this.backendApi.endpoints.branchChanges.fetch(
 			{
 				projectId: args.projectId,
-				stackId: args.stackId,
 				branch: args.branch,
 			},
 			{ transform: (result) => selectChangesByPaths(result.changes, args.paths) },
@@ -549,11 +541,13 @@ export class StackService {
 		return this.backendApi.endpoints.newBranch.useMutation();
 	}
 
-	async uncommit(args: { projectId: string; stackId: string; commitIds: string[] }) {
+	async uncommit(args: { projectId: string; stackId?: string; commitIds: string[] }) {
 		const result = await this.backendApi.endpoints.uncommit.mutate(args);
-		const selection = this.uiState.lane(args.stackId).selection;
-		if (selection.current?.commitId && args.commitIds.includes(selection.current.commitId)) {
-			selection.set(undefined);
+		if (args.stackId) {
+			const selection = this.uiState.lane(args.stackId).selection;
+			if (selection.current?.commitId && args.commitIds.includes(selection.current.commitId)) {
+				selection.set(undefined);
+			}
 		}
 		return result;
 	}
@@ -750,7 +744,6 @@ export class StackService {
 
 		await this.squashCommits({
 			projectId,
-			stackId,
 			sourceCommitIds: squashCommits.map((commit) => commit.id),
 			targetCommitId: targetCommit.id,
 		});

--- a/apps/desktop/src/lib/state/uiState.svelte.ts
+++ b/apps/desktop/src/lib/state/uiState.svelte.ts
@@ -63,7 +63,7 @@ export type ExclusiveAction =
 	| {
 			type: "edit-commit-message";
 			stackId: string | undefined;
-			branchName: string;
+			branchName: string | undefined;
 			commitId: string;
 	  }
 	| {


### PR DESCRIPTION
Plain git mode (no GitButler metadata, no stack id) and the related
single-branch / unmanaged-workspace cases broke the StackView tree in
two ways:

- Many commit-level mutations called `ensureValue(stackId)` on what
  the backend already treats as an optional or unused parameter — so
  any action button leaked through `isReadOnly` (true when there's no
  stack id) threw an exception instead of no-oping.
- Every component re-queried
  `selectWorkspaceStackDetails(workspaceDetails, stackId, ...)` for
  its slice of the stack, which returns nothing when the stack has
  `id === null`. The data was already inlined in the workspace-level
  `head_info` query — re-fetching by id was redundant *and* broken
  for the null-id case.

Two-pronged fix.

1. Drop stack id from mutations where the Tauri handler ignores it
   (commit_reword, commit_amend, commit_squash, commit_uncommit,
   commit_create, tear_off_branch, create_reference, branch_diff).
   Make it optional where the handler still uses it as a tag for
   cache invalidation. 10 of 19 ensureValue(stackId) call sites go
   away; the remaining 9 either guard post-newStackMutation results
   (real defensive code given the SDK widens StackEntryNoOpt to
   StackEntry) or feed mutations the backend still genuinely keys on
   stack id (push_stack, unapply_stack, integrate_branch_with_steps,
   etc.).

2. Thread Stack / Segment / Commit objects as props from the
   top-level head_info query (already in MultiStackView) all the way
   down through the StackView subtree, so no component re-queries by
   id. New data flow:

   WorkspaceView
     → MultiStackView {stacks}
       → StackView {stack}
         → StackPanel {branches, topBranchName, ...}
         → StackDetails {branches, ...}
           → BranchView {segment, branches, ...}
             → BranchReview {segment, branches, ...}
               → ReviewCreation, StackedPullRequestCard,
                 CanPublishReviewPlugin (all prop-fed)
           → CommitView {commit, ...}
         → BranchList → BranchCard
           → CreateReviewBox, PushButton,
             BranchHeaderContextMenu (all prop-fed)
         → BranchCommitList {segment}  (already prop-fed pre-refactor)

   Every stackId-keyed lookup inside this tree is gone:
   stackService.branches, branchDetails, defaultBranch, commitById,
   branchParentByName, branchChildByName, commits. The selectWorkspace
   adapter and these methods stay for now — they're still used by
   out-of-tree components (BranchesView, BranchIntegrationModal,
   CommitFailedFileEntry).

Side effects:

- StackController keys on stackId: () => string | undefined; the
  exposed surface stays the same.
- branchChanges query keys cache on branch name instead of stack id
  (the backend handler takes only `branch: String`; stack id was
  silently ignored). Mutations that used to invalidate
  BranchChanges(stackId) switch to list-level or branch-name keying.
- isCommitView requires only commitId — branchName is no longer
  load-bearing for the CommitView path, so clicking a commit in an
  anonymous segment opens the drawer.
- CommitKey.branchName and ExclusiveAction[edit-commit-message]
  .branchName become optional.