### PR TITLE
branch icon: get styling from push status

### DIFF
--- a/apps/desktop/src/components/branch/BranchCard.svelte
+++ b/apps/desktop/src/components/branch/BranchCard.svelte
@@ -52,6 +52,7 @@
 
 	interface StackBranchProps extends BranchCardProps {
 		type: "stack-branch";
+		branchColor: string;
 		iconName: BranchIconName;
 		stackId?: string;
 		laneId: string;
@@ -197,7 +198,8 @@
 				isEmpty={args.isNewBranch}
 				selected={args.selected}
 				draft={false}
-				{lineColor}
+				branchColor={args.branchColor}
+				iconName={args.iconName}
 				isCommitting={args.isCommitting}
 				{isCommitTarget}
 				commitId={args.baseCommit}
@@ -209,7 +211,6 @@
 						branchName,
 					});
 				}}
-				iconName={args.iconName}
 				{updateBranchName}
 				isUpdatingName={nameUpdate.current.isLoading}
 				failedMisserablyToUpdateBranchName={nameUpdate.current.isError}
@@ -317,7 +318,7 @@
 			isEmpty={args.isNewBranch}
 			selected={args.selected}
 			draft={false}
-			{lineColor}
+			branchColor={lineColor}
 			iconName={args.iconName}
 			{updateBranchName}
 			isUpdatingName={nameUpdate.current.isLoading}
@@ -339,7 +340,7 @@
 			isEmpty
 			selected={args.selected}
 			draft={false}
-			{lineColor}
+			branchColor={lineColor}
 			iconName="branch"
 			{updateBranchName}
 			isUpdatingName={nameUpdate.current.isLoading}

--- a/apps/desktop/src/components/branch/BranchHeader.svelte
+++ b/apps/desktop/src/components/branch/BranchHeader.svelte
@@ -34,9 +34,9 @@
 		commitId?: string;
 		onCommitGoesHereClick?: () => void;
 		isPushed: boolean;
-		lineColor: string;
 		conflicts?: boolean;
 		iconName: ComponentProps<typeof BranchHeaderIcon>["iconName"];
+		branchColor: string;
 		roundedBottom?: boolean;
 		onclick?: () => void;
 		disableClick?: boolean;
@@ -66,7 +66,7 @@
 		failedMisserablyToUpdateBranchName,
 		readonly,
 		isPushed,
-		lineColor,
+		branchColor,
 		conflicts,
 		iconName,
 		roundedBottom,
@@ -156,7 +156,7 @@
 
 			<div class="branch-header__title text-14 text-bold">
 				<div class="branch-header__title-content">
-					<BranchHeaderIcon color={lineColor} {iconName} />
+					<BranchHeaderIcon color={branchColor} {iconName} />
 					<BranchLabel
 						name={branchName}
 						fontSize="15"

--- a/apps/desktop/src/components/lib.ts
+++ b/apps/desktop/src/components/lib.ts
@@ -1,6 +1,6 @@
 import type { BranchIconName } from "$lib/branches/branchIcon";
 import type { CommitStatusType } from "$lib/commits/commit";
-import type { Commit, CommitState, PushStatus, UpstreamCommit } from "@gitbutler/but-sdk";
+import type { Commit, PushStatus, UpstreamCommit } from "@gitbutler/but-sdk";
 
 const colorMap: Record<CommitStatusType, string> & { Error: string } = {
 	LocalOnly: "var(--commit-local)",
@@ -11,22 +11,33 @@ const colorMap: Record<CommitStatusType, string> & { Error: string } = {
 	Error: "var(--fill-danger-bg)",
 };
 
-export function getIconFromCommitState(
-	commitId?: string,
-	commitState?: CommitState,
-): BranchIconName {
-	if (!commitId || !commitState) {
-		return "branch-local";
-	}
-	switch (commitState.type) {
-		case "LocalOnly":
+export function getIconFromBranchPushStatus(pushStatus: PushStatus): BranchIconName {
+	switch (pushStatus) {
+		case "nothingToPush":
+			return "branch";
+		case "unpushedCommits":
+			return "branch-double-commit";
+		case "unpushedCommitsRequiringForce":
+			return "branch-double-commit";
+		case "completelyUnpushed":
 			return "branch-local";
-		case "LocalAndRemote":
-			return commitState.subject !== commitId ? "branch-double-commit" : "branch";
-		case "Integrated":
+		case "integrated":
 			return "branch-merge";
-		default:
-			return "branch-local";
+	}
+}
+
+export function getColorFromBranchPushStatus(pushStatus: PushStatus): string {
+	switch (pushStatus) {
+		case "nothingToPush":
+			return colorMap.LocalAndRemote;
+		case "unpushedCommits":
+			return colorMap.LocalAndRemote;
+		case "unpushedCommitsRequiringForce":
+			return colorMap.LocalAndRemote;
+		case "completelyUnpushed":
+			return colorMap.LocalOnly;
+		case "integrated":
+			return colorMap.Integrated;
 	}
 }
 

--- a/apps/desktop/src/components/views/BranchList.svelte
+++ b/apps/desktop/src/components/views/BranchList.svelte
@@ -8,7 +8,11 @@
 	import BranchReorderDropzone from "$components/branch/BranchReorderDropzone.svelte";
 	import ChangedFilesPanel from "$components/files/ChangedFilesPanel.svelte";
 	import PushButton from "$components/forge/PushButton.svelte";
-	import { getColorFromCommitState, getIconFromCommitState } from "$components/lib";
+	import {
+		getColorFromBranchPushStatus,
+		getColorFromCommitState,
+		getIconFromBranchPushStatus,
+	} from "$components/lib";
 	import ReduxResult from "$components/shared/ReduxResult.svelte";
 	import BranchCommitList from "$components/views/BranchCommitList.svelte";
 	import { URL_SERVICE } from "$lib/backend/url";
@@ -107,7 +111,8 @@
 
 		{@const firstBranch = i === 0}
 		{@const lastBranch = i === segments.length - 1}
-		{@const iconName = getIconFromCommitState(commit?.id, commit?.state)}
+		{@const iconName = getIconFromBranchPushStatus(segment.pushStatus)}
+		{@const branchColor = getColorFromBranchPushStatus(segment.pushStatus)}
 		{@const lineColor = commit
 			? getColorFromCommitState(
 					commit.state.type,
@@ -280,6 +285,7 @@
 		<BranchCard
 			type="stack-branch"
 			{projectId}
+			{branchColor}
 			stackId={branchName ? stackId : undefined}
 			{laneId}
 			branchName={branchLabel}


### PR DESCRIPTION
Get the styling from the branch push status, not its first commit.

---

The issue when creating a new ref on top of pushed commits, is that those commits have a remote counterpart.
Meaning that they are shown as blue commits. The branch itself has not been pushed, even if the commit is.

The fix is to separate the state of the branch from the commits it contains. We derive the styling from its push status.

fixes GB-1527
