### PR TITLE
but-rebase: more docs in merge_commit_changes.rs

### DIFF
--- a/crates/but-rebase/src/graph_rebase/merge_commit_changes.rs
+++ b/crates/but-rebase/src/graph_rebase/merge_commit_changes.rs
@@ -161,13 +161,15 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
 
         for commit_id in &selected_commit_ids {
             if !traversal
-                .selected_metadata_by_commit
+                .first_parent_metadata_by_selected_commit_id
                 .contains_key(commit_id)
             {
                 bail!("Failed to find commit {commit_id} in rebase editor");
             }
         }
 
+        // A map from selected commit ID to how many child commits it has that
+        // are also selected.
         let mut selected_child_count = HashMap::<gix::ObjectId, usize>::with_capacity(
             traversal.ordered_selected_commit_ids.len(),
         );
@@ -175,7 +177,7 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
             selected_child_count.insert(commit_id, 0);
         }
         for selected_parent_id in traversal
-            .selected_metadata_by_commit
+            .first_parent_metadata_by_selected_commit_id
             .values()
             .filter_map(|metadata| metadata.selected_first_parent_id)
         {
@@ -191,6 +193,14 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
                 .copied()
                 .unwrap_or_default()
                 == 0;
+            // Skip over non-tips (i.e. selected commits that have at least one
+            // child that is itself selected) and commits that are ancestors of
+            // the target. The changes in non-tips are subsumed into the tip of
+            // the chain it's part of.
+            //
+            // For example, consider the chain M<-A<-B<-C where A,B,C are
+            // selected. A and B will be skipped; we will only emit one change C
+            // with base M, which thus includes all changes in A and B too.
             if !is_selected_chain_tip || traversal.target_ancestor_commit_ids.contains(&commit_id) {
                 continue;
             }
@@ -198,7 +208,7 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
             let base_tree_id = base_tree_id_for_emitted_tip(
                 self,
                 commit_id,
-                &traversal.selected_metadata_by_commit,
+                &traversal.first_parent_metadata_by_selected_commit_id,
                 &traversal.target_ancestor_commit_ids,
             )?;
             planned_commit_changes.push(PlannedCommitChange {
@@ -211,16 +221,25 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
     }
 }
 
+/// First-parent metadata for a selected commit. This is subsequently used to
+/// detect chains of selected commits, where each link of the chain is between a
+/// selected commit and its also-selected first parent.
 #[derive(Debug, Clone, Copy)]
-struct SelectedCommitPlanningMetadata {
+struct FirstParentMetadata {
+    /// The first parent ID of the commit, if one exists.
     first_parent_id: Option<gix::ObjectId>,
+    /// Identical to `first_parent_id` if it is also selected; otherwise,
+    /// `None`.
     selected_first_parent_id: Option<gix::ObjectId>,
 }
 
 #[derive(Debug, Default)]
 struct SelectedCommitPlanningTraversal {
+    /// Selected commit IDs in reverse topological order.
     ordered_selected_commit_ids: Vec<gix::ObjectId>,
-    selected_metadata_by_commit: HashMap<gix::ObjectId, SelectedCommitPlanningMetadata>,
+    /// First parent metadata for each element of [Self::ordered_selected_commit_ids].
+    first_parent_metadata_by_selected_commit_id: HashMap<gix::ObjectId, FirstParentMetadata>,
+    /// The target commit ID and all its ancestor commits in the graph.
     target_ancestor_commit_ids: HashSet<gix::ObjectId>,
 }
 
@@ -233,16 +252,14 @@ enum TraversalMode {
 
 /// Traverse the editor graph and return information relevant for the planning.
 ///
-/// The traversal collects information about:
-/// - Which commits are ancestors of the target commit.
-/// - The deterministic order in which selected commits should be considered.
+/// The order of elements in the returned
+/// [SelectedCommitPlanningTraversal::ordered_selected_commit_ids] is
+/// deterministic and based solely on the graph.
 ///
 /// This walk intentionally uses the editor step graph only as a traversal
 /// structure. Parent/tree semantics are still read from the in-memory
 /// repository commits, so callers must only use this planner when the editor
 /// graph and the in-memory repository represent the same commit topology.
-///
-/// Returns [SelectedCommitPlanningTraversal].
 fn traverse_graph_for_planning<M: RefMetadata>(
     editor: &Editor<'_, '_, M>,
     target_commit_id: gix::ObjectId,
@@ -266,14 +283,12 @@ fn traverse_graph_for_planning<M: RefMetadata>(
                 TraversalMode::Normal => {
                     if expanded {
                         if let Step::Pick(Pick { id, .. }) = editor.graph[node] {
-                            if let Some(selected_metadata) = selected_metadata_for_traversed_pick(
-                                editor,
-                                id,
-                                selected_commit_ids,
-                            )? {
+                            if let Some(first_parent_metadata) =
+                                get_first_parent_metadata(editor, id, selected_commit_ids)?
+                            {
                                 traversal
-                                    .selected_metadata_by_commit
-                                    .insert(id, selected_metadata);
+                                    .first_parent_metadata_by_selected_commit_id
+                                    .insert(id, first_parent_metadata);
                                 if seen_selected_commit_ids.insert(id) {
                                     traversal.ordered_selected_commit_ids.push(id);
                                 }
@@ -323,7 +338,7 @@ fn traverse_graph_for_planning<M: RefMetadata>(
     Ok(traversal)
 }
 
-/// Pick repository-backed first-parent metadata for a selected commit.
+/// Returns first-parent metadata if `commit_id` is selected.
 ///
 /// This intentionally reads the commit object from the editor's in-memory
 /// repository instead of inferring first-parent semantics from the step graph.
@@ -332,11 +347,11 @@ fn traverse_graph_for_planning<M: RefMetadata>(
 /// commit DAG that owns the trees and SHAs being merged, so callers are
 /// expected to keep the editor step graph aligned with that in-memory
 /// repository topology.
-fn selected_metadata_for_traversed_pick<M: RefMetadata>(
+fn get_first_parent_metadata<M: RefMetadata>(
     editor: &Editor<'_, '_, M>,
     commit_id: gix::ObjectId,
     selected_commit_ids: &HashSet<gix::ObjectId>,
-) -> Result<Option<SelectedCommitPlanningMetadata>> {
+) -> Result<Option<FirstParentMetadata>> {
     if !selected_commit_ids.contains(&commit_id) {
         return Ok(None);
     }
@@ -346,7 +361,7 @@ fn selected_metadata_for_traversed_pick<M: RefMetadata>(
     let selected_first_parent_id =
         first_parent_id.filter(|parent_id| selected_commit_ids.contains(parent_id));
 
-    Ok(Some(SelectedCommitPlanningMetadata {
+    Ok(Some(FirstParentMetadata {
         first_parent_id,
         selected_first_parent_id,
     }))
@@ -354,16 +369,16 @@ fn selected_metadata_for_traversed_pick<M: RefMetadata>(
 
 /// Get the base tree ID to use for the merger of the given commit.
 ///
-/// This function is reponsible for determining the base in the following way:
-/// 1. If the first parent of the commit is an ancestor of the target commit, we return its tree.
-/// 2. If the first parent of the commit is part of the selected commits but is not an ancestor of
-///    the target commit, we check the second parent. We continue until we find a parent that's either
-///    not in the selected commits or is an ancestor of the target commit.
-/// 3. If there is no parent, we return an empty tree.
+/// The base tree ID is obtained by following the first parent link until a
+/// non-selected commit or a target ancestor is encountered; the base tree ID is
+/// thus the tree of that commit.
+///
+/// If the first parent link cannot be followed due to a commit not having any
+/// parents, the empty tree is returned.
 fn base_tree_id_for_emitted_tip<M: RefMetadata>(
     editor: &Editor<'_, '_, M>,
     tip_commit_id: gix::ObjectId,
-    selected_metadata_by_commit: &HashMap<gix::ObjectId, SelectedCommitPlanningMetadata>,
+    selected_metadata_by_commit: &HashMap<gix::ObjectId, FirstParentMetadata>,
     target_ancestor_commit_ids: &HashSet<gix::ObjectId>,
 ) -> Result<gix::ObjectId> {
     let mut current_commit_id = tip_commit_id;


### PR DESCRIPTION
Some additional docs for the things I looked at.

I saw some potential code improvements too, but this part will probably be revamped as part of supporting conflicts with more than two sides, so I limited myself to documentation and identifier renaming.