### PR TITLE
Add a diff font size setting

### DIFF
--- a/apps/desktop/src/components/commit/CommitFailedFileEntry.svelte
+++ b/apps/desktop/src/components/commit/CommitFailedFileEntry.svelte
@@ -64,6 +64,7 @@
 									"tabSize",
 									"wrapText",
 									"diffFont",
+									"diffFontSize",
 									"diffLigatures",
 									"strongContrast",
 									"colorBlindFriendly",

--- a/apps/desktop/src/components/diff/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/diff/UnifiedDiffView.svelte
@@ -287,6 +287,7 @@
 								"tabSize",
 								"wrapText",
 								"diffFont",
+								"diffFontSize",
 								"strongContrast",
 								"colorBlindFriendly",
 								"inlineUnifiedDiffs",

--- a/apps/desktop/src/components/irc/IrcHunk.svelte
+++ b/apps/desktop/src/components/irc/IrcHunk.svelte
@@ -44,6 +44,7 @@
 				"tabSize",
 				"wrapText",
 				"diffFont",
+				"diffFontSize",
 				"strongContrast",
 				"colorBlindFriendly",
 				"inlineUnifiedDiffs",

--- a/apps/desktop/src/components/projectSettings/AppearanceSettings.svelte
+++ b/apps/desktop/src/components/projectSettings/AppearanceSettings.svelte
@@ -261,8 +261,7 @@
 				maxVal={32}
 				showCountActions
 				onchange={(value: string) => {
-					const size = parseInt(value) || diffFontSize.current;
-					diffFontSize.set(Math.min(32, Math.max(8, size)));
+					diffFontSize.set(parseInt(value) || diffFontSize.current);
 				}}
 				placeholder={diffFontSize.current.toString()}
 			/>

--- a/apps/desktop/src/components/projectSettings/AppearanceSettings.svelte
+++ b/apps/desktop/src/components/projectSettings/AppearanceSettings.svelte
@@ -25,6 +25,7 @@
 	const diffLigatures = uiState.global.diffLigatures;
 	const wrapText = uiState.global.wrapText;
 	const diffFont = uiState.global.diffFont;
+	const diffFontSize = uiState.global.diffFontSize;
 	const strongContrast = uiState.global.strongContrast;
 	const colorBlindFriendly = uiState.global.colorBlindFriendly;
 	const inlineUnifiedDiffs = uiState.global.inlineUnifiedDiffs;
@@ -165,6 +166,7 @@
 				"tabSize",
 				"wrapText",
 				"diffFont",
+				"diffFontSize",
 				"diffLigatures",
 				"strongContrast",
 				"colorBlindFriendly",
@@ -239,6 +241,31 @@
 				diffFont.set(value);
 			}}
 		/>
+	</CardGroup.Item>
+
+	<CardGroup.Item alignment="center">
+		{#snippet title()}
+			Font size
+		{/snippet}
+		{#snippet caption()}
+			Font size of the code in the diff view.
+		{/snippet}
+
+		{#snippet actions()}
+			<Textbox
+				type="number"
+				width={100}
+				textAlign="center"
+				value={diffFontSize.current.toString()}
+				minVal={8}
+				maxVal={32}
+				showCountActions
+				onchange={(value: string) => {
+					diffFontSize.set(parseInt(value) || diffFontSize.current);
+				}}
+				placeholder={diffFontSize.current.toString()}
+			/>
+		{/snippet}
 	</CardGroup.Item>
 
 	<CardGroup.Item labelFor="allowDiffLigatures">

--- a/apps/desktop/src/components/projectSettings/AppearanceSettings.svelte
+++ b/apps/desktop/src/components/projectSettings/AppearanceSettings.svelte
@@ -245,7 +245,7 @@
 
 	<CardGroup.Item alignment="center">
 		{#snippet title()}
-			Font size
+			Diff Font Size
 		{/snippet}
 		{#snippet caption()}
 			Font size of the code in the diff view.
@@ -261,7 +261,8 @@
 				maxVal={32}
 				showCountActions
 				onchange={(value: string) => {
-					diffFontSize.set(parseInt(value) || diffFontSize.current);
+					const size = parseInt(value) || diffFontSize.current;
+					diffFontSize.set(Math.min(32, Math.max(8, size)));
 				}}
 				placeholder={diffFontSize.current.toString()}
 			/>

--- a/apps/desktop/src/components/projectSettings/AppearanceSettings.svelte
+++ b/apps/desktop/src/components/projectSettings/AppearanceSettings.svelte
@@ -32,6 +32,8 @@
 	const svgAsImage = uiState.global.svgAsImage;
 	const scrollbarVisibilityState = uiState.global.scrollbarVisibilityState;
 	const defaultFileListMode = uiState.global.defaultFileListMode;
+	const MIN_DIFF_FONT_SIZE = 8;
+	const MAX_DIFF_FONT_SIZE = 32;
 
 	// Sync persisted syntax theme settings to the shiki highlighter.
 	$effect(() => {
@@ -57,6 +59,15 @@
 		) as ScrollbarVisilitySettings;
 
 		scrollbarVisibilityState.set(selectedScrollbarVisibility);
+	}
+
+	function clampDiffFontSize(value: string) {
+		if (value.trim() === "") return diffFontSize.current;
+
+		const parsed = Number(value);
+		if (!Number.isFinite(parsed)) return diffFontSize.current;
+
+		return Math.round(Math.min(Math.max(parsed, MIN_DIFF_FONT_SIZE), MAX_DIFF_FONT_SIZE));
 	}
 </script>
 
@@ -257,11 +268,11 @@
 				width={100}
 				textAlign="center"
 				value={diffFontSize.current.toString()}
-				minVal={8}
-				maxVal={32}
+				minVal={MIN_DIFF_FONT_SIZE}
+				maxVal={MAX_DIFF_FONT_SIZE}
 				showCountActions
 				onchange={(value: string) => {
-					diffFontSize.set(parseInt(value) || diffFontSize.current);
+					diffFontSize.set(clampDiffFontSize(value));
 				}}
 				placeholder={diffFontSize.current.toString()}
 			/>

--- a/apps/desktop/src/components/projectSettings/AppearanceSettings.svelte
+++ b/apps/desktop/src/components/projectSettings/AppearanceSettings.svelte
@@ -245,7 +245,7 @@
 
 	<CardGroup.Item alignment="center">
 		{#snippet title()}
-			Diff Font Size
+			Font size
 		{/snippet}
 		{#snippet caption()}
 			Font size of the code in the diff view.

--- a/apps/desktop/src/lib/state/uiState.svelte.ts
+++ b/apps/desktop/src/lib/state/uiState.svelte.ts
@@ -184,6 +184,7 @@ export type GlobalUiState = {
 	tabSize: number;
 	wrapText: boolean;
 	diffFont: string;
+	diffFontSize: number;
 	diffLigatures: boolean;
 	inlineUnifiedDiffs: boolean;
 	strongContrast: boolean;
@@ -266,6 +267,7 @@ export class UiState {
 		tabSize: 4,
 		wrapText: false,
 		diffFont: "Geist Mono, Menlo, monospace",
+		diffFontSize: 12,
 		diffLigatures: false,
 		inlineUnifiedDiffs: false,
 		strongContrast: false,

--- a/packages/ui/src/lib/components/hunkDiff/HunkDiff.svelte
+++ b/packages/ui/src/lib/components/hunkDiff/HunkDiff.svelte
@@ -80,9 +80,12 @@
 	let tableWrapperElem = $state<HTMLElement>();
 	let isVisible = $state(false);
 
-	// Rough line count for height reservation while body is not yet mounted
+	// Reserve roughly the rendered height per line (font size x line-height, kept in
+	// sync with .table__textContent) while the body is not yet mounted, so it scales
+	// with the diff font size.
+	const DIFF_LINE_HEIGHT = 1.25;
 	const estimatedBodyHeight = $derived(
-		Math.max(hunkStr.split("\n").length - 1, 1) * ((diffFontSize * 22) / 12),
+		Math.max(hunkStr.split("\n").length - 1, 1) * Math.ceil(diffFontSize * DIFF_LINE_HEIGHT),
 	);
 
 	$effect(() => {

--- a/packages/ui/src/lib/components/hunkDiff/HunkDiff.svelte
+++ b/packages/ui/src/lib/components/hunkDiff/HunkDiff.svelte
@@ -81,7 +81,9 @@
 	let isVisible = $state(false);
 
 	// Rough line count for height reservation while body is not yet mounted
-	const estimatedBodyHeight = $derived(Math.max(hunkStr.split("\n").length - 1, 1) * 22);
+	const estimatedBodyHeight = $derived(
+		Math.max(hunkStr.split("\n").length - 1, 1) * ((diffFontSize * 22) / 12),
+	);
 
 	$effect(() => {
 		if (!tableWrapperElem) return;

--- a/packages/ui/src/lib/components/hunkDiff/HunkDiff.svelte
+++ b/packages/ui/src/lib/components/hunkDiff/HunkDiff.svelte
@@ -24,6 +24,7 @@
 		tabSize?: number;
 		wrapText?: boolean;
 		diffFont?: string;
+		diffFontSize?: number;
 		diffLigatures?: boolean;
 		inlineUnifiedDiffs?: boolean;
 		strongContrast?: boolean;
@@ -47,6 +48,7 @@
 		tabSize = 4,
 		wrapText = true,
 		diffFont = "var(--font-mono)",
+		diffFontSize = 12,
 		diffLigatures = true,
 		strongContrast = false,
 		colorBlindFriendly = false,
@@ -126,7 +128,7 @@
 	class="table__wrapper"
 	class:contrast-strong={strongContrast}
 	class:colorblind-friendly={colorBlindFriendly}
-	style="--tab-size: {tabSize}; --diff-font: {diffFont};"
+	style="--tab-size: {tabSize}; --diff-font: {diffFont}; --diff-font-size: {diffFontSize}px;"
 	style:font-variant-ligatures={diffLigatures ? "common-ligatures" : "none"}
 >
 	{#if !draggingDisabled}

--- a/packages/ui/src/lib/components/hunkDiff/HunkDiffRow.svelte
+++ b/packages/ui/src/lib/components/hunkDiff/HunkDiffRow.svelte
@@ -275,7 +275,7 @@
 		background-color: var(--diff-count-bg);
 		color: var(--diff-count-text);
 		font-size: calc(var(--diff-font-size, 12px) - 1px);
-		line-height: 1.5; /* scales with the diff font, kept ~1px below the diff lines */
+		line-height: 1.25; /* match the diff line line-height so numbers stay aligned at any size */
 		text-align: right;
 		vertical-align: top;
 		touch-action: none;

--- a/packages/ui/src/lib/components/hunkDiff/HunkDiffRow.svelte
+++ b/packages/ui/src/lib/components/hunkDiff/HunkDiffRow.svelte
@@ -274,8 +274,8 @@
 		border-right: 1px solid var(--diff-count-border);
 		background-color: var(--diff-count-bg);
 		color: var(--diff-count-text);
-		font-size: 11px;
-		line-height: 1.5; /* Visually centered with 12px font size that diff lines have */
+		font-size: calc(var(--diff-font-size, 12px) - 1px);
+		line-height: 1.5; /* scales with the diff font, kept ~1px below the diff lines */
 		text-align: right;
 		vertical-align: top;
 		touch-action: none;

--- a/packages/ui/src/lib/components/hunkDiff/HunkDiffRow.svelte
+++ b/packages/ui/src/lib/components/hunkDiff/HunkDiffRow.svelte
@@ -224,7 +224,7 @@
 	.table__textContent {
 		width: 100%;
 		padding-left: 4px;
-		font-size: 12px;
+		font-size: var(--diff-font-size, 12px);
 		line-height: 1.25;
 		white-space: var(--pre-wrap);
 		cursor: text;


### PR DESCRIPTION
Fixes #2693

Adds a **Font size** control for the diff/code view, so the diff text can be scaled on its own — without zooming the rest of the UI (the ask in #2693).

### What changed
- `HunkDiff` takes a new `diffFontSize` prop, surfaced as a `--diff-font-size` CSS variable (default `12px`); the diff line content reads it. The default keeps the current appearance unchanged.
- Stored as `diffFontSize` in the global UI state.
- New **Font size** control (8–32) in **Settings → Appearance**, alongside *Font family* and *Tab size*, with the live diff preview bound to it.
- Threaded into the diff views that render `HunkDiff` with user prefs: `UnifiedDiffView` (which also backs `MultiDiffView` / `FloatingDiffModal`), the commit-failed file entry, and IRC hunks.

Only the code inside the diff scales — the surrounding labels and controls stay put.

### Demo

https://github.com/user-attachments/assets/427ac9d9-c7a7-46c4-872e-c6a69ef4d2f4