### PR TITLE
Single-branch mode E2E: Test commit actions

### DIFF
--- a/e2e/playwright/scripts/project-in-single-branch-mode.sh
+++ b/e2e/playwright/scripts/project-in-single-branch-mode.sh
@@ -27,11 +27,13 @@ pushd local-clone
   "$BUT" config target "$target_branch"
 
   git checkout -b single-branch-fixture master
-  echo "single branch commit 1" >> a_file
-  git commit -am "single-branch: first commit"
+  echo "single branch commit 1" > single_branch_first.txt
+  git add single_branch_first.txt
+  git commit -m "single-branch: first commit"
 
-  echo "single branch commit 2" >> a_file
-  git commit -am "single-branch: second commit"
+  echo "single branch commit 2" > single_branch_second.txt
+  git add single_branch_second.txt
+  git commit -m "single-branch: second commit"
 
   echo "single branch file" > single_branch_file.txt
   git add single_branch_file.txt

--- a/e2e/playwright/src/file.ts
+++ b/e2e/playwright/src/file.ts
@@ -30,8 +30,7 @@ export function writeFiles(files: Record<string, string>): void {
 }
 
 export async function assertFileContent(filePath: string, expectedContent: string): Promise<void> {
-	const actualContent = fs.readFileSync(filePath, "utf-8");
-	await expect.poll(() => actualContent).toBe(expectedContent);
+	await expect.poll(() => fs.readFileSync(filePath, "utf-8")).toBe(expectedContent);
 }
 
 /**

--- a/e2e/playwright/tests/singleBranch/commitActions.spec.ts
+++ b/e2e/playwright/tests/singleBranch/commitActions.spec.ts
@@ -1,0 +1,113 @@
+import { setupSingleBranchProject, SINGLE_BRANCH_NAME } from "./helpers.ts";
+import {
+	assertBranch,
+	assertCleanWorktree,
+	assertCommitSubjects,
+	assertDirtyWorktree,
+} from "../../src/branch.ts";
+import {
+	openCommitDrawer,
+	startEditingCommitMessage,
+	updateCommitMessage,
+	verifyCommitDrawerContent,
+	verifyCommitMessageEditor,
+	verifyCommitPlaceholderPosition,
+} from "../../src/commit.ts";
+import { assertFileContent, unstageAllFiles, writeToFile } from "../../src/file.ts";
+import { test } from "../../src/test.ts";
+import { clickByTestId, commitRow, dragAndDropByLocator, getByTestId } from "../../src/util.ts";
+import { expect } from "@playwright/test";
+
+test.use({
+	gitbutlerOptions: {
+		config: {
+			onboardingComplete: true,
+			featureFlags: { singleBranch: true },
+		},
+	},
+});
+
+test("can commit new changes on the checked-out branch", async ({ page, gitbutler }) => {
+	const localClone = await setupSingleBranchProject(gitbutler, page);
+	await assertBranch(SINGLE_BRANCH_NAME, localClone);
+
+	const fileName = "single_branch_new_file.txt";
+	const fileContent = "new single branch content\n";
+	writeToFile(gitbutler.pathInWorkdir("local-clone", fileName), fileContent);
+
+	await expect(getByTestId(page, "file-list-item").filter({ hasText: fileName })).toBeVisible();
+	await clickByTestId(page, "start-commit-button");
+	await verifyCommitPlaceholderPosition(page);
+	await unstageAllFiles(page);
+	await getByTestId(page, "file-list-item")
+		.filter({ hasText: fileName })
+		.locator('input[type="checkbox"]')
+		.click();
+
+	const title = "single-branch: commit from e2e";
+	const body = "Committed while HEAD is on a normal Git branch.";
+	await verifyCommitMessageEditor(page, "", "");
+	await updateCommitMessage(page, title, body);
+	await clickByTestId(page, "commit-drawer-action-button");
+
+	await expect(commitRow(page, title)).toBeVisible();
+	await assertBranch(SINGLE_BRANCH_NAME, localClone);
+	await assertCleanWorktree(localClone);
+	await assertFileContent(gitbutler.pathInWorkdir("local-clone", fileName), fileContent);
+	await assertCommitSubjects(
+		[
+			title,
+			"single-branch: add file",
+			"single-branch: second commit",
+			"single-branch: first commit",
+		],
+		localClone,
+	);
+});
+
+test("can edit a commit message on the checked-out branch", async ({ page, gitbutler }) => {
+	const localClone = await setupSingleBranchProject(gitbutler, page);
+
+	const originalTitle = "single-branch: add file";
+	const newTitle = "single-branch: reworded add file";
+	const newBody = "Reworded in single-branch mode.";
+
+	const drawer = await openCommitDrawer(page, originalTitle);
+	await startEditingCommitMessage(page, drawer);
+	await verifyCommitMessageEditor(page, originalTitle, "");
+
+	await updateCommitMessage(page, newTitle, newBody);
+	await clickByTestId(page, "commit-drawer-action-button");
+
+	await verifyCommitDrawerContent(drawer, newTitle, newBody);
+	await assertBranch(SINGLE_BRANCH_NAME, localClone);
+	await assertCleanWorktree(localClone);
+	await assertCommitSubjects(
+		[newTitle, "single-branch: second commit", "single-branch: first commit"],
+		localClone,
+	);
+});
+
+test("can amend file changes into an existing commit", async ({ page, gitbutler }) => {
+	const localClone = await setupSingleBranchProject(gitbutler, page);
+
+	const filePath = gitbutler.pathInWorkdir("local-clone", "single_branch_file.txt");
+	const amendedContent = "single branch file\namended while in single-branch mode\n";
+	writeToFile(filePath, amendedContent);
+	await assertDirtyWorktree(localClone);
+
+	const fileLocator = getByTestId(page, "file-list-item").filter({
+		hasText: "single_branch_file.txt",
+	});
+	await expect(fileLocator).toBeVisible();
+
+	await dragAndDropByLocator(page, fileLocator, commitRow(page, "single-branch: add file"));
+
+	await assertBranch(SINGLE_BRANCH_NAME, localClone);
+	await assertCleanWorktree(localClone);
+	await assertFileContent(filePath, amendedContent);
+	await assertCommitSubjects(
+		["single-branch: add file", "single-branch: second commit", "single-branch: first commit"],
+		localClone,
+	);
+});

--- a/e2e/playwright/tests/singleBranch/commitSelection.spec.ts
+++ b/e2e/playwright/tests/singleBranch/commitSelection.spec.ts
@@ -1,0 +1,64 @@
+import { setupSingleBranchProject, SINGLE_BRANCH_NAME } from "./helpers.ts";
+import { assertBranch, assertCommitSubjects, assertDirtyWorktree } from "../../src/branch.ts";
+import { assertFileIsUncommitted } from "../../src/file.ts";
+import { test } from "../../src/test.ts";
+import {
+	commitRow,
+	getByTestId,
+	MOD_KEY,
+	waitForElementToStabilize,
+	waitForTestId,
+} from "../../src/util.ts";
+import { expect } from "@playwright/test";
+
+test.use({
+	gitbutlerOptions: {
+		config: {
+			onboardingComplete: true,
+			featureFlags: { singleBranch: true },
+		},
+	},
+});
+
+test("can squash selected commits on the checked-out branch", async ({ page, gitbutler }) => {
+	const localClone = await setupSingleBranchProject(gitbutler, page);
+
+	const top = commitRow(page, "single-branch: add file");
+	await top.click();
+	await commitRow(page, "single-branch: second commit").click({ modifiers: [MOD_KEY] });
+	await top.click({ button: "right" });
+
+	const squashItem = await waitForTestId(page, "commit-row-context-menu-squash-selected");
+	await waitForElementToStabilize(page, squashItem);
+	await expect(squashItem).toContainText("Squash 2 commits");
+	await squashItem.click();
+
+	await expect(commitRow(page, "single-branch: first commit")).toBeVisible();
+	await expect(getByTestId(page, "global-modal-commit-failed")).toHaveCount(0);
+	await assertBranch(SINGLE_BRANCH_NAME, localClone);
+	await assertCommitSubjects(
+		["single-branch: second commit", "single-branch: first commit"],
+		localClone,
+	);
+});
+
+test("can uncommit selected commits back into the worktree", async ({ page, gitbutler }) => {
+	const localClone = await setupSingleBranchProject(gitbutler, page);
+
+	const top = commitRow(page, "single-branch: add file");
+	await top.click();
+	await commitRow(page, "single-branch: second commit").click({ modifiers: [MOD_KEY] });
+	await top.click({ button: "right" });
+
+	const uncommitItem = await waitForTestId(page, "commit-row-context-menu-uncommit-selected");
+	await waitForElementToStabilize(page, uncommitItem);
+	await expect(uncommitItem).toContainText("Uncommit 2 commits");
+	await uncommitItem.click();
+
+	await expect(commitRow(page, "single-branch: first commit")).toBeVisible();
+	await assertFileIsUncommitted(page, "single_branch_file.txt");
+	await assertFileIsUncommitted(page, "single_branch_second.txt");
+	await assertBranch(SINGLE_BRANCH_NAME, localClone);
+	await assertDirtyWorktree(localClone);
+	await assertCommitSubjects(["single-branch: first commit", "base: initial commit"], localClone);
+});

--- a/e2e/playwright/tests/singleBranch/dragAndDrop.spec.ts
+++ b/e2e/playwright/tests/singleBranch/dragAndDrop.spec.ts
@@ -1,0 +1,35 @@
+import { setupSingleBranchProject, SINGLE_BRANCH_NAME } from "./helpers.ts";
+import { assertBranch, assertCleanWorktree, assertCommitSubjects } from "../../src/branch.ts";
+import { test } from "../../src/test.ts";
+import { commitRow, dragAndDropByLocator, getByTestId } from "../../src/util.ts";
+import { expect } from "@playwright/test";
+
+test.use({
+	gitbutlerOptions: {
+		config: {
+			onboardingComplete: true,
+			featureFlags: { singleBranch: true },
+		},
+	},
+});
+
+test("can squash commits by dragging one commit onto another", async ({ page, gitbutler }) => {
+	const localClone = await setupSingleBranchProject(gitbutler, page);
+	await assertCleanWorktree(localClone);
+
+	await expect(commitRow(page)).toHaveCount(4);
+
+	await dragAndDropByLocator(
+		page,
+		commitRow(page, "single-branch: add file"),
+		commitRow(page, "single-branch: second commit"),
+	);
+
+	await expect(getByTestId(page, "global-modal-commit-failed")).toHaveCount(0);
+	await expect(commitRow(page, "single-branch: first commit")).toBeVisible();
+	await assertBranch(SINGLE_BRANCH_NAME, localClone);
+	await assertCommitSubjects(
+		["single-branch: second commit", "single-branch: first commit"],
+		localClone,
+	);
+});

--- a/e2e/playwright/tests/singleBranch/helpers.ts
+++ b/e2e/playwright/tests/singleBranch/helpers.ts
@@ -1,7 +1,15 @@
 import { openWorkspace } from "../../src/setup.ts";
 import { expect, type Page } from "@playwright/test";
+import type { GitButler } from "../../src/setup.ts";
 
 export const SINGLE_BRANCH_NAME = "single-branch-fixture";
+
+export async function setupSingleBranchProject(gitbutler: GitButler, page: Page): Promise<string> {
+	await gitbutler.runScript("project-in-single-branch-mode.sh");
+	const localClone = gitbutler.pathInWorkdir("local-clone");
+	await openSingleBranchWorkspace(page);
+	return localClone;
+}
 
 export async function openSingleBranchWorkspace(page: Page): Promise<void> {
 	await openWorkspace(page);


### PR DESCRIPTION
Add tests for:
- Commit creation
- Uncommit
- Commit amend
- Commit squash

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #14133 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #14130 
<!-- GitButler Footer Boundary Bottom -->

