### PR TITLE
POC: Contextual mouse line selections

### DIFF
--- a/apps/lite/ui/src/hunk.ts
+++ b/apps/lite/ui/src/hunk.ts
@@ -65,17 +65,22 @@ const hunkHeadersEqual = (a: HunkHeader, b: HunkHeader): boolean =>
 	a.newStart === b.newStart &&
 	a.newLines === b.newLines;
 
-export type HunkLineSelectionGroup = {
+type HunkLineSelectionGroup = {
 	side: SelectionSide;
 	start: number;
 	lines: number;
 };
 
-export type HunkLineSelection = {
+export type HunkLineSelectionSegment = {
 	/** The full parsed hunk containing the selected line groups. */
 	hunkHeader: HunkHeader;
-	/** Changed-line groups covered by the single visual range, in hunk order. */
+	/** Changed-line groups covered by the visual range within this hunk, in hunk order. */
 	lineGroups: Array<HunkLineSelectionGroup>;
+};
+
+export type HunkLineSelection = {
+	/** Per-hunk pieces covered by the single visual range, in file order. */
+	segments: Array<HunkLineSelectionSegment>;
 	/** The single CodeView selection range to show for this selection. */
 	range: SelectedLineRange;
 };
@@ -84,6 +89,11 @@ type HunkLineRow = {
 	additionLine?: number;
 	changedLine?: { side: SelectionSide; line: number };
 	deletionLine?: number;
+};
+
+type HunkLinePosition = {
+	hunkIndex: number;
+	rowIndex: number;
 };
 
 const lineGroupsFromChangeContent = (
@@ -155,6 +165,31 @@ const rowMatchesPoint = (row: HunkLineRow, line: number, side?: SelectionSide): 
 			? row.deletionLine === line
 			: row.additionLine === line;
 
+const compareLinePositions = (a: HunkLinePosition, b: HunkLinePosition): number =>
+	a.hunkIndex === b.hunkIndex ? a.rowIndex - b.rowIndex : a.hunkIndex - b.hunkIndex;
+
+const orderedLinePositions = (
+	a: HunkLinePosition,
+	b: HunkLinePosition,
+): [HunkLinePosition, HunkLinePosition] => (compareLinePositions(a, b) <= 0 ? [a, b] : [b, a]);
+
+const findLinePosition = ({
+	hunks,
+	line,
+	side,
+}: {
+	hunks: Array<Hunk>;
+	line: number;
+	side?: SelectionSide;
+}): HunkLinePosition | null => {
+	for (const [hunkIndex, hunk] of hunks.entries()) {
+		const rowIndex = lineRowsFromHunk(hunk).findIndex((row) => rowMatchesPoint(row, line, side));
+		if (rowIndex !== -1) return { hunkIndex, rowIndex };
+	}
+
+	return null;
+};
+
 const lineGroupsFromRows = (rows: Array<HunkLineRow>): Array<HunkLineSelectionGroup> => {
 	const lineGroups: Array<HunkLineSelectionGroup> = [];
 
@@ -205,8 +240,12 @@ export const contiguousSelectionsFromHunk = (hunk: Hunk): Array<HunkLineSelectio
 		if (!Array.isNonEmptyArray(lineGroups)) return [];
 
 		return {
-			hunkHeader: hunkHeaderFromHunk(hunk),
-			lineGroups,
+			segments: [
+				{
+					hunkHeader: hunkHeaderFromHunk(hunk),
+					lineGroups,
+				},
+			],
 			range: rangeFromLineGroups(lineGroups),
 		};
 	});
@@ -222,8 +261,10 @@ export const contiguousSelectionByLine = ({
 }): HunkLineSelection | null => {
 	for (const hunk of hunks)
 		for (const sel of contiguousSelectionsFromHunk(hunk)) {
-			const containsChangedLine = sel.lineGroups.some(
-				(group) => group.side === side && line >= group.start && line < group.start + group.lines,
+			const containsChangedLine = sel.segments.some((segment) =>
+				segment.lineGroups.some(
+					(group) => group.side === side && line >= group.start && line < group.start + group.lines,
+				),
 			);
 			if (containsChangedLine) return sel;
 		}
@@ -238,28 +279,36 @@ export const lineSelectionFromRange = ({
 	hunks: Array<Hunk>;
 	range: SelectedLineRange;
 }): HunkLineSelection | null => {
-	const startSide = range.side;
-	const endSide = range.endSide ?? range.side;
+	const startPosition = findLinePosition({ hunks, line: range.start, side: range.side });
+	const endPosition = findLinePosition({
+		hunks,
+		line: range.end,
+		side: range.endSide ?? range.side,
+	});
+	if (startPosition === null || endPosition === null) return null;
 
-	for (const hunk of hunks) {
+	const [firstPosition, lastPosition] = orderedLinePositions(startPosition, endPosition);
+	const segments: Array<HunkLineSelectionSegment> = [];
+
+	for (const [hunkIndex, hunk] of hunks.entries()) {
+		if (hunkIndex < firstPosition.hunkIndex || hunkIndex > lastPosition.hunkIndex) continue;
+
 		const rows = lineRowsFromHunk(hunk);
-		const startIndex = rows.findIndex((row) => rowMatchesPoint(row, range.start, startSide));
-		const endIndex = rows.findIndex((row) => rowMatchesPoint(row, range.end, endSide));
+		if (rows.length === 0) continue;
 
-		if (startIndex === -1 || endIndex === -1) continue;
-
+		const startIndex = hunkIndex === firstPosition.hunkIndex ? firstPosition.rowIndex : 0;
+		const endIndex = hunkIndex === lastPosition.hunkIndex ? lastPosition.rowIndex : rows.length - 1;
 		const lineGroups = lineGroupsFromRows(
 			rows.slice(Math.min(startIndex, endIndex), Math.max(startIndex, endIndex) + 1),
 		);
 
-		return {
+		segments.push({
 			hunkHeader: hunkHeaderFromHunk(hunk),
 			lineGroups,
-			range,
-		};
+		});
 	}
 
-	return null;
+	return { segments, range };
 };
 
 const lineGroupsIntersect = (a: HunkLineSelectionGroup, b: HunkLineSelectionGroup): boolean => {
@@ -271,7 +320,15 @@ const lineGroupsIntersect = (a: HunkLineSelectionGroup, b: HunkLineSelectionGrou
 };
 
 export const lineSelectionsIntersect = (a: HunkLineSelection, b: HunkLineSelection): boolean =>
-	a.lineGroups.some((aGroup) => b.lineGroups.some((bGroup) => lineGroupsIntersect(aGroup, bGroup)));
+	a.segments.some((aSegment) =>
+		b.segments.some(
+			(bSegment) =>
+				hunkHeadersEqual(aSegment.hunkHeader, bSegment.hunkHeader) &&
+				aSegment.lineGroups.some((aGroup) =>
+					bSegment.lineGroups.some((bGroup) => lineGroupsIntersect(aGroup, bGroup)),
+				),
+		),
+	);
 
 const lineSelectionPosition = ({
 	hunks,
@@ -279,28 +336,21 @@ const lineSelectionPosition = ({
 }: {
 	hunks: Array<Hunk>;
 	selection: HunkLineSelection;
-}): { hunkIndex: number; startRow: number; endRow: number } | null => {
-	const hunkIndex = hunks.findIndex((hunk) =>
-		hunkHeadersEqual(hunkHeaderFromHunk(hunk), selection.hunkHeader),
-	);
-	if (hunkIndex === -1) return null;
+}): { start: HunkLinePosition; end: HunkLinePosition } | null => {
+	const startPosition = findLinePosition({
+		hunks,
+		line: selection.range.start,
+		side: selection.range.side,
+	});
+	const endPosition = findLinePosition({
+		hunks,
+		line: selection.range.end,
+		side: selection.range.endSide ?? selection.range.side,
+	});
+	if (startPosition === null || endPosition === null) return null;
 
-	const hunk = hunks[hunkIndex];
-	if (hunk === undefined) return null;
-	const rows = lineRowsFromHunk(hunk);
-	const startIndex = rows.findIndex((row) =>
-		rowMatchesPoint(row, selection.range.start, selection.range.side),
-	);
-	const endIndex = rows.findIndex((row) =>
-		rowMatchesPoint(row, selection.range.end, selection.range.endSide ?? selection.range.side),
-	);
-	if (startIndex === -1 || endIndex === -1) return null;
-
-	return {
-		hunkIndex,
-		startRow: Math.min(startIndex, endIndex),
-		endRow: Math.max(startIndex, endIndex),
-	};
+	const [start, end] = orderedLinePositions(startPosition, endPosition);
+	return { start, end };
 };
 
 export const compareLineSelections = ({
@@ -316,9 +366,8 @@ export const compareLineSelections = ({
 	const bPosition = lineSelectionPosition({ hunks, selection: b });
 	if (aPosition === null || bPosition === null) return null;
 
-	if (aPosition.hunkIndex !== bPosition.hunkIndex) return aPosition.hunkIndex - bPosition.hunkIndex;
-	if (aPosition.endRow < bPosition.startRow) return -1;
-	if (aPosition.startRow > bPosition.endRow) return 1;
+	if (compareLinePositions(aPosition.end, bPosition.start) < 0) return -1;
+	if (compareLinePositions(aPosition.start, bPosition.end) > 0) return 1;
 	return 0;
 };
 
@@ -326,22 +375,24 @@ export const diffSpecHunkHeadersForLineSelection = (
 	lineSelection: HunkLineSelection,
 	action: "commit" | "discard",
 ): Array<HunkHeader> =>
-	lineSelection.lineGroups.map((group) => {
-		if (group.side === "deletions")
-			return {
-				oldStart: group.start,
-				oldLines: group.lines,
-				newStart: action === "commit" ? 0 : lineSelection.hunkHeader.newStart,
-				newLines: action === "commit" ? 0 : lineSelection.hunkHeader.newLines,
-			};
+	lineSelection.segments.flatMap((segment) =>
+		segment.lineGroups.map((group) => {
+			if (group.side === "deletions")
+				return {
+					oldStart: group.start,
+					oldLines: group.lines,
+					newStart: action === "commit" ? 0 : segment.hunkHeader.newStart,
+					newLines: action === "commit" ? 0 : segment.hunkHeader.newLines,
+				};
 
-		return {
-			oldStart: action === "commit" ? 0 : lineSelection.hunkHeader.oldStart,
-			oldLines: action === "commit" ? 0 : lineSelection.hunkHeader.oldLines,
-			newStart: group.start,
-			newLines: group.lines,
-		};
-	});
+			return {
+				oldStart: action === "commit" ? 0 : segment.hunkHeader.oldStart,
+				oldLines: action === "commit" ? 0 : segment.hunkHeader.oldLines,
+				newStart: group.start,
+				newLines: group.lines,
+			};
+		}),
+	);
 
 const lineEndingForDiff = (diff: string): string => (diff.includes("\r\n") ? "\r\n" : "\n");
 

--- a/apps/lite/ui/src/hunk.ts
+++ b/apps/lite/ui/src/hunk.ts
@@ -59,6 +59,12 @@ const hunkHeaderFromHunk = (hunk: Hunk): HunkHeader => ({
 	newLines: hunk.additionCount,
 });
 
+const hunkHeadersEqual = (a: HunkHeader, b: HunkHeader): boolean =>
+	a.oldStart === b.oldStart &&
+	a.oldLines === b.oldLines &&
+	a.newStart === b.newStart &&
+	a.newLines === b.newLines;
+
 export type HunkLineSelectionGroup = {
 	side: SelectionSide;
 	start: number;
@@ -142,8 +148,12 @@ const lineRowsFromHunk = (hunk: Hunk): Array<HunkLineRow> => {
 	return rows;
 };
 
-const rowMatchesPoint = (row: HunkLineRow, line: number, side: SelectionSide): boolean =>
-	side === "deletions" ? row.deletionLine === line : row.additionLine === line;
+const rowMatchesPoint = (row: HunkLineRow, line: number, side?: SelectionSide): boolean =>
+	side === undefined
+		? row.deletionLine === line || row.additionLine === line
+		: side === "deletions"
+			? row.deletionLine === line
+			: row.additionLine === line;
 
 const lineGroupsFromRows = (rows: Array<HunkLineRow>): Array<HunkLineSelectionGroup> => {
 	const lineGroups: Array<HunkLineSelectionGroup> = [];
@@ -230,7 +240,6 @@ export const lineSelectionFromRange = ({
 }): HunkLineSelection | null => {
 	const startSide = range.side;
 	const endSide = range.endSide ?? range.side;
-	if (startSide === undefined || endSide === undefined) return null;
 
 	for (const hunk of hunks) {
 		const rows = lineRowsFromHunk(hunk);
@@ -242,7 +251,6 @@ export const lineSelectionFromRange = ({
 		const lineGroups = lineGroupsFromRows(
 			rows.slice(Math.min(startIndex, endIndex), Math.max(startIndex, endIndex) + 1),
 		);
-		if (!Array.isNonEmptyArray(lineGroups)) return null;
 
 		return {
 			hunkHeader: hunkHeaderFromHunk(hunk),
@@ -264,6 +272,55 @@ const lineGroupsIntersect = (a: HunkLineSelectionGroup, b: HunkLineSelectionGrou
 
 export const lineSelectionsIntersect = (a: HunkLineSelection, b: HunkLineSelection): boolean =>
 	a.lineGroups.some((aGroup) => b.lineGroups.some((bGroup) => lineGroupsIntersect(aGroup, bGroup)));
+
+const lineSelectionPosition = ({
+	hunks,
+	selection,
+}: {
+	hunks: Array<Hunk>;
+	selection: HunkLineSelection;
+}): { hunkIndex: number; startRow: number; endRow: number } | null => {
+	const hunkIndex = hunks.findIndex((hunk) =>
+		hunkHeadersEqual(hunkHeaderFromHunk(hunk), selection.hunkHeader),
+	);
+	if (hunkIndex === -1) return null;
+
+	const hunk = hunks[hunkIndex];
+	if (hunk === undefined) return null;
+	const rows = lineRowsFromHunk(hunk);
+	const startIndex = rows.findIndex((row) =>
+		rowMatchesPoint(row, selection.range.start, selection.range.side),
+	);
+	const endIndex = rows.findIndex((row) =>
+		rowMatchesPoint(row, selection.range.end, selection.range.endSide ?? selection.range.side),
+	);
+	if (startIndex === -1 || endIndex === -1) return null;
+
+	return {
+		hunkIndex,
+		startRow: Math.min(startIndex, endIndex),
+		endRow: Math.max(startIndex, endIndex),
+	};
+};
+
+export const compareLineSelections = ({
+	hunks,
+	a,
+	b,
+}: {
+	hunks: Array<Hunk>;
+	a: HunkLineSelection;
+	b: HunkLineSelection;
+}): number | null => {
+	const aPosition = lineSelectionPosition({ hunks, selection: a });
+	const bPosition = lineSelectionPosition({ hunks, selection: b });
+	if (aPosition === null || bPosition === null) return null;
+
+	if (aPosition.hunkIndex !== bPosition.hunkIndex) return aPosition.hunkIndex - bPosition.hunkIndex;
+	if (aPosition.endRow < bPosition.startRow) return -1;
+	if (aPosition.startRow > bPosition.endRow) return 1;
+	return 0;
+};
 
 export const diffSpecHunkHeadersForLineSelection = (
 	lineSelection: HunkLineSelection,

--- a/apps/lite/ui/src/hunk.ts
+++ b/apps/lite/ui/src/hunk.ts
@@ -74,6 +74,12 @@ export type HunkLineSelection = {
 	range: SelectedLineRange;
 };
 
+type HunkLineRow = {
+	additionLine?: number;
+	changedLine?: { side: SelectionSide; line: number };
+	deletionLine?: number;
+};
+
 const lineGroupsFromChangeContent = (
 	hunk: Hunk,
 	content: ChangeContent,
@@ -97,6 +103,73 @@ const lineGroupsFromChangeContent = (
 			]
 		: []),
 ];
+
+const lineRowsFromHunk = (hunk: Hunk): Array<HunkLineRow> => {
+	const rows: Array<HunkLineRow> = [];
+
+	for (const content of hunk.hunkContent) {
+		const deletionStart = hunk.deletionStart + content.deletionLineIndex - hunk.deletionLineIndex;
+		const additionStart = hunk.additionStart + content.additionLineIndex - hunk.additionLineIndex;
+
+		if (content.type === "context") {
+			for (let i = 0; i < content.lines; i++)
+				rows.push({
+					deletionLine: deletionStart + i,
+					additionLine: additionStart + i,
+				});
+			continue;
+		}
+
+		for (let i = 0; i < content.deletions; i++)
+			rows.push({
+				deletionLine: deletionStart + i,
+				changedLine: {
+					side: "deletions",
+					line: deletionStart + i,
+				},
+			});
+
+		for (let i = 0; i < content.additions; i++)
+			rows.push({
+				additionLine: additionStart + i,
+				changedLine: {
+					side: "additions",
+					line: additionStart + i,
+				},
+			});
+	}
+
+	return rows;
+};
+
+const rowMatchesPoint = (row: HunkLineRow, line: number, side: SelectionSide): boolean =>
+	side === "deletions" ? row.deletionLine === line : row.additionLine === line;
+
+const lineGroupsFromRows = (rows: Array<HunkLineRow>): Array<HunkLineSelectionGroup> => {
+	const lineGroups: Array<HunkLineSelectionGroup> = [];
+
+	for (const row of rows) {
+		if (!row.changedLine) continue;
+
+		const last = lineGroups.at(-1);
+		if (
+			last &&
+			last.side === row.changedLine.side &&
+			last.start + last.lines === row.changedLine.line
+		) {
+			last.lines++;
+			continue;
+		}
+
+		lineGroups.push({
+			side: row.changedLine.side,
+			start: row.changedLine.line,
+			lines: 1,
+		});
+	}
+
+	return lineGroups;
+};
 
 const rangeFromLineGroups = (
 	lineGroups: Array.NonEmptyArray<HunkLineSelectionGroup>,
@@ -147,6 +220,50 @@ export const contiguousSelectionByLine = ({
 
 	return null;
 };
+
+export const lineSelectionFromRange = ({
+	hunks,
+	range,
+}: {
+	hunks: Array<Hunk>;
+	range: SelectedLineRange;
+}): HunkLineSelection | null => {
+	const startSide = range.side;
+	const endSide = range.endSide ?? range.side;
+	if (startSide === undefined || endSide === undefined) return null;
+
+	for (const hunk of hunks) {
+		const rows = lineRowsFromHunk(hunk);
+		const startIndex = rows.findIndex((row) => rowMatchesPoint(row, range.start, startSide));
+		const endIndex = rows.findIndex((row) => rowMatchesPoint(row, range.end, endSide));
+
+		if (startIndex === -1 || endIndex === -1) continue;
+
+		const lineGroups = lineGroupsFromRows(
+			rows.slice(Math.min(startIndex, endIndex), Math.max(startIndex, endIndex) + 1),
+		);
+		if (!Array.isNonEmptyArray(lineGroups)) return null;
+
+		return {
+			hunkHeader: hunkHeaderFromHunk(hunk),
+			lineGroups,
+			range,
+		};
+	}
+
+	return null;
+};
+
+const lineGroupsIntersect = (a: HunkLineSelectionGroup, b: HunkLineSelectionGroup): boolean => {
+	if (a.side !== b.side) return false;
+
+	const aEnd = a.start + a.lines;
+	const bEnd = b.start + b.lines;
+	return a.start < bEnd && b.start < aEnd;
+};
+
+export const lineSelectionsIntersect = (a: HunkLineSelection, b: HunkLineSelection): boolean =>
+	a.lineGroups.some((aGroup) => b.lineGroups.some((bGroup) => lineGroupsIntersect(aGroup, bGroup)));
 
 export const diffSpecHunkHeadersForLineSelection = (
 	lineSelection: HunkLineSelection,

--- a/apps/lite/ui/src/operands.ts
+++ b/apps/lite/ui/src/operands.ts
@@ -118,14 +118,7 @@ export const operandIdentityKey = (operand: Operand): string =>
 			Branch: (x) => JSON.stringify(["Branch", x.stackId, x.branchRef]),
 			Commit: (x) => JSON.stringify(["Commit", x.stackId, x.commitId]),
 			Hunk: (x) =>
-				JSON.stringify([
-					"Hunk",
-					x.parent,
-					x.hunkHeader,
-					x.lineGroups,
-					x.range,
-					x.isResultOfBinaryToTextConversion,
-				]),
+				JSON.stringify(["Hunk", x.parent, x.segments, x.range, x.isResultOfBinaryToTextConversion]),
 		}),
 	);
 

--- a/apps/lite/ui/src/operations/diff-specs.ts
+++ b/apps/lite/ui/src/operations/diff-specs.ts
@@ -77,6 +77,7 @@ const resolvedDiffSpecsFromOperand = ({
 					lineSelection,
 					parent.parent._tag === "Changes" ? "commit" : "discard",
 				);
+				if (hunkHeaders.length === 0) return null;
 
 				return [createDiffSpec(change, hunkHeaders)];
 			},

--- a/apps/lite/ui/src/operations/operation.ts
+++ b/apps/lite/ui/src/operations/operation.ts
@@ -477,7 +477,9 @@ export type OperationType = "squash" | "moveAbove" | "moveBelow";
 const isOperationSourceEnabled = (source: Operand): boolean =>
 	Match.value(source).pipe(
 		Match.when({ _tag: "Hunk", isResultOfBinaryToTextConversion: true }, () => false),
-		Match.when({ _tag: "Hunk" }, ({ lineGroups }) => lineGroups.length > 0),
+		Match.when({ _tag: "Hunk" }, ({ segments }) =>
+			segments.some((segment) => segment.lineGroups.length > 0),
+		),
 		Match.orElse(() => true),
 	);
 

--- a/apps/lite/ui/src/operations/operation.ts
+++ b/apps/lite/ui/src/operations/operation.ts
@@ -477,6 +477,7 @@ export type OperationType = "squash" | "moveAbove" | "moveBelow";
 const isOperationSourceEnabled = (source: Operand): boolean =>
 	Match.value(source).pipe(
 		Match.when({ _tag: "Hunk", isResultOfBinaryToTextConversion: true }, () => false),
+		Match.when({ _tag: "Hunk" }, ({ lineGroups }) => lineGroups.length > 0),
 		Match.orElse(() => true),
 	);
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -52,6 +52,11 @@
 	display: grid;
 }
 
+.diffContentsGestureBoundary {
+	display: grid;
+	min-height: 0;
+}
+
 .diffContents {
 	--diffs-bg-selection-number-override: color-mix(var(--fill-gray-bg) 60%, transparent);
 	--diffs-bg-selection-override: transparent;

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -66,6 +66,7 @@ import {
 	type FileTreeItem,
 } from "#ui/routes/project/$id/workspace/FilesTree.tsx";
 import {
+	compareLineSelections,
 	contiguousSelectionByLine,
 	contiguousSelectionsFromHunk,
 	getDependencyCommitIds,
@@ -339,6 +340,45 @@ const DiffContents: FC<{
 		});
 	};
 
+	const adjacentBlockForUnmatchedRange = (
+		selection: HunkOperand,
+		offset: -1 | 1,
+	): HunkOperand | null | undefined => {
+		const selectedItem = itemsMetadataMap.get(
+			codeViewItemId({ changesetKey, path: selection.parent.path }),
+		);
+		if (selectedItem === undefined) return undefined;
+
+		let previousItem: HunkOperand | null = null;
+		let seenSelectedFile = false;
+
+		for (const item of navigationIndex.items) {
+			const sameFile =
+				fileOperandIdentityKey(item.parent) === fileOperandIdentityKey(selection.parent);
+
+			if (!sameFile) {
+				if (seenSelectedFile) return offset === 1 ? item : previousItem;
+				previousItem = item;
+				continue;
+			}
+
+			seenSelectedFile = true;
+
+			const order = compareLineSelections({
+				hunks: selectedItem.item.fileDiff.hunks,
+				a: item,
+				b: selection,
+			});
+			if (order === null) return undefined;
+			if (order > 0) return offset === 1 ? item : previousItem;
+
+			previousItem = item;
+		}
+
+		if (!seenSelectedFile) return undefined;
+		return offset === 1 ? null : previousItem;
+	};
+
 	useNavigationIndexHotkeys({
 		navigationIndex,
 		projectId,
@@ -355,7 +395,8 @@ const DiffContents: FC<{
 			const selectedBlockIndexes = navigationIndex.items.flatMap((item, index) =>
 				hunkOperandsIntersect(selection, item) ? [index] : [],
 			);
-			if (!Array.isNonEmptyArray(selectedBlockIndexes)) return undefined;
+			if (!Array.isNonEmptyArray(selectedBlockIndexes))
+				return adjacentBlockForUnmatchedRange(selection, offset);
 
 			const nextIndex =
 				offset === 1

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -25,7 +25,11 @@ import {
 	type HunkOperand,
 	type Operand,
 } from "#ui/operands.ts";
-import { projectActions, selectProjectFilesVisible } from "#ui/projects/state.ts";
+import {
+	projectActions,
+	selectProjectFilesVisible,
+	selectProjectSelectionDiff,
+} from "#ui/projects/state.ts";
 import { getButtonClassName } from "#ui/components/Button.tsx";
 import { Icon } from "#ui/components/Icon.tsx";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
@@ -50,15 +54,11 @@ import {
 import { CodeView, type CodeViewHandle } from "@pierre/diffs/react";
 import { useSuspenseQueries } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
-import { Hash, Match } from "effect";
+import { Array, Hash, Match } from "effect";
 import { ComponentProps, FC, type RefObject, Suspense, useDeferredValue, useRef } from "react";
 import styles from "./Details.module.css";
 import { workspaceHotkeys } from "#ui/hotkeys.ts";
-import {
-	type SelectionScope,
-	useDiffSelection,
-	useNavigationIndexHotkeys,
-} from "#ui/selection-scopes.ts";
+import { type SelectionScope, useNavigationIndexHotkeys } from "#ui/selection-scopes.ts";
 import {
 	FilesTree,
 	changeFileTreeItem,
@@ -66,10 +66,12 @@ import {
 	type FileTreeItem,
 } from "#ui/routes/project/$id/workspace/FilesTree.tsx";
 import {
-	getDependencyCommitIds,
-	getHunkDependencyDiffsByPath,
 	contiguousSelectionByLine,
 	contiguousSelectionsFromHunk,
+	getDependencyCommitIds,
+	getHunkDependencyDiffsByPath,
+	lineSelectionFromRange,
+	lineSelectionsIntersect,
 	synthesizeFilePatch,
 } from "#ui/hunk.ts";
 import { buildNavigationIndex, NavigationIndex } from "#ui/workspace/navigation-index.ts";
@@ -87,6 +89,13 @@ const fileOperandIdentityKey = (operand: FileOperand): string =>
 
 const hunkOperandIdentityKey = (operand: HunkOperand): string =>
 	operandIdentityKey(hunkOperand(operand));
+
+const rangeIsSinglePoint = (range: CodeViewLineSelection["range"]): boolean =>
+	range.start === range.end && range.side === (range.endSide ?? range.side);
+
+const hunkOperandsIntersect = (a: HunkOperand, b: HunkOperand): boolean =>
+	fileOperandIdentityKey(a.parent) === fileOperandIdentityKey(b.parent) &&
+	lineSelectionsIntersect(a, b);
 
 const getCommitFileTreeItems = ({
 	commit,
@@ -212,10 +221,6 @@ type BuildOut = {
 	 * Map from file operand identity key to the file's first contiguous block hunk.
 	 */
 	initialFileHunks: Map<string, HunkOperand>;
-	/**
-	 * Map from hunk operand identity key to the hunk's computed selection range.
-	 */
-	selectedRangeByHunk: Map<string, CodeViewLineSelection>;
 };
 
 /** Build relationships between our SDK data and Pierre's view. */
@@ -233,8 +238,6 @@ const build = ({ fileParent, changes, treeChangeDiffs, changesetKey }: BuildIn):
 	>();
 
 	const initialFileHunks = new Map<string, HunkOperand>();
-
-	const selectedRangeByHunk = new Map<string, CodeViewLineSelection>();
 
 	for (const [ci, change] of changes.entries()) {
 		const mdiff = treeChangeDiffs[ci];
@@ -269,11 +272,6 @@ const build = ({ fileParent, changes, treeChangeDiffs, changesetKey }: BuildIn):
 					navigationIndex.indexByKey.set(hunkKey, len - 1);
 
 					if (!initialFileHunks.has(fileKey)) initialFileHunks.set(fileKey, hunkOperand);
-
-					selectedRangeByHunk.set(hunkKey, {
-						id: item.id,
-						range: hunkOperand.range,
-					});
 				}
 		}
 	}
@@ -283,7 +281,6 @@ const build = ({ fileParent, changes, treeChangeDiffs, changesetKey }: BuildIn):
 		itemsMetadataMap,
 		initialFileHunks,
 		navigationIndex,
-		selectedRangeByHunk,
 	};
 };
 
@@ -300,7 +297,6 @@ const DiffContents: FC<{
 		string,
 		{ item: CodeViewDiffItem; change: TreeChange; patch: UnifiedPatch | null }
 	>;
-	selectedRangeByHunk: Map<string, CodeViewLineSelection>;
 }> = ({
 	selectionScopeRef,
 	onViewerFileSelection,
@@ -311,19 +307,28 @@ const DiffContents: FC<{
 	navigationIndex,
 	items,
 	itemsMetadataMap,
-	selectedRangeByHunk,
 }) => {
 	const dispatch = useAppDispatch();
+	const rawDiffSelection = useAppSelector((state) => selectProjectSelectionDiff(state, projectId));
+	const pointerGestureIdRef = useRef(0);
+	const blockSnapGestureRef = useRef<{ blockKey: string; gestureId: number } | null>(null);
+	const rangeGestureIdRef = useRef<number | null>(null);
 
-	const diffSelection = useDiffSelection(projectId, navigationIndex);
-	const selectedRange = diffSelection
-		? (selectedRangeByHunk.get(hunkOperandIdentityKey(diffSelection)) ?? null)
-		: null;
+	const diffSelection = rawDiffSelection ?? navigationIndex.items[0] ?? null;
+	const selectionLineRange = (selection: HunkOperand | null): CodeViewLineSelection | null => {
+		if (!selection) return null;
+
+		const id = codeViewItemId({ changesetKey, path: selection.parent.path });
+		if (!itemsMetadataMap.has(id)) return null;
+
+		return { id, range: selection.range };
+	};
+	const selectedRange = selectionLineRange(diffSelection);
 
 	const selectDiff = (selection: HunkOperand) => {
 		dispatch(projectActions.selectDiff({ projectId, selection }));
 
-		const selectedRange = selectedRangeByHunk.get(hunkOperandIdentityKey(selection));
+		const selectedRange = selectionLineRange(selection);
 		if (!selectedRange) return;
 
 		viewerRef.current?.scrollTo({
@@ -344,6 +349,21 @@ const DiffContents: FC<{
 		ref: selectionScopeRef,
 		getKey: hunkOperandIdentityKey,
 		operationSourceForItem: hunkOperand,
+		getAdjacentItem: ({ selection, offset }) => {
+			if (!selection) return undefined;
+
+			const selectedBlockIndexes = navigationIndex.items.flatMap((item, index) =>
+				hunkOperandsIntersect(selection, item) ? [index] : [],
+			);
+			if (!Array.isNonEmptyArray(selectedBlockIndexes)) return undefined;
+
+			const nextIndex =
+				offset === 1
+					? Array.lastNonEmpty(selectedBlockIndexes) + 1
+					: Array.headNonEmpty(selectedBlockIndexes) - 1;
+
+			return navigationIndex.items[nextIndex] ?? null;
+		},
 	});
 
 	const selectFileAtViewportTop = (scrollTop: number, viewer: CodeViewClass<undefined>) => {
@@ -361,37 +381,98 @@ const DiffContents: FC<{
 		});
 	};
 
-	// We currently only support selecting contiguous blocks.
+	const containingNavigationBlock = (selection: HunkOperand | null): HunkOperand | null => {
+		if (selection === null) return null;
+
+		return navigationIndex.items.find((item) => hunkOperandsIntersect(selection, item)) ?? null;
+	};
+
+	const handlePointerDown = () => {
+		pointerGestureIdRef.current++;
+		blockSnapGestureRef.current = null;
+		rangeGestureIdRef.current = null;
+	};
+
 	const handleLinesSelected = (sel: CodeViewLineSelection | null): void => {
-		if (!sel) return void dispatch(projectActions.selectDiff({ projectId, selection: null }));
+		if (!sel) {
+			const selection = containingNavigationBlock(rawDiffSelection);
+			if (selection !== null)
+				blockSnapGestureRef.current = {
+					blockKey: hunkOperandIdentityKey(selection),
+					gestureId: pointerGestureIdRef.current,
+				};
+
+			return void dispatch(projectActions.selectDiff({ projectId, selection }));
+		}
 
 		const itemBySel = itemsMetadataMap.get(sel.id);
 		if (!itemBySel) throw new Error("Missing item ID in metadata map");
 		if (itemBySel.patch?.type !== "Patch") throw new Error("Selected hunk has no patch metadata");
 
+		const parent: FileOperand = {
+			parent: fileParent,
+			path: itemBySel.change.path,
+		};
+		const isResultOfBinaryToTextConversion =
+			itemBySel.patch.subject.isResultOfBinaryToTextConversion;
 		const side = sel.range.endSide ?? sel.range.side;
-		if (side === undefined) return;
-
-		const selection = contiguousSelectionByLine({
+		const contiguousSelection =
+			side === undefined
+				? null
+				: contiguousSelectionByLine({
+						hunks: itemBySel.item.fileDiff.hunks,
+						// The end range is more reliable in shift+click with preexisting selection scenarios.
+						line: sel.range.end,
+						side,
+					});
+		const contiguousOperand: HunkOperand | null = contiguousSelection && {
+			parent,
+			...contiguousSelection,
+			isResultOfBinaryToTextConversion,
+		};
+		const contiguousOperandKey =
+			contiguousOperand === null ? null : hunkOperandIdentityKey(contiguousOperand);
+		const rangeSelection = lineSelectionFromRange({
 			hunks: itemBySel.item.fileDiff.hunks,
-			// The end range is more reliable in shift+click with preexisting selection scenarios.
-			line: sel.range.end,
-			side,
+			range: sel.range,
 		});
+		const rangeOperand: HunkOperand | null = rangeSelection && {
+			parent,
+			...rangeSelection,
+			isResultOfBinaryToTextConversion,
+		};
+		const rawSelectionIntersectsClickedBlock =
+			rawDiffSelection !== null &&
+			contiguousOperand !== null &&
+			hunkOperandsIntersect(rawDiffSelection, contiguousOperand);
+		const snappedClickedBlockThisGesture =
+			contiguousOperandKey !== null &&
+			blockSnapGestureRef.current?.gestureId === pointerGestureIdRef.current &&
+			blockSnapGestureRef.current.blockKey === contiguousOperandKey;
+		const isSinglePointRange = rangeIsSinglePoint(sel.range);
+		if (!isSinglePointRange && rangeOperand !== null)
+			rangeGestureIdRef.current = pointerGestureIdRef.current;
+
+		const gestureHasSelectedRange = rangeGestureIdRef.current === pointerGestureIdRef.current;
+		const shouldUseRange =
+			rangeOperand !== null &&
+			(!isSinglePointRange ||
+				gestureHasSelectedRange ||
+				(rawSelectionIntersectsClickedBlock && !snappedClickedBlockThisGesture));
+		const selection = shouldUseRange ? rangeOperand : (contiguousOperand ?? rangeOperand);
+
 		if (!selection) return;
+
+		if (selection === contiguousOperand && contiguousOperandKey !== null)
+			blockSnapGestureRef.current = {
+				blockKey: contiguousOperandKey,
+				gestureId: pointerGestureIdRef.current,
+			};
 
 		dispatch(
 			projectActions.selectDiff({
 				projectId,
-				selection: {
-					parent: {
-						parent: fileParent,
-						path: itemBySel.change.path,
-					},
-					...selection,
-					isResultOfBinaryToTextConversion:
-						itemBySel.patch.subject.isResultOfBinaryToTextConversion,
-				},
+				selection,
 			}),
 		);
 	};
@@ -399,57 +480,58 @@ const DiffContents: FC<{
 	return items.length === 0 ? (
 		<p className="text-13">No changes.</p>
 	) : (
-		<CodeView
-			ref={viewerRef}
-			renderCustomHeader={(item) => {
-				if (item.type === "file") throw new Error("Only diff items may be rendered");
+		<div className={styles.diffContentsGestureBoundary} onPointerDownCapture={handlePointerDown}>
+			<CodeView
+				ref={viewerRef}
+				renderCustomHeader={(item) => {
+					if (item.type === "file") throw new Error("Only diff items may be rendered");
 
-				const change = itemsMetadataMap.get(item.id)?.change;
+					const change = itemsMetadataMap.get(item.id)?.change;
 
-				// CodeView may briefly hold onto stale snapshots of our data.
-				if (change === undefined) return <div style={{ height: 38 }} />;
+					// CodeView may briefly hold onto stale snapshots of our data.
+					if (change === undefined) return <div style={{ height: 38 }} />;
 
-				return (
-					<DiffFileHeader
-						projectId={projectId}
-						item={item}
-						operand={{
-							parent: fileParent,
-							path: change.path,
-						}}
-						change={change}
-						hasDiff={item.fileDiff.hunks.length !== 0}
-					/>
-				);
-			}}
-			onScroll={selectFileAtViewportTop}
-			className={styles.diffContents}
-			items={items}
-			selectedLines={selectedRange}
-			onSelectedLinesChange={handleLinesSelected}
-			options={{
-				diffStyle: "unified",
-				themeType: "system",
-				stickyHeaders: true,
-				enableLineSelection: true,
-				layout: {
-					paddingTop: 0,
-					// Match --panel-padding.
-					paddingBottom: 16,
-					gap: 10,
-				},
-				// This appears to validate before our custom header has been slotted, in which case - if
-				// our metrics are correct - we should see deltas in multiples of our custom header height
-				// as defined in the metrics. We'll see an additional set of logs if there are other issues
-				// with our metrics.
-				__devOnlyValidateItemHeights: false,
-				itemMetrics: {
-					// Computed custom header height.
-					diffHeaderHeight: 38,
-					// Default spacing plus our 1px border.
-					paddingBottom: 9,
-				},
-				unsafeCSS: `
+					return (
+						<DiffFileHeader
+							projectId={projectId}
+							item={item}
+							operand={{
+								parent: fileParent,
+								path: change.path,
+							}}
+							change={change}
+							hasDiff={item.fileDiff.hunks.length !== 0}
+						/>
+					);
+				}}
+				onScroll={selectFileAtViewportTop}
+				className={styles.diffContents}
+				items={items}
+				selectedLines={selectedRange}
+				onSelectedLinesChange={handleLinesSelected}
+				options={{
+					diffStyle: "unified",
+					themeType: "system",
+					stickyHeaders: true,
+					enableLineSelection: true,
+					layout: {
+						paddingTop: 0,
+						// Match --panel-padding.
+						paddingBottom: 16,
+						gap: 10,
+					},
+					// This appears to validate before our custom header has been slotted, in which case - if
+					// our metrics are correct - we should see deltas in multiples of our custom header height
+					// as defined in the metrics. We'll see an additional set of logs if there are other issues
+					// with our metrics.
+					__devOnlyValidateItemHeights: false,
+					itemMetrics: {
+						// Computed custom header height.
+						diffHeaderHeight: 38,
+						// Default spacing plus our 1px border.
+						paddingBottom: 9,
+					},
+					unsafeCSS: `
           [data-code] {
             border-width: 0 1px 1px 1px;
             border-style: solid;
@@ -457,8 +539,9 @@ const DiffContents: FC<{
             border-radius: 0 0 10px 10px;
           }
         `,
-			}}
-		/>
+				}}
+			/>
+		</div>
 	);
 };
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/operationSourceLabel.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/operationSourceLabel.ts
@@ -27,8 +27,12 @@ export const operationSourceLabel = ({
 					: shortCommitId(commitId);
 			},
 			Stack: () => "Stack",
-			Hunk: ({ lineGroups }) => {
-				const count = lineGroups.reduce((sum, group) => sum + group.lines, 0);
+			Hunk: ({ segments }) => {
+				const count = segments.reduce(
+					(sum, segment) =>
+						sum + segment.lineGroups.reduce((segmentSum, group) => segmentSum + group.lines, 0),
+					0,
+				);
 				return `${count} changed line${count !== 1 ? "s" : ""}`;
 			},
 		}),

--- a/apps/lite/ui/src/selection-scopes.ts
+++ b/apps/lite/ui/src/selection-scopes.ts
@@ -1,18 +1,10 @@
 import { selectionOperationHotkeys, type CommandGroup } from "#ui/hotkeys.ts";
 import { type OperationType } from "#ui/operations/operation.ts";
 import { keyboardTransferOperationMode } from "#ui/outline/mode.ts";
-import {
-	fileOperand,
-	hunkOperand,
-	HunkOperand,
-	operandIdentityKey,
-	type FileOperand,
-	type Operand,
-} from "#ui/operands.ts";
+import { fileOperand, operandIdentityKey, type FileOperand, type Operand } from "#ui/operands.ts";
 import {
 	projectActions,
 	selectProjectOutlineModeState,
-	selectProjectSelectionDiff,
 	selectProjectSelectionFiles,
 	selectProjectSelectionOutline,
 } from "#ui/projects/state.ts";
@@ -106,17 +98,6 @@ export const useOutlineSelection = ({
 	return resolveNavigationIndexSelection(navigationIndex, selectionState, operandIdentityKey);
 };
 
-const hunkOperandIdentityKey = (operand: HunkOperand): string =>
-	operandIdentityKey(hunkOperand(operand));
-
-export const useDiffSelection = (
-	projectId: string,
-	navigationIndex: NavigationIndex<HunkOperand>,
-) => {
-	const selection = useAppSelector((state) => selectProjectSelectionDiff(state, projectId));
-	return resolveNavigationIndexSelection(navigationIndex, selection, hunkOperandIdentityKey);
-};
-
 export const useNavigationIndexHotkeys = <T>({
 	navigationIndex,
 	projectId,
@@ -128,6 +109,7 @@ export const useNavigationIndexHotkeys = <T>({
 	selectSectionPredicate,
 	operationSourceForItem,
 	getKey,
+	getAdjacentItem,
 }: {
 	navigationIndex: NavigationIndex<T>;
 	projectId: string;
@@ -139,6 +121,12 @@ export const useNavigationIndexHotkeys = <T>({
 	selectSectionPredicate?: (item: T) => boolean;
 	operationSourceForItem: (item: T) => Operand;
 	getKey: (item: T) => string;
+	getAdjacentItem?: (input: {
+		navigationIndex: NavigationIndex<T>;
+		selection: T | null;
+		offset: -1 | 1;
+		getKey: (item: T) => string;
+	}) => T | null | undefined;
 }) => {
 	const dispatch = useAppDispatch();
 
@@ -148,10 +136,18 @@ export const useNavigationIndexHotkeys = <T>({
 	};
 
 	const moveSelection = (offset: -1 | 1) => {
+		const customAdjacentItem = getAdjacentItem?.({
+			navigationIndex,
+			selection,
+			offset,
+			getKey,
+		});
 		const newItem =
-			selection === null
-				? navigationIndex.items.at(offset === 1 ? 0 : -1)
-				: getAdjacent({ navigationIndex, selection, offset, getKey });
+			customAdjacentItem !== undefined
+				? customAdjacentItem
+				: selection === null
+					? navigationIndex.items.at(offset === 1 ? 0 : -1)
+					: getAdjacent({ navigationIndex, selection, offset, getKey });
 		if (newItem === null || newItem === undefined) return;
 		selectAndFocus(newItem);
 	};


### PR DESCRIPTION
POC for GB-1589. This entire thing has been quickly clanked out. If we agree on direction I'll delete this and start from scratch, so I wouldn't bother looking at the diff. 🤠 

UX problem: How do we drag the selection around if dragging selects a range?

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #14215 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #14214 
<!-- GitButler Footer Boundary Bottom -->

