### PR TITLE
Draggable diff file headers

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -37,11 +37,11 @@
 	grid-template-rows: minmax(0, 1fr);
 	grid-template-columns: 1fr;
 	column-gap: 12px;
+	padding-inline: var(--panel-padding);
 }
 
 .diffWithFiles {
 	grid-template-columns: 300px minmax(300px, 1fr);
-	padding-inline-start: var(--panel-padding);
 }
 
 .diffFiles {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -97,23 +97,23 @@
 	white-space: pre-line;
 }
 
-.fileDiffsList {
-	display: flex;
-	flex-direction: column;
-	gap: 10px;
-}
-
-.fileDiff {
-	border: 1px solid var(--border-3);
-	border-radius: 10px;
-}
-
 .fileHeader {
-	border-bottom: 1px solid var(--border-3);
+	display: grid;
+	grid-template-columns: 1fr auto auto;
+	align-items: center;
+	justify-content: space-between;
+	padding: 8px;
+	gap: 12px;
+	border: 1px solid var(--border-3);
+	border-radius: 10px 10px 0 0;
+	white-space: nowrap;
+
+	&.lone {
+		border-radius: 10px;
+	}
 }
 
 .filePath {
-	margin: 8px;
 	overflow: hidden;
 	color: var(--text-3);
 
@@ -121,7 +121,14 @@
 	direction: rtl;
 	text-align: left;
 	text-overflow: ellipsis;
-	white-space: nowrap;
+}
+
+.fileDiffAdded {
+	color: var(--text-safe);
+}
+
+.fileDiffDeleted {
+	color: #d34832;
 }
 
 .pathLast {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -35,11 +35,15 @@ import type {
 	DiffHunk,
 	TreeChange,
 	TreeChanges,
+	UnifiedPatch,
 	WorktreeChanges,
 } from "@gitbutler/but-sdk";
-import { parsePatchFiles } from "@pierre/diffs";
-import { type CodeView as CodeViewClass } from "@pierre/diffs";
-import { CodeView, type CodeViewDiffItem, type CodeViewHandle } from "@pierre/diffs/react";
+import {
+	type CodeViewDiffItem,
+	type CodeView as CodeViewClass,
+	parsePatchFiles,
+} from "@pierre/diffs";
+import { CodeView, type CodeViewHandle } from "@pierre/diffs/react";
 import { useSuspenseQueries } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
 import { Array, Hash, Match } from "effect";
@@ -256,16 +260,26 @@ const DiffContents: FC<{
 		Match.orElseAbsurd,
 	);
 
-	const items = Array.zip(changes, treeChangeDiffs).flatMap(
-		([change, mdiff]) =>
-			Match.value(mdiff).pipe(
-				Match.when({ type: "Patch" }, (patch) =>
-					mkCodeViewItem(change, changesetKey, patch.subject.hunks),
-				),
-				Match.when({ type: "Binary" }, () => mkCodeViewItem(change, changesetKey, [])),
-				Match.orElse(() => null),
-			) ?? [],
-	);
+	// CodeView only gives us back the CodeViewItem in custom renders, however we need this prior data
+	// hence a reverse map by ID.
+	const itemsMetadataMap = new Map<string, [TreeChange, UnifiedPatch]>();
+
+	const items = Array.zip(changes, treeChangeDiffs).flatMap(([change, mdiff]) => {
+		if (!mdiff) return [];
+
+		const mitem = Match.value(mdiff).pipe(
+			Match.when({ type: "Patch" }, (patch) =>
+				mkCodeViewItem(change, changesetKey, patch.subject.hunks),
+			),
+			Match.when({ type: "Binary" }, () => mkCodeViewItem(change, changesetKey, [])),
+			Match.orElse(() => null),
+		);
+		if (!mitem) return [];
+
+		itemsMetadataMap.set(mitem.id, [change, mdiff]);
+
+		return mitem;
+	});
 
 	const selectFileAtViewportTop = (scrollTop: number, viewer: CodeViewClass<undefined>) => {
 		const activeItem = viewer
@@ -287,8 +301,27 @@ const DiffContents: FC<{
 	) : (
 		<CodeView
 			ref={viewerRef}
+			renderCustomHeader={(item) => {
+				if (item.type === "file") throw new Error("Only diff items may be rendered");
+
+				const path = itemsMetadataMap.get(item.id)?.[0].path;
+				if (path === undefined) throw new Error("Missing item ID in metadata map");
+
+				return (
+					<DiffFileHeader
+						projectId={projectId}
+						item={item}
+						operand={fileOperand({
+							parent: fileParent,
+							path,
+						})}
+						path={path}
+						hasDiff={item.fileDiff.hunks.length !== 0}
+					/>
+				);
+			}}
 			onScroll={selectFileAtViewportTop}
-			className={classes(styles.diffContents, uiStyles.scrollerWithSeparator)}
+			className={styles.diffContents}
 			items={items}
 			options={{
 				diffStyle: "unified",
@@ -299,8 +332,55 @@ const DiffContents: FC<{
 					paddingBottom: 0,
 					gap: 10,
 				},
+				// This appears to validate before our custom header has been slotted, in which case - if
+				// our metrics are correct - we should see deltas in multiples of our custom header height
+				// as defined in the metrics. We'll see an additional set of logs if there are other issues
+				// with our metrics.
+				__devOnlyValidateItemHeights: false,
+				itemMetrics: {
+					// Computed custom header height.
+					diffHeaderHeight: 38,
+				},
 			}}
 		/>
+	);
+};
+
+type DiffFileHeaderProps = {
+	projectId: string;
+	item: CodeViewDiffItem;
+	operand: Operand;
+	path: string;
+	hasDiff: boolean;
+};
+
+const DiffFileHeader: FC<DiffFileHeaderProps> = (p) => {
+	const lastSepIdx = p.path.lastIndexOf("/");
+	const mpathInit = lastSepIdx !== -1 ? p.path.slice(0, lastSepIdx + 1) : null;
+	const pathLast = lastSepIdx !== -1 ? p.path.slice(lastSepIdx + 1) : p.path;
+
+	const changeType = Match.value(p.item.fileDiff.type).pipe(
+		Match.when("new", () => "Added"),
+		Match.whenOr("change", "rename-changed", () => "Modified"),
+		Match.when("rename-pure", () => "Renamed"),
+		Match.when("deleted", () => "Deleted"),
+		Match.exhaustive,
+	);
+
+	return (
+		<OperationSourceC projectId={p.projectId} source={p.operand} selectionScope="diff">
+			<header className={classes(styles.fileHeader, !p.hasDiff && styles.lone)}>
+				<h4 className={classes("text-13", styles.filePath)}>
+					{mpathInit}
+					<span className={styles.pathLast}>{pathLast}</span>
+				</h4>
+				<span>{changeType}</span>
+				<span>
+					<span className={styles.fileDiffAdded}>+{p.item.fileDiff.additionLines.length}</span>{" "}
+					<span className={styles.fileDiffDeleted}>-{p.item.fileDiff.deletionLines.length}</span>
+				</span>
+			</header>
+		</OperationSourceC>
 	);
 };
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -259,12 +259,11 @@ const DiffContents: FC<{
 	const items = Array.zip(changes, treeChangeDiffs).flatMap(
 		([change, mdiff]) =>
 			Match.value(mdiff).pipe(
-				Match.when(
-					{ type: "Patch" },
-					(patch) => mkCodeViewItem(change, changesetKey, patch.subject.hunks) ?? [],
+				Match.when({ type: "Patch" }, (patch) =>
+					mkCodeViewItem(change, changesetKey, patch.subject.hunks),
 				),
 				Match.when({ type: "Binary" }, () => mkCodeViewItem(change, changesetKey, [])),
-				Match.orElse(() => []),
+				Match.orElse(() => null),
 			) ?? [],
 	);
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -329,7 +329,8 @@ const DiffContents: FC<{
 				stickyHeaders: true,
 				layout: {
 					paddingTop: 0,
-					paddingBottom: 0,
+					// Match --panel-padding.
+					paddingBottom: 16,
 					gap: 10,
 				},
 				// This appears to validate before our custom header has been slotted, in which case - if
@@ -340,7 +341,17 @@ const DiffContents: FC<{
 				itemMetrics: {
 					// Computed custom header height.
 					diffHeaderHeight: 38,
+					// Default spacing plus our 1px border.
+					paddingBottom: 9,
 				},
+				unsafeCSS: `
+          [data-code] {
+            border-width: 0 1px 1px 1px;
+            border-style: solid;
+            border-color: var(--border-3);
+            border-radius: 0 0 10px 10px;
+          }
+        `,
 			}}
 		/>
 	);


### PR DESCRIPTION
Closes GB-1559.

See the kerfuffle around `__devOnlyValidateItemHeights`. I’m actually seeing that prop report errors in a tiny repro without even a custom header 🫤 edit: https://github.com/pierrecomputer/pierre/issues/786