### PR TITLE
upstream integration fixes

### DIFF
--- a/apps/desktop/src/components/upstream/IntegrateUpstreamModal.svelte
+++ b/apps/desktop/src/components/upstream/IntegrateUpstreamModal.svelte
@@ -51,12 +51,7 @@
 
 	const baseLoaded = $derived(!!base);
 	const isBaseDiverged = $derived(!!base?.targetShaAheadOfRef);
-	const canIntegrate = $derived(
-		baseLoaded &&
-			!isBaseDiverged &&
-			!!integrationStatuses &&
-			integrationStatuses.updates.length > 0,
-	);
+	const canIntegrate = $derived(baseLoaded && !isBaseDiverged && !!integrationStatuses);
 	const worktreeConflicts = $derived(integrationStatuses?.worktreeConflicts ?? []);
 	const [integrateUpstream] = $derived(upstreamIntegrationService.integrateUpstream());
 

--- a/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
+++ b/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
@@ -1,6 +1,5 @@
 import {
 	buildUpstreamIntegrationUpdates,
-	clearUpstreamIntegrationStatuses,
 	deriveUpstreamIntegrationStatuses,
 	type UpstreamIntegrationStatuses,
 } from "$lib/upstream/types";
@@ -21,14 +20,6 @@ export class UpstreamIntegrationService {
 	async upstreamStatuses(projectId: string): Promise<UpstreamIntegrationStatuses> {
 		const stacks = await this.stackService.fetchStacks(projectId);
 		const updates = buildUpstreamIntegrationUpdates(stacks);
-
-		if (updates.length === 0) {
-			return {
-				subject: clearUpstreamIntegrationStatuses(stacks),
-				updates,
-				worktreeConflicts: [],
-			};
-		}
 
 		const preview = await this.backendApi.endpoints.workspaceIntegrateUpstream.mutate({
 			projectId,

--- a/apps/desktop/src/lib/upstream/upstreamIntegrationService.test.ts
+++ b/apps/desktop/src/lib/upstream/upstreamIntegrationService.test.ts
@@ -1,0 +1,80 @@
+import { UpstreamIntegrationService } from "$lib/upstream/upstreamIntegrationService.svelte";
+import { describe, expect, test, vi } from "vitest";
+import type { RefInfo, Segment, Stack } from "@gitbutler/but-sdk";
+
+function segment(): Segment {
+	return {
+		refName: null,
+		remoteTrackingRefName: null,
+		commits: [],
+		commitsOnRemote: [],
+		commitsOutside: null,
+		metadata: null,
+		isEntrypoint: false,
+		pushStatus: "unpushedCommits",
+		base: null,
+	};
+}
+
+function stack(segments: Segment[]): Stack {
+	return {
+		id: "stack-1",
+		base: null,
+		segments,
+	};
+}
+
+function refInfo(stacks: Stack[]): RefInfo {
+	return {
+		workspaceRef: null,
+		stacks,
+		target: null,
+		isManagedRef: true,
+		isManagedCommit: true,
+		isEntrypoint: true,
+	};
+}
+
+describe("UpstreamIntegrationService", () => {
+	test("previews empty update sets through the backend", async () => {
+		const stacks = [stack([segment()])];
+		const mutate = vi.fn().mockResolvedValue({
+			workspaceState: {
+				headInfo: refInfo([]),
+				changes: [],
+				replacedCommits: {},
+			},
+			worktreeConflicts: [],
+		});
+		const service = new UpstreamIntegrationService(
+			{
+				endpoints: {
+					workspaceIntegrateUpstream: {
+						mutate,
+					},
+				},
+			} as any,
+			{
+				fetchStacks: vi.fn().mockResolvedValue(stacks),
+			} as any,
+		);
+
+		const statuses = await service.upstreamStatuses("project-1");
+
+		expect(mutate).toHaveBeenCalledWith({
+			projectId: "project-1",
+			updates: [],
+			dryRun: true,
+		});
+		expect(statuses).toMatchObject({
+			updates: [],
+			worktreeConflicts: [],
+			subject: [
+				{
+					status: "clear",
+					fullyIntegrated: false,
+				},
+			],
+		});
+	});
+});

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -292,6 +292,11 @@ pub fn integrate_upstream<'ws, 'meta, M: RefMetadata>(
         for selector in &fully_integrated_workspace_parents {
             editor.remove_edges(workspace_commit_selector, *selector)?;
         }
+        if !fully_integrated_workspace_parents.is_empty()
+            && editor.direct_parents(workspace_commit_selector)?.is_empty()
+        {
+            editor.add_edge(workspace_commit_selector, target_ref_selector, 0)?;
+        }
     }
 
     for stack in &stacks {

--- a/crates/but-workspace/tests/fixtures/scenario/fully-integrated-single-branch-target-advanced-through-merge.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/fully-integrated-single-branch-target-advanced-through-merge.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A single stack points at A on top of the old target commit C, while the target ref has
+# advanced to X through a merge commit D. D has C and A as parents.
+git init
+commit-file C.txt C
+setup_target_to_match_main
+
+git checkout -b A
+commit-file B.txt B
+commit-file A.txt A
+
+git checkout -b upstream-main main
+git merge --no-ff -m "D" A
+commit-file X.txt X
+git update-ref refs/remotes/origin/main upstream-main
+
+git checkout A
+git branch -D upstream-main
+create_workspace_commit_once A

--- a/crates/but-workspace/tests/fixtures/scenario/fully-integrated-single-branch-target-advanced.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/fully-integrated-single-branch-target-advanced.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A single stack points at A on top of the old target commit C, while the target ref has
+# advanced to X. Integrating the fully integrated stack should leave the
+# workspace commit parented to X.
+git init
+commit-file C.txt C
+setup_target_to_match_main
+
+git checkout -b A
+commit-file B.txt B
+commit-file A.txt A
+
+git branch upstream-main
+
+git checkout upstream-main
+commit-file X.txt X
+git update-ref refs/remotes/origin/main upstream-main
+
+git checkout A
+git branch -D upstream-main
+create_workspace_commit_once A

--- a/crates/but-workspace/tests/fixtures/scenario/fully-integrated-two-stacks.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/fully-integrated-two-stacks.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# Two independent stacks are merged into a workspace commit. Both stacks are
+# historically integrated into the target ref and should leave the workspace
+# after integration.
+git init
+commit M1
+setup_target_to_match_main
+
+git checkout -b A
+commit-file A.txt A1
+
+git checkout main
+git checkout -b B
+commit-file B.txt B1
+
+create_workspace_commit_once A B
+
+git checkout main
+git merge --no-ff -m "Merging A into base" A
+git merge --no-ff -m "Merging B into base" B
+git update-ref refs/remotes/origin/main main
+git checkout gitbutler/workspace

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -557,9 +557,162 @@ fn fully_integrated_single_branch_leaves_workspace_shape() -> Result<()> {
     let workspace = graph.into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&workspace), @"📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 905d6e5");
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
-    * be76b24 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * f88e9ce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 905d6e5 (origin/main) add A1
     * 3183e43 (main) M1
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn fully_integrated_single_branch_reparents_workspace_commit_to_advanced_target() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("fully-integrated-single-branch-target-advanced")?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    add_stack(&mut meta, 1, "A", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 9de7db5 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    | * 6b20716 (origin/main) add X
+    |/  
+    * ffde79e (A) add A
+    * 86b55e6 add B
+    * 8d5739f (main) add C
+    ");
+
+    let mut workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 8d5739f
+    └── ≡📙:3:A on 8d5739f {1}
+        └── 📙:3:A
+            ├── ·ffde79e (🏘️|✓)
+            └── ·86b55e6 (🏘️|✓)
+    ");
+
+    let but_workspace::IntegrateUpstreamOutcome { rebase, ws_meta } = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A^")?.detach()),
+        }],
+    )?;
+
+    let materialized = rebase.materialize()?;
+    if let Some(ref_name) = materialized.workspace.ref_name() {
+        let mut md = materialized.meta.workspace(ref_name)?;
+        *md = ws_meta;
+        materialized.meta.set_workspace(&md)?;
+    }
+    drop(materialized);
+
+    let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
+    let workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 6b20716");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * fa202eb (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 6b20716 (origin/main) add X
+    * ffde79e add A
+    * 86b55e6 add B
+    * 8d5739f (main) add C
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn fully_integrated_single_branch_reparents_workspace_commit_to_advanced_merge_target() -> Result<()>
+{
+    let (_tmp, repo, mut meta, _description) = named_writable_scenario_with_description(
+        "fully-integrated-single-branch-target-advanced-through-merge",
+    )?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    add_stack(&mut meta, 1, "A", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 9de7db5 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    | * f27db86 (origin/main) add X
+    | *   4f5589a D
+    | |\  
+    | |/  
+    |/|   
+    * | ffde79e (A) add A
+    * | 86b55e6 add B
+    |/  
+    * 8d5739f (main) add C
+    ");
+
+    let mut workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on 8d5739f
+    └── ≡📙:3:A on 8d5739f {1}
+        └── 📙:3:A
+            ├── ·ffde79e (🏘️|✓)
+            └── ·86b55e6 (🏘️|✓)
+    ");
+
+    let but_workspace::IntegrateUpstreamOutcome { rebase, ws_meta } = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A^")?.detach()),
+        }],
+    )?;
+
+    let materialized = rebase.materialize()?;
+    if let Some(ref_name) = materialized.workspace.ref_name() {
+        let mut md = materialized.meta.workspace(ref_name)?;
+        *md = ws_meta;
+        materialized.meta.set_workspace(&md)?;
+    }
+    drop(materialized);
+
+    let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
+    let workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on f27db86");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * d60856a (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * f27db86 (origin/main) add X
+    *   4f5589a D
+    |\  
+    | * ffde79e add A
+    | * 86b55e6 add B
+    |/  
+    * 8d5739f (main) add C
     ");
 
     Ok(())
@@ -842,6 +995,100 @@ fn fully_integrated_multi_branch_stack_leaves_workspace_shape() -> Result<()> {
     * 44c9428 (origin/main) add A1
     * f1e7451 add C1
     * 3183e43 (main) M1
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn fully_integrated_two_stacks_leave_workspace_shape() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("fully-integrated-two-stacks")?;
+    let target_sha = repo.rev_parse_single("main~2")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    add_stack(&mut meta, 1, "A", StackState::InWorkspace);
+    add_stack(&mut meta, 2, "B", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   9d7da88 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | | *   5f7d45e (origin/main, main) Merging B into base
+    | | |\  
+    | |_|/  
+    |/| |   
+    * | | b38b04b (B) add B1
+    | | * 1f7670a Merging A into base
+    | |/| 
+    |/|/  
+    | * 905d6e5 (A) add A1
+    |/  
+    * 3183e43 M1
+    ");
+
+    let mut workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @r"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on 3183e43
+    ├── ≡📙:4:A on 3183e43 {1}
+    │   └── 📙:4:A
+    │       └── ·905d6e5 (🏘️|✓)
+    └── ≡📙:5:B on 3183e43 {2}
+        └── 📙:5:B
+            └── ·b38b04b (🏘️|✓)
+    ");
+
+    let but_workspace::IntegrateUpstreamOutcome { rebase, ws_meta } = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![
+            BottomUpdate {
+                kind: BottomUpdateKind::Rebase,
+                selector: RelativeTo::Commit(repo.rev_parse_single("A")?.detach()),
+            },
+            BottomUpdate {
+                kind: BottomUpdateKind::Rebase,
+                selector: RelativeTo::Commit(repo.rev_parse_single("B")?.detach()),
+            },
+        ],
+    )?;
+
+    let materialized = rebase.materialize()?;
+    if let Some(ref_name) = materialized.workspace.ref_name() {
+        let mut md = materialized.meta.workspace(ref_name)?;
+        *md = ws_meta;
+        materialized.meta.set_workspace(&md)?;
+    }
+    drop(materialized);
+
+    let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
+    let workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 5f7d45e");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * b44fd24 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   5f7d45e (origin/main, main) Merging B into base
+    |\  
+    | * b38b04b add B1
+    * |   1f7670a Merging A into base
+    |\ \  
+    | |/  
+    |/|   
+    | * 905d6e5 add A1
+    |/  
+    * 3183e43 M1
     ");
 
     Ok(())

--- a/e2e/playwright/scripts/project-with-remote-branches__fast-forward-base-through-branch1-and-add-commit.sh
+++ b/e2e/playwright/scripts/project-with-remote-branches__fast-forward-base-through-branch1-and-add-commit.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "GIT CONFIG $GIT_CONFIG_GLOBAL"
+echo "DATA DIR $E2E_TEST_APP_DATA_DIR"
+echo "BUT $BUT"
+
+pushd remote-project
+  git checkout master
+  git merge --ff-only branch1
+  echo "base advanced after integrated branch" >> x_file
+  git add x_file
+  git commit -m "base: advanced after integrated branch"
+popd

--- a/e2e/playwright/scripts/project-with-remote-branches__merge-branch1-to-base-and-add-commit.sh
+++ b/e2e/playwright/scripts/project-with-remote-branches__merge-branch1-to-base-and-add-commit.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "GIT CONFIG $GIT_CONFIG_GLOBAL"
+echo "DATA DIR $E2E_TEST_APP_DATA_DIR"
+echo "BUT $BUT"
+
+pushd remote-project
+  git checkout master
+  git merge --no-ff -m "Merging branch1 into base" branch1
+  echo "base advanced after merge" >> x_file
+  git add x_file
+  git commit -m "base: advanced after merge"
+popd

--- a/e2e/playwright/tests/upstreamIntegration.spec.ts
+++ b/e2e/playwright/tests/upstreamIntegration.spec.ts
@@ -10,11 +10,28 @@ import {
 	waitForTestIdToNotExist,
 } from "../src/util.ts";
 import { expect, type Page } from "@playwright/test";
+import { execFileSync } from "node:child_process";
 
 async function syncAndIntegrate(page: Page) {
 	await clickByTestId(page, "sync-button");
 	await clickByTestId(page, "integrate-upstream-commits-button");
 	await clickByTestId(page, "integrate-upstream-action-button");
+}
+
+async function expectWorkspaceCommitParentToBeOriginMaster(pathToRepo: string) {
+	await expect
+		.poll(() => git(pathToRepo, ["rev-parse", "gitbutler/workspace^"]), {
+			message: "Expected the workspace commit to be parented to origin/master",
+			intervals: [100, 200, 500, 1000],
+		})
+		.toBe(git(pathToRepo, ["rev-parse", "origin/master"]));
+}
+
+function git(pathToRepo: string, args: string[]): string {
+	return execFileSync("git", args, {
+		cwd: pathToRepo,
+		encoding: "utf8",
+	}).trim();
 }
 
 test("should handle the update of workspace with one conflicting branch gracefully", async ({
@@ -62,6 +79,48 @@ test("should handle the update of workspace with integrated branch gracefully", 
 	await waitForTestIdToNotExist(page, "stack");
 });
 
+test("should reparent workspace commit to advanced target after integrating all stacks", async ({
+	page,
+	gitbutler,
+}) => {
+	const localClone = gitbutler.pathInWorkdir("local-clone");
+
+	await gitbutler.runScript("project-with-remote-branches.sh");
+	await applyUpstream(gitbutler, "branch1");
+	await openWorkspace(page);
+
+	await expect(stack(page)).toHaveCount(1);
+
+	await gitbutler.runScript(
+		"project-with-remote-branches__fast-forward-base-through-branch1-and-add-commit.sh",
+	);
+	await syncAndIntegrate(page);
+
+	await waitForTestIdToNotExist(page, "stack");
+	await expectWorkspaceCommitParentToBeOriginMaster(localClone);
+});
+
+test("should reparent workspace commit to advanced merge target after integrating all stacks", async ({
+	page,
+	gitbutler,
+}) => {
+	const localClone = gitbutler.pathInWorkdir("local-clone");
+
+	await gitbutler.runScript("project-with-remote-branches.sh");
+	await applyUpstream(gitbutler, "branch1");
+	await openWorkspace(page);
+
+	await expect(stack(page)).toHaveCount(1);
+
+	await gitbutler.runScript(
+		"project-with-remote-branches__merge-branch1-to-base-and-add-commit.sh",
+	);
+	await syncAndIntegrate(page);
+
+	await waitForTestIdToNotExist(page, "stack");
+	await expectWorkspaceCommitParentToBeOriginMaster(localClone);
+});
+
 test("should handle the update of workspace with integrated parent branch in stack gracefully", async ({
 	page,
 	gitbutler,
@@ -102,6 +161,24 @@ test("should handle the update of the workspace with multiple stacks gracefully"
 	await syncAndIntegrate(page);
 
 	await expect(stack(page)).toHaveCount(1);
+});
+
+test("should handle the update of the workspace with two integrated stacks gracefully", async ({
+	page,
+	gitbutler,
+}) => {
+	await gitbutler.runScript("project-with-stacks.sh");
+	await applyUpstream(gitbutler, "branch1", "branch2");
+	await openWorkspace(page);
+
+	await expect(stack(page)).toHaveCount(2);
+
+	await gitbutler.runScript("merge-upstream-branch-to-base.sh", ["branch1"]);
+	await gitbutler.runScript("merge-upstream-branch-to-base.sh", ["branch2"]);
+	await syncAndIntegrate(page);
+
+	await expect(stack(page)).toHaveCount(0);
+	await waitForTestIdToNotExist(page, "integrate-upstream-commits-button");
 });
 
 test("should handle the update of an empty branch gracefully", async ({ page, gitbutler }) => {


### PR DESCRIPTION
- We should be able to update empty workspaces.
- We should reparent the workspace commit correctly onto the latest tip of the target ref after updating the workspace

---
Basically I didn't account for the scenario of leaving the workspace commit orphan. Now we have the new ref adopt it correctly

### More tests
- More tests in the rust side and on the app e2e