### PR TITLE
feat(but-api): add api to open file in editor

### DIFF
--- a/apps/lite/electron/src/ipc.ts
+++ b/apps/lite/electron/src/ipc.ts
@@ -7,6 +7,7 @@ import type {
 	BranchListing,
 	BranchListingFilter,
 	BottomUpdate,
+	Editor,
 	CommitAbsorption,
 	HunkAssignmentRequest,
 	CommitDetails,
@@ -183,6 +184,12 @@ export interface MoveBranchParams {
 	dryRun: boolean;
 }
 
+export interface OpenInEditorParams {
+	projectId: string;
+	editorId: string;
+	path: string;
+}
+
 export interface PeelRestoreSnapshotParams {
 	projectId: string;
 	sha: string;
@@ -306,8 +313,10 @@ export interface LiteElectronApi {
 		projectId: string,
 		filter: BranchListingFilter | null,
 	) => Promise<Array<BranchListing>>;
+	listEditors: () => Promise<Array<Editor>>;
 	listProjects: () => Promise<Array<ProjectForFrontend>>;
 	moveBranch: (params: MoveBranchParams) => Promise<MoveBranchResult>;
+	openInEditor: (params: OpenInEditorParams) => Promise<void>;
 	pathJoin: (...paths: Array<string>) => Promise<string>;
 	updateBranchName: (params: UpdateBranchNameParams) => Promise<void>;
 	tearOffBranch: (params: TearOffBranchParams) => Promise<MoveBranchResult>;
@@ -357,8 +366,10 @@ export const liteIpcChannels = {
 	getVersion: "lite:get-version",
 	headInfo: "workspace:head-info",
 	listBranches: "workspace:list-branches",
+	listEditors: "workspace:list-editors",
 	listProjects: "projects:list",
 	moveBranch: "workspace:move-branch",
+	openInEditor: "workspace:open-in-editor",
 	pathJoin: "lite:path-join",
 	updateBranchName: "workspace:update-branch-name",
 	tearOffBranch: "workspace:tear-off-branch",

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -21,6 +21,7 @@ import {
 	type CommitMoveChangesBetweenParams,
 	type CommitUncommitChangesParams,
 	type MoveBranchParams,
+	type OpenInEditorParams,
 	type PushStackParams,
 	type RemoveBranchParams,
 	type TearOffBranchParams,
@@ -61,8 +62,10 @@ import {
 	commitDetailsWithLineStats,
 	commitMoveChangesBetween,
 	listBranches,
+	listEditors,
 	listProjectsStateless,
 	moveBranch,
+	openInEditor,
 	removeBranch,
 	tearOffBranch,
 	treeChangeDiffs,
@@ -419,11 +422,17 @@ const registerIpcHandlers = (): void => {
 		liteIpcChannels.listBranches,
 		(_e, projectId: string, filter: BranchListingFilter | null) => listBranches(projectId, filter),
 	);
+	senderValidatingHandle(liteIpcChannels.listEditors, () => listEditors());
 	senderValidatingHandle(liteIpcChannels.listProjects, () => listProjectsStateless());
 	senderValidatingHandle(
 		liteIpcChannels.moveBranch,
 		(_e, { projectId, subjectBranch, targetBranch, dryRun }: MoveBranchParams) =>
 			moveBranch(projectId, subjectBranch, targetBranch, dryRun),
+	);
+	senderValidatingHandle(
+		liteIpcChannels.openInEditor,
+		(_e, { projectId, editorId, path }: OpenInEditorParams) =>
+			openInEditor(projectId, editorId, path),
 	);
 	senderValidatingHandle(liteIpcChannels.pathJoin, (_e, ...paths: Array<string>) =>
 		path.join(...paths),

--- a/apps/lite/electron/src/preload.cts
+++ b/apps/lite/electron/src/preload.cts
@@ -9,6 +9,7 @@ import type {
 	BranchListing,
 	CommitDetails,
 	DiffSpec,
+	Editor,
 	ProjectForFrontend,
 	PushResult,
 	RefInfo,
@@ -111,9 +112,11 @@ const api: LiteElectronApi = {
 		ipcRenderer.invoke("workspace:list-branches", projectId, filter) as Promise<
 			Array<BranchListing>
 		>,
+	listEditors: () => ipcRenderer.invoke("workspace:list-editors") as Promise<Array<Editor>>,
 	listProjects: () => ipcRenderer.invoke("projects:list") as Promise<Array<ProjectForFrontend>>,
 	moveBranch: (params) =>
 		ipcRenderer.invoke("workspace:move-branch", params) as Promise<MoveBranchResult>,
+	openInEditor: (params) => ipcRenderer.invoke("workspace:open-in-editor", params) as Promise<void>,
 	pathJoin: (path, ...paths) =>
 		ipcRenderer.invoke("lite:path-join", path, ...paths) as Promise<string>,
 	updateBranchName: (params) =>

--- a/crates/but-api/src/open/editor.rs
+++ b/crates/but-api/src/open/editor.rs
@@ -1,0 +1,137 @@
+use std::{path::Path, process::Stdio};
+
+use serde::Serialize;
+
+/// Supported editor configuration used internally to launch editors.
+#[derive(Clone)]
+pub struct EditorSpec<'a> {
+    /// Identifier used to refer to the editor.
+    pub id: &'a str,
+    /// Name of the editor.
+    pub name: &'a str,
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    /// Name of or path to the executable.
+    pub executable: &'a str,
+    #[cfg(target_os = "macos")]
+    /// macOS bundle identifier for the application.
+    pub bundle_identifier: &'a str,
+}
+
+/// Supported editor configuration for API clients.
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "napi", napi_derive::napi(object))]
+pub struct Editor {
+    /// Identifier used to refer to the editor.
+    pub id: String,
+    /// Name of the editor.
+    pub name: String,
+}
+
+impl From<&EditorSpec<'_>> for Editor {
+    fn from(editor: &EditorSpec<'_>) -> Self {
+        Self {
+            id: editor.id.to_string(),
+            name: editor.name.to_string(),
+        }
+    }
+}
+
+pub(crate) const EDITORS: &[EditorSpec] = &[
+    EditorSpec {
+        id: "cursor",
+        name: "Cursor",
+        #[cfg(target_os = "linux")]
+        executable: "cursor",
+        #[cfg(target_os = "windows")]
+        executable: "Cursor.exe",
+        #[cfg(target_os = "macos")]
+        // This looks insane but it's actually the correct bundle ID, see https://forum.cursor.com/t/cursor-bundle-identifier/779
+        bundle_identifier: "com.todesktop.230313mzl4w4u92",
+    },
+    EditorSpec {
+        id: "sublime",
+        name: "Sublime Text",
+        #[cfg(target_os = "linux")]
+        executable: "subl",
+        #[cfg(target_os = "windows")]
+        executable: "subl.exe",
+        #[cfg(target_os = "macos")]
+        bundle_identifier: "com.sublimetext.4",
+    },
+    EditorSpec {
+        id: "vscode",
+        name: "VS Code",
+        #[cfg(target_os = "linux")]
+        executable: "code",
+        #[cfg(target_os = "windows")]
+        executable: "code.exe",
+        #[cfg(target_os = "macos")]
+        bundle_identifier: "com.microsoft.VSCode",
+    },
+    #[cfg(target_os = "macos")]
+    EditorSpec {
+        id: "xcode",
+        name: "Xcode",
+        bundle_identifier: "com.apple.dt.Xcode",
+    },
+    EditorSpec {
+        id: "zed",
+        name: "Zed",
+        #[cfg(target_os = "linux")]
+        executable: "zed",
+        #[cfg(target_os = "windows")]
+        executable: "zed.exe",
+        #[cfg(target_os = "macos")]
+        bundle_identifier: "dev.zed.Zed",
+    },
+];
+
+/// Low-level API to open a `path` with a specified `editor`.
+///
+/// # WARNING
+/// It is up to the caller to assure that the `path` is safe to open and that the `editor` is safe
+/// to use. Therefore, this should never be exposed to an untrusted context, such as the GUI
+/// renderer.
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+pub fn open_in_editor_unchecked(path: &Path, editor: &EditorSpec<'_>) -> anyhow::Result<()> {
+    use crate::open::spawn::spawn_and_reap;
+
+    let mut cmd = std::process::Command::new(editor.executable);
+    cmd.arg(path);
+    cmd.stdout(Stdio::null()).stderr(Stdio::null());
+
+    spawn_and_reap(cmd, editor.executable, &path.to_string_lossy())?;
+
+    Ok(())
+}
+
+/// Low-level API to open a `path` with a specified `editor`.
+///
+/// # WARNING
+/// It is up to the caller to assure that the `path` is safe to open and that the `editor` is safe
+/// to use. Therefore, this should never be exposed to an untrusted context, such as the GUI
+/// renderer.
+///
+/// For untrusted clients, use [`open_in_editor`] instead.
+#[cfg(target_os = "macos")]
+pub fn open_in_editor_unchecked(path: &Path, editor: &EditorSpec<'_>) -> anyhow::Result<()> {
+    let mut cmd = std::process::Command::new("/usr/bin/open");
+    let status = cmd
+        .arg("-b")
+        .arg(editor.bundle_identifier)
+        .arg(path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()?;
+
+    if !status.success() {
+        anyhow::bail!(
+            "failed to open {path:?} with editor bundle identifier '{}'",
+            editor.bundle_identifier
+        );
+    }
+
+    Ok(())
+}

--- a/crates/but-api/src/open/mod.rs
+++ b/crates/but-api/src/open/mod.rs
@@ -3,11 +3,23 @@ use std::env;
 
 use anyhow::{Context as _, Result, bail};
 use but_api_macros::but_api;
+use but_error::bail_precondition;
 use tracing::instrument;
 use url::Url;
 
+use crate::open::{
+    editor::{EDITORS, Editor, open_in_editor_unchecked},
+    spawn::spawn_and_reap,
+};
+
 /// Terminal configuration and detection.
 pub mod terminal;
+
+/// Editor configuration.
+pub mod editor;
+
+/// Spawn helpers.
+pub(crate) mod spawn;
 
 /// Opens a supported URL or file path with the platform's default handler.
 ///
@@ -338,34 +350,6 @@ pub fn open_url(url: String) -> Result<()> {
 pub fn open_in_terminal(terminal_id: String, path: String) -> Result<()> {
     use std::process::Command;
 
-    /// Spawn a terminal process and reap it on a background thread.
-    ///
-    /// Terminal launches are fire-and-forget from the caller perspective, but we still
-    /// wait on the child process asynchronously to avoid leaving zombie processes behind.
-    fn spawn_and_reap(mut cmd: Command, terminal_name: &str, path: &str) -> Result<()> {
-        tracing::info!(?cmd, "terminal command");
-        let mut child = cmd
-            .spawn()
-            .with_context(|| format!("Failed to launch {terminal_name} at '{path}'"))?;
-
-        let terminal_name = terminal_name.to_owned();
-        let thread_terminal_name = terminal_name.clone();
-        std::thread::Builder::new()
-            .name(format!("reap-{terminal_name}"))
-            .stack_size(512 * 1024)
-            .spawn(move || match child.wait() {
-                Ok(stat) => if !stat.success() {
-                    tracing::warn!(terminal = %thread_terminal_name, status = ?stat, "Terminal process exited with error");
-                },
-                Err(err) => {
-                    tracing::warn!(terminal = %thread_terminal_name, error = %err, "Failed to reap terminal process")
-                }
-            })
-            .ok();
-
-        Ok(())
-    }
-
     if cfg!(target_os = "macos") {
         use std::process::Stdio;
 
@@ -637,4 +621,44 @@ pub fn show_in_finder(path: String) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// List all supported editors.
+#[but_api(napi)]
+#[instrument(err(Debug))]
+pub fn list_editors() -> anyhow::Result<Vec<Editor>> {
+    Ok(EDITORS.iter().map(Into::into).collect())
+}
+
+/// Open `path` within the given project's workdir.
+///
+/// `path` must be relative to the workdir of the repository and must resolve to a file or directory
+/// within the workdir, including the workdir root itself. Otherwise an error is returned.
+///
+/// [`list_editors`] provides the available `editor_id`s.
+#[but_api(napi)]
+#[instrument(skip(ctx), err(Debug))]
+pub fn open_in_editor(
+    ctx: &mut but_ctx::Context,
+    editor_id: String,
+    path: String,
+) -> anyhow::Result<()> {
+    let repo = ctx.repo.get()?;
+    let workdir_path = gix::path::realpath(repo.workdir().context("project must have a workdir")?)?;
+    let git_dir_path = gix::path::realpath(repo.path())?;
+    let resolved_path = gix::path::realpath(workdir_path.join(&path))?;
+
+    if resolved_path.strip_prefix(&workdir_path).is_err() {
+        bail_precondition!("{path:?} is outside repository workdir at {workdir_path:?}");
+    }
+
+    if resolved_path.strip_prefix(&git_dir_path).is_ok() {
+        bail_precondition!("{path:?} is inside repository .git directory at {git_dir_path:?}");
+    }
+
+    let Some(editor) = EDITORS.iter().find(|editor| editor.id == editor_id) else {
+        bail_precondition!("editor_id '{editor_id}' does not exist");
+    };
+
+    open_in_editor_unchecked(&resolved_path, editor)
 }

--- a/crates/but-api/src/open/spawn.rs
+++ b/crates/but-api/src/open/spawn.rs
@@ -1,0 +1,35 @@
+use std::process::Command;
+
+use anyhow::Context;
+
+/// Spawn a process and reap it on a background thread.
+///
+/// Spawns like this are fire-and-forget from the caller perspective, but we still
+/// wait on the child process asynchronously to avoid leaving zombie processes behind.
+pub(crate) fn spawn_and_reap(
+    mut cmd: Command,
+    executable_name: &str,
+    path: &str,
+) -> anyhow::Result<()> {
+    tracing::info!(?cmd, "spawn command");
+    let mut child = cmd
+        .spawn()
+        .with_context(|| format!("Failed to launch {executable_name} at '{path}'"))?;
+
+    let executable_name = executable_name.to_owned();
+    let thread_executable_name = executable_name.clone();
+    std::thread::Builder::new()
+            .name(format!("reap-{executable_name}"))
+            .stack_size(512 * 1024)
+            .spawn(move || match child.wait() {
+                Ok(stat) => if !stat.success() {
+                    tracing::warn!(executable = %thread_executable_name, status = ?stat, "Process exited with error");
+                },
+                Err(err) => {
+                    tracing::warn!(executable = %thread_executable_name, error = %err, "Failed to reap process")
+                }
+            })
+            .ok();
+
+    Ok(())
+}

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -233,6 +233,14 @@ export declare function commitUncommitChanges(projectId: string, commitId: strin
  */
 export declare function discardWorktreeChanges(projectId: string, worktreeChanges: Array<DiffSpec>): Promise<Array<DiffSpec>>
 
+/** Supported editor configuration for API clients. */
+export interface Editor {
+  /** Identifier used to refer to the editor. */
+  id: string
+  /** Name of the editor. */
+  name: string
+}
+
 /**
  * Web compare URL for a branch — drives the "Open in browser"
  * affordances without making the renderer hold per-forge URL
@@ -287,6 +295,9 @@ export declare function listBranches(projectId: string, filter: BranchListingFil
 
 export declare function listCiChecks(projectId: string, reference: string, cacheConfig: CacheConfig | null): Promise<Array<CiCheck>>
 
+/** List all supported editors. */
+export declare function listEditors(): Promise<Array<Editor>>
+
 export declare function listProjectsStateless(): Promise<Array<ProjectForFrontend>>
 
 export declare function listReviews(projectId: string, cacheConfig: CacheConfig | null): Promise<Array<ForgeReview>>
@@ -305,6 +316,16 @@ export declare function mergeReview(projectId: string, reviewId: number, mergeMe
  * entry is persisted.
  */
 export declare function moveBranch(projectId: string, subjectBranch: string, targetBranch: string, dryRun: boolean): Promise<MoveBranchResult>
+
+/**
+ * Open `path` within the given project's workdir.
+ *
+ * `path` must be relative to the workdir of the repository and must resolve to a file or directory
+ * within the workdir, including the workdir root itself. Otherwise an error is returned.
+ *
+ * [`list_editors`] provides the available `editor_id`s.
+ */
+export declare function openInEditor(projectId: string, editorId: string, path: string): Promise<void>
 
 /**
  * Find the final snapshot that a restore snapshot will restore from.

--- a/packages/but-sdk/src/generated/index.js
+++ b/packages/but-sdk/src/generated/index.js
@@ -579,7 +579,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { absorb, absorptionPlan, apply, applyBranchIntegration, assignHunk, branchCreate, branchDetails, branchDiff, changesInWorktree, changesInWorktreeWithPerm, commitAmend, commitCreate, commitDetailsWithLineStats, commitDiscard, commitDiscardChanges, commitInsertBlank, commitMove, commitMoveChangesBetween, commitReword, commitSquash, commitUncommit, commitUncommitChanges, discardWorktreeChanges, forgeCompareBranchUrl, forgeInfo, forgeProvider, getInitialBranchIntegration, getRedoTargetSnapshot, getRepoInfo, getReview, getReviewBaseRepoUrl, getReviewMergeStatus, getUndoTargetSnapshot, headInfo, listAvailableReviewTemplates, listBranches, listCiChecks, listProjectsStateless, listReviews, listReviewsForBranch, mergeReview, moveBranch, peelRestoreSnapshot, publishReview, pushStack, removeBranch, restoreSnapshotWithKind, reviewTemplate, setReviewAutoMerge, setReviewDraftiness, setReviewTemplate, tearOffBranch, treeChangeDiffs, unapplyStack, updateBranchName, updateReview, updateReviewFooters, warmCiChecksCache, workspaceBranchAndAncestorsPush, workspaceIntegrateUpstream, WatcherHandle, askpassInit, askpassSubmitPromptResponse, watcherStart } = nativeBinding
+const { absorb, absorptionPlan, apply, applyBranchIntegration, assignHunk, branchCreate, branchDetails, branchDiff, changesInWorktree, changesInWorktreeWithPerm, commitAmend, commitCreate, commitDetailsWithLineStats, commitDiscard, commitDiscardChanges, commitInsertBlank, commitMove, commitMoveChangesBetween, commitReword, commitSquash, commitUncommit, commitUncommitChanges, discardWorktreeChanges, forgeCompareBranchUrl, forgeInfo, forgeProvider, getInitialBranchIntegration, getRedoTargetSnapshot, getRepoInfo, getReview, getReviewBaseRepoUrl, getReviewMergeStatus, getUndoTargetSnapshot, headInfo, listAvailableReviewTemplates, listBranches, listCiChecks, listEditors, listProjectsStateless, listReviews, listReviewsForBranch, mergeReview, moveBranch, openInEditor, peelRestoreSnapshot, publishReview, pushStack, removeBranch, restoreSnapshotWithKind, reviewTemplate, setReviewAutoMerge, setReviewDraftiness, setReviewTemplate, tearOffBranch, treeChangeDiffs, unapplyStack, updateBranchName, updateReview, updateReviewFooters, warmCiChecksCache, workspaceBranchAndAncestorsPush, workspaceIntegrateUpstream, WatcherHandle, askpassInit, askpassSubmitPromptResponse, watcherStart } = nativeBinding
 export { absorb }
 export { absorptionPlan }
 export { apply }
@@ -617,11 +617,13 @@ export { headInfo }
 export { listAvailableReviewTemplates }
 export { listBranches }
 export { listCiChecks }
+export { listEditors }
 export { listProjectsStateless }
 export { listReviews }
 export { listReviewsForBranch }
 export { mergeReview }
 export { moveBranch }
+export { openInEditor }
 export { peelRestoreSnapshot }
 export { publishReview }
 export { pushStack }


### PR DESCRIPTION
This is a barebones version of a safe API for opening files in an editor. The API function `open_in_editor()` ensures that the path the caller wants to open is contained within the repository, and uses one of a selection of preconfigured editors to open it.

The lower level `open_in_editor_unchecked()` is meant to be used by the `but` CLI, probably supporting the Git-configured editor. I'm still experimenting with how that should work.

On Windows and Linux, we use the executable name, assuming PATH is properly populated. On macOS, it's more reliable to use bundle identifiers as the PATH variable typically isn't set for GUI apps launched outside of a shell.

Future improvements include opening at a specific line and column, as well as allowing users to specify custom editors (probably via a configuration file). And also having some more graceful way of dealing with an editor not actually being installed - right now you'll just get an error back.

> Note: Expect this API to evolve as we find new needs!