### PR TITLE
upstream integration: fix row ordering

### DIFF
--- a/apps/desktop/src/components/upstream/IntegrateUpstreamModal.svelte
+++ b/apps/desktop/src/components/upstream/IntegrateUpstreamModal.svelte
@@ -123,7 +123,7 @@
 	function integrationRowSeries(
 		statusInfo: UpstreamIntegrationStackStatus,
 	): { name: string; status: "integrated" | "conflicted" | "clear" }[] {
-		return [...statusInfo.branchStatuses].reverse();
+		return [...statusInfo.branchStatuses];
 	}
 </script>
 


### PR DESCRIPTION
Inside the new upstream integration modal, we were rendering the branches within a stack in the wrong order