### PR TITLE
fix(cli): fix `branch show` failing to find non-stack-head branches

### DIFF
--- a/crates/but/src/args/atoms/branch_arg.rs
+++ b/crates/but/src/args/atoms/branch_arg.rs
@@ -1,4 +1,4 @@
-use bstr::BStr;
+use bstr::{BStr, ByteSlice};
 use gix::refs::{Category, FullName};
 
 use crate::{CliError, CliResult, bad_input};
@@ -106,15 +106,28 @@ impl BranchArg {
     }
 
     /// Resolve the argument to a branch that exists in the repository.
-    pub fn resolve_branch(
-        &self,
-        ctx: &but_ctx::Context,
-    ) -> CliResult<gitbutler_branch_actions::BranchListing> {
-        let branches = but_api::legacy::virtual_branches::list_branches(ctx, None)?;
-        let Some(branch) = branches.iter().find(|b| b.name.to_string() == self.0) else {
-            return Err(bad_input(format!("Branch '{self}' not found")).into());
-        };
-        Ok(branch.clone())
+    pub fn resolve_branch(&self, ctx: &but_ctx::Context) -> CliResult<ResolvedBranchRef> {
+        let repo = ctx.repo.get()?;
+
+        for category in [Category::LocalBranch, Category::RemoteBranch] {
+            let branch_name = category.to_full_name(&*self.0)?;
+            if let Some(resolved) = resolve_branch_ref(&repo, &branch_name)? {
+                return Ok(resolved);
+            }
+        }
+
+        for remote_name in repo.remote_names() {
+            let branch_name = Category::RemoteBranch.to_full_name(&*format!(
+                "{}/{}",
+                remote_name.as_bstr().to_str_lossy(),
+                self.0
+            ))?;
+            if let Some(resolved) = resolve_branch_ref(&repo, &branch_name)? {
+                return Ok(resolved);
+            }
+        }
+
+        Err(bad_input(format!("Branch '{self}' not found")).into())
     }
 
     /// Try to resolve the branch to a stack that exists in the workspace.
@@ -136,4 +149,26 @@ impl AsRef<str> for BranchArg {
     fn as_ref(&self) -> &str {
         self.0.as_ref()
     }
+}
+
+fn resolve_branch_ref(
+    repo: &gix::Repository,
+    branch_name: &FullName,
+) -> CliResult<Option<ResolvedBranchRef>> {
+    let Some(mut ref_info) = repo.try_find_reference(branch_name)? else {
+        return Ok(None);
+    };
+
+    let Ok(commit) = ref_info.peel_to_id() else {
+        return Ok(None);
+    };
+
+    Ok(Some(ResolvedBranchRef {
+        head: commit.detach(),
+    }))
+}
+
+#[expect(missing_docs, reason = "only used internally by CLI command helpers")]
+pub struct ResolvedBranchRef {
+    pub head: gix::ObjectId,
 }

--- a/crates/but/src/command/legacy/branch/show.rs
+++ b/crates/but/src/command/legacy/branch/show.rs
@@ -115,15 +115,10 @@ struct CommitRef {
 // TODO(perf): re-write with `gix`, just avoid duplicate work there (get_merge_conflict_paths) isn't needed.
 // TODO(perf): re-write this to use a graph that includes all branches from the listing, needs a listing that uses
 //             the graph.
-fn check_merge_conflicts(ctx: &Context, branch_name: &str) -> Result<MergeCheck, anyhow::Error> {
+fn check_merge_conflicts(ctx: &Context, branch_name: &str) -> CliResult<MergeCheck> {
     use but_core::RepositoryExt;
 
-    // Find the branch by name
-    let branches = but_api::legacy::virtual_branches::list_branches(ctx, None)?;
-    let branch = branches
-        .iter()
-        .find(|b| b.name.to_string() == branch_name)
-        .ok_or_else(|| anyhow::anyhow!("Branch '{branch_name}' not found"))?;
+    let branch = BranchArg(branch_name.to_owned()).resolve_branch(ctx)?;
 
     // Find merge base
     let guard = ctx.shared_worktree_access();

--- a/crates/but/tests/but/command/branch/show.rs
+++ b/crates/but/tests/but/command/branch/show.rs
@@ -107,3 +107,160 @@ Branch: A (1 commits ahead)
 
     Ok(())
 }
+
+#[test]
+fn show_works_for_remote_only_branches() -> anyhow::Result<()> {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.invoke_bash(
+        r#"
+git checkout origin/main
+git commit -m 'Add remote feature' --allow-empty
+git update-ref refs/remotes/origin/remote-feature HEAD
+git checkout gitbutler/workspace
+"#,
+    );
+
+    env.but("branch show origin/remote-feature")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Branch: origin/remote-feature (1 commits ahead)
+
+ba02e5f Add remote feature
+    2000-01-02 00:00:00 by author
+    0 files changed, 0 insertions, 0 deletions
+
+"#]]);
+
+    env.but("branch show remote-feature")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Branch: remote-feature (1 commits ahead)
+
+ba02e5f Add remote feature
+    2000-01-02 00:00:00 by author
+    0 files changed, 0 insertions, 0 deletions
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn showing_branch_that_isnt_top_of_stack() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "one-stack-three-dependent-branches",
+    )
+    .unwrap();
+    env.setup_metadata(&["A", "B", "C"]).unwrap();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [C]
+┊●   aebb090 add C
+┊│
+┊├┄h0 [B]
+┊●   582f37b add B
+┊│
+┊├┄i0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("branch show C")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Branch: C (3 commits ahead)
+
+aebb090 add C
+    2000-01-02 00:00:00 by author
+    1 file changed, 1 insertion, 0 deletions
+
+582f37b add B
+    2000-01-02 00:00:00 by author
+    1 file changed, 1 insertion, 0 deletions
+
+9477ae7 add A
+    2000-01-02 00:00:00 by author
+    1 file changed, 1 insertion, 0 deletions
+
+"#]]);
+
+    env.but("branch show B")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Branch: B (2 commits ahead)
+
+582f37b add B
+    2000-01-02 00:00:00 by author
+    1 file changed, 1 insertion, 0 deletions
+
+9477ae7 add A
+    2000-01-02 00:00:00 by author
+    1 file changed, 1 insertion, 0 deletions
+
+"#]]);
+
+    env.but("branch show A")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Branch: A (1 commits ahead)
+
+9477ae7 add A
+    2000-01-02 00:00:00 by author
+    1 file changed, 1 insertion, 0 deletions
+
+"#]]);
+}
+
+#[test]
+fn checking_merge_status_of_branch_that_isnt_top_of_stack() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "one-stack-three-dependent-branches",
+    )
+    .unwrap();
+    env.setup_metadata(&["A", "B", "C"]).unwrap();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [C]
+┊●   aebb090 add C
+┊│
+┊├┄h0 [B]
+┊●   582f37b add B
+┊│
+┊├┄i0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("branch show C --check").assert().success();
+
+    env.but("branch show B --check").assert().success();
+
+    env.but("branch show A --check").assert().success();
+}


### PR DESCRIPTION
Apparently `but branch show` wasn't able to find branches that weren't at the head of a stack. Seems to have been broken always.