### PR TITLE
feat(but-api): add line number to `open_in_editor`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,6 +998,8 @@ dependencies = [
  "itertools",
  "napi",
  "napi-derive",
+ "objc2-app-kit",
+ "objc2-foundation",
  "open",
  "schemars 1.2.1",
  "serde",

--- a/apps/lite/electron/src/ipc.ts
+++ b/apps/lite/electron/src/ipc.ts
@@ -196,6 +196,7 @@ export interface OpenInEditorParams {
 	projectId: string;
 	editorId: string;
 	path: string;
+	lineNr: number | null;
 }
 
 export interface PeelRestoreSnapshotParams {

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -437,8 +437,8 @@ const registerIpcHandlers = (): void => {
 	);
 	senderValidatingHandle(
 		liteIpcChannels.openInEditor,
-		(_e, { projectId, editorId, path }: OpenInEditorParams) =>
-			openInEditor(projectId, editorId, path),
+		(_e, { projectId, editorId, path, lineNr }: OpenInEditorParams) =>
+			openInEditor(projectId, editorId, path, lineNr),
 	);
 	senderValidatingHandle(liteIpcChannels.pathJoin, (_e, ...paths: Array<string>) =>
 		path.join(...paths),

--- a/apps/lite/ui/src/routes/project/$id/workspace/useFileMenuItems.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useFileMenuItems.ts
@@ -54,6 +54,7 @@ export const useFileMenuItems = ({
 									projectId,
 									editorId: editor.id,
 									path,
+									lineNr: null,
 								}),
 						}),
 					) ?? [],

--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -141,6 +141,10 @@ url.workspace = true
 which = "8.0.2"
 but-schemars.workspace = true
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["std", "NSWorkspace"] }
+objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "NSString", "NSURL"] }
+
 [dev-dependencies]
 but-api = { path = ".", features = ["legacy"] }
 but-testsupport.workspace = true

--- a/crates/but-api/src/open/editor.rs
+++ b/crates/but-api/src/open/editor.rs
@@ -237,6 +237,7 @@ pub fn open_in_editor_unchecked(
         editor
             .cli_arg_supplier
             .open_on_line(&mut cmd, path, line_nr)?;
+        cmd.stdout(Stdio::null()).stderr(Stdio::null());
         spawn_and_reap(cmd, editor.name, &path.to_string_lossy())?;
     } else {
         let mut cmd = Command::new("/usr/bin/open");

--- a/crates/but-api/src/open/editor.rs
+++ b/crates/but-api/src/open/editor.rs
@@ -1,8 +1,11 @@
 use std::{
     ffi::OsString,
-    path::{Path, PathBuf},
+    path::Path,
     process::{Command, Stdio},
 };
+
+#[cfg(target_os = "macos")]
+use std::path::PathBuf;
 
 use crate::open::spawn::spawn_and_reap;
 
@@ -32,34 +35,34 @@ impl<'a> EditorSpec<'a> {
     #[cfg(target_os = "macos")]
     fn resolve_cli_wrapper_abspath(&self) -> anyhow::Result<PathBuf> {
         let app_dir_path = self.find_app_directory()?;
-        Ok(app_dir_path.join(&self.cli_wrapper_path))
+        let cli_wrapper_path = self
+            .cli_wrapper_path
+            .ok_or_else(|| anyhow::anyhow!("No CLI wrapper configured for {}", self.name))?;
+        Ok(app_dir_path.join(cli_wrapper_path))
     }
 
     #[cfg(target_os = "macos")]
     fn find_app_directory(&self) -> anyhow::Result<PathBuf> {
-        use std::os::unix::ffi::OsStringExt;
+        use objc2_app_kit::NSWorkspace;
+        use objc2_foundation::NSString;
 
-        let output = Command::new("/usr/bin/mdfind")
-            .arg(format!(
-                r#"kMDItemCFBundleIdentifier == "{}""#,
+        let workspace = NSWorkspace::sharedWorkspace();
+        let bundle_identifier = NSString::from_str(self.bundle_identifier);
+        let app_url = workspace
+            .URLForApplicationWithBundleIdentifier(&bundle_identifier)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Could not find application for '{}'",
+                    self.bundle_identifier
+                )
+            })?;
+
+        app_url.to_file_path().ok_or_else(|| {
+            anyhow::anyhow!(
+                "Could not resolve application path for '{}'",
                 self.bundle_identifier
-            ))
-            .output()?;
-        if !output.status.success() {
-            tracing::error!("{:?}", OsString::from_vec(output.stderr));
-            return Err(anyhow::anyhow!(
-                "Could not find application for '{}'",
-                self.bundle_identifier
-            ));
-        }
-
-        let first_line = output
-            .stdout
-            .split(|&b| b == b'\n')
-            .find(|line| !line.is_empty())
-            .expect("BUG: No output from mdfind");
-
-        Ok(PathBuf::from(OsString::from_vec(first_line.to_vec())))
+            )
+        })
     }
 }
 
@@ -234,7 +237,7 @@ pub fn open_in_editor_unchecked(
         editor
             .cli_arg_supplier
             .open_on_line(&mut cmd, path, line_nr)?;
-        spawn_and_reap(cmd, editor.executable, &path.to_string_lossy())?;
+        spawn_and_reap(cmd, editor.name, &path.to_string_lossy())?;
     } else {
         let mut cmd = Command::new("/usr/bin/open");
         let status = cmd

--- a/crates/but-api/src/open/editor.rs
+++ b/crates/but-api/src/open/editor.rs
@@ -1,4 +1,10 @@
-use std::{path::Path, process::Stdio};
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+};
+
+use crate::open::spawn::spawn_and_reap;
 
 use serde::Serialize;
 
@@ -9,12 +15,52 @@ pub struct EditorSpec<'a> {
     pub id: &'a str,
     /// Name of the editor.
     pub name: &'a str,
+    /// The CLI argument formatter for e.g. opening a specific line in a file.
+    cli_arg_supplier: CliArgumentSupplier,
     #[cfg(any(target_os = "linux", target_os = "windows"))]
     /// Name of or path to the executable.
     pub executable: &'a str,
     #[cfg(target_os = "macos")]
     /// macOS bundle identifier for the application.
     pub bundle_identifier: &'a str,
+    #[cfg(target_os = "macos")]
+    /// Location of the CLI wrapper inside the application bundle, if it exists.
+    pub cli_wrapper_path: Option<&'a str>,
+}
+
+impl<'a> EditorSpec<'a> {
+    #[cfg(target_os = "macos")]
+    fn resolve_cli_wrapper_abspath(&self) -> anyhow::Result<PathBuf> {
+        let app_dir_path = self.find_app_directory()?;
+        Ok(app_dir_path.join(&self.cli_wrapper_path))
+    }
+
+    #[cfg(target_os = "macos")]
+    fn find_app_directory(&self) -> anyhow::Result<PathBuf> {
+        use std::os::unix::ffi::OsStringExt;
+
+        let output = Command::new("/usr/bin/mdfind")
+            .arg(format!(
+                r#"kMDItemCFBundleIdentifier == "{}""#,
+                self.bundle_identifier
+            ))
+            .output()?;
+        if !output.status.success() {
+            tracing::error!("{:?}", OsString::from_vec(output.stderr));
+            return Err(anyhow::anyhow!(
+                "Could not find application for '{}'",
+                self.bundle_identifier
+            ));
+        }
+
+        let first_line = output
+            .stdout
+            .split(|&b| b == b'\n')
+            .find(|line| !line.is_empty())
+            .expect("BUG: No output from mdfind");
+
+        Ok(PathBuf::from(OsString::from_vec(first_line.to_vec())))
+    }
 }
 
 /// Supported editor configuration for API clients.
@@ -38,10 +84,48 @@ impl From<&EditorSpec<'_>> for Editor {
     }
 }
 
+#[derive(Clone)]
+enum CliArgumentSupplier {
+    VSCodeLike,
+    Zed,
+    Sublime,
+    #[cfg(target_os = "macos")]
+    Xcode,
+}
+
+impl CliArgumentSupplier {
+    /// Add argument(s) to `cmd` to open the file on the specific line, or error if it's not
+    /// supported.
+    fn open_on_line<'a>(
+        &self,
+        cmd: &'a mut Command,
+        path: &Path,
+        line_nr: i32,
+    ) -> anyhow::Result<&'a mut Command> {
+        match self {
+            Self::VSCodeLike => cmd.arg("--goto").arg(self.path_with_line_nr(path, line_nr)),
+            Self::Zed => cmd.arg(self.path_with_line_nr(path, line_nr)),
+            Self::Sublime => cmd.arg(self.path_with_line_nr(path, line_nr)),
+            #[cfg(target_os = "macos")]
+            Self::Xcode => cmd.arg("--line").arg(line_nr.to_string()).arg(path),
+        };
+
+        Ok(cmd)
+    }
+
+    fn path_with_line_nr(&self, path: &Path, line_nr: i32) -> OsString {
+        let mut arg = path.as_os_str().to_owned();
+        arg.push(":");
+        arg.push(line_nr.to_string());
+        arg
+    }
+}
+
 pub(crate) const EDITORS: &[EditorSpec] = &[
     EditorSpec {
         id: "cursor",
         name: "Cursor",
+        cli_arg_supplier: CliArgumentSupplier::VSCodeLike,
         #[cfg(target_os = "linux")]
         executable: "cursor",
         #[cfg(target_os = "windows")]
@@ -49,42 +133,55 @@ pub(crate) const EDITORS: &[EditorSpec] = &[
         #[cfg(target_os = "macos")]
         // This looks insane but it's actually the correct bundle ID, see https://forum.cursor.com/t/cursor-bundle-identifier/779
         bundle_identifier: "com.todesktop.230313mzl4w4u92",
+        #[cfg(target_os = "macos")]
+        cli_wrapper_path: Some("Contents/Resources/app/bin/cursor"),
     },
     EditorSpec {
         id: "sublime",
         name: "Sublime Text",
+        cli_arg_supplier: CliArgumentSupplier::Sublime,
         #[cfg(target_os = "linux")]
         executable: "subl",
         #[cfg(target_os = "windows")]
         executable: "subl.exe",
         #[cfg(target_os = "macos")]
         bundle_identifier: "com.sublimetext.4",
+        #[cfg(target_os = "macos")]
+        cli_wrapper_path: Some("Contents/SharedSupport/bin/subl"),
     },
     EditorSpec {
         id: "vscode",
         name: "VS Code",
+        cli_arg_supplier: CliArgumentSupplier::VSCodeLike,
         #[cfg(target_os = "linux")]
         executable: "code",
         #[cfg(target_os = "windows")]
         executable: "code.exe",
         #[cfg(target_os = "macos")]
         bundle_identifier: "com.microsoft.VSCode",
+        #[cfg(target_os = "macos")]
+        cli_wrapper_path: Some("Contents/Resources/app/bin/code"),
     },
     #[cfg(target_os = "macos")]
     EditorSpec {
         id: "xcode",
         name: "Xcode",
+        cli_arg_supplier: CliArgumentSupplier::Xcode,
         bundle_identifier: "com.apple.dt.Xcode",
+        cli_wrapper_path: Some("Contents/Developer/usr/bin/xed"),
     },
     EditorSpec {
         id: "zed",
         name: "Zed",
+        cli_arg_supplier: CliArgumentSupplier::Zed,
         #[cfg(target_os = "linux")]
         executable: "zed",
         #[cfg(target_os = "windows")]
         executable: "zed.exe",
         #[cfg(target_os = "macos")]
         bundle_identifier: "dev.zed.Zed",
+        #[cfg(target_os = "macos")]
+        cli_wrapper_path: Some("Contents/MacOS/cli"),
     },
 ];
 
@@ -95,11 +192,21 @@ pub(crate) const EDITORS: &[EditorSpec] = &[
 /// to use. Therefore, this should never be exposed to an untrusted context, such as the GUI
 /// renderer.
 #[cfg(any(target_os = "linux", target_os = "windows"))]
-pub fn open_in_editor_unchecked(path: &Path, editor: &EditorSpec<'_>) -> anyhow::Result<()> {
-    use crate::open::spawn::spawn_and_reap;
+pub fn open_in_editor_unchecked(
+    editor: &EditorSpec<'_>,
+    path: &Path,
+    line_nr: Option<i32>,
+) -> anyhow::Result<()> {
+    let mut cmd = Command::new(editor.executable);
 
-    let mut cmd = std::process::Command::new(editor.executable);
-    cmd.arg(path);
+    if let Some(line_nr) = line_nr {
+        editor
+            .cli_arg_supplier
+            .open_on_line(&mut cmd, path, line_nr)?
+    } else {
+        cmd.arg(path)
+    };
+
     cmd.stdout(Stdio::null()).stderr(Stdio::null());
 
     spawn_and_reap(cmd, editor.executable, &path.to_string_lossy())?;
@@ -116,21 +223,34 @@ pub fn open_in_editor_unchecked(path: &Path, editor: &EditorSpec<'_>) -> anyhow:
 ///
 /// For untrusted clients, use [`open_in_editor`] instead.
 #[cfg(target_os = "macos")]
-pub fn open_in_editor_unchecked(path: &Path, editor: &EditorSpec<'_>) -> anyhow::Result<()> {
-    let mut cmd = std::process::Command::new("/usr/bin/open");
-    let status = cmd
-        .arg("-b")
-        .arg(editor.bundle_identifier)
-        .arg(path)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()?;
+pub fn open_in_editor_unchecked(
+    editor: &EditorSpec<'_>,
+    path: &Path,
+    line_nr: Option<i32>,
+) -> anyhow::Result<()> {
+    if let Some(line_nr) = line_nr {
+        let cli_abspath = editor.resolve_cli_wrapper_abspath()?;
+        let mut cmd = Command::new(cli_abspath);
+        editor
+            .cli_arg_supplier
+            .open_on_line(&mut cmd, path, line_nr)?;
+        spawn_and_reap(cmd, editor.executable, &path.to_string_lossy())?;
+    } else {
+        let mut cmd = Command::new("/usr/bin/open");
+        let status = cmd
+            .arg("-b")
+            .arg(editor.bundle_identifier)
+            .arg(path)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()?;
 
-    if !status.success() {
-        anyhow::bail!(
-            "failed to open {path:?} with editor bundle identifier '{}'",
-            editor.bundle_identifier
-        );
+        if !status.success() {
+            anyhow::bail!(
+                "failed to open {path:?} with editor bundle identifier '{}'",
+                editor.bundle_identifier
+            );
+        }
     }
 
     Ok(())

--- a/crates/but-api/src/open/mod.rs
+++ b/crates/but-api/src/open/mod.rs
@@ -650,6 +650,7 @@ pub fn open_in_editor(
     ctx: &mut but_ctx::Context,
     editor_id: String,
     path: String,
+    line_nr: Option<i32>,
 ) -> anyhow::Result<()> {
     let repo = ctx.repo.get()?;
     let workdir_path = gix::path::realpath(repo.workdir().context("project must have a workdir")?)?;
@@ -668,5 +669,5 @@ pub fn open_in_editor(
         bail_precondition!("editor_id '{editor_id}' does not exist");
     };
 
-    open_in_editor_unchecked(&resolved_path, editor)
+    open_in_editor_unchecked(editor, &resolved_path, line_nr)
 }

--- a/crates/but-api/src/open/mod.rs
+++ b/crates/but-api/src/open/mod.rs
@@ -638,10 +638,12 @@ pub fn list_editors() -> anyhow::Result<Vec<Editor>> {
     Ok(EDITORS.iter().map(Into::into).collect())
 }
 
-/// Open `path` within the given project's workdir.
+/// Open `path` within the given project's workdir using the editor specified by `editor_id`.
 ///
 /// `path` must be relative to the workdir of the repository and must resolve to a file or directory
 /// within the workdir, including the workdir root itself. Otherwise an error is returned.
+///
+/// `line_nr` can be provided to open a file at a specific line.
 ///
 /// [`list_editors`] provides the available `editor_id`s.
 #[but_api(napi)]

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -338,10 +338,12 @@ export declare function mergeReview(projectId: string, reviewId: number, mergeMe
 export declare function moveBranch(projectId: string, subjectBranch: string, targetBranch: string, dryRun: boolean): Promise<MoveBranchResult>
 
 /**
- * Open `path` within the given project's workdir.
+ * Open `path` within the given project's workdir using the editor specified by `editor_id`.
  *
  * `path` must be relative to the workdir of the repository and must resolve to a file or directory
  * within the workdir, including the workdir root itself. Otherwise an error is returned.
+ *
+ * `line_nr` can be provided to open a file at a specific line.
  *
  * [`list_editors`] provides the available `editor_id`s.
  */

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -345,7 +345,7 @@ export declare function moveBranch(projectId: string, subjectBranch: string, tar
  *
  * [`list_editors`] provides the available `editor_id`s.
  */
-export declare function openInEditor(projectId: string, editorId: string, path: string): Promise<void>
+export declare function openInEditor(projectId: string, editorId: string, path: string, lineNr: number | null): Promise<void>
 
 /**
  * Find the final snapshot that a restore snapshot will restore from.


### PR DESCRIPTION
Allows for opening a file in an editor at a specific line.

There are a bunch of rough edges in the API that I will be ironing out. For example, if you try to open a directory with a line number, different editors do different things. VS Code will create a file called `:<line_nr>` in that directory, and Zed will just drop the line number. Others may do other things still.

I intend to add something like "capabilities" to the editors returned in `list_editors()` so the frontend can know what each editor can do. But for now, every editor supports every (reasonable) thing you can do with the API.

I'm also going to add in a way to add user-defined custom editors, but I haven't quite worked out what that should look like yet.