### PR TITLE
fix(tui): retain mode after entering and leaving full screen details

### DIFF
--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -127,7 +127,7 @@ pub struct TuiLaunchOptions {
 pub enum TuiRunOptions {
     #[default]
     Normal,
-    #[expect(dead_code)]
+    #[cfg_attr(not(test), expect(dead_code))]
     PickChanges,
 }
 
@@ -141,7 +141,7 @@ pub enum TuiRunOptions {
 #[must_use]
 pub enum TuiOutcome {
     None,
-    #[expect(dead_code)]
+    #[cfg_attr(not(test), expect(dead_code))]
     CliIds(Vec<CliId>),
 }
 

--- a/crates/but/src/command/legacy/status/tui/backstack.rs
+++ b/crates/but/src/command/legacy/status/tui/backstack.rs
@@ -67,6 +67,11 @@ impl Backstack {
     pub(super) fn clear(&mut self) {
         self.stack.clear();
     }
+
+    #[cfg(test)]
+    pub(super) fn iter(&self) -> impl Iterator<Item = &BackstackEntry> {
+        self.stack.iter()
+    }
 }
 
 #[derive(Debug, PartialEq, Copy, Clone)]

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -56,9 +56,9 @@ use crate::{
                 message_on_drop::MessageOnDrop,
                 mode::{
                     CommandMode, CommandModeKind, CommitMessageComposer, CommitMode, CommitSource,
-                    DetailsMode, InlineRewordMode, Mode, ModeDiscriminant, MoveMode, MoveSource,
-                    NormalMode, PickUncommittedMode, RubMode, RubSource, StackCommitSource,
-                    StackMode, UnassignedCommitSource,
+                    DetailsMode, DetailsReturnMode, InlineRewordMode, Mode, ModeDiscriminant,
+                    MoveMode, MoveSource, NormalMode, PickUncommittedMode, RubMode, RubSource,
+                    StackCommitSource, StackMode, UnassignedCommitSource,
                 },
                 operations::stack_has_assigned_changes,
                 toast::{ToastKind, Toasts},
@@ -905,7 +905,7 @@ impl App {
     }
 
     fn handle_unfocus_details(&mut self, messages: &mut Vec<Message>) {
-        if let Mode::Details(DetailsMode { full_screen }) = &*self.mode
+        if let Mode::Details(DetailsMode { full_screen, .. }) = &*self.mode
             && *full_screen
         {
             return;
@@ -965,23 +965,13 @@ impl App {
     fn handle_backstack_entry(&mut self, entry: BackstackEntry, messages: &mut Vec<Message>) {
         match entry {
             BackstackEntry::LeaveNormalMode => {
-                if let Mode::Details(details_mode) = &*self.mode {
-                    if details_mode.full_screen {
-                        messages.extend([
-                            Message::UnfocusDetails,
-                            Message::DetailsLayout(DetailsLayoutMessage::ToggleVisibility),
-                        ]);
-                    } else {
-                        messages.push(Message::UnfocusDetails);
-                    }
-                }
-
-                *self
-                    .mode
-                    .get_mut_without_updating_backstack_and_i_promise_not_to_change_state() =
-                    Mode::Normal(NormalMode {
-                        marks: self.marks().cloned().unwrap_or_default(),
+                if !self.restore_mode_before_details(messages) {
+                    let marks = self.marks().cloned().unwrap_or_default();
+                    self.mode.update(&mut self.backstack, |backstack, mode| {
+                        let _ = backstack;
+                        *mode = Mode::Normal(NormalMode { marks });
                     });
+                }
                 self.maybe_move_cursor_into_file_list();
             }
             BackstackEntry::ShowFileList => {
@@ -1020,6 +1010,34 @@ impl App {
                 ));
             }
         }
+    }
+
+    fn restore_mode_before_details(&mut self, messages: &mut Vec<Message>) -> bool {
+        self.mode.update(&mut self.backstack, |backstack, mode| {
+            let previous_mode = std::mem::replace(mode, Mode::Normal(NormalMode::default()));
+            let Mode::Details(details_mode) = previous_mode else {
+                *mode = previous_mode;
+                return false;
+            };
+
+            backstack.remove_leave_normal_mode();
+            if details_mode.full_screen {
+                backstack.remove_open_details_view();
+                messages.push(Message::DetailsLayout(
+                    DetailsLayoutMessage::ToggleVisibility,
+                ));
+            } else {
+                messages.push(Message::Details(DetailsMessage::Deselect));
+            }
+
+            *mode = match details_mode.return_mode {
+                DetailsReturnMode::Normal(normal_mode) => Mode::Normal(normal_mode),
+                DetailsReturnMode::PickChanges(pick_uncommitted_mode) => {
+                    Mode::PickChanges(pick_uncommitted_mode)
+                }
+            };
+            true
+        })
     }
 
     fn maybe_move_cursor_into_file_list(&mut self) {
@@ -1068,7 +1086,24 @@ impl App {
 
         self.mode
             .update_and_push_leave_normal_mode(&mut self.backstack, |mode| {
-                *mode = Mode::Details(DetailsMode { full_screen });
+                let previous_mode = std::mem::replace(mode, Mode::Normal(NormalMode::default()));
+                let return_mode = match previous_mode {
+                    Mode::PickChanges(pick_uncommitted_mode) => {
+                        DetailsReturnMode::PickChanges(pick_uncommitted_mode)
+                    }
+                    Mode::Details(details_mode) => details_mode.return_mode,
+                    Mode::Normal(normal_mode) => DetailsReturnMode::Normal(normal_mode),
+                    Mode::Rub(..)
+                    | Mode::InlineReword(..)
+                    | Mode::Command(..)
+                    | Mode::Commit(..)
+                    | Mode::Move(..)
+                    | Mode::Stack(..) => DetailsReturnMode::Normal(NormalMode::default()),
+                };
+                *mode = Mode::Details(DetailsMode {
+                    full_screen,
+                    return_mode,
+                });
             });
     }
 
@@ -1079,12 +1114,9 @@ impl App {
                     full_screen: true,
                 }));
             }
-            Mode::Details(DetailsMode { full_screen }) => {
+            Mode::Details(DetailsMode { full_screen, .. }) => {
                 if *full_screen {
-                    self.unfocus_details_regardless_if_we_are_full_screen_or_not(messages);
-                    messages.push(Message::DetailsLayout(
-                        DetailsLayoutMessage::ToggleVisibility,
-                    ));
+                    self.restore_mode_before_details(messages);
                 } else {
                     messages.push(Message::DetailsLayout(DetailsLayoutMessage::Focus {
                         full_screen: true,
@@ -1112,7 +1144,9 @@ impl App {
         } else {
             self.backstack.remove_open_details_view();
             self.details.reset_scroll();
-            messages.push(Message::UnfocusDetails);
+            if matches!(&*self.mode, Mode::Details(..)) {
+                messages.push(Message::UnfocusDetails);
+            }
         }
     }
 

--- a/crates/but/src/command/legacy/status/tui/mode.rs
+++ b/crates/but/src/command/legacy/status/tui/mode.rs
@@ -371,6 +371,13 @@ impl PartialEq<CliId> for MoveSource {
 #[derive(Debug)]
 pub(super) struct DetailsMode {
     pub(super) full_screen: bool,
+    pub(super) return_mode: DetailsReturnMode,
+}
+
+#[derive(Debug)]
+pub(super) enum DetailsReturnMode {
+    Normal(NormalMode),
+    PickChanges(PickUncommittedMode),
 }
 
 #[derive(Debug)]

--- a/crates/but/src/command/legacy/status/tui/tests/details_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/details_tests.rs
@@ -3,7 +3,9 @@ use crossterm::event::{KeyCode, KeyModifiers};
 use snapbox::{file, str};
 use temp_env::with_var;
 
-use crate::command::legacy::status::tui::tests::utils::{test_tui, test_tui_with_size};
+use crate::command::legacy::status::tui::tests::utils::{
+    TestTuiOptions, test_tui, test_tui_with_options,
+};
 
 #[test]
 fn toggle_details_view_for_commit() {
@@ -55,7 +57,14 @@ fn details_view_supports_scroll_controls() {
         .collect::<String>();
     env.file("large.txt", file_contents);
 
-    let mut tui = test_tui_with_size(env, 100, 10);
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            width: 100,
+            height: 10,
+            ..Default::default()
+        },
+    );
 
     tui.input_then_render('d')
         .assert_rendered_term_svg_eq(file![
@@ -88,7 +97,14 @@ fn commit_message_wraps_in_details_view() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
     env.setup_metadata(&["A"]).unwrap();
 
-    let mut tui = test_tui_with_size(env, 80, 14);
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            width: 80,
+            height: 14,
+            ..Default::default()
+        },
+    );
 
     tui.input_then_render([KeyCode::Down, KeyCode::Down])
         .assert_rendered_term_svg_eq(file![
@@ -132,7 +148,14 @@ fn details_view_renders_multiple_hunks_and_files() {
     env.file("alpha.txt", first_file);
     env.file("beta.txt", second_file);
 
-    let mut tui = test_tui_with_size(env, 100, 18);
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            width: 100,
+            height: 18,
+            ..Default::default()
+        },
+    );
 
     tui.input_then_render('d')
         .assert_rendered_term_svg_eq(file![
@@ -147,7 +170,14 @@ fn details_diff_svg_shows_plus_and_minus_backgrounds() {
 
     env.file("A", "A-changed\n");
 
-    let mut tui = test_tui_with_size(env, 100, 12);
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            width: 100,
+            height: 12,
+            ..Default::default()
+        },
+    );
 
     tui.input_then_render('d')
         .assert_rendered_term_svg_eq(file![
@@ -164,7 +194,14 @@ fn toggling_details_off_and_on_resets_scroll_position() {
         .collect::<String>();
     env.file("large.txt", file_contents);
 
-    let mut tui = test_tui_with_size(env, 100, 10);
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            width: 100,
+            height: 10,
+            ..Default::default()
+        },
+    );
 
     tui.input_then_render('d')
         .assert_rendered_term_svg_eq(file![
@@ -201,7 +238,14 @@ fn details_view_syntax_highlighting_survives_scrolling() {
         .collect::<String>();
     env.file("syntax.rs", rust_code);
 
-    let mut tui = test_tui_with_size(env, 100, 10);
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            width: 100,
+            height: 10,
+            ..Default::default()
+        },
+    );
 
     tui.input_then_render('d')
         .assert_rendered_term_svg_eq(file![
@@ -224,7 +268,14 @@ fn details_view_can_grow_and_shrink() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
     env.setup_metadata(&["A"]).unwrap();
 
-    let mut tui = test_tui_with_size(env, 100, 16);
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            width: 100,
+            height: 16,
+            ..Default::default()
+        },
+    );
 
     tui.input_then_render('d');
     tui.input_then_render("++-")
@@ -236,7 +287,14 @@ fn details_view_resize_clamps_to_max_and_min_width() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
     env.setup_metadata(&["A"]).unwrap();
 
-    let mut tui = test_tui_with_size(env, 100, 16);
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            width: 100,
+            height: 16,
+            ..Default::default()
+        },
+    );
 
     tui.input_then_render('d');
     tui.input_then_render("++++++++++++++++++++");
@@ -258,7 +316,14 @@ fn details_cursor_stays_visible_after_resizing() {
     env.file("alpha.txt", long_lines);
     env.file("beta.txt", "beta\n");
 
-    let mut tui = test_tui_with_size(env, 80, 10);
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            width: 80,
+            height: 10,
+            ..Default::default()
+        },
+    );
 
     tui.input_then_render('d');
     tui.input_then_render('l');
@@ -365,12 +430,19 @@ fn full_screen_details_scrolls_selected_hunk_to_include_final_line() {
     env.file("first-added.txt", first_file_contents);
     env.file("second-added.txt", second_file_contents);
 
-    let mut tui = test_tui_with_size(env, 100, 12);
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            width: 100,
+            height: 12,
+            ..Default::default()
+        },
+    );
 
     tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('D')));
     tui.render_with_messages(None, Vec::new());
 
-    let output = tui.render_with_messages('j', Vec::new()).output();
+    let output = tui.render_with_messages('j', Vec::new()).rendered_output();
     assert!(
         output.contains("second-04"),
         "selected second hunk should include its final line, got:\n{output}"

--- a/crates/but/src/command/legacy/status/tui/tests/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/mod.rs
@@ -6,8 +6,12 @@ use crossterm::event::*;
 use snapbox::{file, str};
 use temp_env::with_var;
 
-use crate::command::legacy::status::tui::tests::utils::{test_tui, test_tui_with_size};
-use crate::command::legacy::status::tui::{Message, ReloadCause};
+use crate::CliId;
+use crate::command::legacy::status::tui::tests::utils::{
+    TestTuiOptions, test_tui, test_tui_with_options,
+};
+use crate::command::legacy::status::tui::{BackstackEntry, Message, ReloadCause};
+use crate::command::legacy::status::{TuiOutcome, TuiRunOptions};
 
 mod branch_picker_tests;
 mod branch_tests;
@@ -101,7 +105,14 @@ fn narrow_hotbar_prioritizes_help_and_quit() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
     env.setup_metadata(&["A"]).unwrap();
 
-    let mut tui = test_tui_with_size(env, 42, 20);
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            width: 42,
+            height: 20,
+            ..Default::default()
+        },
+    );
 
     tui.input_then_render(None)
         .assert_rendered_term_svg_eq(file![
@@ -114,7 +125,14 @@ fn narrow_hotbar_keeps_help_and_quit_visible_in_modal_modes() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
     env.setup_metadata(&["A"]).unwrap();
 
-    let mut tui = test_tui_with_size(env, 36, 20);
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            width: 36,
+            height: 20,
+            ..Default::default()
+        },
+    );
 
     tui.input_then_render('r')
         .assert_rendered_term_svg_eq(file![
@@ -141,7 +159,14 @@ fn help_popup_scrolls() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
     env.setup_metadata(&["A"]).unwrap();
 
-    let mut tui = test_tui_with_size(env, 100, 10);
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            width: 100,
+            height: 10,
+            ..Default::default()
+        },
+    );
 
     tui.input_then_render('?')
         .assert_rendered_term_svg_eq(file!["snapshots/help_popup_scrolls_001.svg"]);
@@ -341,7 +366,14 @@ fn cursor_movement_scrolls_viewport_down() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
     env.setup_metadata(&["A", "B"]).unwrap();
 
-    let mut tui = test_tui_with_size(env, 100, 8);
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            width: 100,
+            height: 8,
+            ..Default::default()
+        },
+    );
 
     tui.input_then_render(None)
         .assert_rendered_term_svg_eq(file![
@@ -361,7 +393,14 @@ fn cursor_movement_scrolls_viewport_up() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
     env.setup_metadata(&["A", "B"]).unwrap();
 
-    let mut tui = test_tui_with_size(env, 100, 8);
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            width: 100,
+            height: 8,
+            ..Default::default()
+        },
+    );
 
     tui.input_then_render([KeyCode::Down, KeyCode::Down, KeyCode::Down, KeyCode::Down])
         .assert_rendered_term_svg_eq(file![
@@ -381,7 +420,14 @@ fn scrolling_keeps_three_rows_of_context_when_possible() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
     env.setup_metadata(&["A", "B"]).unwrap();
 
-    let mut tui = test_tui_with_size(env, 100, 8);
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            width: 100,
+            height: 8,
+            ..Default::default()
+        },
+    );
     let visible_height = 6;
 
     tui.input_then_render(None);
@@ -403,7 +449,14 @@ fn section_jumps_scroll_viewport_when_target_is_offscreen() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
     env.setup_metadata(&["A", "B"]).unwrap();
 
-    let mut tui = test_tui_with_size(env, 100, 8);
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            width: 100,
+            height: 8,
+            ..Default::default()
+        },
+    );
 
     tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('J')))
         .assert_rendered_term_svg_eq(file![
@@ -429,7 +482,14 @@ fn moving_to_merge_base_scrolls_to_keep_selection_visible() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
     env.setup_metadata(&["A", "B"]).unwrap();
 
-    let mut tui = test_tui_with_size(env, 100, 8);
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            width: 100,
+            height: 8,
+            ..Default::default()
+        },
+    );
 
     tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('J')))
         .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
@@ -446,7 +506,14 @@ fn reload_preserves_visible_selection_when_scrolled() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
     env.setup_metadata(&["A", "B"]).unwrap();
 
-    let mut tui = test_tui_with_size(env, 100, 8);
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            width: 100,
+            height: 8,
+            ..Default::default()
+        },
+    );
 
     tui.input_then_render([KeyCode::Down, KeyCode::Down, KeyCode::Down, KeyCode::Down]);
 
@@ -465,7 +532,14 @@ fn inline_reword_renders_on_visible_row_when_scrolled() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
     env.setup_metadata(&["A", "B"]).unwrap();
 
-    let mut tui = test_tui_with_size(env, 100, 8);
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            width: 100,
+            height: 8,
+            ..Default::default()
+        },
+    );
 
     tui.input_then_render([
         KeyCode::Down,
@@ -830,7 +904,14 @@ fn commit_file_toggle_on_commit_without_files_is_noop() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
     env.setup_metadata(&["A"]).unwrap();
 
-    let mut tui = test_tui_with_size(env, 100, 12);
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            width: 100,
+            height: 12,
+            ..Default::default()
+        },
+    );
 
     tui.input_then_render(KeyCode::Down)
         .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
@@ -962,4 +1043,95 @@ fn commit_file_toggle_off_from_commit_row_preserves_commit_selection() {
         .assert_rendered_term_svg_eq(file![
             "snapshots/commit_file_toggle_off_from_commit_row_preserves_commit_selection_final.svg"
         ]);
+}
+
+#[test]
+fn pick_changes_mode() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
+    env.setup_metadata(&[]).unwrap();
+
+    env.file("one", "content of one");
+    env.file("two", "content of two");
+
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            run_options: TuiRunOptions::PickChanges,
+            ..Default::default()
+        },
+    );
+
+    tui.input_then_render(None)
+        .assert_rendered_contains("pick changes");
+
+    tui.input_then_render('j');
+    tui.input_then_render(' ');
+    let outcome = tui
+        .input_then_render(KeyCode::Enter)
+        .take_outcome()
+        .unwrap();
+
+    let cli_ids = match outcome {
+        TuiOutcome::CliIds(cli_ids) => cli_ids,
+        _ => panic!("unexpected outcome {outcome:#?}"),
+    };
+
+    for id in &cli_ids {
+        assert!(matches!(dbg!(id), CliId::Uncommitted(..)));
+    }
+    assert_eq!(cli_ids.len(), 1);
+}
+
+#[test]
+fn stays_in_pick_change_mode_after_full_screen_details() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
+    env.setup_metadata(&[]).unwrap();
+
+    env.file("one", "content of one");
+    env.file("two", "content of two");
+
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            run_options: TuiRunOptions::PickChanges,
+            ..Default::default()
+        },
+    );
+
+    tui.input_then_render(None)
+        .assert_rendered_contains("pick changes")
+        .assert_backstack_eq([]);
+
+    // mark some changes
+    tui.input_then_render('j');
+    tui.input_then_render(' ')
+        .assert_backstack_eq([BackstackEntry::Mark]);
+
+    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('D')))
+        .assert_rendered_contains("details")
+        .assert_backstack_eq([
+            BackstackEntry::LeaveNormalMode,
+            BackstackEntry::OpenFullScreenDetailsView,
+            BackstackEntry::Mark,
+        ]);
+
+    tui.input_then_render(KeyCode::Esc)
+        .assert_rendered_contains("pick changes")
+        .assert_backstack_eq([BackstackEntry::Mark]);
+
+    // ensure the changes are still marked after returning from details mode
+    let outcome = tui
+        .input_then_render(KeyCode::Enter)
+        .take_outcome()
+        .unwrap();
+
+    let cli_ids = match outcome {
+        TuiOutcome::CliIds(cli_ids) => cli_ids,
+        _ => panic!("unexpected outcome {outcome:#?}"),
+    };
+
+    for id in &cli_ids {
+        assert!(matches!(dbg!(id), CliId::Uncommitted(..)));
+    }
+    assert_eq!(cli_ids.len(), 1);
 }

--- a/crates/but/src/command/legacy/status/tui/tests/move_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/move_tests.rs
@@ -4,7 +4,7 @@ use snapbox::{file, str};
 
 use crate::command::legacy::status::tui::{
     Message, ReloadCause,
-    tests::utils::{test_tui, test_tui_with_size},
+    tests::utils::{TestTuiOptions, test_tui, test_tui_with_options},
 };
 
 #[test]
@@ -33,7 +33,14 @@ fn move_mode_keeps_selected_commit_and_extension_visible_when_scrolled() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
     env.setup_metadata(&["A"]).unwrap();
 
-    let mut tui = test_tui_with_size(env, 100, 6);
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            width: 100,
+            height: 6,
+            ..Default::default()
+        },
+    );
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unassigned changes] (no changes)"]);

--- a/crates/but/src/command/legacy/status/tui/tests/utils.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/utils.rs
@@ -13,9 +13,9 @@ use temp_env::with_var;
 use crate::{
     args::OutputFormat,
     command::legacy::status::{
-        StatusFlags, StatusOutput, StatusRenderMode, TuiLaunchOptions, TuiRunOptions,
+        StatusFlags, StatusOutput, StatusRenderMode, TuiLaunchOptions, TuiOutcome, TuiRunOptions,
         build_status_context, build_status_output,
-        tui::{App, EventPolling, Message, ReloadCause, render_loop_once},
+        tui::{App, BackstackEntry, EventPolling, Message, ReloadCause, render_loop_once},
     },
     theme,
     tui::TerminalGuard,
@@ -38,11 +38,40 @@ enum SvgSnapshotComparison {
     Hint,
 }
 
-pub(super) fn test_tui(env: Sandbox) -> TestTui {
-    test_tui_with_size(env, 100, 20)
+pub(super) struct TestTuiOptions {
+    pub(super) width: u16,
+    pub(super) height: u16,
+    pub(super) run_options: TuiRunOptions,
 }
 
-pub(super) fn test_tui_with_size(env: Sandbox, width: u16, height: u16) -> TestTui {
+impl Default for TestTuiOptions {
+    fn default() -> Self {
+        Self {
+            width: 100,
+            height: 20,
+            run_options: Default::default(),
+        }
+    }
+}
+
+pub(super) fn test_tui(env: Sandbox) -> TestTui {
+    test_tui_with_options(
+        env,
+        TestTuiOptions {
+            width: 100,
+            height: 20,
+            ..Default::default()
+        },
+    )
+}
+
+pub(super) fn test_tui_with_options(env: Sandbox, options: TestTuiOptions) -> TestTui {
+    let TestTuiOptions {
+        width,
+        height,
+        run_options,
+    } = options;
+
     env.invoke_git("config user.name committer");
     env.invoke_git("config user.email committer@example.com");
 
@@ -57,7 +86,6 @@ pub(super) fn test_tui_with_size(env: Sandbox, width: u16, height: u16) -> TestT
         debug: false,
         ..Default::default()
     };
-    let run_options = TuiRunOptions::Normal;
 
     let mut guard = ctx.exclusive_worktree_access();
 
@@ -148,7 +176,14 @@ impl TestTui {
         let env = self.env.take().expect(
             "env already removed?! This shouldn't happen, only TestTui::recreate removes the env",
         );
-        self = test_tui_with_size(env, self.width, self.height);
+        self = test_tui_with_options(
+            env,
+            TestTuiOptions {
+                width: self.width,
+                height: self.height,
+                ..Default::default()
+            },
+        );
         self
     }
 }
@@ -172,7 +207,7 @@ impl Drop for TestTui {
 
         eprintln!("\nCurrent terminal state:");
 
-        for (idx, line) in render_result.output().lines().enumerate() {
+        for (idx, line) in render_result.rendered_output().lines().enumerate() {
             let line = line.trim_matches('"');
             if selected_row.is_some_and(|row| row == idx) {
                 colored::control::set_override(true);
@@ -222,7 +257,7 @@ pub(super) struct TestTuiInputThenRenderResult<'a>(&'a mut TestTui);
 impl TestTuiInputThenRenderResult<'_> {
     #[track_caller]
     pub(super) fn assert_rendered_contains(self, expected: &str) -> Self {
-        let output = self.output();
+        let output = self.rendered_output();
         assert!(
             output.contains(expected),
             "expected rendered output to contain {expected:?}, got:\n{output}"
@@ -231,7 +266,7 @@ impl TestTuiInputThenRenderResult<'_> {
         self
     }
 
-    pub(super) fn output(&self) -> String {
+    pub(super) fn rendered_output(&self) -> String {
         self.0.terminal.backend().to_string()
     }
 
@@ -286,6 +321,23 @@ impl TestTuiInputThenRenderResult<'_> {
             std::panic::Location::caller(),
         );
         snapbox::assert_data_eq!(svg, expected);
+        self
+    }
+
+    pub(super) fn take_outcome(self) -> Option<TuiOutcome> {
+        self.0.app.outcome.take()
+    }
+
+    #[track_caller]
+    pub(super) fn assert_backstack_eq(
+        self,
+        entries: impl IntoIterator<Item = BackstackEntry>,
+    ) -> Self {
+        let expected = entries.into_iter().collect::<Vec<_>>();
+        let actual = self.0.app.backstack.iter().copied().collect::<Vec<_>>();
+        if expected != actual {
+            panic!("wrong backstack\n  expected: {expected:?}\n  actual: {actual:?}");
+        }
         self
     }
 }


### PR DESCRIPTION
If you were in "pick changes" mode (used with `commit2 --interactive`) and you entered and left full screen details you'd end up in normal mode, not "pick changes". The marks would also be lost.