### PR TITLE
Lite: focusable disabled buttons

### DIFF
--- a/apps/lite/ui/src/components/Button.module.css
+++ b/apps/lite/ui/src/components/Button.module.css
@@ -18,7 +18,8 @@
 		background-color 0.08s ease,
 		color 0.08s ease;
 
-	&:disabled {
+	&:disabled,
+	&[data-disabled] {
 		opacity: 0.5;
 	}
 }
@@ -62,7 +63,7 @@
 	--button-group-divider-color: color-mix(in srgb, var(--scale-pop-40) 20%, transparent);
 }
 
-.pop:not(:disabled):hover {
+.pop:not(:disabled, [data-disabled]):hover {
 	background-color: color-mix(in srgb, var(--scale-pop-60) 70%, transparent);
 }
 
@@ -72,7 +73,7 @@
 	--button-group-divider-color: color-mix(in srgb, var(--fill-gray-fg) 18%, transparent);
 }
 
-.gray:not(:disabled):hover {
+.gray:not(:disabled, [data-disabled]):hover {
 	background-color: color-mix(in srgb, var(--fill-gray-bg) 45%, var(--scale-gray-0));
 }
 
@@ -82,7 +83,7 @@
 	--button-group-divider-color: color-mix(in srgb, var(--text-1-invert) 18%, transparent);
 }
 
-.inverted:not(:disabled):hover {
+.inverted:not(:disabled, [data-disabled]):hover {
 	background-color: color-mix(in srgb, var(--scale-gray-100) 5%, transparent);
 }
 
@@ -91,7 +92,7 @@
 	--button-group-divider-color: color-mix(in srgb, var(--fill-gray-bg) 30%, transparent);
 }
 
-.outline:not(:disabled):hover {
+.outline:not(:disabled, [data-disabled]):hover {
 	background-color: color-mix(in srgb, var(--scale-gray-0) 5%, transparent);
 }
 
@@ -101,7 +102,7 @@
 	--button-group-divider-color: color-mix(in srgb, var(--scale-danger-50) 20%, transparent);
 }
 
-.danger:not(:disabled):hover {
+.danger:not(:disabled, [data-disabled]):hover {
 	background-color: color-mix(in srgb, var(--scale-danger-50) 20%, transparent);
 }
 
@@ -109,7 +110,7 @@
 	--button-group-divider-color: color-mix(in srgb, var(--scale-gray-0) 14%, transparent);
 }
 
-.ghost:not(:disabled):hover {
+.ghost:not(:disabled, [data-disabled]):hover {
 	background-color: color-mix(in srgb, var(--scale-gray-0) 5%, transparent);
 }
 
@@ -118,8 +119,8 @@
 	opacity: 0.6;
 }
 
-.ghost:not(:disabled):hover :where([data-icon]),
-.outline:not(:disabled):hover :where([data-icon]) {
+.ghost:not(:disabled, [data-disabled]):hover :where([data-icon]),
+.outline:not(:disabled, [data-disabled]):hover :where([data-icon]) {
 	opacity: 0.8;
 }
 
@@ -130,9 +131,9 @@
 	opacity: 0.7;
 }
 
-.pop:not(:disabled):hover :where([data-icon]),
-.gray:not(:disabled):hover :where([data-icon]),
-.inverted:not(:disabled):hover :where([data-icon]),
-.danger:not(:disabled):hover :where([data-icon]) {
+.pop:not(:disabled, [data-disabled]):hover :where([data-icon]),
+.gray:not(:disabled, [data-disabled]):hover :where([data-icon]),
+.inverted:not(:disabled, [data-disabled]):hover :where([data-icon]),
+.danger:not(:disabled, [data-disabled]):hover :where([data-icon]) {
 	opacity: 0.9;
 }

--- a/apps/lite/ui/src/routes/RootLayout.tsx
+++ b/apps/lite/ui/src/routes/RootLayout.tsx
@@ -6,7 +6,7 @@ import { PickerDialog } from "#ui/components/PickerDialog.tsx";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
 import { classes } from "#ui/components/classes.ts";
 import { globalHotkeys } from "#ui/hotkeys.ts";
-import { Tooltip } from "@base-ui/react";
+import { Button, Tooltip } from "@base-ui/react";
 import { HotkeysProvider, useHotkey } from "@tanstack/react-hotkeys";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Outlet, useMatch, useNavigate } from "@tanstack/react-router";
@@ -59,7 +59,7 @@ const Projects: FC = () => {
 							style={{ "--hue": hue }}
 							// We pass `disabled` here because we want to disable the button, not
 							// the tooltip. Other props should be passed above.
-							render={<button type="button" disabled={isSelected} />}
+							render={<Button focusableWhenDisabled disabled={isSelected} />}
 						>
 							<div className={styles.folderFront}>
 								<span className={classes("text-bold", styles.folderFrontText)}>

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineModeTooltip.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineModeTooltip.tsx
@@ -14,7 +14,7 @@ import {
 } from "#ui/operations/operation.ts";
 import { projectActions, selectProjectOutlineModeState } from "#ui/projects/state.ts";
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
-import { Tooltip, useRender } from "@base-ui/react";
+import { Button, Tooltip, useRender } from "@base-ui/react";
 import { Toggle } from "@base-ui/react/toggle";
 import { ToggleGroup } from "@base-ui/react/toggle-group";
 import { type AbsorptionTarget } from "@gitbutler/but-sdk";
@@ -70,7 +70,7 @@ const AbsorbControls: FC<{
 					onClick={confirm}
 					// We pass `disabled` here because we want to disable the button, not
 					// the tooltip. Other props should be passed above.
-					render={<button type="button" disabled={!canAbsorb} />}
+					render={<Button focusableWhenDisabled disabled={!canAbsorb} />}
 				>
 					Absorb
 				</Tooltip.Trigger>
@@ -258,7 +258,7 @@ const TransferOperationControls: FC<{
 					onClick={run}
 					// We pass `disabled` here because we want to disable the button, not
 					// the tooltip. Other props should be passed above.
-					render={<button type="button" disabled={!operation} />}
+					render={<Button focusableWhenDisabled disabled={!operation} />}
 				>
 					Confirm
 				</Tooltip.Trigger>

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
@@ -59,7 +59,7 @@ import { OperationTarget } from "#ui/routes/project/$id/workspace/OperationTarge
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { classes } from "#ui/components/classes.ts";
 import { navigationIndexIncludes, type NavigationIndex } from "#ui/workspace/navigation-index.ts";
-import { mergeProps, Popover, Toast, Tooltip, useRender } from "@base-ui/react";
+import { Button, mergeProps, Popover, Toast, Tooltip, useRender } from "@base-ui/react";
 import { Combobox } from "@base-ui/react/combobox";
 import { Toolbar } from "@base-ui/react/toolbar";
 import {
@@ -1327,14 +1327,7 @@ const Changes: FC<{
 							<Combobox.Trigger
 								className={classes(getButtonClassName({}), styles.commitTargetComboboxTrigger)}
 								aria-label="Select branch"
-								render={(props, state) => (
-									<Tooltip.Trigger
-										{...props}
-										// We pass `disabled` here because we want to disable the button, not
-										// the tooltip. Other props should be passed above.
-										render={<button type="button" disabled={state.disabled} />}
-									/>
-								)}
+								render={<Button focusableWhenDisabled render={<Tooltip.Trigger />} />}
 							>
 								<Combobox.Value placeholder="Select branch" />
 							</Combobox.Trigger>
@@ -1361,7 +1354,7 @@ const Changes: FC<{
 								className={getButtonClassName({})}
 								// We pass `disabled` here because we want to disable the button, not
 								// the tooltip. Other props should be passed above.
-								render={<button type="submit" disabled={!canCommitOrAmend} />}
+								render={<Button focusableWhenDisabled type="submit" disabled={!canCommitOrAmend} />}
 							>
 								{isAmendMode ? "Amend" : "Commit"}
 							</Tooltip.Trigger>

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -56,7 +56,7 @@ import { PickerDialog, type PickerDialogGroup } from "#ui/components/PickerDialo
 import { Details } from "./Details.tsx";
 import styles from "./WorkspacePage.module.css";
 import { OutlineTree } from "#ui/routes/project/$id/workspace/OutlineTree.tsx";
-import { Tooltip } from "@base-ui/react";
+import { Button, Tooltip } from "@base-ui/react";
 import { useActiveElement } from "#ui/focus.ts";
 import { classes } from "#ui/components/classes.ts";
 import { Icon } from "#ui/components/Icon.tsx";
@@ -542,7 +542,7 @@ const WorkspacePage: FC = () => {
 									onClick={rebaseAllStacks}
 									// We pass `disabled` here because we want to disable the button, not
 									// the tooltip. Other props should be passed above.
-									render={<button type="button" disabled={!canRebaseAllStacks} />}
+									render={<Button focusableWhenDisabled disabled={!canRebaseAllStacks} />}
 								>
 									<Icon name="arrow-line-down" />
 								</Tooltip.Trigger>


### PR DESCRIPTION
A common pattern is to show loading states in buttons and disable them whilst loading. A good example is the commit button.

The problem with this is: disabling the button means it loses focus.

This might be a reason to use Base UI's Button component, which has a [`focusableWhenDisabled` prop](https://base-ui.com/react/components/button#loading-states). Under-the-hood it will render a `<button>` but apply `aria-disabled` instead of a `disabled` attribute.

Ideally we'd [avoid disabled buttons](https://adamsilver.io/blog/the-problem-with-disabled-buttons-and-what-to-do-instead/) but it's not always possible.

The other nice thing about `<Button focusableWhenDisabled />` is it means we can show a tooltip to keyboard users when they keyboard navigate to it, unlike `<button disabled />` which isn't focusable. A few examples can be seen in the diff of this PR.
