### PR TITLE
Fix: commit tail height

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.module.css
@@ -37,7 +37,7 @@
 	flex-direction: column;
 }
 
-.segmentParentItemRow:last-child {
+.segmentParentItemRow {
 	height: 8px;
 	min-height: auto;
 	overflow: hidden;


### PR DESCRIPTION
Each branch in a stack should have the same tail height.

Before:
<img width="337" height="283" alt="image" src="https://github.com/user-attachments/assets/8a81cf36-9291-42db-ad65-345ba9372498" />

<img width="373" height="429" alt="Screenshot 2026-06-15 at 16 36 38" src="https://github.com/user-attachments/assets/e39c24da-0b55-463d-8864-b40183d9cbde" />

Fix:

<img width="370" height="288" alt="Screenshot 2026-06-15 at 16 48 09" src="https://github.com/user-attachments/assets/10ca10cf-63db-4e95-a6f5-29f340fa049a" />

