### PR TITLE
but-api: Test harness

### DIFF
--- a/crates/but-api/tests/api/branch_checkout.rs
+++ b/crates/but-api/tests/api/branch_checkout.rs
@@ -1,0 +1,229 @@
+#[test]
+fn checkout_returns_head_info_matching_fresh_head_info() -> anyhow::Result<()> {
+    let (repo, _tmp) = crate::support::writable_scenario("checkout-head-info");
+    crate::support::persist_default_target(&repo)?;
+
+    insta::assert_snapshot!(crate::support::repository_graph(&repo)?, @"
+    * b720e1f (sibling) sibling
+    | * edd8381 (feature) feature
+    |/  
+    * 5374caf (HEAD -> main, origin/main) main
+    ");
+
+    let mut ctx = but_ctx::Context::from_repo(repo)?.with_memory_app_cache();
+    let result = but_api::branch::branch_checkout(
+        &mut ctx,
+        gix::refs::FullName::try_from("refs/heads/feature")?,
+    )?;
+
+    {
+        let repo = ctx.repo.get()?;
+        let head_name = repo.head_name()?.expect("HEAD is symbolic after checkout");
+        assert_eq!(head_name.as_bstr(), "refs/heads/feature");
+
+        insta::assert_snapshot!(crate::support::repository_graph(&repo)?, @"
+        * b720e1f (sibling) sibling
+        | * edd8381 (HEAD -> feature) feature
+        |/  
+        * 5374caf (origin/main, main) main
+        ");
+    }
+
+    insta::assert_snapshot!(crate::support::workspace_graph(&ctx)?, @r"
+    ⌂:0:feature[🌳] <> ✓refs/remotes/origin/main on 5374caf
+    └── ≡:0:feature[🌳] on 5374caf {1}
+        └── :0:feature[🌳]
+            └── ·edd8381
+    ");
+
+    let returned_head_info = format!("{:#?}", result.workspace.head_info);
+    let fresh_head_info = format!("{:#?}", crate::support::fresh_head_info(&ctx)?);
+    assert_eq!(
+        returned_head_info, fresh_head_info,
+        "checkout API should return the same head info a fresh post-checkout read sees"
+    );
+
+    insta::assert_snapshot!(returned_head_info, @r#"
+    RefInfo {
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/feature",
+                ),
+                commit_id: Some(
+                    Sha1(edd838127f5665b9675a440e81f51bc5f170140f),
+                ),
+                worktree: Some(
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
+                ),
+            },
+        ),
+        symbolic_remote_names: {
+            "origin",
+        },
+        stacks: [
+            Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
+                base: Some(
+                    Sha1(5374caf21933aee76b72bad8d6e30949c7a30e04),
+                ),
+                segments: [
+                    ref_info::ui::Segment {
+                        id: NodeIndex(0),
+                        ref_name: "►feature[🌳]",
+                        remote_tracking_ref_name: "None",
+                        commits: [
+                            LocalCommit(edd8381, "feature\n", local),
+                        ],
+                        commits_on_remote: [],
+                        commits_outside: None,
+                        metadata: "None",
+                        push_status: CompletelyUnpushed,
+                        base: "5374caf",
+                    },
+                ],
+            },
+        ],
+        target_ref: Some(
+            TargetRef {
+                ref_name: FullName(
+                    "refs/remotes/origin/main",
+                ),
+                segment_index: NodeIndex(2),
+                commits_ahead: 0,
+            },
+        ),
+        target_commit: Some(
+            TargetCommit {
+                commit_id: Sha1(5374caf21933aee76b72bad8d6e30949c7a30e04),
+                segment_index: NodeIndex(1),
+            },
+        ),
+        lower_bound: Some(
+            NodeIndex(1),
+        ),
+        is_managed_ref: false,
+        is_managed_commit: false,
+        ancestor_workspace_commit: None,
+        is_entrypoint: true,
+    }
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn checkout_new_returns_head_info_matching_fresh_head_info() -> anyhow::Result<()> {
+    let (repo, _tmp) = crate::support::writable_scenario("checkout-head-info");
+    let target_commit_id = crate::support::persist_default_target(&repo)?;
+
+    let mut ctx = but_ctx::Context::from_repo(repo)?.with_memory_app_cache();
+    let result = but_api::branch::branch_checkout_new(&mut ctx, Some("new branch".into()))?;
+
+    {
+        let repo = ctx.repo.get()?;
+        let head_name = repo.head_name()?.expect("HEAD is symbolic after checkout");
+        assert_eq!(head_name.as_bstr(), "refs/heads/new-branch");
+
+        let mut created = repo.find_reference("refs/heads/new-branch")?;
+        assert_eq!(
+            created.peel_to_id()?.detach(),
+            target_commit_id,
+            "new branch should be created at the configured project target"
+        );
+
+        insta::assert_snapshot!(crate::support::repository_graph(&repo)?, @"
+        * b720e1f (sibling) sibling
+        | * edd8381 (feature) feature
+        |/  
+        * 5374caf (HEAD -> new-branch, origin/main, main) main
+        ");
+    }
+
+    insta::assert_snapshot!(crate::support::workspace_graph(&ctx)?, @r"
+    ⌂:0:new-branch[🌳] <> ✓refs/remotes/origin/main on 5374caf
+    └── ≡:0:new-branch[🌳] {1}
+        └── :0:new-branch[🌳]
+    ");
+
+    let returned_head_info = format!("{:#?}", result.workspace.head_info);
+    let fresh_head_info = format!("{:#?}", crate::support::fresh_head_info(&ctx)?);
+    assert_eq!(
+        returned_head_info, fresh_head_info,
+        "checkout-new API should return the same head info a fresh post-checkout read sees"
+    );
+
+    insta::assert_snapshot!(returned_head_info, @r#"
+    RefInfo {
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/new-branch",
+                ),
+                commit_id: Some(
+                    Sha1(5374caf21933aee76b72bad8d6e30949c7a30e04),
+                ),
+                worktree: Some(
+                    Worktree {
+                        kind: Main,
+                        owned_by_repo: true,
+                    },
+                ),
+            },
+        ),
+        symbolic_remote_names: {
+            "origin",
+        },
+        stacks: [
+            Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
+                base: None,
+                segments: [
+                    ref_info::ui::Segment {
+                        id: NodeIndex(0),
+                        ref_name: "►new-branch[🌳]",
+                        remote_tracking_ref_name: "None",
+                        commits: [],
+                        commits_on_remote: [],
+                        commits_outside: None,
+                        metadata: "None",
+                        push_status: CompletelyUnpushed,
+                        base: "None",
+                    },
+                ],
+            },
+        ],
+        target_ref: Some(
+            TargetRef {
+                ref_name: FullName(
+                    "refs/remotes/origin/main",
+                ),
+                segment_index: NodeIndex(1),
+                commits_ahead: 0,
+            },
+        ),
+        target_commit: Some(
+            TargetCommit {
+                commit_id: Sha1(5374caf21933aee76b72bad8d6e30949c7a30e04),
+                segment_index: NodeIndex(0),
+            },
+        ),
+        lower_bound: Some(
+            NodeIndex(0),
+        ),
+        is_managed_ref: false,
+        is_managed_commit: false,
+        ancestor_workspace_commit: None,
+        is_entrypoint: true,
+    }
+    "#);
+
+    Ok(())
+}

--- a/crates/but-api/tests/api/main.rs
+++ b/crates/but-api/tests/api/main.rs
@@ -1,0 +1,2 @@
+mod branch_checkout;
+mod support;

--- a/crates/but-api/tests/api/support.rs
+++ b/crates/but-api/tests/api/support.rs
@@ -1,0 +1,43 @@
+use but_core::ref_metadata::ProjectMeta;
+use but_testsupport::gix_testtools::tempfile::TempDir;
+
+pub fn writable_scenario(name: &str) -> (gix::Repository, TempDir) {
+    but_testsupport::writable_scenario(name)
+}
+
+pub fn persist_default_target(repo: &gix::Repository) -> anyhow::Result<gix::ObjectId> {
+    let target_commit_id = repo.rev_parse_single("refs/heads/main")?.detach();
+    ProjectMeta {
+        target_ref: Some("refs/remotes/origin/main".try_into()?),
+        target_commit_id: Some(target_commit_id),
+        push_remote: Some("origin".into()),
+    }
+    .persist_to_local_config(repo)?;
+    Ok(target_commit_id)
+}
+
+pub fn repository_graph(repo: &gix::Repository) -> anyhow::Result<String> {
+    Ok(but_testsupport::visualize_commit_graph_all(repo)?)
+}
+
+pub fn workspace_graph(ctx: &but_ctx::Context) -> anyhow::Result<String> {
+    let (_guard, _repo, ws, _db) = ctx.workspace_and_db()?;
+    Ok(but_testsupport::graph_workspace(&ws).to_string())
+}
+
+pub fn fresh_head_info(ctx: &but_ctx::Context) -> anyhow::Result<but_workspace::RefInfo> {
+    let project_meta = ctx.project_meta()?;
+    let meta = ctx.meta()?;
+    let repo = ctx.repo.get()?;
+    but_workspace::head_info(
+        &repo,
+        &meta,
+        but_workspace::ref_info::Options {
+            project_meta,
+            traversal: but_graph::init::Options::limited(),
+            expensive_commit_info: true,
+            ..Default::default()
+        },
+    )
+    .map(but_workspace::RefInfo::pruned_to_entrypoint)
+}

--- a/crates/but-api/tests/fixtures/scenario/checkout-head-info.sh
+++ b/crates/but-api/tests/fixtures/scenario/checkout-head-info.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+function tick() {
+  if test -z "${tick+set}"; then
+    tick=1675176957
+  else
+    tick=$(($tick + 60))
+  fi
+  GIT_COMMITTER_DATE="$tick +0100"
+  GIT_AUTHOR_DATE="$tick +0100"
+  export GIT_COMMITTER_DATE GIT_AUTHOR_DATE
+}
+
+function commit_file() {
+  local name="${1:?First argument is the filename}"
+  local content="${2:?Second argument is the content}"
+  local message="${3:?Third argument is the commit message}"
+  tick
+  echo "$content" >"$name"
+  git add "$name"
+  git commit -m "$message"
+}
+
+git init
+echo "feature and sibling branches off main, head on main" >.git/description
+
+git config user.name GitButler
+git config user.email gitbutler@example.com
+
+commit_file shared.txt main "main"
+
+mkdir -p .git/refs/remotes/origin
+cp .git/refs/heads/main .git/refs/remotes/origin/main
+
+cat <<EOF >>.git/config
+[remote "origin"]
+	url = ./fake/local/path/which-is-fine-as-we-dont-fetch-or-push
+	fetch = +refs/heads/*:refs/remotes/origin/*
+EOF
+
+git checkout -b feature
+commit_file feature.txt feature "feature"
+
+git checkout main
+git checkout -b sibling
+commit_file sibling.txt sibling "sibling"
+
+git checkout main


### PR DESCRIPTION
Add an integration test harness for the but-api crate, similar to the
but-workspace one.
Currently just test branch checkout