### PR TITLE
Lite: use branch operand as source/target for whole branch rather than just branch reference

### DIFF
--- a/apps/lite/ui/src/operations/operation.ts
+++ b/apps/lite/ui/src/operations/operation.ts
@@ -431,14 +431,22 @@ const moveOperation = ({
 
 	if (branchMoveOperation) return branchMoveOperation;
 
-	const relativeTo: RelativeTo | null = Match.value(target).pipe(
-		Match.tags({
-			Commit: ({ commitId }): RelativeTo | null => ({ type: "commit", subject: commitId }),
-			Branch: ({ branchRef }): RelativeTo | null => ({
-				type: "referenceBytes",
-				subject: branchRef,
-			}),
-		}),
+	const relativeTo: RelativeTo | null = Match.value({ target, side }).pipe(
+		Match.when({ target: { _tag: "Commit" } }, ({ target }): RelativeTo | null => ({
+			type: "commit",
+			subject: target.commitId,
+		})),
+		Match.when(
+			{
+				target: { _tag: "Branch" },
+				// We use the branch operand as the source/target for the branch
+				// contents. However, `RelativeTo` is interpreted to mean just the
+				// branch reference rather than the branch bucket, meaning `side:
+				// "below"` won't work as expected.
+				side: "above",
+			},
+			({ target }): RelativeTo | null => ({ type: "referenceBytes", subject: target.branchRef }),
+		),
 		Match.orElse((): RelativeTo | null => null),
 	);
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
@@ -2378,30 +2378,25 @@ const BranchSegment: FC<{
 			operand={operand}
 			aria-label={refName.displayName}
 			aria-expanded
+			render={<OperandC projectId={projectId} operand={operand} />}
 		>
-			<OperandC
+			<BranchRow
 				projectId={projectId}
-				operand={operand}
-				render={
-					<BranchRow
-						projectId={projectId}
-						refName={refName}
-						stackId={stackId}
-						canTearOffBranch={canTearOffBranch}
-						canRemoveBranch={canRemoveBranch}
-						partialStackState={partialStackState}
-						isCommitTarget={
-							commitTarget
-								? relativeToEquals(commitTarget, {
-										type: "referenceBytes",
-										subject: refName.fullNameBytes,
-									})
-								: false
-						}
-						pushStatus={segment.pushStatus}
-						bottomRelativeTo={segmentBottomRelativeTo(segment)}
-					/>
+				refName={refName}
+				stackId={stackId}
+				canTearOffBranch={canTearOffBranch}
+				canRemoveBranch={canRemoveBranch}
+				partialStackState={partialStackState}
+				isCommitTarget={
+					commitTarget
+						? relativeToEquals(commitTarget, {
+								type: "referenceBytes",
+								subject: refName.fullNameBytes,
+							})
+						: false
 				}
+				pushStatus={segment.pushStatus}
+				bottomRelativeTo={segmentBottomRelativeTo(segment)}
 			/>
 
 			<div role="group">


### PR DESCRIPTION
Revives https://github.com/gitbutlerapp/gitbutler/pull/13807

Before:

https://github.com/user-attachments/assets/445bd5ec-e755-42a0-a9f8-4c4d85d369b5

After:

https://github.com/user-attachments/assets/68810c1b-8de6-4a9e-9c91-619975d9e096




Table of all permutations for future reference. In Jujutsu I believe all of these operations can be expressed as follows, using `-r` for commit sources and `-b` for branch sources:

- above (after): `jj rebase <source> -A <target>`
- onto: `jj rebase <source> -o <target>`
- below (before): `jj rebase <source> -B <target>`

| Source | Target | Side | Function |
|---|---|---|---|
| Whole branch | Whole branch | above | `moveBranch` |
| Whole branch | Whole branch | onto | missing |
| Whole branch | Whole branch | below | missing |
| Whole branch | Branch reference | above | `moveBranch` |
| Whole branch | Branch reference | onto | missing |
| Whole branch | Branch reference | below | missing |
| Whole branch | Commit | above | missing |
| Whole branch | Commit | onto | missing |
| Whole branch | Commit | below | missing |
| Commit | Whole branch | above | `commitMove` with `relativeTo: { type: "referenceBytes" }` |
| Commit | Whole branch | onto | missing |
| Commit | Whole branch | below | missing |
| Commit | Branch reference | above | `commitMove` with `relativeTo: { type: "referenceBytes" }` |
| Commit | Branch reference | onto | missing |
| Commit | Branch reference | below | `commitMove` with `relativeTo: { type: "referenceBytes" }` |
| Commit | Commit | above | `commitMove` with `relativeTo: { type: "commit" }` |
| Commit | Commit | onto | missing |
| Commit | Commit | below | `commitMove` with `relativeTo: { type: "commit" }` |