### PR TITLE
Prefer authored date for commits

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -648,7 +648,7 @@ const CommitDetailsContent: FC<{
 				hour: "2-digit",
 				minute: "2-digit",
 				hour12: false,
-			}).format(commitDetails.commit.committedAt);
+			}).format(commitDetails.commit.authoredAt);
 
 			const body = commitBody(commitDetails.commit.message);
 


### PR DESCRIPTION
A small pet peeve resolved, closing GB-1593. (We can use the committed date again in the future, that's a design question.)