### PR TITLE
Return new branch reference in `updateBranchName`

### DIFF
--- a/apps/desktop/src/lib/stacks/stackEndpoints.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.ts
@@ -659,7 +659,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 			],
 		}),
 		updateBranchName: build.mutation<
-			void,
+			string,
 			{
 				projectId: string;
 				stackId?: string;

--- a/apps/desktop/src/lib/stacks/stackEndpoints.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.ts
@@ -26,6 +26,7 @@ import type {
 	AbsorptionTarget,
 	CommitAbsorption,
 	BranchDetails,
+	BranchReference,
 	UpstreamCommit,
 	Commit,
 	InitialBranchIntegration,
@@ -659,7 +660,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 			],
 		}),
 		updateBranchName: build.mutation<
-			string,
+			BranchReference,
 			{
 				projectId: string;
 				stackId?: string;

--- a/apps/lite/electron/src/ipc.ts
+++ b/apps/lite/electron/src/ipc.ts
@@ -2,6 +2,7 @@ import type {
 	AbsorptionTarget,
 	ApplyOutcome,
 	BranchCheckoutResult,
+	BranchReference,
 	BranchCreatePlacement,
 	BranchCreateResult,
 	BranchDetails,
@@ -252,7 +253,7 @@ export interface UpdateBranchNameParams {
 	newName: string;
 }
 
-export type UpdateBranchNameResult = string;
+export type UpdateBranchNameResult = BranchReference;
 
 export interface WatcherSubscribeParams {
 	projectId: string;

--- a/apps/lite/electron/src/ipc.ts
+++ b/apps/lite/electron/src/ipc.ts
@@ -252,6 +252,8 @@ export interface UpdateBranchNameParams {
 	newName: string;
 }
 
+export type UpdateBranchNameResult = string;
+
 export interface WatcherSubscribeParams {
 	projectId: string;
 }
@@ -326,7 +328,7 @@ export interface LiteElectronApi {
 	moveBranch: (params: MoveBranchParams) => Promise<MoveBranchResult>;
 	openInEditor: (params: OpenInEditorParams) => Promise<void>;
 	pathJoin: (...paths: Array<string>) => Promise<string>;
-	updateBranchName: (params: UpdateBranchNameParams) => Promise<void>;
+	updateBranchName: (params: UpdateBranchNameParams) => Promise<UpdateBranchNameResult>;
 	tearOffBranch: (params: TearOffBranchParams) => Promise<MoveBranchResult>;
 	peelRestoreSnapshot: (params: PeelRestoreSnapshotParams) => Promise<Snapshot | null>;
 	pushStack: (params: PushStackParams) => Promise<PushResult>;

--- a/apps/lite/electron/src/preload.cts
+++ b/apps/lite/electron/src/preload.cts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from "electron";
-import type { LiteElectronApi, WatcherSubscribeResult } from "./ipc";
+import type { LiteElectronApi, UpdateBranchNameResult, WatcherSubscribeResult } from "./ipc";
 import type { UpdateDownloadedEvent } from "electron-updater";
 import type {
 	CommitAbsorption,
@@ -123,7 +123,7 @@ const api: LiteElectronApi = {
 	pathJoin: (path, ...paths) =>
 		ipcRenderer.invoke("lite:path-join", path, ...paths) as Promise<string>,
 	updateBranchName: (params) =>
-		ipcRenderer.invoke("workspace:update-branch-name", params) as Promise<void>,
+		ipcRenderer.invoke("workspace:update-branch-name", params) as Promise<UpdateBranchNameResult>,
 	tearOffBranch: (params) =>
 		ipcRenderer.invoke("workspace:tear-off-branch", params) as Promise<MoveBranchResult>,
 	peelRestoreSnapshot: (params) =>

--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -1,5 +1,4 @@
 import { renameBranchInHeadInfo, resolveRelativeTo } from "#ui/api/ref-info.ts";
-import { encodeBytes } from "#ui/api/ref-name.ts";
 import { changesInWorktreeQueryOptions, headInfoQueryOptions } from "#ui/api/queries.ts";
 import { shortCommitId } from "#ui/commit.ts";
 import { errorMessageForToast } from "#ui/errors.ts";
@@ -755,11 +754,10 @@ export const useUpdateBranchName = ({
 
 	return useMutation({
 		mutationFn: window.lite.updateBranchName,
-		onSuccess: async (newBranchName, _input, _context, mutation) => {
-			const newBranchRef = encodeBytes(`refs/heads/${newBranchName}`);
+		onSuccess: async (newRef, _input, _context, mutation) => {
 			const newBranch: BranchOperand = {
 				stackId,
-				branchRef: newBranchRef,
+				branchRef: newRef.fullNameBytes,
 			};
 
 			mutation.client.setQueryData(headInfoQueryOptions(projectId).queryKey, (headInfo) => {
@@ -769,8 +767,8 @@ export const useUpdateBranchName = ({
 					headInfo,
 					stackId,
 					branchRef,
-					newName: newBranchName,
-					newBranchRef,
+					newName: newRef.displayName,
+					newBranchRef: newRef.fullNameBytes,
 				});
 			});
 

--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -756,10 +756,11 @@ export const useUpdateBranchName = ({
 	return useMutation({
 		mutationFn: window.lite.updateBranchName,
 		onSuccess: async (_response, input, _context, mutation) => {
-			const newBranchRef = encodeBytes(`refs/heads/${input.newName}`);
+			// TODO: ideally the API would return the new branch name and ref?
+			const newBranchName = input.newName.replaceAll(/-+/g, "-").replaceAll(/\s+/g, "-");
+			const newBranchRef = encodeBytes(`refs/heads/${newBranchName}`);
 			const newBranch: BranchOperand = {
 				stackId,
-				// TODO: ideally the API would return the new ref?
 				branchRef: newBranchRef,
 			};
 
@@ -770,7 +771,7 @@ export const useUpdateBranchName = ({
 					headInfo,
 					stackId,
 					branchRef,
-					newName: input.newName,
+					newName: newBranchName,
 					newBranchRef,
 				});
 			});

--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -755,9 +755,7 @@ export const useUpdateBranchName = ({
 
 	return useMutation({
 		mutationFn: window.lite.updateBranchName,
-		onSuccess: async (_response, input, _context, mutation) => {
-			// TODO: ideally the API would return the new branch name and ref?
-			const newBranchName = input.newName.replaceAll(/-+/g, "-").replaceAll(/\s+/g, "-");
+		onSuccess: async (newBranchName, _input, _context, mutation) => {
 			const newBranchRef = encodeBytes(`refs/heads/${newBranchName}`);
 			const newBranch: BranchOperand = {
 				stackId,

--- a/crates/but-api/src/legacy/stack.rs
+++ b/crates/but-api/src/legacy/stack.rs
@@ -9,6 +9,7 @@ use but_core::{
 };
 use but_ctx::Context;
 use but_oplog::legacy::{OperationKind, SnapshotDetails, Trailer};
+use but_workspace::ui::ref_info::BranchReference;
 use gitbutler_branch_actions::stack::CreateSeriesRequest;
 use gitbutler_git::PushResult;
 use gitbutler_oplog::SnapshotExt;
@@ -299,7 +300,7 @@ pub fn update_branch_name(
     stack_id: StackId,
     branch_name: String,
     new_name: String,
-) -> Result<String> {
+) -> Result<BranchReference> {
     let mut guard = ctx.exclusive_worktree_access();
     update_branch_name_with_perm(
         ctx,
@@ -321,14 +322,18 @@ pub fn update_branch_name_with_perm(
     branch_name: String,
     new_name: String,
     perm: &mut RepoExclusive,
-) -> Result<String> {
-    gitbutler_branch_actions::stack::update_branch_name_with_perm(
+) -> Result<BranchReference> {
+    let normalized_name = gitbutler_branch_actions::stack::update_branch_name_with_perm(
         ctx,
         stack_id,
         branch_name,
         new_name,
         perm,
-    )
+    )?;
+    let full_name = Category::LocalBranch
+        .to_full_name(normalized_name.as_str())
+        .map_err(anyhow::Error::from)?;
+    Ok(full_name.into())
 }
 
 #[but_api]

--- a/crates/but-api/src/legacy/stack.rs
+++ b/crates/but-api/src/legacy/stack.rs
@@ -299,7 +299,7 @@ pub fn update_branch_name(
     stack_id: StackId,
     branch_name: String,
     new_name: String,
-) -> Result<()> {
+) -> Result<String> {
     let mut guard = ctx.exclusive_worktree_access();
     update_branch_name_with_perm(
         ctx,
@@ -307,8 +307,7 @@ pub fn update_branch_name(
         branch_name,
         new_name,
         guard.write_permission(),
-    )?;
-    Ok(())
+    )
 }
 
 /// Apply the rename from `branch_name` to `new_name` in the stack identified by
@@ -322,15 +321,14 @@ pub fn update_branch_name_with_perm(
     branch_name: String,
     new_name: String,
     perm: &mut RepoExclusive,
-) -> Result<()> {
+) -> Result<String> {
     gitbutler_branch_actions::stack::update_branch_name_with_perm(
         ctx,
         stack_id,
         branch_name,
         new_name,
         perm,
-    )?;
-    Ok(())
+    )
 }
 
 #[but_api]

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -443,7 +443,7 @@ export declare function unapplyStack(projectId: string, stackId: string): Promis
  *
  * See [`update_branch_name_with_perm()`] for the underlying mutation.
  */
-export declare function updateBranchName(projectId: string, stackId: string, branchName: string, newName: string): Promise<void>
+export declare function updateBranchName(projectId: string, stackId: string, branchName: string, newName: string): Promise<string>
 
 /**
  * Update arbitrary fields of a single review (body, state, target base).

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -443,7 +443,7 @@ export declare function unapplyStack(projectId: string, stackId: string): Promis
  *
  * See [`update_branch_name_with_perm()`] for the underlying mutation.
  */
-export declare function updateBranchName(projectId: string, stackId: string, branchName: string, newName: string): Promise<string>
+export declare function updateBranchName(projectId: string, stackId: string, branchName: string, newName: string): Promise<BranchReference>
 
 /**
  * Update arbitrary fields of a single review (body, state, target base).


### PR DESCRIPTION
The client needs the new branch name after normalization in order to preserve the user's selection.

I took the liberty of using AI to write the Rust code. It seems simple enough, but feel free to jump on the PR because I have no idea what I'm doing… 🙈