### PR TITLE
Don't require metadata when updating workspace

### DIFF
--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -211,7 +211,9 @@ pub fn workspace_integrate_upstream_only_with_perm(
         let materialized = rebase.materialize()?;
         project_meta.persist_to_local_config(&repo)?;
 
-        if let Some(ref_name) = materialized.workspace.ref_name() {
+        if let Some(ref_name) = materialized.workspace.ref_name()
+            && let Some(ws_meta) = ws_meta
+        {
             let mut md = materialized.meta.workspace(ref_name)?;
             *md = ws_meta;
             md.set_project_meta(project_meta);

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -39,7 +39,7 @@ pub struct BottomUpdate {
 /// The outcome of integrating upstream
 pub struct IntegrateUpstreamOutcome<'ws, 'meta, M: RefMetadata> {
     /// The updated workspace metadata.
-    pub ws_meta: but_core::ref_metadata::Workspace,
+    pub ws_meta: Option<but_core::ref_metadata::Workspace>,
     /// The updated project metadata.
     pub project_meta: ProjectMeta,
     /// The rebased outcome.
@@ -51,6 +51,14 @@ struct AnnotatedNode {
     to_rebase: bool,
     historically_integrated: bool,
     content_integrated: bool,
+    /// Only set to Some on references. Set to Some(<reference getting
+    /// integrated>) if all the nodes exclusive to the current reference are
+    /// marked as content or historically integrated or if the reference itself
+    /// is historically integrated.
+    ///
+    /// Can be a remote reference, so care out to be exercised to ensure we
+    /// don't try deleting remote references unexpectedly.
+    reference_integrated: Option<gix::refs::FullName>,
 }
 
 impl AnnotatedNode {
@@ -59,6 +67,7 @@ impl AnnotatedNode {
             to_rebase: false,
             historically_integrated: false,
             content_integrated: false,
+            reference_integrated: None,
         }
     }
 }
@@ -128,10 +137,7 @@ pub fn integrate_upstream<'ws, 'meta, M: RefMetadata>(
     repo: &gix::Repository,
     updates: Vec<BottomUpdate>,
 ) -> Result<IntegrateUpstreamOutcome<'ws, 'meta, M>> {
-    let mut ws_meta = workspace
-        .metadata
-        .clone()
-        .context("Cannot update a workspace with no metadata")?;
+    let mut ws_meta = workspace.metadata.clone();
     let target_sha = project_meta
         .target_commit_id
         .context("Cannot update a workspace without a target sha")?;
@@ -227,67 +233,46 @@ pub fn integrate_upstream<'ws, 'meta, M: RefMetadata>(
     let workspace_commit_selector = head_is_workspace_commit
         .then(|| editor.select_commit(head_commit_id))
         .transpose()?;
-    let mut integrated_branch_refs = HashSet::new();
     let mut fully_integrated_workspace_parents = HashSet::new();
     for stack in &stacks {
         let is_selected = stack.nodes.values().any(|attrs| attrs.to_rebase) || stack.to_merge;
-        let is_fully_integrated = stack
-            .nodes
-            .values()
-            .all(|attrs| attrs.historically_integrated || attrs.content_integrated);
+        let is_fully_integrated = stack.nodes.values().all(|attrs| {
+            attrs.historically_integrated
+                || attrs.content_integrated
+                || attrs.reference_integrated.is_some()
+        });
         if !is_selected {
             continue;
         }
 
-        for ws_stack in ws_meta
-            .stacks
-            .iter()
-            .filter(|stack| stack.workspacecommit_relation.is_in_workspace())
-        {
-            for branch in &ws_stack.branches {
-                if branch.ref_name.as_ref() == target_ref.ref_name.as_ref() {
+        if is_fully_integrated {
+            // TODO: Look into what happens when the head is an irrelevant
+            // reference like the target_sha or a remote reference. In these
+            // cases, we should look to see if it has a relevant reference
+            // parent.
+            for head in &stack.heads {
+                let Step::Reference { refname } = editor.lookup_step(*head)? else {
+                    continue;
+                };
+                if refname.as_ref() == target_ref.ref_name.as_ref() {
                     continue;
                 }
+                fully_integrated_workspace_parents.insert(*head);
+            }
+        }
 
-                let ref_selector = match branch.ref_name.to_selector(&editor) {
-                    Ok(selector) => selector,
-                    Err(_) => continue,
-                };
-                let direct_parents = editor.direct_parents(ref_selector)?;
-                if !direct_parents.is_empty()
-                    && direct_parents.iter().all(|(parent, _)| {
-                        stack.nodes.get(parent).is_some_and(|attrs| {
-                            attrs.historically_integrated || attrs.content_integrated
-                        })
-                    })
-                {
-                    integrated_branch_refs.insert(branch.ref_name.clone());
+        // Remove integrated refs from the workspace and from git.
+        // TODO: allow to keep some references.
+        for (selector, attrs) in &stack.nodes {
+            if let Some(ref_name) = attrs.reference_integrated.as_ref()
+                && ref_name.category() == Some(gix::refs::Category::LocalBranch)
+            {
+                editor.replace(*selector, Step::None)?;
+                if let Some(ws_meta) = ws_meta.as_mut() {
+                    ws_meta.remove_segment(ref_name.as_ref());
                 }
             }
         }
-
-        if !is_fully_integrated {
-            continue;
-        }
-
-        for head in &stack.heads {
-            let Step::Reference { refname } = editor.lookup_step(*head)? else {
-                continue;
-            };
-            if refname.as_ref() == target_ref.ref_name.as_ref() {
-                continue;
-            }
-            fully_integrated_workspace_parents.insert(*head);
-        }
-    }
-
-    // Remove integrated refs from the workspace and from git.
-    // TODO: allow to keep some references.
-    for ref_name in &integrated_branch_refs {
-        if let Ok(ref_selector) = ref_name.to_selector(&editor) {
-            editor.replace(ref_selector, Step::None)?;
-        }
-        ws_meta.remove_segment(ref_name.as_ref());
     }
 
     // Disconnect all stack heads from the workspace commit, if any.
@@ -502,41 +487,70 @@ fn collect_stacks<'ws, 'meta, M: RefMetadata>(
             }
         }
 
-        // Propagate content_integrated up to Reference or None steps who's
-        // parents are _all_ content_integrated.
+        let reference_nodes = stack
+            .nodes
+            .keys()
+            .filter_map(|n| {
+                editor
+                    .lookup_step(*n)
+                    .map(|step| match step {
+                        Step::Reference { refname } => Some((*n, refname)),
+                        _ => None,
+                    })
+                    .transpose()
+            })
+            .collect::<Result<HashMap<_, _>>>()?;
+
+        // Identify whether all the commits that are exclusively referenced by a
+        // given reference in the stack are all integrated upstream.
         //
-        // We shouldn't need to do the same for historically_integrated
-        // references because they should already be covered by the topography
-        // on the Editor's graph.
-        let mut tips = bottoms
-            .iter()
-            .filter_map(|b| stack.nodes.get(b)?.content_integrated.then_some(*b))
-            .collect::<Vec<_>>();
-        let mut seen = tips.iter().cloned().collect::<HashSet<_>>();
+        // If all the commits are integrated, or if the reference itself is
+        // considered historically integrated, we set the `reference_integrated`
+        // flag which flags the reference for deletion, if it's a selected
+        // target to be updated.
+        for (r_sel, r_name) in reference_nodes.iter() {
+            let mut tips = vec![*r_sel];
+            let mut seen = tips.iter().cloned().collect::<HashSet<_>>();
+            let mut all_integrated = true;
+            let mut traversed_commits = false;
 
-        while let Some(tip) = tips.pop() {
-            for (child, _) in editor.direct_children(tip)? {
-                if editor
-                    .direct_parents(child)?
-                    .into_iter()
-                    .filter_map(|(p, _)| stack.nodes.get(&p))
-                    .any(|p_attr| !p_attr.content_integrated)
-                {
-                    continue;
-                }
+            'traversal: while let Some(tip) = tips.pop() {
+                for (parent, _) in editor.direct_parents(tip)? {
+                    let Some(attrs) = stack.nodes.get(&parent) else {
+                        continue;
+                    };
+                    let parent_is_non_local_reference =
+                        if let Some(r_parent_name) = reference_nodes.get(&parent) {
+                            if r_parent_name.category() == Some(gix::refs::Category::LocalBranch) {
+                                continue;
+                            } else {
+                                true
+                            }
+                        } else {
+                            traversed_commits = true;
+                            false
+                        };
 
-                let c_step = editor.lookup_step(child)?;
-                let Some(c_attrs) = stack.nodes.get_mut(&child) else {
-                    continue;
-                };
-                if matches!(c_step, Step::Pick(_)) && !c_attrs.content_integrated {
-                    continue;
+                    if seen.insert(parent) {
+                        if !(parent_is_non_local_reference
+                            || attrs.content_integrated
+                            || attrs.historically_integrated)
+                        {
+                            all_integrated = false;
+                            break 'traversal;
+                        }
+                        tips.push(parent);
+                    }
                 }
-                if seen.insert(child) {
-                    tips.push(child);
+            }
+            let Some(node) = stack.nodes.get_mut(r_sel) else {
+                continue;
+            };
 
-                    c_attrs.content_integrated = true;
-                }
+            if traversed_commits {
+                node.reference_integrated = all_integrated.then_some(r_name.clone());
+            } else {
+                node.reference_integrated = node.historically_integrated.then_some(r_name.clone());
             }
         }
     }

--- a/crates/but-workspace/tests/fixtures/scenario/integrated-bottom-branch-no-workspace.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/integrated-bottom-branch-no-workspace.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A single stack of two branches, A on top of B, with no workspace branch,
+# workspace commit, or virtual-branch metadata. HEAD is checked out directly on
+# the top of the stack (A). The bottom branch B is historically integrated into
+# the target, and the target ref (origin/main) has advanced one commit (X) past
+# B, while A remains to be integrated.
+git init
+commit M1
+setup_target_to_match_main
+
+git checkout -b B
+commit-file B.txt B1
+
+git checkout -b A
+commit-file A.txt A1
+
+# Advance the target one commit beyond the integrated bottom branch B.
+git checkout -b upstream-main B
+commit-file X.txt X1
+git update-ref refs/remotes/origin/main upstream-main
+
+git checkout A
+git branch -D upstream-main

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -87,8 +87,8 @@ fn diamond_partially_historically_integrated_rebase() -> Result<()> {
     * 7de2393 (origin/master, master) o4
     *   7d62953 (o3) o3
     |\  
-    | * ffb801b (B) B
-    | * 448b195 (A) A
+    | * ffb801b B
+    | * 448b195 A
     * | d1b2089 o2
     |/  
     * 85aa44b (o1) o1
@@ -173,9 +173,9 @@ fn diamond_partially_historically_integrated_merge() -> Result<()> {
     | |_|/  
     |/| |   
     | * | d6a7004 (D) D
-    * | | ffb801b (B) B
+    * | | ffb801b B
     |/ /  
-    * / 448b195 (A) A
+    * / 448b195 A
     |/  
     * 85aa44b (o1) o1
     ");
@@ -334,12 +334,173 @@ fn diamond_partially_content_integrated_merge() -> Result<()> {
     * |   4827d2f (C) C
     |\ \  
     | * | d8d0970 (D) D
-    * | | 3d3bfa7 (B) B
+    * | | 3d3bfa7 B
     |/ /  
-    * / f5b02d3 (A) A
+    * / f5b02d3 A
     |/  
     * 85aa44b (o1) o1
     ");
+
+    Ok(())
+}
+
+#[test]
+fn integrated_bottom_branch_no_workspace_rebase() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("integrated-bottom-branch-no-workspace")?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+
+    // No workspace branch, commit, or stack metadata: HEAD is checked out directly on `A`,
+    // the top of a two-branch stack whose bottom branch `B` is integrated into the target.
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta(&meta)?,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * e792f40 (HEAD -> A) add A1
+    | * 8c8a843 (origin/main) add X1
+    |/  
+    * b38b04b (B) add B1
+    * 3183e43 (main) M1
+    ");
+
+    let mut workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    ⌂:0:A[🌳] <> ✓refs/remotes/origin/main⇣2 on 3183e43
+    └── ≡:0:A[🌳] on 3183e43 {1}
+        ├── :0:A[🌳]
+        │   └── ·e792f40
+        └── :3:B
+            └── ·b38b04b
+    ");
+    let project_meta = workspace.graph.project_meta.clone();
+    let but_workspace::IntegrateUpstreamOutcome { rebase, .. } = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        project_meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("B")?.detach()),
+        }],
+    )?;
+
+    rebase.materialize()?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * 10e781b (HEAD -> A) add A1
+    * 8c8a843 (origin/main) add X1
+    * b38b04b add B1
+    * 3183e43 (main) M1
+    ");
+
+    assert!(
+        repo.try_find_reference("B")?.is_none(),
+        "the integrated bottom branch should be removed from the refs after rebase integration"
+    );
+    assert_eq!(
+        repo.rev_parse_single("A^")?.detach(),
+        repo.rev_parse_single("origin/main")?.detach(),
+        "the top branch should be reparented directly onto the integrated target tip"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn integrated_bottom_branch_no_workspace_merge() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("integrated-bottom-branch-no-workspace")?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+
+    // No workspace branch, commit, or stack metadata: HEAD is checked out directly on `A`,
+    // the top of a two-branch stack whose bottom branch `B` is integrated into the target.
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta(&meta)?,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * e792f40 (HEAD -> A) add A1
+    | * 8c8a843 (origin/main) add X1
+    |/  
+    * b38b04b (B) add B1
+    * 3183e43 (main) M1
+    ");
+
+    let mut workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    ⌂:0:A[🌳] <> ✓refs/remotes/origin/main⇣2 on 3183e43
+    └── ≡:0:A[🌳] on 3183e43 {1}
+        ├── :0:A[🌳]
+        │   └── ·e792f40
+        └── :3:B
+            └── ·b38b04b
+    ");
+    let project_meta = workspace.graph.project_meta.clone();
+    let but_workspace::IntegrateUpstreamOutcome { rebase, .. } = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        project_meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Merge,
+            selector: RelativeTo::Commit(repo.rev_parse_single("B")?.detach()),
+        }],
+    )?;
+
+    rebase.materialize()?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   7ce831c (HEAD -> A) Merge refs/remotes/origin/main into merge
+    |\  
+    | * 8c8a843 (origin/main) add X1
+    * | e792f40 add A1
+    |/  
+    * b38b04b add B1
+    * 3183e43 (main) M1
+    ");
+
+    assert!(
+        repo.try_find_reference("B")?.is_none(),
+        "the integrated bottom branch should be removed from the refs after merge integration"
+    );
+
+    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?.detach())?;
+    let parents = branch_tip.parent_ids().collect::<Vec<_>>();
+    assert_eq!(
+        parents.len(),
+        2,
+        "merge integration should create a merge commit at the top of the stack"
+    );
+    assert_eq!(
+        parents[1].detach(),
+        repo.rev_parse_single("origin/main")?.detach(),
+        "merge integration should keep the integrated target tip as the second parent"
+    );
 
     Ok(())
 }
@@ -1523,7 +1684,9 @@ fn integrate_and_materialize<M: RefMetadata>(
         project_meta,
     } = integrate_upstream(workspace, meta, project_meta(&*meta)?, repo, updates)?;
     let materialized = rebase.materialize()?;
-    if let Some(ref_name) = materialized.workspace.ref_name() {
+    if let Some(ref_name) = materialized.workspace.ref_name()
+        && let Some(ws_meta) = ws_meta
+    {
         let mut md = materialized.meta.workspace(ref_name)?;
         *md = ws_meta;
         md.set_project_meta(project_meta);


### PR DESCRIPTION
This changes the mechanism for detecting whether individual references are integrated from using the ws_meta to one that does some inspection of the graph.

We want to delete a reference if all the commits that it exclusivly references in the stack have been either historically or content integrated.

We will also delete references if they have been deemed historically integrated and they have no child commits.
