### PR TITLE
feat(tui): api for picking changes via the tui

### DIFF
--- a/crates/but-api/src/legacy/modes.rs
+++ b/crates/but-api/src/legacy/modes.rs
@@ -1,7 +1,7 @@
 //! In place of commands.rs
 use anyhow::Result;
 use but_api_macros::but_api;
-use but_core::{ref_metadata::StackId, ui::TreeChange};
+use but_core::{ref_metadata::StackId, sync::RepoShared, ui::TreeChange};
 use but_ctx::Context;
 use gitbutler_edit_mode::ConflictEntryPresence;
 use gitbutler_operating_modes::{EditModeMetadata, OperatingMode};
@@ -33,6 +33,20 @@ pub fn operating_mode(ctx: &Context) -> Result<HeadAndMode, Error> {
     Ok(HeadAndMode {
         head: head_ref_short,
         operating_mode: gitbutler_operating_modes::operating_mode(ctx, guard.read_permission())?,
+    })
+}
+
+pub fn operating_mode_with_perm(ctx: &Context, perm: &RepoShared) -> Result<HeadAndMode, Error> {
+    let repo = ctx.repo.get()?;
+    let head = repo.head();
+    let head_ref_short = match head.as_ref().map(|head| head.referent_name()) {
+        Ok(Some(head_ref)) => Some(head_ref.shorten().to_string()),
+        _ => None,
+    };
+
+    Ok(HeadAndMode {
+        head: head_ref_short,
+        operating_mode: gitbutler_operating_modes::operating_mode(ctx, perm)?,
     })
 }
 

--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -852,7 +852,7 @@ pub fn fetch_from_remotes(ctx: &Context, action: Option<String>) -> Result<BaseB
 /// Compute upstream integration statuses, optionally scoped to `target_commit_id`.
 #[but_api]
 #[instrument(err(Debug))]
-pub async fn upstream_integration_statuses(
+pub fn upstream_integration_statuses(
     ctx: ThreadSafeContext,
     target_commit_id: Option<gix::ObjectId>,
 ) -> Result<StackStatuses> {
@@ -868,9 +868,35 @@ pub async fn upstream_integration_statuses(
         )
     };
 
-    let resolved_reviews = resolve_review_map(ctx.clone(), &base_branch).await?;
+    let resolved_reviews = resolve_review_map(ctx.clone(), &base_branch)?;
     let mut ctx = ctx.into_thread_local();
     gitbutler_branch_actions::upstream_integration_statuses(&mut ctx, commit_id, &resolved_reviews)
+}
+
+pub fn upstream_integration_statuses_with_perm(
+    ctx: ThreadSafeContext,
+    target_commit_id: Option<gix::ObjectId>,
+    perm: &mut RepoExclusive,
+) -> Result<StackStatuses> {
+    let (base_branch, commit_id, ctx) = {
+        let ctx = ctx.into_thread_local();
+
+        // Get all the actively applied reviews
+        (
+            gitbutler_branch_actions::base::get_base_branch_data(&ctx, perm.read_permission())?,
+            target_commit_id,
+            ctx.into_sync(),
+        )
+    };
+
+    let resolved_reviews = resolve_review_map(ctx.clone(), &base_branch)?;
+    let mut ctx = ctx.into_thread_local();
+    gitbutler_branch_actions::upstream_integration_statuses_with_perm(
+        &mut ctx,
+        commit_id,
+        &resolved_reviews,
+        perm,
+    )
 }
 
 #[but_api]
@@ -887,7 +913,7 @@ pub async fn integrate_upstream(
             gitbutler_branch_actions::base::get_base_branch_data(&ctx, guard.read_permission())?;
         (base_branch, ctx.to_sync())
     };
-    let resolved_reviews = resolve_review_map(ctx.clone(), &base_branch).await?;
+    let resolved_reviews = resolve_review_map(ctx.clone(), &base_branch)?;
     let mut ctx = ctx.into_thread_local();
     let outcome = gitbutler_branch_actions::integrate_upstream(
         &mut ctx,
@@ -913,7 +939,7 @@ pub async fn resolve_upstream_integration(
             gitbutler_branch_actions::base::get_base_branch_data(&ctx, guard.read_permission())?;
         (base_branch, ctx.into_sync())
     };
-    let resolved_reviews = resolve_review_map(sync_ctx.clone(), &base_branch).await?;
+    let resolved_reviews = resolve_review_map(sync_ctx.clone(), &base_branch)?;
     let mut ctx = sync_ctx.into_thread_local();
     let new_target_id = gitbutler_branch_actions::resolve_upstream_integration(
         &mut ctx,
@@ -924,7 +950,7 @@ pub async fn resolve_upstream_integration(
 }
 
 /// Resolve all actively applied reviews for the given project and command context
-async fn resolve_review_map(
+fn resolve_review_map(
     ctx: ThreadSafeContext,
     base_branch: &BaseBranch,
 ) -> Result<HashMap<String, but_forge::ForgeReview>> {

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -1189,7 +1189,7 @@ async fn handle_command(
             match params {
                 Ok(params) => {
                     let result =
-                        legacy::virtual_branches::upstream_integration_statuses_cmd(params).await;
+                        legacy::virtual_branches::upstream_integration_statuses_cmd(params);
                     result.map(|r| json!(r))
                 }
                 Err(e) => Err(e),

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -881,7 +881,7 @@ async fn github_oauth(mut inout: InputOutputChannel<'_>) -> Result<()> {
 
 async fn display_authenticated_github_accounts(
     known_gh_accounts: &Vec<but_github::GithubAccountIdentifier>,
-    out: &mut (dyn Write + 'static),
+    out: &mut dyn Write,
 ) -> Result<bool, anyhow::Error> {
     let t = theme::get();
     writeln!(
@@ -921,7 +921,7 @@ async fn display_authenticated_github_accounts(
 
 async fn display_authenticated_gitlab_accounts(
     known_gl_accounts: &Vec<but_gitlab::GitlabAccountIdentifier>,
-    out: &mut (dyn Write + 'static),
+    out: &mut dyn Write,
 ) -> Result<bool, anyhow::Error> {
     let t = theme::get();
     if known_gl_accounts.is_empty() {

--- a/crates/but/src/command/legacy/branch/list.rs
+++ b/crates/but/src/command/legacy/branch/list.rs
@@ -556,7 +556,7 @@ fn print_applied_branches_table(
     commits_ahead_map: Option<&HashMap<String, usize>>,
     merge_status_map: Option<&HashMap<String, bool>>,
     allow_truncation: bool,
-    out: &mut (dyn std::fmt::Write + 'static),
+    out: &mut dyn std::fmt::Write,
 ) -> Result<(), anyhow::Error> {
     use crate::tui::{Table, table::Cell};
 
@@ -691,7 +691,7 @@ fn print_branches_table(
     commits_ahead_map: Option<&HashMap<String, usize>>,
     merge_status_map: Option<&HashMap<String, bool>>,
     allow_truncation: bool,
-    out: &mut (dyn std::fmt::Write + 'static),
+    out: &mut dyn std::fmt::Write,
 ) -> Result<(), anyhow::Error> {
     use crate::tui::{Table, table::Cell};
     let t = theme::get();

--- a/crates/but/src/command/legacy/pull/mod.rs
+++ b/crates/but/src/command/legacy/pull/mod.rs
@@ -89,8 +89,7 @@ async fn handle_check(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<
     writeln!(progress, "Checking integration statuses...")?;
 
     let status =
-        but_api::legacy::virtual_branches::upstream_integration_statuses(ctx.to_sync(), None)
-            .await?;
+        but_api::legacy::virtual_branches::upstream_integration_statuses(ctx.to_sync(), None)?;
 
     if let Some(out) = out.for_json() {
         let (up_to_date, has_worktree_conflicts, branch_statuses) = match &status {
@@ -342,8 +341,7 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
 
     // Step 2: Check integration status
     let status =
-        but_api::legacy::virtual_branches::upstream_integration_statuses(ctx.to_sync(), None)
-            .await?;
+        but_api::legacy::virtual_branches::upstream_integration_statuses(ctx.to_sync(), None)?;
 
     let resolutions = match status {
         UpToDate => {
@@ -494,8 +492,7 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
                 let post_status = but_api::legacy::virtual_branches::upstream_integration_statuses(
                     ctx.to_sync(),
                     None,
-                )
-                .await?;
+                )?;
 
                 // Report detailed results for each resolution
                 let mut successful_rebases: Vec<String> = Vec::new();

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -4,7 +4,12 @@ use anyhow::Context as _;
 use assignment::FileAssignment;
 use bstr::{BStr, BString, ByteSlice};
 use but_api::diff::ComputeLineStats;
-use but_core::{RepositoryExt, TreeStatus, ref_metadata::StackId, ui};
+use but_core::{
+    RepositoryExt, TreeStatus,
+    ref_metadata::StackId,
+    sync::{RepoExclusive, RepoExclusiveGuard},
+    ui,
+};
 use but_ctx::Context;
 use but_forge::ForgeReview;
 use but_graph::SegmentIndex;
@@ -31,8 +36,8 @@ use crate::{
     id::{SegmentWithId, ShortId, StackWithId, TreeChangeWithId},
     tui::text::truncate_text,
     utils::{
-        OutputChannel, WriteWithUtils, shorten_hex_object_id, shorten_object_id,
-        time::format_relative_time_verbose,
+        IntermediateChannel, OutputChannel, WriteWithUtils, shorten_hex_object_id,
+        shorten_object_id, time::format_relative_time_verbose,
     },
 };
 
@@ -118,6 +123,28 @@ pub struct TuiLaunchOptions {
     pub quit_after_rendering_full_diff: bool,
 }
 
+#[derive(Debug, Default, Copy, Clone)]
+pub enum TuiRunOptions {
+    #[default]
+    Normal,
+    #[expect(dead_code)]
+    PickChanges,
+}
+
+/// The outcome of running the TUI.
+///
+/// Under normal circumstances this will be [`TuiOutcome::None`] but if the TUI is launched via
+/// [`tui_with_options`] it might be something else.
+///
+/// Will also be [`TuiOutcome::None`] if the user quits by pressing `q`.
+#[derive(Debug)]
+#[must_use]
+pub enum TuiOutcome {
+    None,
+    #[expect(dead_code)]
+    CliIds(Vec<CliId>),
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum CommitClassification {
     Upstream,
@@ -197,7 +224,19 @@ pub(crate) async fn worktree(
         return show_edit_mode_status(ctx, out);
     }
 
-    let status_ctx = build_status_context(ctx, out, &mode, flags, render_mode).await?;
+    let status_ctx = {
+        let mut guard = ctx.exclusive_worktree_access();
+        let format = out.format();
+        build_status_context(
+            ctx,
+            guard.write_permission(),
+            out,
+            format,
+            &mode,
+            flags,
+            render_mode,
+        )?
+    };
 
     {
         // Re-acquire repo for use after the async call
@@ -219,13 +258,26 @@ pub(crate) async fn worktree(
             let mut output = StatusOutput::Immediate { out: human_out };
             build_status_output(ctx, &status_ctx, &mut output)?;
         }
-        StatusRenderMode::Tui(options) => {
+        StatusRenderMode::Tui(launch_options) => {
+            let run_options = TuiRunOptions::Normal;
+
             let mut lines = Vec::new();
             let mut output = StatusOutput::Buffer { lines: &mut lines };
             build_status_output(ctx, &status_ctx, &mut output)?;
-            let final_lines = tui::render_tui(ctx, out, &mode, flags, lines, options).await?;
+            let (final_lines, _outcome) = {
+                let mut out = IntermediateChannel::new(out);
+                tui::render_tui(
+                    ctx,
+                    &mut out,
+                    &mode,
+                    flags,
+                    lines,
+                    launch_options,
+                    run_options,
+                )?
+            };
 
-            if !options.skip_status_after
+            if !launch_options.skip_status_after
                 && let Some(human_out) = out.for_human()
             {
                 for line in final_lines {
@@ -238,9 +290,52 @@ pub(crate) async fn worktree(
     Ok(())
 }
 
-async fn build_status_context<'a>(
+#[expect(dead_code)]
+pub(crate) fn tui_with_options(
     ctx: &mut Context,
-    out: &mut OutputChannel,
+    mut guard: RepoExclusiveGuard,
+    out: &mut IntermediateChannel<'_>,
+    run_options: TuiRunOptions,
+) -> anyhow::Result<(RepoExclusiveGuard, TuiOutcome)> {
+    let flags = StatusFlags::for_tui();
+    let mode = but_api::legacy::modes::operating_mode_with_perm(ctx, guard.read_permission())?
+        .operating_mode;
+    let launch_options = TuiLaunchOptions::default();
+    let render_mode = StatusRenderMode::Tui(launch_options);
+
+    let status_ctx = build_status_context(
+        ctx,
+        guard.write_permission(),
+        out,
+        OutputFormat::Human,
+        &mode,
+        flags,
+        render_mode,
+    )?;
+
+    // Drop the guard while the tui runs, since it might require its own guard momentarily to
+    // perform certain operations such as reloading
+    //
+    // We don't want to hold a lock for the entire duration the tui runs since that'll block
+    // running other `but` commands.
+    drop(guard);
+
+    let mut lines = Vec::new();
+    let mut output = StatusOutput::Buffer { lines: &mut lines };
+    build_status_output(ctx, &status_ctx, &mut output)?;
+    let (_final_lines, outcome) =
+        tui::render_tui(ctx, out, &mode, flags, lines, launch_options, run_options)?;
+
+    let guard = ctx.exclusive_worktree_access();
+
+    Ok((guard, outcome))
+}
+
+fn build_status_context<'a>(
+    ctx: &mut Context,
+    perm: &mut RepoExclusive,
+    out: &mut dyn WriteWithUtils,
+    format: OutputFormat,
     mode: &'a OperatingMode,
     flags: StatusFlags,
     render_mode: StatusRenderMode,
@@ -255,10 +350,8 @@ async fn build_status_context<'a>(
     ) = {
         let context_lines = ctx.settings.context_lines;
         let mut meta = ctx.meta()?;
-        let mut guard;
         {
-            let (new_guard, repo, mut ws, mut db) = ctx.workspace_mut_and_db_mut()?;
-            guard = new_guard;
+            let (repo, mut ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
             if let Ok(rules) = but_rules::list_rules(&db) {
                 but_rules::process_rules(
                     rules,
@@ -266,14 +359,14 @@ async fn build_status_context<'a>(
                     &mut ws,
                     &mut db,
                     &mut meta,
-                    guard.write_permission(),
+                    perm,
                     context_lines,
                 )
                 .ok(); // TODO: this is doing double work (hunk-dependencies can be reused)
             }
         }
 
-        let (repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
+        let (repo, ws, _db) = ctx.workspace_and_db_with_perm(perm.read_permission())?;
         let head_info = but_workspace::graph_to_ref_info(
             &ws,
             &repo,
@@ -321,7 +414,8 @@ async fn build_status_context<'a>(
     };
     let review_map = review::get_review_map(ctx, Some(cache_config.clone()))?;
 
-    let worktree_changes = but_api::diff::changes_in_worktree(ctx)?;
+    let worktree_changes =
+        but_api::diff::changes_in_worktree_with_perm(ctx, perm.read_permission())?;
 
     let id_map = IdMap::new(stacks, worktree_changes.assignments.clone())?;
 
@@ -351,8 +445,7 @@ async fn build_status_context<'a>(
     // to ensure repo reference is dropped before any async operations
     let (common_merge_base_data, upstream_state, last_fetched_ms, base_branch) = {
         let base_branch = {
-            let mut guard = ctx.exclusive_worktree_access();
-            but_api::legacy::virtual_branches::get_base_branch_data(ctx, guard.write_permission())
+            but_api::legacy::virtual_branches::get_base_branch_data(ctx, perm)
                 .ok()
                 .flatten()
         };
@@ -434,17 +527,16 @@ async fn build_status_context<'a>(
         )
     };
 
-    // Compute upstream integration statuses if --upstream flag is set
-    // We need to drop locks before computing merge statuses
-    // because upstream_integration_statuses requires exclusive access
+    // Compute upstream integration statuses if --upstream flag is set, reusing the existing
+    // worktree lock so status collection does not try to acquire it recursively.
     let branch_merge_statuses: BTreeMap<String, UpstreamBranchStatus> = if flags.show_upstream {
-        compute_branch_merge_statuses(ctx).await?
+        compute_branch_merge_statuses(ctx, perm)?
     } else {
         BTreeMap::new()
     };
 
     let is_paged = out.is_paged();
-    let should_truncate_for_terminal = truncation_policy(out.format(), render_mode, is_paged);
+    let should_truncate_for_terminal = truncation_policy(format, render_mode, is_paged);
 
     Ok(StatusContext {
         stack_details,
@@ -474,7 +566,7 @@ fn truncation_policy(format: OutputFormat, render_mode: StatusRenderMode, is_pag
 }
 
 fn build_status_output(
-    ctx: &mut Context,
+    ctx: &Context,
     status_ctx: &StatusContext<'_>,
     output: &mut StatusOutput<'_>,
 ) -> anyhow::Result<()> {
@@ -493,7 +585,7 @@ fn build_status_output(
 
 /// Print update information for human output when a newer `but` version is available.
 fn print_update_notice(
-    ctx: &mut Context,
+    ctx: &Context,
     status_ctx: &StatusContext<'_>,
     output: &mut StatusOutput<'_>,
 ) -> anyhow::Result<()> {
@@ -566,7 +658,7 @@ fn print_hint(
 
 /// Display upstream state information when upstream has commits ahead of the workspace base.
 fn print_upstream_state(
-    ctx: &mut Context,
+    ctx: &Context,
     status_ctx: &StatusContext<'_>,
     output: &mut StatusOutput<'_>,
 ) -> anyhow::Result<()> {
@@ -705,7 +797,7 @@ fn print_common_merge_base_summary(
 
 /// Print per-stack status sections for human-readable output.
 fn print_worktree_status(
-    ctx: &mut Context,
+    ctx: &Context,
     status_ctx: &StatusContext<'_>,
     output: &mut StatusOutput<'_>,
 ) -> anyhow::Result<()> {
@@ -892,7 +984,7 @@ fn print_assignments(
 }
 
 fn print_group(
-    ctx: &mut Context,
+    ctx: &Context,
     status_ctx: &StatusContext<'_>,
     stack_with_id: &Option<StackWithId>,
     assignments: &[FileAssignment],
@@ -1711,15 +1803,18 @@ impl CliDisplay for but_update::AvailableUpdate {
     }
 }
 
-async fn compute_branch_merge_statuses(
+fn compute_branch_merge_statuses(
     ctx: &Context,
+    perm: &mut RepoExclusive,
 ) -> anyhow::Result<BTreeMap<String, UpstreamBranchStatus>> {
     use gitbutler_branch_actions::upstream_integration::StackStatuses;
 
     // Get upstream integration statuses using the public API
-    let statuses =
-        but_api::legacy::virtual_branches::upstream_integration_statuses(ctx.to_sync(), None)
-            .await?;
+    let statuses = but_api::legacy::virtual_branches::upstream_integration_statuses_with_perm(
+        ctx.to_sync(),
+        None,
+        perm,
+    )?;
 
     let mut result = BTreeMap::new();
 

--- a/crates/but/src/command/legacy/status/tui/backstack.rs
+++ b/crates/but/src/command/legacy/status/tui/backstack.rs
@@ -83,6 +83,10 @@ pub(super) enum BackstackEntry {
 pub(super) struct RememberToUpdateBackstack<T>(T);
 
 impl<T> RememberToUpdateBackstack<T> {
+    pub(super) fn new(value: T) -> Self {
+        Self(value)
+    }
+
     /// Get mutable access to the inner value together with the backstack.
     ///
     /// rustc will give "unused variable" warnings if we forget to use the backstack passed into

--- a/crates/but/src/command/legacy/status/tui/cursor/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         FilesStatusFlag, StatusOutputLine,
         output::StatusOutputLineData,
         tui::{
-            CommitSource, Mode, MoveSource, SelectAfterReload,
+            CommitSource, Mode, MoveSource, NormalMode, PickUncommittedMode, SelectAfterReload,
             marking::{MarkClasses, Markable, Marks},
             render::{commit_operation_display, move_operation_display, stack_operation_display},
         },
@@ -648,6 +648,7 @@ fn is_discard_commit_boundary(line: &StatusOutputLine) -> bool {
 fn is_section_header(line: &StatusOutputLine, mode: &Mode) -> bool {
     match mode {
         Mode::Normal(..)
+        | Mode::PickChanges(..)
         | Mode::InlineReword(..)
         | Mode::Command(..)
         | Mode::Commit(..)
@@ -806,35 +807,45 @@ pub(super) fn is_selectable_in_mode(
         Mode::Command(..)
         | Mode::InlineReword(..)
         | Mode::Normal(..)
+        | Mode::PickChanges(..)
         | Mode::Details(..)
         | Mode::Stack(..) => {}
     }
 
     // don't allow mixing marks
-    if let Mode::Normal(normal_mode) = mode
-        && !normal_mode.marks.is_empty()
-    {
-        let MarkClasses {
-            marked_commits,
-            marked_uncommitted,
-        } = normal_mode.marks.classify();
-        if marked_commits
-            && !matches!(
-                &line.data,
-                StatusOutputLineData::Branch { .. } | StatusOutputLineData::Commit { .. }
-            )
-        {
-            return false;
+    match mode {
+        Mode::Normal(NormalMode { marks }) | Mode::PickChanges(PickUncommittedMode { marks }) => {
+            if !marks.is_empty() {
+                let MarkClasses {
+                    marked_commits,
+                    marked_uncommitted,
+                } = marks.classify();
+                if marked_commits
+                    && !matches!(
+                        &line.data,
+                        StatusOutputLineData::Branch { .. } | StatusOutputLineData::Commit { .. }
+                    )
+                {
+                    return false;
+                }
+                if marked_uncommitted
+                    && !matches!(
+                        &line.data,
+                        StatusOutputLineData::UnassignedChanges { .. }
+                            | StatusOutputLineData::UnassignedFile { .. },
+                    )
+                {
+                    return false;
+                }
+            }
         }
-        if marked_uncommitted
-            && !matches!(
-                &line.data,
-                StatusOutputLineData::UnassignedChanges { .. }
-                    | StatusOutputLineData::UnassignedFile { .. },
-            )
-        {
-            return false;
-        }
+        Mode::Rub(..)
+        | Mode::InlineReword(..)
+        | Mode::Command(..)
+        | Mode::Commit(..)
+        | Mode::Move(..)
+        | Mode::Details(..)
+        | Mode::Stack(..) => {}
     }
 
     match mode {
@@ -857,6 +868,20 @@ pub(super) fn is_selectable_in_mode(
         Mode::Commit(commit_mode) => commit_operation_display(&line.data, commit_mode).is_some(),
         Mode::Move(move_mode) => move_operation_display(&line.data, move_mode).is_some(),
         Mode::Stack(stack_mode) => stack_operation_display(&line.data, stack_mode).is_some(),
+        Mode::PickChanges(..) => {
+            if let Some(cli_id) = line.data.cli_id() {
+                match &**cli_id {
+                    CliId::Uncommitted(..) | CliId::Unassigned { .. } => true,
+                    CliId::PathPrefix { .. }
+                    | CliId::CommittedFile { .. }
+                    | CliId::Branch { .. }
+                    | CliId::Commit { .. }
+                    | CliId::Stack { .. } => false,
+                }
+            } else {
+                false
+            }
+        }
         Mode::InlineReword(..) | Mode::Command(..) => {
             // you can't actually move the selection in these modes
             // but returning `false` would dim every line which hurts UX

--- a/crates/but/src/command/legacy/status/tui/details/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/details/mod.rs
@@ -153,6 +153,7 @@ impl Details {
             Message::JustRender
             | Message::CopySelection
             | Message::Quit
+            | Message::ConfirmAndQuit
             | Message::DetailsLayout(DetailsLayoutMessage::Focus { .. })
             | Message::Discard
             | Message::DropToBeDiscarded
@@ -732,11 +733,11 @@ impl DetailsAndDiffWidget {
 
         let first = diff_line_items
             .iter()
-            .position(|line| matches!(line, RenderedDiffLine::DiffLine { section_id, .. } if section_id == section))?;
+            .position(|line| matches!(line, RenderedDiffLine::DiffLine { section_id, .. } if section_id.eq(section)))?;
 
         let last = diff_line_items
             .iter()
-            .rposition(|line| matches!(line, RenderedDiffLine::DiffLine { section_id, .. } if section_id == section))?;
+            .rposition(|line| matches!(line, RenderedDiffLine::DiffLine { section_id, .. } if section_id.eq(section)))?;
 
         Some((
             rows_before_diff.saturating_add(first),

--- a/crates/but/src/command/legacy/status/tui/help.rs
+++ b/crates/but/src/command/legacy/status/tui/help.rs
@@ -34,6 +34,18 @@ impl Help {
 
         for key_binds in key_binds {
             for mode in ModeDiscriminant::iter() {
+                match mode {
+                    ModeDiscriminant::PickChanges => continue,
+                    ModeDiscriminant::Normal
+                    | ModeDiscriminant::Rub
+                    | ModeDiscriminant::InlineReword
+                    | ModeDiscriminant::Command
+                    | ModeDiscriminant::Commit
+                    | ModeDiscriminant::Move
+                    | ModeDiscriminant::Details
+                    | ModeDiscriminant::Stack => {}
+                }
+
                 let section = mode_to_sections.entry(mode).or_insert_with(|| HelpSection {
                     mode: Some(mode),
                     items: Vec::new(),

--- a/crates/but/src/command/legacy/status/tui/key_bind/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/key_bind/mod.rs
@@ -25,6 +25,11 @@ pub(super) fn default_key_binds() -> KeyBinds {
             ModeDiscriminant::Normal => {
                 register_normal_mode_key_binds(&mut builder, true);
             }
+            ModeDiscriminant::PickChanges => {
+                builder.mark().register();
+                builder.confirm_and_quit().register();
+                register_non_mode_specific_key_binds(&mut builder);
+            }
             ModeDiscriminant::Rub => {
                 builder.rub_confirm().register();
                 builder.rub_use_target_message().register();
@@ -695,6 +700,15 @@ impl KeyBindsBuilder<'_> {
         self.key_bind("back", press().code(KeyCode::Esc), Message::Back)
             .hide_from_hotbar()
             .show_only_in_normal_mode_help_section()
+    }
+
+    fn confirm_and_quit(&mut self) -> KeyBindsInModesBuilder<'_> {
+        self.key_bind(
+            "confirm",
+            press().code(KeyCode::Enter),
+            Message::ConfirmAndQuit,
+        )
+        .long_description("Rub target into selection")
     }
 
     fn rub_use_target_message(&mut self) -> KeyBindsInModesBuilder<'_> {

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -37,7 +37,7 @@ use crate::{
         self, ShowDiffInEditor,
         reword::get_branch_name_from_editor,
         status::{
-            StatusFlags, StatusOutputLine, TuiLaunchOptions,
+            StatusFlags, StatusOutputLine, TuiLaunchOptions, TuiOutcome, TuiRunOptions,
             tui::{
                 backstack::{Backstack, BackstackEntry, RememberToUpdateBackstack},
                 branch_picker::{BranchPicker, BranchPickerMessage},
@@ -57,8 +57,8 @@ use crate::{
                 mode::{
                     CommandMode, CommandModeKind, CommitMessageComposer, CommitMode, CommitSource,
                     DetailsMode, InlineRewordMode, Mode, ModeDiscriminant, MoveMode, MoveSource,
-                    NormalMode, RubMode, RubSource, StackCommitSource, StackMode,
-                    UnassignedCommitSource,
+                    NormalMode, PickUncommittedMode, RubMode, RubSource, StackCommitSource,
+                    StackMode, UnassignedCommitSource,
                 },
                 operations::stack_has_assigned_changes,
                 toast::{ToastKind, Toasts},
@@ -69,7 +69,7 @@ use crate::{
     theme::Theme,
     tui::{CrosstermTerminalGuard, HeadlessTerminalGuard, TerminalGuard},
     utils::{
-        DebugAsType, OutputChannel, binary_path::current_exe_for_but_exec,
+        DebugAsType, IntermediateChannel, WriteWithUtils, binary_path::current_exe_for_but_exec,
         diff_specs::DiffSpecBuilder,
     },
 };
@@ -120,22 +120,23 @@ const WATCHER_SELF_ECHO_SUPPRESSION: Duration = if cfg!(windows) {
     Duration::from_millis(500)
 };
 
-pub(super) async fn render_tui(
+pub(super) fn render_tui(
     ctx: &mut Context,
-    out: &mut OutputChannel,
+    out: &mut IntermediateChannel<'_>,
     mode: &OperatingMode,
     flags: StatusFlags,
     status_lines: Vec<StatusOutputLine>,
-    options: TuiLaunchOptions,
-) -> anyhow::Result<Vec<StatusOutputLine>> {
-    let mut app = App::new(status_lines, flags, options);
+    launch_options: TuiLaunchOptions,
+    run_options: TuiRunOptions,
+) -> anyhow::Result<(Vec<StatusOutputLine>, TuiOutcome)> {
+    let mut app = App::new(status_lines, flags, launch_options, run_options);
 
     let mut messages = Vec::new();
 
     // second buffer so we can send messages from `App::handle_message`
     let mut other_messages = Vec::new();
 
-    if app.options.headless {
+    let outcome = if app.launch_options.headless {
         let mut terminal_guard = HeadlessTerminalGuard::new(240, 240)?;
         let event_polling = NoopEventPolling;
 
@@ -149,8 +150,7 @@ pub(super) async fn render_tui(
             ctx,
             out,
             mode,
-        )
-        .await?;
+        )?
     } else {
         let (_watcher_handle, received_watcher_event) =
             start_watcher(ctx).context("failed to start filesystem watcher")?;
@@ -168,14 +168,13 @@ pub(super) async fn render_tui(
             ctx,
             out,
             mode,
-        )
-        .await?;
-    }
+        )?
+    };
 
-    Ok(app.status_lines)
+    Ok((app.status_lines, outcome))
 }
 
-async fn render_loop<T, E>(
+fn render_loop<T, E>(
     app: &mut App,
     terminal_guard: &mut T,
     event_polling: E,
@@ -183,9 +182,9 @@ async fn render_loop<T, E>(
     other_messages: &mut Vec<Message>,
     received_watcher_event: Arc<AtomicBool>,
     ctx: &mut Context,
-    out: &mut OutputChannel,
+    out: &mut IntermediateChannel<'_>,
     mode: &OperatingMode,
-) -> anyhow::Result<()>
+) -> anyhow::Result<TuiOutcome>
 where
     T: TerminalGuard,
     anyhow::Error: From<<T::Backend as Backend>::Error>,
@@ -195,11 +194,11 @@ where
 
     loop {
         if app
-            .options
+            .launch_options
             .quit_after
             .is_some_and(|quit_after| quit_after <= app.updates)
         {
-            break Ok(());
+            break Ok(TuiOutcome::None);
         }
 
         render_loop_once(
@@ -212,17 +211,16 @@ where
             ctx,
             out,
             mode,
-        )
-        .await?;
+        )?;
 
-        if app.should_quit {
-            break Ok(());
+        if let Some(outcome) = app.outcome.take() {
+            break Ok(outcome);
         }
     }
 }
 
 #[expect(clippy::too_many_arguments)]
-async fn render_loop_once<T, E>(
+fn render_loop_once<T, E>(
     app: &mut App,
     terminal_guard: &mut T,
     event_polling: E,
@@ -230,7 +228,7 @@ async fn render_loop_once<T, E>(
     other_messages: &mut Vec<Message>,
     received_watcher_event: &AtomicBool,
     ctx: &mut Context,
-    out: &mut OutputChannel,
+    out: &mut IntermediateChannel<'_>,
     mode: &OperatingMode,
 ) -> anyhow::Result<()>
 where
@@ -248,8 +246,7 @@ where
         ctx,
         out,
         mode,
-    )
-    .await?;
+    )?;
 
     render(app, terminal_guard)?;
 
@@ -259,7 +256,7 @@ where
 }
 
 #[expect(clippy::too_many_arguments)]
-async fn update<T, E>(
+fn update<T, E>(
     app: &mut App,
     terminal_guard: &mut T,
     event_polling: E,
@@ -267,7 +264,7 @@ async fn update<T, E>(
     other_messages: &mut Vec<Message>,
     received_watcher_event: &AtomicBool,
     ctx: &mut Context,
-    out: &mut OutputChannel,
+    out: &mut IntermediateChannel<'_>,
     mode: &OperatingMode,
 ) -> anyhow::Result<()>
 where
@@ -343,8 +340,7 @@ where
                     did_reload = true;
                 }
             }
-            app.handle_message(ctx, out, mode, terminal_guard, other_messages, msg)
-                .await;
+            app.handle_message(ctx, out, mode, terminal_guard, other_messages, msg);
         }
         std::mem::swap(messages, other_messages);
     }
@@ -370,8 +366,8 @@ where
         match app.details.update(ctx, selection) {
             Ok(Some(result)) => match result {
                 RenderNextChunkResult::Done => {
-                    if app.options.quit_after_rendering_full_diff {
-                        app.should_quit = true;
+                    if app.launch_options.quit_after_rendering_full_diff {
+                        app.outcome = Some(TuiOutcome::None);
                     }
                 }
                 RenderNextChunkResult::Meta | RenderNextChunkResult::Diff => {}
@@ -411,7 +407,7 @@ where
 struct App {
     status_lines: Vec<StatusOutputLine>,
     flags: StatusFlags,
-    should_quit: bool,
+    outcome: Option<TuiOutcome>,
     should_render: bool,
     cursor: Cursor,
     scroll_top: usize,
@@ -424,7 +420,7 @@ struct App {
     modal: Option<Modal>,
     details: Details,
     is_details_visible: bool,
-    options: TuiLaunchOptions,
+    launch_options: TuiLaunchOptions,
     delayed_messages: Vec<Message>,
     incoming_out_of_band_messages: Vec<Rc<Receiver<Message>>>,
     fps: FpsCounter,
@@ -462,9 +458,10 @@ impl App {
     fn new(
         status_lines: Vec<StatusOutputLine>,
         flags: StatusFlags,
-        options: TuiLaunchOptions,
+        launch_options: TuiLaunchOptions,
+        run_options: TuiRunOptions,
     ) -> Self {
-        let cursor = if let Some(object_id) = options.select_commit {
+        let cursor = if let Some(object_id) = launch_options.select_commit {
             Cursor::select_commit(object_id, &status_lines)
                 .unwrap_or_else(|| Cursor::new(&status_lines))
         } else {
@@ -473,7 +470,7 @@ impl App {
 
         let theme = crate::theme::get();
 
-        let (mut details, is_details_visible) = (Details::new(theme), options.show_diff);
+        let (mut details, is_details_visible) = (Details::new(theme), launch_options.show_diff);
         if is_details_visible {
             details.mark_dirty();
         }
@@ -483,14 +480,19 @@ impl App {
             normal_with_marks_key_binds: normal_with_marks_key_binds(),
         };
 
+        let mode = RememberToUpdateBackstack::new(match run_options {
+            TuiRunOptions::Normal => Mode::default(),
+            TuiRunOptions::PickChanges => Mode::PickChanges(Default::default()),
+        });
+
         Self {
             status_lines,
             flags,
             cursor,
             scroll_top: 0,
-            should_quit: false,
+            outcome: None,
             should_render: true,
-            mode: Default::default(),
+            mode,
             toasts: Default::default(),
             renders: 0,
             updates: 0,
@@ -505,7 +507,7 @@ impl App {
             fps: FpsCounter::new(),
             details,
             is_details_visible,
-            options,
+            launch_options,
             status_width_percentage: 50,
             theme,
             has_focus: true,
@@ -530,10 +532,10 @@ impl App {
     }
 
     #[tracing::instrument(level = Level::TRACE, skip(self, ctx, out, mode, terminal_guard, messages))]
-    async fn handle_message<T>(
+    fn handle_message<T>(
         &mut self,
         ctx: &mut Context,
-        out: &mut OutputChannel,
+        out: &mut IntermediateChannel<'_>,
         mode: &OperatingMode,
         terminal_guard: &mut T,
         messages: &mut Vec<Message>,
@@ -542,18 +544,15 @@ impl App {
         T: TerminalGuard,
         anyhow::Error: From<<T::Backend as Backend>::Error>,
     {
-        if let Err(err) = self
-            .try_handle_message(ctx, out, mode, terminal_guard, messages, msg)
-            .await
-        {
+        if let Err(err) = self.try_handle_message(ctx, out, mode, terminal_guard, messages, msg) {
             messages.push(Message::ShowError(Arc::new(err)));
         }
     }
 
-    async fn try_handle_message<T>(
+    fn try_handle_message<T>(
         &mut self,
         ctx: &mut Context,
-        out: &mut OutputChannel,
+        out: &mut IntermediateChannel<'_>,
         mode: &OperatingMode,
         terminal_guard: &mut T,
         messages: &mut Vec<Message>,
@@ -579,7 +578,10 @@ impl App {
 
         match msg {
             Message::Quit => {
-                self.should_quit = true;
+                self.handle_quit();
+            }
+            Message::ConfirmAndQuit => {
+                self.handle_confirm_and_quit();
             }
             Message::JustRender => {}
             Message::MoveCursorUp => {
@@ -710,8 +712,7 @@ impl App {
                 }
             },
             Message::Reload(select_after_reload, cause) => {
-                self.handle_reload(ctx, out, mode, select_after_reload, cause)
-                    .await?
+                self.handle_reload(ctx, out, mode, select_after_reload, cause)?
             }
             Message::ShowError(err) => self.handle_show_error(err, messages),
             Message::Commit(commit_message) => match commit_message {
@@ -806,8 +807,7 @@ impl App {
                 self.to_be_discarded.clear();
             }
             Message::AndThen { lhs, rhs } => {
-                Box::pin(self.try_handle_message(ctx, out, mode, terminal_guard, messages, *lhs))
-                    .await?;
+                self.try_handle_message(ctx, out, mode, terminal_guard, messages, *lhs)?;
 
                 // Push `rhs` to the end of the queue. That way any messages enqueued by `lhs` will
                 // be handled first.
@@ -877,6 +877,31 @@ impl App {
         }
 
         Ok(())
+    }
+
+    fn handle_quit(&mut self) {
+        self.outcome = Some(TuiOutcome::None);
+    }
+
+    fn handle_confirm_and_quit(&mut self) {
+        self.outcome = match &*self.mode {
+            Mode::Normal(..)
+            | Mode::Rub(..)
+            | Mode::InlineReword(..)
+            | Mode::Command(..)
+            | Mode::Commit(..)
+            | Mode::Move(..)
+            | Mode::Details(..)
+            | Mode::Stack(..) => Some(TuiOutcome::None),
+            Mode::PickChanges(PickUncommittedMode { marks }) => {
+                let ids = marks
+                    .iter()
+                    .cloned()
+                    .map(|mark| mark.into_cli_id())
+                    .collect();
+                Some(TuiOutcome::CliIds(ids))
+            }
+        };
     }
 
     fn handle_unfocus_details(&mut self, messages: &mut Vec<Message>) {
@@ -970,6 +995,9 @@ impl App {
                 Mode::Normal(normal_mode) => {
                     normal_mode.marks.clear();
                 }
+                Mode::PickChanges(pick_uncommitted_mode) => {
+                    pick_uncommitted_mode.marks.clear();
+                }
                 Mode::Rub(..) => {
                     *self
                         .mode
@@ -1046,7 +1074,7 @@ impl App {
 
     fn handle_toggle_details_full_screen(&mut self, messages: &mut Vec<Message>) {
         match &*self.mode {
-            Mode::Normal(..) => {
+            Mode::Normal(..) | Mode::PickChanges(..) => {
                 messages.push(Message::DetailsLayout(DetailsLayoutMessage::Focus {
                     full_screen: true,
                 }));
@@ -1484,15 +1512,15 @@ impl App {
     }
 
     /// Handles reloading status output and restoring selection.
-    async fn handle_reload(
+    fn handle_reload(
         &mut self,
         ctx: &mut Context,
-        out: &mut OutputChannel,
+        out: &mut dyn WriteWithUtils,
         mode: &OperatingMode,
         select_after_reload: Option<SelectAfterReload>,
         cause: ReloadCause,
     ) -> anyhow::Result<()> {
-        let new_lines = operations::reload_legacy(ctx, out, mode, self.flags, self.options).await?;
+        let new_lines = operations::reload_legacy(ctx, out, mode, self.flags, self.launch_options)?;
 
         self.cursor = if let Some(select_after_reload) = select_after_reload {
             match select_after_reload {
@@ -2832,13 +2860,18 @@ impl App {
     fn handle_command_confirm<T>(
         &mut self,
         terminal_guard: &mut T,
-        out: &mut OutputChannel,
+        out: &mut IntermediateChannel<'_>,
         messages: &mut Vec<Message>,
     ) -> anyhow::Result<()>
     where
         T: TerminalGuard,
         anyhow::Error: From<<T::Backend as Backend>::Error>,
     {
+        //
+        // `cfg!(test)` is false for integration tests but we currently don't have integration
+        // tests of the TUI so thats fine for now.
+        const IN_TEST: bool = cfg!(test);
+
         let Mode::Command(CommandMode { textarea, kind }) = &*self.mode else {
             messages.push(Message::EnterNormalModeAfterConfirmingOperation);
             return Ok(());
@@ -2872,7 +2905,9 @@ impl App {
 
         let status = cmd.spawn()?.wait()?;
 
-        self.prompt_to_continue(out)?;
+        if !IN_TEST && let Some(mut input_channel) = out.prepare_for_terminal_input() {
+            input_channel.prompt_single_line("\npress enter to continue...")?;
+        }
 
         if status.success() {
             messages.extend([
@@ -2887,21 +2922,6 @@ impl App {
         }
 
         drop(_suspend_guard);
-
-        Ok(())
-    }
-
-    /// Prompts the user to press enter before returning from a command execution.
-    fn prompt_to_continue(&mut self, out: &mut OutputChannel) -> anyhow::Result<()> {
-        // don't prompt for user input during tests
-        //
-        // `cfg!(test)` is false for integration tests but we currently don't have integration
-        // tests of the TUI so thats fine for now.
-        const IN_TEST: bool = cfg!(test);
-
-        if !IN_TEST && let Some(mut input_channel) = out.prepare_for_terminal_input() {
-            input_channel.prompt_single_line("\npress enter to continue...")?;
-        }
 
         Ok(())
     }
@@ -3048,7 +3068,7 @@ impl App {
 
         match &**selection {
             CliId::Commit { .. } | CliId::Uncommitted(..) => {
-                if handle_mark_commit(
+                if handle_mark_cli_id(
                     selection,
                     self.mode
                         .get_mut_without_updating_backstack_and_i_promise_not_to_change_state(),
@@ -3066,21 +3086,42 @@ impl App {
                 stack_id,
             } => {
                 // you cannot select branches in rub mode so we don't need to care about that
-                if let Mode::Normal(normal_mode) = self
-                    .mode
-                    .get_mut_without_updating_backstack_and_i_promise_not_to_change_state()
-                    && let Some(stack_id) = *stack_id
-                {
-                    handle_mark_branch(&mut normal_mode.marks, ctx, stack_id, name)?;
+                if let Some(stack_id) = *stack_id {
+                    match self
+                        .mode
+                        .get_mut_without_updating_backstack_and_i_promise_not_to_change_state()
+                    {
+                        Mode::Normal(NormalMode { marks })
+                        | Mode::PickChanges(PickUncommittedMode { marks }) => {
+                            handle_mark_branch(marks, ctx, stack_id, name)?;
+                        }
+                        Mode::Rub(..)
+                        | Mode::InlineReword(..)
+                        | Mode::Command(..)
+                        | Mode::Commit(..)
+                        | Mode::Move(..)
+                        | Mode::Details(..)
+                        | Mode::Stack(..) => {}
+                    }
                 }
             }
             CliId::Unassigned { .. } => {
                 // you cannot select unassigned changes in rub mode so we don't need to care about that
-                if let Mode::Normal(normal_mode) = self
+                match self
                     .mode
                     .get_mut_without_updating_backstack_and_i_promise_not_to_change_state()
                 {
-                    handle_mark_unassigned(&mut normal_mode.marks, &self.status_lines);
+                    Mode::Normal(NormalMode { marks })
+                    | Mode::PickChanges(PickUncommittedMode { marks }) => {
+                        handle_mark_unassigned(marks, &self.status_lines);
+                    }
+                    Mode::Rub(..)
+                    | Mode::InlineReword(..)
+                    | Mode::Command(..)
+                    | Mode::Commit(..)
+                    | Mode::Move(..)
+                    | Mode::Details(..)
+                    | Mode::Stack(..) => {}
                 }
             }
             CliId::PathPrefix { .. } | CliId::CommittedFile { .. } | CliId::Stack { .. } => {}
@@ -3327,6 +3368,7 @@ fn event_to_messages(
                         | Mode::Rub(..)
                         | Mode::Commit(..)
                         | Mode::Stack(..)
+                        | Mode::PickChanges(..)
                         | Mode::Move(..) => {}
                     }
                 }
@@ -3347,6 +3389,7 @@ fn event_to_messages(
             | Mode::Rub(..)
             | Mode::Commit(..)
             | Mode::Stack(..)
+            | Mode::PickChanges(..)
             | Mode::Move(..) => {
                 messages.push(Message::JustRender);
             }
@@ -3361,7 +3404,7 @@ fn event_to_messages(
     }
 }
 
-fn handle_mark_commit(commit: &CliId, mode: &mut Mode) -> bool {
+fn handle_mark_cli_id(commit: &CliId, mode: &mut Mode) -> bool {
     let Some(markable) = Markable::try_from_cli_id(commit) else {
         return false;
     };
@@ -3369,6 +3412,9 @@ fn handle_mark_commit(commit: &CliId, mode: &mut Mode) -> bool {
     match mode {
         Mode::Normal(normal_mode) => {
             normal_mode.marks.toggle(markable);
+        }
+        Mode::PickChanges(pick_uncommitted_mode) => {
+            pick_uncommitted_mode.marks.toggle(markable);
         }
         Mode::Rub(rub_mode) => {
             match &mut rub_mode.source {
@@ -3627,6 +3673,7 @@ enum Message {
     // Lifecycle
     JustRender,
     Quit,
+    ConfirmAndQuit,
     EnterNormalModeAfterConfirmingOperation,
     Reload(Option<SelectAfterReload>, ReloadCause),
     ShowError(Arc<anyhow::Error>),

--- a/crates/but/src/command/legacy/status/tui/mode.rs
+++ b/crates/but/src/command/legacy/status/tui/mode.rs
@@ -26,6 +26,7 @@ pub(super) enum Mode {
     Move(MoveMode),
     Details(DetailsMode),
     Stack(StackMode),
+    PickChanges(PickUncommittedMode),
 }
 
 impl Default for Mode {
@@ -57,6 +58,7 @@ impl Mode {
                 | CommitSource::Uncommitted(..)
                 | CommitSource::Stack(..) => None,
             },
+            Mode::PickChanges(pick_uncommitted_mode) => Some(&pick_uncommitted_mode.marks),
             Mode::InlineReword(..)
             | Mode::Command(..)
             | Mode::Move(..)
@@ -70,7 +72,7 @@ impl ModeDiscriminant {
     pub(super) fn bg(self, theme: &'static Theme) -> Color {
         match self {
             Self::Normal => theme.tui_mode_normal.bg.unwrap_or(Color::DarkGray),
-            Self::Commit => theme.tui_mode_commit.bg.unwrap_or(Color::Green),
+            Self::Commit | Self::PickChanges => theme.tui_mode_commit.bg.unwrap_or(Color::Green),
             Self::Rub => theme.tui_mode_rub.bg.unwrap_or(Color::Blue),
             Self::InlineReword | Self::Stack => {
                 theme.tui_mode_inline_reword.bg.unwrap_or(Color::Magenta)
@@ -87,7 +89,7 @@ impl ModeDiscriminant {
     pub(super) fn fg(self, theme: &'static Theme) -> Color {
         match self {
             Self::Normal => theme.tui_mode_normal.fg.unwrap_or(Color::White),
-            Self::Commit => theme.tui_mode_commit.fg.unwrap_or(Color::Black),
+            Self::Commit | Self::PickChanges => theme.tui_mode_commit.fg.unwrap_or(Color::Black),
             Self::Rub => theme.tui_mode_rub.fg.unwrap_or(Color::Black),
             Self::InlineReword | Self::Stack => {
                 theme.tui_mode_inline_reword.fg.unwrap_or(Color::Black)
@@ -105,6 +107,7 @@ impl ModeDiscriminant {
             Self::InlineReword => "reword",
             Self::Command => "command",
             Self::Commit => "commit",
+            Self::PickChanges => "pick changes",
             Self::Move => "move",
             Self::Details => "details",
             Self::Stack => "stack",
@@ -373,4 +376,9 @@ pub(super) struct DetailsMode {
 #[derive(Debug)]
 pub(super) struct StackMode {
     pub(super) stack_heads: Vec<FullName>,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct PickUncommittedMode {
+    pub(super) marks: Marks,
 }

--- a/crates/but/src/command/legacy/status/tui/operations.rs
+++ b/crates/but/src/command/legacy/status/tui/operations.rs
@@ -19,6 +19,7 @@ use gitbutler_oplog::entry::Snapshot;
 
 use crate::{
     CliId,
+    args::OutputFormat,
     command::legacy::{
         self, ShowDiffInEditor,
         rub::RubOperation,
@@ -27,36 +28,43 @@ use crate::{
             tui::SelectAfterReload,
         },
     },
-    utils::{OutputChannel, diff_specs},
+    utils::{WriteWithUtils, diff_specs},
 };
 
-pub(super) async fn reload_legacy(
+pub(super) fn reload_legacy(
     ctx: &mut Context,
-    out: &mut OutputChannel,
+    out: &mut dyn WriteWithUtils,
     mode: &OperatingMode,
     flags: StatusFlags,
     options: TuiLaunchOptions,
 ) -> anyhow::Result<Vec<StatusOutputLine>> {
+    let mut guard = ctx.exclusive_worktree_access();
+
     {
         let meta = ctx.meta()?;
         let project_meta = ctx.project_meta()?;
-        let (_guard, repo, mut ws, _) = ctx.workspace_mut_and_db()?;
+        let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(guard.write_permission())?;
         ws.refresh_from_head(&repo, &meta, project_meta)?;
     }
 
     let mut new_lines = Vec::new();
 
-    legacy::status::build_status_context(ctx, out, mode, flags, StatusRenderMode::Tui(options))
-        .await
-        .and_then(|status_ctx| {
-            legacy::status::build_status_output(
-                ctx,
-                &status_ctx,
-                &mut StatusOutput::Buffer {
-                    lines: &mut new_lines,
-                },
-            )
-        })?;
+    let status_ctx = legacy::status::build_status_context(
+        ctx,
+        guard.write_permission(),
+        out,
+        OutputFormat::Human,
+        mode,
+        flags,
+        StatusRenderMode::Tui(options),
+    )?;
+    legacy::status::build_status_output(
+        ctx,
+        &status_ctx,
+        &mut StatusOutput::Buffer {
+            lines: &mut new_lines,
+        },
+    )?;
 
     Ok(new_lines)
 }

--- a/crates/but/src/command/legacy/status/tui/render.rs
+++ b/crates/but/src/command/legacy/status/tui/render.rs
@@ -38,7 +38,7 @@ pub(super) fn render_app(app: &App, frame: &mut Frame) {
         Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(frame.area());
     let main_content_area = content_layout[0];
 
-    let (main_content_area, debug_area) = if app.options.debug {
+    let (main_content_area, debug_area) = if app.launch_options.debug {
         let layout = Layout::horizontal([Constraint::Percentage(70), Constraint::Percentage(30)])
             .split(main_content_area);
         (layout[0], Some(layout[1]))
@@ -382,7 +382,11 @@ fn render_status_list_item_with_stack_highlight(
         line.extend([Span::raw("<< discard >>").black().on_red(), Span::raw(" ")]);
     } else if is_selected {
         match &*app.mode {
-            Mode::Normal(..) | Mode::InlineReword(..) | Mode::Command(..) | Mode::Details(..) => {}
+            Mode::Normal(..)
+            | Mode::PickChanges(..)
+            | Mode::InlineReword(..)
+            | Mode::Command(..)
+            | Mode::Details(..) => {}
             Mode::Rub(RubMode {
                 source,
                 how_to_combine_messages,
@@ -428,6 +432,7 @@ fn render_status_list_item_with_stack_highlight(
     } else {
         match &*app.mode {
             Mode::Normal(..)
+            | Mode::PickChanges(..)
             | Mode::InlineReword(..)
             | Mode::Command(..)
             | Mode::Details(..)
@@ -557,6 +562,7 @@ fn render_status_list_item_with_stack_highlight(
             }
         }
         Mode::Normal(..)
+        | Mode::PickChanges(..)
         | Mode::Details(..)
         | Mode::Move(..)
         | Mode::Stack(..)
@@ -647,6 +653,7 @@ fn render_status_list_item_with_stack_highlight(
                 }
             }
             Mode::Normal(..)
+            | Mode::PickChanges(..)
             | Mode::Details(..)
             | Mode::Rub(..)
             | Mode::Stack(..)
@@ -829,6 +836,7 @@ fn render_hotbar(app: &App, area: Rect, frame: &mut Frame) {
 
     match &*app.mode {
         Mode::Normal(..)
+        | Mode::PickChanges(..)
         | Mode::Details(..)
         | Mode::Rub(..)
         | Mode::Commit(..)

--- a/crates/but/src/command/legacy/status/tui/tests/utils.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/utils.rs
@@ -13,13 +13,13 @@ use temp_env::with_var;
 use crate::{
     args::OutputFormat,
     command::legacy::status::{
-        StatusFlags, StatusOutput, StatusRenderMode, TuiLaunchOptions, build_status_context,
-        build_status_output,
+        StatusFlags, StatusOutput, StatusRenderMode, TuiLaunchOptions, TuiRunOptions,
+        build_status_context, build_status_output,
         tui::{App, EventPolling, Message, ReloadCause, render_loop_once},
     },
     theme,
     tui::TerminalGuard,
-    utils::OutputChannel,
+    utils::{IntermediateChannel, OutputChannel},
 };
 
 pub(super) struct TestTui {
@@ -28,7 +28,6 @@ pub(super) struct TestTui {
     env: Option<Sandbox>,
     out: OutputChannel,
     mode: OperatingMode,
-    async_runtime: tokio::runtime::Runtime,
     width: u16,
     height: u16,
     svg_snapshot_comparison: Option<SvgSnapshotComparison>,
@@ -44,10 +43,6 @@ pub(super) fn test_tui(env: Sandbox) -> TestTui {
 }
 
 pub(super) fn test_tui_with_size(env: Sandbox, width: u16, height: u16) -> TestTui {
-    let async_runtime = tokio::runtime::Builder::new_current_thread()
-        .build()
-        .expect("failed to build async runtime");
-
     env.invoke_git("config user.name committer");
     env.invoke_git("config user.email committer@example.com");
 
@@ -58,26 +53,31 @@ pub(super) fn test_tui_with_size(env: Sandbox, width: u16, height: u16) -> TestT
     let mut out = OutputChannel::new(OutputFormat::Human);
 
     let flags = StatusFlags::all_false();
-    let options = TuiLaunchOptions {
+    let launch_options = TuiLaunchOptions {
         debug: false,
         ..Default::default()
     };
+    let run_options = TuiRunOptions::Normal;
 
-    let status_ctx = async_runtime
-        .block_on(build_status_context(
-            &mut ctx,
-            &mut out,
-            &mode,
-            flags,
-            StatusRenderMode::Tui(options),
-        ))
-        .expect("failed to build status context");
+    let mut guard = ctx.exclusive_worktree_access();
+
+    let format = out.format();
+    let status_ctx = build_status_context(
+        &mut ctx,
+        guard.write_permission(),
+        &mut out,
+        format,
+        &mode,
+        flags,
+        StatusRenderMode::Tui(launch_options),
+    )
+    .expect("failed to build status context");
     let mut lines = Vec::new();
     let mut status_output = StatusOutput::Buffer { lines: &mut lines };
-    build_status_output(&mut ctx, &status_ctx, &mut status_output)
+    build_status_output(&ctx, &status_ctx, &mut status_output)
         .expect("failed to build status output");
 
-    let app = App::new(lines, flags, options);
+    let app = App::new(lines, flags, launch_options, run_options);
     let terminal =
         Terminal::new(TestBackend::new(width, height)).expect("failed to create test terminal");
 
@@ -87,7 +87,6 @@ pub(super) fn test_tui_with_size(env: Sandbox, width: u16, height: u16) -> TestT
         env: Some(env),
         out,
         mode,
-        async_runtime,
         width,
         height,
         svg_snapshot_comparison: None,
@@ -125,19 +124,19 @@ impl TestTui {
 
         with_var("GIT_AUTHOR_DATE", Some("2000-01-01T00:00:00Z"), || {
             with_var("GIT_COMMITTER_DATE", Some("2000-01-01T00:00:00Z"), || {
-                self.async_runtime
-                    .block_on(render_loop_once(
-                        &mut self.app,
-                        &mut self.terminal,
-                        event,
-                        &mut messages,
-                        &mut other_messages,
-                        &AtomicBool::default(),
-                        &mut ctx,
-                        &mut self.out,
-                        &self.mode,
-                    ))
-                    .unwrap();
+                let mut out = IntermediateChannel::new(&mut self.out);
+                render_loop_once(
+                    &mut self.app,
+                    &mut self.terminal,
+                    event,
+                    &mut messages,
+                    &mut other_messages,
+                    &AtomicBool::default(),
+                    &mut ctx,
+                    &mut out,
+                    &self.mode,
+                )
+                .unwrap();
             });
         });
 

--- a/crates/but/src/utils/mod.rs
+++ b/crates/but/src/utils/mod.rs
@@ -1,7 +1,6 @@
 use std::io::Write;
 
 mod output_channel;
-#[cfg(all(feature = "legacy", feature = "but-2"))]
 pub use output_channel::experimental::*;
 pub use output_channel::{
     Confirm, ConfirmDefault, ConfirmOrEmpty, InputOutputChannel, OutputChannel, WriteWithUtils,

--- a/crates/but/src/utils/output_channel.rs
+++ b/crates/but/src/utils/output_channel.rs
@@ -11,7 +11,6 @@ use crate::{
     },
 };
 
-#[cfg(all(feature = "legacy", feature = "but-2"))]
 pub mod experimental;
 
 /// Default value for a confirmation prompt.
@@ -123,7 +122,7 @@ impl OutputChannel {
 }
 
 /// An [`std::fmt::Write`] implementation that supports additional utility methods for output formatting.
-pub trait WriteWithUtils: std::fmt::Write + 'static {
+pub trait WriteWithUtils: std::fmt::Write {
     /// Truncate the given text to the specified maximum width, unless the output is passed through a pager
     /// or the output format opts out of truncation.
     ///

--- a/crates/but/src/utils/output_channel/experimental.rs
+++ b/crates/but/src/utils/output_channel/experimental.rs
@@ -5,7 +5,7 @@
 use crate::{
     args::OutputFormat,
     theme::Theme,
-    utils::{OutputChannel, WriteWithUtils},
+    utils::{InputOutputChannel, OutputChannel, WriteWithUtils},
 };
 
 pub struct IntermediateChannel<'out> {
@@ -18,29 +18,31 @@ impl std::fmt::Write for IntermediateChannel<'_> {
     }
 }
 
+impl<'out> WriteWithUtils for IntermediateChannel<'out> {
+    fn truncate_if_unpaged(&self, text: &str, max_width: usize) -> String {
+        self.out.truncate_if_unpaged(text, max_width)
+    }
+
+    fn is_paged(&self) -> bool {
+        self.out.is_paged()
+    }
+}
+
 impl<'out> IntermediateChannel<'out> {
     pub fn new(out: &'out mut OutputChannel) -> Self {
         Self { out }
     }
 
-    // TODO: some functions for prompting the user
-    // pub fn can_prompt(&self) -> bool {
-    //     self.out.can_prompt()
-    // }
-
-    // pub fn prompt(&self) -> anyhow::Result<()> {
-    //     if !self.can_prompt() {
-    //         anyhow::bail!("BUG: attempted to prompt when prompting is not allowed")
-    //     } else {
-    //         Ok(())
-    //     }
-    // }
+    pub fn prepare_for_terminal_input(&mut self) -> Option<InputOutputChannel<'_>> {
+        self.out.prepare_for_terminal_input()
+    }
 }
 
 pub trait CliOutputHuman {
     fn on_human(self, out: &mut dyn WriteWithUtils, theme: &Theme) -> anyhow::Result<()>;
 }
 
+#[allow(dead_code)]
 pub trait CliOutput: CliOutputHuman {
     fn on_shell(self, out: &mut dyn WriteWithUtils) -> anyhow::Result<()>;
 
@@ -48,9 +50,10 @@ pub trait CliOutput: CliOutputHuman {
 }
 
 pub trait OutputChannelExt {
+    #[allow(dead_code)]
     fn print_cli_output(&mut self, output: impl CliOutput) -> anyhow::Result<()>;
 
-    #[expect(dead_code)]
+    #[allow(dead_code)]
     fn print_cli_output_human(&mut self, output: impl CliOutputHuman) -> anyhow::Result<()>;
 }
 

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -142,15 +142,23 @@ pub fn upstream_integration_statuses(
     review_map: &std::collections::HashMap<String, but_forge::ForgeReview>,
 ) -> Result<StackStatuses> {
     let mut guard = ctx.exclusive_worktree_access();
-
-    let repo = ctx.repo.get()?;
-    let context = UpstreamIntegrationContext::open(
+    upstream_integration_statuses_with_perm(
         ctx,
         target_commit_oid,
-        guard.write_permission(),
-        &repo,
         review_map,
-    )?;
+        guard.write_permission(),
+    )
+}
+
+pub fn upstream_integration_statuses_with_perm(
+    ctx: &mut Context,
+    target_commit_oid: Option<gix::ObjectId>,
+    review_map: &std::collections::HashMap<String, but_forge::ForgeReview>,
+    perm: &mut RepoExclusive,
+) -> Result<StackStatuses> {
+    let repo = ctx.repo.get()?;
+    let context =
+        UpstreamIntegrationContext::open(ctx, target_commit_oid, perm, &repo, review_map)?;
 
     upstream_integration::upstream_integration_statuses(&context)
 }

--- a/crates/gitbutler-branch-actions/src/lib.rs
+++ b/crates/gitbutler-branch-actions/src/lib.rs
@@ -10,7 +10,7 @@ pub use actions::{
     create_virtual_branch, create_virtual_branch_from_branch_with_perm,
     get_initial_integration_steps_for_branch, integrate_branch_with_steps, integrate_upstream,
     integrate_upstream_commits, push_base_branch, resolve_upstream_integration, set_base_branch,
-    set_target_push_remote, upstream_integration_statuses,
+    set_target_push_remote, upstream_integration_statuses, upstream_integration_statuses_with_perm,
 };
 
 mod r#virtual;


### PR DESCRIPTION
```rust
let (guard, outcome) = crate::command::legacy::status::tui_with_options(
    ctx,
    guard,
    &mut out,
    TuiRunOptions::PickChanges,
)?;

match outcome {
    TuiOutcome::None => {
        // the user quit
    },
    TuiOutcome::CliIds(cli_ids) => {
        // the user marked `cli_ids` and confirmed
    },
}
```