### PR TITLE
but-rebase: write 3+ sides of conflicts (sometimes)

### DIFF
--- a/crates/but-core/src/commit/mod.rs
+++ b/crates/but-core/src/commit/mod.rs
@@ -621,6 +621,36 @@ impl<'repo> Commit<'repo> {
         )))
     }
 
+    /// If the commit is not conflicted, returns an empty vec.
+    pub fn base_tree_ids(&self) -> anyhow::Result<Vec<gix::ObjectId>> {
+        if !self.is_conflicted() {
+            return Ok(Vec::new());
+        }
+        let tree = self.inner.tree.attach(self.id.repo).object()?.into_tree();
+        let mut ids = Vec::new();
+        let mut i = 0;
+        while let Some(entry) = tree.find_entry(format!(".conflict-base-{i}")) {
+            ids.push(entry.id().detach());
+            i += 1;
+        }
+        Ok(ids)
+    }
+
+    /// If the commit is not conflicted, returns the commit's tree as a single-element vec..
+    pub fn side_tree_ids(&self) -> anyhow::Result<Vec<gix::ObjectId>> {
+        if !self.is_conflicted() {
+            return Ok(vec![self.inner.tree]);
+        }
+        let tree = self.inner.tree.attach(self.id.repo).object()?.into_tree();
+        let mut ids = Vec::new();
+        let mut i = 0;
+        while let Some(entry) = tree.find_entry(format!(".conflict-side-{i}")) {
+            ids.push(entry.id().detach());
+            i += 1;
+        }
+        Ok(ids)
+    }
+
     /// Return our custom headers, of present.
     pub fn headers(&self) -> Option<Headers> {
         Headers::try_from_commit(&self.inner)
@@ -788,7 +818,8 @@ pub use conflict::{
 };
 
 /// Write a GitButler conflicted tree that wraps `resolved_tree_id` together
-/// with the conflict side trees and conflict file list.
+/// with the conflict base trees, the conflict side trees, and the conflict
+/// file list.
 ///
 /// - `repo` - is the repository that owns all tree objects involved and receives
 ///   the newly written conflicted tree.
@@ -796,9 +827,12 @@ pub use conflict::{
 /// - `resolved_tree_id` - is the visible auto-resolved tree that callers want to
 ///   present as the conflicted commit's main tree.
 ///
-/// - `base_tree_id` - is the merge-base tree used for the conflicted merge step.
+/// - `base_tree_ids` - are the base trees. A conflict from a 3-way merge will
+///   have 1 base.
 ///
-/// - `ours_tree_id` - is the accumulated tree on the "ours" side of the conflict.
+/// - `side_tree_ids` - are the side trees. A conflict from a 3-way merge will
+///   have 2 sides, the first side being "ours" and the second side being
+///   "theirs".
 ///
 /// - `theirs_tree_id` - is the incoming tree on the "theirs" side of the conflict.
 ///
@@ -807,30 +841,20 @@ pub use conflict::{
 pub fn write_conflicted_tree(
     repo: &gix::Repository,
     resolved_tree_id: gix::ObjectId,
-    base_tree_id: gix::ObjectId,
-    ours_tree_id: gix::ObjectId,
-    theirs_tree_id: gix::ObjectId,
+    base_tree_ids: impl IntoIterator<Item = gix::ObjectId>,
+    side_tree_ids: impl IntoIterator<Item = gix::ObjectId>,
     conflict_entries: &ConflictEntries,
 ) -> anyhow::Result<gix::ObjectId> {
     let conflicted_files_string = toml::to_string(conflict_entries)?;
     let conflicted_files_blob = repo.write_blob(conflicted_files_string.as_bytes())?;
 
     let mut tree = repo.find_tree(resolved_tree_id)?.edit()?;
-    tree.upsert(
-        TreeKind::Ours.as_tree_entry_name(),
-        EntryKind::Tree,
-        ours_tree_id,
-    )?;
-    tree.upsert(
-        TreeKind::Theirs.as_tree_entry_name(),
-        EntryKind::Tree,
-        theirs_tree_id,
-    )?;
-    tree.upsert(
-        TreeKind::Base.as_tree_entry_name(),
-        EntryKind::Tree,
-        base_tree_id,
-    )?;
+    for (i, tree_id) in base_tree_ids.into_iter().enumerate() {
+        tree.upsert(format!(".conflict-base-{i}"), EntryKind::Tree, tree_id)?;
+    }
+    for (i, tree_id) in side_tree_ids.into_iter().enumerate() {
+        tree.upsert(format!(".conflict-side-{i}"), EntryKind::Tree, tree_id)?;
+    }
     tree.upsert(
         TreeKind::AutoResolution.as_tree_entry_name(),
         EntryKind::Tree,

--- a/crates/but-rebase/src/graph_rebase/merge_commit_changes.rs
+++ b/crates/but-rebase/src/graph_rebase/merge_commit_changes.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../../docs/merge_commit_changes.md")]
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use anyhow::{Context, Result, bail};
 use but_core::{RefMetadata, RepositoryExt};
@@ -41,12 +41,10 @@ pub struct MergeCommitChangesOutcome {
 /// merged change-range result.
 #[derive(Debug, Clone, PartialEq)]
 pub struct MergeCommitChangesConflict {
-    /// The merge base tree for the conflicted merge step.
-    pub base_tree_id: gix::ObjectId,
-    /// The accumulated tree on the "ours" side of the conflicted merge step.
-    pub ours_tree_id: gix::ObjectId,
-    /// The selected commit tree on the "theirs" side of the conflicted merge step.
-    pub theirs_tree_id: gix::ObjectId,
+    /// The merge base trees for the conflicted merge step.
+    pub base_tree_ids: Vec<gix::ObjectId>,
+    /// The merge side trees for the conflicted merge step.
+    pub side_tree_ids: Vec<gix::ObjectId>,
     /// The paths that remained conflicted after auto-resolution.
     pub conflict_entries: but_core::commit::ConflictEntries,
 }
@@ -64,53 +62,53 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
         merge_options: gix::merge::tree::Options,
     ) -> Result<MergeCommitChangesOutcome> {
         let target_commit = but_core::Commit::from_id(target_commit_id.attach(&self.repo))?;
-        let target_tree_id = target_commit.tree_id_or_auto_resolution()?.detach();
         let merge_plan =
             self.plan_commit_changes_for_merge(target_commit_id, subject_commit_ids)?;
-        if merge_plan.is_empty() {
-            let tree_id = target_tree_id;
-            let conflict = if target_commit.is_conflicted() {
-                let (base_tree_id, ours_tree_id, theirs_tree_id) = target_commit
-                    .conflicted_tree_ids()?
-                    .context("conflicted commit is missing conflicted tree sides")?;
-                Some(MergeCommitChangesConflict {
-                    base_tree_id: base_tree_id.detach(),
-                    ours_tree_id: ours_tree_id.detach(),
-                    theirs_tree_id: theirs_tree_id.detach(),
-                    conflict_entries: target_commit
-                        .conflict_entries()?
-                        .context("conflicted commit is missing conflict entries")?,
-                })
-            } else {
-                None
-            };
-            return Ok(MergeCommitChangesOutcome { tree_id, conflict });
+
+        let mut bases = VecDeque::from(target_commit.base_tree_ids()?);
+        let mut sides = VecDeque::from(target_commit.side_tree_ids()?);
+        for change in merge_plan {
+            bases.push_back(change.base_tree_id);
+            let commit = but_core::Commit::from_id(change.commit_id.attach(&self.repo))?;
+            bases.extend(commit.base_tree_ids()?);
+            sides.extend(commit.side_tree_ids()?);
         }
 
-        let mut ours = target_tree_id;
-        let mut conflict = None;
-        let conflict_kind = gix::merge::tree::TreatAsUnresolved::forced_resolution();
+        // Simplify: a base and a side that are identical cancel each other out
+        for i in (0..bases.len()).rev() {
+            if let Some(position) = sides.iter().position(|side| *side == bases[i]) {
+                sides.remove(position);
+                bases.remove(i);
+            }
+        }
 
-        for change in merge_plan {
-            let theirs = but_core::Commit::from_id(change.commit_id.attach(&self.repo))?
-                .tree_id_or_auto_resolution()?
-                .detach();
-            let mut merge = self
-                .repo
-                .merge_trees(
-                    change.base_tree_id,
-                    ours,
-                    theirs,
-                    self.repo.default_merge_labels(),
-                    merge_options.clone(),
-                )
-                .context("failed to merge commit trees")?;
+        let conflict_kind = gix::merge::tree::TreatAsUnresolved::forced_resolution();
+        let mut ours = sides
+            .pop_front()
+            .context("BUG: target_commit should have at least one side")?;
+        while let Some(base) = bases.pop_front() {
+            let theirs = sides
+                .pop_front()
+                .context("attempting to merge commit with unbalanced bases and sides")?;
+            let mut merge = self.repo.merge_trees(
+                base,
+                ours,
+                theirs,
+                self.repo.default_merge_labels(),
+                merge_options.clone(),
+            )?;
             let merged_tree_id = merge.tree.write()?.detach();
+
             if merge.has_unresolved_conflicts(conflict_kind) {
-                conflict = Some(MergeCommitChangesConflict {
-                    base_tree_id: change.base_tree_id,
-                    ours_tree_id: ours,
-                    theirs_tree_id: theirs,
+                // Push back the things that conflict when merged. Note that
+                // "ours" needs to be the frontmost, so we push "theirs" then
+                // "ours".
+                sides.push_front(theirs);
+                sides.push_front(ours);
+                bases.push_front(base);
+                let conflict = Some(MergeCommitChangesConflict {
+                    base_tree_ids: bases.into(),
+                    side_tree_ids: sides.into(),
                     conflict_entries: but_core::commit::conflict_entries_from_merge_outcome(
                         &self.repo,
                         merged_tree_id,
@@ -118,15 +116,20 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
                         conflict_kind,
                     )?,
                 });
-                ours = merged_tree_id;
-                break;
+                return Ok(MergeCommitChangesOutcome {
+                    // As described in the module-level documentation, we stop
+                    // at the first unresolved merge conflict.
+                    tree_id: merged_tree_id,
+                    conflict,
+                });
             }
+
             ours = merged_tree_id;
         }
 
         Ok(MergeCommitChangesOutcome {
             tree_id: ours,
-            conflict,
+            conflict: None,
         })
     }
 

--- a/crates/but-rebase/tests/rebase/graph_rebase/merge_commit_changes.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/merge_commit_changes.rs
@@ -163,16 +163,15 @@ fn reports_conflicts() -> Result<()> {
         .conflict
         .expect("conflicting merge should report conflict metadata");
     assert_eq!(
-        conflict.base_tree_id,
-        repo.rev_parse_single("A~1^{tree}")?.detach()
+        conflict.base_tree_ids,
+        vec![repo.rev_parse_single("A~1^{tree}")?.detach()]
     );
     assert_eq!(
-        conflict.ours_tree_id,
-        repo.rev_parse_single("A^{tree}")?.detach()
-    );
-    assert_eq!(
-        conflict.theirs_tree_id,
-        repo.rev_parse_single("B^{tree}")?.detach()
+        conflict.side_tree_ids,
+        vec![
+            repo.rev_parse_single("A^{tree}")?.detach(),
+            repo.rev_parse_single("B^{tree}")?.detach()
+        ]
     );
     assert!(conflict.conflict_entries.has_entries());
 

--- a/crates/but-workspace/src/branch/integrate_branch_upstream/plan.rs
+++ b/crates/but-workspace/src/branch/integrate_branch_upstream/plan.rs
@@ -312,9 +312,8 @@ fn apply_merge_commit_changes_outcome(
         commit.tree = write_conflicted_tree(
             repo,
             outcome.tree_id,
-            conflict.base_tree_id,
-            conflict.ours_tree_id,
-            conflict.theirs_tree_id,
+            conflict.base_tree_ids,
+            conflict.side_tree_ids,
             &conflict.conflict_entries,
         )?;
         commit.message = add_conflict_markers(BStr::new(&message));


### PR DESCRIPTION
The start of the effort to support a jj-like conflict tree algebra (with many sides and bases) instead of the current system that only supports at most 2 sides and 1 base.

---

`merge_commit_changes_to_tree()` currently only writes 2 sides + 1 base of a conflict, silently dropping other sides and bases. Teach it not to drop them, and to use all sides and bases of conflicted commits when merging.

This is written in a backwards-compatible way: due to the merging process stopping at the first conflict (as documented in the module-level documentation), the first 2 sides and the first base that are written are the same before and after this commit. The only difference is that additional sides and bases are preserved. So code that only understands 2 sides + 1 base will still work.

This only affects a limited number of cases. I plan to take a look at `merged_tree_from_commits()` next and see if it can be made to share code with this commit.

There was an optimization: when the target commit is conflicted and nothing is to be merged into it, the target commit tree is reused as-is (instead of performing a merge). This optimization is probably not worth the code, since the situation in which it is triggered is so unlikely, so I have not reimplemented it.
