### PR TITLE
Fix "part N of M" numbering in CLI stacked-PR footers

### DIFF
--- a/crates/but-forge/src/review.rs
+++ b/crates/but-forge/src/review.rs
@@ -1523,7 +1523,10 @@ fn generate_footer(for_pr_number: i64, all_pr_numbers: &[i64], symbol: &str) -> 
         .iter()
         .position(|&n| n == for_pr_number)
         .unwrap_or(0);
-    let nth = stack_length - stack_index;
+    // `all_pr_numbers` is ordered base-to-top, and the `<kbd>` labels below number
+    // the base as 1 and the top as `stack_length`. Number "part N" the same way so
+    // the two indicators agree (see #13362).
+    let nth = stack_index + 1;
 
     let mut footer = String::new();
     footer.push_str(STACKING_FOOTER_BOUNDARY_TOP);
@@ -1844,6 +1847,8 @@ mod tests {
 
         assert!(pr_100_line.contains("👈"));
         assert!(pr_100_line.contains("<kbd>&nbsp;1&nbsp;</kbd>"));
+        // The base PR is "part 1", agreeing with its `<kbd>&nbsp;1&nbsp;</kbd>` label.
+        assert!(footer.contains("part 1 of 3 in a stack"));
     }
 
     #[test]
@@ -1856,6 +1861,8 @@ mod tests {
 
         assert!(pr_102_line.contains("👈"));
         assert!(pr_102_line.contains("<kbd>&nbsp;3&nbsp;</kbd>"));
+        // The top PR is "part 3", agreeing with its `<kbd>&nbsp;3&nbsp;</kbd>` label.
+        assert!(footer.contains("part 3 of 3 in a stack"));
     }
 
     #[test]
@@ -1885,7 +1892,8 @@ mod tests {
         let all_prs: Vec<i64> = (1..=10).collect();
         let footer = generate_footer(5, &all_prs, "#");
 
-        assert!(footer.contains("part 6 of 10 in a stack"));
+        // #5 is the 5th from the base, so it is "part 5" (matching its `<kbd>` label).
+        assert!(footer.contains("part 5 of 10 in a stack"));
 
         // Verify all PRs are listed
         for pr in &all_prs {


### PR DESCRIPTION
Fixes #13362

### Problem

In stacked-PR description footers, the `<kbd>` labels number the stack base = 1 … top = M, but the **"part N of M"** text used the opposite convention — so the base PR showed *"part 3 of 3"* next to its `<kbd>&nbsp;1&nbsp;</kbd>` label, and the top PR showed *"part 1 of 3"* next to `<kbd>&nbsp;3&nbsp;</kbd>`. This was reported (and reproduced by others) as **CLI-only**.

### Root cause

There are two footer generators:
- **CLI / backend:** `crates/but-forge/src/review.rs` `generate_footer`
- **Desktop GUI:** `apps/desktop/src/lib/forge/shared/prFooter.ts` `generateFooter`

In the Rust generator, `all_pr_numbers` is ordered **base→top** and the `<kbd>` loop iterates `.rev()` (so labels are correct: base = 1). But `nth` was computed as `stack_length - stack_index`, which is the inverse of the label — hence the contradiction.

The desktop GUI goes through the **TypeScript** generator (`ReviewCreation.svelte` and the drag handlers import `updatePrDescriptionTables` / `updateStackPrs` from `prFooter.ts`), which orders the list top→base and already renders correctly. That's why this only manifested on the CLI.

### Fix

One line in `review.rs`: number `nth = stack_index + 1` so "part N" agrees with the `<kbd>` label at every position (base → 1, top → M). The desktop `prFooter.ts` generator is **intentionally left unchanged** — it is already correct, and as @Byron noted on #13363 the GUI renders as expected.

### Tests

- Corrected `test_generate_footer_large_stack`, which had asserted the buggy `part 6 of 10` for PR #5 (now `part 5 of 10`).
- Added `part 1 of 3` / `part 3 of 3` assertions to the base/top footer tests so the "part N" / `<kbd>` agreement is locked in (assertion idea from #13363).

Verified locally: `cargo test -p but-forge footer` → 11/11 pass; reverting the one-line change fails exactly those 3 tests. `clippy` and `fmt` clean.

### Relation to #13363

#13363 targets the same issue but also rewrites the desktop `prFooter.ts` generator (changing its numbering and reversing its loop). Since the desktop generator is already correct, this PR keeps the change scoped to the Rust/CLI path where the bug actually lives, avoiding a regression to the GUI footer.