### PR TITLE
Contiguous block selections

### DIFF
--- a/apps/lite/ui/src/hunk.ts
+++ b/apps/lite/ui/src/hunk.ts
@@ -1,16 +1,17 @@
 /**
  * @file We have two representations of hunks: `Hunk` from Pierre, and the assorted hunk types from
  * the SDK.
+ *
+ * When a selection does not exactly match the original SDK hunk it may need to be sent back as
+ * multiple synthetic hunk headers: selected additions and deletions are separate headers, ordered
+ * by their position in the diff, with context lines omitted.
  */
 
 import type { DiffHunk, HunkDependencies, HunkHeader, TreeChange } from "@gitbutler/but-sdk";
-import type { Hunk, SelectedLineRange, SelectionSide } from "@pierre/diffs";
+import type { ChangeContent, Hunk, SelectedLineRange, SelectionSide } from "@pierre/diffs";
 import { Array, Match } from "effect";
 
 type HunkDependencyDiff = HunkDependencies["diffs"][number];
-
-export const formatHunkHeader = (hunk: HunkHeader): string =>
-	`-${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines}`;
 
 const hunkContainsHunk = (a: HunkHeader, b: HunkHeader): boolean =>
 	a.oldStart <= b.oldStart &&
@@ -51,7 +52,7 @@ export const getDependencyCommitIds = ({
 	return Array.isNonEmptyArray(dependencyCommitIds) ? dependencyCommitIds : undefined;
 };
 
-export const hunkHeaderFromHunk = (hunk: Hunk): HunkHeader => ({
+const hunkHeaderFromHunk = (hunk: Hunk): HunkHeader => ({
 	oldStart: hunk.deletionStart,
 	oldLines: hunk.deletionCount,
 	newStart: hunk.additionStart,
@@ -65,7 +66,22 @@ export const hunkContainsLine = (hunk: Hunk, line: number, side: SelectionSide):
 	return line >= start && line < start + count;
 };
 
-export const selectEntireHunk = (hunk: Hunk): SelectedLineRange => {
+export type HunkLineSelectionGroup = {
+	side: SelectionSide;
+	start: number;
+	lines: number;
+};
+
+export type HunkLineSelection = {
+	/** The full parsed hunk containing the selected line groups. */
+	hunkHeader: HunkHeader;
+	/** Changed-line groups covered by the single visual range, in hunk order. */
+	lineGroups: Array<HunkLineSelectionGroup>;
+	/** The single CodeView selection range to show for this selection. */
+	range: SelectedLineRange;
+};
+
+const selectEntireHunk = (hunk: Hunk): SelectedLineRange => {
 	if (hunk.deletionCount > 0 && hunk.additionCount > 0) {
 		const lastContent = hunk.hunkContent.at(-1);
 		const startsWithAddition =
@@ -95,6 +111,59 @@ export const selectEntireHunk = (hunk: Hunk): SelectedLineRange => {
 		end: hunk.additionStart + hunk.additionCount - 1,
 	};
 };
+
+const lineGroupsFromChangeContent = (
+	hunk: Hunk,
+	content: ChangeContent,
+): Array<HunkLineSelectionGroup> => [
+	...(content.deletions > 0
+		? [
+				{
+					side: "deletions" as const,
+					start: hunk.deletionStart + content.deletionLineIndex - hunk.deletionLineIndex,
+					lines: content.deletions,
+				},
+			]
+		: []),
+	...(content.additions > 0
+		? [
+				{
+					side: "additions" as const,
+					start: hunk.additionStart + content.additionLineIndex - hunk.additionLineIndex,
+					lines: content.additions,
+				},
+			]
+		: []),
+];
+
+export const lineSelectionFromHunk = (hunk: Hunk): HunkLineSelection => ({
+	hunkHeader: hunkHeaderFromHunk(hunk),
+	lineGroups: hunk.hunkContent.flatMap((content) =>
+		content.type === "change" ? lineGroupsFromChangeContent(hunk, content) : [],
+	),
+	range: selectEntireHunk(hunk),
+});
+
+export const diffSpecHunkHeadersForLineSelection = (
+	lineSelection: HunkLineSelection,
+	action: "commit" | "discard",
+): Array<HunkHeader> =>
+	lineSelection.lineGroups.map((group) => {
+		if (group.side === "deletions")
+			return {
+				oldStart: group.start,
+				oldLines: group.lines,
+				newStart: action === "commit" ? 0 : lineSelection.hunkHeader.newStart,
+				newLines: action === "commit" ? 0 : lineSelection.hunkHeader.newLines,
+			};
+
+		return {
+			oldStart: action === "commit" ? 0 : lineSelection.hunkHeader.oldStart,
+			oldLines: action === "commit" ? 0 : lineSelection.hunkHeader.oldLines,
+			newStart: group.start,
+			newLines: group.lines,
+		};
+	});
 
 const lineEndingForDiff = (diff: string): string => (diff.includes("\r\n") ? "\r\n" : "\n");
 

--- a/apps/lite/ui/src/hunk.ts
+++ b/apps/lite/ui/src/hunk.ts
@@ -81,19 +81,19 @@ const lineGroupsFromChangeContent = (
 	...(content.deletions > 0
 		? [
 				{
-					side: "deletions" as const,
+					side: "deletions",
 					start: hunk.deletionStart + content.deletionLineIndex - hunk.deletionLineIndex,
 					lines: content.deletions,
-				},
+				} satisfies HunkLineSelectionGroup,
 			]
 		: []),
 	...(content.additions > 0
 		? [
 				{
-					side: "additions" as const,
+					side: "additions",
 					start: hunk.additionStart + content.additionLineIndex - hunk.additionLineIndex,
 					lines: content.additions,
-				},
+				} satisfies HunkLineSelectionGroup,
 			]
 		: []),
 ];
@@ -115,7 +115,7 @@ const rangeFromLineGroups = (
 };
 
 export const contiguousSelectionsFromHunk = (hunk: Hunk): Array<HunkLineSelection> =>
-	hunk.hunkContent.flatMap((content) => {
+	hunk.hunkContent.flatMap((content): HunkLineSelection | [] => {
 		if (content.type !== "change") return [];
 
 		const lineGroups = lineGroupsFromChangeContent(hunk, content);
@@ -152,7 +152,7 @@ export const diffSpecHunkHeadersForLineSelection = (
 	lineSelection: HunkLineSelection,
 	action: "commit" | "discard",
 ): Array<HunkHeader> =>
-	lineSelection.lineGroups.map((group) => {
+	lineSelection.lineGroups.map((group): HunkHeader => {
 		if (group.side === "deletions")
 			return {
 				oldStart: group.start,

--- a/apps/lite/ui/src/hunk.ts
+++ b/apps/lite/ui/src/hunk.ts
@@ -59,13 +59,6 @@ const hunkHeaderFromHunk = (hunk: Hunk): HunkHeader => ({
 	newLines: hunk.additionCount,
 });
 
-export const hunkContainsLine = (hunk: Hunk, line: number, side: SelectionSide): boolean => {
-	const start = side === "deletions" ? hunk.deletionStart : hunk.additionStart;
-	const count = side === "deletions" ? hunk.deletionCount : hunk.additionCount;
-
-	return line >= start && line < start + count;
-};
-
 export type HunkLineSelectionGroup = {
 	side: SelectionSide;
 	start: number;
@@ -79,37 +72,6 @@ export type HunkLineSelection = {
 	lineGroups: Array<HunkLineSelectionGroup>;
 	/** The single CodeView selection range to show for this selection. */
 	range: SelectedLineRange;
-};
-
-const selectEntireHunk = (hunk: Hunk): SelectedLineRange => {
-	if (hunk.deletionCount > 0 && hunk.additionCount > 0) {
-		const lastContent = hunk.hunkContent.at(-1);
-		const startsWithAddition =
-			hunk.hunkContent[0]?.type === "change" && hunk.hunkContent[0].deletions === 0;
-		const endsWithDeletion = lastContent?.type === "change" && lastContent.additions === 0;
-
-		return {
-			start: startsWithAddition ? hunk.additionStart : hunk.deletionStart,
-			side: startsWithAddition ? "additions" : "deletions",
-			end: endsWithDeletion
-				? hunk.deletionStart + hunk.deletionCount - 1
-				: hunk.additionStart + hunk.additionCount - 1,
-			endSide: endsWithDeletion ? "deletions" : "additions",
-		};
-	}
-
-	if (hunk.deletionCount > 0)
-		return {
-			start: hunk.deletionStart,
-			side: "deletions",
-			end: hunk.deletionStart + hunk.deletionCount - 1,
-		};
-
-	return {
-		start: hunk.additionStart,
-		side: "additions",
-		end: hunk.additionStart + hunk.additionCount - 1,
-	};
 };
 
 const lineGroupsFromChangeContent = (
@@ -136,13 +98,55 @@ const lineGroupsFromChangeContent = (
 		: []),
 ];
 
-export const lineSelectionFromHunk = (hunk: Hunk): HunkLineSelection => ({
-	hunkHeader: hunkHeaderFromHunk(hunk),
-	lineGroups: hunk.hunkContent.flatMap((content) =>
-		content.type === "change" ? lineGroupsFromChangeContent(hunk, content) : [],
-	),
-	range: selectEntireHunk(hunk),
-});
+const rangeFromLineGroups = (
+	lineGroups: Array.NonEmptyArray<HunkLineSelectionGroup>,
+): SelectedLineRange => {
+	const first = Array.headNonEmpty(lineGroups);
+	const last = Array.lastNonEmpty(lineGroups);
+	const range: SelectedLineRange = {
+		start: first.start,
+		side: first.side,
+		end: last.start + last.lines - 1,
+	};
+
+	if (last.side !== first.side) range.endSide = last.side;
+
+	return range;
+};
+
+export const contiguousSelectionsFromHunk = (hunk: Hunk): Array<HunkLineSelection> =>
+	hunk.hunkContent.flatMap((content) => {
+		if (content.type !== "change") return [];
+
+		const lineGroups = lineGroupsFromChangeContent(hunk, content);
+		if (!Array.isNonEmptyArray(lineGroups)) return [];
+
+		return {
+			hunkHeader: hunkHeaderFromHunk(hunk),
+			lineGroups,
+			range: rangeFromLineGroups(lineGroups),
+		};
+	});
+
+export const contiguousSelectionByLine = ({
+	hunks,
+	line,
+	side,
+}: {
+	hunks: Array<Hunk>;
+	line: number;
+	side: SelectionSide;
+}): HunkLineSelection | null => {
+	for (const hunk of hunks)
+		for (const sel of contiguousSelectionsFromHunk(hunk)) {
+			const containsChangedLine = sel.lineGroups.some(
+				(group) => group.side === side && line >= group.start && line < group.start + group.lines,
+			);
+			if (containsChangedLine) return sel;
+		}
+
+	return null;
+};
 
 export const diffSpecHunkHeadersForLineSelection = (
 	lineSelection: HunkLineSelection,

--- a/apps/lite/ui/src/hunk.ts
+++ b/apps/lite/ui/src/hunk.ts
@@ -153,5 +153,5 @@ const patchHeaderForChange = (change: TreeChange, lineEnding: string): string =>
 export const synthesizeFilePatch = (change: TreeChange, hunks: Array<DiffHunk>): string => {
 	const lineEnding = lineEndingForDiff(hunks[0]?.diff ?? "");
 	const header = patchHeaderForChange(change, lineEnding);
-	return [header, ...hunks.map((hunk) => hunk.diff)].join(lineEnding);
+	return header + hunks.map((hunk) => hunk.diff).join("");
 };

--- a/apps/lite/ui/src/operands.ts
+++ b/apps/lite/ui/src/operands.ts
@@ -1,5 +1,5 @@
 import { Match } from "effect";
-import { type HunkHeader } from "@gitbutler/but-sdk";
+import type { HunkLineSelection } from "#ui/hunk.ts";
 
 /** @public */
 export type BranchFileParent = { stackId: string; branchRef: Array<number> };
@@ -52,9 +52,8 @@ export type FileOperand = {
 };
 
 /** @public */
-export type HunkOperand = {
+export type HunkOperand = HunkLineSelection & {
 	parent: FileOperand;
-	hunkHeader: HunkHeader;
 	isResultOfBinaryToTextConversion: boolean;
 };
 
@@ -101,13 +100,13 @@ export const fileOperand = ({ parent, path }: FileOperand): Operand => ({
 /** @public */
 export const hunkOperand = ({
 	parent,
-	hunkHeader,
 	isResultOfBinaryToTextConversion,
+	...lineSelection
 }: HunkOperand): Operand => ({
 	_tag: "Hunk",
 	parent,
-	hunkHeader,
 	isResultOfBinaryToTextConversion,
+	...lineSelection,
 });
 
 export const operandIdentityKey = (operand: Operand): string =>
@@ -119,7 +118,14 @@ export const operandIdentityKey = (operand: Operand): string =>
 			Branch: (x) => JSON.stringify(["Branch", x.stackId, x.branchRef]),
 			Commit: (x) => JSON.stringify(["Commit", x.stackId, x.commitId]),
 			Hunk: (x) =>
-				JSON.stringify(["Hunk", x.parent, x.hunkHeader, x.isResultOfBinaryToTextConversion]),
+				JSON.stringify([
+					"Hunk",
+					x.parent,
+					x.hunkHeader,
+					x.lineGroups,
+					x.range,
+					x.isResultOfBinaryToTextConversion,
+				]),
 		}),
 	);
 

--- a/apps/lite/ui/src/operations/diff-specs.ts
+++ b/apps/lite/ui/src/operations/diff-specs.ts
@@ -12,6 +12,7 @@ import {
 	WorktreeChanges,
 } from "@gitbutler/but-sdk";
 import { Match } from "effect";
+import { diffSpecHunkHeadersForLineSelection } from "#ui/hunk.ts";
 
 export const createDiffSpec = (change: TreeChange, hunkHeaders: Array<HunkHeader>): DiffSpec => ({
 	pathBytes: change.pathBytes,
@@ -58,7 +59,8 @@ const resolvedDiffSpecsFromOperand = ({
 				const changes = worktreeChanges.changes.map((change) => createDiffSpec(change, []));
 				return changes;
 			},
-			Hunk: ({ parent, hunkHeader }) => {
+			Hunk: (lineSelection) => {
+				const { parent } = lineSelection;
 				const changes = Match.value(parent.parent).pipe(
 					Match.tagsExhaustive({
 						Changes: () => worktreeChanges?.changes,
@@ -71,7 +73,12 @@ const resolvedDiffSpecsFromOperand = ({
 				const change = changes.find((candidate) => candidate.path === parent.path);
 				if (!change) return null;
 
-				return [createDiffSpec(change, [hunkHeader])];
+				const hunkHeaders = diffSpecHunkHeadersForLineSelection(
+					lineSelection,
+					parent.parent._tag === "Changes" ? "commit" : "discard",
+				);
+
+				return [createDiffSpec(change, hunkHeaders)];
 			},
 		}),
 		Match.orElse(() => null),

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -68,8 +68,8 @@ import {
 import {
 	getDependencyCommitIds,
 	getHunkDependencyDiffsByPath,
-	hunkContainsLine,
-	lineSelectionFromHunk,
+	contiguousSelectionByLine,
+	contiguousSelectionsFromHunk,
 	synthesizeFilePatch,
 } from "#ui/hunk.ts";
 import { buildNavigationIndex, NavigationIndex } from "#ui/workspace/navigation-index.ts";
@@ -209,7 +209,7 @@ type BuildOut = {
 		{ item: CodeViewDiffItem; change: TreeChange; patch: UnifiedPatch | null }
 	>;
 	/**
-	 * Map from file operand identity key to the file's first hunk.
+	 * Map from file operand identity key to the file's first contiguous block hunk.
 	 */
 	initialFileHunks: Map<string, HunkOperand>;
 	/**
@@ -249,31 +249,33 @@ const build = ({ fileParent, changes, treeChangeDiffs, changesetKey }: BuildIn):
 
 		itemsMetadataMap.set(item.id, { item, change, patch: mdiff ?? null });
 
-		if (mdiff?.type === "Patch")
-			for (const [hi, hunk] of item.fileDiff.hunks.entries()) {
-				const file: FileOperand = {
-					parent: fileParent,
-					path: change.path,
-				};
-				const fileKey = fileOperandIdentityKey(file);
+		if (mdiff?.type === "Patch") {
+			const file: FileOperand = {
+				parent: fileParent,
+				path: change.path,
+			};
+			const fileKey = fileOperandIdentityKey(file);
 
-				const hunkOperand: HunkOperand = {
-					parent: file,
-					...lineSelectionFromHunk(hunk),
-					isResultOfBinaryToTextConversion: mdiff.subject.isResultOfBinaryToTextConversion,
-				};
-				const hunkKey = hunkOperandIdentityKey(hunkOperand);
+			for (const hunk of item.fileDiff.hunks)
+				for (const selection of contiguousSelectionsFromHunk(hunk)) {
+					const hunkOperand: HunkOperand = {
+						parent: file,
+						...selection,
+						isResultOfBinaryToTextConversion: mdiff.subject.isResultOfBinaryToTextConversion,
+					};
+					const hunkKey = hunkOperandIdentityKey(hunkOperand);
 
-				const len = navigationIndex.items.push(hunkOperand);
-				navigationIndex.indexByKey.set(hunkKey, len - 1);
+					const len = navigationIndex.items.push(hunkOperand);
+					navigationIndex.indexByKey.set(hunkKey, len - 1);
 
-				if (hi === 0) initialFileHunks.set(fileKey, hunkOperand);
+					if (!initialFileHunks.has(fileKey)) initialFileHunks.set(fileKey, hunkOperand);
 
-				selectedRangeByHunk.set(hunkKey, {
-					id: item.id,
-					range: hunkOperand.range,
-				});
-			}
+					selectedRangeByHunk.set(hunkKey, {
+						id: item.id,
+						range: hunkOperand.range,
+					});
+				}
+		}
 	}
 
 	return {
@@ -359,7 +361,7 @@ const DiffContents: FC<{
 		});
 	};
 
-	// We currently only support selecting entire hunks.
+	// We currently only support selecting contiguous blocks.
 	const handleLinesSelected = (sel: CodeViewLineSelection | null): void => {
 		if (!sel) return void dispatch(projectActions.selectDiff({ projectId, selection: null }));
 
@@ -367,15 +369,16 @@ const DiffContents: FC<{
 		if (!itemBySel) throw new Error("Missing item ID in metadata map");
 		if (itemBySel.patch?.type !== "Patch") throw new Error("Selected hunk has no patch metadata");
 
-		const hunk = itemBySel.item.fileDiff.hunks.find((hunk) =>
-			hunkContainsLine(
-				hunk,
-				// The end range is more reliable in shift+click with preexisting selection scenarios.
-				sel.range.end,
-				sel.range.endSide ?? sel.range.side ?? "additions",
-			),
-		);
-		if (!hunk) throw new Error("No hunk found for selected range");
+		const side = sel.range.endSide ?? sel.range.side;
+		if (side === undefined) return;
+
+		const selection = contiguousSelectionByLine({
+			hunks: itemBySel.item.fileDiff.hunks,
+			// The end range is more reliable in shift+click with preexisting selection scenarios.
+			line: sel.range.end,
+			side,
+		});
+		if (!selection) return;
 
 		dispatch(
 			projectActions.selectDiff({
@@ -385,7 +388,7 @@ const DiffContents: FC<{
 						parent: fileParent,
 						path: itemBySel.change.path,
 					},
-					...lineSelectionFromHunk(hunk),
+					...selection,
 					isResultOfBinaryToTextConversion:
 						itemBySel.patch.subject.isResultOfBinaryToTextConversion,
 				},

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -69,8 +69,7 @@ import {
 	getDependencyCommitIds,
 	getHunkDependencyDiffsByPath,
 	hunkContainsLine,
-	hunkHeaderFromHunk,
-	selectEntireHunk,
+	lineSelectionFromHunk,
 	synthesizeFilePatch,
 } from "#ui/hunk.ts";
 import { buildNavigationIndex, NavigationIndex } from "#ui/workspace/navigation-index.ts";
@@ -260,7 +259,7 @@ const build = ({ fileParent, changes, treeChangeDiffs, changesetKey }: BuildIn):
 
 				const hunkOperand: HunkOperand = {
 					parent: file,
-					hunkHeader: hunkHeaderFromHunk(hunk),
+					...lineSelectionFromHunk(hunk),
 					isResultOfBinaryToTextConversion: mdiff.subject.isResultOfBinaryToTextConversion,
 				};
 				const hunkKey = hunkOperandIdentityKey(hunkOperand);
@@ -272,7 +271,7 @@ const build = ({ fileParent, changes, treeChangeDiffs, changesetKey }: BuildIn):
 
 				selectedRangeByHunk.set(hunkKey, {
 					id: item.id,
-					range: selectEntireHunk(hunk),
+					range: hunkOperand.range,
 				});
 			}
 	}
@@ -386,7 +385,7 @@ const DiffContents: FC<{
 						parent: fileParent,
 						path: itemBySel.change.path,
 					},
-					hunkHeader: hunkHeaderFromHunk(hunk),
+					...lineSelectionFromHunk(hunk),
 					isResultOfBinaryToTextConversion:
 						itemBySel.patch.subject.isResultOfBinaryToTextConversion,
 				},

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -360,7 +360,7 @@ const DiffContents: FC<{
 		});
 	};
 
-	// We currently only support selecting entire hunks in a unified view.
+	// We currently only support selecting entire hunks.
 	const handleLinesSelected = (sel: CodeViewLineSelection | null): void => {
 		if (!sel) return void dispatch(projectActions.selectDiff({ projectId, selection: null }));
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/operationSourceLabel.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/operationSourceLabel.ts
@@ -3,7 +3,6 @@ import { commitTitle, shortCommitId } from "#ui/commit.ts";
 import { Match } from "effect";
 import { type RefInfo } from "@gitbutler/but-sdk";
 import { Operand } from "#ui/operands.ts";
-import { formatHunkHeader } from "#ui/hunk.ts";
 import { assert } from "#ui/assert.ts";
 
 export const operationSourceLabel = ({
@@ -28,6 +27,9 @@ export const operationSourceLabel = ({
 					: shortCommitId(commitId);
 			},
 			Stack: () => "Stack",
-			Hunk: ({ hunkHeader }) => `Hunk ${formatHunkHeader(hunkHeader)}`,
+			Hunk: ({ lineGroups }) => {
+				const count = lineGroups.reduce((sum, group) => sum + group.lines, 0);
+				return `${count} changed line${count !== 1 ? "s" : ""}`;
+			},
 		}),
 	);


### PR DESCRIPTION
Closes GB-1554, following #14138.

Our hunk operands are no longer 1:1 with what we get back from the SDK. Some selections are materialised to multiple hunk headers.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #14215 
- <kbd>&nbsp;1&nbsp;</kbd> #14214 👈 
<!-- GitButler Footer Boundary Bottom -->

