### PR TITLE
feat(but): allow multiple `-m|--message` for `commit2`

### DIFF
--- a/crates/but/src/args/commit2.rs
+++ b/crates/but/src/args/commit2.rs
@@ -5,7 +5,7 @@ pub struct Platform {
     #[clap(long)]
     pub no_message: bool,
     #[clap(short, long, conflicts_with = "no_message")]
-    pub message: Option<String>,
+    pub message: Option<Vec<String>>,
     #[clap(short, long)]
     pub branch: Option<BranchArg>,
 }

--- a/crates/but/src/command/legacy/commit2.rs
+++ b/crates/but/src/command/legacy/commit2.rs
@@ -128,7 +128,7 @@ fn resolve(
     let reword_op = match (no_message, message) {
         (true, None) => RewordCommitOperation::NoMessage,
         (false, None) => RewordCommitOperation::UseEditor,
-        (false, Some(message)) => RewordCommitOperation::Message(message),
+        (false, Some(message)) => RewordCommitOperation::Message(message.join("\n\n")),
         (true, Some(_)) => {
             unreachable!("--no-message and --message are mutually exclusive")
         }

--- a/crates/but/tests/but/command/commit2.rs
+++ b/crates/but/tests/but/command/commit2.rs
@@ -155,6 +155,58 @@ Hint: run `but help` for all commands
 }
 
 #[test]
+fn can_repeat_message() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.file("file.txt", "Some text");
+
+    env.but("commit2 -m 'add file.txt' -m 'with more' -m 'text lines'")
+        .assert()
+        .success();
+
+    env.but("status -v")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊● b141567 author 2000-01-01 00:00:00 +0000
+┊│     add file.txt  with more  text lines
+┊● 9477ae7 author 2000-01-01 00:00:00 +0000
+┊│     add A 
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("show b141567")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Commit:    b14156794f81a138bd06c2a5287fd5db15408b56
+Change-ID: 1
+Author:    author <author@example.com>
+Date:      2000-01-02 00:00:00 +0000 (26y ago)
+Committer: committer <committer@example.com>
+
+add file.txt
+
+with more
+
+text lines
+
+Files changed:
+  A file.txt
+
+"#]]);
+}
+
+#[test]
 fn editor_user_writes_no_message() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
     env.setup_metadata(&["A"]).unwrap();


### PR DESCRIPTION
Each `-m` is output on its own line, with a blank line in between