### PR TITLE
fix(tui): show marks while focused on split details

### DIFF
--- a/crates/but/src/command/legacy/status/tui/key_bind/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/key_bind/mod.rs
@@ -76,6 +76,7 @@ pub(super) fn default_key_binds() -> KeyBinds {
                 builder.grow_details().register();
                 builder.shrink_details().register();
                 builder.details_focus_status().register();
+                builder.focus_details().hide_from_hotbar().register();
 
                 builder.command().register();
                 builder.shell_command().register();

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -905,9 +905,13 @@ impl App {
     }
 
     fn handle_unfocus_details(&mut self, messages: &mut Vec<Message>) {
-        if let Mode::Details(DetailsMode { full_screen, .. }) = &*self.mode
-            && *full_screen
-        {
+        if let Mode::Details(DetailsMode { full_screen, .. }) = &*self.mode {
+            if *full_screen {
+                return;
+            }
+
+            self.restore_mode_before_details(messages);
+            self.maybe_move_cursor_into_file_list();
             return;
         }
 
@@ -1068,6 +1072,15 @@ impl App {
     }
 
     fn handle_focus_details(&mut self, full_screen: bool, messages: &mut Vec<Message>) {
+        if !full_screen
+            && let Mode::Details(DetailsMode {
+                full_screen: false, ..
+            }) = &*self.mode
+        {
+            self.restore_mode_before_details(messages);
+            return;
+        }
+
         if self.is_details_visible {
             messages.push(Message::Details(DetailsMessage::SelectFirstSection));
         } else {

--- a/crates/but/src/command/legacy/status/tui/mode.rs
+++ b/crates/but/src/command/legacy/status/tui/mode.rs
@@ -59,11 +59,8 @@ impl Mode {
                 | CommitSource::Stack(..) => None,
             },
             Mode::PickChanges(pick_uncommitted_mode) => Some(&pick_uncommitted_mode.marks),
-            Mode::InlineReword(..)
-            | Mode::Command(..)
-            | Mode::Move(..)
-            | Mode::Details(..)
-            | Mode::Stack(..) => None,
+            Mode::Details(details_mode) => Some(details_mode.return_mode.marks()),
+            Mode::InlineReword(..) | Mode::Command(..) | Mode::Move(..) | Mode::Stack(..) => None,
         }
     }
 }
@@ -378,6 +375,15 @@ pub(super) struct DetailsMode {
 pub(super) enum DetailsReturnMode {
     Normal(NormalMode),
     PickChanges(PickUncommittedMode),
+}
+
+impl DetailsReturnMode {
+    fn marks(&self) -> &Marks {
+        match self {
+            DetailsReturnMode::Normal(normal_mode) => &normal_mode.marks,
+            DetailsReturnMode::PickChanges(pick_uncommitted_mode) => &pick_uncommitted_mode.marks,
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/crates/but/src/command/legacy/status/tui/tests/marking_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/marking_tests.rs
@@ -2,7 +2,7 @@ use but_testsupport::Sandbox;
 use crossterm::event::*;
 use snapbox::{file, str};
 
-use crate::command::legacy::status::tui::tests::utils::test_tui;
+use crate::command::legacy::status::tui::{BackstackEntry, tests::utils::test_tui};
 
 #[test]
 fn marking_individual_commit_toggles_mark_indicator() {
@@ -101,4 +101,56 @@ fn multi_squash_marked_commits_into_selected_marked_target() {
         .assert_rendered_term_svg_eq(file![
             "snapshots/multi_squash_marked_commits_into_selected_marked_target_final.svg"
         ]);
+}
+
+#[test]
+fn marks_still_show_in_split_details() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
+    env.setup_metadata(&[]).unwrap();
+
+    env.file("one", "content of one");
+    env.file("two", "content of two");
+
+    let mut tui = test_tui(env);
+
+    // mark some things
+    tui.input_then_render('j');
+    tui.input_then_render(' ')
+        .assert_rendered_contains("┊✔︎    kl A one")
+        .assert_rendered_contains("┊   twop A two")
+        .assert_backstack_eq([BackstackEntry::Mark])
+        .assert_rendered_term_svg_eq(file!["snapshots/marks_still_show_in_split_details_001.svg"]);
+
+    // open details view and still see the marks
+    tui.input_then_render('d')
+        .assert_rendered_contains("+content of two")
+        .assert_rendered_contains("┊✔︎    kl A one")
+        .assert_rendered_contains("┊   twop A two")
+        .assert_backstack_eq([BackstackEntry::OpenSplitDetailsView, BackstackEntry::Mark])
+        .assert_rendered_term_svg_eq(file!["snapshots/marks_still_show_in_split_details_002.svg"]);
+    tui.input_then_render('d')
+        .assert_backstack_eq([BackstackEntry::Mark])
+        .assert_rendered_term_svg_eq(file!["snapshots/marks_still_show_in_split_details_003.svg"]);
+
+    // opening and focusing details should still show marks
+    tui.input_then_render('l')
+        .assert_rendered_contains("details")
+        .assert_rendered_contains("+content of two")
+        .assert_rendered_contains("┊✔︎    kl A one")
+        .assert_rendered_contains("┊   twop A two")
+        .assert_backstack_eq([
+            BackstackEntry::LeaveNormalMode,
+            BackstackEntry::OpenSplitDetailsView,
+            BackstackEntry::Mark,
+        ])
+        .assert_rendered_term_svg_eq(file!["snapshots/marks_still_show_in_split_details_004.svg"]);
+
+    // going back to normal mode should retain marks and keep details open
+    tui.input_then_render('h')
+        .assert_rendered_contains("normal")
+        .assert_rendered_contains("+content of two")
+        .assert_rendered_contains("┊✔︎    kl A one")
+        .assert_rendered_contains("┊   twop A two")
+        .assert_backstack_eq([BackstackEntry::OpenSplitDetailsView, BackstackEntry::Mark])
+        .assert_rendered_term_svg_eq(file!["snapshots/marks_still_show_in_split_details_005.svg"]);
 }

--- a/crates/but/src/command/legacy/status/tui/tests/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/mod.rs
@@ -1062,10 +1062,11 @@ fn pick_changes_mode() {
     );
 
     tui.input_then_render(None)
-        .assert_rendered_contains("pick changes");
+        .assert_rendered_term_svg_eq(file!["snapshots/pick_changes_mode_001.svg"]);
 
     tui.input_then_render('j');
-    tui.input_then_render(' ');
+    tui.input_then_render(' ')
+        .assert_rendered_term_svg_eq(file!["snapshots/pick_changes_mode_002.svg"]);
     let outcome = tui
         .input_then_render(KeyCode::Enter)
         .take_outcome()
@@ -1099,16 +1100,23 @@ fn stays_in_pick_change_mode_after_full_screen_details() {
     );
 
     tui.input_then_render(None)
-        .assert_rendered_contains("pick changes")
+        .assert_rendered_term_svg_eq(file![
+            "snapshots/stays_in_pick_change_mode_after_full_screen_details_001.svg"
+        ])
         .assert_backstack_eq([]);
 
     // mark some changes
     tui.input_then_render('j');
     tui.input_then_render(' ')
-        .assert_backstack_eq([BackstackEntry::Mark]);
+        .assert_backstack_eq([BackstackEntry::Mark])
+        .assert_rendered_term_svg_eq(file![
+            "snapshots/stays_in_pick_change_mode_after_full_screen_details_002.svg"
+        ]);
 
     tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('D')))
-        .assert_rendered_contains("details")
+        .assert_rendered_term_svg_eq(file![
+            "snapshots/stays_in_pick_change_mode_after_full_screen_details_003.svg"
+        ])
         .assert_backstack_eq([
             BackstackEntry::LeaveNormalMode,
             BackstackEntry::OpenFullScreenDetailsView,
@@ -1116,7 +1124,9 @@ fn stays_in_pick_change_mode_after_full_screen_details() {
         ]);
 
     tui.input_then_render(KeyCode::Esc)
-        .assert_rendered_contains("pick changes")
+        .assert_rendered_term_svg_eq(file![
+            "snapshots/stays_in_pick_change_mode_after_full_screen_details_004.svg"
+        ])
         .assert_backstack_eq([BackstackEntry::Mark]);
 
     // ensure the changes are still marked after returning from details mode

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_still_show_in_split_details_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_still_show_in_split_details_001.svg
@@ -1,0 +1,357 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
+  <rect x="0" y="0" width="820" height="380" fill="#000000" />
+  <rect x="18" y="28" width="8" height="18" fill="#0000AA" />
+  <rect x="26" y="28" width="8" height="18" fill="#0000AA" />
+  <rect x="10" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="18" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="26" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="34" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="42" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="50" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="58" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="66" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="74" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="82" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="90" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="98" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="106" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="114" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="122" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="130" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="138" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="146" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="154" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="162" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="170" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="178" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="186" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="194" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="202" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="210" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="218" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="226" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="234" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="242" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="250" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="258" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="266" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="274" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="282" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="290" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="298" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="306" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="314" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="322" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="330" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="338" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="346" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="354" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="362" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="370" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="378" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="386" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="394" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="402" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="410" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="418" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="426" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="434" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="442" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="450" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="458" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="466" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="474" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="482" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="490" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="498" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="506" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="514" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="522" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="530" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="538" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="546" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="554" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="562" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="570" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="578" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="586" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="594" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="602" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="610" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="618" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="626" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="634" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="642" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="650" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="658" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="666" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="674" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="682" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="690" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="698" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="706" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="714" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="722" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="730" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="738" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="746" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="754" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="762" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="770" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="778" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="786" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="794" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="802" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="10" y="352" width="8" height="18" fill="#555555" />
+  <rect x="18" y="352" width="8" height="18" fill="#555555" />
+  <rect x="26" y="352" width="8" height="18" fill="#555555" />
+  <rect x="34" y="352" width="8" height="18" fill="#555555" />
+  <rect x="42" y="352" width="8" height="18" fill="#555555" />
+  <rect x="50" y="352" width="8" height="18" fill="#555555" />
+  <rect x="58" y="352" width="8" height="18" fill="#555555" />
+  <rect x="66" y="352" width="8" height="18" fill="#555555" />
+  <rect x="74" y="352" width="8" height="18" fill="#555555" />
+  <rect x="82" y="352" width="8" height="18" fill="#555555" />
+  <text x="10" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
+  <text x="18" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
+  <text x="26" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="34" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="50" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="58" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="66" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="74" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="82" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="90" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="98" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="106" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="114" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="122" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="130" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="146" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="154" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="162" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="178" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="186" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="194" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="202" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="10" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="42" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">✔︎</text>
+  <text x="58" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="66" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="82" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="98" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="106" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="114" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="42" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="50" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="58" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="66" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="82" y="60" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="98" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="106" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="114" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="10" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="10" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┴</text>
+  <text x="26" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="34" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="42" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="50" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="58" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
+  <text x="66" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="74" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="90" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
+  <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="106" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="122" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="130" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="138" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="154" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="162" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="178" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="186" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
+  <text x="202" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="210" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="218" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="226" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="234" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="242" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="250" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="258" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="266" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="274" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="290" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="298" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="306" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="322" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
+  <text x="10" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="18" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="34" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="42" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="50" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="58" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="66" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="74" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="82" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="90" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="98" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="106" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="114" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="122" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="130" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="138" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="146" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="154" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="162" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="170" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="178" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="186" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="194" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="202" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="210" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="218" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="226" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="234" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="242" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="250" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="258" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="266" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="274" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="282" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="290" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="298" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="306" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="314" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="322" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="330" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="338" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="346" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="354" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="362" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="370" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="378" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="386" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="394" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="402" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="410" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="418" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="426" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="434" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="442" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="450" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="458" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="466" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="474" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="482" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="490" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="498" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="506" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="514" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="522" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="530" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="538" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="546" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="554" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="562" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="570" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="578" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="586" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="594" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="602" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="610" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="618" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="626" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="634" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="642" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="650" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="658" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="666" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="674" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="682" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="690" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="698" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="706" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="714" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="722" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="730" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="738" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="746" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="754" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="762" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="770" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="778" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="786" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="794" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="802" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="34" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="42" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="50" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="58" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="66" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="98" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↑</text>
+  <text x="106" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="114" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="130" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="138" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="154" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="170" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↓</text>
+  <text x="178" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="186" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">j</text>
+  <text x="202" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="210" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="218" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="226" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="242" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="258" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="274" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="282" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="290" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="306" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="322" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="338" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="346" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="354" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="362" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="370" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="378" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="394" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="410" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="426" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="434" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="442" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="450" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="458" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="466" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="474" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="490" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="506" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="522" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="530" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="538" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="546" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="554" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="570" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="578" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="586" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="594" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="602" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="610" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="618" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="634" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="650" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">?</text>
+  <text x="666" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="674" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="682" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="690" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="706" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="722" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="738" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="746" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="754" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="762" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+</svg>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_still_show_in_split_details_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_still_show_in_split_details_002.svg
@@ -1,0 +1,410 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
+  <rect x="0" y="0" width="820" height="380" fill="#000000" />
+  <rect x="18" y="28" width="8" height="18" fill="#0000AA" />
+  <rect x="26" y="28" width="8" height="18" fill="#0000AA" />
+  <rect x="10" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="18" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="26" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="34" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="42" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="50" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="58" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="66" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="74" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="82" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="90" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="98" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="106" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="114" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="122" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="130" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="138" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="146" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="154" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="162" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="170" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="178" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="186" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="194" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="202" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="210" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="218" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="226" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="234" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="242" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="250" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="258" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="266" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="274" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="282" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="290" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="298" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="306" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="314" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="322" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="330" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="338" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="346" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="354" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="362" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="370" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="378" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="386" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="394" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="402" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="482" y="118" width="8" height="18" fill="#004100" />
+  <rect x="490" y="118" width="8" height="18" fill="#004100" />
+  <rect x="498" y="118" width="8" height="18" fill="#004100" />
+  <rect x="506" y="118" width="8" height="18" fill="#004100" />
+  <rect x="514" y="118" width="8" height="18" fill="#004100" />
+  <rect x="522" y="118" width="8" height="18" fill="#004100" />
+  <rect x="530" y="118" width="8" height="18" fill="#004100" />
+  <rect x="538" y="118" width="8" height="18" fill="#004100" />
+  <rect x="546" y="118" width="8" height="18" fill="#004100" />
+  <rect x="554" y="118" width="8" height="18" fill="#004100" />
+  <rect x="562" y="118" width="8" height="18" fill="#004100" />
+  <rect x="570" y="118" width="8" height="18" fill="#004100" />
+  <rect x="578" y="118" width="8" height="18" fill="#004100" />
+  <rect x="586" y="118" width="8" height="18" fill="#004100" />
+  <rect x="594" y="118" width="8" height="18" fill="#004100" />
+  <rect x="10" y="352" width="8" height="18" fill="#555555" />
+  <rect x="18" y="352" width="8" height="18" fill="#555555" />
+  <rect x="26" y="352" width="8" height="18" fill="#555555" />
+  <rect x="34" y="352" width="8" height="18" fill="#555555" />
+  <rect x="42" y="352" width="8" height="18" fill="#555555" />
+  <rect x="50" y="352" width="8" height="18" fill="#555555" />
+  <rect x="58" y="352" width="8" height="18" fill="#555555" />
+  <rect x="66" y="352" width="8" height="18" fill="#555555" />
+  <rect x="74" y="352" width="8" height="18" fill="#555555" />
+  <rect x="82" y="352" width="8" height="18" fill="#555555" />
+  <text x="10" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
+  <text x="18" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
+  <text x="26" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="34" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="50" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="58" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="66" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="74" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="82" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="90" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="98" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="106" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="114" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="122" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="130" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="146" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="154" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="162" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="178" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="186" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="194" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="202" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="410" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="418" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="426" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="434" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="442" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="450" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="458" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="466" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="474" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="482" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="490" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╮</text>
+  <text x="10" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="42" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">✔︎</text>
+  <text x="58" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="66" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="82" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="98" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="106" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="114" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="410" y="42" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="426" y="42" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">j</text>
+  <text x="434" y="42" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="442" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">:</text>
+  <text x="458" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="466" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="474" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="490" y="42" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="42" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="50" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="58" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="66" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="82" y="60" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="98" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="106" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="114" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="410" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="418" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="426" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="434" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="442" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="450" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="458" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="466" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="474" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="482" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="490" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
+  <text x="10" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="410" y="78" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="10" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┴</text>
+  <text x="26" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="34" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="42" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="50" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="58" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
+  <text x="66" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="74" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="90" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
+  <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="106" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="122" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="130" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="138" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="154" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="162" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="178" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="186" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
+  <text x="202" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="210" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="218" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="226" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="234" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="242" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="250" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="258" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="266" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="274" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="290" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="298" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="306" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="322" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
+  <text x="410" y="96" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="418" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">@</text>
+  <text x="426" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">@</text>
+  <text x="442" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="450" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="458" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">,</text>
+  <text x="466" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="482" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">+</text>
+  <text x="490" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="498" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">,</text>
+  <text x="506" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="522" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">@</text>
+  <text x="530" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">@</text>
+  <text x="410" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="418" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="426" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="434" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="442" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="450" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="458" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="466" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="474" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="482" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="490" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="498" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="506" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="514" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="522" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="530" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="410" y="132" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="434" y="132" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="450" y="132" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="466" y="132" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="482" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">+</text>
+  <text x="490" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="498" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="506" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="514" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="522" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="530" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="538" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="554" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="562" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="578" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="586" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="594" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="410" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="168" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="186" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="204" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="222" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="240" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="276" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="294" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="312" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="330" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="10" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="18" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="34" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="42" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="50" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="58" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="66" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="74" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="82" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="90" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="98" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="106" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="114" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="122" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="130" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="138" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="146" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="154" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="162" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="170" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="178" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="186" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="194" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="202" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="210" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="218" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="226" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="234" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="242" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="250" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="258" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="266" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="274" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="282" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="290" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="298" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="306" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="314" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="322" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="330" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="338" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="346" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="354" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="362" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="370" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="378" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="386" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="394" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="402" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="410" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="418" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="426" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="434" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="442" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="450" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="458" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="466" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="474" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="482" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="490" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="498" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="506" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="514" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="522" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="530" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="538" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="546" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="554" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="562" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="570" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="578" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="586" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="594" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="602" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="610" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="618" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="626" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="634" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="642" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="650" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="658" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="666" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="674" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="682" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="690" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="698" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="706" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="714" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="722" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="730" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="738" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="746" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="754" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="762" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="770" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="778" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="786" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="794" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="802" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="26" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="34" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="42" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="50" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="58" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="66" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="98" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↑</text>
+  <text x="106" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="114" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="130" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="138" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="154" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="170" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↓</text>
+  <text x="178" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="186" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">j</text>
+  <text x="202" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="210" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="218" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="226" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="242" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="258" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="274" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="282" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="290" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="306" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="322" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="338" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="346" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="354" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="362" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="370" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="378" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="394" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="410" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="426" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="434" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="442" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="450" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="458" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="466" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="474" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="490" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="506" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="522" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="530" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="538" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="546" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="554" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="570" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="578" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="586" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="594" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="602" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="610" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="618" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="634" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="650" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">?</text>
+  <text x="666" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="674" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="682" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="690" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="706" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="722" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="738" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="746" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="754" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="762" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+</svg>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_still_show_in_split_details_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_still_show_in_split_details_003.svg
@@ -1,0 +1,357 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
+  <rect x="0" y="0" width="820" height="380" fill="#000000" />
+  <rect x="18" y="28" width="8" height="18" fill="#0000AA" />
+  <rect x="26" y="28" width="8" height="18" fill="#0000AA" />
+  <rect x="10" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="18" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="26" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="34" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="42" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="50" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="58" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="66" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="74" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="82" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="90" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="98" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="106" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="114" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="122" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="130" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="138" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="146" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="154" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="162" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="170" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="178" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="186" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="194" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="202" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="210" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="218" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="226" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="234" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="242" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="250" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="258" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="266" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="274" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="282" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="290" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="298" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="306" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="314" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="322" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="330" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="338" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="346" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="354" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="362" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="370" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="378" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="386" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="394" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="402" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="410" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="418" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="426" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="434" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="442" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="450" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="458" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="466" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="474" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="482" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="490" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="498" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="506" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="514" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="522" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="530" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="538" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="546" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="554" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="562" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="570" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="578" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="586" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="594" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="602" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="610" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="618" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="626" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="634" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="642" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="650" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="658" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="666" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="674" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="682" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="690" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="698" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="706" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="714" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="722" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="730" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="738" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="746" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="754" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="762" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="770" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="778" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="786" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="794" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="802" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="10" y="352" width="8" height="18" fill="#555555" />
+  <rect x="18" y="352" width="8" height="18" fill="#555555" />
+  <rect x="26" y="352" width="8" height="18" fill="#555555" />
+  <rect x="34" y="352" width="8" height="18" fill="#555555" />
+  <rect x="42" y="352" width="8" height="18" fill="#555555" />
+  <rect x="50" y="352" width="8" height="18" fill="#555555" />
+  <rect x="58" y="352" width="8" height="18" fill="#555555" />
+  <rect x="66" y="352" width="8" height="18" fill="#555555" />
+  <rect x="74" y="352" width="8" height="18" fill="#555555" />
+  <rect x="82" y="352" width="8" height="18" fill="#555555" />
+  <text x="10" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
+  <text x="18" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
+  <text x="26" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="34" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="50" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="58" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="66" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="74" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="82" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="90" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="98" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="106" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="114" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="122" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="130" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="146" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="154" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="162" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="178" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="186" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="194" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="202" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="10" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="42" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">✔︎</text>
+  <text x="58" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="66" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="82" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="98" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="106" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="114" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="42" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="50" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="58" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="66" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="82" y="60" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="98" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="106" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="114" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="10" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="10" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┴</text>
+  <text x="26" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="34" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="42" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="50" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="58" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
+  <text x="66" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="74" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="90" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
+  <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="106" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="122" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="130" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="138" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="154" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="162" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="178" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="186" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
+  <text x="202" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="210" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="218" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="226" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="234" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="242" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="250" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="258" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="266" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="274" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="290" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="298" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="306" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="322" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
+  <text x="10" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="18" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="34" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="42" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="50" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="58" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="66" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="74" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="82" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="90" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="98" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="106" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="114" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="122" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="130" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="138" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="146" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="154" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="162" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="170" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="178" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="186" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="194" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="202" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="210" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="218" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="226" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="234" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="242" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="250" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="258" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="266" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="274" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="282" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="290" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="298" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="306" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="314" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="322" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="330" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="338" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="346" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="354" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="362" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="370" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="378" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="386" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="394" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="402" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="410" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="418" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="426" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="434" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="442" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="450" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="458" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="466" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="474" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="482" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="490" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="498" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="506" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="514" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="522" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="530" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="538" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="546" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="554" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="562" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="570" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="578" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="586" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="594" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="602" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="610" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="618" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="626" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="634" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="642" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="650" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="658" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="666" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="674" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="682" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="690" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="698" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="706" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="714" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="722" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="730" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="738" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="746" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="754" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="762" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="770" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="778" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="786" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="794" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="802" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="34" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="42" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="50" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="58" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="66" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="98" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↑</text>
+  <text x="106" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="114" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="130" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="138" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="154" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="170" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↓</text>
+  <text x="178" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="186" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">j</text>
+  <text x="202" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="210" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="218" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="226" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="242" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="258" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="274" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="282" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="290" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="306" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="322" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="338" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="346" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="354" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="362" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="370" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="378" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="394" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="410" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="426" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="434" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="442" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="450" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="458" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="466" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="474" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="490" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="506" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="522" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="530" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="538" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="546" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="554" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="570" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="578" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="586" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="594" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="602" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="610" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="618" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="634" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="650" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">?</text>
+  <text x="666" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="674" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="682" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="690" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="706" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="722" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="738" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="746" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="754" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="762" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+</svg>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_still_show_in_split_details_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_still_show_in_split_details_004.svg
@@ -1,0 +1,404 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
+  <rect x="0" y="0" width="820" height="380" fill="#000000" />
+  <rect x="18" y="28" width="8" height="18" fill="#0000AA" />
+  <rect x="26" y="28" width="8" height="18" fill="#0000AA" />
+  <rect x="10" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="18" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="26" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="34" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="42" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="50" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="58" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="66" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="74" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="82" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="90" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="98" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="106" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="114" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="122" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="130" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="138" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="146" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="154" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="162" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="170" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="178" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="186" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="194" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="202" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="210" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="218" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="226" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="234" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="242" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="250" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="258" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="266" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="274" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="282" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="290" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="298" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="306" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="314" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="322" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="330" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="338" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="346" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="354" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="362" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="370" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="378" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="386" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="394" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="402" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="482" y="118" width="8" height="18" fill="#004100" />
+  <rect x="490" y="118" width="8" height="18" fill="#004100" />
+  <rect x="498" y="118" width="8" height="18" fill="#004100" />
+  <rect x="506" y="118" width="8" height="18" fill="#004100" />
+  <rect x="514" y="118" width="8" height="18" fill="#004100" />
+  <rect x="522" y="118" width="8" height="18" fill="#004100" />
+  <rect x="530" y="118" width="8" height="18" fill="#004100" />
+  <rect x="538" y="118" width="8" height="18" fill="#004100" />
+  <rect x="546" y="118" width="8" height="18" fill="#004100" />
+  <rect x="554" y="118" width="8" height="18" fill="#004100" />
+  <rect x="562" y="118" width="8" height="18" fill="#004100" />
+  <rect x="570" y="118" width="8" height="18" fill="#004100" />
+  <rect x="578" y="118" width="8" height="18" fill="#004100" />
+  <rect x="586" y="118" width="8" height="18" fill="#004100" />
+  <rect x="594" y="118" width="8" height="18" fill="#004100" />
+  <rect x="10" y="352" width="8" height="18" fill="#FFA500" />
+  <rect x="18" y="352" width="8" height="18" fill="#FFA500" />
+  <rect x="26" y="352" width="8" height="18" fill="#FFA500" />
+  <rect x="34" y="352" width="8" height="18" fill="#FFA500" />
+  <rect x="42" y="352" width="8" height="18" fill="#FFA500" />
+  <rect x="50" y="352" width="8" height="18" fill="#FFA500" />
+  <rect x="58" y="352" width="8" height="18" fill="#FFA500" />
+  <rect x="66" y="352" width="8" height="18" fill="#FFA500" />
+  <rect x="74" y="352" width="8" height="18" fill="#FFA500" />
+  <rect x="82" y="352" width="8" height="18" fill="#FFA500" />
+  <rect x="90" y="352" width="8" height="18" fill="#FFA500" />
+  <text x="10" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
+  <text x="18" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
+  <text x="26" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="34" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="50" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="58" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="66" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="74" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="82" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="90" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="98" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="106" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="114" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="122" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="130" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="146" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="154" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="162" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="178" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="186" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="194" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="202" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="410" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="418" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="426" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="434" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="442" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="450" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="458" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="466" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="474" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="482" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="490" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╮</text>
+  <text x="10" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="42" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">✔︎</text>
+  <text x="58" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="66" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="82" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="98" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="106" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="114" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="410" y="42" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="426" y="42" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">j</text>
+  <text x="434" y="42" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="442" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">:</text>
+  <text x="458" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="466" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="474" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="490" y="42" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="42" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="50" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="58" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="66" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="82" y="60" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="98" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="106" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="114" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="410" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="418" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="426" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="434" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="442" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="450" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="458" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="466" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="474" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="482" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="490" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
+  <text x="10" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="410" y="78" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="10" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┴</text>
+  <text x="26" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="34" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="42" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="50" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="58" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
+  <text x="66" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="74" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="90" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
+  <text x="98" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="106" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="114" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="122" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="130" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="138" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="154" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="162" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="178" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="186" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
+  <text x="202" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="210" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="218" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="226" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="234" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="242" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="250" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="258" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="266" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="274" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="290" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="298" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="306" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="322" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
+  <text x="410" y="96" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="418" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">@</text>
+  <text x="426" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">@</text>
+  <text x="442" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="450" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="458" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">,</text>
+  <text x="466" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="482" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">+</text>
+  <text x="490" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="498" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">,</text>
+  <text x="506" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="522" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">@</text>
+  <text x="530" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">@</text>
+  <text x="410" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="418" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="426" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="434" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="442" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="450" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="458" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="466" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="474" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="482" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="490" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="498" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="506" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="514" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="522" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="530" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="410" y="132" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="434" y="132" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="450" y="132" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="466" y="132" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="482" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">+</text>
+  <text x="490" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="498" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="506" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="514" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="522" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="530" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="538" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="554" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="562" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="578" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="586" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="594" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="410" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="168" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="186" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="204" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="222" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="240" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="276" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="294" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="312" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="330" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="10" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="18" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="26" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="34" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="42" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="50" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="58" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="66" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="74" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="82" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="90" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="98" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="106" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="114" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="122" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="130" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="138" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="146" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="154" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="162" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="170" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="178" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="186" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="194" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="202" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="210" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="218" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="226" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="234" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="242" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="250" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="258" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="266" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="274" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="282" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="290" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="298" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="306" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="314" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="322" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="330" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="338" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="346" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="354" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="362" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="370" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="378" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="386" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="394" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="402" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="410" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="418" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="426" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="434" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="442" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="450" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="458" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="466" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="474" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="482" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="490" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="498" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="506" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="514" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="522" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="530" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="538" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="546" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="554" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="562" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="570" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="578" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="586" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="594" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="602" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="610" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="618" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="626" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="634" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="642" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="650" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="658" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="666" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="674" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="682" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="690" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="698" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="706" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="714" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="722" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="730" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="738" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="746" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="754" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="762" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="770" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="778" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="786" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="794" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="802" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="34" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="42" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="50" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="58" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="66" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="74" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="106" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↓</text>
+  <text x="114" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="122" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">j</text>
+  <text x="138" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="146" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="154" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">x</text>
+  <text x="162" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="178" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="186" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="194" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="202" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="218" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="234" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↑</text>
+  <text x="242" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="250" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="266" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="274" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="282" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="290" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">v</text>
+  <text x="306" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="314" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="322" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="330" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="346" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="362" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="370" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="378" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="386" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="394" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="402" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">+</text>
+  <text x="410" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">j</text>
+  <text x="426" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="434" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="442" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="450" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="458" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="466" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="482" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="490" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="498" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="506" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="522" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="538" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">?</text>
+  <text x="554" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="562" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="570" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="578" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="594" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="610" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="626" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="634" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="642" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="650" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+</svg>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_still_show_in_split_details_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_still_show_in_split_details_005.svg
@@ -1,0 +1,410 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
+  <rect x="0" y="0" width="820" height="380" fill="#000000" />
+  <rect x="18" y="28" width="8" height="18" fill="#0000AA" />
+  <rect x="26" y="28" width="8" height="18" fill="#0000AA" />
+  <rect x="10" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="18" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="26" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="34" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="42" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="50" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="58" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="66" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="74" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="82" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="90" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="98" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="106" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="114" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="122" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="130" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="138" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="146" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="154" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="162" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="170" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="178" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="186" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="194" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="202" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="210" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="218" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="226" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="234" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="242" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="250" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="258" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="266" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="274" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="282" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="290" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="298" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="306" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="314" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="322" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="330" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="338" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="346" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="354" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="362" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="370" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="378" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="386" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="394" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="402" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="482" y="118" width="8" height="18" fill="#004100" />
+  <rect x="490" y="118" width="8" height="18" fill="#004100" />
+  <rect x="498" y="118" width="8" height="18" fill="#004100" />
+  <rect x="506" y="118" width="8" height="18" fill="#004100" />
+  <rect x="514" y="118" width="8" height="18" fill="#004100" />
+  <rect x="522" y="118" width="8" height="18" fill="#004100" />
+  <rect x="530" y="118" width="8" height="18" fill="#004100" />
+  <rect x="538" y="118" width="8" height="18" fill="#004100" />
+  <rect x="546" y="118" width="8" height="18" fill="#004100" />
+  <rect x="554" y="118" width="8" height="18" fill="#004100" />
+  <rect x="562" y="118" width="8" height="18" fill="#004100" />
+  <rect x="570" y="118" width="8" height="18" fill="#004100" />
+  <rect x="578" y="118" width="8" height="18" fill="#004100" />
+  <rect x="586" y="118" width="8" height="18" fill="#004100" />
+  <rect x="594" y="118" width="8" height="18" fill="#004100" />
+  <rect x="10" y="352" width="8" height="18" fill="#555555" />
+  <rect x="18" y="352" width="8" height="18" fill="#555555" />
+  <rect x="26" y="352" width="8" height="18" fill="#555555" />
+  <rect x="34" y="352" width="8" height="18" fill="#555555" />
+  <rect x="42" y="352" width="8" height="18" fill="#555555" />
+  <rect x="50" y="352" width="8" height="18" fill="#555555" />
+  <rect x="58" y="352" width="8" height="18" fill="#555555" />
+  <rect x="66" y="352" width="8" height="18" fill="#555555" />
+  <rect x="74" y="352" width="8" height="18" fill="#555555" />
+  <rect x="82" y="352" width="8" height="18" fill="#555555" />
+  <text x="10" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
+  <text x="18" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
+  <text x="26" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="34" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="50" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="58" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="66" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="74" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="82" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="90" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="98" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="106" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="114" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="122" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="130" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="146" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="154" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="162" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="178" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="186" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="194" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="202" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="410" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="418" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="426" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="434" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="442" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="450" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="458" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="466" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="474" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="482" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="490" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╮</text>
+  <text x="10" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="42" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">✔︎</text>
+  <text x="58" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="66" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="82" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="98" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="106" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="114" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="410" y="42" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="426" y="42" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">j</text>
+  <text x="434" y="42" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="442" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">:</text>
+  <text x="458" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="466" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="474" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="490" y="42" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="42" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="50" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="58" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="66" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="82" y="60" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="98" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="106" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="114" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="410" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="418" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="426" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="434" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="442" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="450" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="458" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="466" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="474" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="482" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="490" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
+  <text x="10" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="410" y="78" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="10" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┴</text>
+  <text x="26" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="34" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="42" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="50" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="58" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
+  <text x="66" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="74" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="90" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
+  <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="106" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="122" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="130" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="138" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="154" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="162" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="178" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="186" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
+  <text x="202" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="210" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="218" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="226" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="234" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="242" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="250" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="258" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="266" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="274" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="290" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="298" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="306" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="322" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
+  <text x="410" y="96" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="418" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">@</text>
+  <text x="426" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">@</text>
+  <text x="442" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="450" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="458" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">,</text>
+  <text x="466" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="482" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">+</text>
+  <text x="490" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="498" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">,</text>
+  <text x="506" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="522" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">@</text>
+  <text x="530" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">@</text>
+  <text x="410" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="418" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="426" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="434" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="442" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="450" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="458" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="466" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="474" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="482" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="490" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="498" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="506" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="514" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="522" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="530" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="410" y="132" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="434" y="132" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="450" y="132" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="466" y="132" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="482" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">+</text>
+  <text x="490" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="498" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="506" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="514" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="522" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="530" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="538" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="554" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="562" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="578" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="586" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="594" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="410" y="150" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="168" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="186" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="204" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="222" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="240" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="258" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="276" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="294" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="312" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="410" y="330" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="10" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="18" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="34" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="42" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="50" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="58" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="66" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="74" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="82" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="90" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="98" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="106" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="114" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="122" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="130" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="138" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="146" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="154" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="162" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="170" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="178" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="186" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="194" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="202" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="210" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="218" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="226" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="234" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="242" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="250" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="258" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="266" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="274" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="282" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="290" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="298" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="306" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="314" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="322" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="330" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="338" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="346" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="354" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="362" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="370" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="378" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="386" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="394" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="402" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="410" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="418" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="426" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="434" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="442" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="450" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="458" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="466" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="474" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="482" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="490" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="498" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="506" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="514" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="522" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="530" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="538" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="546" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="554" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="562" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="570" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="578" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="586" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="594" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="602" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="610" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="618" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="626" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="634" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="642" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="650" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="658" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="666" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="674" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="682" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="690" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="698" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="706" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="714" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="722" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="730" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="738" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="746" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="754" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="762" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="770" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="778" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="786" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="794" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="802" y="348" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="26" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="34" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="42" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="50" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="58" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="66" y="366" style="fill:#FFFFFF;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="98" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↑</text>
+  <text x="106" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="114" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="130" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="138" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="154" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="170" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↓</text>
+  <text x="178" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="186" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">j</text>
+  <text x="202" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="210" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="218" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="226" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="242" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="258" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="274" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="282" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="290" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="306" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="322" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="338" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="346" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="354" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="362" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="370" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="378" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="394" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="410" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="426" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="434" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="442" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="450" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="458" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="466" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="474" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="490" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="506" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="522" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="530" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="538" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="546" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="554" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="570" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="578" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="586" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="594" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="602" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="610" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="618" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="634" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="650" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">?</text>
+  <text x="666" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="674" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="682" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="690" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="706" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="722" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="738" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="746" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="754" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="762" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+</svg>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/pick_changes_mode_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/pick_changes_mode_001.svg
@@ -1,0 +1,361 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
+  <rect x="0" y="0" width="820" height="380" fill="#000000" />
+  <rect x="10" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="18" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="26" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="34" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="42" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="50" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="58" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="66" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="74" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="82" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="90" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="98" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="106" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="114" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="122" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="130" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="138" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="146" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="154" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="162" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="170" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="178" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="186" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="194" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="202" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="210" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="218" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="226" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="234" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="242" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="250" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="258" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="266" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="274" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="282" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="290" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="298" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="306" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="314" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="322" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="330" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="338" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="346" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="354" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="362" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="370" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="378" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="386" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="394" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="402" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="410" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="418" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="426" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="434" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="442" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="450" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="458" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="466" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="474" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="482" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="490" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="498" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="506" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="514" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="522" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="530" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="538" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="546" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="554" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="562" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="570" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="578" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="586" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="594" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="602" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="610" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="618" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="626" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="634" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="642" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="650" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="658" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="666" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="674" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="682" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="690" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="698" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="706" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="714" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="722" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="730" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="738" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="746" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="754" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="762" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="770" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="778" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="786" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="794" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="802" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="10" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="18" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="26" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="34" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="42" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="50" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="58" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="66" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="74" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="82" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="90" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="98" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="106" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="114" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="122" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="130" y="352" width="8" height="18" fill="#00AA00" />
+  <text x="10" y="24" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
+  <text x="18" y="24" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
+  <text x="26" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="34" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="50" y="24" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="58" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="66" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="74" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="82" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="90" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="98" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="106" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="114" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="122" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="130" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="146" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="154" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="162" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="178" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="186" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="194" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="202" y="24" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="10" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="58" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="66" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="82" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="98" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="106" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="114" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="10" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="42" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="50" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="58" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="66" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="82" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="98" y="60" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="106" y="60" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="114" y="60" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="10" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="10" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┴</text>
+  <text x="26" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="34" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="42" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="50" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="58" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
+  <text x="66" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="74" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="90" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
+  <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="106" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="122" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="130" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="138" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="154" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="162" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="178" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="186" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
+  <text x="202" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="210" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="218" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="226" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="234" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="242" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="250" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="258" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="266" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="274" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="290" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="298" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="306" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="322" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
+  <text x="10" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="18" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="34" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="42" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="50" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="58" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="66" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="74" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="82" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="90" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="98" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="106" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="114" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="122" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="130" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="138" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="146" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="154" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="162" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="170" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="178" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="186" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="194" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="202" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="210" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="218" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="226" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="234" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="242" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="250" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="258" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="266" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="274" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="282" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="290" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="298" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="306" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="314" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="322" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="330" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="338" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="346" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="354" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="362" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="370" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="378" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="386" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="394" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="402" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="410" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="418" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="426" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="434" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="442" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="450" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="458" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="466" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="474" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="482" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="490" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="498" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="506" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="514" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="522" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="530" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="538" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="546" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="554" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="562" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="570" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="578" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="586" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="594" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="602" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="610" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="618" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="626" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="634" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="642" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="650" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="658" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="666" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="674" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="682" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="690" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="698" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="706" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="714" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="722" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="730" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="738" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="746" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="754" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="762" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="770" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="778" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="786" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="794" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="802" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="34" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="42" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="50" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="66" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="74" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="82" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="90" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="98" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="106" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="114" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="146" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="154" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="162" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="178" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="194" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="202" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="210" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="218" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="234" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="250" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="258" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="266" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="274" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="282" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="298" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="306" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="314" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="322" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="330" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="338" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="346" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="362" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="378" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↑</text>
+  <text x="386" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="394" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="410" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="418" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="434" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="450" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↓</text>
+  <text x="458" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="466" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">j</text>
+  <text x="482" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="490" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="498" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="506" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="522" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="538" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="554" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="562" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="570" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="578" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="586" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="594" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="602" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="618" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="634" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">?</text>
+  <text x="650" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="658" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="666" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="674" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="690" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="706" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="722" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="730" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="738" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="746" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+</svg>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/pick_changes_mode_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/pick_changes_mode_002.svg
@@ -1,0 +1,364 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
+  <rect x="0" y="0" width="820" height="380" fill="#000000" />
+  <rect x="18" y="28" width="8" height="18" fill="#0000AA" />
+  <rect x="26" y="28" width="8" height="18" fill="#0000AA" />
+  <rect x="10" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="18" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="26" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="34" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="42" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="50" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="58" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="66" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="74" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="82" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="90" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="98" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="106" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="114" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="122" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="130" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="138" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="146" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="154" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="162" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="170" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="178" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="186" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="194" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="202" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="210" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="218" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="226" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="234" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="242" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="250" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="258" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="266" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="274" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="282" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="290" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="298" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="306" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="314" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="322" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="330" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="338" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="346" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="354" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="362" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="370" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="378" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="386" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="394" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="402" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="410" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="418" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="426" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="434" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="442" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="450" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="458" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="466" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="474" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="482" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="490" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="498" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="506" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="514" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="522" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="530" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="538" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="546" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="554" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="562" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="570" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="578" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="586" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="594" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="602" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="610" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="618" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="626" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="634" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="642" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="650" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="658" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="666" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="674" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="682" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="690" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="698" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="706" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="714" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="722" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="730" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="738" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="746" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="754" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="762" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="770" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="778" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="786" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="794" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="802" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="10" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="18" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="26" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="34" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="42" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="50" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="58" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="66" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="74" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="82" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="90" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="98" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="106" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="114" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="122" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="130" y="352" width="8" height="18" fill="#00AA00" />
+  <text x="10" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
+  <text x="18" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
+  <text x="26" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="34" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="50" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="58" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="66" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="74" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="82" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="90" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="98" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="106" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="114" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="122" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="130" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="146" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="154" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="162" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="178" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="186" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="194" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="202" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="10" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="42" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">✔︎</text>
+  <text x="58" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="66" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="82" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="98" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="106" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="114" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="42" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="50" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="58" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="66" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="82" y="60" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="98" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="106" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="114" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="10" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="10" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┴</text>
+  <text x="26" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="34" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="42" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="50" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="58" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
+  <text x="66" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="74" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="90" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
+  <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="106" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="122" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="130" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="138" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="154" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="162" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="178" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="186" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
+  <text x="202" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="210" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="218" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="226" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="234" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="242" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="250" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="258" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="266" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="274" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="290" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="298" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="306" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="322" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
+  <text x="10" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="18" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="34" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="42" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="50" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="58" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="66" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="74" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="82" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="90" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="98" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="106" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="114" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="122" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="130" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="138" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="146" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="154" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="162" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="170" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="178" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="186" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="194" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="202" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="210" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="218" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="226" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="234" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="242" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="250" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="258" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="266" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="274" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="282" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="290" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="298" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="306" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="314" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="322" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="330" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="338" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="346" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="354" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="362" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="370" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="378" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="386" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="394" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="402" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="410" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="418" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="426" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="434" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="442" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="450" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="458" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="466" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="474" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="482" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="490" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="498" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="506" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="514" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="522" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="530" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="538" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="546" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="554" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="562" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="570" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="578" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="586" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="594" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="602" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="610" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="618" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="626" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="634" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="642" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="650" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="658" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="666" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="674" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="682" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="690" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="698" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="706" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="714" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="722" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="730" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="738" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="746" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="754" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="762" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="770" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="778" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="786" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="794" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="802" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="34" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="42" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="50" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="66" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="74" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="82" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="90" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="98" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="106" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="114" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="146" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="154" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="162" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="178" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="194" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="202" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="210" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="218" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="234" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="250" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="258" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="266" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="274" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="282" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="298" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="306" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="314" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="322" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="330" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="338" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="346" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="362" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="378" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↑</text>
+  <text x="386" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="394" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="410" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="418" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="434" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="450" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↓</text>
+  <text x="458" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="466" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">j</text>
+  <text x="482" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="490" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="498" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="506" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="522" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="538" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="554" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="562" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="570" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="578" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="586" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="594" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="602" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="618" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="634" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">?</text>
+  <text x="650" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="658" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="666" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="674" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="690" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="706" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="722" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="730" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="738" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="746" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+</svg>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/stays_in_pick_change_mode_after_full_screen_details_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/stays_in_pick_change_mode_after_full_screen_details_001.svg
@@ -1,0 +1,361 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
+  <rect x="0" y="0" width="820" height="380" fill="#000000" />
+  <rect x="10" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="18" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="26" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="34" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="42" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="50" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="58" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="66" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="74" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="82" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="90" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="98" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="106" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="114" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="122" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="130" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="138" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="146" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="154" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="162" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="170" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="178" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="186" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="194" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="202" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="210" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="218" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="226" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="234" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="242" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="250" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="258" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="266" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="274" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="282" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="290" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="298" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="306" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="314" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="322" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="330" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="338" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="346" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="354" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="362" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="370" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="378" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="386" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="394" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="402" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="410" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="418" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="426" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="434" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="442" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="450" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="458" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="466" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="474" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="482" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="490" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="498" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="506" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="514" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="522" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="530" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="538" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="546" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="554" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="562" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="570" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="578" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="586" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="594" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="602" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="610" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="618" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="626" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="634" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="642" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="650" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="658" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="666" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="674" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="682" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="690" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="698" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="706" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="714" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="722" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="730" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="738" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="746" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="754" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="762" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="770" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="778" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="786" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="794" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="802" y="10" width="8" height="18" fill="#45475A" />
+  <rect x="10" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="18" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="26" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="34" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="42" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="50" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="58" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="66" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="74" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="82" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="90" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="98" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="106" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="114" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="122" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="130" y="352" width="8" height="18" fill="#00AA00" />
+  <text x="10" y="24" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
+  <text x="18" y="24" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
+  <text x="26" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="34" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="50" y="24" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="58" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="66" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="74" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="82" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="90" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="98" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="106" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="114" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="122" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="130" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="146" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="154" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="162" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="178" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="186" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="194" y="24" style="fill:#00AAAA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="202" y="24" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="10" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="58" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="66" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="82" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="98" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="106" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="114" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="10" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="42" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="50" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="58" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="66" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="82" y="60" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="98" y="60" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="106" y="60" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="114" y="60" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="10" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="10" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┴</text>
+  <text x="26" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="34" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="42" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="50" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="58" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
+  <text x="66" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="74" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="90" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
+  <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="106" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="122" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="130" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="138" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="154" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="162" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="178" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="186" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
+  <text x="202" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="210" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="218" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="226" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="234" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="242" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="250" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="258" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="266" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="274" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="290" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="298" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="306" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="322" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
+  <text x="10" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="18" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="34" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="42" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="50" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="58" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="66" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="74" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="82" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="90" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="98" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="106" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="114" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="122" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="130" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="138" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="146" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="154" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="162" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="170" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="178" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="186" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="194" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="202" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="210" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="218" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="226" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="234" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="242" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="250" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="258" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="266" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="274" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="282" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="290" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="298" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="306" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="314" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="322" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="330" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="338" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="346" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="354" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="362" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="370" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="378" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="386" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="394" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="402" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="410" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="418" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="426" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="434" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="442" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="450" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="458" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="466" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="474" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="482" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="490" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="498" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="506" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="514" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="522" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="530" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="538" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="546" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="554" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="562" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="570" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="578" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="586" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="594" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="602" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="610" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="618" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="626" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="634" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="642" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="650" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="658" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="666" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="674" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="682" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="690" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="698" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="706" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="714" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="722" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="730" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="738" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="746" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="754" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="762" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="770" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="778" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="786" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="794" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="802" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="34" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="42" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="50" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="66" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="74" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="82" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="90" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="98" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="106" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="114" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="146" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="154" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="162" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="178" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="194" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="202" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="210" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="218" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="234" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="250" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="258" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="266" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="274" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="282" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="298" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="306" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="314" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="322" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="330" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="338" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="346" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="362" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="378" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↑</text>
+  <text x="386" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="394" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="410" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="418" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="434" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="450" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↓</text>
+  <text x="458" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="466" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">j</text>
+  <text x="482" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="490" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="498" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="506" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="522" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="538" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="554" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="562" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="570" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="578" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="586" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="594" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="602" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="618" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="634" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">?</text>
+  <text x="650" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="658" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="666" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="674" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="690" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="706" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="722" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="730" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="738" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="746" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+</svg>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/stays_in_pick_change_mode_after_full_screen_details_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/stays_in_pick_change_mode_after_full_screen_details_002.svg
@@ -1,0 +1,364 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
+  <rect x="0" y="0" width="820" height="380" fill="#000000" />
+  <rect x="18" y="28" width="8" height="18" fill="#0000AA" />
+  <rect x="26" y="28" width="8" height="18" fill="#0000AA" />
+  <rect x="10" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="18" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="26" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="34" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="42" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="50" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="58" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="66" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="74" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="82" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="90" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="98" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="106" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="114" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="122" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="130" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="138" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="146" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="154" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="162" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="170" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="178" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="186" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="194" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="202" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="210" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="218" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="226" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="234" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="242" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="250" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="258" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="266" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="274" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="282" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="290" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="298" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="306" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="314" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="322" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="330" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="338" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="346" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="354" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="362" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="370" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="378" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="386" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="394" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="402" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="410" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="418" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="426" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="434" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="442" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="450" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="458" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="466" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="474" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="482" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="490" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="498" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="506" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="514" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="522" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="530" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="538" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="546" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="554" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="562" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="570" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="578" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="586" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="594" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="602" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="610" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="618" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="626" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="634" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="642" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="650" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="658" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="666" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="674" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="682" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="690" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="698" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="706" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="714" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="722" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="730" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="738" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="746" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="754" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="762" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="770" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="778" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="786" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="794" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="802" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="10" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="18" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="26" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="34" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="42" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="50" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="58" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="66" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="74" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="82" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="90" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="98" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="106" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="114" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="122" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="130" y="352" width="8" height="18" fill="#00AA00" />
+  <text x="10" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
+  <text x="18" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
+  <text x="26" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="34" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="50" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="58" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="66" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="74" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="82" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="90" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="98" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="106" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="114" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="122" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="130" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="146" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="154" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="162" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="178" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="186" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="194" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="202" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="10" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="42" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">✔︎</text>
+  <text x="58" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="66" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="82" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="98" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="106" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="114" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="42" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="50" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="58" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="66" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="82" y="60" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="98" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="106" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="114" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="10" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="10" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┴</text>
+  <text x="26" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="34" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="42" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="50" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="58" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
+  <text x="66" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="74" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="90" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
+  <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="106" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="122" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="130" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="138" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="154" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="162" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="178" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="186" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
+  <text x="202" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="210" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="218" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="226" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="234" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="242" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="250" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="258" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="266" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="274" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="290" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="298" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="306" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="322" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
+  <text x="10" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="18" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="34" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="42" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="50" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="58" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="66" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="74" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="82" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="90" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="98" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="106" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="114" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="122" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="130" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="138" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="146" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="154" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="162" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="170" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="178" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="186" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="194" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="202" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="210" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="218" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="226" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="234" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="242" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="250" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="258" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="266" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="274" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="282" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="290" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="298" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="306" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="314" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="322" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="330" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="338" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="346" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="354" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="362" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="370" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="378" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="386" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="394" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="402" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="410" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="418" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="426" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="434" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="442" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="450" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="458" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="466" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="474" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="482" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="490" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="498" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="506" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="514" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="522" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="530" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="538" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="546" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="554" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="562" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="570" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="578" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="586" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="594" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="602" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="610" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="618" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="626" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="634" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="642" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="650" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="658" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="666" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="674" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="682" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="690" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="698" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="706" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="714" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="722" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="730" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="738" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="746" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="754" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="762" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="770" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="778" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="786" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="794" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="802" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="34" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="42" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="50" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="66" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="74" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="82" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="90" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="98" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="106" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="114" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="146" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="154" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="162" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="178" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="194" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="202" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="210" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="218" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="234" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="250" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="258" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="266" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="274" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="282" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="298" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="306" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="314" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="322" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="330" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="338" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="346" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="362" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="378" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↑</text>
+  <text x="386" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="394" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="410" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="418" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="434" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="450" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↓</text>
+  <text x="458" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="466" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">j</text>
+  <text x="482" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="490" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="498" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="506" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="522" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="538" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="554" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="562" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="570" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="578" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="586" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="594" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="602" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="618" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="634" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">?</text>
+  <text x="650" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="658" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="666" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="674" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="690" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="706" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="722" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="730" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="738" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="746" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+</svg>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/stays_in_pick_change_mode_after_full_screen_details_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/stays_in_pick_change_mode_after_full_screen_details_003.svg
@@ -1,0 +1,259 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
+  <rect x="0" y="0" width="820" height="380" fill="#000000" />
+  <rect x="74" y="118" width="8" height="18" fill="#004100" />
+  <rect x="82" y="118" width="8" height="18" fill="#004100" />
+  <rect x="90" y="118" width="8" height="18" fill="#004100" />
+  <rect x="98" y="118" width="8" height="18" fill="#004100" />
+  <rect x="106" y="118" width="8" height="18" fill="#004100" />
+  <rect x="114" y="118" width="8" height="18" fill="#004100" />
+  <rect x="122" y="118" width="8" height="18" fill="#004100" />
+  <rect x="130" y="118" width="8" height="18" fill="#004100" />
+  <rect x="138" y="118" width="8" height="18" fill="#004100" />
+  <rect x="146" y="118" width="8" height="18" fill="#004100" />
+  <rect x="154" y="118" width="8" height="18" fill="#004100" />
+  <rect x="162" y="118" width="8" height="18" fill="#004100" />
+  <rect x="170" y="118" width="8" height="18" fill="#004100" />
+  <rect x="178" y="118" width="8" height="18" fill="#004100" />
+  <rect x="186" y="118" width="8" height="18" fill="#004100" />
+  <rect x="10" y="352" width="8" height="18" fill="#FFA500" />
+  <rect x="18" y="352" width="8" height="18" fill="#FFA500" />
+  <rect x="26" y="352" width="8" height="18" fill="#FFA500" />
+  <rect x="34" y="352" width="8" height="18" fill="#FFA500" />
+  <rect x="42" y="352" width="8" height="18" fill="#FFA500" />
+  <rect x="50" y="352" width="8" height="18" fill="#FFA500" />
+  <rect x="58" y="352" width="8" height="18" fill="#FFA500" />
+  <rect x="66" y="352" width="8" height="18" fill="#FFA500" />
+  <rect x="74" y="352" width="8" height="18" fill="#FFA500" />
+  <rect x="82" y="352" width="8" height="18" fill="#FFA500" />
+  <rect x="90" y="352" width="8" height="18" fill="#FFA500" />
+  <text x="10" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="18" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="26" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="34" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="42" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="50" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="58" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="66" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="74" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="82" y="24" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╮</text>
+  <text x="18" y="42" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">j</text>
+  <text x="26" y="42" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="34" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">:</text>
+  <text x="50" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="58" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="66" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="82" y="42" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="10" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="18" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="26" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="34" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="42" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="50" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="58" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="66" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="74" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="82" y="60" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╯</text>
+  <text x="10" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">@</text>
+  <text x="18" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">@</text>
+  <text x="34" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="42" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="50" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">,</text>
+  <text x="58" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="74" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">+</text>
+  <text x="82" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="90" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">,</text>
+  <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">@</text>
+  <text x="122" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">@</text>
+  <text x="10" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="18" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="26" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="34" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="42" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="50" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="58" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="66" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="74" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="82" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="90" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="98" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="106" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="114" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="122" y="114" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">─</text>
+  <text x="26" y="132" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="42" y="132" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="58" y="132" style="fill:#555555;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">│</text>
+  <text x="74" y="132" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">+</text>
+  <text x="82" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="90" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="98" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="106" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="114" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="122" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="130" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="146" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="154" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="170" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="178" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="186" y="132" style="fill:#F8F8F2;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="10" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="18" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="34" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="42" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="50" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="58" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="66" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="74" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="82" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="90" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="98" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="106" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="114" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="122" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="130" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="138" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="146" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="154" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="162" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="170" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="178" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="186" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="194" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="202" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="210" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="218" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="226" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="234" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="242" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="250" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="258" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="266" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="274" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="282" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="290" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="298" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="306" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="314" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="322" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="330" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="338" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="346" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="354" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="362" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="370" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="378" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="386" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="394" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="402" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="410" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="418" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="426" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="434" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="442" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="450" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="458" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="466" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="474" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="482" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="490" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="498" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="506" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="514" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="522" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="530" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="538" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="546" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="554" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="562" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="570" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="578" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="586" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="594" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="602" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="610" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="618" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="626" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="634" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="642" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="650" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="658" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="666" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="674" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="682" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="690" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="698" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="706" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="714" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="722" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="730" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="738" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="746" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="754" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="762" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="770" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="778" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="786" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="794" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="802" y="348" style="fill:#FFA500;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="34" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="42" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="50" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="58" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="66" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="74" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="106" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↓</text>
+  <text x="114" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="122" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">j</text>
+  <text x="138" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="146" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="154" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">x</text>
+  <text x="162" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="178" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="186" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="194" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="202" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="218" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="234" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↑</text>
+  <text x="242" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="250" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="266" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="274" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="282" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="290" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">v</text>
+  <text x="306" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="314" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="322" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="330" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="346" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="362" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="370" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="378" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="386" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="394" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="402" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">+</text>
+  <text x="410" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">j</text>
+  <text x="426" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="434" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="442" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="450" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="458" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="466" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="482" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="490" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="498" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="506" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="522" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="538" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">?</text>
+  <text x="554" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="562" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="570" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="578" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="594" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="610" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="626" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="634" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="642" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="650" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+</svg>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/stays_in_pick_change_mode_after_full_screen_details_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/stays_in_pick_change_mode_after_full_screen_details_004.svg
@@ -1,0 +1,364 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
+  <rect x="0" y="0" width="820" height="380" fill="#000000" />
+  <rect x="18" y="28" width="8" height="18" fill="#0000AA" />
+  <rect x="26" y="28" width="8" height="18" fill="#0000AA" />
+  <rect x="10" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="18" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="26" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="34" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="42" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="50" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="58" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="66" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="74" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="82" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="90" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="98" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="106" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="114" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="122" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="130" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="138" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="146" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="154" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="162" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="170" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="178" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="186" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="194" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="202" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="210" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="218" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="226" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="234" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="242" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="250" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="258" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="266" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="274" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="282" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="290" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="298" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="306" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="314" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="322" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="330" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="338" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="346" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="354" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="362" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="370" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="378" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="386" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="394" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="402" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="410" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="418" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="426" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="434" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="442" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="450" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="458" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="466" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="474" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="482" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="490" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="498" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="506" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="514" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="522" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="530" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="538" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="546" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="554" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="562" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="570" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="578" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="586" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="594" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="602" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="610" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="618" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="626" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="634" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="642" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="650" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="658" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="666" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="674" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="682" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="690" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="698" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="706" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="714" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="722" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="730" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="738" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="746" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="754" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="762" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="770" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="778" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="786" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="794" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="802" y="46" width="8" height="18" fill="#45475A" />
+  <rect x="10" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="18" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="26" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="34" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="42" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="50" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="58" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="66" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="74" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="82" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="90" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="98" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="106" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="114" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="122" y="352" width="8" height="18" fill="#00AA00" />
+  <rect x="130" y="352" width="8" height="18" fill="#00AA00" />
+  <text x="10" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">╭</text>
+  <text x="18" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┄</text>
+  <text x="26" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="34" y="24" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">z</text>
+  <text x="50" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">[</text>
+  <text x="58" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="66" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="74" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="82" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="90" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="98" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="106" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="114" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="122" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="130" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="146" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="154" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="162" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="178" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="186" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="194" y="24" style="fill:#00AAAA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="202" y="24" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">]</text>
+  <text x="10" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="18" y="42" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">✔︎</text>
+  <text x="58" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="66" y="42" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="82" y="42" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="98" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="106" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="114" y="42" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="42" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="50" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="58" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="66" y="60" style="fill:#0000AA;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="82" y="60" style="fill:#FFFFFF;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">A</text>
+  <text x="98" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="106" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="114" y="60" style="fill:#00AA00;font-weight:bold;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="10" y="78" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┊</text>
+  <text x="10" y="96" style="fill:#CCCCCC;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">┴</text>
+  <text x="26" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="34" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="42" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="50" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="58" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">7</text>
+  <text x="66" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="74" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">3</text>
+  <text x="90" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">(</text>
+  <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="106" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="122" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="130" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="138" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="154" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">b</text>
+  <text x="162" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="178" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="186" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">)</text>
+  <text x="202" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="210" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="218" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="226" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="234" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="242" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="250" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">1</text>
+  <text x="258" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">-</text>
+  <text x="266" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">0</text>
+  <text x="274" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">2</text>
+  <text x="290" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="298" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="306" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="322" y="96" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">M</text>
+  <text x="10" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="18" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="34" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="42" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="50" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="58" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="66" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="74" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="82" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="90" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="98" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="106" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="114" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="122" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="130" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="138" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="146" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="154" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="162" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="170" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="178" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="186" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="194" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="202" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="210" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="218" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="226" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="234" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="242" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="250" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="258" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="266" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="274" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="282" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="290" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="298" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="306" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="314" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="322" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="330" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="338" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="346" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="354" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="362" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="370" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="378" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="386" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="394" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="402" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="410" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="418" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="426" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="434" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="442" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="450" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="458" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="466" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="474" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="482" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="490" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="498" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="506" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="514" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="522" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="530" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="538" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="546" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="554" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="562" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="570" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="578" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="586" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="594" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="602" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="610" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="618" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="626" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="634" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="642" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="650" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="658" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="666" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="674" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="682" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="690" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="698" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="706" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="714" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="722" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="730" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="738" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="746" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="754" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="762" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="770" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="778" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="786" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="794" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="802" y="348" style="fill:#00AA00;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">━</text>
+  <text x="26" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="34" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="42" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="50" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="66" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="74" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="82" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="90" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="98" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">g</text>
+  <text x="106" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="114" y="366" style="fill:#000000;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="146" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="154" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="162" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="170" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="178" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="194" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="202" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="210" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="218" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="234" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="250" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="258" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="266" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="274" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="282" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="298" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">c</text>
+  <text x="306" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="314" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="322" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">f</text>
+  <text x="330" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="338" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">r</text>
+  <text x="346" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">m</text>
+  <text x="362" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="378" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↑</text>
+  <text x="386" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="394" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">k</text>
+  <text x="410" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="418" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="434" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="450" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">↓</text>
+  <text x="458" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">/</text>
+  <text x="466" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">j</text>
+  <text x="482" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="490" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">o</text>
+  <text x="498" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">w</text>
+  <text x="506" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">n</text>
+  <text x="522" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="538" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="554" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">d</text>
+  <text x="562" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="570" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+  <text x="578" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">a</text>
+  <text x="586" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="594" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="602" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">s</text>
+  <text x="618" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="634" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">?</text>
+  <text x="650" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">h</text>
+  <text x="658" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">e</text>
+  <text x="666" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">l</text>
+  <text x="674" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">p</text>
+  <text x="690" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">•</text>
+  <text x="706" y="366" style="fill:#0000AA;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="722" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">q</text>
+  <text x="730" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">u</text>
+  <text x="738" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">i</text>
+  <text x="746" y="366" style="fill:#CCCCCC;opacity:0.75;" font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">t</text>
+</svg>


### PR DESCRIPTION
The marks shouldn't be shown while focused on split details.