### PR TITLE
fix(but): ensure cache dir is created

### DIFF
--- a/crates/but-db/src/cache/handle.rs
+++ b/crates/but-db/src/cache/handle.rs
@@ -10,6 +10,9 @@ impl AppCacheHandle {
     /// with an infallible constructor that falls back to an in-memory database.
     pub fn new_in_directory(dir: Option<impl AsRef<Path>>) -> Self {
         let db_path = dir.map_or(":memory:".into(), |d| d.as_ref().join("app-cache.sqlite"));
+        if let Some(cache_dir) = db_path.parent() {
+            create_dir_all_log_failure(cache_dir);
+        }
         Self::new_at_path(db_path)
     }
 
@@ -44,17 +47,8 @@ impl CacheHandle {
     /// Infallible constructor that opens the project-local cache from `dir`,
     /// with an infallible fallback to an in-memory database.
     pub fn new_in_directory(dir: impl AsRef<Path>) -> Self {
-        let dir = dir.as_ref();
-        if !dir.exists()
-            && let Err(err) = std::fs::create_dir_all(dir)
-        {
-            tracing::warn!(
-                ?err,
-                "Failed to create project cache directory at {dir}, falling back to in-memory",
-                dir = dir.display()
-            );
-        }
-        Self::new_at_path(dir.join("but_cache.sqlite"))
+        create_dir_all_log_failure(&dir);
+        Self::new_at_path(dir.as_ref().join("but_cache.sqlite"))
     }
 
     /// Create a new instance at `path`.
@@ -80,5 +74,16 @@ impl std::fmt::Debug for CacheHandle {
         f.debug_struct("CacheHandle")
             .field("db", &self.path)
             .finish()
+    }
+}
+
+/// Attempt to create the given directory, logging failures as warnings.
+fn create_dir_all_log_failure(dir: impl AsRef<Path>) {
+    if let Err(err) = std::fs::create_dir_all(&dir) {
+        tracing::warn!(
+            ?err,
+            "Failed to create project cache directory at {dir}, skipping ...",
+            dir = dir.as_ref().display()
+        );
     }
 }


### PR DESCRIPTION
For some reason, we never attempted to create the cache dir when creating a new `AppCacheHandle`, but we do it for `CacheHandle`. As a result, `but` would never create the cache directory and therefore never store the update check result.

I see no good reason not to create the cache directory for `AppCacheHandle` as well - checking if the directory is there is very cheap so it's a one-time cost.