### PR TITLE
feat(but2): add support for `commit2 --above/--below <commit or branch>`

### DIFF
--- a/crates/but-transaction/src/lib.rs
+++ b/crates/but-transaction/src/lib.rs
@@ -318,6 +318,32 @@ where
             .expect("rebase is always Some(_)")
             .overlayed_graph()?;
         let workspace = graph.into_workspace()?;
+        let anchor_segment_oldest_commit_id = match &anchor {
+            Some(but_workspace::branch::create_reference::Anchor::AtSegment {
+                ref_name, ..
+            }) => {
+                let (_, segment) =
+                    workspace.try_find_segment_and_stack_by_refname(ref_name.as_ref())?;
+                Some(
+                    segment
+                        .commits
+                        .last()
+                        .map(|commit| commit.id)
+                        .or_else(|| {
+                            workspace
+                                .tip_commit_by_segment_id(segment.id)
+                                .map(|commit| commit.id)
+                        })
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "Cannot position reference below unborn segment '{}'",
+                                ref_name.shorten()
+                            )
+                        })?,
+                )
+            }
+            _ => None,
+        };
         let mut meta = RecordingMetadata {
             workspace_name: workspace.ref_name().map(ToOwned::to_owned),
             workspace: workspace.metadata.clone(),
@@ -326,7 +352,7 @@ where
 
         but_workspace::branch::create_reference(
             ref_name,
-            anchor,
+            anchor.clone(),
             self.repo(),
             &workspace,
             &mut meta,
@@ -356,11 +382,71 @@ where
                 .find_reference(ref_name)?
                 .peel_to_id()?
                 .detach();
-            let target = editor.select_commit(target_id)?;
-            let reference = editor.add_step(Step::Reference {
+            let reference = Step::Reference {
                 refname: ref_name.to_owned(),
-            })?;
-            editor.add_edge(reference, target, 0)?;
+            };
+
+            match anchor {
+                Some(but_workspace::branch::create_reference::Anchor::AtCommit {
+                    commit_id,
+                    position: but_workspace::branch::create_reference::Position::Below,
+                }) => {
+                    editor.insert(
+                        editor.select_commit(commit_id)?,
+                        reference,
+                        InsertSide::Below,
+                    )?;
+                }
+                Some(but_workspace::branch::create_reference::Anchor::AtSegment {
+                    ref_name: anchor_ref,
+                    position: but_workspace::branch::create_reference::Position::Above,
+                }) => {
+                    editor.insert(
+                        editor.select_reference(anchor_ref.as_ref())?,
+                        reference,
+                        InsertSide::Above,
+                    )?;
+                }
+                Some(but_workspace::branch::create_reference::Anchor::AtSegment {
+                    position: but_workspace::branch::create_reference::Position::Below,
+                    ..
+                }) => {
+                    let anchor_oldest_commit = anchor_segment_oldest_commit_id
+                        .expect("AtSegment anchor always has oldest commit resolved");
+                    editor.insert(
+                        editor.select_commit(anchor_oldest_commit)?,
+                        reference,
+                        InsertSide::Below,
+                    )?;
+                }
+                Some(but_workspace::branch::create_reference::Anchor::AtReference {
+                    ref_name: anchor_ref,
+                    position,
+                }) => {
+                    let side = match position {
+                        but_workspace::branch::create_reference::Position::Above => {
+                            InsertSide::Above
+                        }
+                        but_workspace::branch::create_reference::Position::Below => {
+                            InsertSide::Below
+                        }
+                    };
+                    editor.insert(
+                        editor.select_reference(anchor_ref.as_ref())?,
+                        reference,
+                        side,
+                    )?;
+                }
+                Some(but_workspace::branch::create_reference::Anchor::AtCommit {
+                    position: but_workspace::branch::create_reference::Position::Above,
+                    ..
+                })
+                | None => {
+                    let target = editor.select_commit(target_id)?;
+                    let reference = editor.add_step(reference)?;
+                    editor.add_edge(reference, target, 0)?;
+                }
+            }
             Ok(((), editor.rebase()?))
         })
     }

--- a/crates/but-transaction/src/tests.rs
+++ b/crates/but-transaction/src/tests.rs
@@ -291,6 +291,77 @@ fn create_reference_then_remove_it_in_same_transaction() {
 }
 
 #[test]
+fn create_reference_then_commit_below_anchor_keeps_commit_in_workspace() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    let [three, base] = find_commits(&env, ["1e25c58", "6674d4f"]);
+
+    let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
+    let mut ctx = Context::from_repo(repo)
+        .map(Context::with_memory_app_cache)
+        .unwrap();
+
+    let mut meta = ctx.meta().unwrap();
+    let snapshot_details = SnapshotDetails::new(OperationKind::CreateCommit);
+    let branch = FullName::try_from("refs/heads/branch").unwrap();
+    let refname = FullName::try_from("refs/heads/new-lower-branch").unwrap();
+
+    let outcome = with_transaction(
+        &mut ctx,
+        &mut meta,
+        snapshot_details,
+        DryRun::No,
+        |mut tx| {
+            tx.create_reference(
+                refname.as_ref(),
+                Anchor::at_segment(branch.as_ref(), Position::Below),
+                |_| but_core::ref_metadata::StackId::generate(),
+                None,
+            )?;
+            let new_commit =
+                tx.insert_blank_commit(RelativeTo::Reference(refname.clone()), InsertSide::Below)?;
+
+            Ok(DynamicOutcome::<_, ()>::Commit(new_commit))
+        },
+    )
+    .unwrap();
+
+    let DynamicOutcome::Commit((new_commit, _workspace)) = outcome else {
+        panic!("transaction should commit");
+    };
+
+    assert_eq!(Some(new_commit), ref_target(&env, refname.as_ref()));
+
+    let repo = env.open_repo().unwrap();
+    let mut branch_commit = ref_target(&env, branch.as_ref()).unwrap();
+    let mut commits_above_new_branch = 0;
+    while branch_commit != new_commit {
+        commits_above_new_branch += 1;
+        let commit = repo.find_commit(branch_commit).unwrap();
+        let commit = commit.decode().unwrap();
+        branch_commit = commit.parents().next().unwrap();
+    }
+    assert_eq!(
+        3, commits_above_new_branch,
+        "new lower branch commit should be below oldest commit in anchored segment"
+    );
+    let lower_branch_tip = repo.find_commit(new_commit).unwrap();
+    let lower_branch_tip = lower_branch_tip.decode().unwrap();
+    assert_eq!(
+        Some(base),
+        lower_branch_tip.parents().next(),
+        "new lower branch commit should be inserted above segment base"
+    );
+    assert_ne!(
+        Some(three),
+        ref_target(&env, branch.as_ref()),
+        "upper branch should be rebased onto inserted lower branch commit"
+    );
+    assert_num_snapshots(&ctx, 1);
+}
+
+#[test]
 fn create_reference_then_commit_relative_to_it() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
     env.setup_metadata(&["A"]).unwrap();

--- a/crates/but/src/args/atoms/branch_arg.rs
+++ b/crates/but/src/args/atoms/branch_arg.rs
@@ -149,12 +149,10 @@ impl BranchArg {
     }
 
     /// Resolve the argument to a branch that exists in the repository.
-    pub fn resolve_branch(&self, ctx: &but_ctx::Context) -> CliResult<ResolvedBranchRef> {
-        let repo = ctx.repo.get()?;
-
+    pub fn resolve_branch(&self, repo: &gix::Repository) -> CliResult<ResolvedBranchRef> {
         for category in [Category::LocalBranch, Category::RemoteBranch] {
             let branch_name = category.to_full_name(&*self.0)?;
-            if let Some(resolved) = resolve_branch_ref(&repo, &branch_name)? {
+            if let Some(resolved) = resolve_branch_ref(repo, &branch_name)? {
                 return Ok(resolved);
             }
         }
@@ -165,7 +163,7 @@ impl BranchArg {
                 remote_name.as_bstr().to_str_lossy(),
                 self.0
             ))?;
-            if let Some(resolved) = resolve_branch_ref(&repo, &branch_name)? {
+            if let Some(resolved) = resolve_branch_ref(repo, &branch_name)? {
                 return Ok(resolved);
             }
         }

--- a/crates/but/src/args/atoms/cli_id.rs
+++ b/crates/but/src/args/atoms/cli_id.rs
@@ -28,12 +28,12 @@ impl CliIdArg {
     /// workspace.
     pub fn resolve_in_workspace(
         &self,
-        ctx: &but_ctx::Context,
+        repo: &gix::Repository,
         id_map: &IdMap,
         purpose: Purpose,
         priority: Option<Priority>,
     ) -> CliResult<ResolvedCliIdArg> {
-        if let Some(id) = self.try_resolve(ctx, id_map, purpose, priority)? {
+        if let Some(id) = self.try_resolve(repo, id_map, purpose, priority)? {
             Ok(id)
         } else {
             Err(bad_input(format!("Could not find {purpose}: '{self}'")).into())
@@ -45,12 +45,12 @@ impl CliIdArg {
     /// Returns `Ok(None)` if it doesn't exist in the workspace.
     pub fn try_resolve(
         &self,
-        ctx: &but_ctx::Context,
+        repo: &gix::Repository,
         id_map: &IdMap,
         purpose: Purpose,
         priority: Option<Priority>,
     ) -> CliResult<Option<ResolvedCliIdArg>> {
-        let Some(id) = try_resolve_cli_id(self, ctx, id_map, purpose, priority)? else {
+        let Some(id) = try_resolve_cli_id(self, repo, id_map, purpose, priority)? else {
             return Ok(None);
         };
         Ok(Some(match id {
@@ -67,10 +67,10 @@ impl CliIdArg {
     /// Resolve the argument to a commit that exists in the workspace.
     pub fn resolve_commit_in_workspace(
         &self,
-        ctx: &but_ctx::Context,
+        repo: &gix::Repository,
         id_map: &IdMap,
     ) -> CliResult<gix::ObjectId> {
-        if let Some(commit) = self.try_resolve_commit(ctx, id_map)? {
+        if let Some(commit) = self.try_resolve_commit(repo, id_map)? {
             Ok(commit)
         } else {
             Err(bad_input(format!("Could not find commit: '{self}'")).into())
@@ -82,11 +82,11 @@ impl CliIdArg {
     /// Returns `Ok(None)` if it doesn't exist in the workspace.
     pub fn try_resolve_commit(
         &self,
-        ctx: &but_ctx::Context,
+        repo: &gix::Repository,
         id_map: &IdMap,
     ) -> CliResult<Option<gix::ObjectId>> {
         let Some(id) =
-            try_resolve_cli_id(self, ctx, id_map, Purpose::Commit, Some(Priority::Commit))?
+            try_resolve_cli_id(self, repo, id_map, Purpose::Commit, Some(Priority::Commit))?
         else {
             return Ok(None);
         };
@@ -107,10 +107,10 @@ impl CliIdArg {
     /// Resolve the argument to a branch that exists in the workspace.
     pub fn resolve_branch_in_workspace(
         &self,
-        ctx: &but_ctx::Context,
+        repo: &gix::Repository,
         id_map: &IdMap,
     ) -> CliResult<BranchArg> {
-        if let Some(branch) = self.try_resolve_branch(ctx, id_map)? {
+        if let Some(branch) = self.try_resolve_branch(repo, id_map)? {
             Ok(branch)
         } else {
             Err(bad_input(format!("Could not find branch: '{self}'")).into())
@@ -122,11 +122,11 @@ impl CliIdArg {
     /// Returns `Ok(None)` if it doesn't exist in the workspace.
     pub fn try_resolve_branch(
         &self,
-        ctx: &but_ctx::Context,
+        repo: &gix::Repository,
         id_map: &IdMap,
     ) -> CliResult<Option<BranchArg>> {
         let Some(id) =
-            try_resolve_cli_id(self, ctx, id_map, Purpose::Branch, Some(Priority::Branch))?
+            try_resolve_cli_id(self, repo, id_map, Purpose::Branch, Some(Priority::Branch))?
         else {
             return Ok(None);
         };
@@ -168,13 +168,13 @@ pub enum Priority {
 // the workspace so we need a specific type for that.
 fn try_resolve_cli_id(
     arg: &CliIdArg,
-    ctx: &but_ctx::Context,
+    repo: &gix::Repository,
     id_map: &IdMap,
     purpose: Purpose,
     priority: Option<Priority>,
 ) -> CliResult<Option<CliId>> {
     let mut target_ids = id_map
-        .parse_using_context(&arg.0, ctx)?
+        .parse_using_repo(&arg.0, repo)?
         .into_iter()
         .peekable();
     let Some(target) = target_ids.next() else {

--- a/crates/but/src/args/commit2.rs
+++ b/crates/but/src/args/commit2.rs
@@ -1,4 +1,4 @@
-use crate::args::atoms::BranchArg;
+use crate::args::atoms::{BranchArg, CliIdArg};
 
 #[derive(Debug, clap::Parser)]
 pub struct Platform {
@@ -6,8 +6,12 @@ pub struct Platform {
     pub no_message: bool,
     #[clap(short, long, conflicts_with = "no_message")]
     pub message: Option<Vec<String>>,
-    #[clap(short, long)]
+    #[clap(short, long, group = "targeting")]
     pub branch: Option<Option<BranchArg>>,
     #[clap(long)]
     pub empty: bool,
+    #[clap(long, group = "targeting")]
+    pub above: Option<CliIdArg>,
+    #[clap(long, group = "targeting")]
+    pub below: Option<CliIdArg>,
 }

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -24,7 +24,8 @@ pub fn delete(
     let branch_arg = {
         let guard = ctx.exclusive_worktree_access();
         let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
-        branch_arg.resolve_branch_in_workspace(ctx, &id_map)?
+        let repo = ctx.repo.get()?;
+        branch_arg.resolve_branch_in_workspace(&repo, &id_map)?
     };
 
     let head_info = but_api::legacy::workspace::head_info(ctx)?;
@@ -70,14 +71,17 @@ pub fn new(
     let mut guard = ctx.exclusive_worktree_access();
     let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
 
-    let resolved_anchor = anchor_arg
-        .clone()
-        .and_then(|anchor| {
-            anchor
-                .try_resolve(ctx, &id_map, Purpose::Anchor, None)
-                .transpose()
-        })
-        .transpose()?;
+    let resolved_anchor = {
+        let repo = ctx.repo.get()?;
+        anchor_arg
+            .clone()
+            .and_then(|anchor| {
+                anchor
+                    .try_resolve(&repo, &id_map, Purpose::Anchor, None)
+                    .transpose()
+            })
+            .transpose()?
+    };
 
     let anchor = resolved_anchor
         .clone()

--- a/crates/but/src/command/legacy/branch/show.rs
+++ b/crates/but/src/command/legacy/branch/show.rs
@@ -24,8 +24,9 @@ pub fn show(
     let branch_arg = {
         let guard = ctx.exclusive_worktree_access();
         let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
+        let repo = ctx.repo.get()?;
         branch_arg
-            .try_resolve_branch(ctx, &id_map)?
+            .try_resolve_branch(&repo, &id_map)?
             .unwrap_or(BranchArg(branch_arg.0))
     };
 
@@ -118,16 +119,16 @@ struct CommitRef {
 fn check_merge_conflicts(ctx: &Context, branch_name: &str) -> CliResult<MergeCheck> {
     use but_core::RepositoryExt;
 
-    let branch = BranchArg(branch_name.to_owned()).resolve_branch(ctx)?;
+    let guard = ctx.shared_worktree_access();
+    let repo = ctx.repo.get()?;
+    let branch = BranchArg(branch_name.to_owned()).resolve_branch(&repo)?;
 
     // Find merge base
-    let guard = ctx.shared_worktree_access();
     let (merge_base, target) = workspace_target::merge_base_with_target_with_perm(
         ctx,
         guard.read_permission(),
         branch.head,
     )?;
-    let repo = ctx.repo.get()?;
     let merge_repo = ctx.clone_repo_for_merging_non_persisting()?;
     let merge_base_tree_id = repo.find_commit(merge_base)?.tree_id()?.detach();
     let target_tree_id = repo.find_commit(target.oid())?.tree_id()?.detach();
@@ -255,16 +256,16 @@ fn get_commits_ahead(
 ) -> CliResult<Vec<CommitInfo>> {
     use gix::prelude::ObjectIdExt as _;
 
-    let branch = branch_arg.resolve_branch(ctx)?;
+    let guard = ctx.shared_worktree_access();
+    let repo = ctx.repo.get()?;
+    let branch = branch_arg.resolve_branch(&repo)?;
 
     // Find merge base
-    let guard = ctx.shared_worktree_access();
     let (merge_base, _) = workspace_target::merge_base_with_target_with_perm(
         ctx,
         guard.read_permission(),
         branch.head,
     )?;
-    let repo = ctx.repo.get()?;
 
     // Walk from branch head to merge base, collecting commits
     let traversal = branch

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -31,45 +31,48 @@ pub(crate) fn insert_blank_commit(
     let mut guard = ctx.exclusive_worktree_access();
     let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
 
-    let (target, insert_side) = if let Some(t) = before {
-        (
-            t.resolve_in_workspace(ctx, &id_map, Purpose::Target, None)?
-                .into_branch_or_commit()?,
-            InsertSide::Below,
-        )
-    } else if let Some(t) = after {
-        (
-            t.resolve_in_workspace(ctx, &id_map, Purpose::Target, None)?
-                .into_branch_or_commit()?,
-            InsertSide::Above,
-        )
-    } else if let Some(t) = target {
-        // Default to --before behavior when using positional argument
-        (
-            t.resolve_in_workspace(ctx, &id_map, Purpose::Target, None)?
-                .into_branch_or_commit()?,
-            InsertSide::Below,
-        )
-    } else {
-        // No arguments provided - default to inserting at top of first branch
+    let (target, insert_side) = {
+        let repo = ctx.repo.get()?;
+        if let Some(t) = before {
+            (
+                t.resolve_in_workspace(&repo, &id_map, Purpose::Target, None)?
+                    .into_branch_or_commit()?,
+                InsertSide::Below,
+            )
+        } else if let Some(t) = after {
+            (
+                t.resolve_in_workspace(&repo, &id_map, Purpose::Target, None)?
+                    .into_branch_or_commit()?,
+                InsertSide::Above,
+            )
+        } else if let Some(t) = target {
+            // Default to --before behavior when using positional argument
+            (
+                t.resolve_in_workspace(&repo, &id_map, Purpose::Target, None)?
+                    .into_branch_or_commit()?,
+                InsertSide::Below,
+            )
+        } else {
+            // No arguments provided - default to inserting at top of first branch
 
-        let stacks = crate::legacy::workspace::applied_stacks(ctx)?;
+            let stacks = crate::legacy::workspace::applied_stacks(ctx)?;
 
-        // Find the first stack with branches and convert BString to String
-        let branch_name = stacks
-            .iter()
-            .filter(|stack| stack.id.is_some())
-            .find_map(|stack| stack.top_branch_name().map(ToOwned::to_owned))
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "No branches found. Create a branch first or specify a target explicitly."
-                )
-            })?;
+            // Find the first stack with branches and convert BString to String
+            let branch_name = stacks
+                .iter()
+                .filter(|stack| stack.id.is_some())
+                .find_map(|stack| stack.top_branch_name().map(ToOwned::to_owned))
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "No branches found. Create a branch first or specify a target explicitly."
+                    )
+                })?;
 
-        (
-            BranchOrCommit::Branch(BranchArg(branch_name)),
-            InsertSide::Below,
-        )
+            (
+                BranchOrCommit::Branch(BranchArg(branch_name)),
+                InsertSide::Below,
+            )
+        }
     };
 
     let position_desc = match insert_side {
@@ -314,8 +317,9 @@ pub(crate) fn commit(
     let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
 
     let branch_hint = if let Some(branch_arg) = branch_arg {
+        let repo = ctx.repo.get()?;
         if let Some(branch) = branch_arg
-            .try_resolve(ctx, &id_map, Purpose::Branch, Some(Priority::Branch))?
+            .try_resolve(&repo, &id_map, Purpose::Branch, Some(Priority::Branch))?
             .and_then(|id| {
                 if let ResolvedCliIdArg::Branch(BranchArg(branch)) = id {
                     Some(branch)

--- a/crates/but/src/command/legacy/commit2.rs
+++ b/crates/but/src/command/legacy/commit2.rs
@@ -282,9 +282,8 @@ fn route_commit_operation(
                     format!("BUG: Segment resolved from branch name {branch} has no ref info")
                 })?;
 
-                let target = CommitRelativeToTarget::Reference {
+                let target = CommitRelativeToTarget::BranchTip {
                     name: ref_info.ref_name,
-                    position: CommitRelativeToTargetPosition::Below,
                 };
 
                 Ok(CommitOperation::CommitAt(CommitAtOperation { target }))
@@ -316,9 +315,8 @@ fn route_commit_operation(
                     .and_then(|segment| segment.ref_info.as_ref())
                     .context("Head stack as no ref")?;
 
-                let target = CommitRelativeToTarget::Reference {
+                let target = CommitRelativeToTarget::BranchTip {
                     name: ref_info.ref_name.clone(),
-                    position: CommitRelativeToTargetPosition::Below,
                 };
 
                 return Ok(CommitOperation::CommitAt(CommitAtOperation { target }));
@@ -349,7 +347,7 @@ fn route_commit_above_or_below(
             commit_id,
             position,
         },
-        BranchOrCommit::Branch(arg) => CommitRelativeToTarget::Branch {
+        BranchOrCommit::Branch(arg) => CommitRelativeToTarget::BranchBucket {
             name: arg.resolve_local_branch_name()?,
             position,
         },
@@ -429,7 +427,7 @@ impl CommitAtOperation {
                 commit_id,
                 position,
             } => (RelativeTo::Commit(commit_id), position.into(), None),
-            CommitRelativeToTarget::Branch { name, position } => {
+            CommitRelativeToTarget::BranchBucket { name, position } => {
                 let new_branch_name = but_core::branch::unique_canned_refname(tx.repo())?;
                 let anchor = Anchor::at_segment(name.as_ref(), position.into());
                 tx.create_reference(
@@ -445,9 +443,9 @@ impl CommitAtOperation {
                     Some(BranchNameTarget::New(new_branch_name)),
                 )
             }
-            CommitRelativeToTarget::Reference { name, position } => (
+            CommitRelativeToTarget::BranchTip { name } => (
                 RelativeTo::Reference(name.clone()),
-                position.into(),
+                InsertSide::Below,
                 Some(BranchNameTarget::Existing(name)),
             ),
         };
@@ -459,17 +457,21 @@ impl CommitAtOperation {
     }
 }
 
+/// Place a commit relative to something in the workspace.
 #[derive(Clone)]
 enum CommitRelativeToTarget {
+    /// Place the commit relative to this commit, within the same branch.
     Commit {
         commit_id: gix::ObjectId,
         position: CommitRelativeToTargetPosition,
     },
-    Reference {
-        name: FullName,
-        position: CommitRelativeToTargetPosition,
-    },
-    Branch {
+    /// Place the commit at the tip of the branch denoted by this reference, moving the reference to
+    /// the new commit. This is effectively the same as committing to a branch.
+    BranchTip { name: FullName },
+    /// Place the commit relative to this branch, treating the branch as a bucket.
+    ///
+    /// The commit is always inserted on a new branch with a canned name.
+    BranchBucket {
         name: FullName,
         position: CommitRelativeToTargetPosition,
     },

--- a/crates/but/src/command/legacy/commit2.rs
+++ b/crates/but/src/command/legacy/commit2.rs
@@ -338,20 +338,21 @@ fn route_commit_above_or_below(
     position: CommitRelativeToTargetPosition,
 ) -> CliResult<CommitOperation> {
     let target = match cli_id
-        .resolve_in_workspace(repo, id_map, Purpose::Anchor, None)?
-        .into_branch_or_commit()?
+        .resolve_in_workspace(repo, id_map, Purpose::Target, None)
+        .hint(
+            "Target must be an applied branch or commit. Run `but status` for applicable targets.",
+        )?
+        .into_branch_or_commit()
+        .hint("Run `but status` to show applicable targets")?
     {
         BranchOrCommit::Commit(commit_id) => CommitRelativeToTarget::Commit {
             commit_id,
             position,
         },
-        BranchOrCommit::Branch(arg) => {
-            let _ = arg.resolve_branch(repo)?; // checks branch exists in workspace
-            CommitRelativeToTarget::Branch {
-                name: arg.resolve_local_branch_name()?,
-                position,
-            }
-        }
+        BranchOrCommit::Branch(arg) => CommitRelativeToTarget::Branch {
+            name: arg.resolve_local_branch_name()?,
+            position,
+        },
     };
     Ok(CommitOperation::CommitAt(CommitAtOperation { target }))
 }

--- a/crates/but/src/command/legacy/commit2.rs
+++ b/crates/but/src/command/legacy/commit2.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use anyhow::Context;
 use bstr::{BString, ByteSlice};
 use but_api::{diff::ComputeLineStats, json::HexHash};
@@ -7,14 +9,20 @@ use but_core::{
 use but_error::Code;
 use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
 use but_transaction::{DynamicOutcome, IntermediateCommitCreateResult, Transaction};
-use but_workspace::RefInfo;
+use but_workspace::{
+    RefInfo,
+    branch::create_reference::{Anchor, Position},
+};
 use gitbutler_oplog::entry::{OperationKind, SnapshotDetails};
 use gix::{prelude::ObjectIdExt as _, refs::FullName};
 use serde::Serialize;
 
 use crate::{
-    CliResult, CliResultExt,
-    args::{atoms::BranchArg, commit2::Platform},
+    CliResult, CliResultExt, IdMap,
+    args::{
+        atoms::{BranchArg, BranchOrCommit, CliIdArg, Purpose},
+        commit2::Platform,
+    },
     bad_input,
     command::legacy::{ShowDiffInEditor, reword::get_commit_message_from_editor},
     id::UNASSIGNED,
@@ -27,7 +35,7 @@ use crate::{
 #[must_use]
 pub struct CommitOutcome {
     new_commit: gix::ObjectId,
-    branch_name: BranchNameTarget,
+    branch_name: Option<BranchNameTarget>,
 }
 
 /// `--format json` should only include newly created things. So if the branch already existed it
@@ -43,17 +51,23 @@ impl CliOutputHuman for CommitOutcome {
             new_commit,
             branch_name,
         } = self;
-        let branch_name = match branch_name {
-            BranchNameTarget::Existing(branch_name) | BranchNameTarget::New(branch_name) => {
-                branch_name
-            }
-        };
-        writeln!(
-            out,
-            "Created commit {} on {}",
-            theme::Commit(new_commit),
-            theme::Branch(branch_name.shorten()),
-        )?;
+
+        match branch_name {
+            Some(BranchNameTarget::New(branch_name)) => writeln!(
+                out,
+                "Created commit {} on new branch {}",
+                theme::Commit(new_commit),
+                theme::Branch(branch_name.shorten().as_bstr())
+            )?,
+            Some(BranchNameTarget::Existing(branch_name)) => writeln!(
+                out,
+                "Created commit {} on branch {}",
+                theme::Commit(new_commit),
+                theme::Branch(branch_name.shorten().as_bstr())
+            )?,
+            None => writeln!(out, "Created commit {}", theme::Commit(new_commit))?,
+        }
+
         Ok(())
     }
 }
@@ -82,10 +96,8 @@ impl CliOutput for CommitOutcome {
         } = self;
 
         let branch_name = match branch_name {
-            BranchNameTarget::Existing(_) => None,
-            BranchNameTarget::New(full_name) => {
-                Some(full_name.shorten().to_str_lossy().to_string())
-            }
+            Some(BranchNameTarget::New(branch_name)) => Some(branch_name.shorten().to_string()),
+            _ => None,
         };
 
         Output {
@@ -103,11 +115,12 @@ pub fn commit(
     let mut guard = ctx.exclusive_worktree_access();
     let perm = guard.write_permission();
     let mut meta = ctx.meta()?;
+    let id_map = IdMap::new_from_context(ctx, None, perm.read_permission())?;
 
     let (commit_op, commit_selection, reword_op) = {
         let head_info = but_api::legacy::workspace::head_info(ctx)?;
         let repo = ctx.repo.get()?;
-        resolve(&repo, args, &head_info)?
+        resolve(&repo, args, &head_info, &id_map)?
     };
     run(ctx, &mut meta, perm, commit_op, commit_selection, reword_op)
 }
@@ -116,15 +129,32 @@ fn resolve(
     repo: &gix::Repository,
     args: Platform,
     head_info: &RefInfo,
+    id_map: &IdMap,
 ) -> CliResult<(CommitOperation, CommitSelection, RewordCommitOperation)> {
     let Platform {
         no_message,
         message,
         branch,
         empty,
+        above,
+        below,
     } = args;
 
-    let commit_op = route_commit_operation(repo, head_info, branch)?;
+    let target_ish = match (branch, above, below) {
+        (Some(Some(branch)), None, None) => CommitOperationTargetIsh::Branch(branch),
+        (Some(None), None, None) => CommitOperationTargetIsh::UnstackedCannedBranch,
+        (None, Some(cli_id), None) => CommitOperationTargetIsh::Above(cli_id),
+        (None, None, Some(cli_id)) => CommitOperationTargetIsh::Below(cli_id),
+        (None, None, None) => CommitOperationTargetIsh::Default,
+        _ => {
+            return Err(anyhow::anyhow!(
+                "BUG: Should not be able to supply more than one of above, below or branch"
+            )
+            .into());
+        }
+    };
+
+    let commit_op = route_commit_operation(repo, head_info, id_map, target_ish)?;
 
     let commit_selection = if empty {
         CommitSelection::Nothing
@@ -214,65 +244,116 @@ fn run(
     })
 }
 
+/// Targeting modes for committing.
+enum CommitOperationTargetIsh {
+    /// Target the branch if it exists, or create it at the newest base if it does not.
+    Branch(BranchArg),
+    /// Target newest base with a new canned branch name.
+    UnstackedCannedBranch,
+    /// Targets above the [`CliIdArg`], which must denote either a commit or a branch.
+    Above(CliIdArg),
+    /// Targets below the [`CliIdArg`], which must denote either a commit or a branch. For commits,
+    /// this is directly below. For branches, this is below the segment.
+    Below(CliIdArg),
+    /// The default target, makes a sensible choice about where to put the commit, creating a branch
+    /// if necessary. This should be used if there is no input from the user about where to put the
+    /// commit.
+    Default,
+}
+
 fn route_commit_operation(
     repo: &gix::Repository,
     head_info: &RefInfo,
-    branch: Option<Option<BranchArg>>,
+    id_map: &IdMap,
+    target: CommitOperationTargetIsh,
 ) -> CliResult<CommitOperation> {
-    match branch {
-        Some(Some(branch)) => {
+    match target {
+        CommitOperationTargetIsh::Above(cli_id) => {
+            let position = CommitRelativeToTargetPosition::Above;
+            route_commit_above_or_below(repo, id_map, cli_id, position)
+        }
+        CommitOperationTargetIsh::Below(cli_id) => {
+            let position = CommitRelativeToTargetPosition::Below;
+            route_commit_above_or_below(repo, id_map, cli_id, position)
+        }
+        CommitOperationTargetIsh::Branch(branch) => {
             if let Some(segment) = branch.try_resolve_segment(head_info)? {
                 let ref_info = segment.ref_info.with_context(|| {
                     format!("BUG: Segment resolved from branch name {branch} has no ref info")
                 })?;
 
-                return Ok(CommitOperation::CommitToExistingBranch(
-                    CommitToExistingBranchOperation {
-                        branch_name: ref_info.ref_name,
-                    },
-                ));
+                let target = CommitRelativeToTarget::Reference {
+                    name: ref_info.ref_name,
+                    position: CommitRelativeToTargetPosition::Below,
+                };
+
+                Ok(CommitOperation::CommitAt(CommitAtOperation { target }))
             } else {
                 let branch_name = BranchArg(branch.resolve_for_creation(repo, head_info).hint(
                     format!("Run `but apply {branch}` to apply the branch first"),
                 )?)
                 .resolve_local_branch_name()?;
-                return Ok(CommitOperation::CommitToNewBranch(
+                Ok(CommitOperation::CommitToNewBranch(
                     CommitToNewBranchOperation {
                         branch_name: Some(branch_name),
                     },
-                ));
+                ))
             }
         }
-        Some(None) => {
-            return Ok(CommitOperation::CommitToNewBranch(
+        CommitOperationTargetIsh::UnstackedCannedBranch => Ok(CommitOperation::CommitToNewBranch(
+            CommitToNewBranchOperation { branch_name: None },
+        )),
+        CommitOperationTargetIsh::Default => {
+            let mut stacks = head_info.stacks.iter();
+            if let Some(stack) = stacks.next() {
+                if stacks.next().is_some() {
+                    return Err(anyhow::anyhow!("Found more than one stack, badness!").into());
+                }
+
+                let ref_info = stack
+                    .segments
+                    .first()
+                    .and_then(|segment| segment.ref_info.as_ref())
+                    .context("Head stack as no ref")?;
+
+                let target = CommitRelativeToTarget::Reference {
+                    name: ref_info.ref_name.clone(),
+                    position: CommitRelativeToTargetPosition::Below,
+                };
+
+                return Ok(CommitOperation::CommitAt(CommitAtOperation { target }));
+            }
+
+            Ok(CommitOperation::CommitToNewBranch(
                 CommitToNewBranchOperation { branch_name: None },
-            ));
+            ))
         }
-        None => (),
-    };
-
-    let mut stacks = head_info.stacks.iter();
-    if let Some(stack) = stacks.next() {
-        if stacks.next().is_some() {
-            return Err(anyhow::anyhow!("Found more than one stack, badness!").into());
-        }
-
-        let ref_info = stack
-            .segments
-            .first()
-            .and_then(|segment| segment.ref_info.as_ref())
-            .context("Head stack as no ref")?;
-
-        return Ok(CommitOperation::CommitToExistingBranch(
-            CommitToExistingBranchOperation {
-                branch_name: ref_info.ref_name.clone(),
-            },
-        ));
     }
+}
 
-    Ok(CommitOperation::CommitToNewBranch(
-        CommitToNewBranchOperation { branch_name: None },
-    ))
+fn route_commit_above_or_below(
+    repo: &gix::Repository,
+    id_map: &IdMap,
+    cli_id: CliIdArg,
+    position: CommitRelativeToTargetPosition,
+) -> CliResult<CommitOperation> {
+    let target = match cli_id
+        .resolve_in_workspace(repo, id_map, Purpose::Anchor, None)?
+        .into_branch_or_commit()?
+    {
+        BranchOrCommit::Commit(commit_id) => CommitRelativeToTarget::Commit {
+            commit_id,
+            position,
+        },
+        BranchOrCommit::Branch(arg) => {
+            let _ = arg.resolve_branch(repo)?; // checks branch exists in workspace
+            CommitRelativeToTarget::Branch {
+                name: arg.resolve_local_branch_name()?,
+                position,
+            }
+        }
+    };
+    Ok(CommitOperation::CommitAt(CommitAtOperation { target }))
 }
 
 enum CommitSelection {
@@ -281,8 +362,8 @@ enum CommitSelection {
 }
 
 enum CommitOperation {
-    CommitToExistingBranch(CommitToExistingBranchOperation),
     CommitToNewBranch(CommitToNewBranchOperation),
+    CommitAt(CommitAtOperation),
 }
 
 impl CommitOperation {
@@ -290,37 +371,11 @@ impl CommitOperation {
         self,
         tx: &mut Transaction<'_, '_, impl RefMetadata>,
         changes: Vec<DiffSpec>,
-    ) -> anyhow::Result<(IntermediateCommitCreateResult, BranchNameTarget)> {
+    ) -> anyhow::Result<(IntermediateCommitCreateResult, Option<BranchNameTarget>)> {
         match self {
-            CommitOperation::CommitToExistingBranch(op) => op.execute(tx, changes),
             CommitOperation::CommitToNewBranch(op) => op.execute(tx, changes),
+            CommitOperation::CommitAt(op) => op.execute(tx, changes),
         }
-    }
-}
-
-struct CommitToExistingBranchOperation {
-    branch_name: FullName,
-}
-
-impl CommitToExistingBranchOperation {
-    fn execute(
-        self,
-        tx: &mut Transaction<'_, '_, impl RefMetadata>,
-        changes: Vec<DiffSpec>,
-    ) -> anyhow::Result<(IntermediateCommitCreateResult, BranchNameTarget)> {
-        let Self { branch_name } = self;
-
-        let commit_create_result = tx.create_commit(
-            RelativeTo::Reference(branch_name.clone()),
-            InsertSide::Below,
-            changes,
-            String::new(),
-        )?;
-
-        Ok((
-            commit_create_result,
-            BranchNameTarget::Existing(branch_name),
-        ))
     }
 }
 
@@ -333,7 +388,7 @@ impl CommitToNewBranchOperation {
         self,
         tx: &mut Transaction<'_, '_, impl RefMetadata>,
         changes: Vec<DiffSpec>,
-    ) -> anyhow::Result<(IntermediateCommitCreateResult, BranchNameTarget)> {
+    ) -> anyhow::Result<(IntermediateCommitCreateResult, Option<BranchNameTarget>)> {
         let Self { branch_name } = self;
 
         let branch_name = if let Some(branch_name) = branch_name {
@@ -351,7 +406,105 @@ impl CommitToNewBranchOperation {
             String::new(),
         )?;
 
-        Ok((commit_create_result, BranchNameTarget::New(branch_name)))
+        Ok((
+            commit_create_result,
+            Some(BranchNameTarget::New(branch_name)),
+        ))
+    }
+}
+
+struct CommitAtOperation {
+    target: CommitRelativeToTarget,
+}
+
+impl CommitAtOperation {
+    fn execute(
+        self,
+        tx: &mut Transaction<'_, '_, impl RefMetadata>,
+        changes: Vec<DiffSpec>,
+    ) -> anyhow::Result<(IntermediateCommitCreateResult, Option<BranchNameTarget>)> {
+        let (relative_to, side, branch_name_target) = match self.target {
+            CommitRelativeToTarget::Commit {
+                commit_id,
+                position,
+            } => (RelativeTo::Commit(commit_id), position.into(), None),
+            CommitRelativeToTarget::Branch { name, position } => {
+                let new_branch_name = but_core::branch::unique_canned_refname(tx.repo())?;
+                let anchor = Anchor::at_segment(name.as_ref(), position.into());
+                tx.create_reference(
+                    new_branch_name.as_ref(),
+                    Some(anchor),
+                    |_| StackId::generate(),
+                    Some(0),
+                )?;
+
+                (
+                    RelativeTo::Reference(new_branch_name.clone()),
+                    InsertSide::Below,
+                    Some(BranchNameTarget::New(new_branch_name)),
+                )
+            }
+            CommitRelativeToTarget::Reference { name, position } => (
+                RelativeTo::Reference(name.clone()),
+                position.into(),
+                Some(BranchNameTarget::Existing(name)),
+            ),
+        };
+
+        let commit_create_result =
+            tx.create_commit(relative_to.clone(), side, changes, String::new())?;
+
+        Ok((commit_create_result, branch_name_target))
+    }
+}
+
+#[derive(Clone)]
+enum CommitRelativeToTarget {
+    Commit {
+        commit_id: gix::ObjectId,
+        position: CommitRelativeToTargetPosition,
+    },
+    Reference {
+        name: FullName,
+        position: CommitRelativeToTargetPosition,
+    },
+    Branch {
+        name: FullName,
+        position: CommitRelativeToTargetPosition,
+    },
+}
+
+#[derive(Clone)]
+enum CommitRelativeToTargetPosition {
+    Above,
+    Below,
+}
+
+impl Display for CommitRelativeToTargetPosition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let pretty = match self {
+            Self::Above => "above",
+            Self::Below => "below",
+        };
+        write!(f, "{pretty}")
+    }
+}
+
+impl From<CommitRelativeToTargetPosition> for InsertSide {
+    fn from(value: CommitRelativeToTargetPosition) -> Self {
+        match value {
+            CommitRelativeToTargetPosition::Above => Self::Above,
+            CommitRelativeToTargetPosition::Below => Self::Below,
+        }
+    }
+}
+
+impl From<CommitRelativeToTargetPosition> for Position {
+    fn from(value: CommitRelativeToTargetPosition) -> Self {
+        match value {
+            CommitRelativeToTargetPosition::Above => Self::Above,
+            CommitRelativeToTargetPosition::Below => Self::Below,
+        }
     }
 }
 

--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -36,7 +36,10 @@ pub(crate) fn reword_target(
     let mut guard = ctx.exclusive_worktree_access();
     let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
 
-    let target = target.resolve_in_workspace(ctx, &id_map, Purpose::Target, None)?;
+    let target = {
+        let repo = ctx.repo.get()?;
+        target.resolve_in_workspace(&repo, &id_map, Purpose::Target, None)?
+    };
 
     match target.into_branch_or_commit()? {
         BranchOrCommit::Branch(BranchArg(name)) => {

--- a/crates/but/tests/but/command/commit2.rs
+++ b/crates/but/tests/but/command/commit2.rs
@@ -36,7 +36,7 @@ fn no_args_single_head_no_message_human_output() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Created commit 7bbfdca on 'A'
+Created commit 7bbfdca on branch 'A'
 
 "#]]);
 
@@ -514,5 +514,461 @@ Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage 
 "#]]);
 }
 
-// -b without branch name
-// commit2 -m 'add file.txt' -b
+#[test]
+fn commit_empty_above_commit() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊●   fe12bcd add first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("commit2 --no-message --above fe")
+        .assert()
+        .success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   955bee4 add second
+┊●   4400448 (no commit message) (no changes)
+┊●   fe12bcd add first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn commit_empty_below_commit() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊●   fe12bcd add first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("commit2 --no-message --below fe")
+        .assert()
+        .success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   eee1eaf add second
+┊●   c149530 add first
+┊●   8b16ff4 (no commit message) (no changes)
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn commit_above_commit() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.file("file.txt", "Some changes");
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes]
+┊   uv A file.txt
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊●   fe12bcd add first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+
+"#]]);
+
+    env.but("commit2 -m 'add file.txt' --above fe")
+        .assert()
+        .success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   e38b8f7 add second
+┊●   94fecae add file.txt
+┊●   fe12bcd add first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn commit_above_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.file("file.txt", "Some changes");
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes]
+┊   uv A file.txt
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+
+"#]]);
+
+    env.but("commit2 -m 'add file.txt' --above g0")
+        .assert()
+        .success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄br [a-branch-1]
+┊●   092d7a9 add file.txt
+┊│
+┊├┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn commit_below_commit() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.file("file.txt", "Some changes");
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes]
+┊   uv A file.txt
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊●   fe12bcd add first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+
+"#]]);
+
+    env.but("commit2 -m 'add file.txt' --below fe")
+        .assert()
+        .success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   d7e6d8f add second
+┊●   12982b7 add first
+┊●   bdfeaa4 add file.txt
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn commit_below_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.file("file.txt", "Some changes");
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes]
+┊   uv A file.txt
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+
+"#]]);
+
+    env.but("commit2 -m 'add file.txt' --below g0")
+        .assert()
+        .success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   8a3fbb3 add A
+┊│
+┊├┄br [a-branch-1]
+┊●   28e38bd add file.txt
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn commit_below_branch_with_multiple_commits_treats_branch_as_bucket() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.file("file.txt", "Some changes");
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes]
+┊   uv A file.txt
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊●   fe12bcd add first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+
+"#]]);
+
+    env.but("commit2 -m 'add file.txt' --below g0")
+        .assert()
+        .success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   d7e6d8f add second
+┊●   12982b7 add first
+┊│
+┊├┄br [a-branch-1]
+┊●   bdfeaa4 add file.txt
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn commit_above_refuses_on_conflicts() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊●   fe12bcd add first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.file("second", "Conflicting with commit 9ac4652");
+
+    env.but("commit2 -m 'add second' --above fe")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: Couldn't commit all changes
+
+"#]]);
+}
+
+#[test]
+fn commit_below_refuses_on_conflicts() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊●   fe12bcd add first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.file("second", "Conflicting with commit 9ac4652");
+
+    env.but("commit2 -m 'add second' --below 9a")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: Couldn't commit all changes
+
+"#]]);
+}
+
+#[test]
+fn refuses_above_and_below() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.but("commit2 --above dontcare --below dontcare")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+error: the argument '--above <ABOVE>' cannot be used with '--below <BELOW>'
+
+Usage: but commit2 --above <ABOVE>
+
+For more information, try '--help'.
+
+"#]]);
+}
+
+#[test]
+fn refuses_above_and_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.but("commit2 --above dontcare -b")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+error: the argument '--above <ABOVE>' cannot be used with '--branch [<BRANCH>]'
+
+Usage: but commit2 --above <ABOVE>
+
+For more information, try '--help'.
+
+"#]]);
+}
+
+#[test]
+fn refuses_below_and_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.but("commit2 --below dontcare -b")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+error: the argument '--below <BELOW>' cannot be used with '--branch [<BRANCH>]'
+
+Usage: but commit2 --below <BELOW>
+
+For more information, try '--help'.
+
+"#]]);
+}

--- a/crates/but/tests/but/command/commit2.rs
+++ b/crates/but/tests/but/command/commit2.rs
@@ -972,3 +972,75 @@ For more information, try '--help'.
 
 "#]]);
 }
+
+#[test]
+fn above_branch_not_in_workspace_returns_bad_input() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
+    env.setup_metadata(&["A", "B"]).unwrap();
+
+    env.but("unapply B").assert().success();
+
+    env.but("commit2 --above B")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: Could not find target: 'B'
+
+Hint: Target must be an applied branch or commit. Run `but status` for applicable targets.
+
+"#]]);
+}
+
+#[test]
+fn above_commit_not_in_workspace_returns_bad_input() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
+    env.setup_metadata(&["A", "B"]).unwrap();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┊╭┄h0 [B]
+┊●   d3e2ba3 add B
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("unapply B").assert().success();
+
+    env.but("commit2 --above d3")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: Could not find target: 'd3'
+
+Hint: Target must be an applied branch or commit. Run `but status` for applicable targets.
+
+"#]]);
+}
+
+#[test]
+fn above_non_branch_non_commit_target_returns_bad_input() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
+    env.setup_metadata(&[]).unwrap();
+
+    env.but("commit2 --above zz")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: Expected a commit or a branch, got unassigned changes
+
+Hint: Run `but status` to show applicable targets
+
+"#]]);
+}


### PR DESCRIPTION
## 🧢 Changes
Adds support for `--above/--below` position for `commit2`.

Also attempts to fix reference insertion in the `RecordingMetadata` implementation. That commit is clanked and I don't have high confidence in it - but the entire implementation is that way so right now we just want to move forward with the code that matters. It may not be entirely correct but at least we know about it and this unblocks us.