### PR TITLE
Prune integrated commits by each stack's own fork point

### DIFF
--- a/crates/but-graph/src/projection/stack.rs
+++ b/crates/but-graph/src/projection/stack.rs
@@ -67,30 +67,38 @@ impl Stack {
             a.base_segment_id = b.id.into();
             cur = Some(b);
         }
-        if let Some((last_segment, last_aggregated_sidx)) = segments.last_mut().and_then(|s| {
+        let mut stack = Stack { id, segments };
+        stack.recompute_last_segment_base(graph);
+        stack
+    }
+
+    /// Recompute the last segment's base from its bottom commit's first-parent neighbour.
+    ///
+    /// Needed after the stack's bottom is truncated (e.g. by integrated-trunk pruning),
+    /// which leaves the collection-time base pointing at a segment no longer in the stack.
+    pub(crate) fn recompute_last_segment_base(&mut self, graph: &PetGraph) {
+        let Some((last_segment, last_aggregated_sidx)) = self.segments.last_mut().and_then(|s| {
             let sidx = s.commits_by_segment.last().map(|t| t.0)?;
             Some((s, sidx))
-        }) {
-            let first_parent_sidx = graph
-                .neighbors_directed(last_aggregated_sidx, Direction::Outgoing)
-                .next();
-            last_segment.base = first_parent_sidx.and_then(|sidx| {
-                graph[sidx].commits.first().and_then(|c| {
-                    if c.parent_ids.is_empty() || graph[sidx].commits.get(1).is_some() {
-                        return c.id.into();
-                    }
-                    graph
-                        .neighbors_directed(sidx, Direction::Outgoing)
-                        .next()
-                        .is_some()
-                        .then_some(c.id)
-                })
-            });
-            last_segment.base_segment_id =
-                first_parent_sidx.filter(|_| last_segment.base.is_some());
-        }
-
-        Stack { id, segments }
+        }) else {
+            return;
+        };
+        let first_parent_sidx = graph
+            .neighbors_directed(last_aggregated_sidx, Direction::Outgoing)
+            .next();
+        last_segment.base = first_parent_sidx.and_then(|sidx| {
+            graph[sidx].commits.first().and_then(|c| {
+                if c.parent_ids.is_empty() || graph[sidx].commits.get(1).is_some() {
+                    return c.id.into();
+                }
+                graph
+                    .neighbors_directed(sidx, Direction::Outgoing)
+                    .next()
+                    .is_some()
+                    .then_some(c.id)
+            })
+        });
+        last_segment.base_segment_id = first_parent_sidx.filter(|_| last_segment.base.is_some());
     }
 }
 

--- a/crates/but-graph/src/projection/workspace/init.rs
+++ b/crates/but-graph/src/projection/workspace/init.rs
@@ -1061,18 +1061,20 @@ impl WorkspaceState {
     /// stack, but only those at or below the workspace's target commit.
     /// Integrated commits above the target commit are kept until the user advances
     /// the target via upstream integration.
-    // TODO: we need per-stack target commits/stored-forkpoint to be able to apply
-    //       branches from the future onto workspaces from the past without showing
-    //       too many integrated commits.
-    //       Also, this implementation doesn't adjust the base yet, which leaves the
-    //       workspace inconcistent. This can have repercussions for reference creation
-    //       which currently uses the lowest bound, but this may change.
+    // TODO: the per-stack fork point is recomputed on every projection rather than
+    //       stored; persisting it would avoid re-deriving the target trunk each build.
     fn prune_integrated_segments(&mut self, graph: &Graph) {
-        if !graph
+        // Integrated-commit pruning only applies to workspaces tracking an upstream
+        // target ref; without one, leave the stacks untouched.
+        if self.target_ref.is_none() {
+            return;
+        }
+        // Extra integrated tips mean upstream advanced past the stored target. Bail only
+        // if there's no stored target *commit* to bound pruning against.
+        let upstream_advanced_past_target = !graph
             .integrated_tip_segments_excluding_target_ref_tip(self.target_ref.as_ref())
-            .is_empty()
-            || self.target_ref.is_none()
-        {
+            .is_empty();
+        if self.target_commit.is_none() && upstream_advanced_past_target {
             return;
         }
         // TODO: it seems like we assume this is the lowest commit,
@@ -1085,23 +1087,46 @@ impl WorkspaceState {
             return;
         };
 
-        // Collect all segments that are the target segment itself or ancestors
-        // of it by walking the graph toward its ancestors (Direction::Outgoing).
-        let mut target_or_below_segments = HashSet::new();
-        graph.visit_all_segments_excluding_start_until(
-            target_segment_index,
-            Direction::Outgoing,
-            |s| {
-                target_or_below_segments.insert(s.id);
-                false
-            },
-        );
-        target_or_below_segments.insert(target_segment_index);
+        // Only build the segment set the chosen branch actually uses.
+        let prune_segments = if upstream_advanced_past_target {
+            // The target's first-parent trunk. Commits reaching the target only via a merge's
+            // second parent are off it, so a branch's own work is preserved; only shared trunk
+            // on a stack's first-parent spine is pruned.
+            let mut segments = HashSet::new();
+            graph.visit_segments_downward_along_first_parent_include_start(
+                target_segment_index,
+                |s| {
+                    segments.insert(s.id);
+                    false
+                },
+            );
+            segments
+        } else {
+            // The target segment itself plus all its ancestors (walk toward ancestors).
+            let mut segments = HashSet::new();
+            graph.visit_all_segments_excluding_start_until(
+                target_segment_index,
+                Direction::Outgoing,
+                |s| {
+                    segments.insert(s.id);
+                    false
+                },
+            );
+            segments.insert(target_segment_index);
+            segments
+        };
 
         let metadata = self.metadata.as_ref();
         for stack in &mut self.stacks {
-            prune_integrated_stack_segments(stack, &target_or_below_segments);
+            // Upstream advanced: floor the stack at its fork point but keep a fully-integrated
+            // tip so it survives for `integrate_upstream`. Up to date: prune everything at or
+            // below the target.
+            prune_integrated_stack_segments(stack, &prune_segments, upstream_advanced_past_target);
             remove_empty_branches(stack, metadata);
+            if upstream_advanced_past_target {
+                // Pruning moved the stack's bottom; refresh its base to the new fork point.
+                stack.recompute_last_segment_base(&graph.inner);
+            }
         }
         self.stacks.retain(|stack| !stack.segments.is_empty());
     }
@@ -1294,17 +1319,22 @@ impl WorkspaceState {
     }
 }
 
-/// Prune whole integrated graph segments at the bottom, but only those that are
-/// at or below the target segment. Integrated segments above the target are kept
-/// until the user advances the target via upstream integration.
+/// Prune the integrated tail whose graph segment is in `prune_segments`; commits in other
+/// segments are kept (e.g. above the target, or reaching it only via a merge's 2nd parent).
+///
+/// With `keep_if_fully_integrated`, a stack whose every commit would be pruned is left
+/// untouched, keeping a fully-integrated branch's tip visible for `integrate_upstream`.
 fn prune_integrated_stack_segments(
     stack: &mut Stack,
-    target_or_below_segments: &HashSet<SegmentIndex>,
+    prune_segments: &HashSet<SegmentIndex>,
+    keep_if_fully_integrated: bool,
 ) {
     // Walk stack segments bottom-up, then graph-segment blocks bottom-up within
     // each stack segment. Stop at the first graph segment block that is either
-    // not fully integrated or not at or below the target.
+    // not fully integrated or not in `prune_segments`.
     let mut cut: Option<(usize, usize)> = None;
+    // Whether any commit would survive the cut (not integrated, or not in `prune_segments`).
+    let mut has_surviving_commit = false;
     'outer: for seg_idx in (0..stack.segments.len()).rev() {
         let seg = &stack.segments[seg_idx];
 
@@ -1313,10 +1343,11 @@ fn prune_integrated_stack_segments(
         }
 
         if seg.commits_by_segment.is_empty() {
-            if commits_are_integrated(&seg.commits) && target_or_below_segments.contains(&seg.id) {
+            if commits_are_integrated(&seg.commits) && prune_segments.contains(&seg.id) {
                 cut = Some((seg_idx, 0));
                 continue;
             }
+            has_surviving_commit = true;
             break 'outer;
         }
 
@@ -1328,9 +1359,10 @@ fn prune_integrated_stack_segments(
                 .map_or(seg.commits.len(), |(_, offset)| *offset);
             let commits = &seg.commits[start_offset..end_offset];
 
-            if target_or_below_segments.contains(&segment_id) && commits_are_integrated(commits) {
+            if prune_segments.contains(&segment_id) && commits_are_integrated(commits) {
                 cut = Some((seg_idx, start_offset));
             } else {
+                has_surviving_commit = true;
                 break 'outer;
             }
         }
@@ -1339,6 +1371,12 @@ fn prune_integrated_stack_segments(
     let Some((cut_seg_idx, cut_offset)) = cut else {
         return;
     };
+
+    // The whole stack is integrated trunk. While upstream is ahead, keep it (e.g. a
+    // fully-integrated branch behind its remote) rather than pruning it out of existence.
+    if keep_if_fully_integrated && !has_surviving_commit {
+        return;
+    }
 
     stack.segments[cut_seg_idx].commits.truncate(cut_offset);
     stack.segments[cut_seg_idx]

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -1632,4 +1632,43 @@ EOF
      git checkout my-branch
      create_workspace_commit_once my-branch
   )
+
+  # origin/main has advanced past the stored target, and an old branch forks below
+  # the target - dragging the workspace base below it so the integrated commits
+  # between base and target are exposed in every stack.
+  git init integrated-below-target-upstream-ahead
+  (cd integrated-below-target-upstream-ahead
+     commit init
+     commit base
+     commit target
+     commit upstream
+     setup_target_to_match_main
+
+     # Old branch forks at 'base', below the (later) stored target.
+     git checkout -b old-branch main~2
+       commit O
+     # Real work on top of the stored target.
+     git checkout -b my-branch main~1
+       commit W
+     create_workspace_commit_once my-branch old-branch
+  )
+
+  # X forks below the target (at 'c1') and catches up via `merge origin/main`, so the
+  # target enters X only through the merge's second parent. The trunk below the fork
+  # ('c1', 'init') must be pruned, leaving X's own commits; origin/main stays ahead.
+  git init catchup-merge-leak
+  (cd catchup-merge-leak
+     commit init
+     commit c1
+     commit c2
+     commit T
+     commit B
+     commit U
+     setup_target_to_match_main
+     git checkout -b X main~4
+       commit x1
+       git merge --no-ff main -m "catch up to origin/main"
+       commit x2
+     create_workspace_commit_once X
+  )
 )

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -5932,17 +5932,17 @@ fn applied_stack_below_explicit_lower_bound() -> anyhow::Result<()> {
                 └── →:3:
     ");
 
-    // The base is still adjusted so it matches the actual stacks.
-    // Note how it shows more of the base of `B` due to `A` having a lower base with the target branch.
+    // The base is still adjusted so it matches the actual stacks. With the extra-target
+    // resolved as the target commit, the integrated `f52fcec` is at the target and is
+    // pruned - consistent with the no-extra-target case above.
     insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on bce0c5e
     ├── ≡📙:4:A on bce0c5e {0}
     │   └── 📙:4:A
     │       └── ·6fdab32 (🏘️)
-    └── ≡📙:5:B on bce0c5e {1}
+    └── ≡📙:5:B on f52fcec {1}
         └── 📙:5:B
-            ├── ·78b1b59 (🏘️)
-            └── ·f52fcec (🏘️|✓)
+            └── ·78b1b59 (🏘️)
     ");
 
     Ok(())
@@ -7069,6 +7069,89 @@ fn integrated_commits_above_target_are_kept() -> anyhow::Result<()> {
         "pruning integrated tips should not report a hard-limit traversal stop"
     );
 
+    Ok(())
+}
+
+/// Regression: an old branch applied below the stored target drags the workspace base
+/// below it, exposing the integrated trunk between base and target. Those commits must be
+/// pruned even though `origin/main` has advanced past the target - which previously
+/// disabled integrated-commit pruning entirely.
+#[test]
+fn integrated_commits_below_target_pruned_when_upstream_ahead() -> anyhow::Result<()> {
+    let (repo, mut meta) =
+        read_only_in_memory_scenario("ws/integrated-below-target-upstream-ahead")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   aca392b (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * f458f7d (old-branch) O
+    * | f5055a1 (my-branch) W
+    | | * 7282cb5 (origin/main, main) upstream
+    | |/  
+    |/|   
+    * | 2121f9c target
+    |/  
+    * 322cb14 base
+    * fafd9d0 init
+    ");
+
+    // Stored target is 'target' (main~1); origin/main is one commit ahead at 'upstream'.
+    let target_id = repo.rev_parse_single("main~1")?.detach();
+    add_workspace_with_target(&mut meta, target_id);
+    add_stack_with_segments(&mut meta, 0, "my-branch", StackState::InWorkspace, &[]);
+    add_stack_with_segments(&mut meta, 1, "old-branch", StackState::InWorkspace, &[]);
+
+    // 'W' and 'O' are above/beside the target and kept; 'target' and 'base' are
+    // integrated and at or below the target, so they are pruned from both stacks
+    // even though origin/main has advanced past the target.
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 322cb14
+    ├── ≡📙:4:my-branch on 2121f9c {0}
+    │   └── 📙:4:my-branch
+    │       └── ·f5055a1 (🏘️)
+    └── ≡📙:5:old-branch on 322cb14 {1}
+        └── 📙:5:old-branch
+            └── ·f458f7d (🏘️)
+    ");
+    Ok(())
+}
+
+/// A branch that forks below the target and catches up via `merge origin/main`, so the
+/// target enters X only through the merge's second parent (off X's first-parent spine).
+/// X is floored at its fork point - where its own first-parent work meets the trunk - so
+/// the trunk below the fork (`c1`, `init`) is pruned, leaving X's own commits.
+#[test]
+fn catchup_merge_below_target_floors_at_fork() -> anyhow::Result<()> {
+    let (repo, mut meta) = read_only_in_memory_scenario("ws/catchup-merge-leak")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 254106a (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * f210f41 (X) x2
+    *   f8cd0ce catch up to origin/main
+    |\  
+    | * 0975125 (origin/main, main) U
+    | * a7db886 B
+    | * d263f88 T
+    | * 8bd7dc1 c2
+    * | 4eec82a x1
+    |/  
+    * b4bd43f c1
+    * fafd9d0 init
+    ");
+
+    // Stored target is 'T' (main~2); origin/main is two commits ahead at 'U'.
+    let target_id = repo.rev_parse_single("main~2")?.detach();
+    add_workspace_with_target(&mut meta, target_id);
+    add_stack_with_segments(&mut meta, 0, "X", StackState::InWorkspace, &[]);
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on d263f88
+    └── ≡📙:4:X on b4bd43f {0}
+        └── 📙:4:X
+            ├── ·f210f41 (🏘️)
+            ├── ·f8cd0ce (🏘️)
+            └── ·4eec82a (🏘️)
+    ");
     Ok(())
 }
 


### PR DESCRIPTION
## The bug

Workspace pruning keyed off a single workspace-wide **target** commit. When a stack didn't sit directly on that target, integrated **trunk commits leaked into the stack** — sometimes its whole first-parent history down to the root. Two ways this happened:

### 1. Catch-up merge — target off the stack's spine

Branch `X` forked below the target, then caught up with `git merge origin/main`, so the target enters `X` only through the merge's **second** parent:

```
* f210f41 (X) x2
*   f8cd0ce catch up to origin/main
|\
| * 0975125 (origin/main) U
| * a7db886 B
| * d263f88 T            ← stored target
| * 8bd7dc1 c2
* | 4eec82a x1
|/
* b4bd43f c1             ← X's fork point
* fafd9d0 init
```

`X`'s own work is `x1` → merge → `x2`. Because `T` never lands on `X`'s first-parent spine (it's reached only through the merge's second parent), the old *"does the stack contain the target?"* gate bailed and left the trunk **below the fork** — `c1` and `init` — inside `X`. **Fix:** floor `X` at its fork point `c1` (prunes `c1`, `init`).

### 2. Stale target — base dragged below the target

Applying `old-branch` (forked at `base`, below the target) lowers the workspace base, exposing the trunk between base and target. Upstream has advanced past the target, so the old gate bailed and showed `target`+`base` in **every** stack:

```
*   aca392b GitButler Workspace Commit
|\
| * f458f7d (old-branch) O
* | f5055a1 (my-branch)  W
| | * 7282cb5 (origin/main) upstream   ← advanced past target
| |/
|/|
* | 2121f9c target       ← stored target
|/
* 322cb14 base
* fafd9d0 init
```

`W` and `O` are the stacks' own commits (kept); `target`+`base` are integrated trunk that leaked into both. **Fix:** prune at/below the target, flooring each stack at **its own** fork point — `my-branch` at `target`, `old-branch` at `base`.

## The fix

When upstream has advanced, floor each stack at its fork point — the first commit on its spine lying on the target's first-parent trunk — instead of the single "contains the target" gate. A stack's own commits (and its tip when fully contained) are kept; commits reaching the target only via a merge's second parent stay off the trunk, so a branch pending integration is preserved (`remote_ahead`/`behind`/`diverged` unchanged).

Regression tests: `catchup_merge_below_target_floors_at_fork`, `integrated_commits_below_target_pruned_when_upstream_ahead`.
