### PR TITLE
Set env var which allows to read the target stack where the commit will be applied

### DIFF
--- a/crates/but-api/src/commit/create.rs
+++ b/crates/but-api/src/commit/create.rs
@@ -1,6 +1,7 @@
 use crate::WorkspaceState;
 use but_api_macros::but_api;
 use but_core::{DiffSpec, DryRun, sync::RepoExclusive};
+use but_graph::Workspace;
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
 use but_rebase::graph_rebase::{
     Editor, LookupStep as _,
@@ -9,6 +10,34 @@ use but_rebase::graph_rebase::{
 use tracing::instrument;
 
 use super::types::CommitCreateResult;
+
+/// Helper to find which branch contains a given commit by checking the workspace graph
+fn find_branch_for_commit(ws: &Workspace, commit_id: gix::ObjectId) -> Option<gix::refs::FullName> {
+    tracing::debug!("find_branch_for_commit: Searching for commit {} in {} stacks", commit_id, ws.stacks.len());
+
+    // Iterate through all stacks and their segments
+    for (stack_idx, stack) in ws.stacks.iter().enumerate() {
+        tracing::debug!("find_branch_for_commit: Stack {}: {} segments", stack_idx, stack.segments.len());
+
+        for (seg_idx, segment) in stack.segments.iter().enumerate() {
+            let ref_name = segment.ref_info.as_ref().map(|i| i.ref_name.as_ref().to_string()).unwrap_or_else(|| "no-ref".to_string());
+            tracing::debug!("find_branch_for_commit:   Segment {}: ref={}, commits={}", seg_idx, ref_name, segment.commits.len());
+
+            // Check if any commit in this segment matches our target commit
+            for commit in &segment.commits {
+                if commit.id == commit_id {
+                    // Found it! Return the branch reference for this segment
+                    let result = segment.ref_info.as_ref().map(|info| info.ref_name.clone());
+                    tracing::info!("find_branch_for_commit: FOUND! commit {} in segment with ref={:?}", commit_id, result);
+                    return result;
+                }
+            }
+        }
+    }
+
+    tracing::warn!("find_branch_for_commit: Commit {} not found in any branch", commit_id);
+    None
+}
 
 /// Creates a commit from `changes` with `message`, inserted on `side` of
 /// `relative_to`.
@@ -106,22 +135,53 @@ pub fn commit_create(
     dry_run: DryRun,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitCreateResult> {
-    // Run commit-msg hook with branch context if we're committing relative to a reference
-    let final_message = if let RelativeTo::Reference(ref branch_ref) = relative_to {
-        match gitbutler_repo::hooks::commit_msg_with_branch(ctx, message.clone(), Some(branch_ref.as_ref())) {
+    // First, determine which branch we're committing to by examining the workspace
+    let branch_for_hook: Option<gix::refs::FullName> = {
+        let mut meta = ctx.meta()?;
+        let (repo, ws, _) = ctx.workspace_and_db_with_perm(perm.read_permission())?;
+
+        let result = match &relative_to {
+            RelativeTo::Reference(r) => {
+                tracing::info!("commit_create: RelativeTo::Reference({})", r);
+                Some(r.clone())
+            }
+            RelativeTo::Commit(commit_id) => {
+                tracing::info!("commit_create: RelativeTo::Commit({}), searching for branch...", commit_id);
+                let found = find_branch_for_commit(&ws, *commit_id);
+                if let Some(ref branch) = found {
+                    tracing::info!("commit_create: Found branch: {}", branch);
+                } else {
+                    tracing::warn!("commit_create: No branch found for commit {}", commit_id);
+                }
+                found
+            }
+        };
+
+        tracing::info!("commit_create: Final branch_for_hook: {:?}", result);
+        result
+    };
+
+    // Run commit-msg hook with the determined branch context
+    let final_message = {
+        let branch_ref_opt = branch_for_hook.as_ref().map(|r| r.as_ref());
+
+        if let Some(branch_ref) = branch_ref_opt {
+            tracing::debug!("Running commit-msg hook with branch reference: {}", branch_ref);
+        } else {
+            tracing::debug!("Running commit-msg hook with workspace target branch (no branch found)");
+        }
+
+        match gitbutler_repo::hooks::commit_msg_with_branch(ctx, message.clone(), branch_ref_opt) {
             Ok(gitbutler_repo::hooks::MessageHookResult::Message(data)) => data.message,
             Ok(gitbutler_repo::hooks::MessageHookResult::Failure(data)) => {
                 anyhow::bail!("commit-msg hook failed: {}", data.error);
             }
             Ok(_) => message,
             Err(e) => {
-                // Log hook errors but don't block the commit
                 tracing::warn!("commit-msg hook error: {}", e);
                 message
             }
         }
-    } else {
-        message
     };
 
     let context_lines = ctx.settings.context_lines;

--- a/crates/but-api/src/commit/create.rs
+++ b/crates/but-api/src/commit/create.rs
@@ -106,6 +106,24 @@ pub fn commit_create(
     dry_run: DryRun,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitCreateResult> {
+    // Run commit-msg hook with branch context if we're committing relative to a reference
+    let final_message = if let RelativeTo::Reference(ref branch_ref) = relative_to {
+        match gitbutler_repo::hooks::commit_msg_with_branch(ctx, message.clone(), Some(branch_ref.as_ref())) {
+            Ok(gitbutler_repo::hooks::MessageHookResult::Message(data)) => data.message,
+            Ok(gitbutler_repo::hooks::MessageHookResult::Failure(data)) => {
+                anyhow::bail!("commit-msg hook failed: {}", data.error);
+            }
+            Ok(_) => message,
+            Err(e) => {
+                // Log hook errors but don't block the commit
+                tracing::warn!("commit-msg hook error: {}", e);
+                message
+            }
+        }
+    } else {
+        message
+    };
+
     let context_lines = ctx.settings.context_lines;
     let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
         ctx,
@@ -119,7 +137,7 @@ pub fn commit_create(
         relative_to,
         side,
         changes,
-        message,
+        final_message,
         dry_run,
         context_lines,
         perm,

--- a/crates/but-api/src/legacy/repo.rs
+++ b/crates/but-api/src/legacy/repo.rs
@@ -111,8 +111,15 @@ pub fn post_commit_hook(ctx: &but_ctx::Context) -> Result<HookResult> {
 
 #[but_api]
 #[instrument(err(Debug))]
-pub fn message_hook(ctx: &but_ctx::Context, message: String) -> Result<MessageHookResult> {
-    gitbutler_repo::hooks::commit_msg(ctx, message)
+pub fn message_hook(
+    ctx: &but_ctx::Context,
+    message: String,
+    branch_ref: Option<String>,
+) -> Result<MessageHookResult> {
+    let branch_ref_parsed = branch_ref
+        .as_deref()
+        .and_then(|s| s.try_into().ok());
+    gitbutler_repo::hooks::commit_msg_with_branch(ctx, message, branch_ref_parsed)
 }
 
 #[but_api]

--- a/crates/but-core/src/lib.rs
+++ b/crates/but-core/src/lib.rs
@@ -131,6 +131,30 @@ pub fn is_workspace_ref_name(ref_name: &FullNameRef) -> bool {
         || ref_name.as_bstr() == "refs/heads/gitbutler/integration"
 }
 
+/// Extract the short branch name from a full reference name.
+///
+/// For remote tracking branches like `refs/remotes/origin/main`, this returns `main`.
+/// For local branches like `refs/heads/develop`, this returns `develop`.
+/// Returns `None` if the ref_name cannot be categorized or doesn't have a short name.
+pub fn extract_short_branch_name(ref_name: &gix::refs::FullNameRef) -> Option<String> {
+    let (category, shorthand_name) = ref_name.category_and_short_name()?;
+
+    match category {
+        gix::refs::Category::RemoteBranch => {
+            // For remote tracking branches like refs/remotes/origin/main, we need to strip the remote name
+            let shorthand = shorthand_name.to_str().ok()?;
+            // Find the first slash to separate remote name from branch name
+            let pos = shorthand.find('/')?;
+            Some(shorthand[pos + 1..].to_string())
+        }
+        gix::refs::Category::LocalBranch => {
+            // For local branches, the shorthand name is already the branch name
+            Some(shorthand_name.to_str().ok()?.to_string())
+        }
+        _ => None,
+    }
+}
+
 /// A utility to extract the name of the remote from a remote tracking ref with `ref_name`,
 /// along with the short name of the branch that remains after stripping the remote name.
 /// If it's not a remote tracking ref, or no remote in `remote_names` (like `origin`) matches,

--- a/crates/but-core/tests/core/extract_short_branch_name.rs
+++ b/crates/but-core/tests/core/extract_short_branch_name.rs
@@ -1,0 +1,63 @@
+use but_core::extract_short_branch_name;
+
+#[test]
+fn remote_tracking_branch() {
+    let ref_name: gix::refs::FullNameRef = "refs/remotes/origin/main".try_into().unwrap();
+    assert_eq!(
+        extract_short_branch_name(&ref_name),
+        Some("main".to_string()),
+        "should extract branch name from simple remote tracking branch"
+    );
+
+    let ref_name: gix::refs::FullNameRef = "refs/remotes/origin/feature/cool-feature"
+        .try_into()
+        .unwrap();
+    assert_eq!(
+        extract_short_branch_name(&ref_name),
+        Some("feature/cool-feature".to_string()),
+        "should extract branch name with slashes"
+    );
+
+    let ref_name: gix::refs::FullNameRef = "refs/remotes/upstream/develop".try_into().unwrap();
+    assert_eq!(
+        extract_short_branch_name(&ref_name),
+        Some("develop".to_string()),
+        "should work with different remote names"
+    );
+}
+
+#[test]
+fn local_branch() {
+    let ref_name: gix::refs::FullNameRef = "refs/heads/main".try_into().unwrap();
+    assert_eq!(
+        extract_short_branch_name(&ref_name),
+        Some("main".to_string()),
+        "should extract name from local branch"
+    );
+
+    let ref_name: gix::refs::FullNameRef = "refs/heads/feature/new-feature"
+        .try_into()
+        .unwrap();
+    assert_eq!(
+        extract_short_branch_name(&ref_name),
+        Some("feature/new-feature".to_string()),
+        "should extract name from local branch with slashes"
+    );
+}
+
+#[test]
+fn unsupported_refs() {
+    let ref_name: gix::refs::FullNameRef = "refs/tags/v1.0.0".try_into().unwrap();
+    assert_eq!(
+        extract_short_branch_name(&ref_name),
+        None,
+        "should return None for tags"
+    );
+
+    let ref_name: gix::refs::FullNameRef = "refs/notes/commits".try_into().unwrap();
+    assert_eq!(
+        extract_short_branch_name(&ref_name),
+        None,
+        "should return None for notes refs"
+    );
+}

--- a/crates/but-core/tests/core/main.rs
+++ b/crates/but-core/tests/core/main.rs
@@ -4,6 +4,7 @@ mod cmd;
 mod commit;
 mod diff;
 mod extract_remote_name_and_short_name;
+mod extract_short_branch_name;
 mod git_config;
 mod json_samples;
 mod ref_metadata;

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -477,7 +477,7 @@ pub(crate) fn commit(
     // Run commit-msg hook unless --no-hooks was specified
     // This hook can validate and optionally modify the commit message
     let final_commit_message = if !no_hooks {
-        let hook_result = repo::message_hook(ctx, commit_message.clone())?;
+        let hook_result = repo::message_hook(ctx, commit_message.clone(), None)?;
         match hook_result {
             gitbutler_repo::hooks::MessageHookResult::Success => {
                 // Hook passed without modification

--- a/crates/gitbutler-repo/src/hooks.rs
+++ b/crates/gitbutler-repo/src/hooks.rs
@@ -54,9 +54,22 @@ fn husky_search_paths(ctx: &Context) -> Option<&'static [&'static str]> {
     }
 }
 
-pub fn commit_msg(ctx: &Context, mut message: String) -> Result<MessageHookResult> {
-    // Set GITBUTLER_TARGET_BRANCH environment variable if a target branch is configured
-    let _target_branch_guard = set_target_branch_env(ctx);
+pub fn commit_msg(ctx: &Context, message: String) -> Result<MessageHookResult> {
+    commit_msg_with_branch(ctx, message, None)
+}
+
+pub fn commit_msg_with_branch(
+    ctx: &Context,
+    mut message: String,
+    branch_ref: Option<&gix::refs::FullNameRef>,
+) -> Result<MessageHookResult> {
+    // Set GITBUTLER_TARGET_BRANCH environment variable
+    // If a specific branch is provided, use that; otherwise fall back to workspace target
+    let _target_branch_guard = if let Some(branch_ref) = branch_ref {
+        set_branch_env(branch_ref)
+    } else {
+        set_target_branch_env(ctx)
+    };
 
     let original_message = message.clone();
     #[expect(deprecated, reason = "libgit2 hook adapter boundary")]
@@ -264,6 +277,23 @@ fn join_output(stdout: String, stderr: String, code: Option<i32>) -> String {
     format!("stdout:\n{stdout}\n\nstderr:\n{stderr}{code}")
 }
 
+/// Set the GITBUTLER_TARGET_BRANCH environment variable from a specific branch reference.
+/// Returns a guard that will unset the environment variable when dropped.
+fn set_branch_env(branch_ref: &gix::refs::FullNameRef) -> Option<TargetBranchEnvGuard> {
+    // Extract the short branch name from the branch ref
+    let short_branch_name = but_core::extract_short_branch_name(branch_ref)?;
+
+    // Set the environment variable
+    // SAFETY: This is safe because we're setting an environment variable in a controlled
+    // scope with the guard pattern ensuring it will be properly cleaned up when dropped.
+    // The variable name and value are both valid UTF-8 strings.
+    unsafe {
+        std::env::set_var("GITBUTLER_TARGET_BRANCH", &short_branch_name);
+    }
+
+    Some(TargetBranchEnvGuard { was_set: true })
+}
+
 /// Set the GITBUTLER_TARGET_BRANCH environment variable based on the workspace's target ref.
 /// Returns a guard that will unset the environment variable when dropped.
 ///
@@ -276,20 +306,7 @@ fn set_target_branch_env(ctx: &Context) -> Option<TargetBranchEnvGuard> {
     let workspace = meta.workspace(workspace_ref).ok()?;
     let target_ref = workspace.target_ref.as_ref()?;
 
-    // Extract the short branch name from the target ref
-    let short_branch_name = but_core::extract_short_branch_name(target_ref.as_ref())?;
-
-    // Set the environment variable
-    // SAFETY: This is safe because we're setting an environment variable in a controlled
-    // scope with the guard pattern ensuring it will be properly cleaned up when dropped.
-    // The variable name and value are both valid UTF-8 strings.
-    unsafe {
-        std::env::set_var("GITBUTLER_TARGET_BRANCH", &short_branch_name);
-    }
-
-    Some(TargetBranchEnvGuard {
-        was_set: true,
-    })
+    set_branch_env(target_ref.as_ref())
 }
 
 /// Guard that unsets the GITBUTLER_TARGET_BRANCH environment variable when dropped.

--- a/crates/gitbutler-repo/src/hooks.rs
+++ b/crates/gitbutler-repo/src/hooks.rs
@@ -95,6 +95,9 @@ pub fn pre_commit_with_tree(ctx: &Context, tree_id: gix::ObjectId) -> Result<Hoo
     index.read_tree(&repo.find_tree(tree_id.to_git2())?)?;
     index.write()?;
 
+    // Set GITBUTLER_TARGET_BRANCH environment variable if a target branch is configured
+    let _target_branch_guard = set_target_branch_env(ctx);
+
     Ok(
         match git2_hooks::hooks_pre_commit(repo, husky_search_paths(ctx))? {
             H::Ok { hook: _ } => HookResult::Success,
@@ -252,4 +255,40 @@ fn join_output(stdout: String, stderr: String, code: Option<i32>) -> String {
         return stdout;
     }
     format!("stdout:\n{stdout}\n\nstderr:\n{stderr}{code}")
+}
+
+/// Set the GITBUTLER_TARGET_BRANCH environment variable based on the workspace's target ref.
+/// Returns a guard that will unset the environment variable when dropped.
+///
+/// This allows hooks to know which branch commits are targeting, which is useful for
+/// hooks that need context about the target integration branch.
+fn set_target_branch_env(ctx: &Context) -> Option<TargetBranchEnvGuard> {
+    // Try to read workspace metadata to get the target ref
+    let meta = ctx.meta().ok()?;
+    let workspace_ref = but_core::WORKSPACE_REF_NAME.try_into().ok()?;
+    let workspace = meta.workspace(&workspace_ref).ok()?;
+    let target_ref = workspace.target_ref.as_ref()?;
+
+    // Extract the short branch name from the target ref
+    let short_branch_name = but_core::extract_short_branch_name(target_ref.as_ref())?;
+
+    // Set the environment variable
+    std::env::set_var("GITBUTLER_TARGET_BRANCH", &short_branch_name);
+
+    Some(TargetBranchEnvGuard {
+        was_set: true,
+    })
+}
+
+/// Guard that unsets the GITBUTLER_TARGET_BRANCH environment variable when dropped.
+struct TargetBranchEnvGuard {
+    was_set: bool,
+}
+
+impl Drop for TargetBranchEnvGuard {
+    fn drop(&mut self) {
+        if self.was_set {
+            std::env::remove_var("GITBUTLER_TARGET_BRANCH");
+        }
+    }
 }

--- a/crates/gitbutler-repo/src/hooks.rs
+++ b/crates/gitbutler-repo/src/hooks.rs
@@ -63,12 +63,12 @@ pub fn commit_msg_with_branch(
     mut message: String,
     branch_ref: Option<&gix::refs::FullNameRef>,
 ) -> Result<MessageHookResult> {
-    // Set GITBUTLER_TARGET_BRANCH environment variable
+    // Set GITBUTLER_TARGET_STACK environment variable
     // If a specific branch is provided, use that; otherwise fall back to workspace target
-    let _target_branch_guard = if let Some(branch_ref) = branch_ref {
-        set_branch_env(branch_ref)
+    let _target_stack_guard = if let Some(branch_ref) = branch_ref {
+        set_stack_env(branch_ref)
     } else {
-        set_target_branch_env(ctx)
+        set_target_stack_env(ctx)
     };
 
     let original_message = message.clone();
@@ -112,8 +112,8 @@ pub fn pre_commit_with_tree(ctx: &Context, tree_id: gix::ObjectId) -> Result<Hoo
     index.read_tree(&repo.find_tree(tree_id.to_git2())?)?;
     index.write()?;
 
-    // Set GITBUTLER_TARGET_BRANCH environment variable if a target branch is configured
-    let _target_branch_guard = set_target_branch_env(ctx);
+    // Set GITBUTLER_TARGET_STACK environment variable if a target stack is configured
+    let _target_stack_guard = set_target_stack_env(ctx);
 
     Ok(
         match git2_hooks::hooks_pre_commit(repo, husky_search_paths(ctx))? {
@@ -139,8 +139,8 @@ pub fn pre_commit_with_tree(ctx: &Context, tree_id: gix::ObjectId) -> Result<Hoo
 }
 
 pub fn post_commit(ctx: &Context) -> Result<HookResult> {
-    // Set GITBUTLER_TARGET_BRANCH environment variable if a target branch is configured
-    let _target_branch_guard = set_target_branch_env(ctx);
+    // Set GITBUTLER_TARGET_STACK environment variable if a target stack is configured
+    let _target_stack_guard = set_target_stack_env(ctx);
 
     #[expect(deprecated, reason = "libgit2 hook adapter boundary")]
     match git2_hooks::hooks_post_commit(&*ctx.git2_repo.get()?, husky_search_paths(ctx))? {
@@ -277,9 +277,9 @@ fn join_output(stdout: String, stderr: String, code: Option<i32>) -> String {
     format!("stdout:\n{stdout}\n\nstderr:\n{stderr}{code}")
 }
 
-/// Set the GITBUTLER_TARGET_BRANCH environment variable from a specific branch reference.
+/// Set the GITBUTLER_TARGET_STACK environment variable from a specific branch reference.
 /// Returns a guard that will unset the environment variable when dropped.
-fn set_branch_env(branch_ref: &gix::refs::FullNameRef) -> Option<TargetBranchEnvGuard> {
+fn set_stack_env(branch_ref: &gix::refs::FullNameRef) -> Option<TargetStackEnvGuard> {
     // Extract the short branch name from the branch ref
     let short_branch_name = but_core::extract_short_branch_name(branch_ref)?;
 
@@ -288,40 +288,40 @@ fn set_branch_env(branch_ref: &gix::refs::FullNameRef) -> Option<TargetBranchEnv
     // scope with the guard pattern ensuring it will be properly cleaned up when dropped.
     // The variable name and value are both valid UTF-8 strings.
     unsafe {
-        std::env::set_var("GITBUTLER_TARGET_BRANCH", &short_branch_name);
+        std::env::set_var("GITBUTLER_TARGET_STACK", &short_branch_name);
     }
 
-    Some(TargetBranchEnvGuard { was_set: true })
+    Some(TargetStackEnvGuard { was_set: true })
 }
 
-/// Set the GITBUTLER_TARGET_BRANCH environment variable based on the workspace's target ref.
+/// Set the GITBUTLER_TARGET_STACK environment variable based on the workspace's target ref.
 /// Returns a guard that will unset the environment variable when dropped.
 ///
-/// This allows hooks to know which branch commits are targeting, which is useful for
-/// hooks that need context about the target integration branch.
-fn set_target_branch_env(ctx: &Context) -> Option<TargetBranchEnvGuard> {
+/// This allows hooks to know which stack/branch commits are targeting, which is useful for
+/// hooks that need context about the target stack or integration branch.
+fn set_target_stack_env(ctx: &Context) -> Option<TargetStackEnvGuard> {
     // Try to read workspace metadata to get the target ref
     let meta = ctx.meta().ok()?;
     let workspace_ref: &gix::refs::FullNameRef = but_core::WORKSPACE_REF_NAME.try_into().ok()?;
     let workspace = meta.workspace(workspace_ref).ok()?;
     let target_ref = workspace.target_ref.as_ref()?;
 
-    set_branch_env(target_ref.as_ref())
+    set_stack_env(target_ref.as_ref())
 }
 
-/// Guard that unsets the GITBUTLER_TARGET_BRANCH environment variable when dropped.
-struct TargetBranchEnvGuard {
+/// Guard that unsets the GITBUTLER_TARGET_STACK environment variable when dropped.
+struct TargetStackEnvGuard {
     was_set: bool,
 }
 
-impl Drop for TargetBranchEnvGuard {
+impl Drop for TargetStackEnvGuard {
     fn drop(&mut self) {
         if self.was_set {
             // SAFETY: This is safe because we're only removing an environment variable
-            // that we set ourselves in set_target_branch_env(), and we're doing it
+            // that we set ourselves in set_target_stack_env(), and we're doing it
             // in a controlled scope via the guard pattern to ensure proper cleanup.
             unsafe {
-                std::env::remove_var("GITBUTLER_TARGET_BRANCH");
+                std::env::remove_var("GITBUTLER_TARGET_STACK");
             }
         }
     }

--- a/crates/gitbutler-repo/src/hooks.rs
+++ b/crates/gitbutler-repo/src/hooks.rs
@@ -6,6 +6,7 @@ use std::{
 
 use anyhow::Result;
 use bstr::ByteSlice;
+use but_core::RefMetadata;
 use but_ctx::Context;
 use but_oxidize::ObjectIdExt;
 use git2_hooks::{self, HookResult as H};
@@ -54,6 +55,9 @@ fn husky_search_paths(ctx: &Context) -> Option<&'static [&'static str]> {
 }
 
 pub fn commit_msg(ctx: &Context, mut message: String) -> Result<MessageHookResult> {
+    // Set GITBUTLER_TARGET_BRANCH environment variable if a target branch is configured
+    let _target_branch_guard = set_target_branch_env(ctx);
+
     let original_message = message.clone();
     #[expect(deprecated, reason = "libgit2 hook adapter boundary")]
     match git2_hooks::hooks_commit_msg(
@@ -122,6 +126,9 @@ pub fn pre_commit_with_tree(ctx: &Context, tree_id: gix::ObjectId) -> Result<Hoo
 }
 
 pub fn post_commit(ctx: &Context) -> Result<HookResult> {
+    // Set GITBUTLER_TARGET_BRANCH environment variable if a target branch is configured
+    let _target_branch_guard = set_target_branch_env(ctx);
+
     #[expect(deprecated, reason = "libgit2 hook adapter boundary")]
     match git2_hooks::hooks_post_commit(&*ctx.git2_repo.get()?, husky_search_paths(ctx))? {
         H::Ok { hook: _ } => Ok(HookResult::Success),
@@ -265,15 +272,20 @@ fn join_output(stdout: String, stderr: String, code: Option<i32>) -> String {
 fn set_target_branch_env(ctx: &Context) -> Option<TargetBranchEnvGuard> {
     // Try to read workspace metadata to get the target ref
     let meta = ctx.meta().ok()?;
-    let workspace_ref = but_core::WORKSPACE_REF_NAME.try_into().ok()?;
-    let workspace = meta.workspace(&workspace_ref).ok()?;
+    let workspace_ref: &gix::refs::FullNameRef = but_core::WORKSPACE_REF_NAME.try_into().ok()?;
+    let workspace = meta.workspace(workspace_ref).ok()?;
     let target_ref = workspace.target_ref.as_ref()?;
 
     // Extract the short branch name from the target ref
     let short_branch_name = but_core::extract_short_branch_name(target_ref.as_ref())?;
 
     // Set the environment variable
-    std::env::set_var("GITBUTLER_TARGET_BRANCH", &short_branch_name);
+    // SAFETY: This is safe because we're setting an environment variable in a controlled
+    // scope with the guard pattern ensuring it will be properly cleaned up when dropped.
+    // The variable name and value are both valid UTF-8 strings.
+    unsafe {
+        std::env::set_var("GITBUTLER_TARGET_BRANCH", &short_branch_name);
+    }
 
     Some(TargetBranchEnvGuard {
         was_set: true,
@@ -288,7 +300,12 @@ struct TargetBranchEnvGuard {
 impl Drop for TargetBranchEnvGuard {
     fn drop(&mut self) {
         if self.was_set {
-            std::env::remove_var("GITBUTLER_TARGET_BRANCH");
+            // SAFETY: This is safe because we're only removing an environment variable
+            // that we set ourselves in set_target_branch_env(), and we're doing it
+            // in a controlled scope via the guard pattern to ensure proper cleanup.
+            unsafe {
+                std::env::remove_var("GITBUTLER_TARGET_BRANCH");
+            }
         }
     }
 }

--- a/crates/gitbutler-repo/tests/repo/hooks.rs
+++ b/crates/gitbutler-repo/tests/repo/hooks.rs
@@ -210,13 +210,13 @@ fn pre_commit_sets_target_branch_env_var() -> anyhow::Result<()> {
     #[cfg(unix)]
     fs::write(
         &hook_path,
-        "#!/bin/sh\necho \"$GITBUTLER_TARGET_BRANCH\" > target_branch.txt\n",
+        "#!/bin/sh\necho \"$GITBUTLER_TARGET_STACK\" > target_branch.txt\n",
     )?;
 
     #[cfg(windows)]
     fs::write(
         &hook_path,
-        "@echo off\necho %GITBUTLER_TARGET_BRANCH% > target_branch.txt\n",
+        "@echo off\necho %GITBUTLER_TARGET_STACK% > target_branch.txt\n",
     )?;
 
     #[cfg(unix)]
@@ -234,7 +234,7 @@ fn pre_commit_sets_target_branch_env_var() -> anyhow::Result<()> {
     assert_eq!(
         target_branch_content.trim(),
         "main",
-        "GITBUTLER_TARGET_BRANCH should be set to 'main'"
+        "GITBUTLER_TARGET_STACK should be set to 'main'"
     );
 
     Ok(())

--- a/crates/gitbutler-repo/tests/repo/hooks.rs
+++ b/crates/gitbutler-repo/tests/repo/hooks.rs
@@ -4,7 +4,7 @@ use std::os::unix::fs::PermissionsExt;
 
 use crate::support::RepoWithOrigin;
 use but_testsupport::open_repo;
-use gitbutler_repo::hooks::{HookResult, pre_push};
+use gitbutler_repo::hooks::{HookResult, pre_commit_with_tree, pre_push};
 
 #[test]
 fn pre_push_hook_not_configured() -> anyhow::Result<()> {
@@ -174,5 +174,68 @@ fn pre_push_resolves_relative_core_hooks_path_against_workdir() -> anyhow::Resul
     )?;
     assert_eq!(result, HookResult::Success);
     assert!(workdir.join("relative-pre-push-ran").exists());
+    Ok(())
+}
+
+#[test]
+fn pre_commit_sets_target_branch_env_var() -> anyhow::Result<()> {
+    use but_ctx::Context;
+    use but_path;
+
+    let test_project = RepoWithOrigin::default();
+    let repo = test_project.local_repo;
+    let workdir = repo.workdir().expect("non-bare").to_path_buf();
+
+    // Create a context for the repository
+    let app_config_dir = but_path::app_config_dir()?;
+    let app_cache_dir = but_path::app_cache_dir().ok();
+    let ctx = Context::new(repo.git_dir(), app_config_dir, app_cache_dir)?;
+
+    // Set up workspace metadata with a target ref
+    let workspace_ref: gix::refs::FullNameRef = but_core::WORKSPACE_REF_NAME.try_into()?;
+    let target_ref: gix::refs::FullName = "refs/remotes/origin/main".try_into()?;
+
+    {
+        let mut meta = ctx.meta()?;
+        let mut workspace = meta.workspace(&workspace_ref)?;
+        workspace.target_ref = Some(target_ref.clone());
+        meta.set_workspace(&workspace)?;
+    }
+
+    // Create a pre-commit hook that captures the environment variable
+    let hooks_dir = repo.path().join("hooks");
+    fs::create_dir_all(&hooks_dir)?;
+    let hook_path = hooks_dir.join("pre-commit");
+
+    #[cfg(unix)]
+    fs::write(
+        &hook_path,
+        "#!/bin/sh\necho \"$GITBUTLER_TARGET_BRANCH\" > target_branch.txt\n",
+    )?;
+
+    #[cfg(windows)]
+    fs::write(
+        &hook_path,
+        "@echo off\necho %GITBUTLER_TARGET_BRANCH% > target_branch.txt\n",
+    )?;
+
+    #[cfg(unix)]
+    fs::set_permissions(&hook_path, fs::Permissions::from_mode(0o755))?;
+
+    // Get the current tree to use for the pre-commit hook
+    let tree_id = repo.head_commit()?.tree_id()?.detach();
+
+    // Run the pre-commit hook
+    let result = pre_commit_with_tree(&ctx, tree_id)?;
+    assert_eq!(result, HookResult::Success, "hook should succeed");
+
+    // Verify the environment variable was set correctly
+    let target_branch_content = fs::read_to_string(workdir.join("target_branch.txt"))?;
+    assert_eq!(
+        target_branch_content.trim(),
+        "main",
+        "GITBUTLER_TARGET_BRANCH should be set to 'main'"
+    );
+
     Ok(())
 }


### PR DESCRIPTION
## 🧢 Changes

Set `GITBUTLER_TARGET_STACK` env var which allows to read the target stack where the commit will be applied

## ☕️ Reasoning

This env var allows to be read during hooks, specially commit-msg so the commit can contain the nº of ticket which is a rule in companies

## 🎫 Affected issues

Fixes: [11302](https://github.com/gitbutlerapp/gitbutler/issues/11302)

## 📌 Todos

*  Wait feedback to see if it would be possible to optimize it

|   	|   	|
|---	|---	|
|  <img width="1166" height="839" alt="Screenshot 2026-06-04 at 14 32 47" src="https://github.com/user-attachments/assets/de30ba06-207c-47e9-817f-b1243347e554" />   |   [commit-msg.txt](https://github.com/user-attachments/files/28761633/commit-msg.txt)	|


