### PR TITLE
Add agent-safe text output mode

### DIFF
--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -61,7 +61,7 @@ pub struct OutputFormatArg {
     /// If unset and from a terminal, it defaults to human output, when redirected it's for shells.
     #[clap(
         long,
-        env = "BUT_OUTPUT_FORMAT",
+        env = crate::utils::envs::BUT_OUTPUT_FORMAT,
         default_value = "human",
         global = true
     )]
@@ -74,6 +74,8 @@ pub enum OutputFormat {
     /// The output to write is supposed to be for human consumption, and can be more verbose.
     #[default]
     Human,
+    /// The output is for an AI coding agent, rendered as human-readable text.
+    Agent,
     /// The output should be suitable for shells, and assigning the major result to variables so that it can be reused
     /// in subsequent CLI invocations.
     Shell,
@@ -81,6 +83,33 @@ pub enum OutputFormat {
     Json,
     /// Do not output anything, like redirecting to `/dev/null`.
     None,
+}
+
+impl OutputFormat {
+    /// Whether this format renders human-readable text.
+    pub fn is_human_text(self) -> bool {
+        matches!(self, Self::Human | Self::Agent)
+    }
+
+    /// Whether this format renders plain text.
+    pub fn is_text(self) -> bool {
+        self.is_human_text() || matches!(self, Self::Shell)
+    }
+
+    /// Whether this format may truncate long text when output is not paged.
+    pub fn allows_truncation(self) -> bool {
+        matches!(self, Self::Human | Self::Shell)
+    }
+
+    /// Whether this format may use human terminal UI affordances like pagers, progress, prompts, or ambient messages.
+    pub fn allows_human_ui(self) -> bool {
+        matches!(self, Self::Human)
+    }
+
+    /// Whether this format writes JSON values.
+    pub fn is_json(self) -> bool {
+        matches!(self, Self::Json)
+    }
 }
 
 #[derive(

--- a/crates/but/src/args/tests.rs
+++ b/crates/but/src/args/tests.rs
@@ -314,6 +314,26 @@ fn status_after_is_not_shown_in_help() {
     );
 }
 
+#[test]
+fn output_format_parses_agent() {
+    use clap::Parser;
+
+    let args = Args::try_parse_from(["but", "--format", "agent"]).expect("parse agent format");
+
+    assert!(matches!(args.format.format, OutputFormat::Agent));
+}
+
+#[test]
+fn output_format_agent_is_text_without_human_ui() {
+    let format = OutputFormat::Agent;
+
+    assert!(format.is_human_text());
+    assert!(format.is_text());
+    assert!(!format.allows_human_ui());
+    assert!(!format.allows_truncation());
+    assert!(!format.is_json());
+}
+
 mod agentlog {
     use clap::Parser;
 

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -1081,7 +1081,7 @@ fn ai_config_inner(
 
     match cmd {
         None => {
-            if out.for_human().is_some() {
+            if out.can_prompt() {
                 return ai_config_interactive(repo, out, scope);
             }
             show_ai_config(repo, out, scope)

--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -4,7 +4,7 @@ use strum::IntoEnumIterator as _;
 use crate::args::{Args, SubcommandDiscriminant};
 use crate::theme::{self, Paint};
 use crate::tui::text::{terminal_width, truncate_text};
-use crate::utils::envs;
+use crate::utils::{OutputChannel, envs};
 
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, strum::EnumIter)]
 enum Group {
@@ -31,10 +31,23 @@ impl std::fmt::Display for Group {
     }
 }
 
-pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
+pub fn print_grouped(out: &mut OutputChannel) -> std::fmt::Result {
+    let allow_truncation = out.format().allows_truncation();
+    print_grouped_with_truncation(out, allow_truncation)
+}
+
+fn print_grouped_with_truncation(
+    out: &mut dyn std::fmt::Write,
+    allow_truncation: bool,
+) -> std::fmt::Result {
     use clap::CommandFactory;
 
-    let terminal_width = terminal_width();
+    // Without truncation, an effectively infinite width makes truncate_text a no-op.
+    let terminal_width = if allow_truncation {
+        terminal_width()
+    } else {
+        usize::MAX
+    };
 
     let cmd = Args::command();
     let clap_subcommands: Vec<_> = cmd.get_subcommands().collect();
@@ -252,7 +265,7 @@ pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
         ),
         (
             "      --format <FORMAT>",
-            "   Explicitly control how output should be formatted [possible values: human, shell, json, none]",
+            "   Explicitly control how output should be formatted [possible values: human, agent, shell, json, none]",
         ),
         ("  -h, --help", "              Print help"),
     ];
@@ -283,7 +296,7 @@ mod tests {
     #[cfg(feature = "legacy")]
     fn test_print_grouped() {
         let mut buf = String::new();
-        super::print_grouped(&mut buf).unwrap();
+        super::print_grouped_with_truncation(&mut buf, true).unwrap();
 
         snapbox::assert_data_eq!(
             // test without color because it doesn't work consistently on ci
@@ -369,10 +382,29 @@ Environment variables:
     }
 
     #[test]
+    #[cfg(feature = "legacy")]
+    fn print_grouped_keeps_full_descriptions_when_truncation_is_disabled() {
+        let mut buf = String::new();
+        super::print_grouped_with_truncation(&mut buf, false).unwrap();
+        let output = strip_ansi_codes(&buf);
+
+        assert!(
+            output.contains(
+                "Cherry-pick a commit from an unapplied branch into an applied virtual branch."
+            ),
+            "agent help should keep the full command description"
+        );
+        assert!(
+            output.contains("possible values: human, agent, shell, json, none"),
+            "manual format help should include agent"
+        );
+    }
+
+    #[test]
     #[cfg(not(feature = "legacy"))]
     fn test_print_grouped() {
         let mut buf = String::new();
-        super::print_grouped(&mut buf).unwrap();
+        super::print_grouped_with_truncation(&mut buf, true).unwrap();
 
         snapbox::assert_data_eq!(
             // test without color because it doesn't work consistently on ci

--- a/crates/but/src/command/legacy/branch/list.rs
+++ b/crates/but/src/command/legacy/branch/list.rs
@@ -210,6 +210,7 @@ pub fn list(
         None
     };
 
+    let allow_truncation = out.format().allows_truncation();
     if let Some(out) = out.for_json() {
         output_json(
             &applied_stacks,
@@ -231,6 +232,7 @@ pub fn list(
                 ctx,
                 commits_ahead_map.as_ref(),
                 merge_status_map.as_ref(),
+                allow_truncation,
                 out,
             )?;
         }
@@ -246,6 +248,7 @@ pub fn list(
                 &branch_review_map,
                 commits_ahead_map.as_ref(),
                 merge_status_map.as_ref(),
+                allow_truncation,
                 out,
             )?;
         }
@@ -552,6 +555,7 @@ fn print_applied_branches_table(
     ctx: &Context,
     commits_ahead_map: Option<&HashMap<String, usize>>,
     merge_status_map: Option<&HashMap<String, bool>>,
+    allow_truncation: bool,
     out: &mut (dyn std::fmt::Write + 'static),
 ) -> Result<(), anyhow::Error> {
     use crate::tui::{Table, table::Cell};
@@ -576,7 +580,7 @@ fn print_applied_branches_table(
         Cell::new("AUTHOR"),
     ];
 
-    let mut table = Table::new(headers);
+    let mut table = Table::new(headers).with_truncation(allow_truncation);
 
     for stack in applied_stacks {
         let first_branch = stack.branches.first();
@@ -686,6 +690,7 @@ fn print_branches_table(
     branch_review_map: &HashMap<String, Vec<but_forge::ForgeReview>>,
     commits_ahead_map: Option<&HashMap<String, usize>>,
     merge_status_map: Option<&HashMap<String, bool>>,
+    allow_truncation: bool,
     out: &mut (dyn std::fmt::Write + 'static),
 ) -> Result<(), anyhow::Error> {
     use crate::tui::{Table, table::Cell};
@@ -706,7 +711,7 @@ fn print_branches_table(
         Cell::new("AUTHOR"),
     ];
 
-    let mut table = Table::new(headers);
+    let mut table = Table::new(headers).with_truncation(allow_truncation);
 
     for branch in branches {
         // Ahead column

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -436,13 +436,7 @@ pub(crate) fn commit(
     } else if let Some(msg) = message {
         msg.to_string()
     } else {
-        // In JSON mode, we should have already validated that a message was provided
-        // This is a safeguard in case the validation was missed
-        if out.for_json().is_some() {
-            return Err(anyhow::anyhow!(
-                "In JSON mode, a commit message must be provided via --message (-m), --message-file, or --ai (-i)"
-            ).into());
-        }
+        // The pre-check in lib.rs guarantees a message for formats without an interactive editor.
         get_commit_message_from_editor(ctx, &files_to_commit, &changes, show_diff_in_editor)?
     };
 

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -175,11 +175,13 @@ fn handle_dry_run(
             out.write_value(&DryRunResult { branches: vec![] })?;
         }
 
-        writeln!(
-            progress,
-            "{}",
-            t.hint.paint("No branches have unpushed commits.")
-        )?;
+        if let Some(human) = out.for_human() {
+            writeln!(
+                human,
+                "{}",
+                t.hint.paint("No branches have unpushed commits.")
+            )?;
+        }
         return Ok(());
     }
 
@@ -282,15 +284,18 @@ fn handle_dry_run(
         })?;
     }
 
-    // Output human-readable format
-    writeln!(progress)?;
+    let Some(human) = out.for_human() else {
+        return Ok(());
+    };
+
+    writeln!(human)?;
     writeln!(
-        progress,
+        human,
         "{} {}",
         t.important.paint("Dry run:"),
         t.hint.paint("Showing what would be pushed")
     )?;
-    writeln!(progress)?;
+    writeln!(human)?;
 
     // Group branches by stack
     let mut branches_by_stack: std::collections::HashMap<String, Vec<&DryRunBranchInfo>> =
@@ -311,7 +316,7 @@ fn handle_dry_run(
         // Highlight stacked branches (multiple branches in same stack)
         if branches.len() > 1 {
             writeln!(
-                progress,
+                human,
                 "{} {} {}",
                 t.attention.paint("Stack:"),
                 t.local_branch.paint(stack_name),
@@ -344,9 +349,9 @@ fn handle_dry_run(
             let has_next = is_in_stack && !is_last;
 
             if is_in_stack && !is_first {
-                writeln!(progress, "{}", t.hint.paint("│"))?;
+                writeln!(human, "{}", t.hint.paint("│"))?;
             } else {
-                writeln!(progress)?;
+                writeln!(human)?;
             }
 
             // Determine the gutter character
@@ -365,7 +370,7 @@ fn handle_dry_run(
             // Display branch name with stacking indicator and visual line
             if let Some(stacked_on) = &info.stacked_on {
                 writeln!(
-                    progress,
+                    human,
                     "{} {} {} {} {}",
                     t.hint.paint(gutter),
                     t.important.paint("Branch:"),
@@ -375,7 +380,7 @@ fn handle_dry_run(
                 )?;
             } else {
                 writeln!(
-                    progress,
+                    human,
                     "{} {} {}",
                     t.hint.paint(gutter),
                     t.important.paint("Branch:"),
@@ -396,7 +401,7 @@ fn handle_dry_run(
             let line_prefix = if has_next { "│ " } else { "  " };
 
             writeln!(
-                progress,
+                human,
                 "{}  {} {} {}",
                 t.hint.paint(line_prefix),
                 t.success.paint("→"),
@@ -405,7 +410,7 @@ fn handle_dry_run(
                     .paint(format!("{}/{}", info.remote, branch_name))
             )?;
             writeln!(
-                progress,
+                human,
                 "{}  {} {} unpushed commit{}",
                 t.hint.paint(line_prefix),
                 t.hint.paint("Commits:"),
@@ -415,13 +420,13 @@ fn handle_dry_run(
 
             if !info.commits.is_empty() {
                 if is_in_stack {
-                    writeln!(progress, "{}", t.hint.paint(line_prefix))?;
+                    writeln!(human, "{}", t.hint.paint(line_prefix))?;
                 } else {
-                    writeln!(progress)?;
+                    writeln!(human)?;
                 }
                 for commit in &info.commits {
                     writeln!(
-                        progress,
+                        human,
                         "{}    {} {}",
                         t.hint.paint(line_prefix),
                         t.commit_id.paint(&commit.sha_short),
@@ -431,7 +436,7 @@ fn handle_dry_run(
 
                 if info.unpushed_commits > info.commits.len() {
                     writeln!(
-                        progress,
+                        human,
                         "{}    ... and {} more",
                         t.hint.paint(line_prefix),
                         info.unpushed_commits - info.commits.len()
@@ -441,9 +446,9 @@ fn handle_dry_run(
 
             // Show upstream commits if any
             if !info.upstream_commits.is_empty() {
-                writeln!(progress)?;
+                writeln!(human)?;
                 writeln!(
-                    progress,
+                    human,
                     "{}  {} {} {} commit{}",
                     t.hint.paint(line_prefix),
                     t.sym().warning,
@@ -455,10 +460,10 @@ fn handle_dry_run(
                         "s"
                     }
                 )?;
-                writeln!(progress)?;
+                writeln!(human)?;
                 for commit in &info.upstream_commits {
                     writeln!(
-                        progress,
+                        human,
                         "{}    {} {}",
                         t.hint.paint(line_prefix),
                         t.error.paint(&commit.sha_short),
@@ -469,9 +474,9 @@ fn handle_dry_run(
 
             // Show warning if present
             if let Some(warning) = &info.warning {
-                writeln!(progress)?;
+                writeln!(human)?;
                 writeln!(
-                    progress,
+                    human,
                     "{}  {} {}",
                     t.hint.paint(line_prefix),
                     t.sym().warning.error(),
@@ -481,9 +486,9 @@ fn handle_dry_run(
 
             // Show force push indicator
             if info.requires_force {
-                writeln!(progress)?;
+                writeln!(human)?;
                 writeln!(
-                    progress,
+                    human,
                     "{}  {} {}",
                     t.hint.paint(line_prefix),
                     t.sym().lightning,
@@ -492,15 +497,15 @@ fn handle_dry_run(
             }
         }
 
-        writeln!(progress)?;
+        writeln!(human)?;
     }
 
     let total_commits: usize = dry_run_infos.iter().map(|i| i.unpushed_commits).sum();
     let total_branches = dry_run_infos.len();
 
-    writeln!(progress)?;
+    writeln!(human)?;
     writeln!(
-        progress,
+        human,
         "{} Would push {} {} across {} {}",
         t.important.paint("Summary:"),
         t.attention.paint(total_commits.to_string()),
@@ -516,9 +521,9 @@ fn handle_dry_run(
             "branches"
         }
     )?;
-    writeln!(progress)?;
+    writeln!(human)?;
     writeln!(
-        progress,
+        human,
         "{}",
         t.hint.paint("Run without --dry-run to push these changes.")
     )?;
@@ -552,40 +557,41 @@ fn push_single_branch(
 ) -> anyhow::Result<()> {
     let t = theme::get();
     let result = push_single_branch_impl(ctx, perm, branch_name, args, gerrit_mode)?;
-    let mut progress = out.progress_channel();
 
     if let Some(out) = out.for_json() {
         out.write_value(&result)?;
     }
 
-    writeln!(progress)?;
-    writeln!(progress, "{} Push completed successfully", t.sym().success)?;
-    writeln!(progress)?;
-    if !result.branch_sha_updates.is_empty() {
-        let repo = ctx.repo.get()?.clone().for_commit_shortening();
-        let gerrit_review_ref = if gerrit_mode {
-            Some(gerrit_review_ref(ctx, perm, &repo)?)
-        } else {
-            None
-        };
-        for (branch, before_sha, after_sha) in &result.branch_sha_updates {
-            let before_str = if before_sha == "0000000000000000000000000000000000000000" {
-                "(new branch)".to_string()
+    if let Some(human) = out.for_human() {
+        writeln!(human)?;
+        writeln!(human, "{} Push completed successfully", t.sym().success)?;
+        writeln!(human)?;
+        if !result.branch_sha_updates.is_empty() {
+            let repo = ctx.repo.get()?.clone().for_commit_shortening();
+            let gerrit_review_ref = if gerrit_mode {
+                Some(gerrit_review_ref(ctx, perm, &repo)?)
             } else {
-                shorten_hex_object_id(&repo, before_sha)
+                None
             };
-            let after_str = shorten_hex_object_id(&repo, after_sha);
-            let remote_ref =
-                branch_remote_ref_for_display(&result, branch, gerrit_review_ref.as_deref());
+            for (branch, before_sha, after_sha) in &result.branch_sha_updates {
+                let before_str = if before_sha == "0000000000000000000000000000000000000000" {
+                    "(new branch)".to_string()
+                } else {
+                    shorten_hex_object_id(&repo, before_sha)
+                };
+                let after_str = shorten_hex_object_id(&repo, after_sha);
+                let remote_ref =
+                    branch_remote_ref_for_display(&result, branch, gerrit_review_ref.as_deref());
 
-            writeln!(
-                progress,
-                "  {} -> {} ({} -> {})",
-                t.local_branch.paint(branch),
-                t.hint.paint(&remote_ref),
-                t.hint.paint(&before_str),
-                t.commit_id.paint(&after_str)
-            )?;
+                writeln!(
+                    human,
+                    "  {} -> {} ({} -> {})",
+                    t.local_branch.paint(branch),
+                    t.hint.paint(&remote_ref),
+                    t.hint.paint(&before_str),
+                    t.commit_id.paint(&after_str)
+                )?;
+            }
         }
     }
 
@@ -652,11 +658,13 @@ fn push_all_branches(
             out.write_value(&batch_result)?;
         }
 
-        writeln!(
-            progress,
-            "{}",
-            t.hint.paint("No branches have unpushed commits.")
-        )?;
+        if let Some(human) = out.for_human() {
+            writeln!(
+                human,
+                "{}",
+                t.hint.paint("No branches have unpushed commits.")
+            )?;
+        }
         return Ok(false);
     }
 
@@ -712,73 +720,75 @@ fn push_all_branches(
         out.write_value(&batch_result)?;
     }
 
-    writeln!(progress)?;
+    if let Some(human) = out.for_human() {
+        writeln!(human)?;
 
-    if !pushed_results.is_empty() {
-        writeln!(
-            progress,
-            "{} {} {} {}",
-            t.sym().success,
-            t.success.paint("Successfully pushed"),
-            t.attention.paint(total_commits_pushed.to_string()),
-            if total_commits_pushed == 1 {
-                "commit"
-            } else {
-                "commits"
-            }
-        )?;
-        writeln!(progress)?;
-
-        // Print combined branch, remote, and SHA information for all pushed branches
-        let repo = ctx.repo.get()?.clone().for_commit_shortening();
-        let gerrit_review_ref = if gerrit_mode {
-            Some(gerrit_review_ref(ctx, perm, &repo)?)
-        } else {
-            None
-        };
-        for result in &pushed_results {
-            for (branch, before_sha, after_sha) in &result.branch_sha_updates {
-                let before_str = if before_sha == "0000000000000000000000000000000000000000" {
-                    "(new branch)".to_string()
+        if !pushed_results.is_empty() {
+            writeln!(
+                human,
+                "{} {} {} {}",
+                t.sym().success,
+                t.success.paint("Successfully pushed"),
+                t.attention.paint(total_commits_pushed.to_string()),
+                if total_commits_pushed == 1 {
+                    "commit"
                 } else {
-                    shorten_hex_object_id(&repo, before_sha)
-                };
-                let after_str = shorten_hex_object_id(&repo, after_sha);
-                let remote_ref =
-                    branch_remote_ref_for_display(result, branch, gerrit_review_ref.as_deref());
+                    "commits"
+                }
+            )?;
+            writeln!(human)?;
 
-                writeln!(
-                    progress,
-                    "  {} -> {} ({} -> {})",
-                    t.local_branch.paint(branch),
-                    t.hint.paint(&remote_ref),
-                    t.hint.paint(&before_str),
-                    t.commit_id.paint(&after_str)
-                )?;
+            // Print combined branch, remote, and SHA information for all pushed branches
+            let repo = ctx.repo.get()?.clone().for_commit_shortening();
+            let gerrit_review_ref = if gerrit_mode {
+                Some(gerrit_review_ref(ctx, perm, &repo)?)
+            } else {
+                None
+            };
+            for result in &pushed_results {
+                for (branch, before_sha, after_sha) in &result.branch_sha_updates {
+                    let before_str = if before_sha == "0000000000000000000000000000000000000000" {
+                        "(new branch)".to_string()
+                    } else {
+                        shorten_hex_object_id(&repo, before_sha)
+                    };
+                    let after_str = shorten_hex_object_id(&repo, after_sha);
+                    let remote_ref =
+                        branch_remote_ref_for_display(result, branch, gerrit_review_ref.as_deref());
+
+                    writeln!(
+                        human,
+                        "  {} -> {} ({} -> {})",
+                        t.local_branch.paint(branch),
+                        t.hint.paint(&remote_ref),
+                        t.hint.paint(&before_str),
+                        t.commit_id.paint(&after_str)
+                    )?;
+                }
             }
         }
-    }
 
-    if !failed_branches.is_empty() {
-        writeln!(progress)?;
-        writeln!(
-            progress,
-            "{} Failed to push {} {}:",
-            t.sym().error,
-            t.error.paint(failed_branches.len().to_string()),
-            if failed_branches.len() == 1 {
-                "branch"
-            } else {
-                "branches"
-            }
-        )?;
-        for failed in &failed_branches {
+        if !failed_branches.is_empty() {
+            writeln!(human)?;
             writeln!(
-                progress,
-                "    {} - {}",
-                t.error.paint(&failed.branch_name),
-                t.hint.paint(&failed.error)
+                human,
+                "{} Failed to push {} {}:",
+                t.sym().error,
+                t.error.paint(failed_branches.len().to_string()),
+                if failed_branches.len() == 1 {
+                    "branch"
+                } else {
+                    "branches"
+                }
             )?;
+            for failed in &failed_branches {
+                writeln!(
+                    human,
+                    "    {} - {}",
+                    t.error.paint(&failed.branch_name),
+                    t.hint.paint(&failed.error)
+                )?;
+            }
         }
     }
 

--- a/crates/but/src/command/legacy/resolve.rs
+++ b/crates/but/src/command/legacy/resolve.rs
@@ -166,28 +166,33 @@ fn show_status_impl(
         return show_workflow_help(out);
     }
 
-    let mut progress = out.progress_channel();
-
-    writeln!(
-        progress,
-        "{}\n - resolve all conflicts \n - finalize with {} \n - OR cancel with {}\n",
-        t.important
-            .paint("You are currently in conflict resolution mode."),
-        t.success.paint("but resolve finish"),
-        t.error.paint("but resolve cancel")
-    )?;
+    // The resolution state is the command's result, so it goes to stdout for human
+    // and agent output alike; only the finalize prompt below is terminal-gated.
+    if let Some(human_out) = out.for_human() {
+        writeln!(
+            human_out,
+            "{}\n - resolve all conflicts \n - finalize with {} \n - OR cancel with {}\n",
+            t.important
+                .paint("You are currently in conflict resolution mode."),
+            t.success.paint("but resolve finish"),
+            t.error.paint("but resolve cancel")
+        )?;
+    }
 
     let all_resolved = show_conflicted_files(ctx, out)?;
 
     // If all conflicts are resolved and we're in human mode, offer to finalize
     if all_resolved && prompt_to_finalize {
-        writeln!(progress)?;
-        writeln!(
-            progress,
-            "{}",
-            t.success.paint("All conflicts have been resolved!")
-        )?;
+        if let Some(human_out) = out.for_human() {
+            writeln!(human_out)?;
+            writeln!(
+                human_out,
+                "{}",
+                t.success.paint("All conflicts have been resolved!")
+            )?;
+        }
 
+        let mut progress = out.progress_channel();
         let should_finalize = if let Some(mut inout) = out.prepare_for_terminal_input() {
             if inout.confirm("Finalize the resolution now?", ConfirmDefault::Yes)? == Confirm::Yes {
                 writeln!(progress)?;
@@ -250,46 +255,39 @@ fn show_conflicted_files(ctx: &mut Context, out: &mut OutputChannel) -> Result<b
         }
     }
 
-    let mut progress = out.progress_channel();
-
     let all_resolved = still_conflicted.is_empty();
 
-    if all_resolved {
-        writeln!(
-            progress,
-            "{}",
-            t.success.paint("No conflicted files remaining!")
-        )?;
-        if !resolved.is_empty() {
-            writeln!(progress, "{} resolved:", t.success.paint("Files"))?;
-            for change in &resolved {
+    // The conflicted/resolved listing is the command's result, shown to humans and agents alike.
+    if let Some(human_out) = out.for_human() {
+        if all_resolved {
+            writeln!(
+                human_out,
+                "{}",
+                t.success.paint("No conflicted files remaining!")
+            )?;
+        } else {
+            writeln!(
+                human_out,
+                "{}:",
+                t.attention.paint("Conflicted files remaining")
+            )?;
+            for change in &still_conflicted {
                 writeln!(
-                    progress,
+                    human_out,
                     "  {} {}",
-                    t.sym().success,
-                    t.success.paint(change.path.to_str_lossy())
+                    t.sym().error,
+                    t.attention.paint(change.path.to_str_lossy())
                 )?;
             }
         }
-    } else {
-        writeln!(
-            progress,
-            "{}:",
-            t.attention.paint("Conflicted files remaining")
-        )?;
-        for change in &still_conflicted {
-            writeln!(
-                progress,
-                "  {} {}",
-                t.sym().error,
-                t.attention.paint(change.path.to_str_lossy())
-            )?;
-        }
         if !resolved.is_empty() {
-            writeln!(progress, "\n{} resolved:", t.success.paint("Files"))?;
+            if !all_resolved {
+                writeln!(human_out)?;
+            }
+            writeln!(human_out, "{} resolved:", t.success.paint("Files"))?;
             for change in &resolved {
                 writeln!(
-                    progress,
+                    human_out,
                     "  {} {}",
                     t.sym().success,
                     t.success.paint(change.path.to_str_lossy())
@@ -555,72 +553,7 @@ fn check_and_prompt_for_conflicts(ctx: &mut Context, out: &mut OutputChannel) ->
         return show_workflow_help(out);
     }
 
-    let mut progress = out.progress_channel();
-
-    // We have conflicts - show them grouped by branch
-    if out.for_human().is_some() {
-        writeln!(
-            progress,
-            "{}",
-            t.attention.paint("Found conflicted commits:")
-        )?;
-        writeln!(progress)?;
-
-        let mut all_commits: Vec<&ConflictedCommit> = vec![];
-
-        for (branch_name, commits) in &conflicts_by_branch {
-            writeln!(
-                progress,
-                "{} {}",
-                t.important.paint("Branch:"),
-                t.local_branch.paint(branch_name)
-            )?;
-            for commit in commits {
-                writeln!(
-                    progress,
-                    "  {} {} {}",
-                    t.sym().dot.error(),
-                    t.hint.paint(&commit.commit_short_id),
-                    commit.commit_message
-                )?;
-                all_commits.push(commit);
-            }
-            writeln!(progress)?;
-        }
-
-        // Prompt user to select a commit to resolve
-        writeln!(
-            progress,
-            "{}",
-            t.important
-                .paint("Would you like to start resolving these conflicts?")
-        )?;
-
-        // Find the bottom-most commit (first in topological order) on the first branch
-        let default_commit = all_commits.first();
-
-        // Interactive prompting only for human output mode with terminal
-        let commit_id_to_resolve = if let Some((mut inout, default)) =
-            out.prepare_for_terminal_input().zip(default_commit)
-        {
-            inout
-                .prompt(format!(
-                    "Enter commit ID to resolve [default: {}]",
-                    t.commit_id.paint(&default.commit_short_id)
-                ))?
-                .unwrap_or_else(|| default.commit_short_id.clone())
-                .into()
-        } else {
-            None
-        };
-
-        if let Some(commit_id_to_resolve) = commit_id_to_resolve {
-            // Enter resolution mode for the selected commit
-            writeln!(progress)?;
-            return enter_resolution(ctx, out, &commit_id_to_resolve);
-        }
-    } else if let Some(json_out) = out.for_json() {
-        // JSON output mode
+    if let Some(json_out) = out.for_json() {
         let mut json_conflicts = serde_json::Map::new();
 
         for (branch_name, commits) in &conflicts_by_branch {
@@ -642,6 +575,78 @@ fn check_and_prompt_for_conflicts(ctx: &mut Context, out: &mut OutputChannel) ->
             "conflicted_commits_by_branch": json_conflicts,
             "total_conflicted_commits": conflicts_by_branch.values().map(|v| v.len()).sum::<usize>(),
         }))?;
+        return Ok(());
+    }
+
+    // We have conflicts - show them grouped by branch. The listing is the command's
+    // result, so it goes to stdout for human and agent output alike; only the prompt
+    // below is gated on an interactive terminal.
+    if let Some(human_out) = out.for_human() {
+        writeln!(
+            human_out,
+            "{}",
+            t.attention.paint("Found conflicted commits:")
+        )?;
+        writeln!(human_out)?;
+
+        for (branch_name, commits) in &conflicts_by_branch {
+            writeln!(
+                human_out,
+                "{} {}",
+                t.important.paint("Branch:"),
+                t.local_branch.paint(branch_name)
+            )?;
+            for commit in commits {
+                writeln!(
+                    human_out,
+                    "  {} {} {}",
+                    t.sym().dot.error(),
+                    t.hint.paint(&commit.commit_short_id),
+                    commit.commit_message
+                )?;
+            }
+            writeln!(human_out)?;
+        }
+    }
+
+    // The bottom-most commit (first in topological order) on the first branch
+    let default_commit = conflicts_by_branch.values().flatten().next();
+
+    // Interactive prompting only for human output mode with terminal
+    let commit_id_to_resolve =
+        if let Some((mut inout, default)) = out.prepare_for_terminal_input().zip(default_commit) {
+            // Prompt user to select a commit to resolve
+            writeln!(
+                inout,
+                "{}",
+                t.important
+                    .paint("Would you like to start resolving these conflicts?")
+            )?;
+            inout
+                .prompt(format!(
+                    "Enter commit ID to resolve [default: {}]",
+                    t.commit_id.paint(&default.commit_short_id)
+                ))?
+                .unwrap_or_else(|| default.commit_short_id.clone())
+                .into()
+        } else {
+            None
+        };
+
+    if let Some(commit_id_to_resolve) = commit_id_to_resolve {
+        // Enter resolution mode for the selected commit
+        let mut progress = out.progress_channel();
+        writeln!(progress)?;
+        return enter_resolution(ctx, out, &commit_id_to_resolve);
+    }
+
+    if let Some(human_out) = out.for_human() {
+        writeln!(
+            human_out,
+            "{}",
+            t.hint
+                .paint("Run `but resolve <commit-id>` to start resolving a commit.")
+        )?;
     }
 
     Ok(())

--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -25,6 +25,14 @@ pub(crate) fn reword_target(
     format: bool,
     show_diff_in_editor: ShowDiffInEditor,
 ) -> CliResult<()> {
+    // Formats without an interactive editor must provide the new message up front.
+    if message.is_none() && !format && !out.format().allows_human_ui() {
+        return Err(bad_input(
+            "A message must be provided via --message (-m) for this output format",
+        )
+        .into());
+    }
+
     let mut guard = ctx.exclusive_worktree_access();
     let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
 

--- a/crates/but/src/command/legacy/setup.rs
+++ b/crates/but/src/command/legacy/setup.rs
@@ -144,8 +144,8 @@ pub fn find_or_initialize_repo(
                 }
                 Ok(repo)
             }
-            // If for humans, try to set up a new repo interactively
-            else if out.for_human().is_some() {
+            // If prompting is available, try to set up a new repo interactively.
+            else if out.can_prompt() {
                 match setup_new_repo(repo_path, out) {
                     Ok(repo) => Ok(repo),
                     Err(e) => {
@@ -163,7 +163,9 @@ pub fn find_or_initialize_repo(
                     }
                 }
             } else {
-                anyhow::bail!("No git repository found.");
+                anyhow::bail!(
+                    "No git repository found - run `but setup --init` to initialize a new repository."
+                );
             }
         }
     }

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -20,6 +20,7 @@ use serde::Serialize;
 
 use crate::{
     CLI_DATE, CliId, IdMap,
+    args::OutputFormat,
     command::legacy::{
         forge::review,
         status::output::{
@@ -219,10 +220,6 @@ pub(crate) async fn worktree(
             build_status_output(ctx, &status_ctx, &mut output)?;
         }
         StatusRenderMode::Tui(options) => {
-            if out.for_human().is_none() {
-                return Ok(());
-            }
-
             let mut lines = Vec::new();
             let mut output = StatusOutput::Buffer { lines: &mut lines };
             build_status_output(ctx, &status_ctx, &mut output)?;
@@ -447,7 +444,7 @@ async fn build_status_context<'a>(
     };
 
     let is_paged = out.is_paged();
-    let should_truncate_for_terminal = truncation_policy(render_mode, is_paged);
+    let should_truncate_for_terminal = truncation_policy(out.format(), render_mode, is_paged);
 
     Ok(StatusContext {
         stack_details,
@@ -472,8 +469,8 @@ async fn build_status_context<'a>(
 }
 
 /// Decide if status text should be pre-truncated for terminal output.
-fn truncation_policy(render_mode: StatusRenderMode, is_paged: bool) -> bool {
-    matches!(render_mode, StatusRenderMode::Oneshot) && !is_paged
+fn truncation_policy(format: OutputFormat, render_mode: StatusRenderMode, is_paged: bool) -> bool {
+    format.allows_truncation() && matches!(render_mode, StatusRenderMode::Oneshot) && !is_paged
 }
 
 fn build_status_output(
@@ -1742,6 +1739,7 @@ mod tests {
     use crate::command::legacy::status::TuiLaunchOptions;
 
     use super::{StatusRenderMode, truncate_when_needed, truncation_policy};
+    use crate::args::OutputFormat;
 
     #[test]
     fn truncate_when_needed_truncates_text_when_policy_requests_it() {
@@ -1760,17 +1758,35 @@ mod tests {
 
     #[test]
     fn truncation_policy_enables_truncation_for_oneshot_unpaged() {
-        assert!(truncation_policy(StatusRenderMode::Oneshot, false));
+        assert!(truncation_policy(
+            OutputFormat::Human,
+            StatusRenderMode::Oneshot,
+            false
+        ));
     }
 
     #[test]
     fn truncation_policy_disables_truncation_for_oneshot_paged() {
-        assert!(!truncation_policy(StatusRenderMode::Oneshot, true));
+        assert!(!truncation_policy(
+            OutputFormat::Human,
+            StatusRenderMode::Oneshot,
+            true
+        ));
+    }
+
+    #[test]
+    fn truncation_policy_disables_truncation_for_agent_output() {
+        assert!(!truncation_policy(
+            OutputFormat::Agent,
+            StatusRenderMode::Oneshot,
+            false
+        ));
     }
 
     #[test]
     fn truncation_policy_disables_truncation_for_tui() {
         assert!(!truncation_policy(
+            OutputFormat::Human,
             StatusRenderMode::Tui(TuiLaunchOptions {
                 debug: false,
                 ..Default::default()
@@ -1778,6 +1794,7 @@ mod tests {
             false,
         ));
         assert!(!truncation_policy(
+            OutputFormat::Human,
             StatusRenderMode::Tui(TuiLaunchOptions {
                 debug: false,
                 ..Default::default()

--- a/crates/but/src/command/legacy/status/tui/tests/utils.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/utils.rs
@@ -55,7 +55,7 @@ pub(super) fn test_tui_with_size(env: Sandbox, width: u16, height: u16) -> TestT
     let mode = but_api::legacy::modes::operating_mode(&ctx)
         .expect("failed to get operating mode")
         .operating_mode;
-    let mut out = OutputChannel::new_without_pager_non_json(OutputFormat::Human);
+    let mut out = OutputChannel::new(OutputFormat::Human);
 
     let flags = StatusFlags::all_false();
     let options = TuiLaunchOptions {

--- a/crates/but/src/command/onboarding.rs
+++ b/crates/but/src/command/onboarding.rs
@@ -38,8 +38,8 @@ pub fn handle(out: &mut OutputChannel) -> Result<()> {
         tracing::warn!(?err, "Failed to persist onboarding status");
     }
 
-    // Show the metrics info message (only for human output)
-    if let Some(human_out) = out.for_human() {
+    // Show the metrics info message only for interactive human UI output.
+    if let Some(human_out) = out.for_human_ui() {
         std::fmt::Write::write_str(
             human_out,
             "GitButler uses metrics to help us know what is useful and improve it. Configure with `but config metrics`.\n",

--- a/crates/but/src/command/skill.rs
+++ b/crates/but/src/command/skill.rs
@@ -1082,16 +1082,18 @@ fn install_skill(
 
     // Check if files already exist and warn user
     let skill_md_path = install_path.join("SKILL.md");
-    if skill_md_path.exists() {
-        writeln!(progress)?;
+    if skill_md_path.exists()
+        && let Some(writer) = out.for_human()
+    {
+        writeln!(writer)?;
         writeln!(
-            progress,
+            writer,
             "{} Skill files already exist at {}",
             t.sym().warning,
             t.config_value.paint(install_path.display().to_string())
         )?;
-        writeln!(progress, "  Overwriting existing files...")?;
-        writeln!(progress)?;
+        writeln!(writer, "  Overwriting existing files...")?;
+        writeln!(writer)?;
     }
 
     // Prepare all content before writing (validate UTF-8 and inject version)
@@ -1119,25 +1121,26 @@ fn install_skill(
         write_skill_file(&file_path, content, file.display_name)?;
     }
 
-    // Output success message
-    writeln!(progress)?;
-    writeln!(
-        progress,
-        "{} GitButler skill installed successfully!",
-        t.sym().success
-    )?;
-    writeln!(progress)?;
-    writeln!(
-        progress,
-        "  Location: {}",
-        t.config_value.paint(install_path.display().to_string())
-    )?;
-    writeln!(progress)?;
-    writeln!(progress, "  Files installed:")?;
-    for file in SKILL_FILES {
-        writeln!(progress, "    • {}", file.display_path())?;
+    if let Some(writer) = out.for_human() {
+        writeln!(writer)?;
+        writeln!(
+            writer,
+            "{} GitButler skill installed successfully!",
+            t.sym().success
+        )?;
+        writeln!(writer)?;
+        writeln!(
+            writer,
+            "  Location: {}",
+            t.config_value.paint(install_path.display().to_string())
+        )?;
+        writeln!(writer)?;
+        writeln!(writer, "  Files installed:")?;
+        for file in SKILL_FILES {
+            writeln!(writer, "    • {}", file.display_path())?;
+        }
+        writeln!(writer)?;
     }
-    writeln!(progress)?;
 
     if let Some(out) = out.for_json() {
         let file_paths: Vec<String> = SKILL_FILES.iter().map(|f| f.display_path()).collect();

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -63,6 +63,41 @@ mod tui;
 
 const CLI_DATE: CustomFormat = gix::date::time::format::ISO8601;
 
+/// The format for help output printed before clap parses arguments, taken from a
+/// `--format` argument or the `BUT_OUTPUT_FORMAT` environment variable.
+///
+/// Help is always human-readable text; the format only decides whether terminal affordances
+/// like truncation apply, so formats other than human or agent fall back to human output.
+fn early_help_format(args: &[OsString]) -> OutputFormat {
+    let parse = |value: &str| {
+        <OutputFormat as clap::ValueEnum>::from_str(value, false)
+            .ok()
+            .map(|format| {
+                if format.is_human_text() {
+                    format
+                } else {
+                    OutputFormat::Human
+                }
+            })
+    };
+    args.iter()
+        .enumerate()
+        .find_map(|(index, arg)| {
+            let arg = arg.to_str()?;
+            match arg.strip_prefix("--format=") {
+                Some(value) => parse(value),
+                None if arg == "--format" => parse(args.get(index + 1)?.to_str()?),
+                None => None,
+            }
+        })
+        .or_else(|| {
+            std::env::var(envs::BUT_OUTPUT_FORMAT)
+                .ok()
+                .and_then(|value| parse(&value))
+        })
+        .unwrap_or_default()
+}
+
 /// Handle `args` which must be what's passed by `std::env::args_os()`.
 pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     let theme_preset_from_env: anyhow::Result<theme::ThemePreset> =
@@ -106,7 +141,7 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     let has_help_flag = args.iter().any(|arg| arg == "--help" || arg == "-h");
     let has_subcommand = args.len() > 2 && args[1] != "--help" && args[1] != "-h";
     if has_help_flag && !has_subcommand {
-        let mut out = OutputChannel::new_without_pager_non_json(OutputFormat::Human);
+        let mut out = OutputChannel::new(early_help_format(&args));
         command::help::print_grouped(&mut out)?;
         return Ok(());
     }
@@ -119,7 +154,7 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     if args_vec.iter().any(|arg| arg == "push")
         && args_vec.iter().any(|arg| arg == "--help" || arg == "-h")
     {
-        let mut out = OutputChannel::new_without_pager_non_json(OutputFormat::Human);
+        let mut out = OutputChannel::new(early_help_format(&args));
         command::push::help::print(&mut out)?;
         return Ok(());
     }
@@ -128,25 +163,13 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     if args_vec.iter().any(|arg| arg == "help")
         && args_vec.iter().any(|arg| arg == "--help" || arg == "-h")
     {
-        let mut out = OutputChannel::new_without_pager_non_json(OutputFormat::Human);
+        let mut out = OutputChannel::new(early_help_format(&args));
         command::help::print_grouped(&mut out)?;
         return Ok(());
     }
 
     let mut args: Args = Args::parse_from(args);
     args.status_after = utils::detect_agent::detect().is_some();
-    // Determine if pager should be used based on the command
-    let use_pager = match args.cmd {
-        #[cfg(feature = "legacy")]
-        Some(Subcommands::Status { .. }) => true,
-        #[cfg(feature = "legacy")]
-        Some(Subcommands::Diff { tui, .. }) => !tui,
-        #[cfg(feature = "legacy")]
-        Some(Subcommands::Stage {
-            ref file_or_hunk, ..
-        }) => file_or_hunk.is_some(),
-        _ => false,
-    };
     let _tracing_appender_worker_guard = if args.trace > 0 {
         trace::init(args.trace, args.log_file.as_deref())?
     } else {
@@ -159,9 +182,21 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     let namespace = option_env!("IDENTIFIER").unwrap_or("com.gitbutler.app");
     but_secret::secret::set_application_namespace(namespace);
 
-    let mut out = OutputChannel::new_with_optional_pager(args.format.format, use_pager);
+    let mut out = OutputChannel::new(args.format.format);
+    #[cfg(feature = "legacy")]
+    if matches!(
+        &args.cmd,
+        Some(Subcommands::Status { .. })
+            | Some(Subcommands::Diff { tui: false, .. })
+            | Some(Subcommands::Stage {
+                file_or_hunk: Some(_),
+                ..
+            })
+    ) {
+        out.request_pager();
+    }
 
-    if let (Err(theme_preset_err), Some(out)) = (theme_preset_from_env, out.for_human()) {
+    if let (Err(theme_preset_err), Some(out)) = (theme_preset_from_env, out.for_human_ui()) {
         writeln!(
             out,
             "{}: {theme_preset_err}",
@@ -658,8 +693,7 @@ async fn match_subcommand(
                 use std::fmt::Write;
                 let mut progress = out.progress_channel();
                 writeln!(progress, "Pulling latest...")?;
-                let mut pull_out =
-                    OutputChannel::new_with_optional_pager(OutputFormat::None, false);
+                let mut pull_out = OutputChannel::new(OutputFormat::None);
                 command::legacy::pull::handle(&ctx, &mut pull_out, false).await?;
                 writeln!(progress, "Pull complete.")?;
             }
@@ -743,6 +777,13 @@ async fn match_subcommand(
         } => {
             use crate::command::legacy::status::{StatusFlags, StatusRenderMode, TuiLaunchOptions};
 
+            if !out.format().allows_human_ui() {
+                return Err(bad_input(
+                    "Interactive terminal UI is not available for this output format.",
+                )
+                .into());
+            }
+
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
@@ -809,6 +850,12 @@ async fn match_subcommand(
             tui,
             no_tui,
         } => {
+            if tui && !out.format().allows_human_ui() {
+                return Err(bad_input(
+                    "Interactive terminal UI is not available for this output format.",
+                )
+                .into());
+            }
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
@@ -819,7 +866,7 @@ async fn match_subcommand(
             )?;
             let use_tui = if tui {
                 true
-            } else if no_tui {
+            } else if no_tui || !out.format().allows_human_ui() {
                 false
             } else {
                 // Check git config for but.ui.tui
@@ -962,14 +1009,14 @@ async fn match_subcommand(
                 None => {
                     // Handle the regular `but commit` command
 
-                    // In JSON mode, require either -m, --message-file, or --ai to be specified
-                    if matches!(args.format.format, OutputFormat::Json)
+                    // Formats without an interactive editor must provide the message up front
+                    if !args.format.format.allows_human_ui()
                         && commit_args.message.is_none()
                         && commit_args.message_file.is_none()
                         && commit_args.ai.is_none()
                     {
                         return Err(bad_input(
-                            "In JSON mode, either --message (-m), --message-file, or --ai (-i) must be specified"
+                            "Either --message (-m), --message-file, or --ai (-i) must be specified for this output format"
                         ).into());
                     }
 
@@ -1391,8 +1438,7 @@ async fn match_subcommand(
                     .emit_metrics(metrics_ctx)
             } else {
                 // Interactive mode: but stage [--branch <branch>]
-                use std::io::IsTerminal;
-                if !std::io::stdout().is_terminal() {
+                if !out.can_prompt() {
                     return Err(bad_input(
                         "Interactive stage requires a terminal. Use: but stage <file_or_hunk> <branch>"
                     ).into());
@@ -1658,7 +1704,8 @@ async fn maybe_run_status_after<T, E>(
 /// In JSON mode, combines the mutation's buffered JSON with status JSON into
 /// `{"result": <mutation_output>, "status": <workspace_status>}`.
 /// If the GitButler skill is missing or stale, includes an agent-facing notice
-/// after the status output or under `agent_skill_notice` in JSON.
+/// after the status output or under `agent_skill_notice` in JSON. This function
+/// only runs when the CLI caller was detected as an agent.
 ///
 /// Status errors are handled gracefully: in JSON mode the mutation result is
 /// always emitted (with a `"status_error"` field on failure); in human mode
@@ -1671,7 +1718,9 @@ async fn run_status_after(
 ) {
     use crate::command::legacy::status::StatusFlags;
 
-    let agent_skill_notice = if matches!(out.format(), OutputFormat::Human | OutputFormat::Json) {
+    // Producing a notice burns its global debounce, so compute it only when the
+    // format can deliver it (human text below, or a field in the JSON object).
+    let agent_skill_notice = if out.format().is_human_text() || out.format().is_json() {
         command::skill::agent_skill_freshness_notice_for_context(Some(&mut *ctx))
     } else {
         None

--- a/crates/but/src/setup.rs
+++ b/crates/but/src/setup.rs
@@ -73,14 +73,14 @@ pub(crate) struct InitCtxOptions {
 ///
 /// When `background_sync` is `BackgroundSync::Enabled`, a background sync is initiated if:
 /// - The fetch interval is positive (negative or zero disables background sync)
-/// - The output format is for human consumption (not JSON or shell)
+/// - The output format renders human-readable text (human or agent)
 /// - Either no previous sync exists, or the elapsed time since the last sync
 ///   exceeds the configured interval
 ///
-/// When a background sync is initiated, a human-readable message is written to the output
-/// channel showing how long ago the last sync occurred (e.g., "Last fetch was 15m ago.
-/// Initiated a background fetch..."). The time is formatted as seconds (s), minutes (m),
-/// hours (h), or days (d) depending on the elapsed duration.
+/// When a background sync is initiated and the output format allows human UI messages, a
+/// message is written to the output channel showing how long ago the last sync occurred
+/// (e.g., "Last fetch was 15m ago. Initiated a background fetch..."). The time is formatted
+/// as seconds (s), minutes (m), hours (h), or days (d) depending on the elapsed duration.
 ///
 /// When `background_sync` is `BackgroundSync::Disabled`, no background sync is performed
 /// regardless of the configured interval.
@@ -139,7 +139,9 @@ pub fn init_ctx(
                             })?
                         }
                         SetupPromptResult::Declined => {
-                            anyhow::bail!("Setup required: {message}");
+                            anyhow::bail!(
+                                "Setup required: {message} - run `but setup` to configure the project"
+                            );
                         }
                     }
                 }
@@ -171,7 +173,9 @@ pub fn init_ctx(
                             check_project_setup(&ctx, guard.read_permission())?;
                         }
                         SetupPromptResult::Declined => {
-                            anyhow::bail!("Setup required: {message}");
+                            anyhow::bail!(
+                                "Setup required: {message} - run `but setup` to configure the project"
+                            );
                         }
                     }
                 }
@@ -197,7 +201,7 @@ pub fn init_ctx(
     };
 
     // If this is the first time running GitButler, show a metrics info message and update onboarding status
-    if !ctx.settings.onboarding_complete && out.for_human().is_some() {
+    if !ctx.settings.onboarding_complete && out.format().allows_human_ui() {
         crate::command::onboarding::handle(out)?;
     }
 
@@ -211,8 +215,9 @@ pub fn init_ctx(
                 return Ok(ctx);
             }
 
-            // Background sync only done for human output
-            if !matches!(out.format(), crate::args::OutputFormat::Human) {
+            // Background sync is a data side effect wanted for human and agent sessions
+            // alike; only the ambient message is a human UI affordance.
+            if !out.format().is_human_text() {
                 return Ok(ctx);
             }
 
@@ -222,6 +227,7 @@ pub fn init_ctx(
 
             // Spawn background sync if there's anything to do
             if sync_operations.has_work() {
+                let silent = silent || !out.format().allows_human_ui();
                 spawn_background_sync(args, out, last_fetch, sync_operations, silent);
             }
         }
@@ -407,7 +413,7 @@ fn prompt_for_setup(out: &mut OutputChannel, message: &str) -> SetupPromptResult
     use std::fmt::Write;
     let mut progress = out.progress_channel();
 
-    // Progress channel only writes when output is for humans, so we can write unconditionally
+    // Progress channel only writes when the output format allows progress, so we can write unconditionally.
     _ = writeln!(
         progress,
         "The current project is not configured to be managed by GitButler.\n"
@@ -415,9 +421,7 @@ fn prompt_for_setup(out: &mut OutputChannel, message: &str) -> SetupPromptResult
     writeln!(progress, "{}\n", theme::get().error.paint(message)).ok();
 
     // Check if we have an interactive terminal and prompt the user
-    let user_declined_in_interactive_mode = if let Some(mut inout) =
-        out.prepare_for_terminal_input()
-    {
+    if let Some(mut inout) = out.prepare_for_terminal_input() {
         _ = writeln!(
             progress,
             "In order to manage projects with GitButler, we need to do some changes:\n\n - Switch you to a special `gitbutler/workspace` branch to enable parallel branches\n - Install Git hooks to help manage the tooling\n\nYou can go back to normal git workflows at any time by either:\n\n - Running `but teardown`\n - Manually checking out a normal branch with `git checkout <branch>`\n",
@@ -428,40 +432,18 @@ fn prompt_for_setup(out: &mut OutputChannel, message: &str) -> SetupPromptResult
         {
             return SetupPromptResult::RunSetup;
         }
-        // User declined
-        true // indicates interactive terminal was available
-    } else {
-        false // non-interactive
-    };
-
-    // Now handle the declined/non-interactive cases with a fresh borrow
-    if user_declined_in_interactive_mode {
-        // User declined in interactive mode
-        _ = writeln!(
-            progress,
-            "{}",
-            theme::get()
-                .attention
-                .paint("Please run `but setup` to switch to GitButler management.\n")
-        );
     }
 
+    // The declined/non-interactive cases end in the caller's "Setup required" error,
+    // which carries the `but setup` remediation for every format; JSON additionally
+    // gets it as a structured value.
     if let Some(json_out) = out.for_json() {
         _ = json_out.write_value(serde_json::json!({
             "error": "setup_required",
             "message": message.to_string(),
             "hint": "run `but setup` to configure the project"
         }));
-    } else if out.for_human().is_some() && !user_declined_in_interactive_mode {
-        // Non-interactive terminal, just show the hint
-        _ = writeln!(
-            progress,
-            "{}",
-            theme::get()
-                .attention
-                .paint("Please run `but setup` to switch to GitButler management.\n")
-        );
-    };
+    }
     SetupPromptResult::Declined
 }
 
@@ -491,7 +473,7 @@ fn check_workspace_commits_before_init(
 
     // If the first line is NOT a workspace commit, someone has committed on top
     if !first_line.starts_with("GitButler Workspace Commit") {
-        if let Some(writer) = out.for_human() {
+        if let Some(writer) = out.for_human_ui() {
             writeln!(writer)?;
             writeln!(
                 writer,

--- a/crates/but/src/tui/table.rs
+++ b/crates/but/src/tui/table.rs
@@ -12,6 +12,7 @@ pub(super) mod types {
         pub(super) headers: Vec<Cell>,
         pub(super) rows: Vec<Vec<Cell>>,
         pub(super) terminal_width: usize,
+        pub(super) allow_truncation: bool,
     }
 }
 use types::Table;
@@ -61,7 +62,13 @@ impl Table {
             headers,
             rows: Vec::new(),
             terminal_width,
+            allow_truncation: true,
         }
+    }
+
+    pub fn with_truncation(mut self, allow_truncation: bool) -> Self {
+        self.allow_truncation = allow_truncation;
+        self
     }
 
     pub fn add_row(&mut self, row: Vec<Cell>) {
@@ -101,7 +108,7 @@ impl Table {
             }
 
             let width = column_widths.get(i).copied().unwrap_or(0);
-            let formatted = format_cell(&cell.content, width, cell.align);
+            let formatted = format_cell(&cell.content, width, cell.align, self.allow_truncation);
             write!(out, "{formatted}")?;
         }
         Ok(())
@@ -136,7 +143,7 @@ impl Table {
         // If we exceed terminal width, shrink flexible columns to fit.
         // Columns marked `no_truncate` keep their full content width;
         // only other flexible columns are shrunk.
-        if total_fixed_width > self.terminal_width {
+        if self.allow_truncation && total_fixed_width > self.terminal_width {
             let flexible_indices: Vec<usize> = self
                 .headers
                 .iter()
@@ -191,11 +198,11 @@ impl Table {
     }
 }
 
-fn format_cell(content: &str, width: usize, align: Alignment) -> String {
+fn format_cell(content: &str, width: usize, align: Alignment, allow_truncation: bool) -> String {
     let stripped = strip_ansi_codes(content);
     let content_width = stripped.width();
 
-    if content_width >= width {
+    if allow_truncation && content_width >= width {
         return truncate_text(content, width).into_owned();
     }
 
@@ -204,5 +211,32 @@ fn format_cell(content: &str, width: usize, align: Alignment) -> String {
 
     match align {
         Alignment::Left => format!("{}{}", content, " ".repeat(padding_needed)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Cell, Table};
+
+    #[test]
+    fn render_truncates_cells_by_default() {
+        let mut table = Table::new(vec![Cell::new("NAME").with_width(5)]);
+        table.add_row(vec![Cell::new("hello world")]);
+
+        let mut output = String::new();
+        table.render(&mut output).unwrap();
+
+        assert_eq!(output, "hell…\n");
+    }
+
+    #[test]
+    fn render_keeps_full_cells_when_truncation_is_disabled() {
+        let mut table = Table::new(vec![Cell::new("NAME").with_width(5)]).with_truncation(false);
+        table.add_row(vec![Cell::new("hello world")]);
+
+        let mut output = String::new();
+        table.render(&mut output).unwrap();
+
+        assert_eq!(output, "hello world\n");
     }
 }

--- a/crates/but/src/utils/envs.rs
+++ b/crates/but/src/utils/envs.rs
@@ -1,5 +1,8 @@
 //! Environment variables used by but.
 
+/// Selects the output format when `--format` is not passed; documented via the clap arg in `args`.
+pub const BUT_OUTPUT_FORMAT: &str = "BUT_OUTPUT_FORMAT";
+
 pub const BUT_PAGER: &str = "BUT_PAGER";
 pub const BUT_PAGER_DESCRIPTION: &str = "Sets the pager for large outputs. [default: less]";
 

--- a/crates/but/src/utils/output_channel.rs
+++ b/crates/but/src/utils/output_channel.rs
@@ -51,20 +51,20 @@ pub struct OutputChannel {
 }
 
 /// A channel that implements [`std::io::Write`], to make unbuffered writes to [`std::io::stderr`]
-/// if the error channel is connected to a terminal and the output format is for humans,
+/// if the error channel is connected to a terminal and the output format permits progress,
 /// for providing progress or error information.
 /// Broken pipes will also be ignored, thus the output written to this channel should be considered optional.
 pub struct ProgressChannel {
-    /// The channel writes will go to, if we are connected to a terminal and output is for humans.
+    /// The channel writes will go to, if we are connected to a terminal and progress is enabled.
     inner: Option<std::io::Stderr>,
 }
 
 impl ProgressChannel {
-    /// Create a new progress channel that writes to stderr if it's a terminal and `for_humans` is true.
-    /// If `for_humans` is false, the channel becomes a no-op.
-    pub fn new(for_humans: bool) -> Self {
+    /// Create a new progress channel that writes to stderr if it's a terminal and progress is enabled.
+    /// If progress is disabled, the channel becomes a no-op.
+    pub fn new(progress_enabled: bool) -> Self {
         ProgressChannel {
-            inner: if for_humans {
+            inner: if progress_enabled {
                 let stderr = std::io::stderr();
                 stderr.is_terminal().then_some(stderr)
             } else {
@@ -110,6 +110,10 @@ fn ignore_broken_pipe(err: std::io::Error) -> std::io::Result<()> {
     }
 }
 
+fn ignore_broken_pipe_for_fmt(err: std::io::Error) -> std::fmt::Result {
+    ignore_broken_pipe(err).map_err(|_| std::fmt::Error)
+}
+
 /// Access
 impl OutputChannel {
     /// Get the output format setting.
@@ -120,7 +124,8 @@ impl OutputChannel {
 
 /// An [`std::fmt::Write`] implementation that supports additional utility methods for output formatting.
 pub trait WriteWithUtils: std::fmt::Write + 'static {
-    /// Truncate the given text to the specified maximum width, unless the output is passed through a pager.
+    /// Truncate the given text to the specified maximum width, unless the output is passed through a pager
+    /// or the output format opts out of truncation.
     ///
     /// Note that while copy-on-write is used internally, the returned value is always owned as it's typically
     /// used with coloring, and that always copies the string.
@@ -134,7 +139,7 @@ pub trait WriteWithUtils: std::fmt::Write + 'static {
 
 impl WriteWithUtils for OutputChannel {
     fn truncate_if_unpaged(&self, text: &str, max_width: usize) -> String {
-        if self.pager.is_some() {
+        if self.pager.is_some() || !self.format.allows_truncation() {
             text.to_owned()
         } else {
             crate::tui::text::truncate_text(text, max_width).into_owned()
@@ -148,46 +153,59 @@ impl WriteWithUtils for OutputChannel {
 
 /// Output
 impl OutputChannel {
-    /// Provide a write implementation for humans, if the format setting permits.
+    /// Provide a write implementation for human-readable text, if the format setting permits.
+    ///
+    /// This is `Some` for both human and agent output. Route terminal-only ambient messages
+    /// through [`Self::for_human_ui`] instead, so agents don't receive them.
     pub fn for_human(&mut self) -> Option<&mut dyn WriteWithUtils> {
-        matches!(self.format, OutputFormat::Human).then(|| self as &mut dyn WriteWithUtils)
+        self.format
+            .is_human_text()
+            .then_some(self as &mut dyn WriteWithUtils)
+    }
+    /// Provide a write implementation for ambient human UI messages, if the format setting permits them.
+    ///
+    /// Unlike [`Self::for_human`], this excludes agent output, which receives results as
+    /// human-readable text but without ambient UI messages.
+    pub fn for_human_ui(&mut self) -> Option<&mut dyn WriteWithUtils> {
+        self.format
+            .allows_human_ui()
+            .then_some(self as &mut dyn WriteWithUtils)
     }
     /// Provide a write implementation for Shell output, if the format setting permits.
     pub fn for_shell(&mut self) -> Option<&mut dyn WriteWithUtils> {
-        matches!(self.format, OutputFormat::Shell).then(|| self as &mut dyn WriteWithUtils)
+        matches!(self.format, OutputFormat::Shell).then_some(self as &mut dyn WriteWithUtils)
     }
     /// Provide a write implementation for text output (human or shell), if the format setting permits.
     pub fn for_human_or_shell(&mut self) -> Option<&mut dyn WriteWithUtils> {
-        matches!(self.format, OutputFormat::Human | OutputFormat::Shell)
-            .then(|| self as &mut dyn WriteWithUtils)
+        self.format
+            .is_text()
+            .then_some(self as &mut dyn WriteWithUtils)
     }
     /// Provide a handle to receive a serde-serializable value to write to stdout.
     pub fn for_json(&mut self) -> Option<&mut Self> {
-        matches!(self.format, OutputFormat::Json).then_some(self)
+        self.format.is_json().then_some(self)
     }
 
-    /// A convenience function to create a progress channel that only writes when the output is for humans.
-    /// The progress channel writes to stderr if it's a terminal and the output format is [`OutputFormat::Human`].
+    /// A convenience function to create a progress channel that only writes when the output format permits progress.
+    /// The progress channel writes to stderr if it's a terminal and the output format permits progress.
     pub fn progress_channel(&self) -> ProgressChannel {
-        ProgressChannel::new(matches!(self.format, OutputFormat::Human))
+        ProgressChannel::new(self.format.allows_human_ui())
     }
 }
 
 /// User input
 impl OutputChannel {
     /// Return `true` if external prompt support like [`Selection`](cli_prompts::prompts::Selection) can be used,
-    /// *and* the output is meant *for humans*.
+    /// and the output format permits prompts.
     ///
     /// Note that this is implied to be true if [Self::prepare_for_terminal_input()] returns `Some()`.
     pub fn can_prompt(&self) -> bool {
-        matches!(self.format, OutputFormat::Human)
-            && std::io::stdin().is_terminal()
-            && self.stdout.is_terminal()
+        self.format.allows_human_ui() && std::io::stdin().is_terminal() && self.stdout.is_terminal()
     }
 
     /// Before performing further output, obtain an input channel which always bypasses the pager when writing,
     /// while allowing prompting the user for input.
-    /// If `None` is returned, terminal input isn't available or the output isn't meant for humans,
+    /// If `None` is returned, terminal input isn't available or the output format does not permit prompts,
     /// and the caller should suggest to use command-line arguments to unambiguously specify an operation.
     pub fn prepare_for_terminal_input(&mut self) -> Option<InputOutputChannel<'_>> {
         use std::io::IsTerminal;
@@ -195,9 +213,9 @@ impl OutputChannel {
         if !stdin.is_terminal() || !self.stdout.is_terminal() {
             return None;
         }
-        if self.for_human().is_none() {
+        if !self.format.allows_human_ui() {
             tracing::warn!(
-                "Stdin is a terminal, and output wasn't configured for human consumption"
+                "Stdin is a terminal, and output wasn't configured for interactive prompts"
             );
             return None;
         }
@@ -240,7 +258,7 @@ impl OutputChannel {
     /// begins buffering so mutation output can be captured and later
     /// combined with workspace status.
     pub fn begin_status_after(&mut self, status_after: bool) {
-        if status_after && matches!(self.format, OutputFormat::Json) {
+        if status_after && self.format.is_json() {
             self.start_json_buffering();
         }
     }
@@ -252,48 +270,25 @@ impl OutputChannel {
 
     /// Returns `true` if output is in JSON mode.
     pub fn is_json(&self) -> bool {
-        matches!(self.format, OutputFormat::Json)
+        self.format.is_json()
     }
 }
 
 impl std::fmt::Write for OutputChannel {
     fn write_str(&mut self, s: &str) -> std::fmt::Result {
         use std::io::Write;
-        match self.format {
-            OutputFormat::Human | OutputFormat::Shell => {
-                match self.pager.as_mut() {
-                    Some(Pager::Builtin(pager)) => pager.write_str(s),
-                    Some(Pager::External(_, stdin)) => {
-                        stdin.write_all(s.as_bytes()).or_else(|err| {
-                            if err.kind() == std::io::ErrorKind::BrokenPipe {
-                                // Ignore broken pipes and keep writing.
-                                // This allows the caller to use `?` without having to think
-                                // about ignoring errors selectively.
-                                Ok(())
-                            } else {
-                                Err(std::fmt::Error)
-                            }
-                        })
-                    }
-                    None => {
-                        self.stdout.write_all(s.as_bytes()).or_else(|err| {
-                            if err.kind() == std::io::ErrorKind::BrokenPipe {
-                                // Ignore broken pipes and keep writing.
-                                // This allows the caller to use `?` without having to think
-                                // about ignoring errors selectively.
-                                Ok(())
-                            } else {
-                                Err(std::fmt::Error)
-                            }
-                        })
-                    }
-                }
-            }
-            OutputFormat::Json | OutputFormat::None => {
-                // It's not an error to try to write in JSON mode, it's a feature.
-                // However, the only way to write JSON is to use [Self::write_value()].
-                Ok(())
-            }
+        if !self.format.is_text() {
+            return Ok(());
+        }
+        match self.pager.as_mut() {
+            Some(Pager::Builtin(pager)) => pager.write_str(s),
+            Some(Pager::External(_, stdin)) => stdin
+                .write_all(s.as_bytes())
+                .or_else(ignore_broken_pipe_for_fmt),
+            None => self
+                .stdout
+                .write_all(s.as_bytes())
+                .or_else(ignore_broken_pipe_for_fmt),
         }
     }
 }
@@ -595,43 +590,27 @@ impl Drop for InputOutputChannel<'_> {
 
 /// Lifecycle
 impl OutputChannel {
-    /// Create a new instance to output with `format` (advisory), which affects where it prints to.
-    /// The `use_pager` parameter controls whether a pager should be created.
-    ///
-    /// It's configured to print to stdout unless [`OutputFormat::Json`] is used, then it prints everything
-    /// to a `/dev/null` equivalent, so callers never have to worry if they interleave JSON with other output.
-    pub fn new_with_optional_pager(format: OutputFormat, use_pager: bool) -> Self {
-        let stdout = std::io::stdout();
-        let pager = if !use_pager
-            || !matches!(format, OutputFormat::Human)
-            || std::env::var_os("NOPAGER").is_some()
-            || !stdout.is_terminal()
-        {
-            None
-        } else {
-            pager::try_init_pager()
-        };
-
+    /// Create a new instance to output with `format`.
+    pub fn new(format: OutputFormat) -> Self {
         OutputChannel {
             format,
-            stdout,
-            pager,
-            json_buffer: None,
-        }
-    }
-
-    /// Like [`Self::new_with_optional_pager`], but will never create a pager or write JSON.
-    /// Use this if a second instance of a channel is needed, and the first one could have a pager.
-    pub fn new_without_pager_non_json(format: OutputFormat) -> Self {
-        OutputChannel {
-            format: match format {
-                OutputFormat::Human | OutputFormat::Shell | OutputFormat::None => format,
-                OutputFormat::Json => OutputFormat::None,
-            },
             stdout: std::io::stdout(),
             pager: None,
             json_buffer: None,
         }
+    }
+
+    /// Request paging for large output. The pager is only started when human UI is allowed,
+    /// stdout is a terminal, and paging is not disabled by the environment.
+    pub fn request_pager(&mut self) {
+        if self.pager.is_some()
+            || !self.format.allows_human_ui()
+            || std::env::var_os("NOPAGER").is_some()
+            || !self.stdout.is_terminal()
+        {
+            return;
+        }
+        self.pager = pager::try_init_pager();
     }
 }
 
@@ -665,7 +644,9 @@ impl Drop for OutputChannel {
 mod tests {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-    use super::{KeyEditAction, key_to_edit_action};
+    use crate::args::OutputFormat;
+
+    use super::{KeyEditAction, OutputChannel, WriteWithUtils, key_to_edit_action};
 
     #[test]
     fn ctrl_c_ends_input() {
@@ -694,5 +675,44 @@ mod tests {
             ),
             KeyEditAction::Ignore
         );
+    }
+
+    #[test]
+    fn agent_output_is_human_text_not_json() {
+        let mut out = OutputChannel::new(OutputFormat::Agent);
+
+        assert!(
+            out.for_human().is_some(),
+            "agent output should allow human text rendering"
+        );
+        assert!(
+            out.for_json().is_none(),
+            "agent output should not be treated as JSON"
+        );
+        assert!(!out.is_json(), "agent output should not be JSON mode");
+    }
+
+    #[test]
+    fn agent_output_does_not_truncate_unpaged_text() {
+        let out = OutputChannel::new(OutputFormat::Agent);
+        let text = "0123456789abcdef";
+
+        assert_eq!(out.truncate_if_unpaged(text, 4), text);
+    }
+
+    #[test]
+    fn agent_output_does_not_allow_progress() {
+        let out = OutputChannel::new(OutputFormat::Agent);
+
+        assert!(!out.format.allows_human_ui());
+        assert!(out.progress_channel().inner.is_none());
+    }
+
+    #[test]
+    fn agent_output_never_uses_pager() {
+        let mut out = OutputChannel::new(OutputFormat::Agent);
+        out.request_pager();
+
+        assert!(!out.is_paged(), "agent output should not use a pager");
     }
 }

--- a/crates/but/src/utils/output_channel/experimental.rs
+++ b/crates/but/src/utils/output_channel/experimental.rs
@@ -57,7 +57,7 @@ pub trait OutputChannelExt {
 impl OutputChannelExt for OutputChannel {
     fn print_cli_output(&mut self, output: impl CliOutput) -> anyhow::Result<()> {
         match self.format {
-            OutputFormat::Human => output.on_human(self, crate::theme::get()),
+            OutputFormat::Human | OutputFormat::Agent => output.on_human(self, crate::theme::get()),
             OutputFormat::Shell => output.on_shell(self),
             OutputFormat::Json => {
                 let value = output.on_json();

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -756,7 +756,7 @@ fn commit_json_mode_requires_message_or_file() -> anyhow::Result<()> {
         .assert()
         .failure()
         .stderr_eq(str![[r#"
-Error: In JSON mode, either --message (-m), --message-file, or --ai (-i) must be specified
+Error: Either --message (-m), --message-file, or --ai (-i) must be specified for this output format
 
 "#]]);
 

--- a/crates/but/tests/but/command/format.rs
+++ b/crates/but/tests/but/command/format.rs
@@ -56,7 +56,7 @@ fn default_command_respects_c_flag_for_setup_checks() -> anyhow::Result<()> {
     env.but("-C repo")
         .assert()
         .stderr_eq(snapbox::str![[r#"
-Error: Setup required: No GitButler project found at repo
+Error: Setup required: No GitButler project found at repo - run `but setup` to configure the project
 
 "#]])
         .failure();
@@ -77,7 +77,7 @@ git config but.alias.default "-C repo status"
     );
 
     env.but("").assert().failure().stderr_eq(snapbox::str![[r#"
-Error: Setup required: No GitButler project found at repo
+Error: Setup required: No GitButler project found at repo - run `but setup` to configure the project
 
 "#]]);
 
@@ -101,7 +101,7 @@ git config but.alias.default "-C repo status"
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Setup required: No GitButler project found at repo2
+Error: Setup required: No GitButler project found at repo2 - run `but setup` to configure the project
 
 "#]]);
 

--- a/crates/but/tests/but/command/help.rs
+++ b/crates/but/tests/but/command/help.rs
@@ -79,6 +79,7 @@ Options:
           Possible values:
           - human: The output to write is supposed to be for human consumption, and can be more
             verbose
+          - agent: The output is for an AI coding agent, rendered as human-readable text
           - shell: The output should be suitable for shells, and assigning the major result to
             variables so that it can be reused in subsequent CLI invocations
           - json:  Output detailed information as JSON for tool consumption
@@ -102,7 +103,7 @@ Arguments:
 
 Options:
       --format <FORMAT>  Explicitly control how output should be formatted [env: BUT_OUTPUT_FORMAT=]
-                         [default: human] [possible values: human, shell, json, none]
+                         [default: human] [possible values: human, agent, shell, json, none]
   -h, --help             Print help (see more with '--help')
 
 "#]]);
@@ -136,6 +137,24 @@ fn help_help_should_be_help() -> anyhow::Result<()> {
 
     let help = env.but("help").output()?.stdout;
     env.but("help --help")
+        .assert()
+        .success()
+        .stdout_eq(help.to_str_lossy().to_string());
+
+    Ok(())
+}
+
+#[test]
+fn top_level_help_honors_agent_format_after_help_flag() -> anyhow::Result<()> {
+    let env = Sandbox::empty()?;
+    let help = env.but("help --format agent").output()?.stdout;
+
+    env.but("--help --format agent")
+        .assert()
+        .success()
+        .stdout_eq(help.to_str_lossy().to_string());
+
+    env.but("--help --format=agent")
         .assert()
         .success()
         .stdout_eq(help.to_str_lossy().to_string());

--- a/crates/but/tests/but/command/push.rs
+++ b/crates/but/tests/but/command/push.rs
@@ -3,8 +3,7 @@ use snapbox::str;
 use super::util::find_branch;
 use crate::utils::{CommandExt, Sandbox};
 
-#[test]
-fn push_dry_run_json_reports_remote_and_remote_ref() -> anyhow::Result<()> {
+fn repo_with_unpushed_branch() -> anyhow::Result<Sandbox> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
     env.setup_metadata(&["A"])?;
 
@@ -21,6 +20,13 @@ fn push_dry_run_json_reports_remote_and_remote_ref() -> anyhow::Result<()> {
     env.but("commit -m 'first commit' branchB")
         .assert()
         .success();
+
+    Ok(env)
+}
+
+#[test]
+fn push_dry_run_json_reports_remote_and_remote_ref() -> anyhow::Result<()> {
+    let env = repo_with_unpushed_branch()?;
 
     let output = env
         .but("push --dry-run --format json branchB")
@@ -59,6 +65,31 @@ fn push_dry_run_json_reports_remote_and_remote_ref() -> anyhow::Result<()> {
         String::from_utf8(bytes)?
     };
     assert_eq!(remote_ref, "refs/remotes/origin/branchB");
+
+    Ok(())
+}
+
+#[test]
+fn push_dry_run_agent_reports_human_summary() -> anyhow::Result<()> {
+    let env = repo_with_unpushed_branch()?;
+
+    let output = env.but("push --dry-run --format agent branchB").output()?;
+    assert!(
+        output.status.success(),
+        "push --dry-run --format agent branchB failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Dry run:") && stdout.contains("Run without --dry-run"),
+        "agent dry-run push should print the human summary, got: {stdout}"
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "agent dry-run push should not print progress, got: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     Ok(())
 }

--- a/crates/but/tests/but/command/setup.rs
+++ b/crates/but/tests/but/command/setup.rs
@@ -476,7 +476,7 @@ fn json_output_not_a_git_repo() -> anyhow::Result<()> {
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: No git repository found.
+Error: No git repository found - run `but setup --init` to initialize a new repository.
 
 "#]])
         .stdout_eq(snapbox::str![]);

--- a/crates/but/tests/but/command/skill.rs
+++ b/crates/but/tests/but/command/skill.rs
@@ -131,6 +131,38 @@ fn skill_install_absolute_path_outside_repo_does_not_require_global() -> anyhow:
 }
 
 #[test]
+fn skill_install_agent_outputs_success_message() -> anyhow::Result<()> {
+    let env = Sandbox::empty()?;
+    let install_dir = env.projects_root().join("agent-skill-install");
+
+    let output = env
+        .but("")
+        .arg("skill")
+        .arg("install")
+        .args(["--format", "agent", "--global"])
+        .arg("--path")
+        .arg(&install_dir)
+        .assert()
+        .success()
+        .stderr_eq(str![[]])
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = std::str::from_utf8(&output)?;
+    assert!(
+        stdout.contains("GitButler skill installed successfully"),
+        "agent skill install should print the human success message, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Files installed:"),
+        "agent skill install should print installed files, got: {stdout}"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn skill_check_detects_agent_skills_installation_in_repo() -> anyhow::Result<()> {
     let env = Sandbox::open_with_default_settings("repo-no-remote")?;
     let install_path = relative_agent_skill_path(".agents");

--- a/crates/but/tests/but/command/snapshots/status/edit-mode/status-delegates-to-resolve-status.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/edit-mode/status-delegates-to-resolve-status.stdout.term.svg
@@ -1,11 +1,14 @@
-<svg width="740px" height="20px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="182px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-green { fill: #00AA00 }
+    .fg-red { fill: #AA0000 }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -16,6 +19,24 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="bold">You are currently in conflict resolution mode.</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> - resolve all conflicts </tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan> - finalize with </tspan><tspan class="fg-green">but resolve finish</tspan><tspan> </tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan> - OR cancel with </tspan><tspan class="fg-red">but resolve cancel</tspan>
+</tspan>
+    <tspan x="10px" y="100px">
+</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-green">No conflicted files remaining!</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-green">Files</tspan><tspan> resolved:</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-green bold">✓</tspan><tspan> </tspan><tspan class="fg-green">test-file.txt</tspan>
+</tspan>
+    <tspan x="10px" y="172px">
+</tspan>
   </text>
 
 </svg>

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -51,7 +51,7 @@ fn unborn() -> anyhow::Result<()> {
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Setup required: No GitButler project found at .
+Error: Setup required: No GitButler project found at . - run `but setup` to configure the project
 
 "#]]);
     Ok(())
@@ -67,7 +67,7 @@ fn first_commit_no_workspace() -> anyhow::Result<()> {
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Setup required: No GitButler project found at .
+Error: Setup required: No GitButler project found at . - run `but setup` to configure the project
 
 "#]]);
 


### PR DESCRIPTION
Agents need the same human-readable command output as people, but they
should not receive terminal-only behavior like pagers, prompts, progress
messages, onboarding chatter, or truncation. Add an explicit agent
output format and centralize that policy in OutputFormat and
OutputChannel so commands can request human text while the channel
suppresses human UI affordances.