### PR TITLE
fix(cli): fix `but rub zz commit` not amending all changes

### DIFF
--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -790,27 +790,32 @@ pub fn assignments_to_requests(assignments: Vec<HunkAssignment>) -> Vec<HunkAssi
         .collect()
 }
 
-/// Convert a hunk assignment to a diff spec and populate rename metadata from matching worktree changes.
+/// Convert a hunk assignment to a diff spec and populate metadata from matching worktree changes.
 pub fn diff_spec_from_assignment_with_changes(
     assignment: HunkAssignment,
     changes: &[but_core::ui::TreeChange],
 ) -> DiffSpec {
     let path_bytes = assignment.path_bytes.clone();
     let mut spec = DiffSpec::from(assignment);
-    spec.previous_path = changes.iter().find_map(|change| {
+    for change in changes {
         if change.path_bytes != path_bytes {
-            return None;
+            continue;
         }
         match &change.status {
             but_core::ui::TreeStatus::Rename {
                 previous_path_bytes,
                 ..
-            } => Some(previous_path_bytes.clone()),
+            } => {
+                spec.previous_path = Some(previous_path_bytes.clone());
+            }
             but_core::ui::TreeStatus::Addition { .. }
-            | but_core::ui::TreeStatus::Deletion { .. }
-            | but_core::ui::TreeStatus::Modification { .. } => None,
+            | but_core::ui::TreeStatus::Deletion { .. } => {
+                spec.hunk_headers.clear();
+            }
+            but_core::ui::TreeStatus::Modification { .. } => {}
         }
-    });
+        break;
+    }
     spec
 }
 

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -2112,3 +2112,74 @@ fn agent_json_success_has_no_status_error_field() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn rubbing_modified_and_renamed_file() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
+    env.setup_metadata(&[]).unwrap();
+
+    env.file("file", "content");
+    env.file("file-2", "content-2");
+
+    env.but("commit -m 'add files'").assert().success();
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄br [a-branch-1]
+┊●   e3f869d add files
+┊│     e3:qs A file
+┊│     e3:kw A file-2
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.file("file-2", "new content");
+    env.rename_file("file-2", "file");
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes]
+┊   qs M file
+┊   kw D file-2
+┊
+┊╭┄br [a-branch-1]
+┊●   e3f869d add files
+┊│     e3:qs A file
+┊│     e3:kw A file-2
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+
+"#]]);
+
+    env.but("rub zz e3f869d").assert().success();
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄br [a-branch-1]
+┊●   3a32c97 add files
+┊│     3a:qs A file
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}


### PR DESCRIPTION
If a file has been renamed and modified `but rub zz` wouldn't amend all changes.