### PR TITLE
upstream integration: worktree conflicts

### DIFF
--- a/apps/desktop/src/components/upstream/IntegrateUpstreamModal.svelte
+++ b/apps/desktop/src/components/upstream/IntegrateUpstreamModal.svelte
@@ -14,6 +14,7 @@
 	import {
 		Badge,
 		Button,
+		FileListItem,
 		IntegrationSeriesRow,
 		Modal,
 		SimpleCommitRow,
@@ -56,6 +57,7 @@
 			!!integrationStatuses &&
 			integrationStatuses.updates.length > 0,
 	);
+	const worktreeConflicts = $derived(integrationStatuses?.worktreeConflicts ?? []);
 	const [integrateUpstream] = $derived(upstreamIntegrationService.integrateUpstream());
 
 	async function loadStatuses() {
@@ -203,6 +205,30 @@
 				</div>
 			</div>
 		{/if}
+		{#if worktreeConflicts.length > 0}
+			<div class="worktree-conflicts" data-testid={TestId.IntegrateUpstreamWorktreeConflicts}>
+				<h3 class="text-14 text-semibold">Uncommitted changes conflict</h3>
+				<p class="text-12 text-body worktree-conflicts-description">
+					These files will conflict when your current uncommitted changes are applied onto the
+					updated workspace.
+					<br />
+					You're free to proceed, but conflict markers will be added to your uncommitted work.
+				</p>
+				<div class="scroll-wrap">
+					<ScrollableContainer maxHeight="10rem">
+						{#each worktreeConflicts as path, i}
+							<FileListItem
+								filePath={path}
+								clickable={false}
+								conflicted
+								conflictHint="May conflict"
+								isLast={i === worktreeConflicts.length - 1}
+							/>
+						{/each}
+					</ScrollableContainer>
+				</div>
+			</div>
+		{/if}
 	</ScrollableContainer>
 
 	{#snippet controls()}
@@ -273,6 +299,26 @@
 	}
 
 	.target-divergence-description {
+		color: var(--text-2);
+	}
+
+	.worktree-conflicts {
+		display: flex;
+		flex-direction: column;
+		padding: 16px;
+		gap: 10px;
+		border-bottom: 1px solid var(--border-2);
+		background-color: var(--bg-warn);
+
+		.scroll-wrap {
+			overflow: hidden;
+			border: 1px solid var(--border-2);
+			border-radius: var(--radius-m);
+			background-color: var(--bg-1);
+		}
+	}
+
+	.worktree-conflicts-description {
 		color: var(--text-2);
 	}
 

--- a/apps/desktop/src/lib/stacks/stackEndpoints.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.ts
@@ -50,7 +50,7 @@ import type {
 	RefInfo,
 	StackEntryNoOpt,
 	BottomUpdate,
-	WorkspaceState,
+	WorkspaceIntegrateUpstreamOutcome,
 } from "@gitbutler/but-sdk";
 
 export type BranchParams = {
@@ -221,7 +221,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 			},
 		}),
 		workspaceIntegrateUpstream: build.mutation<
-			WorkspaceState,
+			WorkspaceIntegrateUpstreamOutcome,
 			{ projectId: string; updates: BottomUpdate[]; dryRun: boolean }
 		>({
 			extraOptions: {

--- a/apps/desktop/src/lib/upstream/types.ts
+++ b/apps/desktop/src/lib/upstream/types.ts
@@ -18,6 +18,7 @@ export type UpstreamIntegrationStackStatus = {
 export type UpstreamIntegrationStatuses = {
 	subject: UpstreamIntegrationStackStatus[];
 	updates: BottomUpdate[];
+	worktreeConflicts: string[];
 };
 
 const textDecoder = new TextDecoder();

--- a/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
+++ b/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
@@ -26,6 +26,7 @@ export class UpstreamIntegrationService {
 			return {
 				subject: clearUpstreamIntegrationStatuses(stacks),
 				updates,
+				worktreeConflicts: [],
 			};
 		}
 
@@ -36,8 +37,9 @@ export class UpstreamIntegrationService {
 		});
 
 		return {
-			subject: deriveUpstreamIntegrationStatuses(stacks, preview.headInfo),
+			subject: deriveUpstreamIntegrationStatuses(stacks, preview.workspaceState.headInfo),
 			updates,
+			worktreeConflicts: preview.worktreeConflicts,
 		};
 	}
 

--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -4,11 +4,22 @@ use crate::WorkspaceState;
 use but_api_macros::but_api;
 use but_core::{DryRun, RefMetadata, sync::RepoExclusive};
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
+use but_serde::BStringForFrontend;
 use but_workspace::IntegrateUpstreamOutcome;
 use tracing::instrument;
 
+/// Result of integrating upstream changes into the current workspace.
+#[derive(Debug, Clone)]
+pub struct WorkspaceIntegrateUpstreamOutcome {
+    /// The post-operation or preview workspace state.
+    pub workspace_state: WorkspaceState,
+    /// Dirty worktree paths that would conflict when applied onto the resulting workspace head.
+    pub worktree_conflicts: Vec<BStringForFrontend>,
+}
+
 /// JSON transport types for workspace APIs.
 pub mod json {
+    use but_serde::BStringForFrontend;
     use serde::{Deserialize, Serialize};
 
     /// JSON transport type for how a stack bottom should be updated.
@@ -57,23 +68,50 @@ pub mod json {
             }
         }
     }
+
+    /// JSON transport type returned by upstream integration.
+    #[derive(Debug, Serialize)]
+    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+    #[serde(rename_all = "camelCase")]
+    pub struct WorkspaceIntegrateUpstreamOutcome {
+        /// The post-operation or preview workspace state.
+        pub workspace_state: crate::json::WorkspaceState,
+        /// Dirty worktree paths that would conflict when applied onto the resulting workspace head.
+        #[cfg_attr(feature = "export-schema", schemars(with = "Vec<String>"))]
+        pub worktree_conflicts: Vec<BStringForFrontend>,
+    }
+
+    #[cfg(feature = "export-schema")]
+    but_schemars::register_sdk_type!(WorkspaceIntegrateUpstreamOutcome);
+
+    impl TryFrom<super::WorkspaceIntegrateUpstreamOutcome> for WorkspaceIntegrateUpstreamOutcome {
+        type Error = anyhow::Error;
+
+        fn try_from(value: super::WorkspaceIntegrateUpstreamOutcome) -> Result<Self, Self::Error> {
+            Ok(Self {
+                workspace_state: value.workspace_state.try_into()?,
+                worktree_conflicts: value.worktree_conflicts,
+            })
+        }
+    }
 }
 
 /// Integrate upstream changes into the current workspace without recording an
 /// oplog entry.
 ///
 /// This acquires exclusive worktree access from `ctx`, applies the requested
-/// upstream updates, and returns the resulting workspace state. When `dry_run`
+/// upstream updates, and returns the resulting workspace state plus information about
+/// worktree conflicts. When `dry_run`
 /// is enabled, the returned workspace previews the integration without
 /// materializing the rebase. See
 /// [`workspace_integrate_upstream_only_with_perm()`] for lower-level details.
-#[but_api(try_from = crate::json::WorkspaceState)]
+#[but_api(try_from = json::WorkspaceIntegrateUpstreamOutcome)]
 #[instrument(err(Debug))]
 pub fn workspace_integrate_upstream_only(
     ctx: &mut but_ctx::Context,
     updates: Vec<json::BottomUpdate>,
     dry_run: DryRun,
-) -> anyhow::Result<WorkspaceState> {
+) -> anyhow::Result<WorkspaceIntegrateUpstreamOutcome> {
     let mut guard = ctx.exclusive_worktree_access();
     workspace_integrate_upstream_only_with_perm(
         ctx,
@@ -91,13 +129,13 @@ pub fn workspace_integrate_upstream_only(
 /// when the integration succeeds. When `dry_run` is enabled, the returned
 /// workspace previews the integration and no oplog entry is persisted. See
 /// [`workspace_integrate_upstream_with_perm()`] for lower-level details.
-#[but_api(napi, try_from = crate::json::WorkspaceState)]
+#[but_api(napi, try_from = json::WorkspaceIntegrateUpstreamOutcome)]
 #[instrument(err(Debug))]
 pub fn workspace_integrate_upstream(
     ctx: &mut but_ctx::Context,
     updates: Vec<json::BottomUpdate>,
     dry_run: DryRun,
-) -> anyhow::Result<WorkspaceState> {
+) -> anyhow::Result<WorkspaceIntegrateUpstreamOutcome> {
     let mut guard = ctx.exclusive_worktree_access();
     workspace_integrate_upstream_with_perm(
         ctx,
@@ -113,14 +151,14 @@ pub fn workspace_integrate_upstream(
 /// It prepares a best-effort `MergeUpstream` oplog snapshot, performs the
 /// integration, and commits the snapshot only if the mutation succeeds. When
 /// `dry_run` is enabled, it returns a preview of the resulting workspace state
-/// and skips oplog persistence. For lower-level implementation details, see
-/// [`but_workspace::integrate_upstream()`].
+/// plus worktree conflicts and skips oplog persistence.
+/// For lower-level implementation details, see [`but_workspace::integrate_upstream()`].
 pub fn workspace_integrate_upstream_with_perm(
     ctx: &mut but_ctx::Context,
     updates: Vec<but_workspace::BottomUpdate>,
     dry_run: DryRun,
     perm: &mut RepoExclusive,
-) -> anyhow::Result<WorkspaceState> {
+) -> anyhow::Result<WorkspaceIntegrateUpstreamOutcome> {
     let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
         ctx,
         SnapshotDetails::new(OperationKind::MergeUpstream),
@@ -141,21 +179,28 @@ pub fn workspace_integrate_upstream_with_perm(
 /// Integrate upstream changes under caller-held exclusive repository access.
 ///
 /// This delegates to [`but_workspace::integrate_upstream()`] and returns the
-/// resulting workspace state. When `dry_run` is enabled, it returns a preview
-/// of the resulting workspace without materializing the rebase.
+/// resulting workspace state plus worktree conflicts info.
+/// When `dry_run` is enabled, it returns a preview of the resulting workspace
+/// without materializing the rebase.
 pub fn workspace_integrate_upstream_only_with_perm(
     ctx: &mut but_ctx::Context,
     updates: Vec<but_workspace::BottomUpdate>,
     dry_run: DryRun,
     perm: &mut RepoExclusive,
-) -> anyhow::Result<WorkspaceState> {
+) -> anyhow::Result<WorkspaceIntegrateUpstreamOutcome> {
     let mut meta = ctx.meta()?;
     let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let IntegrateUpstreamOutcome { rebase, ws_meta } =
         but_workspace::integrate_upstream(&mut ws, &mut meta, &repo, updates)?;
+    let worktree_conflicts = but_workspace::worktree_conflicts_for_rebase(&rebase)?;
 
     if dry_run.into() {
-        return WorkspaceState::from_rebase_preview(&rebase, rebase.history.commit_mappings());
+        let workspace_state =
+            WorkspaceState::from_rebase_preview(&rebase, rebase.history.commit_mappings())?;
+        return Ok(WorkspaceIntegrateUpstreamOutcome {
+            workspace_state,
+            worktree_conflicts,
+        });
     }
 
     let materialized = rebase.materialize()?;
@@ -166,9 +211,14 @@ pub fn workspace_integrate_upstream_only_with_perm(
         materialized.meta.set_workspace(&md)?;
     }
 
-    WorkspaceState::from_workspace(
+    let workspace_state = WorkspaceState::from_workspace(
         materialized.workspace,
         &repo,
         materialized.history.commit_mappings(),
-    )
+    )?;
+
+    Ok(WorkspaceIntegrateUpstreamOutcome {
+        workspace_state,
+        worktree_conflicts,
+    })
 }

--- a/crates/but-workspace/tests/fixtures/scenario/upstream-integration-worktree-conflict.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/upstream-integration-worktree-conflict.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A workspace branch rebases cleanly onto the updated target, but a dirty
+# worktree edit to shared.txt would conflict when applied onto the new workspace
+# head.
+git init
+echo base >shared.txt
+git add shared.txt
+git commit -m M1
+setup_target_to_match_main
+
+git checkout -b A
+commit-file A.txt A1
+
+create_workspace_commit_once A
+
+git checkout main
+echo upstream >shared.txt
+git add shared.txt
+git commit -m "update shared upstream"
+git update-ref refs/remotes/origin/main main
+
+git checkout gitbutler/workspace

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -1,10 +1,12 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use but_core::{Commit, RefMetadata};
 use but_graph::init::Options;
 use but_meta::virtual_branches_legacy_types::Target;
 use but_rebase::graph_rebase::mutate::RelativeTo;
-use but_testsupport::{graph_workspace, visualize_commit_graph_all};
-use but_workspace::{BottomUpdate, BottomUpdateKind, integrate_upstream};
+use but_testsupport::{CommandExt, git, graph_workspace, visualize_commit_graph_all};
+use but_workspace::{
+    BottomUpdate, BottomUpdateKind, integrate_upstream, worktree_conflicts_for_rebase,
+};
 use gix::prelude::ObjectIdExt;
 
 use crate::ref_info::with_workspace_commit::utils::{
@@ -559,6 +561,105 @@ fn fully_integrated_single_branch_leaves_workspace_shape() -> Result<()> {
     * 905d6e5 (origin/main) add A1
     * 3183e43 (main) M1
     ");
+
+    Ok(())
+}
+
+#[test]
+fn dry_run_reports_dirty_worktree_conflicts_against_resulting_workspace_head() -> Result<()> {
+    let (tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("upstream-integration-worktree-conflict")?;
+    let target_sha = repo.rev_parse_single("main^")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    add_stack(&mut meta, 1, "A", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+    let mut workspace = graph.into_workspace()?;
+
+    std::fs::write(tmp.path().join("shared.txt"), "dirty\n")?;
+    let but_workspace::IntegrateUpstreamOutcome { rebase, .. } = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A")?.detach()),
+        }],
+    )?;
+
+    let conflicts = worktree_conflicts_for_rebase(&rebase)?;
+    assert_eq!(
+        conflicts,
+        vec![but_serde::BStringForFrontend::from("shared.txt")],
+        "dirty worktree conflict preview should report paths that would conflict on the resulting workspace head"
+    );
+    assert_eq!(
+        repo.head()?
+            .id()
+            .context("HEAD should point to gitbutler/workspace")?
+            .detach(),
+        repo.rev_parse_single("gitbutler/workspace")?.detach(),
+        "dry-run conflict preview must not materialize the rebase"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn dry_run_reports_index_only_conflicts_against_resulting_workspace_head() -> Result<()> {
+    let (tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("upstream-integration-worktree-conflict")?;
+    let target_sha = repo.rev_parse_single("main^")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    add_stack(&mut meta, 1, "A", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+    let mut workspace = graph.into_workspace()?;
+
+    std::fs::write(tmp.path().join("shared.txt"), "dirty\n")?;
+    git(&repo).args(["add", "shared.txt"]).run();
+    std::fs::write(tmp.path().join("shared.txt"), "base\n")?;
+
+    let but_workspace::IntegrateUpstreamOutcome { rebase, .. } = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A")?.detach()),
+        }],
+    )?;
+
+    let conflicts = worktree_conflicts_for_rebase(&rebase)?;
+    assert_eq!(
+        conflicts,
+        vec![but_serde::BStringForFrontend::from("shared.txt")],
+        "index-only conflict preview should report staged paths that would conflict on the resulting workspace head"
+    );
 
     Ok(())
 }

--- a/e2e/playwright/scripts/project-with-remote-branches__add-conflicting-base-and-dirty-worktree.sh
+++ b/e2e/playwright/scripts/project-with-remote-branches__add-conflicting-base-and-dirty-worktree.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+echo "GIT CONFIG $GIT_CONFIG_GLOBAL"
+echo "DATA DIR $E2E_TEST_APP_DATA_DIR"
+echo "BUT $BUT"
+
+pushd remote-project
+  git checkout master
+  echo "upstream changed this line" > a_file
+  git add a_file
+  git commit -m "base: change conflicting file"
+popd
+
+pushd local-clone
+  echo "local dirty change" > a_file
+popd

--- a/e2e/playwright/tests/upstreamIntegration.spec.ts
+++ b/e2e/playwright/tests/upstreamIntegration.spec.ts
@@ -31,6 +31,21 @@ test("should handle the update of workspace with one conflicting branch graceful
 	await expect(stack(page)).toHaveCount(1);
 });
 
+test("should show incoming conflicts with uncommitted files", async ({ page, gitbutler }) => {
+	await gitbutler.runScript("project-with-remote-branches.sh");
+	await applyUpstream(gitbutler, "branch3");
+	await openWorkspace(page);
+
+	await gitbutler.runScript(
+		"project-with-remote-branches__add-conflicting-base-and-dirty-worktree.sh",
+	);
+	await clickByTestId(page, "sync-button");
+	await clickByTestId(page, "integrate-upstream-commits-button");
+
+	const worktreeConflicts = await waitForTestId(page, "integrate-upstream-worktree-conflicts");
+	await expect(worktreeConflicts).toContainText("a_file");
+});
+
 test("should handle the update of workspace with integrated branch gracefully", async ({
 	page,
 	gitbutler,

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -406,7 +406,7 @@ export declare function workspaceBranchAndAncestorsPush(projectId: string, withF
  * workspace previews the integration and no oplog entry is persisted. See
  * [`workspace_integrate_upstream_with_perm()`] for lower-level details.
  */
-export declare function workspaceIntegrateUpstream(projectId: string, updates: Array<BottomUpdate>, dryRun: boolean): Promise<WorkspaceState>
+export declare function workspaceIntegrateUpstream(projectId: string, updates: Array<BottomUpdate>, dryRun: boolean): Promise<WorkspaceIntegrateUpstreamOutcome>
 export declare class WatcherHandle {
   /** Stop the underlying watcher if it is still active. */
   stop(): boolean
@@ -2392,6 +2392,14 @@ export type WatcherPayload = {
 export type WatcherWorktreeChangesPayload = {
   /** The file changes in the repository. */
   changes: WorktreeChanges;
+};
+
+/** JSON transport type returned by upstream integration. */
+export type WorkspaceIntegrateUpstreamOutcome = {
+  /** The post-operation or preview workspace state. */
+  workspaceState: WorkspaceState;
+  /** Dirty worktree paths that would conflict when applied onto the resulting workspace head. */
+  worktreeConflicts: Array<string>;
 };
 
 /** Shared JSON transport type for mutation workspace results. */

--- a/packages/ui/src/lib/utils/testIds.ts
+++ b/packages/ui/src/lib/utils/testIds.ts
@@ -58,6 +58,7 @@ export enum TestId {
 	IntegrateUpstreamSeriesRow = "integrate-upstream-series-row",
 	IntegrateUpstreamSeriesRowStatusBadge = "integrate-upstream-series-row-status-badge",
 	IntegrateUpstreamActionButton = "integrate-upstream-action-button",
+	IntegrateUpstreamWorktreeConflicts = "integrate-upstream-worktree-conflicts",
 	FileListModeOption = "file-list-mode-option",
 	FileListTreeFolder = "file-list-tree-folder",
 	StackTab = "stack-tab",


### PR DESCRIPTION
Calculate whether uncommitted files would conflict after the upstream integration.

If that's the case, display it in the Upstream Integration modal

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #14108 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #14107 
- <kbd>&nbsp;1&nbsp;</kbd> #14106 
<!-- GitButler Footer Boundary Bottom -->

