### PR TITLE
feat(desktop): add antigravity ide as a default editor

### DIFF
--- a/apps/desktop/src/components/settings/GeneralSettings.svelte
+++ b/apps/desktop/src/components/settings/GeneralSettings.svelte
@@ -70,6 +70,7 @@
 		{ schemeIdentifer: "zed", displayName: "Zed" },
 		{ schemeIdentifer: "cursor", displayName: "Cursor" },
 		{ schemeIdentifer: "trae", displayName: "Trae" },
+		{ schemeIdentifer: "antigravity-ide", displayName: "Antigravity IDE" },
 	];
 	const editorOptionsForSelect = editorOptions.map((option) => ({
 		label: option.displayName,

--- a/apps/desktop/src/lib/backend/url.test.ts
+++ b/apps/desktop/src/lib/backend/url.test.ts
@@ -2,7 +2,7 @@ import { getEditorUri } from "$lib/backend/url";
 import { describe, expect, test } from "vitest";
 
 describe("getEditorUri", () => {
-	test.each(["vscode", "vscode-insiders", "vscodium", "cursor", "windsurf", "trae"])(
+	test.each(["vscode", "vscode-insiders", "vscodium", "cursor", "windsurf", "trae", "antigravity-ide"])(
 		"%s keeps query parameters",
 		(schemeId) => {
 			expect(

--- a/apps/desktop/src/lib/backend/url.test.ts
+++ b/apps/desktop/src/lib/backend/url.test.ts
@@ -2,18 +2,23 @@ import { getEditorUri } from "$lib/backend/url";
 import { describe, expect, test } from "vitest";
 
 describe("getEditorUri", () => {
-	test.each(["vscode", "vscode-insiders", "vscodium", "cursor", "windsurf", "trae", "antigravity-ide"])(
-		"%s keeps query parameters",
-		(schemeId) => {
-			expect(
-				getEditorUri({
-					schemeId,
-					path: ["/home/example/project"],
-					searchParams: { windowId: "_blank" },
-				}),
-			).toBe(`${schemeId}://file/home/example/project?windowId=_blank`);
-		},
-	);
+	test.each([
+		"vscode",
+		"vscode-insiders",
+		"vscodium",
+		"cursor",
+		"windsurf",
+		"trae",
+		"antigravity-ide",
+	])("%s keeps query parameters", (schemeId) => {
+		expect(
+			getEditorUri({
+				schemeId,
+				path: ["/home/example/project"],
+				searchParams: { windowId: "_blank" },
+			}),
+		).toBe(`${schemeId}://file/home/example/project?windowId=_blank`);
+	});
 
 	test("zed drops query parameters since it treats them as part of the file path", () => {
 		expect(

--- a/apps/desktop/src/lib/backend/url.ts
+++ b/apps/desktop/src/lib/backend/url.ts
@@ -44,6 +44,7 @@ const VSCODE_COMPATIBLE_SCHEMES = new Set([
 	"cursor",
 	"windsurf",
 	"trae",
+	"antigravity-ide",
 ]);
 
 export function getEditorUri(params: EditorUriParams): string {

--- a/crates/but-api/src/open/mod.rs
+++ b/crates/but-api/src/open/mod.rs
@@ -43,6 +43,7 @@ pub(crate) fn open_that(target_url: &Url) -> anyhow::Result<()> {
         "windsurf",
         "cursor",
         "trae",
+        "antigravity-ide",
         "file",
     ]
     .contains(&target_url.scheme())
@@ -190,7 +191,13 @@ fn wsl_editor_invocation(target_url: &Url) -> Option<(&'static str, Vec<String>)
 fn is_vscode_or_compatible(scheme: &str) -> bool {
     matches!(
         scheme,
-        "vscode" | "vscode-insiders" | "vscodium" | "cursor" | "windsurf" | "trae"
+        "vscode"
+            | "vscode-insiders"
+            | "vscodium"
+            | "cursor"
+            | "windsurf"
+            | "trae"
+            | "antigravity-ide"
     )
 }
 
@@ -207,6 +214,7 @@ fn scheme_to_wsl_editor_command(scheme: &str) -> Option<&'static str> {
         "cursor" => Some("cursor"),
         "windsurf" => Some("windsurf"),
         "trae" => Some("trae"),
+        "antigravity-ide" => Some("antigravity-ide"),
         _ => {
             tracing::warn!(%scheme, "missing WSL editor scheme mapping");
             None
@@ -243,6 +251,23 @@ mod wsl_tests {
             wsl_editor_invocation(&url),
             Some((
                 "cursor",
+                vec![
+                    "--goto".to_owned(),
+                    "/home/example/project/src/main.rs:42:7".to_owned(),
+                ],
+            ))
+        );
+    }
+
+    #[test]
+    fn antigravity_editor_url_becomes_goto_cli_invocation() {
+        let url =
+            Url::parse("antigravity-ide://file/home/example/project/src/main.rs:42:7").unwrap();
+
+        assert_eq!(
+            wsl_editor_invocation(&url),
+            Some((
+                "antigravity-ide",
                 vec![
                     "--goto".to_owned(),
                     "/home/example/project/src/main.rs:42:7".to_owned(),

--- a/crates/but-api/src/open/mod.rs
+++ b/crates/but-api/src/open/mod.rs
@@ -260,23 +260,6 @@ mod wsl_tests {
     }
 
     #[test]
-    fn antigravity_editor_url_becomes_goto_cli_invocation() {
-        let url =
-            Url::parse("antigravity-ide://file/home/example/project/src/main.rs:42:7").unwrap();
-
-        assert_eq!(
-            wsl_editor_invocation(&url),
-            Some((
-                "antigravity-ide",
-                vec![
-                    "--goto".to_owned(),
-                    "/home/example/project/src/main.rs:42:7".to_owned(),
-                ],
-            ))
-        );
-    }
-
-    #[test]
     fn vscode_project_url_becomes_new_window_cli_invocation() {
         let url = Url::parse("vscode://file/home/example/project?windowId=_blank").unwrap();
 


### PR DESCRIPTION
## 🧢 Changes
Adds "Open in" editor support for [Antigravity IDE](https://antigravity.google/product/antigravity-ide)

## ☕️ Reasoning
This provides GitButler Desktop with another option to streamline development with Antigravity IDE

## 🎫 Affected issues

Fixes: #14136


<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
