### PR TITLE
desktop: route PR listing by branch via list_reviews + register get_review

### DIFF
--- a/apps/desktop/src/lib/forge/github/github.ts
+++ b/apps/desktop/src/lib/forge/github/github.ts
@@ -61,8 +61,8 @@ export class GitHub implements Forge {
 
 	get listService() {
 		if (!this.authenticated) return;
-		const { api: gitHubApi, backendApi, dispatch } = this.params;
-		return new GitHubListingService(gitHubApi, backendApi, dispatch);
+		const { backendApi, dispatch } = this.params;
+		return new GitHubListingService(backendApi, dispatch);
 	}
 
 	get prService() {

--- a/apps/desktop/src/lib/forge/github/githubListingService.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/githubListingService.svelte.ts
@@ -1,5 +1,3 @@
-import { ghQuery } from "$lib/forge/github/ghQuery";
-import { ghResponseToInstance } from "$lib/forge/github/types";
 import {
 	mapForgeReviewToPullRequest,
 	type ForgeReview,
@@ -11,18 +9,15 @@ import { isDefined } from "@gitbutler/ui/utils/typeguards";
 import { createEntityAdapter, type EntityState } from "@reduxjs/toolkit";
 import type { ForgeListingService } from "$lib/forge/interface/forgeListingService";
 import type { BackendApi } from "$lib/state/backendApi";
-import type { AppDispatch, GitHubApi } from "$lib/state/clientState.svelte";
+import type { AppDispatch } from "$lib/state/clientState.svelte";
 
 export class GitHubListingService implements ForgeListingService {
-	private api: ReturnType<typeof injectEndpoints>;
 	private backendApi: ReturnType<typeof injectBackendEndpoints>;
 
 	constructor(
-		gitHubApi: GitHubApi,
 		backendApi: BackendApi,
 		private readonly dispatch: AppDispatch,
 	) {
-		this.api = injectEndpoints(gitHubApi);
 		this.backendApi = injectBackendEndpoints(backendApi);
 	}
 
@@ -48,13 +43,11 @@ export class GitHubListingService implements ForgeListingService {
 	}
 
 	async fetchByBranch(projectId: string, branchNames: string[]) {
-		const results = await Promise.all(
-			branchNames.map((branch) =>
-				this.api.endpoints.listPrsByBranch.fetch({ projectId, branchName: branch }),
-			),
-		);
-
-		return results.filter(isDefined) ?? [];
+		const result = await this.backendApi.endpoints.listPrs.fetch(projectId);
+		if (!result) return [];
+		return branchNames
+			.map((branch) => prSelectors.selectById(result, branch))
+			.filter(isDefined);
 	}
 
 	async refresh(_projectId: string): Promise<void> {
@@ -80,50 +73,8 @@ function injectBackendEndpoints(api: BackendApi) {
 	});
 }
 
-function injectEndpoints(api: GitHubApi) {
-	return api.injectEndpoints({
-		endpoints: (build) => ({
-			listPrsByBranch: build.query<PullRequest | null, { projectId: string; branchName: string }>({
-				queryFn: async ({ branchName }, api) => {
-					const result = await ghQuery<"pulls", "list", "required">(
-						async (octokit, repository) => ({
-							data: await octokit.paginate(octokit.rest.pulls.list, {
-								...repository,
-								head: `${repository.owner}:${branchName}`,
-							}),
-						}),
-						api.extra,
-						"required",
-					);
-
-					if (result.error) {
-						return { error: result.error };
-					}
-
-					if (result.data.length === 0) {
-						return { data: null };
-					}
-
-					if (result.data.length > 1) {
-						return { error: new Error(`Multiple pull requests found for branch ${branchName}`) };
-					}
-
-					const prData = result.data[0]!;
-
-					const pr = ghResponseToInstance(prData);
-					return { data: pr };
-				},
-			}),
-		}),
-	});
-}
-
 const prAdapter = createEntityAdapter<PullRequest, string>({
 	selectId: (pr) => pr.sourceBranch,
 });
 
 const prSelectors = { ...prAdapter.getSelectors(), selectByIds: createSelectByIds<PullRequest>() };
-
-// if (err.message.includes('you appear to have the correct authorization credentials')) {
-// 	this.disabled = true;
-// }


### PR DESCRIPTION
## Summary

Two small steps in the rolling migration away from `ghQuery` in `apps/desktop/`:

1. **`GitHubListingService.fetchByBranch`** was issuing one Octokit `pulls.list` call per branch via `ghQuery`. The listing service already had a Tauri-backed `listPrs` endpoint wired to `list_reviews`, keyed by `sourceBranch`. `fetchByBranch` now folds over that cached set instead of round-tripping to GitHub per branch. Drops the entire Octokit `injectEndpoints` and `listPrsByBranch` query from this service; the constructor no longer needs `gitHubApi`.

2. **Register `tauri_get_review::get_review`** in the Tauri `invoke_handler`. The `but_api(napi)` macro already generated the Tauri wrapper alongside the napi one — only the registration was missing. Sets up the next slice (migrate `getPr` by number) to use it without another Rust round-trip.

## Context

Follows [#14089](https://github.com/gitbutlerapp/gitbutler/pull/14089) (CI checks migration), continuing the same pattern of moving forge data through `but-forge` instead of direct Octokit. The remaining `ghQuery` callsites still need migration; each of those needs at least one new Rust function (`get_repo_info`, full `update_pull_request`, `create_issue`, plus a decision on how to model "current authenticated user" without an explicit account identifier). Those will land in follow-up PRs.

## Test plan

- [x] `pnpm --filter @gitbutler/desktop check` — 0 errors / 0 warnings
- [x] `cargo check -p gitbutler-tauri` — clean
- [ ] Manual: open the desktop app, observe that the listing UI still finds the PR for the selected branch (uses the cached `list_reviews` result instead of a per-branch fetch)

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #14090 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #14089 
- <kbd>&nbsp;1&nbsp;</kbd> #14085 
<!-- GitButler Footer Boundary Bottom -->

