### PR TITLE
initial `but commit2` implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,6 +813,7 @@ dependencies = [
  "but-core",
  "but-ctx",
  "but-db",
+ "but-error",
  "but-forge",
  "but-forge-storage",
  "but-gerrit",

--- a/crates/but-error/src/lib.rs
+++ b/crates/but-error/src/lib.rs
@@ -172,6 +172,10 @@ pub enum Code {
     /// Not a bug — the user's request simply can't be fulfilled right now.
     /// The frontend should present this as a warning rather than an error.
     PreconditionFailed,
+    /// Used when we run an external editor, for example to write a commit message, and that editor
+    /// exists with a non-zero status code. Allows callers to detect that and show a different
+    /// error message.
+    EditorExitedWithNonZeroStatus,
 }
 
 #[cfg(feature = "export-schema")]

--- a/crates/but-transaction/src/lib.rs
+++ b/crates/but-transaction/src/lib.rs
@@ -1,14 +1,18 @@
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    ops::{Deref, DerefMut},
+};
 
 use bstr::BStr;
 use but_api::WorkspaceState;
 use but_core::{
-    DiffSpec, DryRun, RefMetadata, sync::RepoExclusive, tree::create_tree::RejectionReason,
+    DiffSpec, DryRun, RefMetadata, ref_metadata, sync::RepoExclusive,
+    tree::create_tree::RejectionReason,
 };
 use but_ctx::Context;
 use but_oplog::legacy::SnapshotDetails;
 use but_rebase::graph_rebase::{
-    Editor, LookupStep as _, SuccessfulRebase,
+    Editor, LookupStep as _, Step, SuccessfulRebase,
     mutate::{InsertSide, RelativeTo},
 };
 use but_workspace::commit::{
@@ -16,7 +20,10 @@ use but_workspace::commit::{
 };
 use gix::{
     ObjectId,
-    refs::{FullName, FullNameRef},
+    refs::{
+        FullName, FullNameRef,
+        transaction::{Change, PreviousValue, RefEdit},
+    },
 };
 
 #[cfg(test)]
@@ -114,12 +121,23 @@ where
             db_tx,
             commit_mappings: CommitMappings::default(),
             pending_metadata_removals: Vec::new(),
+            pending_metadata_updates: Vec::new(),
+            pending_created_independent_refs: Vec::new(),
+            pending_ref_changes: PendingRefChanges::default(),
             context_lines,
         };
 
         let callback_outcome = {
             let tx = Transaction { inner: &mut inner };
-            f(tx)?
+            f(tx)
+        };
+
+        let callback_outcome = match callback_outcome {
+            Ok(outcome) => outcome,
+            Err(err) => {
+                inner.pending_ref_changes.rollback(&repo)?;
+                return Err(err);
+            }
         };
 
         let Inner {
@@ -127,20 +145,37 @@ where
             db_tx,
             commit_mappings: _,
             pending_metadata_removals,
+            pending_metadata_updates,
+            pending_created_independent_refs,
+            mut pending_ref_changes,
             context_lines: _,
         } = inner;
         let rebase = rebase.take().expect("rebase is always Some(_)");
 
-        (
-            callback_outcome.should_rollback(),
-            callback_outcome.maybe_commit(
-                &repo,
-                rebase,
-                db_tx,
-                pending_metadata_removals,
-                dry_run,
-            )?,
-        )
+        let should_rollback = callback_outcome.should_rollback();
+        let outcome = callback_outcome.maybe_commit(
+            &repo,
+            rebase,
+            db_tx,
+            pending_metadata_removals,
+            pending_metadata_updates,
+            pending_created_independent_refs,
+            dry_run,
+        );
+
+        let outcome = match outcome {
+            Ok(outcome) => outcome,
+            Err(err) => {
+                pending_ref_changes.rollback(&repo)?;
+                return Err(err);
+            }
+        };
+
+        if should_rollback || dry_run.into() {
+            pending_ref_changes.rollback(&repo)?;
+        }
+
+        (should_rollback, outcome)
     };
 
     if !should_rollback && let Some(snapshot) = maybe_oplog_entry {
@@ -172,12 +207,10 @@ where
     // and put the result back.
     rebase: Option<SuccessfulRebase<'rebase, 'rebase, M>>,
     db_tx: but_db::Transaction<'rebase>,
-    // Metadata removals to apply only if the transaction commits. Applying them immediately would
-    // leak through dry-runs and rollbacks because the current metadata backend writes on drop.
-    //
-    // HACK: When all the meta data is backed by the database we should be able to remove this and
-    // instead use `db_tx`.
     pending_metadata_removals: Vec<FullName>,
+    pending_metadata_updates: Vec<PendingMetadataUpdate>,
+    pending_created_independent_refs: Vec<FullName>,
+    pending_ref_changes: PendingRefChanges,
     // Commits given to `squash_commits`, `reword_commit`, etc are allowed to be the original
     // commits from live repo. This is used to map those to the rebased in-memory commits.
     //
@@ -254,10 +287,82 @@ where
             let rebase = editor.rebase()?;
             Ok(((), rebase))
         })?;
+        let repo = self.repo().clone();
+        self.inner
+            .pending_ref_changes
+            .remove_eagerly_created_ref(&repo, ref_name)?;
         self.inner
             .pending_metadata_removals
             .push(ref_name.to_owned());
         Ok(())
+    }
+
+    pub fn create_reference<'name>(
+        &mut self,
+        ref_name: &FullNameRef,
+        anchor: impl Into<Option<but_workspace::branch::create_reference::Anchor<'name>>>,
+        new_stack_id: impl FnOnce(&FullNameRef) -> ref_metadata::StackId,
+        order: impl Into<Option<usize>>,
+    ) -> anyhow::Result<()> {
+        let anchor = anchor.into();
+        let creates_independent_branch = anchor.is_none();
+        let previous = self
+            .repo()
+            .try_find_reference(ref_name)?
+            .map(|reference| reference.target().into());
+
+        let graph = self
+            .inner
+            .rebase
+            .as_ref()
+            .expect("rebase is always Some(_)")
+            .overlayed_graph()?;
+        let workspace = graph.into_workspace()?;
+        let mut meta = RecordingMetadata {
+            workspace_name: workspace.ref_name().map(ToOwned::to_owned),
+            workspace: workspace.metadata.clone(),
+            updates: Vec::new(),
+        };
+
+        but_workspace::branch::create_reference(
+            ref_name,
+            anchor,
+            self.repo(),
+            &workspace,
+            &mut meta,
+            new_stack_id,
+            order,
+        )?;
+
+        self.inner
+            .pending_metadata_updates
+            .append(&mut meta.updates);
+        if creates_independent_branch {
+            self.inner
+                .pending_created_independent_refs
+                .push(ref_name.to_owned());
+        }
+        self.inner
+            .pending_ref_changes
+            .record_eager_create(ref_name, previous);
+
+        self.rebase(|mut editor, _, _| {
+            if editor.try_select_reference(ref_name).is_some() {
+                return Ok(((), editor.rebase()?));
+            }
+
+            let target_id = editor
+                .repo()
+                .find_reference(ref_name)?
+                .peel_to_id()?
+                .detach();
+            let target = editor.select_commit(target_id)?;
+            let reference = editor.add_step(Step::Reference {
+                refname: ref_name.to_owned(),
+            })?;
+            editor.add_edge(reference, target, 0)?;
+            Ok(((), editor.rebase()?))
+        })
     }
 
     pub fn create_commit(
@@ -418,6 +523,183 @@ where
 }
 
 #[derive(Debug, Default)]
+struct PendingRefChanges {
+    eagerly_created_refs: Vec<EagerlyCreatedRef>,
+}
+
+impl PendingRefChanges {
+    fn record_eager_create(&mut self, ref_name: &FullNameRef, previous: Option<gix::refs::Target>) {
+        self.eagerly_created_refs.push(EagerlyCreatedRef {
+            name: ref_name.to_owned(),
+            previous,
+        });
+    }
+
+    fn remove_eagerly_created_ref(
+        &mut self,
+        repo: &gix::Repository,
+        ref_name: &FullNameRef,
+    ) -> anyhow::Result<()> {
+        if let Some(created_ref_index) = self.eagerly_created_refs.iter().position(|created_ref| {
+            created_ref.name.as_ref() == ref_name && created_ref.previous.is_none()
+        }) {
+            let created_ref = self.eagerly_created_refs.remove(created_ref_index);
+            Self::restore_one(repo, created_ref)?;
+        }
+        Ok(())
+    }
+
+    fn rollback(&mut self, repo: &gix::Repository) -> anyhow::Result<()> {
+        for created_ref in self.eagerly_created_refs.drain(..).rev() {
+            Self::restore_one(repo, created_ref)?;
+        }
+        Ok(())
+    }
+
+    fn restore_one(repo: &gix::Repository, created_ref: EagerlyCreatedRef) -> anyhow::Result<()> {
+        let EagerlyCreatedRef { name, previous } = created_ref;
+        match previous {
+            Some(target) => {
+                repo.edit_references([RefEdit {
+                    name,
+                    change: Change::Update {
+                        log: Default::default(),
+                        expected: PreviousValue::Any,
+                        new: target,
+                    },
+                    deref: false,
+                }])?;
+            }
+            None => {
+                if repo.try_find_reference(name.as_ref())?.is_some() {
+                    repo.edit_references([RefEdit {
+                        name,
+                        change: Change::Delete {
+                            log: gix::refs::transaction::RefLog::AndReference,
+                            expected: PreviousValue::MustExist,
+                        },
+                        deref: false,
+                    }])?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct EagerlyCreatedRef {
+    name: FullName,
+    previous: Option<gix::refs::Target>,
+}
+
+#[derive(Clone)]
+enum PendingMetadataUpdate {
+    Workspace(RecordingMetadataHandle<ref_metadata::Workspace>),
+    Branch(RecordingMetadataHandle<ref_metadata::Branch>),
+}
+
+#[derive(Default)]
+struct RecordingMetadata {
+    workspace_name: Option<FullName>,
+    workspace: Option<ref_metadata::Workspace>,
+    updates: Vec<PendingMetadataUpdate>,
+}
+
+#[derive(Clone)]
+struct RecordingMetadataHandle<T> {
+    name: FullName,
+    value: T,
+    is_default: bool,
+}
+
+impl<T> Deref for RecordingMetadataHandle<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl<T> DerefMut for RecordingMetadataHandle<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.value
+    }
+}
+
+impl<T> AsRef<FullNameRef> for RecordingMetadataHandle<T> {
+    fn as_ref(&self) -> &FullNameRef {
+        self.name.as_ref()
+    }
+}
+
+impl<T> ref_metadata::ValueInfo for RecordingMetadataHandle<T> {
+    fn is_default(&self) -> bool {
+        self.is_default
+    }
+}
+
+impl RefMetadata for RecordingMetadata {
+    type Handle<T> = RecordingMetadataHandle<T>;
+
+    fn iter(&self) -> impl Iterator<Item = anyhow::Result<(FullName, Box<dyn std::any::Any>)>> {
+        std::iter::empty()
+    }
+
+    fn workspace(
+        &self,
+        ref_name: &FullNameRef,
+    ) -> anyhow::Result<Self::Handle<ref_metadata::Workspace>> {
+        let value = self
+            .workspace_name
+            .as_ref()
+            .filter(|name| name.as_ref() == ref_name)
+            .and_then(|_| self.workspace.clone());
+        let is_default = value.is_none();
+        Ok(RecordingMetadataHandle {
+            name: ref_name.to_owned(),
+            value: value.unwrap_or_default(),
+            is_default,
+        })
+    }
+
+    fn branch(&self, ref_name: &FullNameRef) -> anyhow::Result<Self::Handle<ref_metadata::Branch>> {
+        Ok(RecordingMetadataHandle {
+            name: ref_name.to_owned(),
+            value: ref_metadata::Branch::default(),
+            is_default: true,
+        })
+    }
+
+    fn set_workspace(
+        &mut self,
+        value: &Self::Handle<ref_metadata::Workspace>,
+    ) -> anyhow::Result<()> {
+        self.updates
+            .push(PendingMetadataUpdate::Workspace(RecordingMetadataHandle {
+                name: value.name.clone(),
+                value: value.value.clone(),
+                is_default: value.is_default,
+            }));
+        Ok(())
+    }
+
+    fn set_branch(&mut self, value: &Self::Handle<ref_metadata::Branch>) -> anyhow::Result<()> {
+        self.updates
+            .push(PendingMetadataUpdate::Branch(RecordingMetadataHandle {
+                name: value.name.clone(),
+                value: value.value.clone(),
+                is_default: value.is_default,
+            }));
+        Ok(())
+    }
+
+    fn remove(&mut self, _ref_name: &FullNameRef) -> anyhow::Result<bool> {
+        Ok(false)
+    }
+}
+
+#[derive(Debug, Default)]
 struct CommitMappings(BTreeMap<gix::ObjectId, gix::ObjectId>);
 
 impl CommitMappings {
@@ -442,12 +724,15 @@ pub trait TransactionOutcome: sealed::Sealed {
 
     fn should_rollback(&self) -> bool;
 
+    #[expect(private_interfaces, clippy::too_many_arguments)]
     fn maybe_commit<M: RefMetadata>(
         self,
         repo: &gix::Repository,
         rebase: SuccessfulRebase<'_, '_, M>,
         db_tx: but_db::Transaction<'_>,
         pending_metadata_removals: Vec<FullName>,
+        pending_metadata_updates: Vec<PendingMetadataUpdate>,
+        pending_created_independent_refs: Vec<FullName>,
         dry_run: DryRun,
     ) -> anyhow::Result<Self::Outcome>;
 }
@@ -459,15 +744,25 @@ impl TransactionOutcome for () {
         false
     }
 
+    #[expect(private_interfaces)]
     fn maybe_commit<M: RefMetadata>(
         self,
         repo: &gix::Repository,
         rebase: SuccessfulRebase<'_, '_, M>,
         db_tx: but_db::Transaction<'_>,
         pending_metadata_removals: Vec<FullName>,
+        pending_metadata_updates: Vec<PendingMetadataUpdate>,
+        pending_created_independent_refs: Vec<FullName>,
         dry_run: DryRun,
     ) -> anyhow::Result<Self::Outcome> {
-        let ws = workspace_state_from_rebase(rebase, repo, pending_metadata_removals, dry_run)?;
+        let ws = workspace_state_from_rebase(
+            rebase,
+            repo,
+            pending_metadata_removals,
+            pending_metadata_updates,
+            pending_created_independent_refs,
+            dry_run,
+        )?;
         if dry_run == DryRun::No {
             db_tx.commit()?;
         }
@@ -486,12 +781,15 @@ impl<T> TransactionOutcome for Rollback<T> {
         true
     }
 
+    #[expect(private_interfaces)]
     fn maybe_commit<M: RefMetadata>(
         self,
         _repo: &gix::Repository,
         _rebase: SuccessfulRebase<'_, '_, M>,
         _db_tx: but_db::Transaction<'_>,
         _pending_metadata_removals: Vec<FullName>,
+        _pending_metadata_updates: Vec<PendingMetadataUpdate>,
+        _pending_created_independent_refs: Vec<FullName>,
         _dry_run: DryRun,
     ) -> anyhow::Result<Self::Outcome> {
         Ok(self.0)
@@ -512,18 +810,27 @@ impl<T, K> TransactionOutcome for DynamicOutcome<T, K> {
         matches!(self, Self::Rollback(_))
     }
 
+    #[expect(private_interfaces)]
     fn maybe_commit<M: RefMetadata>(
         self,
         repo: &gix::Repository,
         rebase: SuccessfulRebase<'_, '_, M>,
         db_tx: but_db::Transaction<'_>,
         pending_metadata_removals: Vec<FullName>,
+        pending_metadata_updates: Vec<PendingMetadataUpdate>,
+        pending_created_independent_refs: Vec<FullName>,
         dry_run: DryRun,
     ) -> anyhow::Result<Self::Outcome> {
         match self {
             DynamicOutcome::Commit(value) => {
-                let workspace =
-                    workspace_state_from_rebase(rebase, repo, pending_metadata_removals, dry_run)?;
+                let workspace = workspace_state_from_rebase(
+                    rebase,
+                    repo,
+                    pending_metadata_removals,
+                    pending_metadata_updates,
+                    pending_created_independent_refs,
+                    dry_run,
+                )?;
                 if dry_run == DryRun::No {
                     db_tx.commit()?;
                 }
@@ -538,6 +845,8 @@ fn workspace_state_from_rebase<M: RefMetadata>(
     rebase: SuccessfulRebase<'_, '_, M>,
     repo: &gix::Repository,
     pending_metadata_removals: Vec<FullName>,
+    pending_metadata_updates: Vec<PendingMetadataUpdate>,
+    pending_created_independent_refs: Vec<FullName>,
     dry_run: DryRun,
 ) -> anyhow::Result<WorkspaceState> {
     if dry_run.into() {
@@ -545,6 +854,37 @@ fn workspace_state_from_rebase<M: RefMetadata>(
     }
 
     let materialized = rebase.materialize()?;
+    for branch in pending_created_independent_refs {
+        if materialized
+            .workspace
+            .find_segment_and_stack_by_refname(branch.as_ref())
+            .is_some()
+        {
+            continue;
+        }
+        let outcome = but_workspace::branch::apply(
+            branch.as_ref(),
+            materialized.workspace,
+            repo,
+            materialized.meta,
+            Default::default(),
+        )?;
+        *materialized.workspace = outcome.workspace.into_owned();
+    }
+    for update in pending_metadata_updates {
+        match update {
+            PendingMetadataUpdate::Workspace(workspace) => {
+                let mut handle = materialized.meta.workspace(workspace.as_ref())?;
+                *handle = workspace.value;
+                materialized.meta.set_workspace(&handle)?;
+            }
+            PendingMetadataUpdate::Branch(branch) => {
+                let mut handle = materialized.meta.branch(branch.as_ref())?;
+                *handle = branch.value;
+                materialized.meta.set_branch(&handle)?;
+            }
+        }
+    }
     for ref_name in pending_metadata_removals {
         materialized.meta.remove(ref_name.as_ref())?;
     }

--- a/crates/but-transaction/src/tests.rs
+++ b/crates/but-transaction/src/tests.rs
@@ -2,11 +2,24 @@ use but_api::WorkspaceState;
 use but_core::DryRun;
 use but_ctx::Context;
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
+use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
 use but_testsupport::Sandbox;
-use but_workspace::commit::squash_commits::MessageCombinationStrategy;
+use but_workspace::{
+    branch::create_reference::{Anchor, Position},
+    commit::squash_commits::MessageCombinationStrategy,
+};
 use gix::{ObjectId, refs::FullName};
 
 use crate::{DynamicOutcome, with_transaction};
+
+#[track_caller]
+fn ref_target(env: &Sandbox, ref_name: &gix::refs::FullNameRef) -> Option<ObjectId> {
+    env.open_repo()
+        .unwrap()
+        .try_find_reference(ref_name)
+        .unwrap()
+        .map(|mut reference| reference.peel_to_id().unwrap().detach())
+}
 
 // TODO(david): shared.sh is copy-pasted from but tests
 
@@ -122,6 +135,248 @@ fn rollback() {
 "#]]
     );
 
+    assert_num_snapshots(&ctx, 0);
+}
+
+#[test]
+fn create_reference_without_creating_commits() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    let [three] = find_commits(&env, ["1e25c58"]);
+
+    let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
+    let mut ctx = Context::from_repo(repo)
+        .map(Context::with_memory_app_cache)
+        .unwrap();
+
+    let mut meta = ctx.meta().unwrap();
+    let snapshot_details = SnapshotDetails::new(OperationKind::CreateBranch);
+    let refname = FullName::try_from("refs/heads/created-without-commits").unwrap();
+
+    let _workspace: WorkspaceState = with_transaction(
+        &mut ctx,
+        &mut meta,
+        snapshot_details,
+        DryRun::No,
+        |mut tx| {
+            tx.create_reference(
+                refname.as_ref(),
+                Anchor::at_id(three, Position::Above),
+                |_| but_core::ref_metadata::StackId::generate(),
+                None,
+            )?;
+
+            Ok(())
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        Some(three),
+        ref_target(&env, refname.as_ref()),
+        "created reference should be persisted even if no commits are created"
+    );
+    assert_num_snapshots(&ctx, 1);
+}
+
+#[test]
+fn create_reference_relative_to_various_anchors() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    let [three, two, base] = find_commits(&env, ["1e25c58", "9b3b3d5", "6674d4f"]);
+
+    let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
+    let mut ctx = Context::from_repo(repo)
+        .map(Context::with_memory_app_cache)
+        .unwrap();
+
+    let mut meta = ctx.meta().unwrap();
+    let snapshot_details = SnapshotDetails::new(OperationKind::CreateBranch);
+    let branch = FullName::try_from("refs/heads/branch").unwrap();
+    let at_commit_above = FullName::try_from("refs/heads/at-commit-above").unwrap();
+    let at_commit_below = FullName::try_from("refs/heads/at-commit-below").unwrap();
+    let at_segment_above = FullName::try_from("refs/heads/at-segment-above").unwrap();
+    let at_segment_below = FullName::try_from("refs/heads/at-segment-below").unwrap();
+    let independent = FullName::try_from("refs/heads/independent").unwrap();
+
+    let _workspace: WorkspaceState = with_transaction(
+        &mut ctx,
+        &mut meta,
+        snapshot_details,
+        DryRun::No,
+        |mut tx| {
+            for (refname, anchor) in [
+                (
+                    at_commit_above.as_ref(),
+                    Some(Anchor::at_id(three, Position::Above)),
+                ),
+                (
+                    at_commit_below.as_ref(),
+                    Some(Anchor::at_id(three, Position::Below)),
+                ),
+                (
+                    at_segment_above.as_ref(),
+                    Some(Anchor::at_segment(branch.as_ref(), Position::Above)),
+                ),
+                (
+                    at_segment_below.as_ref(),
+                    Some(Anchor::at_segment(branch.as_ref(), Position::Below)),
+                ),
+                (independent.as_ref(), None),
+            ] {
+                tx.create_reference(
+                    refname,
+                    anchor,
+                    |_| but_core::ref_metadata::StackId::generate(),
+                    None,
+                )?;
+            }
+
+            Ok(())
+        },
+    )
+    .unwrap();
+
+    assert_eq!(Some(three), ref_target(&env, at_commit_above.as_ref()));
+    assert_eq!(Some(two), ref_target(&env, at_commit_below.as_ref()));
+    assert_eq!(Some(three), ref_target(&env, at_segment_above.as_ref()));
+    assert_eq!(Some(two), ref_target(&env, at_segment_below.as_ref()));
+    assert_eq!(Some(base), ref_target(&env, independent.as_ref()));
+    assert_num_snapshots(&ctx, 1);
+}
+
+#[test]
+fn create_reference_then_remove_it_in_same_transaction() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    let [three] = find_commits(&env, ["1e25c58"]);
+
+    let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
+    let mut ctx = Context::from_repo(repo)
+        .map(Context::with_memory_app_cache)
+        .unwrap();
+
+    let mut meta = ctx.meta().unwrap();
+    let snapshot_details = SnapshotDetails::new(OperationKind::CreateBranch);
+    let refname = FullName::try_from("refs/heads/create-then-remove").unwrap();
+
+    let _workspace: WorkspaceState = with_transaction(
+        &mut ctx,
+        &mut meta,
+        snapshot_details,
+        DryRun::No,
+        |mut tx| {
+            tx.create_reference(
+                refname.as_ref(),
+                Anchor::at_id(three, Position::Above),
+                |_| but_core::ref_metadata::StackId::generate(),
+                None,
+            )?;
+            tx.remove_reference(refname.as_ref())?;
+
+            Ok(())
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        None,
+        ref_target(&env, refname.as_ref()),
+        "reference created and removed in one transaction should not persist"
+    );
+    assert_num_snapshots(&ctx, 1);
+}
+
+#[test]
+fn create_reference_then_commit_relative_to_it() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    let [three] = find_commits(&env, ["1e25c58"]);
+
+    let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
+    let mut ctx = Context::from_repo(repo)
+        .map(Context::with_memory_app_cache)
+        .unwrap();
+
+    let mut meta = ctx.meta().unwrap();
+    let snapshot_details = SnapshotDetails::new(OperationKind::CreateCommit);
+    let refname = FullName::try_from("refs/heads/new-branch").unwrap();
+
+    let new_commit = with_transaction(
+        &mut ctx,
+        &mut meta,
+        snapshot_details,
+        DryRun::No,
+        |mut tx| {
+            tx.create_reference(
+                refname.as_ref(),
+                Anchor::at_id(three, Position::Above),
+                |_| but_core::ref_metadata::StackId::generate(),
+                None,
+            )?;
+            let new_commit =
+                tx.insert_blank_commit(RelativeTo::Reference(refname.clone()), InsertSide::Below)?;
+
+            Ok(DynamicOutcome::<_, ()>::Commit(new_commit))
+        },
+    )
+    .unwrap();
+
+    let DynamicOutcome::Commit((new_commit, _workspace)) = new_commit else {
+        panic!("transaction should commit");
+    };
+    assert_eq!(
+        Some(new_commit),
+        ref_target(&env, refname.as_ref()),
+        "created reference should point to the commit inserted relative to it"
+    );
+    assert_num_snapshots(&ctx, 1);
+}
+
+#[test]
+fn create_reference_is_removed_on_rollback() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    let [three] = find_commits(&env, ["1e25c58"]);
+
+    let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
+    let mut ctx = Context::from_repo(repo)
+        .map(Context::with_memory_app_cache)
+        .unwrap();
+
+    let mut meta = ctx.meta().unwrap();
+    let snapshot_details = SnapshotDetails::new(OperationKind::CreateCommit);
+    let refname = FullName::try_from("refs/heads/rolled-back").unwrap();
+
+    let outcome = with_transaction(
+        &mut ctx,
+        &mut meta,
+        snapshot_details,
+        DryRun::No,
+        |mut tx| {
+            tx.create_reference(
+                refname.as_ref(),
+                Anchor::at_id(three, Position::Above),
+                |_| but_core::ref_metadata::StackId::generate(),
+                None,
+            )?;
+
+            Ok(DynamicOutcome::<(), _>::Rollback("nope"))
+        },
+    )
+    .unwrap();
+
+    assert!(matches!(outcome, DynamicOutcome::Rollback("nope")));
+    assert_eq!(
+        None,
+        ref_target(&env, refname.as_ref()),
+        "created reference should be removed when the transaction rolls back"
+    );
     assert_num_snapshots(&ctx, 0);
 }
 

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -66,6 +66,7 @@ but-llm.workspace = true
 but-agentlog.workspace = true
 but-transaction.workspace = true
 but-db.workspace = true
+but-error.workspace = true
 
 # What follows is *basically* newly written crates that are built on top of legacy,
 # so need some refactoring/rethinking to become usable.

--- a/crates/but/src/args/atoms/branch_arg.rs
+++ b/crates/but/src/args/atoms/branch_arg.rs
@@ -32,10 +32,20 @@ impl BranchArg {
     /// Resolve the argument to its corresponding segment.
     pub fn resolve_segment(
         &self,
-        ctx: &but_ctx::Context,
+        head_info: &but_workspace::RefInfo,
     ) -> CliResult<but_workspace::ref_info::Segment> {
+        let Some(segment) = self.try_resolve_segment(head_info)? else {
+            return Err(bad_input(format!("Branch '{self}' not found in any stack")).into());
+        };
+        Ok(segment.clone())
+    }
+
+    /// Resolve the argument to its corresponding segment.
+    pub fn try_resolve_segment(
+        &self,
+        head_info: &but_workspace::RefInfo,
+    ) -> CliResult<Option<but_workspace::ref_info::Segment>> {
         let ref_name = self.resolve_local_branch_name()?;
-        let head_info = but_api::legacy::workspace::head_info(ctx)?;
         let segment = head_info
             .stacks
             .iter()
@@ -47,15 +57,51 @@ impl BranchArg {
                     false
                 }
             });
-        let Some(segment) = segment else {
-            return Err(bad_input(format!("Branch '{self}' not found in any stack")).into());
-        };
-        Ok(segment.clone())
+        Ok(segment.cloned())
     }
 
-    /// Validate if the argument is suitable for naming new branches.
-    pub fn resolve_for_creation(&self, repo: &gix::Repository) -> CliResult<String> {
-        check_can_create_branch_with_user_provided_name(repo, &self.0)?;
+    /// Validate that the argument is a valid branch name that does not already exist.
+    ///
+    /// Unlike the GUI, we don't normalize branch names for users in the CLI, as this could lead to
+    /// unexpected behavior in scripts. This function rejects names that are possible to normalize.
+    // TODO(david): might wanna return FullName here
+    pub fn resolve_for_creation(
+        &self,
+        repo: &gix::Repository,
+        head_info: &but_workspace::RefInfo,
+    ) -> CliResult<String> {
+        let branch_name = self.0.as_str();
+        let normalized = but_core::branch::normalize_short_name(branch_name).map_err(|err| {
+            CliError::from(bad_input(format!("Invalid branch name: {err}")).arg_value(branch_name))
+        })?;
+
+        if normalized != <&BStr>::from(branch_name) {
+            return Err(bad_input("Invalid branch name")
+                .arg_value(branch_name)
+                .hint(format!("Try '{normalized}' instead"))
+                .into());
+        }
+
+        let local_name = self.resolve_local_branch_name()?;
+        if head_info
+            .stacks
+            .iter()
+            .flat_map(|stack| &stack.segments)
+            .flat_map(|segment| &segment.ref_info)
+            .any(|ref_info| ref_info.ref_name == local_name)
+        {
+            return Err(
+                bad_input(format!("A branch named '{branch_name}' is already applied")).into(),
+            );
+        }
+
+        if repo.try_find_reference(&local_name)?.is_some() {
+            return Err(bad_input(format!(
+                "A branch named '{branch_name}' exists but is not applied"
+            ))
+            .into());
+        }
+
         Ok(self.0.clone())
     }
 
@@ -90,47 +136,4 @@ impl AsRef<str> for BranchArg {
     fn as_ref(&self) -> &str {
         self.0.as_ref()
     }
-}
-
-/// Validate that `user_provided_branch_name` is a valid branch name that does not already exist.
-///
-/// Unlike the GUI, we don't normalize branch names for users in the CLI, as this could lead to
-/// unexpected behavior in scripts. This function rejects names that are possible to normalize.
-fn check_can_create_branch_with_user_provided_name(
-    repo: &gix::Repository,
-    user_provided_branch_name: &str,
-) -> Result<(), CliError> {
-    let normalized =
-        but_core::branch::normalize_short_name(user_provided_branch_name).map_err(|err| {
-            CliError::from(
-                bad_input(format!("Invalid branch name: {err}"))
-                    .arg_value(user_provided_branch_name),
-            )
-        })?;
-
-    let user_name_bstr: &BStr = user_provided_branch_name.into();
-    if normalized != user_name_bstr {
-        return Err(bad_input("Invalid branch name")
-            .arg_value(user_provided_branch_name)
-            .hint(format!("Try '{normalized}' instead"))
-            .into());
-    }
-
-    let branch_ref_name = if user_provided_branch_name.starts_with("refs/heads") {
-        user_provided_branch_name.to_string()
-    } else {
-        format!("refs/heads/{user_provided_branch_name}")
-    };
-
-    if repo
-        .try_find_reference(&branch_ref_name.to_owned())?
-        .is_some()
-    {
-        return Err(bad_input(format!(
-            "A branch named '{user_provided_branch_name}' already exists"
-        ))
-        .into());
-    }
-
-    Ok(())
 }

--- a/crates/but/src/args/commit2.rs
+++ b/crates/but/src/args/commit2.rs
@@ -1,2 +1,11 @@
+use crate::args::atoms::BranchArg;
+
 #[derive(Debug, clap::Parser)]
-pub struct Platform {}
+pub struct Platform {
+    #[clap(long)]
+    pub no_message: bool,
+    #[clap(short, long, conflicts_with = "no_message")]
+    pub message: Option<String>,
+    #[clap(short, long)]
+    pub branch: Option<BranchArg>,
+}

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -27,7 +27,8 @@ pub fn delete(
         branch_arg.resolve_branch_in_workspace(ctx, &id_map)?
     };
 
-    let segment = branch_arg.resolve_segment(ctx)?;
+    let head_info = but_api::legacy::workspace::head_info(ctx)?;
+    let segment = branch_arg.resolve_segment(&head_info)?;
 
     let ref_name = &segment
         .ref_info
@@ -58,9 +59,10 @@ pub fn new(
     anchor_arg: Option<CliIdArg>,
 ) -> CliResult<()> {
     let t = theme::get();
+    let head_info = but_api::legacy::workspace::head_info(ctx)?;
 
     let branch_name = if let Some(branch_name_arg) = branch_name_arg {
-        branch_name_arg.resolve_for_creation(&*ctx.repo.get()?)?
+        branch_name_arg.resolve_for_creation(&*ctx.repo.get()?, &head_info)?
     } else {
         but_api::legacy::workspace::canned_branch_name(ctx)?
     };

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -358,7 +358,8 @@ pub(crate) fn commit(
             Some(branch)
         } else {
             let repo = ctx.repo.get()?;
-            Some(BranchArg(branch_arg.0).resolve_for_creation(&repo)?)
+            let head_info = but_api::legacy::workspace::head_info(ctx)?;
+            Some(BranchArg(branch_arg.0).resolve_for_creation(&repo, &head_info)?)
         }
     } else {
         None

--- a/crates/but/src/command/legacy/commit2.rs
+++ b/crates/but/src/command/legacy/commit2.rs
@@ -1,37 +1,325 @@
+use std::fmt::Display;
+
+use anyhow::Context;
+use bstr::{BStr, BString, ByteSlice};
+use but_api::{diff::ComputeLineStats, json::HexHash};
+use but_core::{DiffSpec, DryRun, RefMetadata, diff::CommitDetails, ref_metadata::StackId};
+use but_error::Code;
+use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
+use but_transaction::{DynamicOutcome, IntermediateCommitCreateResult, Transaction};
+use but_workspace::RefInfo;
+use gitbutler_oplog::entry::{OperationKind, SnapshotDetails};
+use gix::{prelude::ObjectIdExt as _, refs::FullName};
 use serde::Serialize;
 
 use crate::{
-    CliResult,
-    args::commit2::Platform,
-    theme::Theme,
-    utils::{CliOutput, CliOutputHuman, IntermediateChannel, WriteWithUtils},
+    CliResult, CliResultExt,
+    args::{atoms::BranchArg, commit2::Platform},
+    bad_input,
+    command::legacy::{ShowDiffInEditor, reword::get_commit_message_from_editor},
+    id::UNASSIGNED,
+    theme::{Paint, Theme},
+    utils::{
+        CliOutput, CliOutputHuman, IntermediateChannel, WriteWithUtils,
+        diff_specs::{CommitSource, UnassignedCommitSource, prepare_changes_to_commit},
+    },
 };
 
-#[derive(Serialize)]
 #[must_use]
-pub struct CommitOutcome {}
+pub struct CommitOutcome {
+    new_commit: gix::ObjectId,
+    ref_name: gix::refs::FullName,
+}
 
 impl CliOutputHuman for CommitOutcome {
-    fn on_human(self, _out: &mut dyn WriteWithUtils, _theme: &Theme) -> anyhow::Result<()> {
+    fn on_human(self, out: &mut dyn WriteWithUtils, _theme: &Theme) -> anyhow::Result<()> {
+        let Self {
+            new_commit,
+            ref_name,
+        } = self;
+        writeln!(
+            out,
+            "Created commit {} on {}",
+            Commit(new_commit),
+            Branch(ref_name.shorten()),
+        )?;
         Ok(())
     }
 }
 
 impl CliOutput for CommitOutcome {
-    fn on_shell(self, _out: &mut dyn WriteWithUtils) -> anyhow::Result<()> {
+    fn on_shell(self, out: &mut dyn WriteWithUtils) -> anyhow::Result<()> {
+        let Self {
+            new_commit,
+            ref_name: _,
+        } = self;
+        writeln!(out, "{}", new_commit.to_hex_with_len(7))?;
         Ok(())
     }
 
     fn on_json(self) -> impl serde::Serialize {
-        self
+        #[derive(Serialize)]
+        struct Output {
+            commit: HexHash,
+        }
+
+        Output {
+            commit: self.new_commit.into(),
+        }
     }
 }
 
 pub fn commit(
-    _ctx: &mut but_ctx::Context,
+    ctx: &mut but_ctx::Context,
     _out: IntermediateChannel<'_>,
     args: Platform,
 ) -> CliResult<CommitOutcome> {
-    let Platform {} = args;
-    Ok(CommitOutcome {})
+    let Platform {
+        no_message,
+        message,
+        branch,
+    } = args;
+
+    let mut guard = ctx.exclusive_worktree_access();
+    let perm = guard.write_permission();
+
+    let mut meta = ctx.meta()?;
+    let (changes, operation) = {
+        let context_lines = ctx.settings.context_lines;
+        let (repo, ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
+        let head_info = but_workspace::head_info(&repo, &meta, Default::default())?;
+
+        let operation = route_operation(&repo, &head_info, branch)?;
+
+        let source = CommitSource::Unassigned(UnassignedCommitSource {
+            id: UNASSIGNED.to_string(),
+        });
+        let changes = prepare_changes_to_commit(&mut db, &repo, &ws, context_lines, &source, None)?;
+
+        (changes, operation)
+    };
+
+    let snapshot_details = SnapshotDetails::new(OperationKind::CreateCommit);
+    let result = but_transaction::with_transaction_with_perm(
+        ctx,
+        &mut meta,
+        perm,
+        snapshot_details,
+        DryRun::No,
+        |mut tx| {
+            let (
+                IntermediateCommitCreateResult {
+                    new_commit,
+                    rejected_specs,
+                },
+                ref_name,
+            ) = operation.execute(&mut tx, changes)?;
+
+            anyhow::ensure!(rejected_specs.is_empty(), "Couldn't commit all changes");
+
+            let new_commit =
+                new_commit.context("BUG: rejected_specs is empty yet nothing was committed")?;
+
+            let message = match (no_message, message) {
+                (true, None) => String::new(),
+                (false, None) => {
+                    let repo = tx.repo();
+                    let commit_details = CommitDetails::from_commit_id(
+                        new_commit.attach(repo),
+                        ComputeLineStats::No.into(),
+                    )?;
+
+                    get_commit_message_from_editor(
+                        tx.repo(),
+                        tx.context_lines(),
+                        commit_details,
+                        String::new(),
+                        "",
+                        ShowDiffInEditor::Unspecified,
+                    )?
+                    .unwrap_or_default()
+                }
+                (false, Some(message)) => message,
+                (true, Some(_)) => {
+                    unreachable!("--no-message and --message are mutually exclusive")
+                }
+            };
+
+            let reworded_commit = tx.reword_commit(new_commit, BString::from(message).as_ref())?;
+
+            Ok(DynamicOutcome::<_, std::convert::Infallible>::Commit((
+                reworded_commit,
+                ref_name,
+            )))
+        },
+    );
+
+    let DynamicOutcome::Commit(((new_commit, ref_name), _ws)) = match result {
+        Ok(outcome) => outcome,
+        Err(err) => {
+            return Err(
+                if let Some(Code::EditorExitedWithNonZeroStatus) =
+                    err.downcast_ref::<but_error::Code>()
+                {
+                    bad_input("Editor exited with non-zero status").into()
+                } else {
+                    err.into()
+                },
+            );
+        }
+    };
+
+    Ok(CommitOutcome {
+        new_commit,
+        ref_name,
+    })
+}
+
+fn route_operation(
+    repo: &gix::Repository,
+    head_info: &RefInfo,
+    branch: Option<BranchArg>,
+) -> CliResult<CommitOperation> {
+    if let Some(branch) = branch {
+        if let Some(segment) = branch.try_resolve_segment(head_info)? {
+            let ref_info = segment.ref_info.with_context(|| {
+                format!("BUG: Segment resolved from branch name {branch} has no ref info")
+            })?;
+
+            return Ok(CommitOperation::CommitToExistingBranch(
+                CommitToExistingBranchOperation {
+                    branch_name: ref_info.ref_name,
+                },
+            ));
+        } else {
+            let branch_name = BranchArg(branch.resolve_for_creation(repo, head_info).hint(
+                format!("Run `but apply {branch}` to apply the branch first"),
+            )?)
+            .resolve_local_branch_name()?;
+            return Ok(CommitOperation::CommitToNewBranch(
+                CommitToNewBranchOperation {
+                    branch_name: Some(branch_name),
+                },
+            ));
+        }
+    }
+
+    let mut stacks = head_info.stacks.iter();
+    if let Some(stack) = stacks.next() {
+        if stacks.next().is_some() {
+            return Err(anyhow::anyhow!("Found more than one stack, badness!").into());
+        }
+
+        let ref_info = stack
+            .segments
+            .first()
+            .and_then(|segment| segment.ref_info.as_ref())
+            .context("Head stack as no ref")?;
+
+        return Ok(CommitOperation::CommitToExistingBranch(
+            CommitToExistingBranchOperation {
+                branch_name: ref_info.ref_name.clone(),
+            },
+        ));
+    }
+
+    Ok(CommitOperation::CommitToNewBranch(
+        CommitToNewBranchOperation { branch_name: None },
+    ))
+}
+
+enum CommitOperation {
+    CommitToExistingBranch(CommitToExistingBranchOperation),
+    CommitToNewBranch(CommitToNewBranchOperation),
+}
+
+impl CommitOperation {
+    fn execute(
+        self,
+        tx: &mut Transaction<'_, '_, impl RefMetadata>,
+        changes: Vec<DiffSpec>,
+    ) -> anyhow::Result<(IntermediateCommitCreateResult, FullName)> {
+        match self {
+            CommitOperation::CommitToExistingBranch(op) => op.execute(tx, changes),
+            CommitOperation::CommitToNewBranch(op) => op.execute(tx, changes),
+        }
+    }
+}
+
+struct CommitToExistingBranchOperation {
+    branch_name: gix::refs::FullName,
+}
+
+impl CommitToExistingBranchOperation {
+    fn execute(
+        self,
+        tx: &mut Transaction<'_, '_, impl RefMetadata>,
+        changes: Vec<DiffSpec>,
+    ) -> anyhow::Result<(IntermediateCommitCreateResult, FullName)> {
+        let Self {
+            branch_name: ref_name,
+        } = self;
+
+        let commit_create_result = tx.create_commit(
+            RelativeTo::Reference(ref_name.clone()),
+            InsertSide::Below,
+            changes,
+            String::new(),
+        )?;
+
+        Ok((commit_create_result, ref_name))
+    }
+}
+
+struct CommitToNewBranchOperation {
+    branch_name: Option<FullName>,
+}
+
+impl CommitToNewBranchOperation {
+    fn execute(
+        self,
+        tx: &mut Transaction<'_, '_, impl RefMetadata>,
+        changes: Vec<DiffSpec>,
+    ) -> anyhow::Result<(IntermediateCommitCreateResult, FullName)> {
+        let Self { branch_name } = self;
+
+        let branch_name = if let Some(branch_name) = branch_name {
+            branch_name
+        } else {
+            but_core::branch::unique_canned_refname(tx.repo())?
+        };
+
+        tx.create_reference(branch_name.as_ref(), None, |_| StackId::generate(), None)?;
+
+        let commit_create_result = tx.create_commit(
+            RelativeTo::Reference(branch_name.clone()),
+            InsertSide::Below,
+            changes,
+            String::new(),
+        )?;
+
+        Ok((commit_create_result, branch_name))
+    }
+}
+
+struct Commit(gix::ObjectId);
+
+impl Display for Commit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let t = crate::theme::get();
+        write!(
+            f,
+            "{}",
+            t.commit_id.paint(self.0.to_hex_with_len(7).to_string())
+        )
+    }
+}
+
+struct Branch<'a>(&'a BStr);
+
+impl Display for Branch<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let t = crate::theme::get();
+        write!(f, "'{}'", t.local_branch.paint(self.0.to_str_lossy()))
+    }
 }

--- a/crates/but/src/command/legacy/commit_message_prep.rs
+++ b/crates/but/src/command/legacy/commit_message_prep.rs
@@ -1,5 +1,3 @@
-use anyhow::{Result, bail};
-
 /// Returns the canonical commit message representation used for comparisons and storage.
 ///
 /// This currently trims leading and trailing whitespace.
@@ -10,17 +8,6 @@ pub(crate) fn normalize_commit_message(message: &str) -> &str {
 /// Returns `true` if `current_message` and `new_message` differ after normalization.
 pub(crate) fn should_update_commit_message(current_message: &str, new_message: &str) -> bool {
     normalize_commit_message(current_message) != normalize_commit_message(new_message)
-}
-
-/// Prepares a commit message provided directly by the user.
-///
-/// The message is normalized and then validated to be non-empty.
-pub(crate) fn prepare_provided_commit_message(message: &str) -> Result<String> {
-    let normalized = normalize_commit_message(message);
-    if normalized.is_empty() {
-        bail!("Aborting due to empty commit message");
-    }
-    Ok(normalized.to_string())
 }
 
 /// Returns `true` if a commit message should be treated as multi-line for inline rewording.
@@ -38,13 +25,6 @@ mod tests {
     #[test]
     fn normalize_trims_whitespace() {
         assert_eq!(normalize_commit_message("  hello\n"), "hello");
-    }
-
-    #[test]
-    fn prepare_provided_commit_message_rejects_empty_after_trim() {
-        let err = prepare_provided_commit_message(" \n\t ")
-            .expect_err("whitespace-only messages must fail");
-        assert_eq!(err.to_string(), "Aborting due to empty commit message");
     }
 
     #[test]

--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -7,9 +7,7 @@ use gix::prelude::ObjectIdExt;
 
 use super::{
     ShowDiffInEditor,
-    commit_message_prep::{
-        normalize_commit_message, prepare_provided_commit_message, should_update_commit_message,
-    },
+    commit_message_prep::{normalize_commit_message, should_update_commit_message},
     estimate_diff_blob_size,
 };
 use crate::{
@@ -92,7 +90,8 @@ fn edit_branch_name(
 
             let new_branch_name = {
                 let repo = ctx.repo.get()?;
-                BranchArg(non_validated_new_name).resolve_for_creation(&repo)?
+                let head_info = but_api::legacy::workspace::head_info(ctx)?;
+                BranchArg(non_validated_new_name).resolve_for_creation(&repo, &head_info)?
             };
             but_api::legacy::stack::update_branch_name_with_perm(
                 ctx,
@@ -184,7 +183,7 @@ fn edit_commit_message_by_id_and_reword_commit(
             &current_message,
         ))
     } else if let Some(message) = message {
-        Some(prepare_provided_commit_message(message)?)
+        Some(normalize_commit_message(message).to_owned())
     } else {
         get_commit_message_from_editor(
             &*ctx.repo.get()?,
@@ -287,10 +286,6 @@ fn actually_get_commit_message_from_editor(
         Some(template_rest.as_str()).filter(|s| !s.is_empty()),
     )?
     .to_string();
-
-    if lossy_message.is_empty() {
-        bail!("Aborting due to empty commit message");
-    }
 
     Ok(lossy_message)
 }

--- a/crates/but/src/command/legacy/status/tui/cursor/tests.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/tests.rs
@@ -11,11 +11,11 @@ use crate::{
         CommitClassification, FilesStatusFlag,
         output::{StatusOutputContent, StatusOutputLine, StatusOutputLineData},
         tui::{
-            CommitMessageComposer, CommitMode, CommitSource, InlineRewordMode, Mode, MoveMode,
-            MoveSource, NormalMode, RubMode, RubSource, SelectAfterReload,
-            mode::UnassignedCommitSource,
+            CommitMessageComposer, CommitMode, InlineRewordMode, Mode, MoveMode, MoveSource,
+            NormalMode, RubMode, RubSource, SelectAfterReload,
         },
     },
+    utils::diff_specs::{CommitSource, UnassignedCommitSource},
 };
 
 fn line(data: StatusOutputLineData) -> StatusOutputLine {

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -55,9 +55,9 @@ use crate::{
                 marking::{MarkClasses, Markable, Marks},
                 message_on_drop::MessageOnDrop,
                 mode::{
-                    CommandMode, CommandModeKind, CommitMessageComposer, CommitMode, CommitSource,
-                    DetailsMode, InlineRewordMode, Mode, ModeDiscriminant, MoveMode, MoveSource,
-                    NormalMode, RubMode, RubSource, StackCommitSource, UnassignedCommitSource,
+                    CommandMode, CommandModeKind, CommitMessageComposer, CommitMode, DetailsMode,
+                    InlineRewordMode, Mode, ModeDiscriminant, MoveMode, MoveSource, NormalMode,
+                    RubMode, RubSource,
                 },
                 operations::stack_has_assigned_changes,
                 toast::{ToastKind, Toasts},
@@ -67,7 +67,13 @@ use crate::{
     id::UNASSIGNED,
     theme::Theme,
     tui::{CrosstermTerminalGuard, HeadlessTerminalGuard, TerminalGuard},
-    utils::{DebugAsType, OutputChannel, binary_path::current_exe_for_but_exec},
+    utils::{
+        DebugAsType, OutputChannel,
+        binary_path::current_exe_for_but_exec,
+        diff_specs::{
+            CommitSource, StackCommitSource, UnassignedCommitSource, prepare_changes_to_commit,
+        },
+    },
 };
 
 use super::{FilesStatusFlag, output::StatusOutputLineData};
@@ -2055,17 +2061,7 @@ impl App {
             let context_lines = ctx.settings.context_lines;
             let guard = ctx.shared_worktree_access();
             let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(guard.read_permission())?;
-            operations::prepare_changes_to_commit(
-                &mut db,
-                &repo,
-                &ws,
-                context_lines,
-                source,
-                *scope_to_stack,
-            )?
-        };
-        let Some(changes_to_commit) = changes_to_commit else {
-            return Ok(());
+            prepare_changes_to_commit(&mut db, &repo, &ws, context_lines, source, *scope_to_stack)?
         };
 
         let mut meta = ctx.meta()?;

--- a/crates/but/src/command/legacy/status/tui/mode.rs
+++ b/crates/but/src/command/legacy/status/tui/mode.rs
@@ -9,8 +9,9 @@ use ratatui_textarea::TextArea;
 use crate::{
     CliId,
     command::legacy::status::tui::{Markable, Marks, MessageOnDrop},
-    id::{ShortId, UncommittedCliId},
+    id::ShortId,
     theme::Theme,
+    utils::diff_specs::CommitSource,
 };
 
 #[derive(Debug, strum::EnumDiscriminants)]
@@ -190,14 +191,6 @@ pub(super) struct CommitMode {
     pub(super) message_composer: CommitMessageComposer,
 }
 
-/// A subset of [`CliId`] that supports being committed
-#[derive(Debug)]
-pub(super) enum CommitSource {
-    Unassigned(UnassignedCommitSource),
-    Uncommitted(Box<UncommittedCliId>),
-    Stack(StackCommitSource),
-}
-
 #[derive(Debug, Copy, Clone, Default)]
 pub(super) enum CommitMessageComposer {
     /// Open an editor to compose the commit message.
@@ -207,66 +200,6 @@ pub(super) enum CommitMessageComposer {
     Inline,
     /// Create the commit with an empty message.
     Empty,
-}
-
-#[derive(Debug)]
-pub(super) struct UnassignedCommitSource {
-    pub(super) id: ShortId,
-}
-
-#[derive(Debug)]
-pub(super) struct StackCommitSource {
-    pub(super) stack_id: StackId,
-}
-
-impl CommitSource {
-    pub(super) fn try_new(id: CliId) -> Option<Self> {
-        match id {
-            CliId::Unassigned { id } => Some(Self::Unassigned(UnassignedCommitSource { id })),
-            CliId::Uncommitted(uncommitted_cli_id) => {
-                Some(Self::Uncommitted(Box::new(uncommitted_cli_id)))
-            }
-            CliId::Stack { stack_id, .. } => Some(Self::Stack(StackCommitSource { stack_id })),
-            CliId::PathPrefix { .. }
-            | CliId::CommittedFile { .. }
-            | CliId::Branch { .. }
-            | CliId::Commit { .. } => None,
-        }
-    }
-}
-
-impl PartialEq<CliId> for CommitSource {
-    fn eq(&self, other: &CliId) -> bool {
-        match self {
-            CommitSource::Unassigned(UnassignedCommitSource { id: lhs_id }) => {
-                if let CliId::Unassigned { id: rhs_id } = other {
-                    lhs_id == rhs_id
-                } else {
-                    false
-                }
-            }
-            CommitSource::Uncommitted(lhs) => {
-                if let CliId::Uncommitted(rhs) = other {
-                    &**lhs == rhs
-                } else {
-                    false
-                }
-            }
-            CommitSource::Stack(StackCommitSource {
-                stack_id: stack_id_lhs,
-            }) => {
-                if let CliId::Stack {
-                    stack_id: stack_id_rhs,
-                    ..
-                } = other
-                {
-                    stack_id_lhs == stack_id_rhs
-                } else {
-                    false
-                }
-            }
-        }
-    }
 }
 
 #[derive(Debug)]

--- a/crates/but/src/command/legacy/status/tui/operations.rs
+++ b/crates/but/src/command/legacy/status/tui/operations.rs
@@ -24,7 +24,7 @@ use crate::{
         rub::RubOperation,
         status::{
             StatusFlags, StatusOutput, StatusOutputLine, StatusRenderMode, TuiLaunchOptions,
-            tui::{CommitSource, SelectAfterReload, mode::StackCommitSource},
+            tui::SelectAfterReload,
         },
     },
     utils::OutputChannel,
@@ -87,58 +87,6 @@ pub(super) fn create_empty_commit_relative_to_commit(
         InsertSide::Above,
         DryRun::No,
     )
-}
-
-pub(super) fn prepare_changes_to_commit(
-    db: &mut but_db::DbHandle,
-    repo: &gix::Repository,
-    workspace: &but_graph::Workspace,
-    context_lines: u32,
-    source: &CommitSource,
-    scope_to_stack: Option<StackId>,
-) -> anyhow::Result<Option<Vec<DiffSpec>>> {
-    // find what to commit
-    let changes_to_commit = match source {
-        CommitSource::Unassigned(..) => {
-            let changes = but_core::diff::ui::worktree_changes(repo)?.changes;
-            let (assignments, _assignments_error) = but_hunk_assignment::assignments_with_fallback(
-                db.hunk_assignments_mut()?,
-                repo,
-                workspace,
-                Some(changes.clone()),
-                context_lines,
-            )?;
-            let assignments = assignments
-                .into_iter()
-                .filter(|assignment| assignment.stack_id.is_none());
-            but_hunk_assignment::diff_specs_from_assignments_with_changes(assignments, &changes)
-        }
-        CommitSource::Uncommitted(uncommitted_cli_id) => {
-            let changes = but_core::diff::ui::worktree_changes(repo)?.changes;
-            let assignments = uncommitted_cli_id
-                .hunk_assignments
-                .iter()
-                .filter(|assignment| assignment.stack_id == scope_to_stack)
-                .cloned();
-            but_hunk_assignment::diff_specs_from_assignments_with_changes(assignments, &changes)
-        }
-        CommitSource::Stack(StackCommitSource { stack_id, .. }) => {
-            let changes = but_core::diff::ui::worktree_changes(repo)?.changes;
-            let (assignments, _assignments_error) = but_hunk_assignment::assignments_with_fallback(
-                db.hunk_assignments_mut()?,
-                repo,
-                workspace,
-                Some(changes.clone()),
-                context_lines,
-            )?;
-            let assignments = assignments
-                .into_iter()
-                .filter(|assignment| assignment.stack_id.is_some_and(|id| &id == stack_id));
-            but_hunk_assignment::diff_specs_from_assignments_with_changes(assignments, &changes)
-        }
-    };
-
-    Ok(Some(but_workspace::flatten_diff_specs(changes_to_commit)))
 }
 
 pub(super) fn where_to_place_commit(

--- a/crates/but/src/error.rs
+++ b/crates/but/src/error.rs
@@ -131,6 +131,17 @@ impl CliError {
             Self::Internal(value) => Self::Internal(value.context(context)),
         }
     }
+
+    /// Add a hint if the error is a [`Self::BadInput`]
+    pub fn hint<S: AsRef<str>>(self, hint: S) -> Self {
+        match self {
+            Self::BadInput(value) => Self::BadInput(value.hint(hint)),
+            Self::ExternalCommandNotFound(command_name) => {
+                Self::ExternalCommandNotFound(command_name)
+            }
+            Self::Internal(value) => Self::Internal(value),
+        }
+    }
 }
 
 impl Display for CliError {
@@ -160,3 +171,18 @@ pub enum CliError {
 }
 
 pub type CliResult<T> = Result<T, CliError>;
+
+#[cfg_attr(not(feature = "but-2"), expect(dead_code))]
+pub trait CliResultExt<T> {
+    /// Add a hint if the result is a [`CliError::BadInput`].
+    fn hint<S: AsRef<str>>(self, hint: S) -> Self;
+}
+
+impl<T> CliResultExt<T> for CliResult<T> {
+    fn hint<S: AsRef<str>>(self, hint: S) -> Self {
+        match self {
+            Ok(_) => self,
+            Err(err) => Err(err.hint(hint)),
+        }
+    }
+}

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -46,6 +46,8 @@ use crate::{
 };
 
 mod error;
+#[cfg(feature = "but-2")]
+pub(crate) use error::CliResultExt;
 pub(crate) use error::{CliError, CliResult, bad_input};
 
 mod id;

--- a/crates/but/src/tui/get_text.rs
+++ b/crates/but/src/tui/get_text.rs
@@ -5,6 +5,7 @@ use std::{ffi::OsStr, io::Write as _};
 
 use anyhow::{Context as _, Result, bail};
 use bstr::{BStr, BString, ByteSlice};
+use but_error::Code;
 
 const REST_TEXT_MARKER: &str = "# --- ignore-rest ---";
 
@@ -116,7 +117,8 @@ fn from_external_editor(
         .wait()?;
 
     if !status.success() {
-        bail!("Editor exited with non-zero status");
+        return Err(anyhow::anyhow!("Editor exited with non-zero status")
+            .context(Code::EditorExitedWithNonZeroStatus));
     }
 
     Ok(std::fs::read(&tempfile)

--- a/crates/but/src/utils/diff_specs.rs
+++ b/crates/but/src/utils/diff_specs.rs
@@ -1,0 +1,126 @@
+use but_core::{DiffSpec, ref_metadata::StackId};
+
+use crate::{
+    CliId,
+    id::{ShortId, UncommittedCliId},
+};
+
+/// A subset of [`CliId`] that supports being committed
+#[derive(Debug)]
+pub enum CommitSource {
+    Unassigned(UnassignedCommitSource),
+    Uncommitted(Box<UncommittedCliId>),
+    Stack(StackCommitSource),
+}
+
+#[derive(Debug)]
+pub struct UnassignedCommitSource {
+    pub id: ShortId,
+}
+
+#[derive(Debug)]
+pub struct StackCommitSource {
+    pub stack_id: StackId,
+}
+
+pub fn prepare_changes_to_commit(
+    db: &mut but_db::DbHandle,
+    repo: &gix::Repository,
+    workspace: &but_graph::Workspace,
+    context_lines: u32,
+    source: &CommitSource,
+    scope_to_stack: Option<StackId>,
+) -> anyhow::Result<Vec<DiffSpec>> {
+    // find what to commit
+    let changes_to_commit = match source {
+        CommitSource::Unassigned(..) => {
+            let changes = but_core::diff::ui::worktree_changes(repo)?.changes;
+            let (assignments, _assignments_error) = but_hunk_assignment::assignments_with_fallback(
+                db.hunk_assignments_mut()?,
+                repo,
+                workspace,
+                Some(changes.clone()),
+                context_lines,
+            )?;
+            let assignments = assignments
+                .into_iter()
+                .filter(|assignment| assignment.stack_id.is_none());
+            but_hunk_assignment::diff_specs_from_assignments_with_changes(assignments, &changes)
+        }
+        CommitSource::Uncommitted(uncommitted_cli_id) => {
+            let changes = but_core::diff::ui::worktree_changes(repo)?.changes;
+            let assignments = uncommitted_cli_id
+                .hunk_assignments
+                .iter()
+                .filter(|assignment| assignment.stack_id == scope_to_stack)
+                .cloned();
+            but_hunk_assignment::diff_specs_from_assignments_with_changes(assignments, &changes)
+        }
+        CommitSource::Stack(StackCommitSource { stack_id, .. }) => {
+            let changes = but_core::diff::ui::worktree_changes(repo)?.changes;
+            let (assignments, _assignments_error) = but_hunk_assignment::assignments_with_fallback(
+                db.hunk_assignments_mut()?,
+                repo,
+                workspace,
+                Some(changes.clone()),
+                context_lines,
+            )?;
+            let assignments = assignments
+                .into_iter()
+                .filter(|assignment| assignment.stack_id.is_some_and(|id| &id == stack_id));
+            but_hunk_assignment::diff_specs_from_assignments_with_changes(assignments, &changes)
+        }
+    };
+
+    Ok(but_workspace::flatten_diff_specs(changes_to_commit))
+}
+
+impl CommitSource {
+    pub fn try_new(id: CliId) -> Option<Self> {
+        match id {
+            CliId::Unassigned { id } => Some(Self::Unassigned(UnassignedCommitSource { id })),
+            CliId::Uncommitted(uncommitted_cli_id) => {
+                Some(Self::Uncommitted(Box::new(uncommitted_cli_id)))
+            }
+            CliId::Stack { stack_id, .. } => Some(Self::Stack(StackCommitSource { stack_id })),
+            CliId::PathPrefix { .. }
+            | CliId::CommittedFile { .. }
+            | CliId::Branch { .. }
+            | CliId::Commit { .. } => None,
+        }
+    }
+}
+
+impl PartialEq<CliId> for CommitSource {
+    fn eq(&self, other: &CliId) -> bool {
+        match self {
+            CommitSource::Unassigned(UnassignedCommitSource { id: lhs_id }) => {
+                if let CliId::Unassigned { id: rhs_id } = other {
+                    lhs_id == rhs_id
+                } else {
+                    false
+                }
+            }
+            CommitSource::Uncommitted(lhs) => {
+                if let CliId::Uncommitted(rhs) = other {
+                    &**lhs == rhs
+                } else {
+                    false
+                }
+            }
+            CommitSource::Stack(StackCommitSource {
+                stack_id: stack_id_lhs,
+            }) => {
+                if let CliId::Stack {
+                    stack_id: stack_id_rhs,
+                    ..
+                } = other
+                {
+                    stack_id_lhs == stack_id_rhs
+                } else {
+                    false
+                }
+            }
+        }
+    }
+}

--- a/crates/but/src/utils/mod.rs
+++ b/crates/but/src/utils/mod.rs
@@ -24,6 +24,7 @@ pub mod detect_agent;
 pub mod time;
 
 pub(crate) mod binary_path;
+pub(crate) mod diff_specs;
 
 pub trait ResultErrorExt {
     fn show_root_cause_error_then_exit_without_destructors(self, out: OutputChannel) -> !;

--- a/crates/but/tests/but/command/branch/new.rs
+++ b/crates/but/tests/but/command/branch/new.rs
@@ -98,7 +98,7 @@ fn rejects_branch_name_already_applied_in_workspace() -> anyhow::Result<()> {
         .assert()
         .failure()
         .stderr_eq(str![[r#"
-Error: A branch named 'A' already exists
+Error: A branch named 'A' is already applied
 
 "#]]);
 
@@ -115,7 +115,7 @@ fn rejects_name_that_exists_outside_workspace() -> anyhow::Result<()> {
         .assert()
         .failure()
         .stderr_eq(str![[r#"
-Error: A branch named 'A' already exists
+Error: A branch named 'A' exists but is not applied
 
 "#]]);
 

--- a/crates/but/tests/but/command/commit2.rs
+++ b/crates/but/tests/but/command/commit2.rs
@@ -1,36 +1,385 @@
 use crate::utils::Sandbox;
 
 #[test]
-fn commit2_help() {
+fn no_message_nothing_to_commit() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata_at_target(&["A"], "origin/main").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
 
-    env.but("commit2 --help")
+    env.but("commit2 --no-message").assert().success();
+
+    env.but("status")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Usage: but commit2 [OPTIONS]
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   1049574 (no commit message) (no changes)
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
 
-Options:
-      --format <FORMAT>
-          Explicitly control how output should be formatted.
-          
-          If unset and from a terminal, it defaults to human output, when redirected it's for
-          shells.
-
-          Possible values:
-          - human: The output to write is supposed to be for human consumption, and can be more
-            verbose
-          - shell: The output should be suitable for shells, and assigning the major result to
-            variables so that it can be reused in subsequent CLI invocations
-          - json:  Output detailed information as JSON for tool consumption
-          - none:  Do not output anything, like redirecting to /dev/null
-          
-          [env: BUT_OUTPUT_FORMAT=]
-          [default: human]
-
-  -h, --help
-          Print help (see a summary with '-h')
+Hint: run `but help` for all commands
 
 "#]]);
 }
+
+#[test]
+fn no_args_single_head_no_message_human_output() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.file("file.txt", "Some text");
+
+    env.but("commit2 --no-message")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Created commit 7bbfdca on 'A'
+
+"#]]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   7bbfdca (no commit message)
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn no_args_single_head_no_message_shell_output() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.file("file.txt", "Some text");
+
+    env.but("commit2 --no-message --format shell")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+7bbfdca
+
+"#]]);
+}
+
+#[test]
+fn no_args_single_head_no_message_json_output() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.file("file.txt", "Some text");
+
+    env.but("commit2 --no-message --format json")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+{
+  "commit": "7bbfdca68284535242b93595db5f6a5bc885a124"
+}
+
+"#]]);
+}
+
+#[test]
+fn no_args_single_head_message_from_editor() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    // TODO: move this into Sandbox
+    env.file("editor.sh", "printf 'commit from editor\\n' > \"$1\"\n");
+    let editor_path = env.projects_root().join("editor.sh");
+    let editor_command = format!("sh {}", editor_path.display());
+
+    env.file("file.txt", "Some text");
+
+    env.but("commit2")
+        .env("GIT_EDITOR", editor_command)
+        .assert()
+        .success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   d4e7c2a commit from editor
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn single_head_with_message() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.file("file.txt", "Some text");
+
+    env.but("commit2 -m 'add file.txt'").assert().success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   a41148c add file.txt
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn editor_user_writes_no_message() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.file("editor.sh", "printf '' > \"$1\"\n");
+    let editor_path = env.projects_root().join("editor.sh");
+    let editor_command = format!("sh {}", editor_path.display());
+
+    env.file("file.txt", "Some text");
+
+    env.but("commit2")
+        .env("GIT_EDITOR", editor_command)
+        .assert()
+        .success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   3b915b5 (no commit message)
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn editor_fails() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.file("editor.sh", "false");
+    let editor_path = env.projects_root().join("editor.sh");
+    let editor_command = format!("sh {}", editor_path.display());
+
+    env.file("file.txt", "Some text");
+
+    env.but("commit2")
+        .env("GIT_EDITOR", editor_command)
+        .assert()
+        .failure()
+        .stdout_eq(snapbox::str![[r#"
+"#]])
+        .stderr_eq(snapbox::str![[r#"
+Error: Editor exited with non-zero status
+
+"#]]);
+}
+
+#[test]
+fn create_commit_on_new_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
+    env.setup_metadata(&[]).unwrap();
+
+    env.file("file.txt", "Some text");
+
+    env.but("commit2 --no-message").assert().success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄br [a-branch-1]
+┊●   d4910f8 (no commit message)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn create_commit_on_user_provided_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
+    env.setup_metadata(&[]).unwrap();
+
+    env.file("first", "Some text");
+
+    env.but("commit2 -m 'add first' -b file").assert().success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄fi [file]
+┊●   5a6fc56 add first
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.file("second", "change file");
+
+    env.but("commit2 -m 'add second' -b file")
+        .assert()
+        .success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄fi [file]
+┊●   49fc2f0 add second
+┊●   5a6fc56 add first
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.file("third", "change file");
+
+    env.but("commit2 -m 'add third' -b other")
+        .assert()
+        .success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄fi [file]
+┊●   49fc2f0 add second
+┊●   5a6fc56 add first
+├╯
+┊
+┊╭┄ot [other]
+┊●   ed433d3 add third
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.file("fourth", "change file");
+
+    env.but("commit2 -m 'add fourth' -b other")
+        .assert()
+        .success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄fi [file]
+┊●   49fc2f0 add second
+┊●   5a6fc56 add first
+├╯
+┊
+┊╭┄ot [other]
+┊●   81bd527 add fourth
+┊●   ed433d3 add third
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn create_commit_on_branch_that_is_not_applied_fails() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
+    env.setup_metadata(&[]).unwrap();
+
+    env.invoke_git("branch existing");
+
+    env.file("first", "Some text");
+
+    env.but("commit2 -m 'add first' -b existing")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: A branch named 'existing' exists but is not applied
+
+Hint: Run `but apply existing` to apply the branch first
+
+"#]]);
+}
+
+#[test]
+fn bails_on_rejected_specs() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
+    env.setup_metadata(&[]).unwrap();
+
+    env.file("first", "Some text");
+
+    env.but("commit2 -m 'add first' -b foo").assert().success();
+
+    env.file("first", "changes");
+
+    env.but("commit2 -m 'add first' -b bar")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: Couldn't commit all changes
+
+"#]]);
+}
+
+// -b without branch name
+// commit2 -m 'add file.txt' -b

--- a/crates/but/tests/but/command/reword.rs
+++ b/crates/but/tests/but/command/reword.rs
@@ -153,7 +153,7 @@ fn reword_branch_rejects_branch_name_that_already_exists() -> anyhow::Result<()>
         .failure()
         .stdout_eq(str![[]])
         .stderr_eq(str![[r#"
-Error: A branch named 'existing' already exists
+Error: A branch named 'existing' is already applied
 
 "#]]);
 

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -826,7 +826,7 @@ export type Claude = {
  *
  * In practice, it should match its [frontend counterpart](https://github.com/gitbutlerapp/gitbutler/blob/fa973fd8f1ae8807621f47601803d98b8a9cf348/app/src/lib/backend/ipc.ts#L5).
  */
-export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "CliInstallCancelled" | "GitHubTokenExpired" | "PreconditionFailed";
+export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "CliInstallCancelled" | "GitHubTokenExpired" | "PreconditionFailed" | "EditorExitedWithNonZeroStatus";
 
 /** Commit that is a part of a [`StackBranch`](gitbutler_stack::StackBranch) and, as such, containing state derived in relation to the specific branch. */
 export type Commit = {


### PR DESCRIPTION
Adds the initial `but commit2` implementation based on [the design](https://github.com/gitbutlerapp/gitbutler/blob/master/crates/but/but-cli-revamp/commit.md). Allows commit to new/existing branches. Still a bunch to figure out but this version is a decent vertical slice.