### PR TITLE
but-workspace: worktree module

### DIFF
--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -65,6 +65,8 @@ mod upstream_integration;
 pub use upstream_integration::{
     BottomUpdate, BottomUpdateKind, IntegrateUpstreamOutcome, integrate_upstream,
 };
+mod worktree;
+pub use worktree::worktree_conflicts_for_rebase;
 
 /// Information about refs, as seen from within or outsie of a workspace.
 ///

--- a/crates/but-workspace/src/worktree.rs
+++ b/crates/but-workspace/src/worktree.rs
@@ -1,0 +1,104 @@
+//! Utilities for reasoning about the repository worktree.
+
+use std::collections::BTreeSet;
+
+use anyhow::{Context, Result};
+use but_core::{Commit, RefMetadata, RepositoryExt};
+use but_rebase::graph_rebase::SuccessfulRebase;
+use gix::merge::tree::TreatAsUnresolved;
+use gix::prelude::ObjectIdExt;
+
+/// Return paths in the current dirty worktree that would conflict if applied
+/// onto the workspace head produced by `rebase`.
+///
+/// This is intentionally preview-oriented: it uses the in-memory repository
+/// behind the rebase result so callers can compute conflicts before
+/// materialization, including during dry-runs.
+pub fn worktree_conflicts_for_rebase<M: RefMetadata>(
+    rebase: &SuccessfulRebase<'_, '_, M>,
+) -> Result<Vec<but_serde::BStringForFrontend>> {
+    let repo = rebase.repo();
+    let current_head_tree = repo.head_tree_id_or_empty()?.detach();
+    let dirty_worktree_trees = dirty_worktree_trees(repo, current_head_tree)?;
+    if dirty_worktree_trees.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let preview_workspace = rebase.overlayed_graph()?.into_workspace()?;
+    let resulting_head = preview_workspace
+        .graph
+        .entrypoint()?
+        .commit()
+        .context("Cannot compute worktree conflicts without a resulting workspace head")?;
+    let resulting_head_tree =
+        Commit::from_id(resulting_head.id.attach(repo))?.tree_id_or_auto_resolution()?;
+
+    let (merge_options, _) = repo.merge_options_no_rewrites_fail_fast()?;
+    let conflict_kind = TreatAsUnresolved::git();
+    let mut conflicts = BTreeSet::new();
+
+    for dirty_worktree_tree in dirty_worktree_trees {
+        let merge = repo.merge_trees(
+            current_head_tree,
+            resulting_head_tree,
+            dirty_worktree_tree,
+            repo.default_merge_labels(),
+            merge_options
+                .clone()
+                .with_fail_on_conflict(Some(conflict_kind)),
+        )?;
+
+        conflicts.extend(
+            merge
+                .conflicts
+                .iter()
+                .filter(|conflict| conflict.is_unresolved(conflict_kind))
+                .map(|conflict| conflict.ours.location().to_owned()),
+        );
+    }
+
+    Ok(conflicts.into_iter().map(Into::into).collect())
+}
+
+fn dirty_worktree_trees(
+    repo: &gix::Repository,
+    current_head_tree: gix::ObjectId,
+) -> Result<Vec<gix::ObjectId>> {
+    let changes = but_core::diff::worktree_changes_no_renames(repo)?;
+    if changes.changes.is_empty()
+        && changes.index_changes.is_empty()
+        && changes.index_conflicts.is_empty()
+    {
+        return Ok(Vec::new());
+    }
+
+    let mut selection = changes
+        .changes
+        .iter()
+        .map(|change| change.path.clone())
+        .collect::<BTreeSet<_>>();
+    selection.extend(
+        changes
+            .index_changes
+            .iter()
+            .map(|change| change.location().to_owned()),
+    );
+    selection.extend(changes.index_conflicts.iter().map(|(path, _)| path.clone()));
+
+    let snapshot = but_core::snapshot::create_tree(
+        current_head_tree.attach(repo),
+        but_core::snapshot::create_tree::State {
+            changes,
+            selection,
+            head: false,
+        },
+    )?;
+
+    let mut trees = Vec::new();
+    for tree in [snapshot.worktree, snapshot.index].into_iter().flatten() {
+        if tree != current_head_tree && !trees.contains(&tree) {
+            trees.push(tree);
+        }
+    }
+    Ok(trees)
+}

--- a/crates/but-workspace/tests/workspace/main.rs
+++ b/crates/but-workspace/tests/workspace/main.rs
@@ -11,5 +11,6 @@ mod target_history;
 mod tree_manipulation;
 mod ui;
 mod upstream_integration;
+mod worktree;
 
 mod utils;

--- a/crates/but-workspace/tests/workspace/worktree.rs
+++ b/crates/but-workspace/tests/workspace/worktree.rs
@@ -1,0 +1,227 @@
+use anyhow::{Context, Result};
+use but_graph::init::Options;
+use but_meta::virtual_branches_legacy_types::Target;
+use but_rebase::graph_rebase::mutate::RelativeTo;
+use but_workspace::{
+    BottomUpdate, BottomUpdateKind, integrate_upstream, worktree_conflicts_for_rebase,
+};
+
+use crate::ref_info::with_workspace_commit::utils::{
+    StackState, add_stack, named_writable_scenario_with_description,
+};
+
+#[test]
+fn conflict_preview_reports_dirty_worktree_paths() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) = upstream_conflict_fixture()?;
+    std::fs::write(
+        repo.workdir_path("shared.txt").expect("non-bare"),
+        "dirty\n",
+    )?;
+    let mut workspace = workspace_for_stack(&repo, &meta)?;
+
+    let rebase = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A")?.detach()),
+        }],
+    )?
+    .rebase;
+
+    let conflicts = worktree_conflicts_for_rebase(&rebase)?;
+
+    assert_eq!(
+        conflicts,
+        vec![but_serde::BStringForFrontend::from("shared.txt")],
+        "dirty worktree changes conflicting with the preview head should be reported"
+    );
+    Ok(())
+}
+
+#[test]
+fn conflict_preview_includes_index_conflicts_when_worktree_is_dirty() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) = upstream_conflict_fixture()?;
+    std::fs::write(
+        repo.workdir_path("shared.txt").expect("non-bare"),
+        "staged\n",
+    )?;
+    git(&repo, ["add", "shared.txt"])?;
+    std::fs::write(
+        repo.workdir_path("unrelated.txt").expect("non-bare"),
+        "dirty\n",
+    )?;
+    let mut workspace = workspace_for_stack(&repo, &meta)?;
+
+    let rebase = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A")?.detach()),
+        }],
+    )?
+    .rebase;
+
+    let conflicts = worktree_conflicts_for_rebase(&rebase)?;
+
+    assert_eq!(
+        conflicts,
+        vec![but_serde::BStringForFrontend::from("shared.txt")],
+        "staged changes should be checked even when unstaged worktree changes are present"
+    );
+    Ok(())
+}
+
+#[test]
+fn conflict_preview_uses_rebase_repo_for_preview_objects() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) = upstream_conflict_fixture()?;
+    std::fs::write(
+        repo.workdir_path("shared.txt").expect("non-bare"),
+        "dirty\n",
+    )?;
+    let mut workspace = workspace_for_stack(&repo, &meta)?;
+
+    let rebase = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A")?.detach()),
+        }],
+    )?
+    .rebase;
+
+    let preview_workspace = rebase.overlayed_graph()?.into_workspace()?;
+    let preview_head = preview_workspace
+        .graph
+        .entrypoint()?
+        .commit()
+        .context("preview workspace should have a head commit")?
+        .id;
+    assert!(
+        repo.find_object(preview_head).is_err(),
+        "preview commits should not have to exist in the persistent repository before materialization"
+    );
+
+    let conflicts = worktree_conflicts_for_rebase(&rebase)?;
+
+    assert_eq!(
+        conflicts,
+        vec![but_serde::BStringForFrontend::from("shared.txt")],
+        "conflict preview should read rewritten objects from the rebase repository"
+    );
+    Ok(())
+}
+
+#[test]
+fn conflict_preview_returns_empty_for_non_conflicting_dirty_worktree() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) = upstream_conflict_fixture()?;
+    std::fs::write(
+        repo.workdir_path("unrelated.txt").expect("non-bare"),
+        "dirty\n",
+    )?;
+    let mut workspace = workspace_for_stack(&repo, &meta)?;
+
+    let rebase = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A")?.detach()),
+        }],
+    )?
+    .rebase;
+
+    let conflicts = worktree_conflicts_for_rebase(&rebase)?;
+
+    assert!(
+        conflicts.is_empty(),
+        "dirty worktree changes that merge cleanly should not be reported"
+    );
+    Ok(())
+}
+
+#[test]
+fn conflict_preview_returns_empty_for_ignored_only_worktree_changes() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) = upstream_conflict_fixture()?;
+    std::fs::write(repo.git_dir().join("info/exclude"), "ignored.txt\n")?;
+    std::fs::write(
+        repo.workdir_path("ignored.txt").expect("non-bare"),
+        "ignored\n",
+    )?;
+    let mut workspace = workspace_for_stack(&repo, &meta)?;
+
+    let rebase = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A")?.detach()),
+        }],
+    )?
+    .rebase;
+
+    let conflicts = worktree_conflicts_for_rebase(&rebase)?;
+
+    assert!(
+        conflicts.is_empty(),
+        "ignored-only changes cannot be represented in the snapshot and should be a no-op"
+    );
+    Ok(())
+}
+
+fn upstream_conflict_fixture() -> Result<(
+    but_testsupport::gix_testtools::tempfile::TempDir,
+    gix::Repository,
+    but_meta::VirtualBranchesTomlMetadata,
+    String,
+)> {
+    let (tmp, repo, mut meta, description) =
+        named_writable_scenario_with_description("remote-diverged-with-workspace-conflicting")?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "A"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    add_stack(&mut meta, 1, "A", StackState::InWorkspace);
+
+    Ok((tmp, repo, meta, description))
+}
+
+fn workspace_for_stack(
+    repo: &gix::Repository,
+    meta: &but_meta::VirtualBranchesTomlMetadata,
+) -> Result<but_graph::Workspace> {
+    let target_sha = repo.rev_parse_single("main")?.detach();
+    let ws = but_graph::Graph::from_head(
+        repo,
+        meta,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?
+    .into_workspace()?;
+    Ok(ws)
+}
+
+fn git(
+    repo: &gix::Repository,
+    args: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>,
+) -> Result<()> {
+    let status = std::process::Command::new("git")
+        .current_dir(repo.workdir().expect("writable scenarios are non-bare"))
+        .args(args)
+        .status()?;
+    assert!(status.success(), "git command should succeed");
+    Ok(())
+}


### PR DESCRIPTION
Add an utility to detect whether the uncommitted changes would conflict
after a rebase operation.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #14108 
- <kbd>&nbsp;2&nbsp;</kbd> #14107 
- <kbd>&nbsp;1&nbsp;</kbd> #14106 👈 
<!-- GitButler Footer Boundary Bottom -->

