### PR TITLE
Fix stacked-PR footer "part X" numbering to match the position badges

### DIFF
--- a/apps/desktop/src/lib/forge/shared/prFooter.test.ts
+++ b/apps/desktop/src/lib/forge/shared/prFooter.test.ts
@@ -1,0 +1,37 @@
+import { generateFooter } from "$lib/forge/shared/prFooter";
+import { describe, expect, test } from "vitest";
+
+// The desktop receives stack segments child -> parent, i.e. [top, ..., base]
+// (104 is the tip, 100 the base). The footer must render top-first with the base
+// numbered 1, and "part X of N" must match each PR's position badge.
+describe("generateFooter", () => {
+	const topToBase = [104, 103, 102, 101, 100];
+
+	function listLines(footer: string) {
+		return footer.split("\n").filter((l) => l.startsWith("- "));
+	}
+
+	test("lists the stack top-first and numbers the base 1", () => {
+		const footer = generateFooter(100, topToBase, "#");
+		const lines = listLines(footer);
+
+		expect(lines[0]).toContain("#104");
+		expect(lines.at(-1)).toContain("#100");
+		expect(footer).toContain("<kbd>&nbsp;1&nbsp;</kbd> #100");
+		expect(footer).toContain("<kbd>&nbsp;5&nbsp;</kbd> #104");
+	});
+
+	test("'part X of N' matches the current PR's position badge", () => {
+		expect(generateFooter(100, topToBase, "#")).toContain("part 1 of 5 in a stack");
+		expect(generateFooter(104, topToBase, "#")).toContain("part 5 of 5 in a stack");
+		expect(generateFooter(102, topToBase, "#")).toContain("part 3 of 5 in a stack");
+	});
+
+	test("marks only the current PR with the indicator", () => {
+		const footer = generateFooter(102, topToBase, "#");
+		const lines = listLines(footer);
+
+		expect(lines.find((l) => l.includes("#102"))).toContain("👈");
+		expect(lines.find((l) => l.includes("#101"))).not.toContain("👈");
+	});
+});

--- a/apps/desktop/src/lib/forge/shared/prFooter.ts
+++ b/apps/desktop/src/lib/forge/shared/prFooter.ts
@@ -155,14 +155,15 @@ function clearFooter(body: string | undefined) {
 function generateFooter(forPrNumber: number, allPrNumbers: number[], symbol: string) {
 	const stackLength = allPrNumbers.length;
 	const stackIndex = allPrNumbers.findIndex((number) => number === forPrNumber);
-	const nth = stackLength - stackIndex;
+	const nth = stackIndex + 1;
 	let footer = "";
 	footer += STACKING_FOOTER_BOUNDARY_TOP + "\n";
 	footer += "---\n";
 	footer += `This is **part ${nth} of ${stackLength} in a stack** made with GitButler:\n`;
-	allPrNumbers.forEach((prNumber, i) => {
-		const current = i === stackIndex;
-		footer += `- <kbd>&nbsp;${stackLength - i}&nbsp;</kbd> ${symbol}${prNumber} ${current ? "👈 " : ""}\n`;
+	[...allPrNumbers].reverse().forEach((prNumber, i) => {
+		const position = stackLength - i;
+		const current = prNumber === forPrNumber;
+		footer += `- <kbd>&nbsp;${position}&nbsp;</kbd> ${symbol}${prNumber}${current ? " 👈 " : ""}\n`;
 	});
 	footer += STACKING_FOOTER_BOUNDARY_BOTTOM;
 	return footer;

--- a/apps/desktop/src/lib/forge/shared/prFooter.ts
+++ b/apps/desktop/src/lib/forge/shared/prFooter.ts
@@ -152,18 +152,17 @@ function clearFooter(body: string | undefined) {
 /**
  * Generates a footer for use in pull request descriptions when part of a stack.
  */
-function generateFooter(forPrNumber: number, allPrNumbers: number[], symbol: string) {
+export function generateFooter(forPrNumber: number, allPrNumbers: number[], symbol: string) {
 	const stackLength = allPrNumbers.length;
 	const stackIndex = allPrNumbers.findIndex((number) => number === forPrNumber);
-	const nth = stackIndex + 1;
+	const nth = stackLength - stackIndex;
 	let footer = "";
 	footer += STACKING_FOOTER_BOUNDARY_TOP + "\n";
 	footer += "---\n";
 	footer += `This is **part ${nth} of ${stackLength} in a stack** made with GitButler:\n`;
-	[...allPrNumbers].reverse().forEach((prNumber, i) => {
-		const position = stackLength - i;
-		const current = prNumber === forPrNumber;
-		footer += `- <kbd>&nbsp;${position}&nbsp;</kbd> ${symbol}${prNumber}${current ? " 👈 " : ""}\n`;
+	allPrNumbers.forEach((prNumber, i) => {
+		const current = i === stackIndex;
+		footer += `- <kbd>&nbsp;${stackLength - i}&nbsp;</kbd> ${symbol}${prNumber} ${current ? "👈 " : ""}\n`;
 	});
 	footer += STACKING_FOOTER_BOUNDARY_BOTTOM;
 	return footer;

--- a/crates/but-forge/src/review.rs
+++ b/crates/but-forge/src/review.rs
@@ -1523,7 +1523,7 @@ fn generate_footer(for_pr_number: i64, all_pr_numbers: &[i64], symbol: &str) -> 
         .iter()
         .position(|&n| n == for_pr_number)
         .unwrap_or(0);
-    let nth = stack_length - stack_index;
+    let nth = stack_index + 1;
 
     let mut footer = String::new();
     footer.push_str(STACKING_FOOTER_BOUNDARY_TOP);
@@ -1885,11 +1885,34 @@ mod tests {
         let all_prs: Vec<i64> = (1..=10).collect();
         let footer = generate_footer(5, &all_prs, "#");
 
-        assert!(footer.contains("part 6 of 10 in a stack"));
+        assert!(footer.contains("part 5 of 10 in a stack"));
 
         // Verify all PRs are listed
         for pr in &all_prs {
             assert!(footer.contains(&format!("#{pr}")));
+        }
+    }
+
+    #[test]
+    fn test_footer_part_number_matches_position_badge() {
+        let all_prs = vec![100, 101, 102, 103, 104];
+        for (idx, &pr) in all_prs.iter().enumerate() {
+            let footer = generate_footer(pr, &all_prs, "#");
+            let position = idx + 1;
+
+            assert!(
+                footer.contains(&format!("part {position} of {}", all_prs.len())),
+                "PR #{pr} (base position {position}) should be \"part {position}\":\n{footer}"
+            );
+
+            let current_line = footer
+                .lines()
+                .find(|l| l.contains(&format!("#{pr}")) && l.contains("👈"))
+                .unwrap_or_else(|| panic!("no current line for #{pr}:\n{footer}"));
+            assert!(
+                current_line.contains(&format!("<kbd>&nbsp;{position}&nbsp;</kbd>")),
+                "PR #{pr} badge should be {position}:\n{current_line}"
+            );
         }
     }
 


### PR DESCRIPTION
## What

In a stacked PR, the footer renders a header — "This is **part X of N in a stack**" —
above a list of the stack's PRs, each tagged with a `<kbd>` position badge. The badges
number from the base of the stack (`1`) up to the top (`N`). But the header's `X` was
computed as `stack_length - stack_index`, counting from the *top* instead — so the header
and a PR's own badge disagreed for every PR except the exact middle.

### Before (5-PR stack, viewing the base PR `#29`)

```
This is **part 5 of 5 in a stack** made with GitButler:
- <kbd> 5 </kbd> #34
- <kbd> 4 </kbd> #33
- <kbd> 3 </kbd> #32
- <kbd> 2 </kbd> #30
- <kbd> 1 </kbd> #29 👈
```

`#29` is badge **1**, yet the header says **part 5 of 5**.

### After

```
This is **part 1 of 5 in a stack** made with GitButler:
- <kbd> 5 </kbd> #34
- <kbd> 4 </kbd> #33
- <kbd> 3 </kbd> #32
- <kbd> 2 </kbd> #30
- <kbd> 1 </kbd> #29 👈
```

## Root cause & fix

One line in the Rust generator (`crates/but-forge/src/review.rs`, `generate_footer`):
compute the part number as the PR's 1-based position from the base (`stack_index + 1`)
instead of from the top, so it equals the badge.

## Why the desktop generator is *not* changed

It consumes the stack in the opposite order and already produced the correct output; it's
only exported here so it can be unit-tested.

## Tests

- **Rust:** updated `test_generate_footer_large_stack`; added
  `test_footer_part_number_matches_position_badge`, which asserts for every PR in a stack
  that the header's part number equals that PR's `<kbd>` badge — the invariant that was
  broken (fails on `master`).
- **Desktop:** added `prFooter.test.ts` pinning the generator's contract for the desktop's
  `[top, …, base]` input order — top-first listing, base = badge 1, header matching the badge.
