### PR TITLE
insert segment: Insert as first parents

### DIFF
--- a/crates/but-rebase/src/graph_rebase/mutate.rs
+++ b/crates/but-rebase/src/graph_rebase/mutate.rs
@@ -30,6 +30,16 @@ pub enum InsertSide {
 #[cfg(feature = "export-schema")]
 but_schemars::register_sdk_type!(InsertSide);
 
+/// Controls where reparented insertion-location parents are ordered relative to
+/// existing parents on the segment.
+#[derive(Debug, Clone)]
+pub enum ParentReparentingOrder {
+    /// Put reparented insertion-location parents before existing segment parents.
+    Prepend,
+    /// Put reparented insertion-location parents after existing segment parents.
+    Append,
+}
+
 /// Defines the start and end of a segment by pointing to it's parent-most and child-most nodes.
 #[derive(Debug, Clone)]
 pub struct SegmentDelimiter<C, P>
@@ -498,6 +508,63 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
         }
     }
 
+    fn add_edges_to_parents(
+        &mut self,
+        child_node: petgraph::prelude::NodeIndex,
+        new_parent_nodes: impl IntoIterator<Item = petgraph::prelude::NodeIndex>,
+        parent_reparenting_order: ParentReparentingOrder,
+    ) {
+        let mut existing_parent_edges = self
+            .graph
+            .edges_directed(child_node, Direction::Outgoing)
+            .map(|edge| (edge.id(), edge.weight().order, edge.target()))
+            .collect::<Vec<_>>();
+        existing_parent_edges.sort_by_key(|(_, order, _)| *order);
+
+        for (edge_id, _, _) in &existing_parent_edges {
+            self.graph.remove_edge(*edge_id);
+        }
+
+        let new_parent_nodes = new_parent_nodes.into_iter().collect::<Vec<_>>();
+        match parent_reparenting_order {
+            ParentReparentingOrder::Prepend => {
+                for (order, parent_node) in new_parent_nodes.iter().enumerate() {
+                    self.graph
+                        .add_edge(child_node, *parent_node, Edge { order });
+                }
+
+                // Insertion-location parents define the first-parent lane. Existing parents stay
+                // attached after them as merge-side parents.
+                let shifted_by = new_parent_nodes.len();
+                for (offset, (_, _, parent_node)) in existing_parent_edges.into_iter().enumerate() {
+                    self.graph.add_edge(
+                        child_node,
+                        parent_node,
+                        Edge {
+                            order: shifted_by + offset,
+                        },
+                    );
+                }
+            }
+            ParentReparentingOrder::Append => {
+                let shifted_by = existing_parent_edges.len();
+                for (order, (_, _, parent_node)) in existing_parent_edges.into_iter().enumerate() {
+                    self.graph.add_edge(child_node, parent_node, Edge { order });
+                }
+
+                for (offset, parent_node) in new_parent_nodes.into_iter().enumerate() {
+                    self.graph.add_edge(
+                        child_node,
+                        parent_node,
+                        Edge {
+                            order: shifted_by + offset,
+                        },
+                    );
+                }
+            }
+        }
+    }
+
     /// Insert a segment relative to a selector.
     ///
     /// `target` - Selector to insert the segment relative to.
@@ -508,11 +575,21 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
     ///
     /// `nodes_to_connect` - Optional set of selector to connect instead of the parents/children determined.
     ///
+    /// `parent_reparenting_order` - Controls how newly connected parent edges are ordered relative to
+    /// existing parent edges on the parent-most node of the inserted segment. With
+    /// [`ParentReparentingOrder::Prepend`], the newly connected parents become the lowest-order parents,
+    /// which makes the first inserted/reparented parent the first-parent traversal path. Existing parents
+    /// remain attached after them in their previous relative order. With
+    /// [`ParentReparentingOrder::Append`], existing parents keep the lowest parent orders and the newly
+    /// connected parents are appended after them.
+    ///
     /// If `nodes_to_connect` is None:
     ///     If inserted above, all the target selector's children will be disconnected and reconnected to the last
-    ///     node of the segment.
+    ///     node of the segment. If inserted below, all the target selector's parents will be disconnected and
+    ///     reconnected to the parent-most node of the segment using `parent_reparenting_order`.
     /// If `nodes_to_connect` is Some:
-    ///     If inserted above, connect the given nodes as children. If inserted below, connect the given nodes as parents.
+    ///     If inserted above, connect the given nodes as children. If inserted below, connect the given nodes as parents
+    ///     using `parent_reparenting_order`.
     ///
     pub fn insert_segment_into<C, P>(
         &mut self,
@@ -520,6 +597,7 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
         delimiter: SegmentDelimiter<C, P>,
         side: InsertSide,
         nodes_to_connect: Option<SomeSelectors>,
+        parent_reparenting_order: ParentReparentingOrder,
     ) -> Result<()>
     where
         C: ToSelector,
@@ -583,75 +661,37 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
                     }
                 }
 
-                // Find the parent node of the highest order from the parent-most node in the segment being inserted.
-                let chubbiest_grand_parent = self
-                    .graph
-                    .edges_directed(parent.id, Direction::Outgoing)
-                    .map(|e| (e.id(), e.weight().to_owned(), e.target()))
-                    .max_by_key(|gc| gc.1.order);
-
-                let new_weight =
-                    if let Some((_, grand_parent_weight, _)) = chubbiest_grand_parent.as_ref() {
-                        Edge {
-                            order: grand_parent_weight.order + 1,
-                        }
-                    } else {
-                        Edge { order: 0 }
-                    };
-                // Connect the target to the parent-most node in the given segment.
-                self.graph.add_edge(parent.id, target.id, new_weight);
+                // Connect the target to the parent-most node in the given segment according to
+                // the requested parent ordering policy.
+                self.add_edges_to_parents(parent.id, [target.id], parent_reparenting_order);
             }
             InsertSide::Below => {
-                // Find the parent node of the highest order from the parent-most node in the segment being inserted.
-                let chubbiest_grand_parent = self
-                    .graph
-                    .edges_directed(parent.id, Direction::Outgoing)
-                    .map(|e| (e.id(), e.weight().to_owned(), e.target()))
-                    .max_by_key(|gc| gc.1.order);
-
-                if let Some(nodes_to_connect) = nodes_to_connect {
-                    // If there were nodes to connect defined, create edges into them from the parent node of the segment
-                    // being inserted.
-                    for (index, any_selector) in nodes_to_connect.as_slice().iter().enumerate() {
+                let parents_to_add = if let Some(nodes_to_connect) = nodes_to_connect {
+                    let mut nodes = Vec::new();
+                    for any_selector in nodes_to_connect.as_slice() {
                         let selector = any_selector.to_selector(self)?;
                         let node = self.history.normalize_selector(selector)?;
-                        // Avoid weight collision by adding the order value of the highest order parent plus one,
-                        // accommodating for order 0.
-                        let new_weight = if let Some((_, grand_parent_weight, _)) =
-                            chubbiest_grand_parent.as_ref()
-                        {
-                            Edge {
-                                order: index + grand_parent_weight.order + 1,
-                            }
-                        } else {
-                            Edge { order: index }
-                        };
-                        self.graph.add_edge(parent.id, node.id, new_weight);
+                        nodes.push(node.id);
                     }
+                    nodes
                 } else {
-                    let edges = self
+                    let mut edges = self
                         .graph
                         .edges_directed(target.id, Direction::Outgoing)
-                        .map(|e| (e.id(), e.weight().to_owned(), e.target()))
+                        .map(|e| (e.id(), e.weight().order, e.target()))
                         .collect::<Vec<_>>();
+                    edges.sort_by_key(|(_, order, _)| *order);
 
-                    // Connect all target's parents to the parent-most node in the given segment.
-                    for (edge_id, edge_weight, edge_target) in edges {
+                    let mut nodes = Vec::with_capacity(edges.len());
+                    for (edge_id, _, edge_target) in edges {
                         self.graph.remove_edge(edge_id);
-                        // Avoid weight collision by adding the order value of the highest order parent plus one,
-                        // accommodating for order 0.
-                        let new_weight = if let Some((_, grand_parent_weight, _)) =
-                            chubbiest_grand_parent.as_ref()
-                        {
-                            Edge {
-                                order: edge_weight.order + grand_parent_weight.order + 1,
-                            }
-                        } else {
-                            edge_weight
-                        };
-                        self.graph.add_edge(parent.id, edge_target, new_weight);
+                        nodes.push(edge_target);
                     }
-                }
+                    nodes
+                };
+
+                self.add_edges_to_parents(parent.id, parents_to_add, parent_reparenting_order);
+
                 // Find the child node of the highest order from the child-most node in the segment being inserted.
                 let chubbiest_grand_child = self
                     .graph
@@ -680,6 +720,13 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
     ///
     /// If inserted above, all the target selector's children will be disconnected and reconnected to the last
     /// node of the segment.
+    /// If inserted below, all the target selector's parents will be disconnected and reconnected to the
+    /// parent-most node of the segment.
+    ///
+    /// Reparented parents are prepended by default: newly connected parents receive the lowest parent orders,
+    /// so the first inserted/reparented parent becomes the first-parent traversal path and existing parents
+    /// remain attached after them in their previous relative order. Use [`Self::insert_segment_into`] with
+    /// [`ParentReparentingOrder::Append`] when existing parents should keep the lowest parent orders instead.
     ///
     pub fn insert_segment<C, P>(
         &mut self,
@@ -691,7 +738,13 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
         C: ToSelector,
         P: ToSelector,
     {
-        self.insert_segment_into(target, delimiter, side, None)
+        self.insert_segment_into(
+            target,
+            delimiter,
+            side,
+            None,
+            ParentReparentingOrder::Prepend,
+        )
     }
 
     /// Add a step node to the graph.

--- a/crates/but-rebase/tests/rebase/graph_rebase/insert_segment.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/insert_segment.rs
@@ -1,11 +1,30 @@
 //! These tests exercise the insert segment operation.
 use anyhow::{Context, Result};
+use bstr::ByteSlice;
 use but_graph::Graph;
 use but_rebase::graph_rebase::{Editor, mutate};
 use but_testsupport::{git_status, graph_tree, visualize_commit_graph, visualize_commit_graph_all};
 
 use crate::utils::{fixture_writable, standard_options};
 
+fn parent_subjects(repo: &gix::Repository, rev: &str) -> Result<Vec<String>> {
+    let commit = repo.rev_parse_single(rev)?.object()?.peel_to_commit()?;
+    commit
+        .parent_ids()
+        .map(|parent_id| {
+            let parent = parent_id.object()?.peel_to_commit()?;
+            let subject = parent
+                .message_raw()?
+                .as_bstr()
+                .lines()
+                .next()
+                .unwrap_or_default()
+                .to_str_lossy()
+                .into_owned();
+            Ok(subject)
+        })
+        .collect()
+}
 #[test]
 fn insert_single_node_segment_above() -> Result<()> {
     let (repo, _tmp, mut meta) = fixture_writable("three-branches-merged")?;
@@ -55,36 +74,34 @@ fn insert_single_node_segment_above() -> Result<()> {
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:main[🌳]
-        └── ·b78a484 (⌂|1)
+        └── ·ee7f107 (⌂|1)
             ├── ►:1[1]:A
-            │   └── ·706b5e8 (⌂|1)
-            │       ├── ►:3[3]:anon:
-            │       │   └── 🏁·8f0d338 (⌂|1) ►tags/base
-            │       └── ►:4[2]:B
-            │           ├── ·a748762 (⌂|1)
-            │           └── ·62e05ba (⌂|1)
-            │               └── →:3:
+            │   └── ·69221b4 (⌂|1)
+            │       ├── ►:3[2]:B
+            │       │   ├── ·a748762 (⌂|1)
+            │       │   └── ·62e05ba (⌂|1)
+            │       │       └── ►:4[3]:anon:
+            │       │           └── 🏁·8f0d338 (⌂|1) ►tags/base
+            │       └── →:4:
             └── ►:2[1]:C
                 ├── ·930563a (⌂|1)
                 ├── ·68a2fc3 (⌂|1)
                 └── ·984fd1c (⌂|1)
-                    └── →:3:
+                    └── →:4:
     ");
     let outcome = outcome.materialize()?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   b78a484 (HEAD -> main) Merge branches 'A', 'B' and 'C'
+    *   ee7f107 (HEAD -> main) Merge branches 'A', 'B' and 'C'
     |\  
     | * 930563a (C) C: add another 10 lines to new file
     | * 68a2fc3 C: add 10 lines to new file
     | * 984fd1c C: new file with 10 lines
-    * |   706b5e8 (A) A: 10 lines on top
-    |\ \  
-    | |/  
-    |/|   
-    | * a748762 (B) B: another 10 lines at the bottom
-    | * 62e05ba B: 10 lines at the bottom
+    * | 69221b4 (A) A: 10 lines on top
+    |\| 
+    * | a748762 (B) B: another 10 lines at the bottom
+    * | 62e05ba B: 10 lines at the bottom
     |/  
     * 8f0d338 (tag: base) base
     ");
@@ -92,7 +109,6 @@ fn insert_single_node_segment_above() -> Result<()> {
 
     Ok(())
 }
-
 #[test]
 fn insert_single_node_segment_below() -> Result<()> {
     let (repo, _tmp, mut meta) = fixture_writable("three-branches-merged")?;
@@ -142,39 +158,37 @@ fn insert_single_node_segment_below() -> Result<()> {
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:main[🌳]
-        └── ·32e9d3a (⌂|1)
+        └── ·b005f3c (⌂|1)
             ├── ►:1[2]:A
-            │   └── ·032ef08 (⌂|1)
-            │       ├── ►:4[4]:anon:
-            │       │   └── 🏁·8f0d338 (⌂|1) ►tags/base
-            │       └── ►:5[3]:anon:
-            │           └── ·62e05ba (⌂|1)
-            │               └── →:4:
+            │   └── ·7f0cc55 (⌂|1)
+            │       ├── ►:4[3]:anon:
+            │       │   └── ·62e05ba (⌂|1)
+            │       │       └── ►:5[4]:anon:
+            │       │           └── 🏁·8f0d338 (⌂|1) ►tags/base
+            │       └── →:5:
             ├── ►:2[1]:B
-            │   └── ·2d43620 (⌂|1)
+            │   └── ·a3301fe (⌂|1)
             │       └── →:1: (A)
             └── ►:3[1]:C
                 ├── ·930563a (⌂|1)
                 ├── ·68a2fc3 (⌂|1)
                 └── ·984fd1c (⌂|1)
-                    └── →:4:
+                    └── →:5:
     ");
     let outcome = outcome.materialize()?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *-.   32e9d3a (HEAD -> main) Merge branches 'A', 'B' and 'C'
+    *-.   b005f3c (HEAD -> main) Merge branches 'A', 'B' and 'C'
     |\ \  
     | | * 930563a (C) C: add another 10 lines to new file
     | | * 68a2fc3 C: add 10 lines to new file
     | | * 984fd1c C: new file with 10 lines
-    | * | 2d43620 (B) B: another 10 lines at the bottom
+    | * | a3301fe (B) B: another 10 lines at the bottom
     |/ /  
-    * |   032ef08 (A) A: 10 lines on top
-    |\ \  
-    | |/  
-    |/|   
-    | * 62e05ba B: 10 lines at the bottom
+    * | 7f0cc55 (A) A: 10 lines on top
+    |\| 
+    * | 62e05ba B: 10 lines at the bottom
     |/  
     * 8f0d338 (tag: base) base
     ");
@@ -182,7 +196,6 @@ fn insert_single_node_segment_below() -> Result<()> {
 
     Ok(())
 }
-
 #[test]
 fn insert_multi_node_segment_above() -> Result<()> {
     let (repo, _tmp, mut meta) = fixture_writable("three-branches-merged")?;
@@ -236,37 +249,35 @@ fn insert_multi_node_segment_above() -> Result<()> {
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:main[🌳]
-        └── ·85677e6 (⌂|1)
+        └── ·61b2679 (⌂|1)
             ├── ►:1[1]:anon:
-            │   └── ·9da738d (⌂|1) ►A, ►B
+            │   └── ·758c8a3 (⌂|1) ►A, ►B
             │       └── ►:3[2]:anon:
-            │           └── ·8e18b4e (⌂|1)
-            │               ├── ►:4[4]:anon:
-            │               │   └── 🏁·8f0d338 (⌂|1) ►tags/base
-            │               └── ►:5[3]:anon:
-            │                   └── ·add59d2 (⌂|1)
-            │                       └── →:4:
+            │           └── ·db40ffc (⌂|1)
+            │               ├── ►:4[3]:anon:
+            │               │   └── ·add59d2 (⌂|1)
+            │               │       └── ►:5[4]:anon:
+            │               │           └── 🏁·8f0d338 (⌂|1) ►tags/base
+            │               └── →:5:
             └── ►:2[1]:C
                 ├── ·930563a (⌂|1)
                 ├── ·68a2fc3 (⌂|1)
                 └── ·984fd1c (⌂|1)
-                    └── →:4:
+                    └── →:5:
     ");
     let outcome = outcome.materialize()?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   85677e6 (HEAD -> main) Merge branches 'A', 'B' and 'C'
+    *   61b2679 (HEAD -> main) Merge branches 'A', 'B' and 'C'
     |\  
     | * 930563a (C) C: add another 10 lines to new file
     | * 68a2fc3 C: add 10 lines to new file
     | * 984fd1c C: new file with 10 lines
-    * | 9da738d (B, A) B: another 10 lines at the bottom
-    * |   8e18b4e B: 10 lines at the bottom
-    |\ \  
-    | |/  
-    |/|   
-    | * add59d2 A: 10 lines on top
+    * | 758c8a3 (B, A) B: another 10 lines at the bottom
+    * | db40ffc B: 10 lines at the bottom
+    |\| 
+    * | add59d2 A: 10 lines on top
     |/  
     * 8f0d338 (tag: base) base
     ");
@@ -415,6 +426,7 @@ fn insert_single_node_segment_above_with_explicit_children() -> Result<()> {
         delimiter,
         mutate::InsertSide::Above,
         Some(mutate::SomeSelectors::new(vec![c_selector])?),
+        mutate::ParentReparentingOrder::Prepend,
     )?;
 
     let outcome = editor.rebase()?;
@@ -422,18 +434,18 @@ fn insert_single_node_segment_above_with_explicit_children() -> Result<()> {
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:main[🌳]
-        └── ·caf3957 (⌂|1)
+        └── ·cca953f (⌂|1)
             ├── ►:1[2]:A
-            │   └── ·706b5e8 (⌂|1)
-            │       ├── ►:4[4]:anon:
-            │       │   └── 🏁·8f0d338 (⌂|1) ►tags/base
-            │       └── ►:2[3]:B
-            │           ├── ·a748762 (⌂|1)
-            │           └── ·62e05ba (⌂|1)
-            │               └── →:4:
+            │   └── ·69221b4 (⌂|1)
+            │       ├── ►:2[3]:B
+            │       │   ├── ·a748762 (⌂|1)
+            │       │   └── ·62e05ba (⌂|1)
+            │       │       └── ►:4[4]:anon:
+            │       │           └── 🏁·8f0d338 (⌂|1) ►tags/base
+            │       └── →:4:
             ├── →:2: (B)
             └── ►:3[1]:C
-                └── ·23b76e7 (⌂|1)
+                └── ·76e2160 (⌂|1)
                     ├── ►:5[2]:anon:
                     │   ├── ·68a2fc3 (⌂|1)
                     │   └── ·984fd1c (⌂|1)
@@ -444,16 +456,18 @@ fn insert_single_node_segment_above_with_explicit_children() -> Result<()> {
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *-.   caf3957 (HEAD -> main) Merge branches 'A', 'B' and 'C'
+    *-.   cca953f (HEAD -> main) Merge branches 'A', 'B' and 'C'
     |\ \  
-    | | *   23b76e7 (C) C: add another 10 lines to new file
+    | | *   76e2160 (C) C: add another 10 lines to new file
     | | |\  
     | |_|/  
     |/| |   
-    * | | 706b5e8 (A) A: 10 lines on top
-    |\| | 
-    | * | a748762 (B) B: another 10 lines at the bottom
-    | * | 62e05ba B: 10 lines at the bottom
+    * | |   69221b4 (A) A: 10 lines on top
+    |\ \ \  
+    | |/ /  
+    |/| |   
+    * | | a748762 (B) B: another 10 lines at the bottom
+    * | | 62e05ba B: 10 lines at the bottom
     |/ /  
     | * 68a2fc3 C: add 10 lines to new file
     | * 984fd1c C: new file with 10 lines
@@ -516,6 +530,7 @@ fn insert_single_node_segment_below_with_explicit_parents() -> Result<()> {
         delimiter,
         mutate::InsertSide::Below,
         Some(mutate::SomeSelectors::new(vec![c_selector])?),
+        mutate::ParentReparentingOrder::Prepend,
     )?;
 
     let outcome = editor.rebase()?;
@@ -523,43 +538,105 @@ fn insert_single_node_segment_below_with_explicit_parents() -> Result<()> {
     insta::assert_snapshot!(overlayed, @"
 
     └── 👉►:0[0]:main[🌳]
-        └── ·c1cb047 (⌂|1)
+        └── ·54f9cab (⌂|1)
             ├── ►:1[1]:A
-            │   └── ·275b149 (⌂|1)
+            │   └── ·9501727 (⌂|1)
             │       ├── ►:4[4]:anon:
             │       │   └── 🏁·8f0d338 (⌂|1) ►tags/base
             │       └── ►:2[2]:B
-            │           └── ·9c9c689 (⌂|1)
-            │               ├── ►:5[3]:anon:
-            │               │   └── ·62e05ba (⌂|1)
+            │           └── ·347772f (⌂|1)
+            │               ├── ►:3[3]:C
+            │               │   ├── ·930563a (⌂|1)
+            │               │   ├── ·68a2fc3 (⌂|1)
+            │               │   └── ·984fd1c (⌂|1)
             │               │       └── →:4:
-            │               └── ►:3[3]:C
-            │                   ├── ·930563a (⌂|1)
-            │                   ├── ·68a2fc3 (⌂|1)
-            │                   └── ·984fd1c (⌂|1)
+            │               └── ►:5[3]:anon:
+            │                   └── ·62e05ba (⌂|1)
             │                       └── →:4:
             ├── →:2: (B)
             └── →:3: (C)
     ");
     let outcome = outcome.materialize()?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
+    assert_eq!(
+        parent_subjects(&repo, "B")?,
+        [
+            "C: add another 10 lines to new file",
+            "B: 10 lines at the bottom"
+        ]
+    );
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *-.   c1cb047 (HEAD -> main) Merge branches 'A', 'B' and 'C'
+    *-.   54f9cab (HEAD -> main) Merge branches 'A', 'B' and 'C'
     |\ \  
-    * | | 275b149 (A) A: 10 lines on top
+    * | | 9501727 (A) A: 10 lines on top
     |\| | 
-    | * | 9c9c689 (B) B: another 10 lines at the bottom
-    | |\| 
-    | | * 930563a (C) C: add another 10 lines to new file
-    | | * 68a2fc3 C: add 10 lines to new file
-    | | * 984fd1c C: new file with 10 lines
+    | * |   347772f (B) B: another 10 lines at the bottom
+    | |\ \  
+    | | |/  
+    | |/|   
+    | | * 62e05ba B: 10 lines at the bottom
     | |/  
     |/|   
-    | * 62e05ba B: 10 lines at the bottom
+    | * 930563a (C) C: add another 10 lines to new file
+    | * 68a2fc3 C: add 10 lines to new file
+    | * 984fd1c C: new file with 10 lines
     |/  
     * 8f0d338 (tag: base) base
     ");
+    insta::assert_snapshot!(git_status(&repo)?, @"");
+
+    Ok(())
+}
+
+#[test]
+fn insert_single_node_segment_below_can_append_reparented_parent() -> Result<()> {
+    let (repo, _tmp, mut meta) = fixture_writable("three-branches-merged")?;
+    let graph = Graph::from_head(
+        &repo,
+        &*meta,
+        but_core::ref_metadata::ProjectMeta::default(),
+        standard_options(),
+    )?
+    .validated()?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let a = repo.rev_parse_single("A")?.detach();
+    let a_selector = editor
+        .select_commit(a)
+        .context("Failed to find commit a in editor graph")?;
+    let b = repo.rev_parse_single("B")?.detach();
+    let b_selector = editor
+        .select_commit(b)
+        .context("Failed to find commit b in editor graph")?;
+    let c = repo.rev_parse_single("C")?.detach();
+    let c_selector = editor
+        .select_commit(c)
+        .context("Failed to find commit c in editor graph")?;
+
+    let delimiter = mutate::SegmentDelimiter {
+        child: b_selector,
+        parent: b_selector,
+    };
+
+    editor.insert_segment_into(
+        a_selector,
+        delimiter,
+        mutate::InsertSide::Below,
+        Some(mutate::SomeSelectors::new(vec![c_selector])?),
+        mutate::ParentReparentingOrder::Append,
+    )?;
+
+    editor.rebase()?.materialize()?;
+    assert_eq!(
+        parent_subjects(&repo, "B")?,
+        [
+            "B: 10 lines at the bottom",
+            "C: add another 10 lines to new file"
+        ]
+    );
+
     insta::assert_snapshot!(git_status(&repo)?, @"");
 
     Ok(())

--- a/crates/but-workspace/src/branch/move_branch.rs
+++ b/crates/but-workspace/src/branch/move_branch.rs
@@ -130,6 +130,7 @@ pub(super) mod function {
             subject_delimiter,
             but_rebase::graph_rebase::mutate::InsertSide::Above,
             Some(selectors),
+            but_rebase::graph_rebase::mutate::ParentReparentingOrder::Prepend,
         )?;
 
         // Update the workspace meta in order to create a new stack containing the

--- a/crates/but-workspace/tests/fixtures/scenario/gb-1525-reorder-merge-commit.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/gb-1525-reorder-merge-commit.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+git init
+
+echo base >file && git add . && git commit -m "base" && git tag base
+
+git checkout -b feature-parent
+echo parent-one >>parent.txt && git add . && git commit -m "add parent.txt"
+echo parent-two >>parent.txt && git add . && git commit -m "update parent.txt (1)"
+echo parent-three >>parent.txt && git add . && git commit -m "update parent.txt (2)"
+
+git checkout -b main-advanced base
+echo main-one >>main.txt && git add . && git commit -m "update main.txt (1)"
+git branch -f main
+git update-ref refs/remotes/origin/main main
+
+git checkout -b child-stack main
+git merge --no-ff feature-parent -m "M: merge feature-parent"
+git branch M
+
+echo child-one >child-1.txt && git add . && git commit -m "C1: add child-1.txt"
+git branch C1
+
+echo other >other.txt && git add . && git commit -m "C2: add other.txt"
+git branch C2

--- a/crates/but-workspace/tests/workspace/commit/move_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/move_commit.rs
@@ -1,9 +1,21 @@
+use bstr::ByteSlice;
 use but_rebase::graph_rebase::{Editor, mutate::InsertSide};
 use but_testsupport::{graph_workspace, visualize_commit_graph_all};
 
 use crate::ref_info::with_workspace_commit::utils::{
     StackState, add_stack_with_segments, named_writable_scenario_with_description_and_graph,
 };
+
+fn parent_subjects(repo: &gix::Repository, rev: &str) -> anyhow::Result<Vec<String>> {
+    let commit = repo.find_commit(repo.rev_parse_single(rev)?.detach())?;
+    commit
+        .parent_ids()
+        .map(|parent_id| {
+            let parent = repo.find_commit(parent_id.detach())?;
+            Ok(parent.message_raw()?.trim_end().to_str_lossy().to_string())
+        })
+        .collect()
+}
 
 #[test]
 fn move_top_commit_to_top_of_another_stack() -> anyhow::Result<()> {
@@ -708,6 +720,149 @@ fn move_commit_in_non_managed_workspace() -> anyhow::Result<()> {
         │   └── ·16fd221
         └── :3:one
             └── ·8b426d0
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn reorder_merge_commit_above_keeps_child_commits_visible() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph("gb-1525-reorder-merge-commit", |_| {})?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 32c8bda (HEAD -> child-stack, C2) C2: add other.txt
+    * 64dace5 (C1) C1: add child-1.txt
+    *   197bdf1 (M) M: merge feature-parent
+    |\  
+    | * b54108c (feature-parent) update parent.txt (2)
+    | * 1b1a64f update parent.txt (1)
+    | * 40bcd70 add parent.txt
+    * | aa67ae0 (origin/main, main-advanced, main) update main.txt (1)
+    |/  
+    * 7674a5e (tag: base) base
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    ⌂:0:child-stack[🌳] <> ✓refs/remotes/origin/main on aa67ae0
+    └── ≡:0:child-stack[🌳] on aa67ae0 {1}
+        ├── :0:child-stack[🌳]
+        │   └── ·32c8bda ►C2
+        ├── :3:C1
+        │   └── ·64dace5
+        └── :4:M
+            └── ·197bdf1
+    ");
+
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+    let merge_commit = repo.rev_parse_single("M")?.detach();
+    let merge_commit_selector = editor.select_commit(merge_commit)?;
+    let c1_commit = repo.rev_parse_single("C1")?.detach();
+    let c1_commit_selector = editor.select_commit(c1_commit)?;
+
+    let rebase = but_workspace::commit::move_commit(
+        editor,
+        merge_commit_selector,
+        c1_commit_selector,
+        InsertSide::Above,
+    )?;
+
+    rebase.materialize()?;
+    let project_meta = ws.graph.project_meta.clone();
+    ws.refresh_from_head(&repo, &meta, project_meta)?;
+
+    let post_move_graph = visualize_commit_graph_all(&repo)?;
+    assert_eq!(
+        parent_subjects(&repo, "C1")?,
+        vec![
+            "C1: add child-1.txt".to_string(),
+            "update parent.txt (2)".to_string()
+        ],
+        "moving the merge commit above C1 should preserve the visible first-parent lane"
+    );
+    insta::assert_snapshot!(post_move_graph, @r"
+    * 1fa67f9 (HEAD -> child-stack, C2) C2: add other.txt
+    *   88f8bb5 (C1) M: merge feature-parent
+    |\  
+    | * b54108c (feature-parent) update parent.txt (2)
+    | * 1b1a64f update parent.txt (1)
+    | * 40bcd70 add parent.txt
+    * | 40eca7d C1: add child-1.txt
+    * | aa67ae0 (origin/main, main-advanced, main, M) update main.txt (1)
+    |/  
+    * 7674a5e (tag: base) base
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn reorder_merge_commit_below_keeps_child_commits_visible() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph("gb-1525-reorder-merge-commit", |_| {})?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 32c8bda (HEAD -> child-stack, C2) C2: add other.txt
+    * 64dace5 (C1) C1: add child-1.txt
+    *   197bdf1 (M) M: merge feature-parent
+    |\  
+    | * b54108c (feature-parent) update parent.txt (2)
+    | * 1b1a64f update parent.txt (1)
+    | * 40bcd70 add parent.txt
+    * | aa67ae0 (origin/main, main-advanced, main) update main.txt (1)
+    |/  
+    * 7674a5e (tag: base) base
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    ⌂:0:child-stack[🌳] <> ✓refs/remotes/origin/main on aa67ae0
+    └── ≡:0:child-stack[🌳] on aa67ae0 {1}
+        ├── :0:child-stack[🌳]
+        │   └── ·32c8bda ►C2
+        ├── :3:C1
+        │   └── ·64dace5
+        └── :4:M
+            └── ·197bdf1
+    ");
+
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+    let merge_commit = repo.rev_parse_single("M")?.detach();
+    let merge_commit_selector = editor.select_commit(merge_commit)?;
+    let main_commit = repo.rev_parse_single("main")?.detach();
+    let main_commit_selector = editor.select_commit(main_commit)?;
+
+    let rebase = but_workspace::commit::move_commit(
+        editor,
+        merge_commit_selector,
+        main_commit_selector,
+        InsertSide::Below,
+    )?;
+
+    rebase.materialize()?;
+    let project_meta = ws.graph.project_meta.clone();
+    ws.refresh_from_head(&repo, &meta, project_meta)?;
+
+    let post_move_graph = visualize_commit_graph_all(&repo)?;
+    assert_eq!(
+        parent_subjects(&repo, "HEAD~3")?,
+        vec!["base".to_string(), "update parent.txt (2)".to_string()],
+        "moving the merge commit below main should make main's first parent the merge commit's first parent"
+    );
+    insta::assert_snapshot!(post_move_graph, @r"
+    * 3cf4ba4 (HEAD -> child-stack, C2) C2: add other.txt
+    * 7673ad4 (C1) C1: add child-1.txt
+    * 8a192c0 (main-advanced, main, M) update main.txt (1)
+    *   ed12786 M: merge feature-parent
+    |\  
+    | * b54108c (feature-parent) update parent.txt (2)
+    | * 1b1a64f update parent.txt (1)
+    | * 40bcd70 add parent.txt
+    |/  
+    | * aa67ae0 (origin/main) update main.txt (1)
+    |/  
+    * 7674a5e (tag: base) base
     ");
 
     Ok(())


### PR DESCRIPTION
By default, insert the segments as first parents when inserting below. If
insertng above, inserts the target as the first parent.


Fixes GB-1525

Implementation notes:
- Added `ParentReparentingOrder` so advanced callers can choose whether reparented parents are prepended or appended.
- `insert_segment` keeps the default behavior simple by using `Prepend`.
- Added parent-order regression coverage for the GB-1525 merge-commit reorder case and explicit append-policy coverage.