### PR TITLE
Fix Zed IDE compatibility (Open in Editor)

### DIFF
--- a/apps/desktop/src/lib/backend/url.test.ts
+++ b/apps/desktop/src/lib/backend/url.test.ts
@@ -1,0 +1,44 @@
+import { getEditorUri } from "$lib/backend/url";
+import { describe, expect, test } from "vitest";
+
+describe("getEditorUri", () => {
+	test.each(["vscode", "vscode-insiders", "vscodium", "cursor", "windsurf", "trae"])(
+		"%s keeps query parameters",
+		(schemeId) => {
+			expect(
+				getEditorUri({
+					schemeId,
+					path: ["/home/example/project"],
+					searchParams: { windowId: "_blank" },
+				}),
+			).toBe(`${schemeId}://file/home/example/project?windowId=_blank`);
+		},
+	);
+
+	test("zed drops query parameters since it treats them as part of the file path", () => {
+		expect(
+			getEditorUri({
+				schemeId: "zed",
+				path: ["/home/example/project"],
+				searchParams: { windowId: "_blank" },
+			}),
+		).toBe("zed://file/home/example/project");
+	});
+
+	test("line and column suffixes are appended for all editors", () => {
+		expect(
+			getEditorUri({
+				schemeId: "zed",
+				path: ["/home/example/project", "src/main.rs"],
+				line: 42,
+				column: 7,
+			}),
+		).toBe("zed://file/home/example/project/src/main.rs:42:7");
+	});
+
+	test("uris without search params are unchanged", () => {
+		expect(getEditorUri({ schemeId: "vscode", path: ["/home/example/project"] })).toBe(
+			"vscode://file/home/example/project",
+		);
+	});
+});

--- a/apps/desktop/src/lib/backend/url.ts
+++ b/apps/desktop/src/lib/backend/url.ts
@@ -36,8 +36,24 @@ export interface EditorUriParams {
 	column?: number;
 }
 
+// Mirrors `is_vscode_or_compatible` in `crates/but-api/src/open/mod.rs`.
+const VSCODE_COMPATIBLE_SCHEMES = new Set([
+	"vscode",
+	"vscode-insiders",
+	"vscodium",
+	"cursor",
+	"windsurf",
+	"trae",
+]);
+
 export function getEditorUri(params: EditorUriParams): string {
-	const searchParamsString = new URLSearchParams(params.searchParams).toString();
+	// Query parameters (e.g. `windowId=_blank`) are only understood by VS Code
+	// and its forks. Zed treats everything after `zed://file` as a literal file
+	// path, so a query would end up in the opened path.
+	const searchParams = VSCODE_COMPATIBLE_SCHEMES.has(params.schemeId)
+		? params.searchParams
+		: undefined;
+	const searchParamsString = new URLSearchParams(searchParams).toString();
 	// Separator is always a forward slash for editor paths, even on Windows
 	const pathString = params.path.join(SEPARATOR);
 


### PR DESCRIPTION
## 🧢 Changes

Add a set of VSCode-compatible IDEs (similar to those in Rust). Also, depending on this condition, the query parameter `?windowId=_blank` is removed because Zed treats it as part of the project path, which prevents proper functionality.

## ☕️ Reasoning

GitButler didn't open project properly in Zed IDE.

## 🎫 Affected issues

Fixes: #7910