### PR TITLE
Treat Gerrit probe failures as not detected

### DIFF
--- a/crates/but-api/src/legacy/projects.rs
+++ b/crates/but-api/src/legacy/projects.rs
@@ -172,7 +172,13 @@ fn assure_repo_ownership(repo: &gix::Repository) -> Result<()> {
 #[but_api]
 #[instrument(err(Debug))]
 pub fn is_gerrit(ctx: &but_ctx::Context) -> Result<bool> {
-    gitbutler_project::gerrit::is_used_by_default_remote(&*ctx.repo.get()?)
+    let repo = ctx.repo.get()?;
+    Ok(
+        gitbutler_project::gerrit::is_used_by_default_remote(&repo).unwrap_or_else(|err| {
+            tracing::debug!(?err, "Gerrit detection failed");
+            false
+        }),
+    )
 }
 
 #[derive(serde::Serialize)]


### PR DESCRIPTION
Makes the optional Gerrit onboarding check fail closed when remote/auth probing fails, while still surfacing repository-open failures. This prevents silent detection failures from becoming query-error telemetry noise.