### PR TITLE
Rebuild the workspace when applying a branch from outside it

### DIFF
--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -205,10 +205,67 @@ pub fn create_virtual_branch_from_branch_with_perm(
     pr_number: Option<usize>,
     perm: &mut RepoExclusive,
 ) -> Result<gitbutler_branch_actions::CreateBranchFromBranchOutcome> {
+    // Outside the managed workspace (e.g. a stack branch was checked out directly), there is no
+    // workspace merge to add to. Rather than restore the stale `gitbutler/workspace`, rebuild a
+    // fresh one from the currently checked-out branch plus the one being applied.
+    if !gitbutler_operating_modes::in_open_workspace_mode(ctx, perm.read_permission())? {
+        return apply_by_rebuilding_workspace(ctx, branch, perm);
+    }
     let outcome = gitbutler_branch_actions::create_virtual_branch_from_branch_with_perm(
         ctx, branch, pr_number, perm,
     )?;
     Ok(outcome.into())
+}
+
+/// Apply `branch` while HEAD is outside the managed workspace by rebuilding the workspace from
+/// scratch: [`crate::branch::apply`] brings the currently checked-out branch and `branch` into a
+/// freshly created `gitbutler/workspace`. The legacy `pr_number` argument is unused here because PR
+/// associations live in branch metadata (`branch.review.pull_request`), which this rebuild leaves
+/// untouched, so they carry over without being re-applied.
+fn apply_by_rebuilding_workspace(
+    ctx: &mut Context,
+    branch: &Refname,
+    perm: &mut RepoExclusive,
+) -> Result<gitbutler_branch_actions::CreateBranchFromBranchOutcome> {
+    let branch_ref: gix::refs::FullName = branch
+        .to_string()
+        .try_into()
+        .with_context(|| format!("'{branch}' is not a valid full ref name to apply"))?;
+
+    // Discard the existing managed workspace so `apply` rebuilds it from scratch: a fresh
+    // `gitbutler/workspace` from the currently checked-out branch plus the one being applied, with
+    // any other previously-applied stacks left unapplied in metadata.
+    {
+        let mut meta = ctx.meta()?;
+        let repo = ctx.repo.get()?;
+        but_workspace::branch::discard_managed_workspace(&repo, &mut meta)?;
+        // `meta` writes virtual_branches.toml on drop, before `apply` reads it back.
+    }
+    ctx.invalidate_workspace_cache()?;
+
+    let outcome = crate::branch::apply_with_perm(ctx, branch_ref.as_ref(), perm)?;
+
+    // `stack_id` is part of the outcome shape but unused by this path's caller; report the applied
+    // branch's stack when found, otherwise any remaining stack.
+    let stack_id = outcome
+        .workspace
+        .stacks
+        .iter()
+        .find(|stack| {
+            stack.segments.iter().any(|segment| {
+                segment
+                    .ref_name()
+                    .is_some_and(|rn| rn == branch_ref.as_ref())
+            })
+        })
+        .or_else(|| outcome.workspace.stacks.first())
+        .and_then(|stack| stack.id)
+        .unwrap_or_else(StackId::generate);
+    Ok(gitbutler_branch_actions::CreateBranchFromBranchOutcome {
+        stack_id,
+        unapplied_stacks: outcome.conflicting_stack_ids.clone(),
+        unapplied_stacks_short_names: Vec::new(),
+    })
 }
 
 #[but_api]

--- a/crates/but-workspace/src/branch/discard.rs
+++ b/crates/but-workspace/src/branch/discard.rs
@@ -1,0 +1,39 @@
+use but_core::{RefMetadata, WORKSPACE_REF_NAME, ref_metadata::WorkspaceCommitRelation};
+use gix::refs::transaction::{Change, PreviousValue, RefEdit, RefLog};
+
+/// Tear down the managed workspace so a fresh one can be built from the current `HEAD`.
+///
+/// Deletes the `gitbutler/workspace` reference (if present) and marks every stack it contained as
+/// out-of-workspace in `meta`, leaving those stacks in metadata but unapplied. With the reference
+/// gone, a subsequent [`apply`](crate::branch::apply) from an ad-hoc `HEAD` rebuilds the workspace
+/// from scratch — the checked-out branch plus the one being applied — instead of reattaching to the
+/// old workspace merge.
+///
+/// `repo` provides the reference to delete; `meta` is the workspace metadata to update.
+///
+/// The reference is deleted *before* the metadata is touched on purpose: metadata writes reconcile
+/// against the live workspace, so the reference must be gone first or the out-of-workspace marks
+/// would be reverted from the old merge commit.
+pub fn discard_managed_workspace(
+    repo: &gix::Repository,
+    meta: &mut impl RefMetadata,
+) -> anyhow::Result<()> {
+    let ws_ref_name = gix::refs::FullName::try_from(WORKSPACE_REF_NAME)?;
+    if repo.try_find_reference(ws_ref_name.as_ref())?.is_some() {
+        repo.edit_reference(RefEdit {
+            change: Change::Delete {
+                log: RefLog::AndReference,
+                expected: PreviousValue::Any,
+            },
+            name: ws_ref_name.clone(),
+            deref: false,
+        })?;
+    }
+    if let Some(mut ws_md) = meta.workspace_opt(ws_ref_name.as_ref())? {
+        for stack in &mut ws_md.stacks {
+            stack.workspacecommit_relation = WorkspaceCommitRelation::Outside;
+        }
+        meta.set_workspace(&ws_md)?;
+    }
+    Ok(())
+}

--- a/crates/but-workspace/src/branch/mod.rs
+++ b/crates/but-workspace/src/branch/mod.rs
@@ -598,6 +598,10 @@ pub(crate) fn try_find_validated_ref<'repo>(
 pub mod apply;
 pub use apply::apply;
 
+/// Tearing down the managed workspace so it can be rebuilt from scratch.
+pub mod discard;
+pub use discard::discard_managed_workspace;
+
 /// Functions and types related to removing a branch from the workspace.
 pub mod unapply;
 pub use unapply::function::unapply;

--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -82,7 +82,12 @@ pub fn list_branches(
             expensive_commit_info: false,
             gerrit_mode,
         },
-    )?;
+    )?
+    // Like the but-api/CLI `head_info` and the workspace view: when HEAD is outside the
+    // managed workspace (e.g. a stack branch was checked out directly), only the
+    // checked-out stack counts as in-workspace. The others then list as plain branches
+    // and can be applied again, rebuilding the workspace from scratch.
+    .pruned_to_entrypoint();
     let stacks = info
         .stacks
         .into_iter()

--- a/e2e/playwright/scripts/checkout-branch.sh
+++ b/e2e/playwright/scripts/checkout-branch.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+echo "GIT CONFIG $GIT_CONFIG_GLOBAL"
+echo "DATA DIR $E2E_TEST_APP_DATA_DIR"
+echo "BUT $BUT"
+echo "BRANCH TO CHECKOUT: $1"
+echo "DIRECTORY: $2"
+
+# Simulate an external `git checkout` (e.g. from a terminal) of a branch.
+pushd "$2"
+  git checkout "$1"
+popd

--- a/e2e/playwright/tests/singleBranch/checkoutStack.spec.ts
+++ b/e2e/playwright/tests/singleBranch/checkoutStack.spec.ts
@@ -1,0 +1,90 @@
+import { expectCurrentBranchChip } from "./helpers.ts";
+import { assertBranch } from "../../src/branch.ts";
+import { applyUpstream, openWorkspace } from "../../src/setup.ts";
+import { test } from "../../src/test.ts";
+import { clickByTestId, getByTestId, stack, waitForTestId } from "../../src/util.ts";
+import { expect } from "@playwright/test";
+
+test.describe("single-branch mode enabled", () => {
+	test.use({
+		gitbutlerOptions: {
+			config: {
+				onboardingComplete: true,
+				featureFlags: { singleBranch: true },
+			},
+		},
+	});
+
+	// Checking out a stack branch leaves the managed workspace; the workspace view and the
+	// branches page then reflect just that stack. Applying the other branch from the branches
+	// page rebuilds a fresh workspace from the current branch plus the applied one.
+	test("checking out one of two stacks shows only that stack, and re-applying the other restores both", async ({
+		page,
+		gitbutler,
+	}) => {
+		await gitbutler.runScript("project-with-stacks.sh");
+		await applyUpstream(gitbutler, "branch1", "branch2");
+		await openWorkspace(page);
+
+		const localClone = gitbutler.pathInWorkdir("local-clone");
+
+		// Initial workspace: two independent stacks on gitbutler/workspace.
+		await assertBranch("gitbutler/workspace", localClone);
+		await expect(stack(page)).toHaveCount(2);
+
+		// External `git checkout` of one stack branch — only that stack stays in view.
+		await gitbutler.runScript("checkout-branch.sh", ["branch1", "local-clone"]);
+		await assertBranch("branch1", localClone);
+
+		await expect(getByTestId(page, "workspace-view")).toBeVisible();
+		await expectCurrentBranchChip(page, "branch1");
+		await expect(stack(page)).toHaveCount(1);
+		await expect(stack(page, "branch1")).toHaveCount(1);
+		await expect(stack(page, "branch2")).toHaveCount(0);
+
+		// Applying the other branch re-enters the managed workspace with both stacks.
+		await clickByTestId(page, "navigation-branches-button");
+		await getByTestId(page, "branch-list-card").filter({ hasText: "branch2" }).click();
+		await clickByTestId(page, "branches-view-apply-branch-button");
+		await waitForTestId(page, "workspace-view");
+
+		await assertBranch("gitbutler/workspace", localClone);
+		await expectCurrentBranchChip(page, "gitbutler/workspace");
+		await expect(stack(page)).toHaveCount(2);
+		await expect(stack(page, "branch1")).toHaveCount(1);
+		await expect(stack(page, "branch2")).toHaveCount(1);
+	});
+
+	// The rebuilt workspace contains strictly the current branch plus the applied one: a third stack
+	// that was applied before checking out is dropped (it stays available on the branches page).
+	test("rebuilding the workspace drops stacks other than the current and applied branch", async ({
+		page,
+		gitbutler,
+	}) => {
+		await gitbutler.runScript("project-with-stacks.sh");
+		await applyUpstream(gitbutler, "branch1", "branch2", "branch3");
+		await openWorkspace(page);
+
+		const localClone = gitbutler.pathInWorkdir("local-clone");
+
+		await assertBranch("gitbutler/workspace", localClone);
+		await expect(stack(page)).toHaveCount(3);
+
+		// Leave the workspace by checking out branch1; only branch1 stays in view.
+		await gitbutler.runScript("checkout-branch.sh", ["branch1", "local-clone"]);
+		await assertBranch("branch1", localClone);
+		await expect(stack(page)).toHaveCount(1);
+
+		// Apply branch2: the workspace rebuilds from branch1 + branch2 only — branch3 is dropped.
+		await clickByTestId(page, "navigation-branches-button");
+		await getByTestId(page, "branch-list-card").filter({ hasText: "branch2" }).click();
+		await clickByTestId(page, "branches-view-apply-branch-button");
+		await waitForTestId(page, "workspace-view");
+
+		await assertBranch("gitbutler/workspace", localClone);
+		await expect(stack(page)).toHaveCount(2);
+		await expect(stack(page, "branch1")).toHaveCount(1);
+		await expect(stack(page, "branch2")).toHaveCount(1);
+		await expect(stack(page, "branch3")).toHaveCount(0);
+	});
+});


### PR DESCRIPTION
After checking out a stack branch (leaving gitbutler/workspace), the branch
listing still showed the other stacks as applied, and applying one errored on
the open-workspace check.

- list_branches prunes head_info to the entrypoint, matching the but-api/CLI
  head_info and the workspace view, so stacks that are not the checked-out one
  list as plain, appliable branches.
- Applying a branch from outside the workspace now discards the stale
  gitbutler/workspace ref and marks its stacks out-of-workspace, then rebuilds a
  fresh workspace from the current branch plus the applied one. Other stacks stay
  in metadata, unapplied. The teardown lives in the new
  but_workspace::branch::discard_managed_workspace; but-api just orchestrates.

Adds single-branch-mode e2e coverage for the basic flow and the strict
current+applied rebuild.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>