### PR TITLE
Fix phantom uncommitted changes from stale workspace merge-base

### DIFF
--- a/crates/but-workspace/src/legacy/head.rs
+++ b/crates/but-workspace/src/legacy/head.rs
@@ -52,36 +52,54 @@ pub fn remerged_workspace_tree_v2(
     let target_base_oid = ctx.persisted_default_target()?.sha;
     let mut stacks: Vec<Stack> = vb_state.list_stacks_in_workspace()?;
 
-    let target_commit = repo.find_commit(target_base_oid)?;
-    let mut workspace_tree_id = repo
-        .find_real_tree(&target_commit, Default::default())?
-        .detach();
-
-    let (merge_options_fail_fast, conflict_kind) = repo.merge_options_fail_fast()?;
-    let merge_tree_id = target_commit.tree_id()?.detach();
-    for stack in stacks.iter_mut() {
-        let stack_head = repo.find_commit(stack.head_oid(ctx)?)?;
-        let branch_tree_id = repo
-            .find_real_tree(&stack_head, Default::default())?
+    let heads = stacks
+        .iter()
+        .map(|s| s.head_oid(ctx))
+        .collect::<Result<Vec<_>>>()?;
+    let workspace_tree_id = if heads.is_empty() {
+        repo.find_real_tree(&repo.find_commit(target_base_oid)?, Default::default())?
+            .detach()
+    } else if heads.len() == 1 {
+        let commit = repo.find_commit(*heads.first().expect("Heads is length 1"))?;
+        let first_head = repo.find_real_tree(&commit, Default::default())?;
+        first_head.detach()
+    } else {
+        let base_tree_id = repo
+            .find_real_tree(
+                &repo.find_commit(repo.merge_base_octopus(heads)?)?,
+                Default::default(),
+            )?
             .detach();
+        let mut workspace_tree_id = base_tree_id;
 
-        let mut merge = repo.merge_trees(
-            merge_tree_id,
-            workspace_tree_id,
-            branch_tree_id,
-            repo.default_merge_labels(),
-            merge_options_fail_fast.clone(),
-        )?;
+        let (merge_options_fail_fast, conflict_kind) = repo.merge_options_fail_fast()?;
+        for stack in stacks.iter_mut() {
+            let stack_head = repo.find_commit(stack.head_oid(ctx)?)?;
+            let branch_tree_id = repo
+                .find_real_tree(&stack_head, Default::default())?
+                .detach();
 
-        if !merge.has_unresolved_conflicts(conflict_kind) {
-            workspace_tree_id = merge.tree.write()?.detach();
-        } else {
-            // This branch should have already been unapplied during the "update" command but for some reason that failed
-            tracing::warn!("Merge conflict between base and {:?}", stack.name());
-            stack.in_workspace = false;
-            vb_state.set_stack(stack.clone())?;
+            let mut merge = repo.merge_trees(
+                base_tree_id,
+                workspace_tree_id,
+                branch_tree_id,
+                repo.default_merge_labels(),
+                merge_options_fail_fast.clone(),
+            )?;
+
+            if !merge.has_unresolved_conflicts(conflict_kind) {
+                workspace_tree_id = merge.tree.write()?.detach();
+            } else {
+                // This branch should have already been unapplied during the "update" command but for some reason that failed
+                tracing::warn!("Merge conflict between base and {:?}", stack.name());
+                stack.in_workspace = false;
+                vb_state.set_stack(stack.clone())?;
+            }
         }
-    }
+
+        workspace_tree_id
+    };
+
     Ok((workspace_tree_id, stacks, target_base_oid))
 }
 

--- a/crates/gitbutler-branch-actions/tests/branch-actions/driverless.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/driverless.rs
@@ -177,17 +177,12 @@ fn seed_fixture(repo: &gix::Repository, script_name: &str, repo_name: &str) -> R
         ("workspace-commit.sh", "diverged-stacks") => vec![
             StackSpec {
                 id: 1,
-                branches_base_to_top: &["stack_a"],
+                branches_base_to_top: &["stack_c"],
                 in_workspace: true,
             },
             StackSpec {
                 id: 2,
-                branches_base_to_top: &["stack_b"],
-                in_workspace: true,
-            },
-            StackSpec {
-                id: 3,
-                branches_base_to_top: &["stack_c"],
+                branches_base_to_top: &["stack_d"],
                 in_workspace: true,
             },
         ],

--- a/crates/gitbutler-branch-actions/tests/branch-actions/workspace_commit.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/workspace_commit.rs
@@ -4,7 +4,9 @@
 )]
 
 use anyhow::Result;
+use but_testsupport::visualize_tree;
 use gitbutler_stack::VirtualBranchesHandle;
+use gix::prelude::ObjectIdExt;
 use tempfile::TempDir;
 
 use but_ctx::Context;
@@ -109,42 +111,83 @@ fn merge_workspace_succeeds_with_adjacent_hunks_from_both_sides() -> Result<()> 
     Ok(())
 }
 
-/// Regression test for a merge-base mismatch between `merge_workspace` and
-/// `remerged_workspace_tree_v2`.
+/// Regression test for a merge-base mismatch in `merge_workspace`.
 ///
-/// Three stacks based on different upstream commits inherit different versions
-/// of `shared.txt` that none of them intentionally modified. The fix uses the
-/// target's tree as merge base (matching `remerged_workspace_tree_v2`), which
-/// produces a clean merge. The old behavior used `merge_base_octopus` which
-/// fell behind the target, causing false conflicts.
+/// The graph is:
 ///
-/// This directly tests `WorkspaceState::create_from_heads_and_target` and
-/// `merge_workspace` — the exact code path that was fixed.
+/// ```text
+/// * C: {x, y, c}
+/// |
+/// * B: {x, b, c} (target)
+/// |
+/// |  * D: {a, b, z}
+/// |/
+/// * A: {a, b, c}
+/// ```
+///
+/// Merging C and D against their real merge base A applies `A -> C` plus
+/// `A -> D`, producing `{x, y, z}`. Using the target B as the merge base would
+/// also apply the inverse of B's change and incorrectly produce `{a, y, z}`.
 #[test]
 fn merge_workspace_with_diverged_stacks() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("diverged-stacks")?;
 
     let repo = ctx.repo.get()?;
-    let target_oid = repo.rev_parse_single("current-target")?.detach();
-    let head_oids: Vec<gix::ObjectId> = ["stack_a", "stack_b", "stack_c"]
+    let target_oid = repo.rev_parse_single("target-b")?.detach();
+    let head_oids: Vec<gix::ObjectId> = ["stack_c", "stack_d"]
         .iter()
         .map(|name| repo.rev_parse_single(*name).map(|id| id.detach()))
         .collect::<Result<_, _>>()?;
 
-    // Build WorkspaceState from the stack heads and target — this is exactly
-    // what `integrate_upstream` does before calling `merge_workspace`.
     let workspace =
         gitbutler_workspace::branch_trees::WorkspaceState::create_from_heads_and_target(
             &repo, &head_oids, target_oid,
         )?;
 
-    // With the fix (target tree as base), this merges cleanly because each
-    // stack's inherited shared.txt differs in a different section.
-    // With the old code (octopus base = init), this would fail because all
-    // stacks replace "base content" with different multi-line content.
     let gix_repo = ctx.clone_repo_for_merging()?;
-    gitbutler_workspace::branch_trees::merge_workspace(&gix_repo, &workspace)
-        .expect("workspace should merge cleanly with target tree as base");
+    let merged_tree_id = gitbutler_workspace::branch_trees::merge_workspace(&gix_repo, &workspace)
+        .expect("workspace should merge cleanly with per-stack merge bases");
+
+    insta::assert_snapshot!(
+        visualize_tree(merged_tree_id.attach(&gix_repo)),
+        "merged tree should contain x, y, and z when C and D are merged using A as their merge base",
+        @r#"
+    8999a87
+    ├── x:100644:587be6b "x\n"
+    ├── y:100644:975fbec "y\n"
+    └── z:100644:b680253 "z\n"
+    "#
+    );
+
+    Ok(())
+}
+
+/// Regression test for the same merge-base mismatch in
+/// `remerged_workspace_tree_v2`, which updates the workspace commit.
+#[test]
+fn update_workspace_commit_with_diverged_stacks_preserves_target_content() -> Result<()> {
+    let (ctx, _temp_dir) = command_ctx("diverged-stacks")?;
+
+    gitbutler_branch_actions::update_workspace_commit(&ctx, false)?;
+
+    let repo = ctx.repo.get()?;
+    let ws_ref = repo.find_reference("refs/heads/gitbutler/workspace")?;
+    let ws_tree_id = ws_ref
+        .into_fully_peeled_id()?
+        .object()?
+        .try_into_commit()?
+        .tree_id()?;
+
+    insta::assert_snapshot!(
+        visualize_tree(ws_tree_id),
+        "workspace commit tree should contain x, y, and z when C and D are merged using A as their merge base",
+        @r#"
+    8999a87
+    ├── x:100644:587be6b "x\n"
+    ├── y:100644:975fbec "y\n"
+    └── z:100644:b680253 "z\n"
+    "#
+    );
 
     Ok(())
 }

--- a/crates/gitbutler-branch-actions/tests/fixtures/workspace-commit.sh
+++ b/crates/gitbutler-branch-actions/tests/fixtures/workspace-commit.sh
@@ -98,91 +98,43 @@ git clone remote adjacent-stacks
   git commit --allow-empty -m "GitButler Workspace Commit"
 )
 
-# Reproduces a merge-base mismatch between merge_workspace and remerged_workspace_tree_v2.
-#
-# Three stacks based on different upstream commits, so their trees inherit
-# different versions of shared.txt. Neither stack modifies shared.txt itself.
-#
-# Remote history: init -> v1 -> v2 -> v3 (target)
-# v1 and v2 each modify a DIFFERENT section of shared.txt relative to v3.
-# v3 has the "canonical" content (target version).
-#
-# merge_base_octopus(stack_a, stack_b, stack_c, v3) = init ("base content").
-# With init as base, stacks replace "base content" with different multi-line
-# content → conflict.
-# With target (v3) as base, stack_a changes section A only, stack_b changes
-# section B only → non-overlapping → clean merge.
-#
-# The test advances origin/main to v4 to trigger integrate_upstream.
-(cd remote
-  git config user.name "Author"
-  git config user.email "author@example.com"
-
-  # v1: section A differs from v3, sections B and C match v3.
-  printf '%s\n' \
-    "--- section A ---" "ALPHA ONE" "ALPHA TWO" "ALPHA THREE" \
-    "--- section B ---" "line b1" "line b2" "line b3" \
-    "--- section C ---" "line c1" "line c2" "line c3" > shared.txt
-  git add . && git commit -m "upstream: shared.txt v1"
-
-  # v2: section A matches v3, section B differs from v3, section C matches v3.
-  printf '%s\n' \
-    "--- section A ---" "line a1" "line a2" "line a3" \
-    "--- section B ---" "BRAVO ONE" "BRAVO TWO" "BRAVO THREE" \
-    "--- section C ---" "line c1" "line c2" "line c3" > shared.txt
-  git add . && git commit -m "upstream: shared.txt v2"
-
-  # v3 (target): canonical content — all sections in their "final" form.
-  printf '%s\n' \
-    "--- section A ---" "line a1" "line a2" "line a3" \
-    "--- section B ---" "line b1" "line b2" "line b3" \
-    "--- section C ---" "line c1" "line c2" "line c3" > shared.txt
-  git add . && git commit -m "upstream: shared.txt v3"
-)
-
 git clone remote diverged-stacks
 (cd diverged-stacks
   git config user.name "Author"
   git config user.email "author@example.com"
 
-  # v3 is the current target; v4 will be the new upstream the test advances to.
-  git tag current-target origin/main
+  # A: {a, b, c}
+  git rm -q file shared.txt
+  echo "a" > a
+  echo "b" > b
+  echo "c" > c
+  commit_with_tick "A: base set"
+  git tag base-a
 
-  # Create v4 on remote (the commit the test will advance origin/main to).
-  (cd ../remote
-    echo "unrelated new file" > new_upstream.txt
-    git add . && git commit -m "upstream: add new_upstream.txt"
-  )
-  git fetch origin
+  # B: {x, b, c}; this is the target.
+  rm a
+  echo "x" > x
+  commit_with_tick "B: target replaces a with x"
+  git tag target-b
 
-  git tag upstream-target origin/main
+  # C: {x, y, c}
+  rm b
+  echo "y" > y
+  commit_with_tick "C: stack replaces b with y"
+  git branch stack_c
 
-  # stack_a: child of v1, only adds file_a.txt (inherits shared.txt = "v1")
-  git checkout -b stack_a current-target~2
-  echo "stack a work" > file_a.txt
-  commit_with_tick "stack_a: add file_a"
+  # D: {a, b, z}
+  git checkout -b stack_d base-a
+  rm c
+  echo "z" > z
+  commit_with_tick "D: stack replaces c with z"
 
-  # stack_b: child of v2, only adds file_b.txt (inherits shared.txt = "v2 ...")
-  git checkout -b stack_b current-target~1
-  echo "stack b work" > file_b.txt
-  commit_with_tick "stack_b: add file_b"
+  git update-ref refs/remotes/origin/main target-b
 
-  # stack_c: child of v3, only adds file_c.txt (inherits shared.txt = "v3 ...")
-  git checkout -b stack_c current-target
-  echo "stack c work" > file_c.txt
-  commit_with_tick "stack_c: add file_c"
-
-  # Target metadata points to v3 (= current-target).
-  # origin/main still points to v4; the test will set it to upstream-target.
-  git update-ref refs/remotes/origin/main current-target
-
-  # Build a workspace commit with all three stacks as parents so that
-  # stacks_v3 can discover them from the commit graph.
-  stack_a_oid=$(git rev-parse stack_a)
-  stack_b_oid=$(git rev-parse stack_b)
   stack_c_oid=$(git rev-parse stack_c)
+  stack_d_oid=$(git rev-parse stack_d)
   tree=$(git rev-parse stack_c^{tree})
-  ws_commit=$(echo "GitButler Workspace Commit" | git commit-tree "$tree" -p "$stack_a_oid" -p "$stack_b_oid" -p "$stack_c_oid")
+  ws_commit=$(echo "GitButler Workspace Commit" | git commit-tree "$tree" -p "$stack_c_oid" -p "$stack_d_oid")
   git checkout -b gitbutler/workspace
   git reset --hard "$ws_commit"
 )

--- a/crates/gitbutler-workspace/src/branch_trees.rs
+++ b/crates/gitbutler-workspace/src/branch_trees.rs
@@ -40,9 +40,25 @@ impl WorkspaceState {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        // Use the target's tree directly as the merge base, matching
-        // `remerged_workspace_tree_v2`.
-        let base_tree_id = repo.find_commit(target_base_oid)?.tree_id()?.detach();
+        let base_tree_id = if head_oids.is_empty() {
+            repo.find_real_tree(&repo.find_commit(target_base_oid)?, Default::default())?
+                .detach()
+        } else if head_oids.len() == 1 {
+            repo.find_real_tree(
+                &repo.find_commit(*head_oids.first().expect("Head oids is len 1"))?,
+                Default::default(),
+            )?
+            .detach()
+        } else {
+            repo.find_real_tree(
+                &repo
+                    .merge_base_octopus(head_oids.iter().cloned())?
+                    .object()?
+                    .into_commit(),
+                Default::default(),
+            )?
+            .detach()
+        };
 
         Ok(WorkspaceState {
             heads,
@@ -168,6 +184,12 @@ pub fn merge_workspace(
     repo: &gix::Repository,
     workspace: &WorkspaceState,
 ) -> Result<gix::ObjectId> {
+    if workspace.heads.is_empty() {
+        return Ok(workspace.base);
+    } else if workspace.heads.len() == 1 {
+        return Ok(*workspace.heads.first().expect("List is length 1"));
+    }
+
     let mut output = workspace.base;
     let base = workspace.base;
 


### PR DESCRIPTION
## What used to go wrong

The workspace tree is rebuilt by merging the applied stacks. Both rebuild paths — `remerged_workspace_tree_v2` (workspace-HEAD updates) and `merge_workspace` (integrate-upstream) — **seeded the merge with the target tree** and merged each stack onto it.

That breaks the invariant that the workspace tree is a faithful merge of the **stack heads** (the workspace commit's parents). It bites whenever a stack's base has drifted from the persisted target (the `[default_target]` commit in `virtual_branches.toml`, ≈ your local `master`), in two ways — each surfacing as phantom uncommitted changes:

```
o──o──T   (persisted target)
│
└─ stack  (forked below T)
```

1. **Stack below the target loses upstream commits.** With T's tree as the merge base, commits the stack predates look like deletions the stack made → stripped from the workspace tree. (This was the refactor-disappearing case.)
2. **Target ahead of all stacks injects target-only content.** If T has files no stack carries, seeding from T puts them in the workspace tree even though no parent has them.

Either way HEAD's tree stops matching the worktree, so `git status` reports the difference as edits nobody made. Trigger: an op that rebuilds the workspace HEAD — most often an amend on an *unrelated* stack.

## How it's fixed

Octopus-merge the **stack heads only** — the target is never a merge input (only the empty-workspace fallback). Every head is merged against a **single shared base: the octopus merge-base (lowest common ancestor) of all heads**, which keeps the result independent of stack order and turns genuine disagreements into conflicts rather than order-dependent picks.

`WorkspaceState` now holds commit ids (`heads` + `target`) instead of pre-resolved trees; its trivial constructor is `from_heads_and_target`.

> **Why a single base is enough (no recursive/virtual base):** a virtual base would only matter if two stack heads had *multiple* merge-bases (a criss-cross). Cross-stack merges don't exist, so every common ancestor of two heads lives in the target history — and when stacks share a fork point that point dominates everything below, giving exactly one merge-base. The only way to get two is the doubly-anomalous case of stacks forked at *different* target commits **and** a criss-cross in the target's own history straddling those forks.

## Tests

`diverged-stacks` fixture — one change per commit, no reverts; `data.txt` has three slots:

```
A {AAA,BBB,CCC}  base = merge-base of the two stacks
├─ B {XXX,BBB,CCC}  target            (slot1 AAA→XXX)
│  └─ stack_c {XXX,YYY,CCC}  on target (slot2 BBB→YYY)
└─ stack_d {AAA,BBB,ZZZ}  below target (slot3 CCC→ZZZ)
```

| test | guards |
|---|---|
| `merge_workspace_merges_stack_heads_only` | (1) merge is `{XXX,YYY,ZZZ}`; `stack_d` must not resurrect the phantom `AAA` the target introduced |
| `update_workspace_commit_merges_stack_heads_only` | (1) same, end-to-end through the workspace-HEAD path |
| `merge_workspace_excludes_target_only_content` | (2) a target-only file (`only_upstream.txt`) must not leak in |

Each fails on the pre-fix target-seeded behavior (verified by reverting).