### PR TITLE
ci: don't fail check-rust aggregator on cancelled runs

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -614,7 +614,11 @@ jobs:
           destination_dir: "installers/latest"
 
   check-rust:
-    if: always()
+    # Skip the aggregator when the run itself is cancelled: a concurrency-
+    # cancelled twin run has `cancelled` needs, which alls-green scores as
+    # failure — a phantom red required check on the same commit as the live
+    # (green) run.
+    if: ${{ !cancelled() }}
     needs:
       - changes
       - check-rust-windows


### PR DESCRIPTION
When concurrency cancels a superseded workflow run, its needed jobs end up
`cancelled`. The `check-rust` alls-green aggregator runs with `if: always()`,
so it still executes, sees the cancelled needs, and reports `failure` —
leaving a phantom red required check on the commit even though the live run
is green (which in turn shows the PR as blocked).

Use `if: ${{ !cancelled() }}` so the aggregator still runs on success and
real failures, but is skipped when the run itself is cancelled. Branch
protection then only sees the live run's result.

These cancelled duplicates are common: over the last month ~1.4% of
pull_request CI runs (105 of 7,538, on 24 of 32 days) were concurrency-
cancelled twins, each starting a median ~1s after its live counterpart.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>