### PR TITLE
fix brittle test

### DIFF
--- a/crates/but/src/command/branch/update.rs
+++ b/crates/but/src/command/branch/update.rs
@@ -581,6 +581,8 @@ mod tests {
             true,
         );
 
+        let row = strip_ansi_codes(&row);
+
         assert!(
             row.contains("subject {conflicted}"),
             "conflicted commit rows should carry the same marker used by status output"


### PR DESCRIPTION
The test required colored output to be enabled, which it might not be in tests.