### PR TITLE
desktop: refetch CI checks on window focus and reconnect

### DIFF
--- a/apps/desktop/src/lib/forge/checksMonitor.svelte.ts
+++ b/apps/desktop/src/lib/forge/checksMonitor.svelte.ts
@@ -20,6 +20,12 @@ export class ChecksMonitor {
 			{
 				transform: (result) => parseChecks(result),
 				...options,
+				// Refresh checks when the user refocuses the window or reconnects.
+				subscriptionOptions: {
+					refetchOnFocus: true,
+					refetchOnReconnect: true,
+					...options?.subscriptionOptions,
+				},
 			},
 		);
 	}


### PR DESCRIPTION
## What

The CI checks badge (`CIChecksBadge.svelte`) stopped refreshing when the window regained focus or the network reconnected. This restores that behavior.

## Why it regressed

Before the forge refactor (547b87359d, "collapse forge plumbing into direct Rust calls"), the CI checks query lived on the dedicated GitHub/GitLab RTK Query APIs, which set `refetchOnFocus: true` and `refetchOnReconnect: true` globally via a shared `FORGE_API_CONFIG`.

That refactor moved the query onto the unified `backendApi`, which leaves both flags off by default (and uses `keepUnusedDataFor: 0`). `setupListeners()` in `clientState.svelte.ts` still dispatches focus/reconnect events, but with no query opting in, nothing refetched.

## Fix

Opt the checks subscription back into `refetchOnFocus`/`refetchOnReconnect` in `ChecksMonitor.get()`, merged so a caller's `pollingInterval` (and any future overrides) still win. Scoped to the checks query rather than set globally on `backendApi`, which now also serves stack/worktree/git data that shouldn't all refetch on every focus.

## Note

The same root cause means other forge data that previously lived on those APIs (e.g. PR status) also lost focus/reconnect refetch. Those aren't reactive subscribers like the checks query, so they're left out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)