### PR TITLE
refactor(cli): unify all `Vec<DiffSpec>` computation in the CLI

### DIFF
--- a/crates/but/src/command/commit/file.rs
+++ b/crates/but/src/command/commit/file.rs
@@ -1,8 +1,8 @@
-use crate::utils::OutputChannel;
-use anyhow::{Context as _, Result};
+use crate::utils::{OutputChannel, diff_specs::DiffSpecBuilder};
+use anyhow::Result;
 use bstr::BStr;
 use bstr::ByteSlice;
-use but_core::{DiffSpec, DryRun, diff::tree_changes, sync::RepoExclusive};
+use but_core::{DryRun, sync::RepoExclusive};
 use but_ctx::Context;
 
 pub fn commited_file_to_another_commit_with_perm(
@@ -13,7 +13,13 @@ pub fn commited_file_to_another_commit_with_perm(
     out: &mut OutputChannel,
     perm: &mut RepoExclusive,
 ) -> Result<()> {
-    let relevant_changes = changes_for_path_in_commit(ctx, path, source_id)?;
+    let relevant_changes = {
+        let context_lines = ctx.settings.context_lines;
+        let (repo, ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
+        let mut builder = DiffSpecBuilder::new(&mut db, &repo, &ws, context_lines);
+        builder.push_changes_from_path_in_commit(path, source_id, "First parent")?;
+        builder.into_diff_specs()
+    };
 
     but_api::commit::move_changes::commit_move_changes_between_only_with_perm(
         ctx,
@@ -61,9 +67,14 @@ pub fn uncommit_file_and_discard_with_perm(
     emit_output: bool,
     perm: &mut RepoExclusive,
 ) -> Result<()> {
-    let relevant_changes = changes_for_path_in_commit(ctx, path, source_id)?;
-
     let context_lines = ctx.settings.context_lines;
+    let relevant_changes = {
+        let (repo, ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
+        let mut builder = DiffSpecBuilder::new(&mut db, &repo, &ws, context_lines);
+        builder.push_changes_from_path_in_commit(path, source_id, "First parent")?;
+        builder.into_diff_specs()
+    };
+
     but_api::commit::uncommit::commit_uncommit_changes_with_perm(
         ctx,
         source_id,
@@ -98,24 +109,6 @@ pub fn uncommit_file_and_discard_with_perm(
     }
 
     Ok(())
-}
-
-fn changes_for_path_in_commit(
-    ctx: &Context,
-    path: &BStr,
-    source_id: gix::ObjectId,
-) -> Result<Vec<DiffSpec>> {
-    let repo = ctx.repo.get()?;
-
-    let source_commit = repo.find_commit(source_id)?;
-    let source_commit_parent_id = source_commit.parent_ids().next().context("First parent")?;
-
-    let tree_changes = tree_changes(&repo, Some(source_commit_parent_id.detach()), source_id)?;
-    Ok(tree_changes
-        .into_iter()
-        .filter(|tc| tc.path == path)
-        .map(Into::into)
-        .collect())
 }
 
 /// Refresh the workspace commit when legacy workspace state is available.

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, fmt::Write as _};
 use anyhow::{Context, Result, bail};
 use bstr::{BString, ByteSlice};
 use but_api::{commit::create::commit_create, diff, legacy::repo};
-use but_core::{DiffSpec, DryRun, ref_metadata::StackId, sync::RepoExclusive, ui::TreeChange};
+use but_core::{DryRun, ref_metadata::StackId, sync::RepoExclusive, ui::TreeChange};
 use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
 use gitbutler_repo::hooks;
 
@@ -16,7 +16,7 @@ use crate::{
     legacy::workspace::HeadInfoStack,
     theme::{self, Paint},
     tui,
-    utils::{InputOutputChannel, OutputChannel},
+    utils::{InputOutputChannel, OutputChannel, diff_specs},
 };
 
 type TargetStack = (StackId, HeadInfoStack);
@@ -198,37 +198,6 @@ fn generate_unified_diff(
     }
 
     Ok(diff_output)
-}
-
-fn build_diff_specs(files_to_commit: &[FileAssignment], changes: &[TreeChange]) -> Vec<DiffSpec> {
-    files_to_commit
-        .iter()
-        .map(|fa| {
-            // Collect hunk headers from all assignments for this file
-            let hunk_headers: Vec<but_core::HunkHeader> = fa
-                .assignments
-                .iter()
-                .filter_map(|assignment| assignment.inner.hunk_header)
-                .collect();
-
-            let previous_path = changes
-                .iter()
-                .find(|change| change.path_bytes == fa.path)
-                .and_then(|change| match &change.status {
-                    but_core::ui::TreeStatus::Rename {
-                        previous_path_bytes,
-                        ..
-                    } => Some(previous_path_bytes.clone()),
-                    _ => None,
-                });
-
-            DiffSpec {
-                previous_path,
-                path: fa.path.clone(),
-                hunk_headers,
-            }
-        })
-        .collect()
 }
 
 /// Resolves file CliIDs to their corresponding FileAssignments.
@@ -433,7 +402,13 @@ pub(crate) fn commit(
     }
 
     // Convert files to DiffSpec early so we can run pre-commit hooks before prompting for message
-    let diff_specs = build_diff_specs(&files_to_commit, &changes);
+    let diff_specs = {
+        let context_lines = ctx.settings.context_lines;
+        let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(guard.read_permission())?;
+        let mut builder = diff_specs::DiffSpecBuilder::new(&mut db, &repo, &ws, context_lines);
+        builder.push_file_assignments(&files_to_commit)?;
+        builder.into_diff_specs()
+    };
 
     // Run pre-commit hook unless --no-hooks was specified
     // This runs BEFORE getting the commit message so the user doesn't waste time writing a message
@@ -801,62 +776,4 @@ fn get_status_char(path: &BString, changes: &[TreeChange]) -> &'static str {
         }
     }
     "modified:" // fallback
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::str::FromStr;
-
-    fn dummy_file_assignment(path: &str) -> FileAssignment {
-        FileAssignment {
-            path: path.into(),
-            assignments: vec![CLIHunkAssignment {
-                inner: but_hunk_assignment::HunkAssignment {
-                    id: None,
-                    hunk_header: None,
-                    path: path.to_owned(),
-                    path_bytes: path.as_bytes().into(),
-                    stack_id: None,
-                    branch_ref_bytes: None,
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
-                },
-                cli_id: path.to_owned(),
-            }],
-        }
-    }
-
-    fn dummy_state() -> but_core::ui::ChangeState {
-        but_core::ui::ChangeState {
-            id: gix::ObjectId::from_str("0000000000000000000000000000000000000000").unwrap(),
-            kind: gix::object::tree::EntryKind::Blob,
-        }
-    }
-
-    fn dummy_rename_change(path: &str, previous_path: &str) -> TreeChange {
-        TreeChange {
-            path: path.into(),
-            path_bytes: path.as_bytes().into(),
-            status: but_core::ui::TreeStatus::Rename {
-                previous_path: previous_path.into(),
-                previous_path_bytes: previous_path.as_bytes().into(),
-                previous_state: dummy_state(),
-                state: dummy_state(),
-                flags: None,
-            },
-        }
-    }
-
-    #[test]
-    fn build_diff_specs_copies_previous_path_for_rename() {
-        let files_to_commit = vec![dummy_file_assignment("new.txt")];
-        let changes = vec![dummy_rename_change("new.txt", "old.txt")];
-
-        let diff_specs = build_diff_specs(&files_to_commit, &changes);
-
-        assert_eq!(diff_specs.len(), 1);
-        assert_eq!(diff_specs[0].previous_path, Some("old.txt".into()));
-    }
 }

--- a/crates/but/src/command/legacy/commit2.rs
+++ b/crates/but/src/command/legacy/commit2.rs
@@ -20,8 +20,7 @@ use crate::{
     id::UNASSIGNED,
     theme::{Paint, Theme},
     utils::{
-        CliOutput, CliOutputHuman, IntermediateChannel, WriteWithUtils,
-        diff_specs::{CommitSource, UnassignedCommitSource, prepare_changes_to_commit},
+        CliOutput, CliOutputHuman, IntermediateChannel, WriteWithUtils, diff_specs::DiffSpecBuilder,
     },
 };
 
@@ -91,10 +90,9 @@ pub fn commit(
 
         let operation = route_operation(&repo, &head_info, branch)?;
 
-        let source = CommitSource::Unassigned(UnassignedCommitSource {
-            id: UNASSIGNED.to_string(),
-        });
-        let changes = prepare_changes_to_commit(&mut db, &repo, &ws, context_lines, &source, None)?;
+        let mut builder = DiffSpecBuilder::new(&mut db, &repo, &ws, context_lines);
+        builder.push_changes_from_unassigned(&UNASSIGNED.to_string())?;
+        let changes = builder.into_diff_specs();
 
         (changes, operation)
     };

--- a/crates/but/src/command/legacy/discard.rs
+++ b/crates/but/src/command/legacy/discard.rs
@@ -3,17 +3,20 @@
 //! This module provides functionality to discard uncommitted changes from the worktree.
 
 use anyhow::{Context as _, Result, bail};
-use bstr::{BStr, ByteSlice};
+use bstr::ByteSlice;
 use but_api::diff;
-use but_core::{DiffSpec, sync::RepoExclusive};
+use but_core::sync::RepoExclusive;
 use but_ctx::Context;
-use but_hunk_assignment::HunkAssignment;
 use gitbutler_oplog::{
     OplogExt,
     entry::{OperationKind, SnapshotDetails},
 };
 
-use crate::{CliId, IdMap, id::parser::parse_sources, utils::OutputChannel};
+use crate::{
+    CliId, IdMap,
+    id::parser::parse_sources,
+    utils::{OutputChannel, diff_specs},
+};
 
 /// Handle the `but discard <id>` command.
 ///
@@ -32,51 +35,44 @@ pub fn handle(ctx: &mut Context, out: &mut OutputChannel, id: &str) -> Result<()
         bail!("No entity found for the given ID");
     }
 
-    // Get worktree changes once for the Unassigned case
-    // Also used to determine file status for additions/deletions
+    // Get worktree changes once for the Unassigned case.
     let worktree_changes = diff::changes_in_worktree_with_perm(ctx, guard.read_permission())?;
-    let path_status: std::collections::HashMap<_, _> = worktree_changes
-        .worktree_changes
-        .changes
-        .iter()
-        .map(|change| (change.path.as_bstr(), &change.status))
-        .collect();
 
-    // Extract DiffSpecs from all resolved entities
-    let mut diff_specs: Vec<DiffSpec> = Vec::new();
+    // Extract DiffSpecs from all resolved entities.
+    let diff_specs = {
+        let context_lines = ctx.settings.context_lines;
+        let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(guard.read_permission())?;
+        let mut builder = diff_specs::DiffSpecBuilder::new(&mut db, &repo, &ws, context_lines);
 
-    for resolved_id in resolved_ids {
-        match resolved_id {
-            CliId::Uncommitted(uncommitted) => {
-                collect_diff_specs_from_assignments(
-                    uncommitted.hunk_assignments,
-                    &path_status,
-                    &mut diff_specs,
-                );
-            }
-            CliId::PathPrefix { .. } => todo!(),
-            CliId::Unassigned { .. } => {
-                // Discard all uncommitted changes
-                let assignments = worktree_changes.assignments.clone();
-
-                collect_diff_specs_from_assignments(assignments, &path_status, &mut diff_specs);
-            }
-            CliId::Branch { .. } => {
-                bail!("Cannot discard a branch. Use a file or hunk ID instead.");
-            }
-            CliId::Commit { .. } => {
-                bail!("Cannot discard a commit. Use a file or hunk ID instead.");
-            }
-            CliId::CommittedFile { .. } => {
-                bail!(
-                    "Cannot discard a committed file. Use an uncommitted file or hunk ID instead."
-                );
-            }
-            CliId::Stack { .. } => {
-                bail!("Cannot discard a stack. Use a file or hunk ID instead.");
+        for resolved_id in resolved_ids {
+            match resolved_id {
+                CliId::Uncommitted(uncommitted) => {
+                    builder.push_hunk_assignments(uncommitted.hunk_assignments)?;
+                }
+                CliId::PathPrefix { .. } => todo!(),
+                CliId::Unassigned { .. } => {
+                    // Discard all uncommitted changes.
+                    builder.push_hunk_assignments(worktree_changes.assignments.clone())?;
+                }
+                CliId::Branch { .. } => {
+                    bail!("Cannot discard a branch. Use a file or hunk ID instead.");
+                }
+                CliId::Commit { .. } => {
+                    bail!("Cannot discard a commit. Use a file or hunk ID instead.");
+                }
+                CliId::CommittedFile { .. } => {
+                    bail!(
+                        "Cannot discard a committed file. Use an uncommitted file or hunk ID instead."
+                    );
+                }
+                CliId::Stack { .. } => {
+                    bail!("Cannot discard a stack. Use a file or hunk ID instead.");
+                }
             }
         }
-    }
+
+        builder.into_diff_specs()
+    };
 
     if diff_specs.is_empty() {
         bail!("No changes found for the given ID");
@@ -158,46 +154,6 @@ pub fn handle(ctx: &mut Context, out: &mut OutputChannel, id: &str) -> Result<()
     Ok(())
 }
 
-fn collect_diff_specs_from_assignments(
-    assignments: impl IntoIterator<Item = HunkAssignment>,
-    path_status: &std::collections::HashMap<&BStr, &but_core::ui::TreeStatus>,
-    diff_specs: &mut Vec<DiffSpec>,
-) {
-    for assignment in assignments {
-        let spec = assignment_to_diff_spec(assignment, path_status);
-        diff_specs.push(spec);
-    }
-}
-
-fn assignment_to_diff_spec(
-    assignment: HunkAssignment,
-    path_status: &std::collections::HashMap<&BStr, &but_core::ui::TreeStatus>,
-) -> DiffSpec {
-    let (is_addition_or_deletion, previous_path) = path_status
-        .get(assignment.path_bytes.as_bstr())
-        .map(|status| match status {
-            but_core::ui::TreeStatus::Addition { .. } => (true, None),
-            but_core::ui::TreeStatus::Deletion { .. } => (true, None),
-            but_core::ui::TreeStatus::Modification { .. } => (false, None),
-            but_core::ui::TreeStatus::Rename {
-                previous_path_bytes,
-                ..
-            } => (false, Some(previous_path_bytes.to_owned())),
-        })
-        .unwrap_or((false, None));
-
-    DiffSpec {
-        previous_path,
-        path: assignment.path_bytes,
-        // For additions/deletions, use empty hunk_headers to signal whole-file mode.
-        hunk_headers: if is_addition_or_deletion {
-            Vec::new()
-        } else {
-            assignment.hunk_header.into_iter().collect()
-        },
-    }
-}
-
 /// Create a snapshot in the oplog before performing an operation
 fn create_snapshot(
     ctx: &mut Context,
@@ -212,90 +168,4 @@ fn create_snapshot(
 
     let details = SnapshotDetails::new(operation).with_trailers(trailers);
     let _snapshot = ctx.create_snapshot(details, perm).ok();
-}
-
-#[cfg(test)]
-mod tests {
-    use std::collections::HashMap;
-
-    use bstr::{BStr, BString};
-    use but_core::HunkHeader;
-    use but_hunk_assignment::HunkAssignment;
-
-    use super::{assignment_to_diff_spec, collect_diff_specs_from_assignments};
-
-    #[test]
-    fn assignment_to_diff_spec_keeps_hunk_for_non_filewide_case() {
-        let assignment = make_assignment("a.txt", Some(hunk(1, 2, 3, 4)));
-        let path_status: HashMap<&BStr, &but_core::ui::TreeStatus> = HashMap::new();
-
-        let spec = assignment_to_diff_spec(assignment, &path_status);
-
-        assert_eq!(spec.path, BString::from("a.txt"));
-        assert_eq!(spec.hunk_headers, vec![hunk(1, 2, 3, 4)]);
-        assert!(spec.previous_path.is_none());
-    }
-
-    #[test]
-    fn collect_diff_specs_from_assignments_preserves_input_granularity() {
-        let assignments = vec![
-            make_assignment("a.txt", Some(hunk(1, 2, 3, 4))),
-            make_assignment("a.txt", Some(hunk(5, 6, 7, 8))),
-            make_assignment("b.txt", Some(hunk(9, 1, 10, 1))),
-        ];
-        let path_status: HashMap<&BStr, &but_core::ui::TreeStatus> = HashMap::new();
-        let mut diff_specs = Vec::new();
-
-        collect_diff_specs_from_assignments(assignments, &path_status, &mut diff_specs);
-
-        assert_eq!(diff_specs.len(), 3);
-
-        assert_eq!(diff_specs[0].path, BString::from("a.txt"));
-        assert_eq!(diff_specs[0].hunk_headers, vec![hunk(1, 2, 3, 4)]);
-
-        assert_eq!(diff_specs[1].path, BString::from("a.txt"));
-        assert_eq!(diff_specs[1].hunk_headers, vec![hunk(5, 6, 7, 8)]);
-
-        assert_eq!(diff_specs[2].path, BString::from("b.txt"));
-        assert_eq!(diff_specs[2].hunk_headers, vec![hunk(9, 1, 10, 1)]);
-    }
-
-    #[test]
-    fn collect_diff_specs_from_assignments_keeps_filewide_and_hunk_entries() {
-        let assignments = vec![
-            make_assignment("a.txt", Some(hunk(1, 2, 3, 4))),
-            make_assignment("a.txt", None),
-        ];
-        let path_status: HashMap<&BStr, &but_core::ui::TreeStatus> = HashMap::new();
-        let mut diff_specs = Vec::new();
-
-        collect_diff_specs_from_assignments(assignments, &path_status, &mut diff_specs);
-
-        assert_eq!(diff_specs.len(), 2);
-        assert_eq!(diff_specs[0].hunk_headers, vec![hunk(1, 2, 3, 4)]);
-        assert!(diff_specs[1].hunk_headers.is_empty());
-    }
-
-    fn make_assignment(path: &str, hunk_header: Option<HunkHeader>) -> HunkAssignment {
-        HunkAssignment {
-            id: None,
-            hunk_header,
-            path: path.to_string(),
-            path_bytes: BString::from(path),
-            stack_id: None,
-            branch_ref_bytes: None,
-            line_nums_added: None,
-            line_nums_removed: None,
-            diff: None,
-        }
-    }
-
-    fn hunk(old_start: u32, old_lines: u32, new_start: u32, new_lines: u32) -> HunkHeader {
-        HunkHeader {
-            old_start,
-            old_lines,
-            new_start,
-            new_lines,
-        }
-    }
 }

--- a/crates/but/src/command/legacy/rub/amend.rs
+++ b/crates/but/src/command/legacy/rub/amend.rs
@@ -8,7 +8,7 @@ use nonempty::NonEmpty;
 
 use crate::{
     theme::{self, Paint},
-    utils::{OutputChannel, shorten_object_id, split_short_id},
+    utils::{OutputChannel, diff_specs::DiffSpecBuilder, shorten_object_id, split_short_id},
 };
 
 pub(crate) fn uncommitted_to_commit_with_perm(
@@ -19,10 +19,13 @@ pub(crate) fn uncommitted_to_commit_with_perm(
     out: &mut OutputChannel,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<()> {
-    let diff_specs: Vec<DiffSpec> = hunk_assignments
-        .into_iter()
-        .map(|assignment| assignment.to_owned().into())
-        .collect();
+    let diff_specs = {
+        let context_lines = ctx.settings.context_lines;
+        let (repo, ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
+        let mut builder = DiffSpecBuilder::new(&mut db, &repo, &ws, context_lines);
+        builder.push_hunk_assignments(hunk_assignments.into_iter().map(ToOwned::to_owned))?;
+        builder.into_diff_specs()
+    };
 
     let new_commit = amend_diff_specs(ctx, diff_specs, oid, perm)?;
     update_workspace_commit(ctx, false)?;

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -1,17 +1,14 @@
 use std::fmt;
 
 use crate::theme::{self, Paint};
-use anyhow::{Context as _, bail};
+use anyhow::bail;
 use bstr::BStr;
 use but_api::commit::types::{
     CommitCreateResult, CommitMoveResult, CommitSquashResult, MoveChangesResult, UncommitResult,
 };
 use but_core::{DiffSpec, DryRun, ref_metadata::StackId, sync::RepoExclusive};
 use but_ctx::Context;
-use but_hunk_assignment::{
-    HunkAssignment, HunkAssignmentRequest, HunkAssignmentTarget,
-    diff_specs_from_assignments_with_changes,
-};
+use but_hunk_assignment::{HunkAssignment, HunkAssignmentRequest, HunkAssignmentTarget};
 use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
 mod amend;
 mod assign;
@@ -30,7 +27,7 @@ use crate::{
     CliError, CliId, IdMap, bad_input,
     command::legacy::rub::assign::stack_id_to_branch_name,
     id::parser::{IdResolutionError, parse_sources_with_disambiguation, prompt_for_disambiguation},
-    utils::{OutputChannel, shorten_object_id, split_short_id},
+    utils::{OutputChannel, diff_specs::DiffSpecBuilder, shorten_object_id, split_short_id},
 };
 
 /// A description of a set of hunks.
@@ -311,12 +308,13 @@ impl<'a> UncommittedToCommitOperation<'a> {
 
     /// Executes this operation without writing any output.
     pub(crate) fn execute_inner(&self, ctx: &mut Context) -> anyhow::Result<CommitCreateResult> {
-        let worktree_changes = but_api::diff::changes_in_worktree(ctx)?;
-        let changes = diff_specs_from_assignments_with_changes(
-            self.hunk_assignments.iter().copied().cloned(),
-            &worktree_changes.worktree_changes.changes,
-        );
-        let changes = but_workspace::flatten_diff_specs(changes);
+        let changes = {
+            let context_lines = ctx.settings.context_lines;
+            let (_guard, repo, ws, mut db) = ctx.workspace_and_db_mut()?;
+            let mut builder = DiffSpecBuilder::new(&mut db, &repo, &ws, context_lines);
+            builder.push_hunk_assignments(self.hunk_assignments.iter().copied().cloned())?;
+            builder.into_diff_specs()
+        };
         but_api::commit::amend::commit_amend(ctx, self.oid, changes, DryRun::No)
     }
 }
@@ -1906,15 +1904,15 @@ fn changes_for_stack_assignment(
     ctx: &mut Context,
     stack_id: Option<StackId>,
 ) -> anyhow::Result<Vec<DiffSpec>> {
-    let worktree_changes = but_api::diff::changes_in_worktree(ctx)?;
-    let changes = diff_specs_from_assignments_with_changes(
-        worktree_changes
-            .assignments
-            .into_iter()
-            .filter(|assignment| assignment.stack_id == stack_id),
-        &worktree_changes.worktree_changes.changes,
-    );
-    Ok(but_workspace::flatten_diff_specs(changes))
+    let assignments = but_api::diff::changes_in_worktree(ctx)?
+        .assignments
+        .into_iter()
+        .filter(|assignment| assignment.stack_id == stack_id);
+    let context_lines = ctx.settings.context_lines;
+    let (_guard, repo, ws, mut db) = ctx.workspace_and_db_mut()?;
+    let mut builder = DiffSpecBuilder::new(&mut db, &repo, &ws, context_lines);
+    builder.push_hunk_assignments(assignments)?;
+    Ok(builder.into_diff_specs())
 }
 
 /// Computes diff specs for changes to `path` in `commit_oid` relative to its first parent.
@@ -1923,17 +1921,11 @@ fn file_changes_from_commit(
     commit_oid: gix::ObjectId,
     path: &bstr::BStr,
 ) -> anyhow::Result<Vec<DiffSpec>> {
-    let repo = ctx.repo.get()?;
-    let source_commit = repo.find_commit(commit_oid)?;
-    let source_commit_parent_id = source_commit.parent_ids().next().context("no parents")?;
-
-    let tree_changes =
-        but_core::diff::tree_changes(&repo, Some(source_commit_parent_id.detach()), commit_oid)?;
-    Ok(tree_changes
-        .into_iter()
-        .filter(|tc| tc.path == path)
-        .map(DiffSpec::from)
-        .collect::<Vec<_>>())
+    let context_lines = ctx.settings.context_lines;
+    let (_guard, repo, ws, mut db) = ctx.workspace_and_db_mut()?;
+    let mut builder = DiffSpecBuilder::new(&mut db, &repo, &ws, context_lines);
+    builder.push_changes_from_path_in_commit(path, commit_oid, "no parents")?;
+    Ok(builder.into_diff_specs())
 }
 
 #[cfg(test)]

--- a/crates/but/src/command/legacy/status/tui/cursor/tests.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/tests.rs
@@ -11,11 +11,10 @@ use crate::{
         CommitClassification, FilesStatusFlag,
         output::{StatusOutputContent, StatusOutputLine, StatusOutputLineData},
         tui::{
-            CommitMessageComposer, CommitMode, InlineRewordMode, Mode, MoveMode, MoveSource,
-            NormalMode, RubMode, RubSource, SelectAfterReload,
+            CommitMessageComposer, CommitMode, CommitSource, InlineRewordMode, Mode, MoveMode,
+            MoveSource, NormalMode, RubMode, RubSource, SelectAfterReload, UnassignedCommitSource,
         },
     },
-    utils::diff_specs::{CommitSource, UnassignedCommitSource},
 };
 
 fn line(data: StatusOutputLineData) -> StatusOutputLine {

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -55,9 +55,9 @@ use crate::{
                 marking::{MarkClasses, Markable, Marks},
                 message_on_drop::MessageOnDrop,
                 mode::{
-                    CommandMode, CommandModeKind, CommitMessageComposer, CommitMode, DetailsMode,
-                    InlineRewordMode, Mode, ModeDiscriminant, MoveMode, MoveSource, NormalMode,
-                    RubMode, RubSource,
+                    CommandMode, CommandModeKind, CommitMessageComposer, CommitMode, CommitSource,
+                    DetailsMode, InlineRewordMode, Mode, ModeDiscriminant, MoveMode, MoveSource,
+                    NormalMode, RubMode, RubSource, StackCommitSource, UnassignedCommitSource,
                 },
                 operations::stack_has_assigned_changes,
                 toast::{ToastKind, Toasts},
@@ -68,11 +68,8 @@ use crate::{
     theme::Theme,
     tui::{CrosstermTerminalGuard, HeadlessTerminalGuard, TerminalGuard},
     utils::{
-        DebugAsType, OutputChannel,
-        binary_path::current_exe_for_but_exec,
-        diff_specs::{
-            CommitSource, StackCommitSource, UnassignedCommitSource, prepare_changes_to_commit,
-        },
+        DebugAsType, OutputChannel, binary_path::current_exe_for_but_exec,
+        diff_specs::DiffSpecBuilder,
     },
 };
 
@@ -2061,7 +2058,20 @@ impl App {
             let context_lines = ctx.settings.context_lines;
             let guard = ctx.shared_worktree_access();
             let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(guard.read_permission())?;
-            prepare_changes_to_commit(&mut db, &repo, &ws, context_lines, source, *scope_to_stack)?
+            let mut builder = DiffSpecBuilder::new(&mut db, &repo, &ws, context_lines)
+                .with_scope_to_stack(*scope_to_stack);
+            match &**source {
+                CommitSource::Unassigned(UnassignedCommitSource { id }) => {
+                    builder.push_changes_from_unassigned(id)?;
+                }
+                CommitSource::Uncommitted(uncommitted_cli_id) => {
+                    builder.push_changes_from_uncommitted(uncommitted_cli_id)?;
+                }
+                CommitSource::Stack(StackCommitSource { stack_id }) => {
+                    builder.push_changes_from_stack(*stack_id)?;
+                }
+            }
+            builder.into_diff_specs()
         };
 
         let mut meta = ctx.meta()?;

--- a/crates/but/src/command/legacy/status/tui/mode.rs
+++ b/crates/but/src/command/legacy/status/tui/mode.rs
@@ -9,9 +9,8 @@ use ratatui_textarea::TextArea;
 use crate::{
     CliId,
     command::legacy::status::tui::{Markable, Marks, MessageOnDrop},
-    id::ShortId,
+    id::{ShortId, UncommittedCliId},
     theme::Theme,
-    utils::diff_specs::CommitSource,
 };
 
 #[derive(Debug, strum::EnumDiscriminants)]
@@ -205,6 +204,74 @@ pub(super) enum CommitMessageComposer {
 #[derive(Debug)]
 pub(super) struct MoveMode {
     pub(super) source: Arc<MoveSource>,
+}
+
+/// A subset of [`CliId`] that supports being committed
+#[derive(Debug)]
+pub(super) enum CommitSource {
+    Unassigned(UnassignedCommitSource),
+    Uncommitted(Box<UncommittedCliId>),
+    Stack(StackCommitSource),
+}
+
+#[derive(Debug)]
+pub(super) struct UnassignedCommitSource {
+    pub(super) id: ShortId,
+}
+
+#[derive(Debug)]
+pub(super) struct StackCommitSource {
+    pub(super) stack_id: StackId,
+}
+
+impl CommitSource {
+    pub fn try_new(id: CliId) -> Option<Self> {
+        match id {
+            CliId::Unassigned { id } => Some(Self::Unassigned(UnassignedCommitSource { id })),
+            CliId::Uncommitted(uncommitted_cli_id) => {
+                Some(Self::Uncommitted(Box::new(uncommitted_cli_id)))
+            }
+            CliId::Stack { stack_id, .. } => Some(Self::Stack(StackCommitSource { stack_id })),
+            CliId::PathPrefix { .. }
+            | CliId::CommittedFile { .. }
+            | CliId::Branch { .. }
+            | CliId::Commit { .. } => None,
+        }
+    }
+}
+
+impl PartialEq<CliId> for CommitSource {
+    fn eq(&self, other: &CliId) -> bool {
+        match self {
+            CommitSource::Unassigned(UnassignedCommitSource { id: lhs_id }) => {
+                if let CliId::Unassigned { id: rhs_id } = other {
+                    lhs_id == rhs_id
+                } else {
+                    false
+                }
+            }
+            CommitSource::Uncommitted(lhs) => {
+                if let CliId::Uncommitted(rhs) = other {
+                    &**lhs == rhs
+                } else {
+                    false
+                }
+            }
+            CommitSource::Stack(StackCommitSource {
+                stack_id: stack_id_lhs,
+            }) => {
+                if let CliId::Stack {
+                    stack_id: stack_id_rhs,
+                    ..
+                } = other
+                {
+                    stack_id_lhs == stack_id_rhs
+                } else {
+                    false
+                }
+            }
+        }
+    }
 }
 
 /// A subset of [`CliId`] that supports being moved

--- a/crates/but/src/command/legacy/status/tui/operations.rs
+++ b/crates/but/src/command/legacy/status/tui/operations.rs
@@ -11,7 +11,7 @@ use but_api::{
     diff::ComputeLineStats,
     legacy::oplog::RestoreKind,
 };
-use but_core::{DiffSpec, DryRun, diff::CommitDetails, ref_metadata::StackId};
+use but_core::{DryRun, diff::CommitDetails, ref_metadata::StackId};
 use but_ctx::Context;
 use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
 use gitbutler_operating_modes::OperatingMode;
@@ -27,7 +27,7 @@ use crate::{
             tui::SelectAfterReload,
         },
     },
-    utils::OutputChannel,
+    utils::{OutputChannel, diff_specs},
 };
 
 pub(super) async fn reload_legacy(
@@ -357,59 +357,17 @@ pub(super) fn reword_branch_legacy(
     gitbutler_branch_actions::stack::update_branch_name(ctx, stack_id, branch_name, new_name)
 }
 
-/// Collect paths whose worktree status is either addition or deletion.
-fn addition_or_deletion_paths(
-    changes: &[but_core::ui::TreeChange],
-) -> std::collections::HashSet<Vec<u8>> {
-    changes
-        .iter()
-        .filter_map(|change| {
-            if matches!(
-                change.status,
-                but_core::ui::TreeStatus::Addition { .. }
-                    | but_core::ui::TreeStatus::Deletion { .. }
-            ) {
-                let path: &bstr::BStr = change.path.as_ref();
-                Some(path.to_vec())
-            } else {
-                None
-            }
-        })
-        .collect()
-}
-
-/// Convert hunk assignments to diff specs, using whole-file mode for additions/deletions.
-fn diff_specs_from_assignments(
-    assignments: impl IntoIterator<Item = but_hunk_assignment::HunkAssignment>,
-    addition_or_deletion_paths: &std::collections::HashSet<Vec<u8>>,
-) -> Vec<DiffSpec> {
-    assignments
-        .into_iter()
-        .map(|assignment| {
-            let is_addition_or_deletion =
-                addition_or_deletion_paths.contains(&assignment.path_bytes.to_vec());
-
-            DiffSpec {
-                previous_path: None,
-                path: assignment.path_bytes,
-                hunk_headers: if is_addition_or_deletion {
-                    Vec::new()
-                } else {
-                    assignment.hunk_header.into_iter().collect()
-                },
-            }
-        })
-        .collect()
-}
-
-/// Discard uncommitted assignments with precomputed addition/deletion paths.
-fn discard_uncommitted_legacy_with_paths(
+fn discard_uncommitted_legacy_with_assignments(
     ctx: &mut Context,
     hunk_assignments: Vec<but_hunk_assignment::HunkAssignment>,
-    addition_or_deletion_paths: &std::collections::HashSet<Vec<u8>>,
 ) -> anyhow::Result<()> {
-    let changes_to_discard =
-        diff_specs_from_assignments(hunk_assignments, addition_or_deletion_paths);
+    let changes_to_discard = {
+        let context_lines = ctx.settings.context_lines;
+        let (_guard, repo, ws, mut db) = ctx.workspace_and_db_mut()?;
+        let mut builder = diff_specs::DiffSpecBuilder::new(&mut db, &repo, &ws, context_lines);
+        builder.push_hunk_assignments(hunk_assignments)?;
+        builder.into_diff_specs()
+    };
 
     if changes_to_discard.is_empty() {
         return Ok(());
@@ -424,37 +382,16 @@ pub(super) fn discard_uncommitted_legacy(
     ctx: &mut Context,
     hunk_assignments: Vec<but_hunk_assignment::HunkAssignment>,
 ) -> anyhow::Result<()> {
-    let addition_or_deletion_paths = {
-        let repo = ctx.repo.get()?;
-        let changes = but_core::diff::ui::worktree_changes(&repo)?.changes;
-        addition_or_deletion_paths(&changes)
-    };
-
-    discard_uncommitted_legacy_with_paths(ctx, hunk_assignments, &addition_or_deletion_paths)
+    discard_uncommitted_legacy_with_assignments(ctx, hunk_assignments)
 }
 
 pub(super) fn discard_unassigned_legacy(ctx: &mut Context) -> anyhow::Result<()> {
-    let context_lines = ctx.settings.context_lines;
     let unassigned_changes = {
+        let context_lines = ctx.settings.context_lines;
         let (_guard, repo, ws, mut db) = ctx.workspace_and_db_mut()?;
-        let changes = but_core::diff::ui::worktree_changes(&repo)?.changes;
-
-        let addition_or_deletion_paths = addition_or_deletion_paths(&changes);
-
-        let (assignments, _assignments_error) = but_hunk_assignment::assignments_with_fallback(
-            db.hunk_assignments_mut()?,
-            &repo,
-            &ws,
-            Some(changes),
-            context_lines,
-        )?;
-
-        let unassigned_assignments = assignments
-            .into_iter()
-            .filter(|assignment| assignment.stack_id.is_none())
-            .collect::<Vec<_>>();
-
-        diff_specs_from_assignments(unassigned_assignments, &addition_or_deletion_paths)
+        let mut builder = diff_specs::DiffSpecBuilder::new(&mut db, &repo, &ws, context_lines);
+        builder.push_changes_from_unassigned(&crate::id::UNASSIGNED.to_string())?;
+        builder.into_diff_specs()
     };
 
     if unassigned_changes.is_empty() {
@@ -467,29 +404,21 @@ pub(super) fn discard_unassigned_legacy(ctx: &mut Context) -> anyhow::Result<()>
 }
 
 pub(super) fn discard_stack(ctx: &mut Context, stack_id: StackId) -> anyhow::Result<()> {
-    let context_lines = ctx.settings.context_lines;
-    let (stack_changes, addition_or_deletion_paths) = {
+    let stack_changes = {
+        let context_lines = ctx.settings.context_lines;
         let (_guard, repo, ws, mut db) = ctx.workspace_and_db_mut()?;
-        let changes = but_core::diff::ui::worktree_changes(&repo)?.changes;
-        let addition_or_deletion_paths = addition_or_deletion_paths(&changes);
-
-        let (assignments, _assignments_error) = but_hunk_assignment::assignments_with_fallback(
-            db.hunk_assignments_mut()?,
-            &repo,
-            &ws,
-            Some(changes),
-            context_lines,
-        )?;
-
-        let stack_changes = assignments
-            .into_iter()
-            .filter(|assignment| assignment.stack_id == Some(stack_id))
-            .collect::<Vec<_>>();
-
-        (stack_changes, addition_or_deletion_paths)
+        let mut builder = diff_specs::DiffSpecBuilder::new(&mut db, &repo, &ws, context_lines);
+        builder.push_changes_from_stack(stack_id)?;
+        builder.into_diff_specs()
     };
 
-    discard_uncommitted_legacy_with_paths(ctx, stack_changes, &addition_or_deletion_paths)
+    if stack_changes.is_empty() {
+        return Ok(());
+    }
+
+    but_api::legacy::workspace::discard_worktree_changes(ctx, stack_changes)?;
+
+    Ok(())
 }
 
 pub(super) fn commit_discard(

--- a/crates/but/src/command/legacy/status/tui/rub_from_detail_view.rs
+++ b/crates/but/src/command/legacy/status/tui/rub_from_detail_view.rs
@@ -8,6 +8,7 @@ use crate::{
     CliId,
     command::legacy::status::tui::{SelectAfterReload, mode::CommittedHunk},
     id::ShortId,
+    utils::diff_specs::DiffSpecBuilder,
 };
 
 pub(super) fn route_operation<'a>(
@@ -56,11 +57,8 @@ impl<'a> Operation<'a> {
                     path,
                 } = source;
 
-                let changes = Vec::from([but_core::DiffSpec {
-                    previous_path: None,
-                    path: Arc::unwrap_or_clone(Arc::clone(path)),
-                    hunk_headers: Vec::from([*header]),
-                }]);
+                let changes =
+                    single_hunk_changes(ctx, Arc::unwrap_or_clone(Arc::clone(path)), *header)?;
 
                 let move_result = but_api::commit::move_changes::commit_move_changes_between(
                     ctx,
@@ -88,11 +86,8 @@ impl<'a> Operation<'a> {
                     path,
                 } = source;
 
-                let changes = Vec::from([but_core::DiffSpec {
-                    previous_path: None,
-                    path: Arc::unwrap_or_clone(Arc::clone(path)),
-                    hunk_headers: Vec::from([*header]),
-                }]);
+                let changes =
+                    single_hunk_changes(ctx, Arc::unwrap_or_clone(Arc::clone(path)), *header)?;
 
                 but_api::commit::uncommit::commit_uncommit_changes(
                     ctx,
@@ -111,11 +106,8 @@ impl<'a> Operation<'a> {
                     path,
                 } = source;
 
-                let changes = Vec::from([but_core::DiffSpec {
-                    previous_path: None,
-                    path: Arc::unwrap_or_clone(Arc::clone(path)),
-                    hunk_headers: Vec::from([*header]),
-                }]);
+                let changes =
+                    single_hunk_changes(ctx, Arc::unwrap_or_clone(Arc::clone(path)), *header)?;
 
                 but_api::commit::uncommit::commit_uncommit_changes(
                     ctx,
@@ -129,6 +121,18 @@ impl<'a> Operation<'a> {
             }
         }
     }
+}
+
+fn single_hunk_changes(
+    ctx: &Context,
+    path: bstr::BString,
+    header: but_core::HunkHeader,
+) -> anyhow::Result<Vec<but_core::DiffSpec>> {
+    let context_lines = ctx.settings.context_lines;
+    let (_guard, repo, ws, mut db) = ctx.workspace_and_db_mut()?;
+    let mut builder = DiffSpecBuilder::new(&mut db, &repo, &ws, context_lines);
+    builder.push_changes_from_single_hunk(path, header);
+    Ok(builder.into_diff_specs())
 }
 
 pub(super) fn rub_operation_display(

--- a/crates/but/src/utils/diff_specs.rs
+++ b/crates/but/src/utils/diff_specs.rs
@@ -1,126 +1,290 @@
-use but_core::{DiffSpec, ref_metadata::StackId};
+use anyhow::Context as _;
+use bstr::{BStr, BString, ByteSlice};
+use but_core::{DiffSpec, HunkHeader, ref_metadata::StackId};
+use but_hunk_assignment::HunkAssignment;
 
 use crate::{
     CliId,
     id::{ShortId, UncommittedCliId},
 };
 
-/// A subset of [`CliId`] that supports being committed
-#[derive(Debug)]
-pub enum CommitSource {
-    Unassigned(UnassignedCommitSource),
-    Uncommitted(Box<UncommittedCliId>),
-    Stack(StackCommitSource),
-}
+#[cfg(feature = "legacy")]
+use crate::command::legacy::status::assignment::FileAssignment;
 
 #[derive(Debug)]
-pub struct UnassignedCommitSource {
-    pub id: ShortId,
-}
-
-#[derive(Debug)]
-pub struct StackCommitSource {
-    pub stack_id: StackId,
-}
-
-pub fn prepare_changes_to_commit(
-    db: &mut but_db::DbHandle,
-    repo: &gix::Repository,
-    workspace: &but_graph::Workspace,
+pub struct DiffSpecBuilder<'a> {
+    db: &'a mut but_db::DbHandle,
+    repo: &'a gix::Repository,
+    workspace: &'a but_graph::Workspace,
     context_lines: u32,
-    source: &CommitSource,
     scope_to_stack: Option<StackId>,
-) -> anyhow::Result<Vec<DiffSpec>> {
-    // find what to commit
-    let changes_to_commit = match source {
-        CommitSource::Unassigned(..) => {
-            let changes = but_core::diff::ui::worktree_changes(repo)?.changes;
-            let (assignments, _assignments_error) = but_hunk_assignment::assignments_with_fallback(
-                db.hunk_assignments_mut()?,
-                repo,
-                workspace,
-                Some(changes.clone()),
-                context_lines,
-            )?;
-            let assignments = assignments
-                .into_iter()
-                .filter(|assignment| assignment.stack_id.is_none());
-            but_hunk_assignment::diff_specs_from_assignments_with_changes(assignments, &changes)
-        }
-        CommitSource::Uncommitted(uncommitted_cli_id) => {
-            let changes = but_core::diff::ui::worktree_changes(repo)?.changes;
-            let assignments = uncommitted_cli_id
-                .hunk_assignments
-                .iter()
-                .filter(|assignment| assignment.stack_id == scope_to_stack)
-                .cloned();
-            but_hunk_assignment::diff_specs_from_assignments_with_changes(assignments, &changes)
-        }
-        CommitSource::Stack(StackCommitSource { stack_id, .. }) => {
-            let changes = but_core::diff::ui::worktree_changes(repo)?.changes;
-            let (assignments, _assignments_error) = but_hunk_assignment::assignments_with_fallback(
-                db.hunk_assignments_mut()?,
-                repo,
-                workspace,
-                Some(changes.clone()),
-                context_lines,
-            )?;
-            let assignments = assignments
-                .into_iter()
-                .filter(|assignment| assignment.stack_id.is_some_and(|id| &id == stack_id));
-            but_hunk_assignment::diff_specs_from_assignments_with_changes(assignments, &changes)
-        }
-    };
-
-    Ok(but_workspace::flatten_diff_specs(changes_to_commit))
+    worktree_changes: Option<Vec<but_core::ui::TreeChange>>,
+    diff_specs: Vec<DiffSpec>,
 }
 
-impl CommitSource {
-    pub fn try_new(id: CliId) -> Option<Self> {
+impl<'a> DiffSpecBuilder<'a> {
+    pub fn new(
+        db: &'a mut but_db::DbHandle,
+        repo: &'a gix::Repository,
+        workspace: &'a but_graph::Workspace,
+        context_lines: u32,
+    ) -> Self {
+        Self {
+            db,
+            repo,
+            workspace,
+            context_lines,
+            scope_to_stack: None,
+            worktree_changes: None,
+            diff_specs: Default::default(),
+        }
+    }
+
+    pub fn with_scope_to_stack(mut self, scope_to_stack: Option<StackId>) -> Self {
+        self.scope_to_stack = scope_to_stack;
+        self
+    }
+
+    #[expect(dead_code)]
+    pub fn push_changes_from_id(&mut self, id: &CliId) -> anyhow::Result<()> {
         match id {
-            CliId::Unassigned { id } => Some(Self::Unassigned(UnassignedCommitSource { id })),
-            CliId::Uncommitted(uncommitted_cli_id) => {
-                Some(Self::Uncommitted(Box::new(uncommitted_cli_id)))
+            CliId::Uncommitted(uncommitted) => self.push_changes_from_uncommitted(uncommitted),
+            CliId::PathPrefix {
+                id,
+                hunk_assignments,
+            } => self.push_changes_from_path_prefix(id, hunk_assignments),
+            CliId::CommittedFile {
+                commit_id,
+                path,
+                id,
+            } => self.push_changes_from_committed_file(*commit_id, path.clone(), id),
+            CliId::Branch { name, id, stack_id } => {
+                self.push_changes_from_branch(name, id, *stack_id)
             }
-            CliId::Stack { stack_id, .. } => Some(Self::Stack(StackCommitSource { stack_id })),
-            CliId::PathPrefix { .. }
-            | CliId::CommittedFile { .. }
-            | CliId::Branch { .. }
-            | CliId::Commit { .. } => None,
+            CliId::Commit { commit_id, id } => self.push_changes_from_commit(*commit_id, id),
+            CliId::Unassigned { id } => self.push_changes_from_unassigned(id),
+            CliId::Stack { id: _, stack_id } => self.push_changes_from_stack(*stack_id),
         }
+    }
+
+    pub fn push_changes_from_uncommitted(
+        &mut self,
+        uncommitted: &UncommittedCliId,
+    ) -> anyhow::Result<()> {
+        let scope_to_stack = self.scope_to_stack;
+        let assignments = uncommitted
+            .hunk_assignments
+            .iter()
+            .filter(|assignment| assignment.stack_id == scope_to_stack)
+            .cloned();
+        self.push_hunk_assignments(assignments)
+    }
+
+    pub fn push_changes_from_path_prefix(
+        &mut self,
+        _id: &ShortId,
+        hunk_assignments: &nonempty::NonEmpty<(ShortId, HunkAssignment)>,
+    ) -> anyhow::Result<()> {
+        self.push_hunk_assignments(
+            hunk_assignments
+                .iter()
+                .map(|(_id, assignment)| assignment.clone()),
+        )
+    }
+
+    pub fn push_changes_from_committed_file(
+        &mut self,
+        commit_id: gix::ObjectId,
+        path: BString,
+        _id: &ShortId,
+    ) -> anyhow::Result<()> {
+        self.push_changes_from_path_in_commit(path.as_bstr(), commit_id, "First parent")
+    }
+
+    pub fn push_changes_from_path_in_commit(
+        &mut self,
+        path: &BStr,
+        commit_id: gix::ObjectId,
+        parent_context: &'static str,
+    ) -> anyhow::Result<()> {
+        let specs = self.diff_specs_for_path_in_commit(path, commit_id, parent_context)?;
+        self.diff_specs.extend(specs);
+        Ok(())
+    }
+
+    pub fn push_changes_from_branch(
+        &mut self,
+        name: &str,
+        _id: &ShortId,
+        _stack_id: Option<StackId>,
+    ) -> anyhow::Result<()> {
+        anyhow::bail!("Cannot compute diff specs for branch `{name}`")
+    }
+
+    pub fn push_changes_from_commit(
+        &mut self,
+        commit_id: gix::ObjectId,
+        _id: &ShortId,
+    ) -> anyhow::Result<()> {
+        let specs = self.diff_specs_for_commit(commit_id, "First parent")?;
+        self.diff_specs.extend(specs);
+        Ok(())
+    }
+
+    pub fn push_changes_from_unassigned(&mut self, _id: &ShortId) -> anyhow::Result<()> {
+        let changes = self.worktree_changes()?.to_vec();
+        let (assignments, _assignments_error) = but_hunk_assignment::assignments_with_fallback(
+            self.db.hunk_assignments_mut()?,
+            self.repo,
+            self.workspace,
+            Some(changes.clone()),
+            self.context_lines,
+        )?;
+        let assignments = assignments
+            .into_iter()
+            .filter(|assignment| assignment.stack_id.is_none());
+        self.push_hunk_assignments_with_changes(assignments, &changes);
+        Ok(())
+    }
+
+    pub fn push_changes_from_stack(&mut self, stack_id: StackId) -> anyhow::Result<()> {
+        let changes = self.worktree_changes()?.to_vec();
+        let (assignments, _assignments_error) = but_hunk_assignment::assignments_with_fallback(
+            self.db.hunk_assignments_mut()?,
+            self.repo,
+            self.workspace,
+            Some(changes.clone()),
+            self.context_lines,
+        )?;
+        let assignments = assignments
+            .into_iter()
+            .filter(|assignment| assignment.stack_id == Some(stack_id));
+        self.push_hunk_assignments_with_changes(assignments, &changes);
+        Ok(())
+    }
+
+    pub fn push_hunk_assignments(
+        &mut self,
+        assignments: impl IntoIterator<Item = HunkAssignment>,
+    ) -> anyhow::Result<()> {
+        let changes = self.worktree_changes()?.to_vec();
+        self.push_hunk_assignments_with_changes(assignments, &changes);
+        Ok(())
+    }
+
+    #[cfg(feature = "legacy")]
+    pub fn push_file_assignments(&mut self, files: &[FileAssignment]) -> anyhow::Result<()> {
+        let changes = self.worktree_changes()?.to_vec();
+        self.diff_specs
+            .extend(diff_specs_from_file_assignments_status_aware(
+                files, &changes,
+            ));
+        Ok(())
+    }
+
+    pub fn push_changes_from_single_hunk(&mut self, path: BString, header: HunkHeader) {
+        self.diff_specs.push(DiffSpec {
+            previous_path: None,
+            path,
+            hunk_headers: Vec::from([header]),
+        });
+    }
+
+    pub fn into_diff_specs(self) -> Vec<DiffSpec> {
+        but_workspace::flatten_diff_specs(self.diff_specs)
+    }
+
+    fn worktree_changes(&mut self) -> anyhow::Result<&[but_core::ui::TreeChange]> {
+        if self.worktree_changes.is_none() {
+            self.worktree_changes = Some(but_core::diff::ui::worktree_changes(self.repo)?.changes);
+        }
+        Ok(self.worktree_changes.as_deref().unwrap_or_default())
+    }
+
+    fn push_hunk_assignments_with_changes(
+        &mut self,
+        assignments: impl IntoIterator<Item = HunkAssignment>,
+        changes: &[but_core::ui::TreeChange],
+    ) {
+        self.diff_specs.extend(
+            but_hunk_assignment::diff_specs_from_assignments_with_changes(assignments, changes),
+        );
+    }
+
+    fn diff_specs_for_path_in_commit(
+        &self,
+        path: &BStr,
+        source_id: gix::ObjectId,
+        parent_context: &'static str,
+    ) -> anyhow::Result<Vec<DiffSpec>> {
+        let source_commit = self.repo.find_commit(source_id)?;
+        let source_commit_parent_id = source_commit.parent_ids().next().context(parent_context)?;
+
+        let tree_changes = but_core::diff::tree_changes(
+            self.repo,
+            Some(source_commit_parent_id.detach()),
+            source_id,
+        )?;
+        Ok(tree_changes
+            .into_iter()
+            .filter(|tc| tc.path == path)
+            .map(Into::into)
+            .collect())
+    }
+
+    fn diff_specs_for_commit(
+        &self,
+        source_id: gix::ObjectId,
+        parent_context: &'static str,
+    ) -> anyhow::Result<Vec<DiffSpec>> {
+        let source_commit = self.repo.find_commit(source_id)?;
+        let source_commit_parent_id = source_commit.parent_ids().next().context(parent_context)?;
+
+        let tree_changes = but_core::diff::tree_changes(
+            self.repo,
+            Some(source_commit_parent_id.detach()),
+            source_id,
+        )?;
+        Ok(tree_changes.into_iter().map(Into::into).collect())
     }
 }
 
-impl PartialEq<CliId> for CommitSource {
-    fn eq(&self, other: &CliId) -> bool {
-        match self {
-            CommitSource::Unassigned(UnassignedCommitSource { id: lhs_id }) => {
-                if let CliId::Unassigned { id: rhs_id } = other {
-                    lhs_id == rhs_id
-                } else {
-                    false
-                }
+#[cfg(feature = "legacy")]
+fn diff_specs_from_file_assignments_status_aware(
+    files_to_commit: &[FileAssignment],
+    changes: &[but_core::ui::TreeChange],
+) -> Vec<DiffSpec> {
+    files_to_commit
+        .iter()
+        .map(|fa| {
+            let (previous_path, is_addition_or_deletion) = changes
+                .iter()
+                .find(|change| change.path_bytes == fa.path)
+                .map(|change| match &change.status {
+                    but_core::ui::TreeStatus::Rename {
+                        previous_path_bytes,
+                        ..
+                    } => (Some(previous_path_bytes.clone()), false),
+                    but_core::ui::TreeStatus::Addition { .. }
+                    | but_core::ui::TreeStatus::Deletion { .. } => (None, true),
+                    but_core::ui::TreeStatus::Modification { .. } => (None, false),
+                })
+                .unwrap_or((None, false));
+
+            let hunk_headers = if is_addition_or_deletion {
+                Vec::new()
+            } else {
+                fa.assignments
+                    .iter()
+                    .filter_map(|assignment| assignment.inner.hunk_header)
+                    .collect()
+            };
+
+            DiffSpec {
+                previous_path,
+                path: fa.path.clone(),
+                hunk_headers,
             }
-            CommitSource::Uncommitted(lhs) => {
-                if let CliId::Uncommitted(rhs) = other {
-                    &**lhs == rhs
-                } else {
-                    false
-                }
-            }
-            CommitSource::Stack(StackCommitSource {
-                stack_id: stack_id_lhs,
-            }) => {
-                if let CliId::Stack {
-                    stack_id: stack_id_rhs,
-                    ..
-                } = other
-                {
-                    stack_id_lhs == stack_id_rhs
-                } else {
-                    false
-                }
-            }
-        }
-    }
+        })
+        .collect()
 }

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -2183,3 +2183,78 @@ Hint: run `but help` for all commands
 
 "#]]);
 }
+
+#[test]
+fn committing_modified_and_renamed_file() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
+    env.setup_metadata(&[]).unwrap();
+
+    env.file("file", "content");
+    env.file("file-2", "content-2");
+
+    env.but("commit -m 'add files'").assert().success();
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄br [a-branch-1]
+┊●   e3f869d add files
+┊│     e3:qs A file
+┊│     e3:kw A file-2
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.file("file-2", "new content");
+    env.rename_file("file-2", "file");
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes]
+┊   qs M file
+┊   kw D file-2
+┊
+┊╭┄br [a-branch-1]
+┊●   e3f869d add files
+┊│     e3:qs A file
+┊│     e3:kw A file-2
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+
+"#]]);
+
+    env.but("commit -m 'change file'").assert().success();
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄br [a-branch-1]
+┊●   e419886 change file
+┊│     e4:qs M file
+┊│     e4:kw D file-2
+┊●   e3f869d add files
+┊│     e3:qs A file
+┊│     e3:kw A file-2
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}


### PR DESCRIPTION
How we compute `Vec<DiffSpec>` to commit/rub/discard/etc in the CLI was very scattered. This aims to unify all that in a single place with a single API:

```rust
// make a DiffSpecBuilder
let mut builder = DiffSpecBuilder::new(...);

// push some sources into it
builder.push_changes_from_unassigned(zz_cli_id)?;
builder.push_changes_from_uncommitted(uncommitted_cli_id)?;
builder.push_changes_from_stack(stack_cli_id)?;
// there are more methods to push other kinds of sources

// get the diff specs out
builder.into_diff_specs()
```