### PR TITLE
upstream integration: use the new API

### DIFF
--- a/apps/desktop/src/components/settings/ExperimentalSettings.svelte
+++ b/apps/desktop/src/components/settings/ExperimentalSettings.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	import { fModeEnabled, newPushFeature } from "$lib/config/uiFeatureFlags";
+	import {
+		fModeEnabled,
+		newIntegrateUpstreamModalFeature,
+		newPushFeature,
+	} from "$lib/config/uiFeatureFlags";
 	import { SETTINGS_SERVICE } from "$lib/settings/appSettings";
 	import { USER_SERVICE } from "$lib/user/userService.svelte";
 	import { inject } from "@gitbutler/core/context";
@@ -67,6 +71,22 @@
 				id="new-push"
 				checked={$newPushFeature}
 				onclick={() => newPushFeature.set(!$newPushFeature)}
+			/>
+		{/snippet}
+	</CardGroup.Item>
+
+	<CardGroup.Item labelFor="new-integrate-upstream-modal">
+		{#snippet title()}
+			New integrate upstream modal
+		{/snippet}
+		{#snippet caption()}
+			Use the newer upstream integration flow. Disable to use the deprecated modal.
+		{/snippet}
+		{#snippet actions()}
+			<Toggle
+				id="new-integrate-upstream-modal"
+				checked={$newIntegrateUpstreamModalFeature}
+				onclick={() => newIntegrateUpstreamModalFeature.set(!$newIntegrateUpstreamModalFeature)}
 			/>
 		{/snippet}
 	</CardGroup.Item>

--- a/apps/desktop/src/components/upstream/IntegrateUpstreamModal.svelte
+++ b/apps/desktop/src/components/upstream/IntegrateUpstreamModal.svelte
@@ -4,45 +4,24 @@
 	import { BASE_BRANCH_SERVICE } from "$lib/baseBranch/baseBranchService.svelte";
 	import { descriptionTitle } from "$lib/commits/commit";
 	import { commitUrl, FORGE_INFO_SERVICE } from "$lib/forge/forgeInfo.svelte";
-	import { getStackBranchNames } from "$lib/stacks/stack";
 	import {
-		getBaseBranchResolution,
-		stackFullyIntegrated,
-		sortStatusInfoV3,
-		getResolutionApproachV3,
-		type StackStatusInfoV3,
-		type StackStatusesWithBranchesV3,
+		sortUpstreamIntegrationStatus,
+		type UpstreamIntegrationStackStatus,
+		type UpstreamIntegrationStatuses,
 	} from "$lib/upstream/types";
 	import { UPSTREAM_INTEGRATION_SERVICE } from "$lib/upstream/upstreamIntegrationService.svelte";
 	import { inject } from "@gitbutler/core/context";
-	import {
-		getBooleanStorageItem,
-		removeStorageItem,
-		setBooleanStorageItem,
-	} from "@gitbutler/shared/persisted";
 	import {
 		Badge,
 		Button,
 		IntegrationSeriesRow,
 		Modal,
 		SimpleCommitRow,
-		FileListItem,
-		Select,
-		SelectItem,
 		ScrollableContainer,
-		type BranchShouldBeDeletedMap,
 		TestId,
 		AsyncButton,
 	} from "@gitbutler/ui";
 	import { tick } from "svelte";
-	import { SvelteMap } from "svelte/reactivity";
-	import type { PullRequest } from "$lib/forge/interface/types";
-	import type {
-		BaseBranchResolutionApproach,
-		BranchStatus,
-		Resolution,
-		StackStatus,
-	} from "@gitbutler/but-sdk";
 
 	type OperationState = "inert" | "loading" | "completed";
 
@@ -65,159 +44,77 @@
 
 	let modal = $state<Modal>();
 	let integratingUpstream = $state<OperationState>("inert");
-	const results = new SvelteMap<string, Resolution>();
-	let statuses = $state<StackStatusInfoV3[]>([]);
-	const baseResolutionOptions = [
-		{ label: "Rebase", value: "rebase" as const },
-		{ label: "Merge", value: "merge" as const },
-		{ label: "Hard reset", value: "hardReset" as const },
-	];
-	let baseResolutionApproach = $state<BaseBranchResolutionApproach | undefined>();
-	let targetCommitOid = $state<string | undefined>(undefined);
-	let branchStatuses = $state<StackStatusesWithBranchesV3 | undefined>();
-	// const stackService = getContext(StackService);
-	// let appliedBranches = $state<string[]>();
-	// Any PRs belonging to applied branches that have been merged
-	let filteredReviews = $state<PullRequest[]>([]);
-	const reviewMap = $derived(new Map(filteredReviews?.map((r) => [r.sourceBranch, r])));
+	let statuses = $state<UpstreamIntegrationStackStatus[]>([]);
+	let integrationStatuses = $state<UpstreamIntegrationStatuses | undefined>();
+	let statusRequest = 0;
 
-	const isDivergedResolved = $derived(base?.targetShaAheadOfRef && !baseResolutionApproach);
+	const baseLoaded = $derived(!!base);
+	const isBaseDiverged = $derived(!!base?.targetShaAheadOfRef);
+	const canIntegrate = $derived(
+		baseLoaded &&
+			!isBaseDiverged &&
+			!!integrationStatuses &&
+			integrationStatuses.updates.length > 0,
+	);
 	const [integrateUpstream] = $derived(upstreamIntegrationService.integrateUpstream());
 
-	function someBranchesShouldNotBeDeleted(branchNames: string[]): boolean {
-		for (const branchName of branchNames) {
-			const key = getDontDeleteBranchStorageKey(branchName);
-			const dontDelete = getBooleanStorageItem(key);
-			if (dontDelete) {
-				return true;
-			}
-		}
-		return false;
+	async function loadStatuses() {
+		const request = ++statusRequest;
+		integrationStatuses = undefined;
+		statuses = [];
+
+		const nextStatuses = await upstreamIntegrationService.upstreamStatuses(projectId);
+		if (request !== statusRequest || isBaseDiverged) return;
+
+		const statusesTmp = [...nextStatuses.subject];
+		statusesTmp.sort(sortUpstreamIntegrationStatus);
+
+		integrationStatuses = nextStatuses;
+		statuses = statusesTmp;
 	}
 
 	$effect(() => {
 		if (!modal?.imports.open) return;
-		if (branchStatuses?.type !== "updatesRequired") {
+
+		if (!baseLoaded) {
+			statusRequest++;
+			integrationStatuses = undefined;
 			statuses = [];
 			return;
 		}
 
-		const statusesTmp = [...branchStatuses.subject];
-		statusesTmp.sort(sortStatusInfoV3);
-
-		// Side effect, refresh results
-		results.clear();
-		for (const status of statusesTmp) {
-			if (status.stack.id) {
-				const dontDelete = someBranchesShouldNotBeDeleted(getStackBranchNames(status.stack));
-
-				results.set(status.stack.id, {
-					stackId: status.stack.id,
-					approach: getResolutionApproachV3(status),
-					deleteIntegratedBranches: !dontDelete,
-				});
-			}
+		if (isBaseDiverged) {
+			statusRequest++;
+			integrationStatuses = undefined;
+			statuses = [];
+			return;
 		}
 
-		statuses = statusesTmp;
+		void loadStatuses();
 	});
-
-	// Re-fetch upstream statuses if the target commit oid changes
-	$effect(() => {
-		if (!modal?.imports.open) return;
-		if (targetCommitOid) {
-			upstreamIntegrationService.upstreamStatuses(projectId, targetCommitOid).then((statuses) => {
-				branchStatuses = statuses;
-			});
-		}
-	});
-
-	// Resolve the target commit oid if the base branch diverged and the the resolution
-	// approach is changed
-	$effect(() => {
-		if (!modal?.imports.open) return;
-		if (base?.targetShaAheadOfRef && baseResolutionApproach) {
-			upstreamIntegrationService
-				.resolveUpstreamIntegrationMutation({
-					projectId,
-					resolutionApproach: baseResolutionApproach,
-				})
-				.then((result) => {
-					targetCommitOid = result;
-				});
-		} else {
-			// If there is no divergence we should set this to undefined.
-			targetCommitOid = undefined;
-		}
-	});
-
-	// async function setFilteredBranches(appliedBranches: string[]) {
-	// 	if (!forgeListingService) return;
-
-	// 	try {
-	// 		// Fetch the base branch and the forge info to ensure we have the
-	// 		// latest data We only need to (and want to) do this if we are also
-	// 		// looking at the reviews.
-	// 		//
-	// 		// This is to handle the case where the reviews might dictacte that
-	// 		// we should remove a branch, but we don't have the have the merge
-	// 		// commit yet. If we were to handle a branch as "integrated" without
-	// 		// the merge commit, files might disappear for a users working tree
-	// 		// in a supprising way.
-	// 		//
-	// 		// We could query both of these simultaneously using Promise.all,
-	// 		// but that is extra complexity that is not needed for now.
-	// 		await baseBranchService.fetchFromRemotes(projectId);
-	// 		const reviews = await forgeListingService.fetchByBranch(projectId, appliedBranches);
-
-	// 		// Find the reviews that have a "mergedAt" timestamp
-	// 		filteredReviews = reviews.filter((r) => !!r.mergedAt);
-	// 	} catch (_e) {
-	// 		// We don't really mind if this fails as additional bonus
-	// 		// information.
-	// 	}
-	// }
-
-	function getDontDeleteBranchStorageKey(branchName: string): string {
-		return `integrate-upstream-modal:dont-delete-branch:${projectId}:${branchName}`;
-	}
-
-	function handleBaseResolutionSelection(value: BaseBranchResolutionApproach["type"]) {
-		baseResolutionApproach = { type: value };
-	}
 
 	async function integrate() {
+		if (!canIntegrate || !integrationStatuses) return;
+
 		integratingUpstream = "loading";
 		await tick();
-		const baseResolution = getBaseBranchResolution(
-			targetCommitOid,
-			baseResolutionApproach ?? { type: "hardReset" },
-		);
 
 		await integrateUpstream({
 			projectId,
-			resolutions: Array.from(results.values()),
-			baseBranchResolution: baseResolution,
+			updates: integrationStatuses.updates,
+			dryRun: false,
 		});
 		await baseBranchService.refreshBaseBranch(projectId);
 		integratingUpstream = "completed";
 		modal?.close();
 	}
 
-	// async function fetchAppliedBranches() {
-	// 	const stacksResponse = await stackService.fetchStacks(projectId);
-	// 	return stacksResponse.data?.flatMap((stack) => stack.heads.map((head) => head.name)) ?? [];
-	// }
-
 	export async function show() {
 		integratingUpstream = "inert";
-		branchStatuses = undefined;
-		filteredReviews = [];
+		integrationStatuses = undefined;
+		statuses = [];
 		await tick();
 		modal?.show();
-		// appliedBranches = await fetchAppliedBranches();
-		// await setFilteredBranches(untrack(() => appliedBranches) ?? []); // TODO: Some day this will be made good
-		branchStatuses = await upstreamIntegrationService.upstreamStatuses(projectId, targetCommitOid);
 	}
 
 	export const imports = {
@@ -226,114 +123,21 @@
 		},
 	};
 
-	function branchStatusToRowEntry(
-		associatedeReview: PullRequest | undefined,
-		branchStatus: BranchStatus,
-	): "integrated" | "conflicted" | "clear" {
-		if (associatedeReview?.mergedAt !== undefined) {
-			return "integrated";
-		}
-
-		if (branchStatus.type === "integrated") {
-			return "integrated";
-		}
-
-		if (branchStatus.type === "conflicted") {
-			return "conflicted";
-		}
-
-		return "clear";
-	}
-
 	function integrationRowSeries(
-		stackStatus: StackStatus,
+		statusInfo: UpstreamIntegrationStackStatus,
 	): { name: string; status: "integrated" | "conflicted" | "clear" }[] {
-		const statuses = stackStatus.branchStatuses.map((series) => {
-			const associatedeReview = reviewMap.get(series.name);
-			return {
-				name: series.name,
-				status: branchStatusToRowEntry(associatedeReview, series.status),
-			};
-		});
-
-		statuses.reverse();
-
-		return statuses;
-	}
-	function getBranchShouldBeDeletedMap(
-		stackId: string,
-		stackStatus: StackStatus,
-	): BranchShouldBeDeletedMap {
-		const branchShouldBeDeletedMap: BranchShouldBeDeletedMap = {};
-		stackStatus.branchStatuses.forEach((branch) => {
-			branchShouldBeDeletedMap[branch.name] = !!results.get(stackId)?.deleteIntegratedBranches;
-		});
-		return branchShouldBeDeletedMap;
-	}
-
-	function updateBranchShouldBeDeletedMap(
-		stackId: string,
-		branchNames: string[],
-		shouldBeDeleted: boolean,
-	): void {
-		const result = results.get(stackId);
-		if (!result) return;
-		for (const branchName of branchNames) {
-			const key = getDontDeleteBranchStorageKey(branchName);
-			if (!shouldBeDeleted) {
-				setBooleanStorageItem(key, true);
-			} else {
-				removeStorageItem(key);
-			}
-		}
-		results.set(stackId, { ...result, deleteIntegratedBranches: shouldBeDeleted });
-	}
-
-	function integrationOptions(
-		stackStatus: StackStatus,
-	): { label: string; value: "rebase" | "unapply" | "merge" }[] {
-		if (stackStatus.branchStatuses.length > 1) {
-			return [
-				{ label: "Rebase", value: "rebase" },
-				{ label: "Stash", value: "unapply" },
-			];
-		} else {
-			return [
-				{ label: "Rebase", value: "rebase" },
-				{ label: "Merge", value: "merge" },
-				{ label: "Stash", value: "unapply" },
-			];
-		}
+		return [...statusInfo.branchStatuses].reverse();
 	}
 </script>
 
-{#snippet stackStatus(stackId: string, stackStatus: StackStatus)}
-	{@const branchShouldBeDeletedMap = getBranchShouldBeDeletedMap(stackId, stackStatus)}
+{#snippet stackStatus(statusInfo: UpstreamIntegrationStackStatus)}
 	<IntegrationSeriesRow
 		testId={TestId.IntegrateUpstreamSeriesRow}
-		series={integrationRowSeries(stackStatus)}
-		{branchShouldBeDeletedMap}
-		updateBranchShouldBeDeletedMap={(branchNames, shouldBeDeleted) =>
-			updateBranchShouldBeDeletedMap(stackId, branchNames, shouldBeDeleted)}
-	>
-		{#if !stackFullyIntegrated(stackStatus) && results.get(stackId)}
-			<Select
-				value={results.get(stackId)!.approach.type}
-				maxWidth={130}
-				onselect={(value) => {
-					const result = results.get(stackId)!;
-					results.set(stackId, { ...result, approach: { type: value } });
-				}}
-				options={integrationOptions(stackStatus)}
-			>
-				{#snippet itemSnippet({ item, highlighted })}
-					<SelectItem selected={highlighted} {highlighted}>
-						{item.label}
-					</SelectItem>
-				{/snippet}
-			</Select>
-		{/if}
-	</IntegrationSeriesRow>
+		series={integrationRowSeries(statusInfo)}
+		branchShouldBeDeletedMap={{}}
+		updateBranchShouldBeDeletedMap={() => {}}
+		showDeleteControls={false}
+	/>
 {/snippet}
 
 <Modal
@@ -370,73 +174,30 @@
 				</div>
 			</div>
 		{/if}
-		<!-- CONFLICTED FILES -->
-		{#if branchStatuses?.type === "updatesRequired" && branchStatuses?.worktreeConflicts.length > 0}
-			<div class="section">
-				<h3 class="text-14 text-semibold section-title">
-					<span>Conflicting uncommitted files</span>
-
-					<Badge>{branchStatuses?.worktreeConflicts.length}</Badge>
-				</h3>
-				<p class="text-12 clr-text-2">
-					Updating the workspace will add conflict markers to the following files.
-				</p>
-				<div class="scroll-wrap">
-					<ScrollableContainer maxHeight="15rem">
-						{@const conflicts = branchStatuses?.worktreeConflicts}
-						{#each conflicts as file, i}
-							<FileListItem
-								listMode="list"
-								filePath={file}
-								clickable={false}
-								conflicted
-								isLast={i === conflicts.length - 1}
-							/>
-						{/each}
-					</ScrollableContainer>
-				</div>
-			</div>
-		{/if}
 		<!-- DIVERGED -->
-		{#if base?.targetShaAheadOfRef}
+		{#if isBaseDiverged}
 			<div class="target-divergence">
 				<img class="target-icon" src="/images/domain-icons/trunk.svg" alt="" />
 
 				<div class="target-divergence-about">
 					<h3 class="text-14 text-semibold">Target branch divergence</h3>
 					<p class="text-12 text-body target-divergence-description">
-						<span class="text-bold">target/main</span> has diverged from the workspace.
+						<span class="text-bold">{base?.branchName ?? "The target branch"}</span> has diverged
+						from the workspace.
 						<br />
-						Select an action to proceed with updating.
+						Resolve target branch divergence before updating the workspace.
 					</p>
-				</div>
-
-				<div class="target-divergence-action">
-					<Select
-						value={baseResolutionApproach?.type}
-						placeholder="Choose…"
-						onselect={handleBaseResolutionSelection}
-						options={baseResolutionOptions}
-					>
-						{#snippet itemSnippet({ item, highlighted })}
-							<SelectItem selected={highlighted} {highlighted}>
-								{item.label}
-							</SelectItem>
-						{/snippet}
-					</Select>
 				</div>
 			</div>
 		{/if}
 		<!-- STACKS AND BRANCHES TO UPDATE -->
 		{#if statuses.length > 0}
-			<div class="section" class:section-disabled={isDivergedResolved}>
+			<div class="section">
 				<h3 class="text-14 text-semibold">To be updated:</h3>
 				<div class="scroll-wrap">
 					<ScrollableContainer maxHeight="15rem">
-						{#each statuses as { stack, status }}
-							{#if stack.id}
-								{@render stackStatus(stack.id, status)}
-							{/if}
+						{#each statuses as status}
+							{@render stackStatus(status)}
 						{/each}
 					</ScrollableContainer>
 				</div>
@@ -451,8 +212,8 @@
 				testId={TestId.IntegrateUpstreamActionButton}
 				wide
 				style="pop"
-				disabled={isDivergedResolved || !branchStatuses}
-				loading={integratingUpstream === "loading" || !branchStatuses}
+				disabled={!canIntegrate}
+				loading={integratingUpstream === "loading" || (!integrationStatuses && !isBaseDiverged)}
 				action={async () => {
 					await integrate();
 				}}
@@ -515,22 +276,10 @@
 		color: var(--text-2);
 	}
 
-	.target-divergence-action {
-		display: flex;
-		flex-direction: column;
-		max-width: 230px;
-	}
-
 	/* CONTROLS */
 	.controls {
 		display: flex;
 		width: 100%;
 		gap: 6px;
-	}
-
-	/* MODIFIERS */
-	.section-disabled {
-		opacity: 0.5;
-		pointer-events: none;
 	}
 </style>

--- a/apps/desktop/src/components/upstream/IntegrateUpstreamModalDeprecated.svelte
+++ b/apps/desktop/src/components/upstream/IntegrateUpstreamModalDeprecated.svelte
@@ -1,0 +1,541 @@
+<script lang="ts">
+	import { CLIPBOARD_SERVICE } from "$lib/backend/clipboard";
+	import { URL_SERVICE } from "$lib/backend/url";
+	import { BASE_BRANCH_SERVICE } from "$lib/baseBranch/baseBranchService.svelte";
+	import { descriptionTitle } from "$lib/commits/commit";
+	import { commitUrl, FORGE_INFO_SERVICE } from "$lib/forge/forgeInfo.svelte";
+	import { getStackBranchNames } from "$lib/stacks/stack";
+	import {
+		getBaseBranchResolution,
+		stackFullyIntegrated,
+		sortStatusInfoV3,
+		getResolutionApproachV3,
+		type StackStatusInfoV3,
+		type StackStatusesWithBranchesV3,
+	} from "$lib/upstream/typesDeprecated";
+	import { UPSTREAM_INTEGRATION_SERVICE_DEPRECATED } from "$lib/upstream/upstreamIntegrationServiceDeprecated.svelte";
+	import { inject } from "@gitbutler/core/context";
+	import {
+		getBooleanStorageItem,
+		removeStorageItem,
+		setBooleanStorageItem,
+	} from "@gitbutler/shared/persisted";
+	import {
+		Badge,
+		Button,
+		IntegrationSeriesRow,
+		Modal,
+		SimpleCommitRow,
+		FileListItem,
+		Select,
+		SelectItem,
+		ScrollableContainer,
+		type BranchShouldBeDeletedMap,
+		TestId,
+		AsyncButton,
+	} from "@gitbutler/ui";
+	import { tick } from "svelte";
+	import { SvelteMap } from "svelte/reactivity";
+	import type { PullRequest } from "$lib/forge/interface/types";
+	import type {
+		BaseBranchResolutionApproach,
+		BranchStatus,
+		Resolution,
+		StackStatus,
+	} from "@gitbutler/but-sdk";
+
+	type OperationState = "inert" | "loading" | "completed";
+
+	interface Props {
+		projectId: string;
+		onClose?: () => void;
+	}
+
+	const { projectId, onClose }: Props = $props();
+
+	const upstreamIntegrationService = inject(UPSTREAM_INTEGRATION_SERVICE_DEPRECATED);
+	const forgeInfoService = inject(FORGE_INFO_SERVICE);
+	const forgeInfoQuery = $derived(forgeInfoService.get(projectId));
+	const forgeInfo = $derived(forgeInfoQuery.response);
+	const baseBranchService = inject(BASE_BRANCH_SERVICE);
+	const baseBranchQuery = $derived(baseBranchService.baseBranch(projectId));
+	const base = $derived(baseBranchQuery.response);
+	const urlService = inject(URL_SERVICE);
+	const clipboardService = inject(CLIPBOARD_SERVICE);
+
+	let modal = $state<Modal>();
+	let integratingUpstream = $state<OperationState>("inert");
+	const results = new SvelteMap<string, Resolution>();
+	let statuses = $state<StackStatusInfoV3[]>([]);
+	const baseResolutionOptions = [
+		{ label: "Rebase", value: "rebase" as const },
+		{ label: "Merge", value: "merge" as const },
+		{ label: "Hard reset", value: "hardReset" as const },
+	];
+	let baseResolutionApproach = $state<BaseBranchResolutionApproach | undefined>();
+	let targetCommitOid = $state<string | undefined>(undefined);
+	let branchStatuses = $state<StackStatusesWithBranchesV3 | undefined>();
+	// const stackService = getContext(StackService);
+	// let appliedBranches = $state<string[]>();
+	// Any PRs belonging to applied branches that have been merged
+	let filteredReviews = $state<PullRequest[]>([]);
+	const reviewMap = $derived(new Map(filteredReviews?.map((r) => [r.sourceBranch, r])));
+
+	const isDivergedResolved = $derived(base?.targetShaAheadOfRef && !baseResolutionApproach);
+	const [integrateUpstream] = $derived(upstreamIntegrationService.integrateUpstream());
+
+	function someBranchesShouldNotBeDeleted(branchNames: string[]): boolean {
+		for (const branchName of branchNames) {
+			const key = getDontDeleteBranchStorageKey(branchName);
+			const dontDelete = getBooleanStorageItem(key);
+			if (dontDelete) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	$effect(() => {
+		if (!modal?.imports.open) return;
+		if (branchStatuses?.type !== "updatesRequired") {
+			statuses = [];
+			return;
+		}
+
+		const statusesTmp = [...branchStatuses.subject];
+		statusesTmp.sort(sortStatusInfoV3);
+
+		// Side effect, refresh results
+		results.clear();
+		for (const status of statusesTmp) {
+			if (status.stack.id) {
+				const dontDelete = someBranchesShouldNotBeDeleted(getStackBranchNames(status.stack));
+
+				results.set(status.stack.id, {
+					stackId: status.stack.id,
+					approach: getResolutionApproachV3(status),
+					deleteIntegratedBranches: !dontDelete,
+				});
+			}
+		}
+
+		statuses = statusesTmp;
+	});
+
+	// Re-fetch upstream statuses if the target commit oid changes
+	$effect(() => {
+		if (!modal?.imports.open) return;
+		if (targetCommitOid) {
+			upstreamIntegrationService.upstreamStatuses(projectId, targetCommitOid).then((statuses) => {
+				branchStatuses = statuses;
+			});
+		}
+	});
+
+	// Resolve the target commit oid if the base branch diverged and the the resolution
+	// approach is changed
+	$effect(() => {
+		if (!modal?.imports.open) return;
+		if (base?.targetShaAheadOfRef && baseResolutionApproach) {
+			upstreamIntegrationService
+				.resolveUpstreamIntegrationMutation({
+					projectId,
+					resolutionApproach: baseResolutionApproach,
+				})
+				.then((result) => {
+					targetCommitOid = result;
+				});
+		} else {
+			// If there is no divergence we should set this to undefined.
+			targetCommitOid = undefined;
+		}
+	});
+
+	// async function setFilteredBranches(appliedBranches: string[]) {
+	// 	if (!forgeListingService) return;
+
+	// 	try {
+	// 		// Fetch the base branch and the forge info to ensure we have the
+	// 		// latest data We only need to (and want to) do this if we are also
+	// 		// looking at the reviews.
+	// 		//
+	// 		// This is to handle the case where the reviews might dictacte that
+	// 		// we should remove a branch, but we don't have the have the merge
+	// 		// commit yet. If we were to handle a branch as "integrated" without
+	// 		// the merge commit, files might disappear for a users working tree
+	// 		// in a supprising way.
+	// 		//
+	// 		// We could query both of these simultaneously using Promise.all,
+	// 		// but that is extra complexity that is not needed for now.
+	// 		await baseBranchService.fetchFromRemotes(projectId);
+	// 		const reviews = await forgeListingService.fetchByBranch(projectId, appliedBranches);
+
+	// 		// Find the reviews that have a "mergedAt" timestamp
+	// 		filteredReviews = reviews.filter((r) => !!r.mergedAt);
+	// 	} catch (_e) {
+	// 		// We don't really mind if this fails as additional bonus
+	// 		// information.
+	// 	}
+	// }
+
+	function getDontDeleteBranchStorageKey(branchName: string): string {
+		return `integrate-upstream-modal:dont-delete-branch:${projectId}:${branchName}`;
+	}
+
+	function handleBaseResolutionSelection(value: BaseBranchResolutionApproach["type"]) {
+		baseResolutionApproach = { type: value };
+	}
+
+	async function integrate() {
+		integratingUpstream = "loading";
+		await tick();
+		const baseResolution = getBaseBranchResolution(
+			targetCommitOid,
+			baseResolutionApproach ?? { type: "hardReset" },
+		);
+
+		await integrateUpstream({
+			projectId,
+			resolutions: Array.from(results.values()),
+			baseBranchResolution: baseResolution,
+		});
+		await baseBranchService.refreshBaseBranch(projectId);
+		integratingUpstream = "completed";
+		modal?.close();
+	}
+
+	// async function fetchAppliedBranches() {
+	// 	const stacksResponse = await stackService.fetchStacks(projectId);
+	// 	return stacksResponse.data?.flatMap((stack) => stack.heads.map((head) => head.name)) ?? [];
+	// }
+
+	export async function show() {
+		integratingUpstream = "inert";
+		branchStatuses = undefined;
+		filteredReviews = [];
+		await tick();
+		modal?.show();
+		// appliedBranches = await fetchAppliedBranches();
+		// await setFilteredBranches(untrack(() => appliedBranches) ?? []); // TODO: Some day this will be made good
+		branchStatuses = await upstreamIntegrationService.upstreamStatuses(projectId, targetCommitOid);
+	}
+
+	export const imports = {
+		get open() {
+			return modal?.imports.open;
+		},
+	};
+
+	function branchStatusToRowEntry(
+		associatedeReview: PullRequest | undefined,
+		branchStatus: BranchStatus,
+	): "integrated" | "conflicted" | "clear" {
+		if (associatedeReview?.mergedAt !== undefined) {
+			return "integrated";
+		}
+
+		if (branchStatus.type === "integrated") {
+			return "integrated";
+		}
+
+		if (branchStatus.type === "conflicted") {
+			return "conflicted";
+		}
+
+		return "clear";
+	}
+
+	function integrationRowSeries(
+		stackStatus: StackStatus,
+	): { name: string; status: "integrated" | "conflicted" | "clear" }[] {
+		const statuses = stackStatus.branchStatuses.map((series) => {
+			const associatedeReview = reviewMap.get(series.name);
+			return {
+				name: series.name,
+				status: branchStatusToRowEntry(associatedeReview, series.status),
+			};
+		});
+
+		statuses.reverse();
+
+		return statuses;
+	}
+	function getBranchShouldBeDeletedMap(
+		stackId: string,
+		stackStatus: StackStatus,
+	): BranchShouldBeDeletedMap {
+		const branchShouldBeDeletedMap: BranchShouldBeDeletedMap = {};
+		stackStatus.branchStatuses.forEach((branch) => {
+			branchShouldBeDeletedMap[branch.name] = !!results.get(stackId)?.deleteIntegratedBranches;
+		});
+		return branchShouldBeDeletedMap;
+	}
+
+	function updateBranchShouldBeDeletedMap(
+		stackId: string,
+		branchNames: string[],
+		shouldBeDeleted: boolean,
+	): void {
+		const result = results.get(stackId);
+		if (!result) return;
+		for (const branchName of branchNames) {
+			const key = getDontDeleteBranchStorageKey(branchName);
+			if (!shouldBeDeleted) {
+				setBooleanStorageItem(key, true);
+			} else {
+				removeStorageItem(key);
+			}
+		}
+		results.set(stackId, { ...result, deleteIntegratedBranches: shouldBeDeleted });
+	}
+
+	function integrationOptions(
+		stackStatus: StackStatus,
+	): { label: string; value: "rebase" | "unapply" | "merge" }[] {
+		if (stackStatus.branchStatuses.length > 1) {
+			return [
+				{ label: "Rebase", value: "rebase" },
+				{ label: "Stash", value: "unapply" },
+			];
+		} else {
+			return [
+				{ label: "Rebase", value: "rebase" },
+				{ label: "Merge", value: "merge" },
+				{ label: "Stash", value: "unapply" },
+			];
+		}
+	}
+</script>
+
+{#snippet stackStatus(stackId: string, stackStatus: StackStatus)}
+	{@const branchShouldBeDeletedMap = getBranchShouldBeDeletedMap(stackId, stackStatus)}
+	<IntegrationSeriesRow
+		testId={TestId.IntegrateUpstreamSeriesRow}
+		series={integrationRowSeries(stackStatus)}
+		{branchShouldBeDeletedMap}
+		updateBranchShouldBeDeletedMap={(branchNames, shouldBeDeleted) =>
+			updateBranchShouldBeDeletedMap(stackId, branchNames, shouldBeDeleted)}
+	>
+		{#if !stackFullyIntegrated(stackStatus) && results.get(stackId)}
+			<Select
+				value={results.get(stackId)!.approach.type}
+				maxWidth={130}
+				onselect={(value) => {
+					const result = results.get(stackId)!;
+					results.set(stackId, { ...result, approach: { type: value } });
+				}}
+				options={integrationOptions(stackStatus)}
+			>
+				{#snippet itemSnippet({ item, highlighted })}
+					<SelectItem selected={highlighted} {highlighted}>
+						{item.label}
+					</SelectItem>
+				{/snippet}
+			</Select>
+		{/if}
+	</IntegrationSeriesRow>
+{/snippet}
+
+<Modal
+	testId={TestId.IntegrateUpstreamCommitsModal}
+	bind:this={modal}
+	{onClose}
+	width={520}
+	noPadding
+	onSubmit={() => integrate()}
+>
+	<ScrollableContainer maxHeight="70vh">
+		{#if base}
+			<div class="section">
+				<h3 class="text-14 text-semibold section-title">
+					<span>Incoming {base.upstreamCommits.length === 1 ? "change" : "changes"}</span><Badge
+						>{base.upstreamCommits.length}</Badge
+					>
+				</h3>
+				<h3 class="text-11 section-title">
+					<Badge style="warning" kind="soft" icon="warning">Deprecated:</Badge>
+					This is the older modal, using deprecated APIs. Please consider enabling the new integration
+					modal in the experimental settings.
+				</h3>
+				<div class="scroll-wrap">
+					<ScrollableContainer maxHeight="16.5rem">
+						{#each base.upstreamCommits as commit}
+							{@const url = forgeInfo ? commitUrl(forgeInfo, commit.id) : undefined}
+							<SimpleCommitRow
+								title={descriptionTitle(commit) ?? ""}
+								sha={commit.id}
+								date={new Date(commit.createdAt)}
+								author={commit.author.name}
+								{url}
+								onOpen={(url) => urlService.openExternalUrl(url)}
+								onCopy={() => clipboardService.write(commit.id, { message: "Commit hash copied" })}
+							/>
+						{/each}
+					</ScrollableContainer>
+				</div>
+			</div>
+		{/if}
+		<!-- CONFLICTED FILES -->
+		{#if branchStatuses?.type === "updatesRequired" && branchStatuses?.worktreeConflicts.length > 0}
+			<div class="section">
+				<h3 class="text-14 text-semibold section-title">
+					<span>Conflicting uncommitted files</span>
+
+					<Badge>{branchStatuses?.worktreeConflicts.length}</Badge>
+				</h3>
+				<p class="text-12 clr-text-2">
+					Updating the workspace will add conflict markers to the following files.
+				</p>
+				<div class="scroll-wrap">
+					<ScrollableContainer maxHeight="15rem">
+						{@const conflicts = branchStatuses?.worktreeConflicts}
+						{#each conflicts as file, i}
+							<FileListItem
+								listMode="list"
+								filePath={file}
+								clickable={false}
+								conflicted
+								isLast={i === conflicts.length - 1}
+							/>
+						{/each}
+					</ScrollableContainer>
+				</div>
+			</div>
+		{/if}
+		<!-- DIVERGED -->
+		{#if base?.targetShaAheadOfRef}
+			<div class="target-divergence">
+				<img class="target-icon" src="/images/domain-icons/trunk.svg" alt="" />
+
+				<div class="target-divergence-about">
+					<h3 class="text-14 text-semibold">Target branch divergence</h3>
+					<p class="text-12 text-body target-divergence-description">
+						<span class="text-bold">target/main</span> has diverged from the workspace.
+						<br />
+						Select an action to proceed with updating.
+					</p>
+				</div>
+
+				<div class="target-divergence-action">
+					<Select
+						value={baseResolutionApproach?.type}
+						placeholder="Choose…"
+						onselect={handleBaseResolutionSelection}
+						options={baseResolutionOptions}
+					>
+						{#snippet itemSnippet({ item, highlighted })}
+							<SelectItem selected={highlighted} {highlighted}>
+								{item.label}
+							</SelectItem>
+						{/snippet}
+					</Select>
+				</div>
+			</div>
+		{/if}
+		<!-- STACKS AND BRANCHES TO UPDATE -->
+		{#if statuses.length > 0}
+			<div class="section" class:section-disabled={isDivergedResolved}>
+				<h3 class="text-14 text-semibold">To be updated:</h3>
+				<div class="scroll-wrap">
+					<ScrollableContainer maxHeight="15rem">
+						{#each statuses as { stack, status }}
+							{#if stack.id}
+								{@render stackStatus(stack.id, status)}
+							{/if}
+						{/each}
+					</ScrollableContainer>
+				</div>
+			</div>
+		{/if}
+	</ScrollableContainer>
+
+	{#snippet controls()}
+		<div class="controls">
+			<Button onclick={() => modal?.close()} kind="outline">Cancel</Button>
+			<AsyncButton
+				testId={TestId.IntegrateUpstreamActionButton}
+				wide
+				style="pop"
+				disabled={isDivergedResolved || !branchStatuses}
+				loading={integratingUpstream === "loading" || !branchStatuses}
+				action={async () => {
+					await integrate();
+				}}
+			>
+				Update workspace
+			</AsyncButton>
+		</div>
+	{/snippet}
+</Modal>
+
+<style>
+	/* INCOMING CHANGES */
+	.section {
+		display: flex;
+		flex-direction: column;
+		padding: 16px;
+		gap: 14px;
+		border-bottom: 1px solid var(--border-2);
+
+		&:last-child {
+			border-bottom: none;
+		}
+
+		.scroll-wrap {
+			overflow: hidden;
+			border: 1px solid var(--border-2);
+			border-radius: var(--radius-m);
+		}
+	}
+
+	.section-title {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+	}
+
+	/* DIVERGANCE */
+	.target-divergence {
+		display: flex;
+		padding: 16px;
+		gap: 14px;
+		border-bottom: 1px solid var(--border-2);
+		background-color: var(--bg-warn);
+	}
+
+	.target-icon {
+		width: 16px;
+		height: 16px;
+		border-radius: var(--radius-s);
+	}
+
+	.target-divergence-about {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		gap: 8px;
+	}
+
+	.target-divergence-description {
+		color: var(--text-2);
+	}
+
+	.target-divergence-action {
+		display: flex;
+		flex-direction: column;
+		max-width: 230px;
+	}
+
+	/* CONTROLS */
+	.controls {
+		display: flex;
+		width: 100%;
+		gap: 6px;
+	}
+
+	/* MODIFIERS */
+	.section-disabled {
+		opacity: 0.5;
+		pointer-events: none;
+	}
+</style>

--- a/apps/desktop/src/components/views/AppHeader.svelte
+++ b/apps/desktop/src/components/views/AppHeader.svelte
@@ -3,8 +3,10 @@
 	import CreateBranchModal from "$components/branch/CreateBranchModal.svelte";
 	import SyncButton from "$components/forge/SyncButton.svelte";
 	import IntegrateUpstreamModal from "$components/upstream/IntegrateUpstreamModal.svelte";
+	import IntegrateUpstreamModalDeprecated from "$components/upstream/IntegrateUpstreamModalDeprecated.svelte";
 	import { BACKEND } from "$lib/backend";
 	import { BASE_BRANCH_SERVICE } from "$lib/baseBranch/baseBranchService.svelte";
+	import { newIntegrateUpstreamModalFeature } from "$lib/config/uiFeatureFlags";
 	import { MODE_SERVICE } from "$lib/mode/modeService";
 	import { handleAddProjectOutcome } from "$lib/project/project";
 	import { PROJECTS_SERVICE } from "$lib/project/projectsService";
@@ -65,7 +67,9 @@
 	const upstreamCommits = $derived(base?.behind ?? 0);
 	const isHasUpstreamCommits = $derived(upstreamCommits > 0);
 
-	let modal = $state<ReturnType<typeof IntegrateUpstreamModal>>();
+	let modal = $state<
+		ReturnType<typeof IntegrateUpstreamModal> | ReturnType<typeof IntegrateUpstreamModalDeprecated>
+	>();
 
 	const projects = $derived(projectsService.projects());
 
@@ -94,7 +98,11 @@
 </script>
 
 {#if projectId}
-	<IntegrateUpstreamModal bind:this={modal} {projectId} />
+	{#if $newIntegrateUpstreamModalFeature}
+		<IntegrateUpstreamModal bind:this={modal} {projectId} />
+	{:else}
+		<IntegrateUpstreamModalDeprecated bind:this={modal} {projectId} />
+	{/if}
 {/if}
 
 <div

--- a/apps/desktop/src/lib/bootstrap/deps.ts
+++ b/apps/desktop/src/lib/bootstrap/deps.ts
@@ -63,6 +63,10 @@ import {
 	UpstreamIntegrationService,
 	UPSTREAM_INTEGRATION_SERVICE,
 } from "$lib/upstream/upstreamIntegrationService.svelte";
+import {
+	UpstreamIntegrationServiceDeprecated,
+	UPSTREAM_INTEGRATION_SERVICE_DEPRECATED,
+} from "$lib/upstream/upstreamIntegrationServiceDeprecated.svelte";
 import { TokenMemoryService } from "$lib/user/tokenMemoryService";
 import { USER_SERVICE, UserService } from "$lib/user/userService.svelte";
 import { WorktreeService, WORKTREE_SERVICE } from "$lib/worktree/worktreeService.svelte";
@@ -232,6 +236,10 @@ export function initDependencies(args: {
 	// WORKFLOWS
 	// ============================================================================
 
+	const upstreamIntegrationServiceDeprecated = new UpstreamIntegrationServiceDeprecated(
+		clientState.backendApi,
+		stackService,
+	);
 	const upstreamIntegrationService = new UpstreamIntegrationService(
 		clientState.backendApi,
 		stackService,
@@ -347,6 +355,7 @@ export function initDependencies(args: {
 		[UNCOMMITTED_SERVICE, uncommittedService],
 		[UPDATER_SERVICE, updaterService],
 		[UPLOADS_SERVICE, uploadsService],
+		[UPSTREAM_INTEGRATION_SERVICE_DEPRECATED, upstreamIntegrationServiceDeprecated],
 		[UPSTREAM_INTEGRATION_SERVICE, upstreamIntegrationService],
 		[URL_SERVICE, urlService],
 		[USER_SERVICE, userService],

--- a/apps/desktop/src/lib/config/uiFeatureFlags.ts
+++ b/apps/desktop/src/lib/config/uiFeatureFlags.ts
@@ -15,3 +15,7 @@ export const stagingBehaviorFeature = persisted<StagingBehavior>("all", "feature
 export const fModeEnabled = persisted(true, "f-mode");
 export const newlineOnEnter = persisted(false, "feature-newline-on-enter");
 export const newPushFeature = persisted(true, "feature-new-push");
+export const newIntegrateUpstreamModalFeature = persisted(
+	true,
+	"feature-new-integrate-upstream-modal",
+);

--- a/apps/desktop/src/lib/stacks/stackEndpoints.test.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.test.ts
@@ -231,4 +231,47 @@ describe("buildStackEndpoints", () => {
 			invalidatesItem(ReduxTag.IntegrationSteps, "refs/heads/feature"),
 		]);
 	});
+
+	test("uses workspace_integrate_upstream for dry-run previews and execution", () => {
+		const endpoints = buildStackEndpoints(createEndpointBuilder());
+		const query = endpoints.workspaceIntegrateUpstream.query;
+		const invalidatesTags = endpoints.workspaceIntegrateUpstream.invalidatesTags;
+		const previewArgs = {
+			projectId: "project-1",
+			updates: [
+				{
+					kind: "rebase" as const,
+					selector: {
+						type: "commit" as const,
+						subject: "1111111111111111111111111111111111111111",
+					},
+				},
+			],
+			dryRun: true,
+		};
+		const executeArgs = { ...previewArgs, dryRun: false };
+
+		expect(endpoints.workspaceIntegrateUpstream.extraOptions).toEqual({
+			command: "workspace_integrate_upstream",
+			actionName: "Update Workspace",
+		});
+		expect(query).toBeDefined();
+		expect(query?.(previewArgs)).toEqual(previewArgs);
+
+		if (typeof invalidatesTags !== "function") {
+			throw new Error("Expected workspaceIntegrateUpstream.invalidatesTags to be callable");
+		}
+
+		expect(invalidatesTags(undefined, undefined, previewArgs, undefined)).toEqual([]);
+		expect(invalidatesTags(undefined, undefined, executeArgs, undefined)).toEqual([
+			invalidatesList(ReduxTag.HeadSha),
+			invalidatesList(ReduxTag.WorktreeChanges),
+			invalidatesList(ReduxTag.Stacks),
+			invalidatesList(ReduxTag.StackDetails),
+			invalidatesList(ReduxTag.BranchChanges),
+			invalidatesList(ReduxTag.BranchListing),
+			invalidatesList(ReduxTag.BaseBranchData),
+			invalidatesList(ReduxTag.UpstreamIntegrationStatus),
+		]);
+	});
 });

--- a/apps/desktop/src/lib/stacks/stackEndpoints.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.ts
@@ -49,6 +49,8 @@ import type {
 	RelativeTo,
 	RefInfo,
 	StackEntryNoOpt,
+	BottomUpdate,
+	WorkspaceState,
 } from "@gitbutler/but-sdk";
 
 export type BranchParams = {
@@ -216,6 +218,30 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 			},
 			transformResponse(response: RefInfo) {
 				return transformWorkspaceDetails(response);
+			},
+		}),
+		workspaceIntegrateUpstream: build.mutation<
+			WorkspaceState,
+			{ projectId: string; updates: BottomUpdate[]; dryRun: boolean }
+		>({
+			extraOptions: {
+				command: "workspace_integrate_upstream",
+				actionName: "Update Workspace",
+			},
+			query: (args) => args,
+			invalidatesTags: (_result, _error, args) => {
+				if (args.dryRun) return [];
+
+				return [
+					invalidatesList(ReduxTag.HeadSha),
+					invalidatesList(ReduxTag.WorktreeChanges),
+					invalidatesList(ReduxTag.Stacks),
+					invalidatesList(ReduxTag.StackDetails),
+					invalidatesList(ReduxTag.BranchChanges),
+					invalidatesList(ReduxTag.BranchListing),
+					invalidatesList(ReduxTag.BaseBranchData),
+					invalidatesList(ReduxTag.UpstreamIntegrationStatus),
+				];
 			},
 		}),
 		createStack: build.mutation<StackEntryNoOpt, { projectId: string; branch: BranchParams }>({

--- a/apps/desktop/src/lib/upstream/types.test.ts
+++ b/apps/desktop/src/lib/upstream/types.test.ts
@@ -1,0 +1,172 @@
+import {
+	bottomUpdateForStack,
+	buildUpstreamIntegrationUpdates,
+	deriveUpstreamIntegrationStatuses,
+} from "$lib/upstream/types";
+import { describe, expect, test } from "vitest";
+import type { Author, Commit, RefInfo, Segment, Stack } from "@gitbutler/but-sdk";
+
+const encoder = new TextEncoder();
+
+function bytes(value: string): number[] {
+	return [...encoder.encode(value)];
+}
+
+const author: Author = {
+	name: "Ada",
+	email: "ada@example.com",
+	gravatarUrl: "",
+};
+
+function commit(id: string, hasConflicts = false): Commit {
+	return {
+		id,
+		parentIds: [],
+		message: id,
+		hasConflicts,
+		state: { type: "LocalOnly" },
+		createdAt: 1000,
+		author,
+		changeId: `I${id}`,
+		gerritReviewUrl: null,
+	};
+}
+
+function segment({
+	name,
+	commits = [],
+}: {
+	name?: string;
+	commits?: Commit[];
+} = {}): Segment {
+	return {
+		refName: name
+			? {
+					fullNameBytes: bytes(`refs/heads/${name}`),
+					displayName: name,
+				}
+			: null,
+		remoteTrackingRefName: null,
+		commits,
+		commitsOnRemote: [],
+		commitsOutside: null,
+		metadata: null,
+		isEntrypoint: false,
+		pushStatus: "unpushedCommits",
+		base: null,
+	};
+}
+
+function stack(segments: Segment[], id = "stack-1"): Stack {
+	return {
+		id,
+		base: null,
+		segments,
+	};
+}
+
+function refInfo(stacks: Stack[]): RefInfo {
+	return {
+		workspaceRef: null,
+		stacks,
+		target: null,
+		isManagedRef: true,
+		isManagedCommit: true,
+		isEntrypoint: true,
+	};
+}
+
+describe("upstream integration types", () => {
+	test("builds a rebase bottom update from the bottom-most commit", () => {
+		const update = bottomUpdateForStack(
+			stack([
+				segment({ name: "top", commits: [commit("top")] }),
+				segment({ name: "bottom", commits: [commit("middle"), commit("bottom")] }),
+			]),
+		);
+
+		expect(update).toEqual({
+			kind: "rebase",
+			selector: {
+				type: "commit",
+				subject: "bottom",
+			},
+		});
+	});
+
+	test("builds a rebase bottom update from a named empty bottom segment", () => {
+		const update = bottomUpdateForStack(stack([segment({ name: "empty" })]));
+
+		expect(update).toEqual({
+			kind: "rebase",
+			selector: {
+				type: "referenceBytes",
+				subject: bytes("refs/heads/empty"),
+			},
+		});
+	});
+
+	test("skips stacks without a valid bottom selector", () => {
+		expect(buildUpstreamIntegrationUpdates([stack([segment()])])).toEqual([]);
+	});
+
+	test("derives branch and stack statuses from preview branch ref names", () => {
+		const current = [
+			stack(
+				[
+					segment({ name: "feature/top", commits: [commit("top")] }),
+					segment({ name: "feature/middle", commits: [commit("middle")] }),
+					segment({ name: "feature/bottom", commits: [commit("bottom")] }),
+				],
+				"stack-1",
+			),
+			stack([segment({ name: "feature/clear", commits: [commit("clear")] })], "stack-2"),
+			stack([segment({ commits: [commit("unnamed")] })], "stack-3"),
+		];
+		const preview = refInfo([
+			stack([
+				segment({ name: "feature/top", commits: [commit("top-preview", true)] }),
+				segment({ name: "feature/clear", commits: [commit("clear-preview")] }),
+			]),
+		]);
+
+		const statuses = deriveUpstreamIntegrationStatuses(current, preview);
+
+		expect(statuses[0]).toMatchObject({
+			status: "conflicted",
+			fullyIntegrated: false,
+			branchStatuses: [
+				{ name: "feature/top", status: "conflicted" },
+				{ name: "feature/middle", status: "integrated" },
+				{ name: "feature/bottom", status: "integrated" },
+			],
+		});
+		expect(statuses[1]).toMatchObject({
+			status: "clear",
+			fullyIntegrated: false,
+			branchStatuses: [{ name: "feature/clear", status: "clear" }],
+		});
+		expect(statuses[2]).toMatchObject({
+			status: "clear",
+			fullyIntegrated: false,
+			branchStatuses: [{ name: "Unnamed segment", status: "clear" }],
+		});
+	});
+
+	test("marks a stack integrated only when all branches are integrated", () => {
+		const statuses = deriveUpstreamIntegrationStatuses(
+			[
+				stack([
+					segment({ name: "feature/top", commits: [commit("top")] }),
+					segment({ name: "feature/bottom", commits: [commit("bottom")] }),
+				]),
+			],
+			refInfo([]),
+		);
+
+		expect(statuses[0]).toMatchObject({
+			status: "integrated",
+			fullyIntegrated: true,
+		});
+	});
+});

--- a/apps/desktop/src/lib/upstream/types.ts
+++ b/apps/desktop/src/lib/upstream/types.ts
@@ -1,64 +1,201 @@
 import { getStackName, type Stack } from "$lib/stacks/stack";
-import type {
-	BaseBranchResolutionApproach,
-	BaseBranchResolution,
-	ResolutionApproach,
-	StackStatus,
-} from "@gitbutler/but-sdk";
+import type { BottomUpdate, RefInfo, Segment } from "@gitbutler/but-sdk";
 
-export type StackStatusInfoV3 = { stack: Stack; status: StackStatus };
+export type UpstreamIntegrationDisplayStatus = "integrated" | "conflicted" | "clear";
 
-export type StackStatusesWithBranchesV3 =
-	| {
-			type: "upToDate";
-	  }
-	| {
-			type: "updatesRequired";
-			worktreeConflicts: string[];
-			subject: StackStatusInfoV3[];
-	  };
+export type UpstreamIntegrationBranchStatus = {
+	name: string;
+	status: UpstreamIntegrationDisplayStatus;
+};
 
-export function stackFullyIntegrated(stackStatus: StackStatus): boolean {
-	return (
-		stackStatus.branchStatuses.every((branchStatus) => branchStatus.status.type === "integrated") &&
-		stackStatus.treeStatus.type === "empty"
-	);
+export type UpstreamIntegrationStackStatus = {
+	stack: Stack;
+	status: UpstreamIntegrationDisplayStatus;
+	branchStatuses: UpstreamIntegrationBranchStatus[];
+	fullyIntegrated: boolean;
+};
+
+export type UpstreamIntegrationStatuses = {
+	subject: UpstreamIntegrationStackStatus[];
+	updates: BottomUpdate[];
+};
+
+const textDecoder = new TextDecoder();
+
+function refNameKey(segment: Segment): string | undefined {
+	if (!segment.refName) return;
+	return textDecoder.decode(Uint8Array.from(segment.refName.fullNameBytes));
 }
 
-export function getBaseBranchResolution(
-	targetCommitOid: string | undefined,
-	approach: BaseBranchResolutionApproach,
-): BaseBranchResolution | undefined {
-	if (!targetCommitOid) return;
+function branchDisplayName(segment: Segment): string {
+	return segment.refName?.displayName ?? "Unnamed segment";
+}
+
+function bottomSegment(stack: Stack): Segment | undefined {
+	return stack.segments.at(-1);
+}
+
+export function bottomUpdateForStack(stack: Stack): BottomUpdate | undefined {
+	const segment = bottomSegment(stack);
+	if (!segment) return;
+
+	const bottomCommit = segment.commits.at(-1);
+	if (bottomCommit) {
+		return {
+			kind: "rebase",
+			selector: {
+				type: "commit",
+				subject: bottomCommit.id,
+			},
+		};
+	}
+
+	if (segment.refName) {
+		return {
+			kind: "rebase",
+			selector: {
+				type: "referenceBytes",
+				subject: segment.refName.fullNameBytes,
+			},
+		};
+	}
+}
+
+/**
+ * Create the bottom updates for the given stacks.
+ *
+ * We create the bottom updates by figuring out the bottom-most commit per stack falling-back to the
+ * bottom-most segment for stacks with empty branches at the bottom.
+ * @param stacks - The stacks to map into bottom updates.
+ * @returns - An array of bottom updates.
+ */
+export function buildUpstreamIntegrationUpdates(stacks: Stack[]): BottomUpdate[] {
+	return stacks.map(bottomUpdateForStack).filter((update): update is BottomUpdate => !!update);
+}
+
+function previewSegmentsByRefName(previewHeadInfo: RefInfo): Map<string, Segment> {
+	const segments = new Map<string, Segment>();
+
+	for (const stack of previewHeadInfo.stacks) {
+		for (const segment of stack.segments) {
+			const key = refNameKey(segment);
+			if (key) segments.set(key, segment);
+		}
+	}
+
+	return segments;
+}
+
+/**
+ * Derive the branch status from the map of preview branches.
+ *
+ * We match the actual branch to the one in the preview.
+ * - If the branch is anonymous, we consider it clear.
+ * - If the branch is not part of the preview, we consider it integrated.
+ * - If the matched branch contains conflicts, we consider it conflicted.
+ * - Otherwise, the branch is considered clear.
+ */
+function deriveBranchStatus(
+	segment: Segment,
+	previewSegments: Map<string, Segment>,
+): UpstreamIntegrationBranchStatus {
+	const key = refNameKey(segment);
+	if (!key) {
+		return {
+			name: branchDisplayName(segment),
+			status: "clear",
+		};
+	}
+
+	const previewSegment = previewSegments.get(key);
+	if (!previewSegment) {
+		return {
+			name: branchDisplayName(segment),
+			status: "integrated",
+		};
+	}
+
+	const hasConflicts = previewSegment.commits.some((commit) => commit.hasConflicts);
 
 	return {
-		targetCommitOid,
-		approach,
+		name: branchDisplayName(segment),
+		status: hasConflicts ? "conflicted" : "clear",
 	};
 }
 
-export function sortStatusInfoV3(a: StackStatusInfoV3, b: StackStatusInfoV3): number {
-	if (
-		(!stackFullyIntegrated(a.status) && !stackFullyIntegrated(b.status)) ||
-		(stackFullyIntegrated(a.status) && stackFullyIntegrated(b.status))
-	) {
-		const aName = (a.stack && getStackName(a.stack)) ?? "Unknown";
-		const bName = (b.stack && getStackName(b.stack)) ?? "Unknown";
-
-		return aName.localeCompare(bName);
+/**
+ * Determine the status of a stack, by the status of its branches.
+ */
+function deriveStackStatus(
+	branchStatuses: UpstreamIntegrationBranchStatus[],
+): UpstreamIntegrationDisplayStatus {
+	if (branchStatuses.every((branchStatus) => branchStatus.status === "integrated")) {
+		return "integrated";
 	}
 
-	if (stackFullyIntegrated(a.status)) {
-		return 1;
-	} else {
-		return -1;
+	if (branchStatuses.some((branchStatus) => branchStatus.status === "conflicted")) {
+		return "conflicted";
 	}
+
+	return "clear";
 }
 
-export function getResolutionApproachV3(statusInfo: StackStatusInfoV3): ResolutionApproach {
-	if (stackFullyIntegrated(statusInfo.status)) {
-		return { type: "delete" };
+/**
+ * Compare a set of current stacks against a preview in order to determine the upcoming statuses.
+ *
+ * We compare the branches of each stack to their preview counterpart in order to determine the status
+ * of the branches, and based on that we determine the status of the stacks.
+ *
+ * @param currentStacks - The set of stacks we want to get statuses for.
+ * @param previewHeadInfo - The preview which will determine the statuses for the given stacks.
+ * @returns - An array of stack statuses.
+ */
+export function deriveUpstreamIntegrationStatuses(
+	currentStacks: Stack[],
+	previewHeadInfo: RefInfo,
+): UpstreamIntegrationStackStatus[] {
+	const previewSegments = previewSegmentsByRefName(previewHeadInfo);
+
+	return currentStacks.map((stack) => {
+		const branchStatuses = stack.segments.map((segment) =>
+			deriveBranchStatus(segment, previewSegments),
+		);
+		const status = deriveStackStatus(branchStatuses);
+
+		return {
+			stack,
+			status,
+			branchStatuses,
+			fullyIntegrated: status === "integrated",
+		};
+	});
+}
+
+export function clearUpstreamIntegrationStatuses(
+	currentStacks: Stack[],
+): UpstreamIntegrationStackStatus[] {
+	return currentStacks.map((stack) => {
+		const branchStatuses = stack.segments.map((segment) => ({
+			name: branchDisplayName(segment),
+			status: "clear" as const,
+		}));
+
+		return {
+			stack,
+			status: "clear",
+			branchStatuses,
+			fullyIntegrated: false,
+		};
+	});
+}
+
+export function sortUpstreamIntegrationStatus(
+	a: UpstreamIntegrationStackStatus,
+	b: UpstreamIntegrationStackStatus,
+): number {
+	if (a.fullyIntegrated === b.fullyIntegrated) {
+		return getStackName(a.stack).localeCompare(getStackName(b.stack));
 	}
 
-	return { type: "rebase" };
+	return a.fullyIntegrated ? 1 : -1;
 }

--- a/apps/desktop/src/lib/upstream/typesDeprecated.ts
+++ b/apps/desktop/src/lib/upstream/typesDeprecated.ts
@@ -1,0 +1,64 @@
+import { getStackName, type Stack } from "$lib/stacks/stack";
+import type {
+	BaseBranchResolutionApproach,
+	BaseBranchResolution,
+	ResolutionApproach,
+	StackStatus,
+} from "@gitbutler/but-sdk";
+
+export type StackStatusInfoV3 = { stack: Stack; status: StackStatus };
+
+export type StackStatusesWithBranchesV3 =
+	| {
+			type: "upToDate";
+	  }
+	| {
+			type: "updatesRequired";
+			worktreeConflicts: string[];
+			subject: StackStatusInfoV3[];
+	  };
+
+export function stackFullyIntegrated(stackStatus: StackStatus): boolean {
+	return (
+		stackStatus.branchStatuses.every((branchStatus) => branchStatus.status.type === "integrated") &&
+		stackStatus.treeStatus.type === "empty"
+	);
+}
+
+export function getBaseBranchResolution(
+	targetCommitOid: string | undefined,
+	approach: BaseBranchResolutionApproach,
+): BaseBranchResolution | undefined {
+	if (!targetCommitOid) return;
+
+	return {
+		targetCommitOid,
+		approach,
+	};
+}
+
+export function sortStatusInfoV3(a: StackStatusInfoV3, b: StackStatusInfoV3): number {
+	if (
+		(!stackFullyIntegrated(a.status) && !stackFullyIntegrated(b.status)) ||
+		(stackFullyIntegrated(a.status) && stackFullyIntegrated(b.status))
+	) {
+		const aName = (a.stack && getStackName(a.stack)) ?? "Unknown";
+		const bName = (b.stack && getStackName(b.stack)) ?? "Unknown";
+
+		return aName.localeCompare(bName);
+	}
+
+	if (stackFullyIntegrated(a.status)) {
+		return 1;
+	} else {
+		return -1;
+	}
+}
+
+export function getResolutionApproachV3(statusInfo: StackStatusInfoV3): ResolutionApproach {
+	if (stackFullyIntegrated(statusInfo.status)) {
+		return { type: "delete" };
+	}
+
+	return { type: "rebase" };
+}

--- a/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
+++ b/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
@@ -1,8 +1,12 @@
+import {
+	buildUpstreamIntegrationUpdates,
+	clearUpstreamIntegrationStatuses,
+	deriveUpstreamIntegrationStatuses,
+	type UpstreamIntegrationStatuses,
+} from "$lib/upstream/types";
 import { InjectionToken } from "@gitbutler/core/context";
-import { isDefined } from "@gitbutler/ui/utils/typeguards";
 import type { StackService } from "$lib/stacks/stackService.svelte";
 import type { BackendApi } from "$lib/state/backendApi";
-import type { StackStatusesWithBranchesV3 } from "$lib/upstream/types";
 
 export const UPSTREAM_INTEGRATION_SERVICE = new InjectionToken<UpstreamIntegrationService>(
 	"UpstreamIntegrationService",
@@ -14,35 +18,27 @@ export class UpstreamIntegrationService {
 		private stackService: StackService,
 	) {}
 
-	async upstreamStatuses(
-		projectId: string,
-		targetCommitOid: string | undefined,
-	): Promise<StackStatusesWithBranchesV3 | undefined> {
+	async upstreamStatuses(projectId: string): Promise<UpstreamIntegrationStatuses> {
 		const stacks = await this.stackService.fetchStacks(projectId);
-		const branchStatuses = await this.backendApi.endpoints.upstreamIntegrationStatuses.fetch({
+		const updates = buildUpstreamIntegrationUpdates(stacks);
+
+		if (updates.length === 0) {
+			return {
+				subject: clearUpstreamIntegrationStatuses(stacks),
+				updates,
+			};
+		}
+
+		const preview = await this.backendApi.endpoints.workspaceIntegrateUpstream.mutate({
 			projectId,
-			targetCommitOid,
+			updates,
+			dryRun: true,
 		});
 
-		if (branchStatuses.type === "upToDate") return branchStatuses;
-
-		const stackStatusesWithBranches: StackStatusesWithBranchesV3 = {
-			type: "updatesRequired",
-			worktreeConflicts: branchStatuses.subject.worktreeConflicts,
-			subject: branchStatuses.subject.statuses
-				.map((status) => {
-					const stack = stacks.find((appliedBranch) => appliedBranch.id === status[0]);
-
-					if (!stack) return;
-					return {
-						stack,
-						status: status[1],
-					};
-				})
-				.filter(isDefined),
+		return {
+			subject: deriveUpstreamIntegrationStatuses(stacks, preview.headInfo),
+			updates,
 		};
-
-		return stackStatusesWithBranches;
 	}
 
 	resolveUpstreamIntegration() {
@@ -54,6 +50,6 @@ export class UpstreamIntegrationService {
 	}
 
 	integrateUpstream() {
-		return this.backendApi.endpoints.integrateUpstream.useMutation();
+		return this.backendApi.endpoints.workspaceIntegrateUpstream.useMutation();
 	}
 }

--- a/apps/desktop/src/lib/upstream/upstreamIntegrationServiceDeprecated.svelte.ts
+++ b/apps/desktop/src/lib/upstream/upstreamIntegrationServiceDeprecated.svelte.ts
@@ -1,0 +1,58 @@
+import { InjectionToken } from "@gitbutler/core/context";
+import { isDefined } from "@gitbutler/ui/utils/typeguards";
+import type { StackService } from "$lib/stacks/stackService.svelte";
+import type { BackendApi } from "$lib/state/backendApi";
+import type { StackStatusesWithBranchesV3 } from "$lib/upstream/typesDeprecated";
+
+export const UPSTREAM_INTEGRATION_SERVICE_DEPRECATED =
+	new InjectionToken<UpstreamIntegrationServiceDeprecated>("UpstreamIntegrationServiceDeprecated");
+
+export class UpstreamIntegrationServiceDeprecated {
+	constructor(
+		private backendApi: BackendApi,
+		private stackService: StackService,
+	) {}
+
+	async upstreamStatuses(
+		projectId: string,
+		targetCommitOid: string | undefined,
+	): Promise<StackStatusesWithBranchesV3 | undefined> {
+		const stacks = await this.stackService.fetchStacks(projectId);
+		const branchStatuses = await this.backendApi.endpoints.upstreamIntegrationStatuses.fetch({
+			projectId,
+			targetCommitOid,
+		});
+
+		if (branchStatuses.type === "upToDate") return branchStatuses;
+
+		const stackStatusesWithBranches: StackStatusesWithBranchesV3 = {
+			type: "updatesRequired",
+			worktreeConflicts: branchStatuses.subject.worktreeConflicts,
+			subject: branchStatuses.subject.statuses
+				.map((status) => {
+					const stack = stacks.find((appliedBranch) => appliedBranch.id === status[0]);
+
+					if (!stack) return;
+					return {
+						stack,
+						status: status[1],
+					};
+				})
+				.filter(isDefined),
+		};
+
+		return stackStatusesWithBranches;
+	}
+
+	resolveUpstreamIntegration() {
+		return this.backendApi.endpoints.resolveUpstreamIntegration.useMutation();
+	}
+
+	get resolveUpstreamIntegrationMutation() {
+		return this.backendApi.endpoints.resolveUpstreamIntegration.mutate;
+	}
+
+	integrateUpstream() {
+		return this.backendApi.endpoints.integrateUpstream.useMutation();
+	}
+}

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -143,6 +143,7 @@ pub fn integrate_upstream<'ws, 'meta, M: RefMetadata>(
         .commit()
         .context("Cannot update workspace without head commit")?;
     let head_commit = repo.find_commit(head_commit.id)?;
+    let head_commit_id = head_commit.id;
     let head_is_workspace_commit = is_managed_workspace_by_message(head_commit.message_raw()?);
 
     let editor_options = GraphEditorOptions {
@@ -214,6 +215,82 @@ pub fn integrate_upstream<'ws, 'meta, M: RefMetadata>(
                     attrs.to_rebase = true;
                 }
             }
+        }
+    }
+
+    // Handle integrated stacks.
+    // Determine which stacks (or branches) are integrated, and remove them from the workspace
+    // if any.
+    let workspace_commit_selector = head_is_workspace_commit
+        .then(|| editor.select_commit(head_commit_id))
+        .transpose()?;
+    let mut integrated_branch_refs = HashSet::new();
+    let mut fully_integrated_workspace_parents = HashSet::new();
+    for stack in &stacks {
+        let is_selected = stack.nodes.values().any(|attrs| attrs.to_rebase) || stack.to_merge;
+        let is_fully_integrated = stack
+            .nodes
+            .values()
+            .all(|attrs| attrs.historically_integrated || attrs.content_integrated);
+        if !is_selected {
+            continue;
+        }
+
+        for ws_stack in ws_meta
+            .stacks
+            .iter()
+            .filter(|stack| stack.workspacecommit_relation.is_in_workspace())
+        {
+            for branch in &ws_stack.branches {
+                if branch.ref_name.as_ref() == target_ref.ref_name.as_ref() {
+                    continue;
+                }
+
+                let ref_selector = match branch.ref_name.to_selector(&editor) {
+                    Ok(selector) => selector,
+                    Err(_) => continue,
+                };
+                let direct_parents = editor.direct_parents(ref_selector)?;
+                if !direct_parents.is_empty()
+                    && direct_parents.iter().all(|(parent, _)| {
+                        stack.nodes.get(parent).is_some_and(|attrs| {
+                            attrs.historically_integrated || attrs.content_integrated
+                        })
+                    })
+                {
+                    integrated_branch_refs.insert(branch.ref_name.clone());
+                }
+            }
+        }
+
+        if !is_fully_integrated {
+            continue;
+        }
+
+        for head in &stack.heads {
+            let Step::Reference { refname } = editor.lookup_step(*head)? else {
+                continue;
+            };
+            if refname.as_ref() == target_ref.ref_name.as_ref() {
+                continue;
+            }
+            fully_integrated_workspace_parents.insert(*head);
+        }
+    }
+
+    // Remove integrated refs from the workspace and from git.
+    // TODO: allow to keep some references.
+    for ref_name in &integrated_branch_refs {
+        if let Ok(ref_selector) = ref_name.to_selector(&editor) {
+            editor.replace(ref_selector, Step::None)?;
+        }
+        ws_meta.remove_segment(ref_name.as_ref());
+    }
+
+    // Disconnect all stack heads from the workspace commit, if any.
+    if let Some(workspace_commit_selector) = workspace_commit_selector {
+        for selector in &fully_integrated_workspace_parents {
+            editor.remove_edges(workspace_commit_selector, *selector)?;
         }
     }
 

--- a/crates/but-workspace/tests/fixtures/scenario/fully-integrated-branch.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/fully-integrated-branch.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# Two branches are merged into a workspace commit. One branch is fully reachable
+# from the target ref and should leave the workspace shape after integration,
+# while the other branch remains in the workspace.
+git init
+commit M1
+setup_target_to_match_main
+
+git checkout -b A
+commit-file A.txt A1
+
+git checkout main
+git checkout -b B
+commit-file B.txt B1
+
+create_workspace_commit_once A B
+
+git update-ref refs/remotes/origin/main A

--- a/crates/but-workspace/tests/fixtures/scenario/fully-integrated-multi-branch-stack.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/fully-integrated-multi-branch-stack.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# Two stacks are merged into a workspace commit:
+# - A stack with A on top of C, where both A and C are historically integrated.
+# - A separate B stack.
+git init
+commit M1
+setup_target_to_match_main
+
+git checkout -b C
+commit-file C.txt C1
+
+git checkout -b A
+commit-file A.txt A1
+
+git checkout main
+git checkout -b B
+commit-file B.txt B1
+
+create_workspace_commit_once A B
+
+git update-ref refs/remotes/origin/main A

--- a/crates/but-workspace/tests/fixtures/scenario/fully-integrated-single-branch.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/fully-integrated-single-branch.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A workspace with only one branch, A. A is fully reachable from the target ref,
+# so rebasing A should remove it from the workspace.
+git init
+commit M1
+setup_target_to_match_main
+
+git checkout -b A
+commit-file A.txt A1
+
+create_workspace_commit_once A
+
+git update-ref refs/remotes/origin/main A

--- a/crates/but-workspace/tests/fixtures/scenario/partially-integrated-multi-branch-stack.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/partially-integrated-multi-branch-stack.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# Two stacks are merged into a workspace commit:
+# - A stack with A on top of C, where C is historically integrated.
+# - A separate B stack.
+git init
+commit M1
+setup_target_to_match_main
+
+git checkout -b C
+commit-file C.txt C1
+
+git checkout -b A
+commit-file A.txt A1
+
+git checkout main
+git checkout -b B
+commit-file B.txt B1
+
+create_workspace_commit_once A B
+
+git update-ref refs/remotes/origin/main C

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use but_core::Commit;
+use but_core::{Commit, RefMetadata};
 use but_graph::init::Options;
 use but_meta::virtual_branches_legacy_types::Target;
 use but_rebase::graph_rebase::mutate::RelativeTo;
@@ -8,7 +8,7 @@ use but_workspace::{BottomUpdate, BottomUpdateKind, integrate_upstream};
 use gix::prelude::ObjectIdExt;
 
 use crate::ref_info::with_workspace_commit::utils::{
-    StackState, add_stack, named_writable_scenario_with_description,
+    StackState, add_stack, add_stack_with_segments, named_writable_scenario_with_description,
 };
 
 #[test]
@@ -408,6 +408,340 @@ fn merge_upstream_with_conflicting_target_materializes_conflicted_merge_commit()
        To manually resolve, check out this commit, remove the directories
        listed above, resolve the conflicts, and amend the commit.
     "#);
+
+    Ok(())
+}
+
+#[test]
+fn fully_historically_integrated_branch_leaves_workspace_shape() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("fully-integrated-branch")?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    add_stack(&mut meta, 1, "A", StackState::InWorkspace);
+    add_stack(&mut meta, 2, "B", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   9d7da88 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 905d6e5 (origin/main, A) add A1
+    * | b38b04b (B) add B1
+    |/  
+    * 3183e43 (main) M1
+    ");
+
+    let mut workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @r"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+    ├── ≡📙:4:A on 3183e43 {1}
+    │   └── 📙:4:A
+    │       └── ·905d6e5 (🏘️|✓)
+    └── ≡📙:3:B on 3183e43 {2}
+        └── 📙:3:B
+            └── ·b38b04b (🏘️)
+    ");
+
+    let but_workspace::IntegrateUpstreamOutcome { rebase, ws_meta } = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![
+            BottomUpdate {
+                kind: BottomUpdateKind::Rebase,
+                selector: RelativeTo::Commit(repo.rev_parse_single("A")?.detach()),
+            },
+            BottomUpdate {
+                kind: BottomUpdateKind::Rebase,
+                selector: RelativeTo::Commit(repo.rev_parse_single("B")?.detach()),
+            },
+        ],
+    )?;
+
+    let materialized = rebase.materialize()?;
+    if let Some(ref_name) = materialized.workspace.ref_name() {
+        let mut md = materialized.meta.workspace(ref_name)?;
+        *md = ws_meta;
+        materialized.meta.set_workspace(&md)?;
+    }
+    drop(materialized);
+
+    let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
+    let workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 905d6e5
+    └── ≡📙:3:B on 905d6e5 {2}
+        └── 📙:3:B
+            └── ·c932222 (🏘️)
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * eaf66d4 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * c932222 (B) add B1
+    * 905d6e5 (origin/main) add A1
+    * 3183e43 (main) M1
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn fully_integrated_single_branch_leaves_workspace_shape() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("fully-integrated-single-branch")?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    add_stack(&mut meta, 1, "A", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * f88e9ce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 905d6e5 (origin/main, A) add A1
+    * 3183e43 (main) M1
+    ");
+
+    let mut workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+    └── ≡📙:3:A on 3183e43 {1}
+        └── 📙:3:A
+            └── ·905d6e5 (🏘️|✓)
+    ");
+
+    let but_workspace::IntegrateUpstreamOutcome { rebase, ws_meta } = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A")?.detach()),
+        }],
+    )?;
+
+    let materialized = rebase.materialize()?;
+    if let Some(ref_name) = materialized.workspace.ref_name() {
+        let mut md = materialized.meta.workspace(ref_name)?;
+        *md = ws_meta;
+        materialized.meta.set_workspace(&md)?;
+    }
+    drop(materialized);
+
+    let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
+    let workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 905d6e5");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * be76b24 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 905d6e5 (origin/main) add A1
+    * 3183e43 (main) M1
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn partially_integrated_branch_leaves_multi_branch_stack() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("partially-integrated-multi-branch-stack")?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    add_stack_with_segments(&mut meta, 1, "A", StackState::InWorkspace, &["C"]);
+    add_stack(&mut meta, 2, "B", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   cf53402 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 44c9428 (A) add A1
+    | * f1e7451 (origin/main, C) add C1
+    * | b38b04b (B) add B1
+    |/  
+    * 3183e43 (main) M1
+    ");
+
+    let mut workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+    ├── ≡📙:3:A on 3183e43 {1}
+    │   ├── 📙:3:A
+    │   │   └── ·44c9428 (🏘️)
+    │   └── 📙:5:C
+    │       └── ·f1e7451 (🏘️|✓)
+    └── ≡📙:4:B on 3183e43 {2}
+        └── 📙:4:B
+            └── ·b38b04b (🏘️)
+    ");
+
+    let but_workspace::IntegrateUpstreamOutcome { rebase, ws_meta } = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![
+            BottomUpdate {
+                kind: BottomUpdateKind::Rebase,
+                selector: RelativeTo::Commit(repo.rev_parse_single("C")?.detach()),
+            },
+            BottomUpdate {
+                kind: BottomUpdateKind::Rebase,
+                selector: RelativeTo::Commit(repo.rev_parse_single("B")?.detach()),
+            },
+        ],
+    )?;
+
+    let materialized = rebase.materialize()?;
+    if let Some(ref_name) = materialized.workspace.ref_name() {
+        let mut md = materialized.meta.workspace(ref_name)?;
+        *md = ws_meta;
+        materialized.meta.set_workspace(&md)?;
+    }
+    drop(materialized);
+
+    let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
+    let workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on f1e7451
+    ├── ≡📙:3:A on f1e7451 {1}
+    │   └── 📙:3:A
+    │       └── ·44c9428 (🏘️)
+    └── ≡📙:4:B on f1e7451 {2}
+        └── 📙:4:B
+            └── ·a27415e (🏘️)
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   780946b (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 44c9428 (A) add A1
+    * | a27415e (B) add B1
+    |/  
+    * f1e7451 (origin/main) add C1
+    * 3183e43 (main) M1
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn fully_integrated_multi_branch_stack_leaves_workspace_shape() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("fully-integrated-multi-branch-stack")?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    add_stack_with_segments(&mut meta, 1, "A", StackState::InWorkspace, &["C"]);
+    add_stack(&mut meta, 2, "B", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   cf53402 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 44c9428 (origin/main, A) add A1
+    | * f1e7451 (C) add C1
+    * | b38b04b (B) add B1
+    |/  
+    * 3183e43 (main) M1
+    ");
+
+    let mut workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+    ├── ≡📙:5:A on 3183e43 {1}
+    │   ├── 📙:5:A
+    │   │   └── ·44c9428 (🏘️|✓)
+    │   └── 📙:3:C
+    │       └── ·f1e7451 (🏘️|✓)
+    └── ≡📙:4:B on 3183e43 {2}
+        └── 📙:4:B
+            └── ·b38b04b (🏘️)
+    ");
+
+    let but_workspace::IntegrateUpstreamOutcome { rebase, ws_meta } = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![
+            BottomUpdate {
+                kind: BottomUpdateKind::Rebase,
+                selector: RelativeTo::Commit(repo.rev_parse_single("C")?.detach()),
+            },
+            BottomUpdate {
+                kind: BottomUpdateKind::Rebase,
+                selector: RelativeTo::Commit(repo.rev_parse_single("B")?.detach()),
+            },
+        ],
+    )?;
+
+    let materialized = rebase.materialize()?;
+    if let Some(ref_name) = materialized.workspace.ref_name() {
+        let mut md = materialized.meta.workspace(ref_name)?;
+        *md = ws_meta;
+        materialized.meta.set_workspace(&md)?;
+    }
+    drop(materialized);
+
+    let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
+    let workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 44c9428
+    └── ≡📙:3:B on 44c9428 {2}
+        └── 📙:3:B
+            └── ·f59d71f (🏘️)
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * 55ce8ae (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * f59d71f (B) add B1
+    * 44c9428 (origin/main) add A1
+    * f1e7451 add C1
+    * 3183e43 (main) M1
+    ");
 
     Ok(())
 }

--- a/packages/ui/src/lib/components/IntegrationSeriesRow.svelte
+++ b/packages/ui/src/lib/components/IntegrationSeriesRow.svelte
@@ -17,6 +17,7 @@
 		series: Branch[];
 		branchShouldBeDeletedMap: BranchShouldBeDeletedMap;
 		updateBranchShouldBeDeletedMap: (branchName: string[], shouldBeDeleted: boolean) => void;
+		showDeleteControls?: boolean;
 		children?: Snippet;
 	}
 </script>
@@ -32,6 +33,7 @@
 		children,
 		updateBranchShouldBeDeletedMap,
 		branchShouldBeDeletedMap,
+		showDeleteControls = true,
 	}: Props = $props();
 
 	const allSeriesAreIntegrated = $derived(series.every((branch) => branch.status === "integrated"));
@@ -78,7 +80,7 @@
 					<span class="series-label text-12 text-semibold truncate"> Stack branches </span>
 				</div>
 
-				{#if allSeriesAreIntegrated}
+				{#if allSeriesAreIntegrated && showDeleteControls}
 					{@const atLeastSomeWillBeDeleted = series.some(
 						(branch) => branchShouldBeDeletedMap[branch.name],
 					)}
@@ -130,7 +132,7 @@
 							{/if}
 						</span>
 
-						{#if branch.status === "integrated"}
+						{#if branch.status === "integrated" && showDeleteControls}
 							<div class="integrated-label-wrap">
 								<span class="integrated-label text-12">Delete local branch</span>
 								<Checkbox


### PR DESCRIPTION
Use the new upstream integration endpoint in the svelte application.

---
### Effects of this PR
- Use the new API in order to update the workspace
- Use the same API in dry-run in order to determine the statuses (integrated, conflicted ok)
- This removes some capabilities, including deciding the integration strategy.
- FIX: Integrated stacks and branches are removed from the workspace correctly.
- Keep the old modal intact for people to be able to go back to it, if they want


<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #14108 
- <kbd>&nbsp;2&nbsp;</kbd> #14107 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #14106 
<!-- GitButler Footer Boundary Bottom -->

