### PR TITLE
Demo of inability to merge a reverted revert

### DIFF
--- a/crates/but-rebase/tests/fixtures/scenario/double-revert.sh
+++ b/crates/but-rebase/tests/fixtures/scenario/double-revert.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git init
+
+tick
+echo A >file.txt
+git add file.txt
+git commit -m A
+
+tick
+echo B >file.txt
+git add file.txt
+git commit -m B
+
+tick
+echo A >file.txt
+git add file.txt
+git commit -m "revert to A"

--- a/crates/but-rebase/tests/rebase/graph_rebase/merge_commit_changes.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/merge_commit_changes.rs
@@ -13,6 +13,40 @@ use std::mem::ManuallyDrop;
 use crate::utils::{fixture, fixture_writable, standard_options};
 
 #[test]
+fn double_revert() -> Result<()> {
+    let (repo, mut meta) = fixture("double-revert")?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * 90492e8 (HEAD -> main) revert to A
+    * 849de96 B
+    * dfb23a6 A
+    ");
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let main = repo.rev_parse_single("main")?.detach();
+    let b = repo.rev_parse_single("main~1")?.detach();
+    let wrong_tree = repo.rev_parse_single("main^{tree}")?.detach();
+    let expected_tree = repo.rev_parse_single("main~1^{tree}")?.detach();
+
+    let actual_tree = editor.merge_commit_changes_to_tree(
+        main,
+        vec![b],
+        editor.repo().merge_options_fail_fast()?.0,
+    )?;
+
+    assert_eq!(
+        actual_tree.tree_id, expected_tree,
+        "wrong tree {:?} right tree {:?}",
+        wrong_tree, expected_tree,
+    );
+    assert!(actual_tree.conflict.is_none());
+    Ok(())
+}
+
+#[test]
 fn matches_clean_octopus_merge() -> Result<()> {
     let (repo, mut meta) = fixture("octopus-merge-with-redundant-input")?;
 


### PR DESCRIPTION
I was looking at supporting conflicts with more than 2 sides, so as part of that, I looked at how the rebase engine merges things. I noticed that selected commits that are ancestors of the target are dropped - is this the behavior that we want?

We might not want to drop ancestors in the case that we want to revert a revert. I've put a test case in the PR describing this - we have a change from A to B that was reverted, but we want to revert the revert by merging B back. I think this is a typical use case that is made impossible because of this dropping-ancestor rule, and I was wondering if we should delete this rule.