### PR TITLE
Lite: use file paths instead of file operands

### DIFF
--- a/apps/lite/ui/src/projects/state.ts
+++ b/apps/lite/ui/src/projects/state.ts
@@ -1,16 +1,15 @@
-import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
-import type { RootState } from "#ui/store.ts";
-import { type AbsorptionTarget, type RefInfo, type RelativeTo } from "@gitbutler/but-sdk";
 import {
 	type BranchOperand,
 	type CommitOperand,
-	type FileOperand,
 	type HunkOperand,
 	type Operand,
 } from "#ui/operands.ts";
-import * as workspace from "#ui/projects/workspace/state.ts";
 import { type OperationType } from "#ui/operations/operation.ts";
 import { type TransferOperationMode } from "#ui/outline/mode.ts";
+import * as workspace from "#ui/projects/workspace/state.ts";
+import type { RootState } from "#ui/store.ts";
+import { type AbsorptionTarget, type RefInfo, type RelativeTo } from "@gitbutler/but-sdk";
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 
 type Dialog =
 	| { _tag: "None" }
@@ -70,7 +69,7 @@ const projectSlice = createSlice({
 		},
 		selectFiles: (
 			state,
-			action: PayloadAction<{ projectId: string; selection: FileOperand | null }>,
+			action: PayloadAction<{ projectId: string; selection: string | null }>,
 		) => {
 			const { projectId, selection } = action.payload;
 			const projectState = ensureProjectState(state, projectId);

--- a/apps/lite/ui/src/projects/workspace/state.ts
+++ b/apps/lite/ui/src/projects/workspace/state.ts
@@ -3,16 +3,12 @@ import { refNamesEqual } from "#ui/api/ref-name.ts";
 import { AbsorptionTarget, type RefInfo, type RelativeTo } from "@gitbutler/but-sdk";
 import { Match } from "effect";
 import {
-	branchFileParent,
 	branchOperand,
-	commitFileParent,
 	commitOperand,
-	fileOperand,
 	hunkOperand,
 	operandEquals,
 	type BranchOperand,
 	type CommitOperand,
-	type FileOperand,
 	type HunkOperand,
 	type Operand,
 } from "#ui/operands.ts";
@@ -33,7 +29,7 @@ import { mapKeys } from "effect/Record";
 
 export type SelectionState = {
 	outline: Operand | null;
-	files: FileOperand | null;
+	files: string | null;
 	diff: HunkOperand | null;
 };
 
@@ -164,13 +160,8 @@ export const selectOutline = (state: WorkspaceState, selection: Operand | null) 
 		exitMode(state);
 };
 
-export const selectFiles = (state: WorkspaceState, selection: FileOperand | null) => {
-	if (
-		selection &&
-		state.selection.files &&
-		operandEquals(fileOperand(state.selection.files), fileOperand(selection))
-	)
-		return;
+export const selectFiles = (state: WorkspaceState, selection: string | null) => {
+	if (state.selection.files === selection) return;
 
 	state.selection.files = selection;
 };
@@ -264,19 +255,6 @@ export const updateRewrittenCommitReferences = (
 	});
 	if (commit) state.selection.outline = commit;
 
-	if (state.selection.files?.parent._tag === "Commit") {
-		const commit = rewrittenCommitOperand({
-			commit: state.selection.files.parent,
-			replacedCommits,
-			headInfo,
-		});
-		if (commit)
-			state.selection.files = {
-				parent: commitFileParent(commit),
-				path: state.selection.files.path,
-			};
-	}
-
 	if (state.commitTarget?.type === "commit") {
 		const commitId = replacedCommits[state.commitTarget.subject];
 		if (commitId !== undefined) state.commitTarget = { type: "commit", subject: commitId };
@@ -317,15 +295,6 @@ export const updateRewrittenBranchReferences = (
 		state.selection.outline = newBranchOperand;
 
 	if (
-		state.selection.files?.parent._tag === "Branch" &&
-		operandEquals(branchOperand(state.selection.files.parent), oldBranchOperand)
-	)
-		state.selection.files = {
-			parent: branchFileParent(newBranch),
-			path: state.selection.files.path,
-		};
-
-	if (
 		state.commitTarget?.type === "referenceBytes" &&
 		refNamesEqual(state.commitTarget.subject, oldBranch.branchRef)
 	)
@@ -346,7 +315,7 @@ export const startRewordCommit = (state: WorkspaceState, commit: CommitOperand) 
 export const selectSelectionOutlineState = (state: WorkspaceState): Operand | null =>
 	state.selection.outline;
 
-export const selectSelectionFilesState = (state: WorkspaceState): FileOperand | null =>
+export const selectSelectionFilesState = (state: WorkspaceState): string | null =>
 	state.selection.files;
 
 export const selectSelectionDiffState = (state: WorkspaceState): HunkOperand | null =>

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -16,11 +16,11 @@ import {
 	changesSectionOperand,
 	commitFileParent,
 	commitOperand,
+	FileOperand,
 	fileOperand,
 	hunkOperand,
 	operandIdentityKey,
 	type CommitOperand,
-	type FileOperand,
 	type FileParent,
 	type HunkOperand,
 	type Operand,
@@ -50,7 +50,7 @@ import {
 import { CodeView, type CodeViewHandle } from "@pierre/diffs/react";
 import { useSuspenseQueries } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
-import { Hash, Match } from "effect";
+import { Hash, identity, Match } from "effect";
 import { ComponentProps, FC, type RefObject, Suspense, useDeferredValue, useRef } from "react";
 import styles from "./Details.module.css";
 import { workspaceHotkeys } from "#ui/hotkeys.ts";
@@ -81,9 +81,6 @@ const codeViewItemId = ({ changesetKey, path }: { changesetKey: string; path: st
 
 const codeViewItemIdPath = ({ changesetKey, id }: { changesetKey: string; id: string }): string =>
 	id.slice(changesetKey.length + 1);
-
-const fileOperandIdentityKey = (operand: FileOperand): string =>
-	operandIdentityKey(fileOperand(operand));
 
 const hunkOperandIdentityKey = (operand: HunkOperand): string =>
 	operandIdentityKey(hunkOperand(operand));
@@ -254,7 +251,6 @@ const build = ({ fileParent, changes, treeChangeDiffs, changesetKey }: BuildIn):
 				parent: fileParent,
 				path: change.path,
 			};
-			const fileKey = fileOperandIdentityKey(file);
 
 			for (const hunk of item.fileDiff.hunks)
 				for (const selection of contiguousSelectionsFromHunk(hunk)) {
@@ -268,7 +264,7 @@ const build = ({ fileParent, changes, treeChangeDiffs, changesetKey }: BuildIn):
 					const len = navigationIndex.items.push(hunkOperand);
 					navigationIndex.indexByKey.set(hunkKey, len - 1);
 
-					if (!initialFileHunks.has(fileKey)) initialFileHunks.set(fileKey, hunkOperand);
+					if (!initialFileHunks.has(file.path)) initialFileHunks.set(file.path, hunkOperand);
 
 					selectedRangeByHunk.set(hunkKey, {
 						id: item.id,
@@ -289,7 +285,7 @@ const build = ({ fileParent, changes, treeChangeDiffs, changesetKey }: BuildIn):
 
 const DiffContents: FC<{
 	selectionScopeRef: RefObject<HTMLDivElement | null>;
-	onViewerFileSelection: (selection: FileOperand) => void;
+	onViewerFileSelection: (selection: string) => void;
 	fileParent: FileParent;
 	changesetKey: string;
 	projectId: string;
@@ -355,10 +351,7 @@ const DiffContents: FC<{
 		// This can happen on very fast scroll.
 		if (activeItem === undefined) return;
 
-		onViewerFileSelection({
-			parent: fileParent,
-			path: codeViewItemIdPath({ changesetKey, id: activeItem.id }),
-		});
+		onViewerFileSelection(codeViewItemIdPath({ changesetKey, id: activeItem.id }));
 	};
 
 	// We currently only support selecting contiguous blocks.
@@ -714,15 +707,15 @@ const Diff: FC<{
 	changes: Array<TreeChange>;
 	filesVisible: boolean;
 	filesItems: Array<FileTreeItem>;
-	onFileSelection: (selection: FileOperand) => void;
+	onFileSelection: (selection: string) => void;
 	outlineSelection: Operand;
 	projectId: string;
 }> = ({ changes, filesVisible, filesItems, onFileSelection, outlineSelection, projectId }) => {
 	const selectionScopeRef = useRef<HTMLDivElement>(null);
 	const viewerRef = useRef<CodeViewHandle<undefined>>(null);
 	const dispatch = useAppDispatch();
-	const files = filesItems.map((item) => item.operand);
-	const filesNavigationIndex = buildNavigationIndex(files, fileOperandIdentityKey);
+	const files = filesItems.map((item) => item.operand.path);
+	const filesNavigationIndex = buildNavigationIndex(files, identity);
 
 	const changesetKey = Match.value(outlineSelection).pipe(
 		Match.tags({
@@ -752,19 +745,19 @@ const Diff: FC<{
 		changesetKey,
 	});
 
-	const selectFileAndNavigateDiff = (selection: FileOperand) => {
+	const selectFileAndNavigateDiff = (selection: string) => {
 		onFileSelection(selection);
 
 		dispatch(
 			projectActions.selectDiff({
 				projectId,
-				selection: initialFileHunks.get(fileOperandIdentityKey(selection)) ?? null,
+				selection: initialFileHunks.get(selection) ?? null,
 			}),
 		);
 
 		viewerRef.current?.scrollTo({
 			type: "item",
-			id: codeViewItemId({ changesetKey, path: selection.path }),
+			id: codeViewItemId({ changesetKey, path: selection }),
 		});
 	};
 
@@ -780,6 +773,7 @@ const Diff: FC<{
 					projectId={projectId}
 					items={filesItems}
 					navigationIndex={filesNavigationIndex}
+					fileParent={fileParent}
 				/>
 			)}
 
@@ -822,7 +816,7 @@ export const Details: FC<
 	const filesVisible = useAppSelector((state) => selectProjectFilesVisible(state, projectId));
 	const outlineSelection = useDeferredValue(urgentOutlineSelection);
 
-	const selectFile = (selection: FileOperand) => {
+	const selectFile = (selection: string) => {
 		dispatch(projectActions.selectFiles({ projectId, selection }));
 	};
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -20,7 +20,6 @@ import {
 	fileOperand,
 	hunkOperand,
 	operandIdentityKey,
-	type CommitOperand,
 	type FileParent,
 	type HunkOperand,
 	type Operand,
@@ -86,10 +85,8 @@ const hunkOperandIdentityKey = (operand: HunkOperand): string =>
 	operandIdentityKey(hunkOperand(operand));
 
 const getCommitFileTreeItems = ({
-	commit,
 	commitDetails,
 }: {
-	commit: CommitOperand;
 	commitDetails: CommitDetails;
 }): Array<FileTreeItem> => {
 	const conflictedPaths = commitDetails.conflictEntries
@@ -106,10 +103,6 @@ const getCommitFileTreeItems = ({
 	return [
 		...conflictedPaths.map((path) =>
 			conflictFileTreeItem({
-				operand: {
-					parent: commitFileParent(commit),
-					path,
-				},
 				path,
 			}),
 		),
@@ -118,10 +111,7 @@ const getCommitFileTreeItems = ({
 			.map((change) =>
 				changeFileTreeItem({
 					change,
-					operand: {
-						parent: commitFileParent(commit),
-						path: change.path,
-					},
+					path: change.path,
 				}),
 			),
 	];
@@ -141,30 +131,16 @@ const getChangesFileTreeItems = (worktreeChanges: WorktreeChanges): Array<FileTr
 		return changeFileTreeItem({
 			change,
 			dependencyCommitIds,
-			operand: {
-				parent: changesFileParent,
-				path: change.path,
-			},
+			path: change.path,
 		});
 	});
 };
 
-const getBranchFileTreeItems = ({
-	stackId,
-	branchRef,
-	branchDiff,
-}: {
-	stackId: string;
-	branchRef: Array<number>;
-	branchDiff: TreeChanges;
-}): Array<FileTreeItem> =>
+const getBranchFileTreeItems = ({ branchDiff }: { branchDiff: TreeChanges }): Array<FileTreeItem> =>
 	branchDiff.changes.map((change) =>
 		changeFileTreeItem({
 			change,
-			operand: {
-				parent: branchFileParent({ stackId, branchRef }),
-				path: change.path,
-			},
+			path: change.path,
 		}),
 	);
 
@@ -714,7 +690,7 @@ const Diff: FC<{
 	const selectionScopeRef = useRef<HTMLDivElement>(null);
 	const viewerRef = useRef<CodeViewHandle<undefined>>(null);
 	const dispatch = useAppDispatch();
-	const files = filesItems.map((item) => item.operand.path);
+	const files = filesItems.map((item) => item.path);
 	const filesNavigationIndex = buildNavigationIndex(files, identity);
 
 	const changesetKey = Match.value(outlineSelection).pipe(
@@ -879,7 +855,7 @@ export const Details: FC<
 								{({ data: commitDetails }) =>
 									render({
 										changes: commitDetails.changes,
-										filesItems: getCommitFileTreeItems({ commit, commitDetails }),
+										filesItems: getCommitFileTreeItems({ commitDetails }),
 									})
 								}
 							</SuspenseQuery>
@@ -894,14 +870,14 @@ export const Details: FC<
 								}
 							</SuspenseQuery>
 						)),
-						Match.tag("Branch", ({ stackId, branchRef }) => (
+						Match.tag("Branch", ({ branchRef }) => (
 							<SuspenseQuery
 								{...branchDiffQueryOptions({ projectId, branch: decodeBytes(branchRef) })}
 							>
 								{({ data: branchDiff }) =>
 									render({
 										changes: branchDiff.changes,
-										filesItems: getBranchFileTreeItems({ stackId, branchRef, branchDiff }),
+										filesItems: getBranchFileTreeItems({ branchDiff }),
 									})
 								}
 							</SuspenseQuery>

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
@@ -1,6 +1,6 @@
 import { changesInWorktreeQueryOptions } from "#ui/api/queries.ts";
 import { showNativeContextMenu, showNativeMenuFromTrigger } from "#ui/native-menu.ts";
-import { changesFileParent, fileOperand, FileParent, type FileOperand } from "#ui/operands.ts";
+import { changesFileParent, fileOperand, FileParent } from "#ui/operands.ts";
 import {
 	projectActions,
 	selectProjectHasCheckedCommits,
@@ -114,28 +114,26 @@ const useFilesTreeHotkeys = ({
 type ChangeFileTreeItem = {
 	change: TreeChange;
 	dependencyCommitIds?: Array.NonEmptyArray<string>;
-	operand: FileOperand;
+	path: string;
 };
 
 export const changeFileTreeItem = ({
 	change,
 	dependencyCommitIds,
-	operand,
+	path,
 }: ChangeFileTreeItem): FileTreeItem => ({
 	_tag: "Change",
 	change,
 	dependencyCommitIds,
-	operand,
+	path,
 });
 
 type ConflictFileTreeItem = {
-	operand: FileOperand;
 	path: string;
 };
 
-export const conflictFileTreeItem = ({ operand, path }: ConflictFileTreeItem): FileTreeItem => ({
+export const conflictFileTreeItem = ({ path }: ConflictFileTreeItem): FileTreeItem => ({
 	_tag: "Conflict",
-	operand,
 	path,
 });
 
@@ -191,9 +189,9 @@ export const FilesTree: FC<
 						<div role="group">
 							{items.map((item) => (
 								<TreeItem
-									key={item.operand.path}
+									key={item.path}
 									projectId={projectId}
-									path={item.operand.path}
+									path={item.path}
 									aria-label={
 										item._tag === "Change"
 											? `${statusLabel(item.change.status)} ${item.change.path}`
@@ -202,14 +200,15 @@ export const FilesTree: FC<
 									render={
 										<OperationSourceC
 											projectId={projectId}
-											source={fileOperand(item.operand)}
-											onDragStart={() => onFileSelection(item.operand.path)}
+											source={fileOperand({ parent: fileParent, path: item.path })}
+											onDragStart={() => onFileSelection(item.path)}
 											render={
 												<FileRow
 													item={item}
-													path={item.operand.path}
+													path={item.path}
 													onFileSelection={onFileSelection}
 													projectId={projectId}
+													fileParent={fileParent}
 												/>
 											}
 										/>
@@ -288,14 +287,15 @@ const FileRow: FC<
 	{
 		item: FileTreeItem;
 		projectId: string;
+		fileParent: FileParent;
 	} & Omit<ComponentProps<typeof ItemRow>, "projectId" | "operand">
-> = ({ item, projectId, ...restProps }) => {
+> = ({ item, projectId, fileParent, ...restProps }) => {
 	const relativePath = item._tag === "Change" ? item.change.path : item.path;
 
 	const outlineMode = useAppSelector((state) => selectProjectOutlineModeState(state, projectId));
 	const menuItems = useFileMenuItems({
 		projectId,
-		operand: item.operand,
+		operand: { parent: fileParent, path: relativePath },
 		path: relativePath,
 		change: item._tag === "Change" ? item.change : undefined,
 	});
@@ -308,7 +308,7 @@ const FileRow: FC<
 		<ItemRow
 			{...restProps}
 			projectId={projectId}
-			path={item.operand.path}
+			path={item.path}
 			className={classes(restProps.className, styles.fileRow)}
 			onContextMenu={(event) => {
 				void showNativeContextMenu(event, menuItems);
@@ -341,10 +341,10 @@ const FileRow: FC<
 
 			{outlineMode._tag === "Default" && (
 				<Toolbar.Root aria-label="File actions" render={<WorkspaceItemRowToolbar />}>
-					{Match.value(item).pipe(
+					{Match.value({ item, fileParent }).pipe(
 						Match.when(
-							{ _tag: "Change", operand: { parent: { _tag: "Changes" } } },
-							(item) =>
+							{ item: { _tag: "Change" }, fileParent: { _tag: "Changes" } },
+							({ item }) =>
 								item.dependencyCommitIds && (
 									<Toolbar.Button
 										render={

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
@@ -292,10 +292,9 @@ const statusLabel = (status: TreeStatus): string =>
 const FileRow: FC<
 	{
 		item: FileTreeItem;
-		onFileSelection: (selection: FileOperand) => void;
 		projectId: string;
-	} & Omit<ComponentProps<typeof ItemRow>, "onFileSelection" | "projectId" | "operand">
-> = ({ item, onFileSelection, projectId, ...restProps }) => {
+	} & Omit<ComponentProps<typeof ItemRow>, "projectId" | "operand">
+> = ({ item, projectId, ...restProps }) => {
 	const relativePath = item._tag === "Change" ? item.change.path : item.path;
 
 	const outlineMode = useAppSelector((state) => selectProjectOutlineModeState(state, projectId));
@@ -315,7 +314,6 @@ const FileRow: FC<
 			{...restProps}
 			projectId={projectId}
 			operand={item.operand}
-			onFileSelection={onFileSelection}
 			className={classes(restProps.className, styles.fileRow)}
 			onContextMenu={(event) => {
 				void showNativeContextMenu(event, menuItems);

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
@@ -1,6 +1,6 @@
 import { changesInWorktreeQueryOptions } from "#ui/api/queries.ts";
 import { showNativeContextMenu, showNativeMenuFromTrigger } from "#ui/native-menu.ts";
-import { fileOperand, operandIdentityKey, type FileOperand } from "#ui/operands.ts";
+import { changesFileParent, fileOperand, FileParent, type FileOperand } from "#ui/operands.ts";
 import {
 	projectActions,
 	selectProjectHasCheckedCommits,
@@ -15,7 +15,7 @@ import { mergeProps, Tooltip, useRender } from "@base-ui/react";
 import { Toolbar } from "@base-ui/react/toolbar";
 import type { TreeChange, TreeStatus } from "@gitbutler/but-sdk";
 import { useQuery } from "@tanstack/react-query";
-import { Array, Match } from "effect";
+import { Array, identity, Match } from "effect";
 import { ComponentProps, createContext, FC, use, useRef } from "react";
 import styles from "./FilesTree.module.css";
 import {
@@ -40,21 +40,20 @@ import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
 import { useFileMenuItems } from "#ui/routes/project/$id/workspace/useFileMenuItems.ts";
 
-const fileOperandIdentityKey = (operand: FileOperand): string =>
-	operandIdentityKey(fileOperand(operand));
-
-const NavigationIndexContext = createContext<NavigationIndex<FileOperand> | null>(null);
+const NavigationIndexContext = createContext<NavigationIndex<string> | null>(null);
 
 const useFilesTreeHotkeys = ({
 	navigationIndex,
 	onFileSelection,
 	projectId,
 	ref,
+	fileParent,
 }: {
-	navigationIndex: NavigationIndex<FileOperand>;
-	onFileSelection: (selection: FileOperand) => void;
+	navigationIndex: NavigationIndex<string>;
+	onFileSelection: (selection: string) => void;
 	projectId: string;
 	ref: React.RefObject<HTMLElement | null>;
+	fileParent: FileParent;
 }) => {
 	const selection = useFilesSelection(projectId, navigationIndex);
 	const outlineMode = useAppSelector((state) => selectProjectOutlineModeState(state, projectId));
@@ -62,20 +61,18 @@ const useFilesTreeHotkeys = ({
 
 	const dispatch = useAppDispatch();
 
-	const selectedChangesFile = selection?.parent._tag === "Changes" ? selection : null;
+	const selectedChangesFile = fileParent._tag === "Changes" ? selection : null;
 
 	const absorbSelectedFile = () => {
 		if (selectedChangesFile === null) return;
 
-		const change = worktreeChanges?.changes.find(
-			(change) => change.path === selectedChangesFile.path,
-		);
+		const change = worktreeChanges?.changes.find((change) => change.path === selectedChangesFile);
 		if (!change) return;
 
 		dispatch(
 			projectActions.enterAbsorbMode({
 				projectId,
-				source: fileOperand(selectedChangesFile),
+				source: fileOperand({ parent: changesFileParent, path: selectedChangesFile }),
 				sourceTarget: {
 					type: "treeChanges",
 					subject: {
@@ -109,8 +106,8 @@ const useFilesTreeHotkeys = ({
 		select: onFileSelection,
 		selection,
 		ref,
-		getKey: fileOperandIdentityKey,
-		operationSourceForItem: fileOperand,
+		getKey: identity,
+		operationSourceForItem: (path) => fileOperand({ parent: fileParent, path }),
 	});
 };
 
@@ -150,10 +147,19 @@ export const FilesTree: FC<
 	{
 		projectId: string;
 		items: Array<FileTreeItem>;
-		onFileSelection: (selection: FileOperand) => void;
-		navigationIndex: NavigationIndex<FileOperand>;
+		onFileSelection: (selection: string) => void;
+		navigationIndex: NavigationIndex<string>;
+		fileParent: FileParent;
 	} & ComponentProps<"div">
-> = ({ items, onFileSelection, projectId, navigationIndex, ref: refProp, ...props }) => {
+> = ({
+	items,
+	onFileSelection,
+	projectId,
+	navigationIndex,
+	fileParent,
+	ref: refProp,
+	...props
+}) => {
 	const selection = useFilesSelection(projectId, navigationIndex);
 
 	const ref = useRef<HTMLDivElement>(null);
@@ -163,6 +169,7 @@ export const FilesTree: FC<
 		onFileSelection,
 		projectId,
 		ref,
+		fileParent,
 	});
 
 	return (
@@ -171,7 +178,7 @@ export const FilesTree: FC<
 				{...props}
 				tabIndex={0}
 				role="tree"
-				aria-activedescendant={selection ? treeItemId(selection) : undefined}
+				aria-activedescendant={selection !== null ? treeItemId(selection) : undefined}
 				className={classes(props.className, styles.tree)}
 				ref={useMergedRefs(refProp, ref)}
 			>
@@ -184,9 +191,9 @@ export const FilesTree: FC<
 						<div role="group">
 							{items.map((item) => (
 								<TreeItem
-									key={fileOperandIdentityKey(item.operand)}
+									key={item.operand.path}
 									projectId={projectId}
-									operand={item.operand}
+									path={item.operand.path}
 									aria-label={
 										item._tag === "Change"
 											? `${statusLabel(item.change.status)} ${item.change.path}`
@@ -196,10 +203,11 @@ export const FilesTree: FC<
 										<OperationSourceC
 											projectId={projectId}
 											source={fileOperand(item.operand)}
-											onDragStart={() => onFileSelection(item.operand)}
+											onDragStart={() => onFileSelection(item.operand.path)}
 											render={
 												<FileRow
 													item={item}
+													path={item.operand.path}
 													onFileSelection={onFileSelection}
 													projectId={projectId}
 												/>
@@ -216,47 +224,34 @@ export const FilesTree: FC<
 	);
 };
 
-const useIsSelected = ({
-	projectId,
-	operand,
-}: {
-	projectId: string;
-	operand: FileOperand;
-}): boolean => {
+const useIsSelected = ({ projectId, path }: { projectId: string; path: string }): boolean => {
 	const navigationIndex = assert(use(NavigationIndexContext));
 	return useAppSelector((state) => {
 		const selectionState = selectProjectSelectionFiles(state, projectId);
-		const selection = resolveNavigationIndexSelection(
-			navigationIndex,
-			selectionState,
-			fileOperandIdentityKey,
-		);
+		const selection = resolveNavigationIndexSelection(navigationIndex, selectionState, identity);
 
-		return (
-			selection !== null && fileOperandIdentityKey(selection) === fileOperandIdentityKey(operand)
-		);
+		return selection !== null && selection === path;
 	});
 };
 
-const treeItemId = (operand: FileOperand): string =>
-	`files-treeitem-${encodeURIComponent(fileOperandIdentityKey(operand))}`;
+const treeItemId = (path: string): string => `files-treeitem-${encodeURIComponent(path)}`;
 
 const ItemRow: FC<
 	{
-		onFileSelection: (selection: FileOperand) => void;
+		onFileSelection: (selection: string) => void;
 		projectId: string;
-		operand: FileOperand;
+		path: string;
 	} & Omit<ComponentProps<typeof WorkspaceItemRow>, "inert" | "isSelected" | "onSelect">
-> = ({ onFileSelection, projectId, operand, ...props }) => {
+> = ({ onFileSelection, projectId, path, ...props }) => {
 	const navigationIndex = assert(use(NavigationIndexContext));
-	const isSelected = useIsSelected({ projectId, operand });
+	const isSelected = useIsSelected({ projectId, path });
 
 	return (
 		<WorkspaceItemRow
 			{...props}
-			inert={!navigationIndexIncludes(navigationIndex, operand, fileOperandIdentityKey)}
+			inert={!navigationIndexIncludes(navigationIndex, path, identity)}
 			isSelected={isSelected}
-			onSelect={() => onFileSelection(operand)}
+			onSelect={() => onFileSelection(path)}
 		/>
 	);
 };
@@ -264,16 +259,16 @@ const ItemRow: FC<
 const TreeItem: FC<
 	{
 		projectId: string;
-		operand: FileOperand;
+		path: string;
 	} & useRender.ComponentProps<"div">
-> = ({ projectId, operand, render, ...props }) => {
-	const isSelected = useIsSelected({ projectId, operand });
+> = ({ projectId, path, render, ...props }) => {
+	const isSelected = useIsSelected({ projectId, path });
 
 	return useRender({
 		render,
 		defaultTagName: "div",
 		props: mergeProps<"div">(props, {
-			id: treeItemId(operand),
+			id: treeItemId(path),
 			role: "treeitem",
 			"aria-selected": isSelected,
 		}),
@@ -313,7 +308,7 @@ const FileRow: FC<
 		<ItemRow
 			{...restProps}
 			projectId={projectId}
-			operand={item.operand}
+			path={item.operand.path}
 			className={classes(restProps.className, styles.fileRow)}
 			onContextMenu={(event) => {
 				void showNativeContextMenu(event, menuItems);

--- a/apps/lite/ui/src/selection-scopes.ts
+++ b/apps/lite/ui/src/selection-scopes.ts
@@ -1,14 +1,7 @@
 import { selectionOperationHotkeys, type CommandGroup } from "#ui/hotkeys.ts";
 import { type OperationType } from "#ui/operations/operation.ts";
 import { keyboardTransferOperationMode } from "#ui/outline/mode.ts";
-import {
-	fileOperand,
-	hunkOperand,
-	HunkOperand,
-	operandIdentityKey,
-	type FileOperand,
-	type Operand,
-} from "#ui/operands.ts";
+import { hunkOperand, HunkOperand, operandIdentityKey, type Operand } from "#ui/operands.ts";
 import {
 	projectActions,
 	selectProjectOutlineModeState,
@@ -23,6 +16,7 @@ import {
 	type NavigationIndex,
 } from "#ui/workspace/navigation-index.ts";
 import { useHotkeySequences, useHotkeys } from "@tanstack/react-hotkeys";
+import { identity } from "effect";
 
 export type SelectionScope = "outline" | "files" | "diff";
 const allSelectionScopes: Array<SelectionScope> = ["outline", "files", "diff"];
@@ -84,15 +78,9 @@ export const resolveNavigationIndexSelection = <T>(
 		? selection
 		: (navigationIndex.items[0] ?? null);
 
-const fileOperandIdentityKey = (operand: FileOperand): string =>
-	operandIdentityKey(fileOperand(operand));
-
-export const useFilesSelection = (
-	projectId: string,
-	navigationIndex: NavigationIndex<FileOperand>,
-) => {
+export const useFilesSelection = (projectId: string, navigationIndex: NavigationIndex<string>) => {
 	const selection = useAppSelector((state) => selectProjectSelectionFiles(state, projectId));
-	return resolveNavigationIndexSelection(navigationIndex, selection, fileOperandIdentityKey);
+	return resolveNavigationIndexSelection(navigationIndex, selection, identity);
 };
 
 export const useOutlineSelection = ({


### PR DESCRIPTION
Unsure if we should use the path string or bytes?