### PR TITLE
feat(but): allow `commit2 -b` (without argument)

### DIFF
--- a/crates/but/src/args/commit2.rs
+++ b/crates/but/src/args/commit2.rs
@@ -7,5 +7,5 @@ pub struct Platform {
     #[clap(short, long, conflicts_with = "no_message")]
     pub message: Option<Vec<String>>,
     #[clap(short, long)]
-    pub branch: Option<BranchArg>,
+    pub branch: Option<Option<BranchArg>>,
 }

--- a/crates/but/src/command/legacy/commit2.rs
+++ b/crates/but/src/command/legacy/commit2.rs
@@ -207,31 +207,39 @@ fn run(
 fn route_commit_operation(
     repo: &gix::Repository,
     head_info: &RefInfo,
-    branch: Option<BranchArg>,
+    branch: Option<Option<BranchArg>>,
 ) -> CliResult<CommitOperation> {
-    if let Some(branch) = branch {
-        if let Some(segment) = branch.try_resolve_segment(head_info)? {
-            let ref_info = segment.ref_info.with_context(|| {
-                format!("BUG: Segment resolved from branch name {branch} has no ref info")
-            })?;
+    match branch {
+        Some(Some(branch)) => {
+            if let Some(segment) = branch.try_resolve_segment(head_info)? {
+                let ref_info = segment.ref_info.with_context(|| {
+                    format!("BUG: Segment resolved from branch name {branch} has no ref info")
+                })?;
 
-            return Ok(CommitOperation::CommitToExistingBranch(
-                CommitToExistingBranchOperation {
-                    branch_name: ref_info.ref_name,
-                },
-            ));
-        } else {
-            let branch_name = BranchArg(branch.resolve_for_creation(repo, head_info).hint(
-                format!("Run `but apply {branch}` to apply the branch first"),
-            )?)
-            .resolve_local_branch_name()?;
+                return Ok(CommitOperation::CommitToExistingBranch(
+                    CommitToExistingBranchOperation {
+                        branch_name: ref_info.ref_name,
+                    },
+                ));
+            } else {
+                let branch_name = BranchArg(branch.resolve_for_creation(repo, head_info).hint(
+                    format!("Run `but apply {branch}` to apply the branch first"),
+                )?)
+                .resolve_local_branch_name()?;
+                return Ok(CommitOperation::CommitToNewBranch(
+                    CommitToNewBranchOperation {
+                        branch_name: Some(branch_name),
+                    },
+                ));
+            }
+        }
+        Some(None) => {
             return Ok(CommitOperation::CommitToNewBranch(
-                CommitToNewBranchOperation {
-                    branch_name: Some(branch_name),
-                },
+                CommitToNewBranchOperation { branch_name: None },
             ));
         }
-    }
+        None => (),
+    };
 
     let mut stacks = head_info.stacks.iter();
     if let Some(stack) = stacks.next() {

--- a/crates/but/tests/but/command/commit2.rs
+++ b/crates/but/tests/but/command/commit2.rs
@@ -394,6 +394,36 @@ Hint: run `but help` for all commands
 }
 
 #[test]
+fn create_commit_on_new_branch_with_canned_name() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.file("file.txt", "Some text");
+
+    env.but("commit2 -m 'add file.txt' -b").assert().success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┊╭┄br [a-branch-1]
+┊●   633b765 add file.txt
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
 fn create_commit_on_branch_that_is_not_applied_fails() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
     env.setup_metadata(&[]).unwrap();
@@ -451,6 +481,3 @@ fn newly_created_branches_are_included_in_json_output() {
 
 "#]]);
 }
-
-// -b without branch name
-// commit2 -m 'add file.txt' -b


### PR DESCRIPTION
This commits to a new, unstacked branch with a canned name.