### PR TITLE
Add support for GitLab pipeline checks

### DIFF
--- a/crates/but-forge/src/ci.rs
+++ b/crates/but-forge/src/ci.rs
@@ -75,6 +75,33 @@ fn ci_checks_for_ref(
                     .collect()
             })
         }
+        ForgeName::GitLab => {
+            let preferred_account = preferred_forge_user
+                .as_ref()
+                .and_then(|user| user.gitlab().cloned());
+            let gl = but_gitlab::GitLabClient::from_storage(storage, preferred_account.as_ref())?;
+
+            // Clone owned data for thread
+            let project_id = but_gitlab::GitLabProjectId::new(owner, repo);
+            let reference = reference.to_string();
+            let reference_for_checks = reference.clone();
+
+            let pipelines = std::thread::spawn(move || -> anyhow::Result<_> {
+                let runtime = tokio::runtime::Runtime::new()
+                    .map_err(|err| anyhow::anyhow!("Failed to create tokio runtime: {err}"))?;
+                runtime.block_on(gl.list_pipeline_jobs_for_ref(project_id, &reference))
+            })
+            .join()
+            .map_err(|e| anyhow::anyhow!("Failed to join thread: {e:?}"))??;
+            Ok(pipelines
+                .into_iter()
+                .map(|pipeline| {
+                    let mut ci_check = CiCheck::from(pipeline);
+                    ci_check.reference = reference_for_checks.to_string();
+                    ci_check
+                })
+                .collect())
+        }
         _ => Err(anyhow::anyhow!(
             "Listing ci checks for forge {forge:?} is not implemented yet."
         )),
@@ -172,6 +199,80 @@ pub struct PullRequestMinimal {
 #[cfg(feature = "export-schema")]
 but_schemars::register_sdk_type!(PullRequestMinimal);
 
+impl From<but_gitlab::GitLabPipelineJob> for CiCheck {
+    fn from(job: but_gitlab::GitLabPipelineJob) -> Self {
+        let started_at = job
+            .started_at
+            .as_deref()
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+            .map(|dt| dt.with_timezone(&chrono::Utc));
+
+        let completed_at = job
+            .finished_at
+            .as_deref()
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+            .map(|dt| dt.with_timezone(&chrono::Utc));
+
+        let status = match job.status.as_str() {
+            "success" => CiStatus::Complete {
+                conclusion: CiConclusion::Success,
+                completed_at,
+            },
+            "failed" => CiStatus::Complete {
+                conclusion: if job.allow_failure {
+                    CiConclusion::Neutral
+                } else {
+                    CiConclusion::Failure
+                },
+                completed_at,
+            },
+            "canceled" => CiStatus::Complete {
+                conclusion: CiConclusion::Cancelled,
+                completed_at,
+            },
+            "skipped" => CiStatus::Complete {
+                conclusion: CiConclusion::Skipped,
+                completed_at,
+            },
+            "manual" => CiStatus::Complete {
+                conclusion: if job.allow_failure {
+                    CiConclusion::Neutral
+                } else {
+                    CiConclusion::ActionRequired
+                },
+                completed_at,
+            },
+            "running" => CiStatus::InProgress,
+            "pending" | "created" | "waiting_for_resource" | "preparing" | "scheduled" => {
+                CiStatus::Queued
+            }
+            _ => CiStatus::Unknown,
+        };
+
+        let job_url = job.web_url.clone().unwrap_or_default();
+        let pipeline_url = job
+            .pipeline
+            .web_url
+            .clone()
+            .unwrap_or_else(|| job_url.clone());
+
+        CiCheck {
+            id: job.id,
+            name: job.name,
+            output: CiOutput::default(),
+            started_at,
+            status,
+            head_sha: String::new(),
+            url: job_url.clone(),
+            html_url: job_url.clone(),
+            details_url: pipeline_url,
+            pull_requests: Vec::new(),
+            reference: String::new(),
+            last_sync_at: chrono::Local::now().naive_local(),
+        }
+    }
+}
+
 impl From<but_github::CheckRun> for CiCheck {
     fn from(value: but_github::CheckRun) -> Self {
         let completed_at = value
@@ -227,5 +328,72 @@ impl From<but_github::CheckRun> for CiCheck {
             reference: String::new(), // Will be set by the caller
             last_sync_at: chrono::Local::now().naive_local(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CiCheck, CiConclusion, CiStatus};
+
+    fn job(status: &str, web_url: Option<&str>) -> but_gitlab::GitLabPipelineJob {
+        but_gitlab::GitLabPipelineJob {
+            id: 42,
+            name: "job".into(),
+            status: status.into(),
+            allow_failure: false,
+            started_at: Some("2026-05-01T12:00:00Z".into()),
+            finished_at: Some("2026-05-01T12:05:00Z".into()),
+            web_url: web_url.map(str::to_owned),
+            pipeline: but_gitlab::GitLabPipelineRef {
+                id: 7,
+                web_url: None,
+                status: None,
+            },
+        }
+    }
+
+    #[test]
+    fn maps_manual_jobs_to_action_required_complete_status() {
+        let check = CiCheck::from(job("manual", Some("https://example.com/job")));
+
+        assert!(matches!(
+            check.status,
+            CiStatus::Complete {
+                conclusion: CiConclusion::ActionRequired,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn maps_allowed_failure_jobs_to_neutral_complete_status() {
+        let mut job = job("failed", Some("https://example.com/job"));
+        job.allow_failure = true;
+
+        let check = CiCheck::from(job);
+
+        assert!(matches!(
+            check.status,
+            CiStatus::Complete {
+                conclusion: CiConclusion::Neutral,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn maps_optional_manual_jobs_to_neutral_complete_status() {
+        let mut job = job("manual", Some("https://example.com/job"));
+        job.allow_failure = true;
+
+        let check = CiCheck::from(job);
+
+        assert!(matches!(
+            check.status,
+            CiStatus::Complete {
+                conclusion: CiConclusion::Neutral,
+                ..
+            }
+        ));
     }
 }

--- a/crates/but-forge/src/forge_info.rs
+++ b/crates/but-forge/src/forge_info.rs
@@ -190,7 +190,7 @@ fn capabilities_for(forge: &ForgeName) -> ForgeCapabilities {
             list_service: true,
         },
         ForgeName::GitLab => ForgeCapabilities {
-            checks: false,
+            checks: true,
             repo_info: true,
             pr_service: true,
             list_service: true,
@@ -323,6 +323,8 @@ mod tests {
 
     #[test]
     fn gitlab_commit_and_mr_urls() {
+        let info = forge_info("https://gitlab.com/group/repo.git").unwrap();
+        assert!(info.capabilities.checks);
         assert_eq!(
             composed_commit_url("https://gitlab.com/group/repo.git", "abc123"),
             "https://gitlab.com/group/repo/-/commit/abc123"

--- a/crates/but-gitlab/src/client.rs
+++ b/crates/but-gitlab/src/client.rs
@@ -2,10 +2,14 @@ use anyhow::{Context, Result, bail};
 use but_secret::Sensitive;
 use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::time::Duration;
 
 use crate::GitLabProjectId;
 
 const GITLAB_API_BASE_URL: &str = "https://gitlab.com/api/v4";
+const GITLAB_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_PIPELINE_JOB_PAGES: usize = 25;
 
 /// An HTTP error with a status code, returned when the API responds with a non-success status.
 ///
@@ -36,6 +40,7 @@ impl GitLabClient {
 
         let client = reqwest::Client::builder()
             .default_headers(headers)
+            .timeout(GITLAB_REQUEST_TIMEOUT)
             .build()?;
 
         Ok(Self {
@@ -72,6 +77,7 @@ impl GitLabClient {
 
         let client = reqwest::Client::builder()
             .default_headers(headers)
+            .timeout(GITLAB_REQUEST_TIMEOUT)
             .build()?;
 
         let base_url = if host.ends_with("/api/v4") {
@@ -498,6 +504,146 @@ impl GitLabClient {
             access_level,
         })
     }
+
+    /// Fetch pipeline jobs for a given branch reference.
+    ///
+    /// Fetches the latest pipeline for the ref, then returns all jobs in that pipeline.
+    /// Returns an empty vec if no pipelines exist for the ref.
+    pub async fn list_pipeline_jobs_for_ref(
+        &self,
+        project_id: GitLabProjectId,
+        reference: &str,
+    ) -> Result<Vec<GitLabPipelineJob>> {
+        #[derive(Deserialize)]
+        struct GitLabPipelineResponse {
+            id: i64,
+            status: String,
+            web_url: Option<String>,
+        }
+
+        let url = format!("{}/projects/{}/pipelines", self.base_url, project_id);
+        let response = self
+            .client
+            .get(&url)
+            .query(&[("ref", reference), ("per_page", "1")])
+            .send()
+            .await
+            .with_context(|| format!("Failed to list GitLab pipelines for ref '{reference}'"))?;
+
+        if !response.status().is_success() {
+            bail!("Failed to list pipelines for ref: {}", response.status());
+        }
+
+        let pipelines: Vec<GitLabPipelineResponse> = response
+            .json()
+            .await
+            .with_context(|| format!("Failed to parse GitLab pipelines for ref '{reference}'"))?;
+        let Some(pipeline) = pipelines.first() else {
+            return Ok(Vec::new());
+        };
+
+        let pipeline_web_url = pipeline.web_url.clone();
+        let pipeline_status = Some(pipeline.status.clone());
+
+        let jobs_url = format!(
+            "{}/projects/{}/pipelines/{}/jobs",
+            self.base_url, project_id, pipeline.id
+        );
+        let mut jobs = Vec::new();
+        let mut next_page = Some("1".to_string());
+        let mut seen_pages = HashSet::new();
+        let mut pages_iterated = 0;
+
+        while let Some(page) = next_page.take() {
+            if pages_iterated >= MAX_PIPELINE_JOB_PAGES || !seen_pages.insert(page.clone()) {
+                bail!(
+                    "Stopped listing GitLab jobs for pipeline {} after unsafe pagination state",
+                    pipeline.id
+                );
+            }
+            pages_iterated += 1;
+
+            let response = self
+                .client
+                .get(&jobs_url)
+                .query(&[("per_page", "100"), ("page", page.as_str())])
+                .send()
+                .await
+                .with_context(|| {
+                    format!("Failed to list GitLab jobs for pipeline {}", pipeline.id)
+                })?;
+
+            if !response.status().is_success() {
+                bail!("Failed to list jobs for pipeline: {}", response.status());
+            }
+
+            next_page = next_page_from_headers(response.headers());
+            let mut page_jobs: Vec<GitLabPipelineJob> =
+                response.json().await.with_context(|| {
+                    format!("Failed to parse GitLab jobs for pipeline {}", pipeline.id)
+                })?;
+            if page_jobs.is_empty() {
+                break;
+            }
+            jobs.append(&mut page_jobs);
+        }
+
+        let jobs = normalize_pipeline_jobs(
+            jobs,
+            pipeline_web_url,
+            pipeline_status,
+            &self.base_url,
+            project_id,
+        );
+        Ok(jobs)
+    }
+}
+
+fn next_page_from_headers(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get("x-next-page")
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn normalize_pipeline_jobs(
+    jobs: Vec<GitLabPipelineJob>,
+    pipeline_web_url: Option<String>,
+    pipeline_status: Option<String>,
+    base_url: &str,
+    project_id: GitLabProjectId,
+) -> Vec<GitLabPipelineJob> {
+    let web_base = base_url
+        .strip_suffix("/api/v4")
+        .unwrap_or(base_url)
+        .trim_end_matches('/');
+    let username = project_id.username();
+    let project_name = project_id.project_name();
+
+    jobs.into_iter()
+        .map(|mut job| {
+            if job.web_url.is_none() {
+                job.web_url = pipeline_web_url
+                    .clone()
+                    .or_else(|| job.pipeline.web_url.clone())
+                    .or_else(|| {
+                        Some(format!(
+                            "{}/{}/{}/-/pipelines/{}",
+                            web_base, username, project_name, job.pipeline.id
+                        ))
+                    });
+            }
+            if job.pipeline.web_url.is_none() {
+                job.pipeline.web_url = pipeline_web_url.clone().or_else(|| job.web_url.clone());
+            }
+            if job.pipeline.status.is_none() {
+                job.pipeline.status = pipeline_status.clone();
+            }
+            job
+        })
+        .collect()
 }
 
 pub struct CreateMergeRequestParams<'a> {
@@ -660,6 +806,29 @@ pub struct GitLabProject {
     pub access_level: Option<i64>,
 }
 
+/// GitLab CI job with the pipeline fields needed to build GitButler check status.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GitLabPipelineJob {
+    pub id: i64,
+    pub name: String,
+    pub status: String,
+    #[serde(default)]
+    pub allow_failure: bool,
+    pub started_at: Option<String>,
+    pub finished_at: Option<String>,
+    pub web_url: Option<String>,
+    pub pipeline: GitLabPipelineRef,
+}
+
+/// Minimal pipeline reference embedded in GitLab job responses.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GitLabPipelineRef {
+    pub id: i64,
+    pub web_url: Option<String>,
+    #[serde(default)]
+    pub status: Option<String>,
+}
+
 #[derive(Debug, Serialize)]
 pub struct MergeRequest {
     pub web_url: String,
@@ -760,7 +929,43 @@ pub(crate) fn resolve_account(
 
 #[cfg(test)]
 mod tests {
-    use super::update_draft_state_in_title;
+    use super::{
+        GitLabPipelineJob, GitLabPipelineRef, next_page_from_headers, normalize_pipeline_jobs,
+        update_draft_state_in_title,
+    };
+    use reqwest::header::{HeaderMap, HeaderValue};
+
+    fn job(
+        id: i64,
+        pipeline_id: i64,
+        web_url: Option<&str>,
+        pipeline_web_url: Option<&str>,
+    ) -> GitLabPipelineJob {
+        GitLabPipelineJob {
+            id,
+            name: format!("job-{id}"),
+            status: "success".into(),
+            allow_failure: false,
+            started_at: None,
+            finished_at: None,
+            web_url: web_url.map(str::to_owned),
+            pipeline: GitLabPipelineRef {
+                id: pipeline_id,
+                web_url: pipeline_web_url.map(str::to_owned),
+                status: None,
+            },
+        }
+    }
+
+    #[test]
+    fn reads_next_page_from_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-next-page", HeaderValue::from_static("2"));
+        assert_eq!(next_page_from_headers(&headers), Some("2".to_string()));
+
+        headers.insert("x-next-page", HeaderValue::from_static(""));
+        assert_eq!(next_page_from_headers(&headers), None);
+    }
 
     #[test]
     fn makes_title_draft() {
@@ -827,6 +1032,47 @@ mod tests {
         assert_eq!(
             update_draft_state_in_title("[WIP] Add API validation", false),
             "Add API validation"
+        );
+    }
+
+    #[test]
+    fn normalize_pipeline_jobs_prefers_pipeline_url_and_backfills_job_urls() {
+        let jobs = normalize_pipeline_jobs(
+            vec![job(1, 123, None, None), job(2, 123, None, None)],
+            Some("https://gitlab.example/pipelines/123".into()),
+            Some("success".into()),
+            "https://gitlab.example/api/v4",
+            crate::GitLabProjectId::new("group", "repo"),
+        );
+
+        assert_eq!(
+            jobs[0].web_url.as_deref(),
+            Some("https://gitlab.example/pipelines/123")
+        );
+        assert_eq!(
+            jobs[1].web_url.as_deref(),
+            Some("https://gitlab.example/pipelines/123")
+        );
+        assert_eq!(
+            jobs[0].pipeline.web_url.as_deref(),
+            Some("https://gitlab.example/pipelines/123")
+        );
+        assert_eq!(jobs[0].pipeline.status.as_deref(), Some("success"));
+    }
+
+    #[test]
+    fn normalize_pipeline_jobs_synthesizes_pipeline_url_when_missing_everywhere() {
+        let jobs = normalize_pipeline_jobs(
+            vec![job(1, 123, None, None)],
+            None,
+            None,
+            "https://gitlab.example/api/v4",
+            crate::GitLabProjectId::new("group", "repo"),
+        );
+
+        assert_eq!(
+            jobs[0].web_url.as_deref(),
+            Some("https://gitlab.example/group/repo/-/pipelines/123")
         );
     }
 }

--- a/crates/but-gitlab/src/lib.rs
+++ b/crates/but-gitlab/src/lib.rs
@@ -5,9 +5,9 @@ mod client;
 pub mod mr;
 mod project;
 pub use client::{
-    CreateMergeRequestParams, GitLabClient, GitLabLabel, GitLabProject, GitLabUser,
-    MergeMergeRequestParams, MergeRequest, MergeRequestMergeStatus, SetMergeRequestAutoMergeParams,
-    SetMergeRequestDraftStateParams, UpdateMergeRequestParams,
+    CreateMergeRequestParams, GitLabClient, GitLabLabel, GitLabPipelineJob, GitLabPipelineRef,
+    GitLabProject, GitLabUser, MergeMergeRequestParams, MergeRequest, MergeRequestMergeStatus,
+    SetMergeRequestAutoMergeParams, SetMergeRequestDraftStateParams, UpdateMergeRequestParams,
 };
 pub use project::{GitLabProjectId, fetch_project};
 mod token;

--- a/crates/but-gitlab/src/project.rs
+++ b/crates/but-gitlab/src/project.rs
@@ -21,6 +21,14 @@ impl GitLabProjectId {
             project_name: project_name.to_string(),
         }
     }
+
+    pub fn username(&self) -> &str {
+        &self.username
+    }
+
+    pub fn project_name(&self) -> &str {
+        &self.project_name
+    }
 }
 
 impl Display for GitLabProjectId {


### PR DESCRIPTION
## 🧢 Changes

Hi! This PR adds support for displaying CI checks for GitLab.

<img width="1959" height="1136" alt="SCR-20260609-iwto" src="https://github.com/user-attachments/assets/54b7b612-cf58-47cd-88e5-3c8c75f8461e" />

Sorry, I have to blur some text since this is one of the private GitLab repos. I hope this is OK.

## ☕️ Reasoning

GitButler displays CI results for GitHub but not for GitLab. Some people use GitHub, some people use GitLab.
It would be good to have some parity and visibility when you use GitButler with GitLab. For example, I use it a lot.

## Note

I am planning to open more PRs to improve GitLab integration in GitButler, so this PR is a somewhat basic version for displaying CI pipeline results. For example, I want to add the ability to click on the check badge to open the pipeline page in the browser. Thanks!

