### PR TITLE
Clean up edit-mode refs when leaving edit mode

### DIFF
--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -19,7 +19,7 @@ use gitbutler_cherry_pick::{ConflictedTreeKey, GixRepositoryExt as _};
 use gitbutler_commit::commit_ext::{CommitExt, CommitMessageBstr};
 use gitbutler_operating_modes::{
     EDIT_BRANCH_REF, EditModeMetadata, INTEGRATION_BRANCH_REF, OperatingMode, WORKSPACE_BRANCH_REF,
-    operating_mode, read_edit_mode_metadata, write_edit_mode_metadata,
+    delete_edit_mode_metadata, operating_mode, read_edit_mode_metadata, write_edit_mode_metadata,
 };
 use gitbutler_workspace::branch_trees::{WorkspaceState, update_uncommitted_changes_with_tree};
 use gix::prelude::ObjectIdExt as _;
@@ -252,6 +252,23 @@ pub(crate) fn enter_edit_mode(
     Ok(edit_mode_metadata)
 }
 
+/// Remove the references and metadata that [`enter_edit_mode`] created.
+///
+/// `HEAD` must already point back at the workspace branch before this is called, otherwise
+/// deleting [`EDIT_BRANCH_REF`] would leave `HEAD` dangling.
+fn cleanup_edit_mode(ctx: &Context, repo: &gix::Repository) -> Result<()> {
+    for ref_name in [EDIT_BRANCH_REF, UNCOMMITTED_CHANGES_REF] {
+        // Tolerate an already-absent ref, but surface real lookup failures.
+        if let Some(reference) = repo.try_find_reference(ref_name)? {
+            reference
+                .delete()
+                .with_context(|| format!("Failed to delete reference {ref_name}"))?;
+        }
+    }
+    delete_edit_mode_metadata(ctx)?;
+    Ok(())
+}
+
 pub(crate) fn abort_and_return_to_workspace(
     ctx: &Context,
     force: bool,
@@ -277,6 +294,8 @@ pub(crate) fn abort_and_return_to_workspace(
         uncommited_changes.as_object(),
         Some(CheckoutBuilder::new().force().remove_untracked(true)),
     )?;
+
+    cleanup_edit_mode(ctx, &*ctx.repo.get()?)?;
 
     Ok(())
 }
@@ -384,6 +403,8 @@ pub(crate) fn save_and_return_to_workspace(ctx: &Context, perm: &mut RepoExclusi
             "evolution-parent",
             &edit_mode_metadata.commit_oid.to_hex().to_string(),
         )?;
+
+    cleanup_edit_mode(ctx, repo)?;
 
     Ok(())
 }

--- a/crates/gitbutler-edit-mode/tests/edit_mode.rs
+++ b/crates/gitbutler-edit-mode/tests/edit_mode.rs
@@ -11,7 +11,7 @@ use gitbutler_edit_mode::commands::{
     abort_and_return_to_workspace, enter_edit_mode, save_and_return_to_workspace,
 };
 use gitbutler_operating_modes::{
-    EditModeMetadata, INTEGRATION_BRANCH_REF, write_edit_mode_metadata,
+    EditModeMetadata, INTEGRATION_BRANCH_REF, read_edit_mode_metadata, write_edit_mode_metadata,
 };
 use tempfile::TempDir;
 
@@ -90,6 +90,27 @@ fn seed_edit_mode_metadata(ctx: &Context, edit_commit_id: &str) -> Result<()> {
     };
     drop(repo);
     write_edit_mode_metadata(ctx, &edit_mode_metadata)?;
+    Ok(())
+}
+
+/// Assert that every artifact [`enter_edit_mode`] creates has been removed, so leaving edit
+/// mode never leaves a dangling ref or stale metadata behind.
+fn assert_edit_mode_cleaned_up(ctx: &Context) -> Result<()> {
+    let repo = ctx.repo.get()?;
+    for ref_name in [
+        "refs/heads/gitbutler/edit",
+        "refs/gitbutler/edit-uncommitted-changes",
+    ] {
+        assert!(
+            repo.try_find_reference(ref_name)?.is_none(),
+            "{ref_name} should be removed when leaving edit mode"
+        );
+    }
+    drop(repo);
+    assert!(
+        read_edit_mode_metadata(ctx).is_err(),
+        "edit mode metadata should be removed when leaving edit mode"
+    );
     Ok(())
 }
 
@@ -272,13 +293,14 @@ fn apply_commit_on_itself() -> Result<()> {
     save_and_return_to_workspace(&mut ctx, guard.write_permission())?;
 
     let repo = &*ctx.repo.get()?;
-    // It works.
+    // It works, and the gitbutler/edit ref is cleaned up on the way out.
     insta::assert_snapshot!(visualize_commit_graph(repo, "refs/heads/gitbutler/workspace")?, @"
-    * 16b549b (HEAD -> gitbutler/workspace, gitbutler/edit) GitButler Workspace Commit
+    * 16b549b (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 6eb9642 (branchy) GitButler Workspace Commit
     * 26804c3 foobar
     * 7950f06 (origin/main, origin/HEAD, main, gitbutler/target) init
     ");
+    assert_edit_mode_cleaned_up(&ctx)?;
 
     Ok(())
 }
@@ -380,6 +402,8 @@ fn abort_requires_force_when_changes_were_made() -> Result<()> {
     )
     "#
     );
+    // Leaving edit mode cleans up every edit-mode artifact instead of leaving them dangling.
+    assert_edit_mode_cleaned_up(&ctx)?;
 
     Ok(())
 }
@@ -464,6 +488,8 @@ fn enter_edit_mode_checks_out_conflicted_commit() -> Result<()> {
     )
     "#
     );
+    // Leaving edit mode cleans up every edit-mode artifact instead of leaving them dangling.
+    assert_edit_mode_cleaned_up(&ctx)?;
 
     Ok(())
 }

--- a/crates/gitbutler-operating-modes/src/lib.rs
+++ b/crates/gitbutler-operating-modes/src/lib.rs
@@ -59,6 +59,16 @@ pub fn write_edit_mode_metadata(
     Ok(())
 }
 
+#[doc(hidden)]
+pub fn delete_edit_mode_metadata(ctx: &Context) -> Result<()> {
+    match fs::remove_file(edit_mode_metadata_path(ctx).as_path()) {
+        Ok(()) => Ok(()),
+        // Already gone - nothing to clean up.
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err).context("Failed to delete edit mode metadata"),
+    }
+}
+
 /// Holds relevant state required to switch to and from edit mode
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]


### PR DESCRIPTION
### Problem

Entering edit mode creates three artifacts that neither exit path cleaned up, so `gitbutler/edit` lingered after every edit session:

- `refs/heads/gitbutler/edit`
- `refs/gitbutler/edit-uncommitted-changes` (stash ref)
- `edit_mode_metadata.toml`

### Fix

A new `cleanup_edit_mode` helper deletes all three, called at the end of both `save_and_return_to_workspace` and `abort_and_return_to_workspace` — **after** `HEAD` is back on the workspace branch, so removing the edit ref can't leave `HEAD` dangling.

Deletion tolerates already-absent targets, and a forced abort still bails before cleanup when there are unsaved changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
