### PR TITLE
docs(but): feature gate raw doc comments

### DIFF
--- a/crates/but-clap/Cargo.toml
+++ b/crates/but-clap/Cargo.toml
@@ -15,6 +15,9 @@ name = "but-clap"
 path = "src/main.rs"
 doctest = false
 
+[features]
+raw-clap-docs = ["but/raw-clap-docs"]
+
 [dependencies]
 but.workspace = true
 clap.workspace = true

--- a/crates/but-clap/README.md
+++ b/crates/but-clap/README.md
@@ -6,10 +6,14 @@ like documentation as well.
 
 Running this command:
 
-`cargo run --bin but-clap`
+`cargo run -p but-clap --features raw-clap-docs`
 
 will create a new directory called `cli-docs` that is Git-ignored and populates
 it with one mdx file for each command.
+
+The `raw-clap-docs` feature is required for website docs generation. It keeps
+Clap doc comments as raw Markdown for MDX output. Normal CLI builds should not
+enable it, so `but --help` uses Clap's formatted help output.
 
 We use the long-about docstrings to do everything. It can take markdown (we use
 the `unstable-markdown` feature in clap to parse correctly) and has some special

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -43,6 +43,8 @@ legacy = [
 tui-profiling = []
 # Enables new experimental CLI commands that'll eventually replace old commands
 but-2 = []
+# Outputs help sections exactly as written, instead of putting them through clap's Markdown formatter. This is useful e.g. for generating docs for the website.
+raw-clap-docs = []
 
 [dependencies]
 but-core.workspace = true

--- a/crates/but/src/args/branch.rs
+++ b/crates/but/src/args/branch.rs
@@ -33,7 +33,7 @@ pub enum Subcommands {
     /// the new branch from. This allows you to create stacked branches.
     ///
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     New {
         /// Name of the new branch
         branch_name: Option<BranchArg>,
@@ -50,7 +50,7 @@ pub enum Subcommands {
     ///
     #[cfg(feature = "legacy")]
     #[clap(short_flag = 'd')]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Delete {
         /// Name of the branch to delete
         branch_name: CliIdArg,
@@ -79,7 +79,7 @@ pub enum Subcommands {
     /// make the command faster.
     ///
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     List {
         /// Filter branches by name (case-insensitive substring match)
         filter: Option<String>,
@@ -150,7 +150,7 @@ pub enum Subcommands {
     /// as a parallel applied branch.
     ///
     #[cfg(not(feature = "legacy"))]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Apply {
         /// Name of the branch to apply
         branch_name: String,
@@ -161,7 +161,7 @@ pub enum Subcommands {
     /// This allows you to resolve the divergence between your local branch and its
     /// tracked remote in different ways.
     #[clap(short_flag = 'u')]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Update {
         /// Name of the local branch to integrate
         branch: String,

--- a/crates/but/src/args/commit.rs
+++ b/crates/but/src/args/commit.rs
@@ -99,7 +99,7 @@ pub enum Subcommands {
     /// ```
     ///
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     #[command(group = clap::ArgGroup::new("position"))]
     Empty {
         /// The target commit or branch to insert relative to.

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -143,7 +143,7 @@ pub enum Subcommands {
     /// ```
     ///
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Status {
         /// Determines whether the committed files should be shown as well.
         #[clap(short = 'f', alias = "files", default_value_t = false)]
@@ -176,7 +176,7 @@ pub enum Subcommands {
     /// - a commit
     /// - a file change within a commit
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Diff {
         /// The CLI ID of the entity to show the diff for
         target: Option<String>,
@@ -223,7 +223,7 @@ pub enum Subcommands {
     /// ```
     ///
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Show {
         /// The commit ID (short or full SHA), branch name, or CLI ID to show details for
         commit: String,
@@ -253,11 +253,11 @@ pub enum Subcommands {
     /// commit that you can amend changes into later using `but mark`, `but rub` or `but absorb`.
     ///
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Commit(commit::Platform),
 
     #[cfg(all(feature = "legacy", feature = "but-2"))]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     #[clap(hide = true)]
     Commit2(commit2::Platform),
 
@@ -271,7 +271,7 @@ pub enum Subcommands {
     ///   `but stage --branch <branch>`           (interactive, specific branch)
     ///   `but stage <file-or-hunk> <branch>`     (direct staging)
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Stage {
         /// File or hunk ID to stage
         file_or_hunk: Option<String>,
@@ -290,7 +290,7 @@ pub enum Subcommands {
     ///
     /// To apply or unapply branches, use `but apply` and `but unapply`.
     ///
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Branch(branch::Platform),
 
     /// Merge a branch into your local target branch.
@@ -314,7 +314,7 @@ pub enum Subcommands {
     /// but merge my-feature-branch
     /// ```
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Merge {
         /// Branch ID or name to merge
         branch: String,
@@ -336,7 +336,7 @@ pub enum Subcommands {
     /// but discard a1
     /// ```
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Discard {
         /// The ID of the file or hunk to discard (as shown in `but status`)
         id: String,
@@ -358,7 +358,7 @@ pub enum Subcommands {
     /// When in resolution mode, `but status` will also show that you're resolving conflicts.
     ///
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Resolve {
         /// Subcommand to run (defaults to entering resolution mode)
         #[clap(subcommand)]
@@ -399,7 +399,7 @@ pub enum Subcommands {
     /// ```
     ///
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Unapply {
         /// CLI ID or name of the branch/stack to unapply
         identifier: String,
@@ -422,7 +422,7 @@ pub enum Subcommands {
     /// ```
     ///
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Apply {
         /// Name of the branch to apply
         branch_name: String,
@@ -440,7 +440,7 @@ pub enum Subcommands {
     /// amended into the marked commit.
     ///
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Mark {
         /// The target entity that will be marked
         target: String,
@@ -454,7 +454,7 @@ pub enum Subcommands {
     /// This will unmark anything that has been marked by the `but mark` command.
     ///
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Unmark,
 
     /// Push changes in a branch to remote.
@@ -471,7 +471,7 @@ pub enum Subcommands {
     /// - `but push feature-branch` - push the branch named "feature-branch"
     ///
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Push(push::Command),
 
     /// Updates all applied branches to be up to date with the target branch.
@@ -486,7 +486,7 @@ pub enum Subcommands {
     /// merged into the target branch before running the update.
     ///
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Pull {
         /// Only check the status without updating (equivalent to the old `but base check`)
         #[clap(long, short = 'c')]
@@ -558,7 +558,7 @@ pub enum Subcommands {
     /// ```
     ///
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Rub {
         /// The source entity to combine
         source: String,
@@ -585,7 +585,7 @@ pub enum Subcommands {
     /// (what changes would be absorbed by which commits) will be shown.
     ///
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Absorb {
         /// If the Source is an uncommitted change - the change will be absorbed.
         /// If the Source is a stack - anything staged to the stack will be absorbed accordingly.
@@ -608,7 +608,7 @@ pub enum Subcommands {
     /// You can also use `but reword <branch-id>` to rename the branch.
     ///
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Reword {
         /// Commit ID to edit the message for, or branch ID to rename
         target: CliIdArg,
@@ -640,7 +640,7 @@ pub enum Subcommands {
     ///
     /// Wrapper for `but rub <source> zz`.
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Uncommit {
         /// Commit ID or file-in-commit ID to uncommit
         source: String,
@@ -653,7 +653,7 @@ pub enum Subcommands {
     ///
     /// Wrapper for `but rub <file> <commit>`.
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Amend {
         /// File ID to amend
         file: String,
@@ -671,7 +671,7 @@ pub enum Subcommands {
     /// 3. Using a branch name: `but squash <branch>`
     ///    - Squashes all commits in the branch into the bottom-most commit
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Squash {
         /// Commit identifiers, a range (commit1..commit2), or a branch name
         commits: Vec<String>,
@@ -730,7 +730,7 @@ pub enum Subcommands {
     /// ```text
     /// but move feature/frontend zz
     /// ```
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Move {
         /// Commit/branch identifier to move
         source: String,
@@ -755,19 +755,19 @@ pub enum Subcommands {
     /// By default, shows the last 20 oplog entries (same as `but oplog list`).
     ///
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Oplog(oplog::Platform),
 
     /// Undo the last operation.
     ///
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Undo,
 
     /// Redo the last undo.
     ///
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Redo,
 
     /// Sets up a GitButler project from a git repository in the current directory.
@@ -791,14 +791,14 @@ pub enum Subcommands {
     /// ```
     ///
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Setup {
         /// Initialize a new git repository with an empty commit if one doesn't exist.
         ///
         /// This is useful when running in non-interactive environments (like CI/CD)
         /// where you want to ensure a git repository exists before setting up GitButler.
         #[clap(long)]
-        #[clap(verbatim_doc_comment)]
+        #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
         init: bool,
     },
 
@@ -827,7 +827,7 @@ pub enum Subcommands {
     /// ```
     ///
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Teardown {
         /// Explicit override for which local branch to checkout to.
         #[clap(long, short = 'c', value_name = "LOCAL_BRANCH")]
@@ -845,7 +845,7 @@ pub enum Subcommands {
     /// You can also just run `but .` as a shorthand to open the GUI.
     ///
     #[clap(visible_alias = ".")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Gui {
         /// Open the project in a new application window.
         #[clap(long, short = 'n', default_value_t = false)]
@@ -855,7 +855,7 @@ pub enum Subcommands {
     },
 
     /// Show an interactive TUI.
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     #[cfg(feature = "legacy")]
     Tui {
         /// Show debug pane with selected-line metadata.
@@ -939,7 +939,7 @@ pub enum Subcommands {
     /// ```
     ///
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Clean {
         /// Preview which branches would be removed without actually deleting them.
         #[clap(long)]
@@ -955,7 +955,7 @@ pub enum Subcommands {
     /// Manage GitButler CLI and app updates.
     ///
     /// Check for new versions, install updates, or suppress update notifications.
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Update(update::Platform),
 
     /// Manage command aliases.
@@ -984,7 +984,7 @@ pub enum Subcommands {
     /// but alias remove st
     /// ```
     ///
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Alias(alias::Platform),
 
     /// View and manage GitButler configuration.
@@ -1026,7 +1026,7 @@ pub enum Subcommands {
     /// but config metrics
     /// ```
     ///
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Config(config::Platform),
 
     /// Cherry-pick a commit from an unapplied branch into an applied virtual branch.
@@ -1065,7 +1065,7 @@ pub enum Subcommands {
     /// ```
     ///
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Pick {
         /// The commit SHA, CLI ID, or unapplied branch name to cherry-pick from
         source: String,
@@ -1098,7 +1098,7 @@ pub enum Subcommands {
     /// ```text
     /// but skill install --global
     /// ```
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Skill(skill::Platform),
 
     /// Open a file in the built-in text editor.
@@ -1114,7 +1114,8 @@ pub enum Subcommands {
     /// but edit README.md
     /// ```
     ///
-    #[clap(verbatim_doc_comment, hide = true)]
+    #[clap(hide = true)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Edit {
         /// Path to the file to edit (created if it doesn't exist)
         file: String,
@@ -1131,7 +1132,7 @@ pub enum Subcommands {
     ///
     #[cfg(feature = "legacy")]
     #[clap(hide = true)]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Worktree(worktree::Platform),
 
     /// Trigger a refresh of remote data fetching from the remote, Pull Requests, and CI status.
@@ -1139,7 +1140,7 @@ pub enum Subcommands {
     /// This is a hidden command primarily used for background sync operations.
     #[cfg(feature = "legacy")]
     #[clap(hide = true)]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     RefreshRemoteData {
         /// Whether to also refresh git fetch from the remote.
         #[clap(long, default_value_t = false)]
@@ -1169,18 +1170,18 @@ pub enum Subcommands {
     ///
     #[cfg(feature = "legacy")]
     #[clap(hide = true)]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Mcp,
 
     /// INTERNAL: GitButler Actions are automated tasks (like macros) that can be performed on a repository.
     #[cfg(feature = "legacy")]
     #[clap(hide = true)]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Actions(actions::Platform),
 
     /// INTERNAL: If metrics are permitted, this subcommand handles posthog event creation.
     #[clap(hide = true)]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Metrics {
         #[clap(long, value_enum)]
         command_name: metrics::CommandName,
@@ -1190,7 +1191,7 @@ pub enum Subcommands {
 
     /// UTILITY: Generate shell completion scripts for the specified or inferred shell.
     #[clap(hide = true)]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Completions {
         /// The shell to generate completions for, or the one extracted from the `SHELL` environment variable.
         #[clap(value_enum)]
@@ -1200,14 +1201,14 @@ pub enum Subcommands {
     /// Hidden command that redirects to `but pull --check`
     #[cfg(feature = "legacy")]
     #[clap(hide = true)]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Fetch,
 
     /// Unstages a file or hunk from a branch.
     ///
     /// Wrapper for `but rub <file-or-hunk> zz`.
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     #[clap(hide = true)]
     Unstage {
         /// File or hunk ID to unstage
@@ -1231,7 +1232,7 @@ pub enum Subcommands {
     ///
     /// This is equivalent to running `but -h` to see the command overview.
     #[clap(hide = true)]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Help,
 
     /// INTERNAL: First-run onboarding that shows metrics info and marks onboarding complete.
@@ -1246,7 +1247,7 @@ pub enum Subcommands {
     /// Outputs workspace status as JSON and a skill-loading nudge.
     /// Intended to fire on the Stop hook.
     #[clap(hide = true)]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     EvalHook,
 
     /// External commands and aliases are resolved to this variant.

--- a/crates/but/src/args/oplog.rs
+++ b/crates/but/src/args/oplog.rs
@@ -17,7 +17,7 @@ pub enum Subcommands {
     /// You can use `but oplog restore <oplog-sha>` to restore to a specific state.
     ///
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     List {
         /// Start from this oplog SHA instead of the head
         #[clap(long)]
@@ -50,7 +50,7 @@ pub enum Subcommands {
     /// which you can find by running `but oplog` or `but oplog list`.
     ///
     #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Restore {
         /// Oplog SHA to restore to
         oplog_sha: String,

--- a/crates/but/src/args/skill.rs
+++ b/crates/but/src/args/skill.rs
@@ -49,7 +49,7 @@ pub enum Subcommands {
     /// but skill install --detect
     /// ```
     ///
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Install {
         /// Install the skill globally instead of in the current repository
         #[clap(long, short = 'g')]
@@ -86,7 +86,7 @@ pub enum Subcommands {
     /// ```text
     /// but skill check --global
     /// ```
-    #[clap(verbatim_doc_comment)]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Check {
         /// Only check global installations (in home directory)
         #[clap(long, short = 'g', conflicts_with = "local")]

--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -313,54 +313,54 @@ commands (blame, log, etc) can also be used, as GitButler is fully Git compatibl
 Checkout the full docs here: https://docs.gitbutler.com/cli-overview
 
 Inspection:
-  status       Overview of the project workspace state.
-  diff         Displays the diff of changes in the repo.
-  show         Shows detailed information about a commit or branch.
+  status       Overview of the project workspace state
+  diff         Displays the diff of changes in the repo
+  show         Shows detailed information about a commit or branch
 
 Branching and Committing:
-  commit       Commit changes to a stack.
-  stage        Stages a file or hunk to a specific branch.
-  branch       Commands for managing branches.
-  merge        Merge a branch into your local target branch.
-  discard      Discard uncommitted changes from the worktree.
-  resolve      Resolve conflicts in a commit.
-  unapply      Unapply a branch from the workspace.
-  apply        Apply a branch to the workspace.
-  clean        Remove empty branches from the workspace.
+  commit       Commit changes to a stack
+  stage        Stages a file or hunk to a specific branch
+  branch       Commands for managing branches
+  merge        Merge a branch into your local target branch
+  discard      Discard uncommitted changes from the worktree
+  resolve      Resolve conflicts in a commit
+  unapply      Unapply a branch from the workspace
+  apply        Apply a branch to the workspace
+  clean        Remove empty branches from the workspace
   pick         Cherry-pick a commit from an unapplied branch into an applied v…
 
 Editing Commits:
   rub          Combines two entities together to perform an operation like ame…
-  absorb       Amends changes into the appropriate commits where they belong.
-  reword       Edit the commit message of the specified commit.
+  absorb       Amends changes into the appropriate commits where they belong
+  reword       Edit the commit message of the specified commit
   uncommit     Uncommit changes from a commit or file-in-commit to the unstage…
   amend        Amend a file change into a specific commit and rebases any depe…
-  squash       Squash commits together.
-  move         Move a commit or branch to a different location.
+  squash       Squash commits together
+  move         Move a commit or branch to a different location
 
 Operation History:
-  oplog        Commands for viewing and managing operation history.
-  undo         Undo the last operation.
-  redo         Redo the last undo.
+  oplog        Commands for viewing and managing operation history
+  undo         Undo the last operation
+  redo         Redo the last undo
 
 Server Interactions:
-  push         Push changes in a branch to remote.
+  push         Push changes in a branch to remote
   pull         Updates all applied branches to be up to date with the target b…
   pr           Commands for creating and managing reviews on a forge, e.g. Git…
 
 Rules:
-  mark         Mark a commit or branch for auto-stage or auto-commit.
-  unmark       Removes any marks from the workspace.
+  mark         Mark a commit or branch for auto-stage or auto-commit
+  unmark       Removes any marks from the workspace
 
 Other Commands:
   setup        Sets up a GitButler project from a git repository in the curren…
-  teardown     Exit GitButler mode and return to normal Git workflow.
-  gui          Open the GitButler GUI for the current project.
-  tui          Show an interactive TUI.
-  update       Manage GitButler CLI and app updates.
-  alias        Manage command aliases.
-  config       View and manage GitButler configuration.
-  skill        Manage AI agent skills for GitButler.
+  teardown     Exit GitButler mode and return to normal Git workflow
+  gui          Open the GitButler GUI for the current project
+  tui          Show an interactive TUI
+  update       Manage GitButler CLI and app updates
+  alias        Manage command aliases
+  config       View and manage GitButler configuration
+  skill        Manage AI agent skills for GitButler
 
 To add command completion, add this to your shell rc: (for example ~/.zshrc)
   eval "$(but completions zsh)"
@@ -390,7 +390,7 @@ Environment variables:
 
         assert!(
             output.contains(
-                "Cherry-pick a commit from an unapplied branch into an applied virtual branch."
+                "Cherry-pick a commit from an unapplied branch into an applied virtual branch"
             ),
             "agent help should keep the full command description"
         );
@@ -421,17 +421,17 @@ commands (blame, log, etc) can also be used, as GitButler is fully Git compatibl
 Checkout the full docs here: https://docs.gitbutler.com/cli-overview
 
 Branching and Committing:
-  branch       Commands for managing branches.
+  branch       Commands for managing branches
 
 Editing Commits:
-  move         Move a commit or branch to a different location.
+  move         Move a commit or branch to a different location
 
 Other Commands:
-  gui          Open the GitButler GUI for the current project.
-  update       Manage GitButler CLI and app updates.
-  alias        Manage command aliases.
-  config       View and manage GitButler configuration.
-  skill        Manage AI agent skills for GitButler.
+  gui          Open the GitButler GUI for the current project
+  update       Manage GitButler CLI and app updates
+  alias        Manage command aliases
+  config       View and manage GitButler configuration
+  skill        Manage AI agent skills for GitButler
 
 To add command completion, add this to your shell rc: (for example ~/.zshrc)
   eval "$(but completions zsh)"

--- a/crates/but/tests/but/command/help.rs
+++ b/crates/but/tests/but/command/help.rs
@@ -12,53 +12,46 @@ fn rub_looks_good() -> anyhow::Result<()> {
     env.but("rub --help").assert().success().stdout_eq(str![[r#"
 Combines two entities together to perform an operation like amend, squash, stage, or move.
 
-The `rub` command is a simple verb that helps you do a number of editing
-operations by doing combinations of two things.
+The rub command is a simple verb that helps you do a number of editing operations by doing
+combinations of two things.
 
-For example, you can "rub" a file onto a branch to stage that file to
-the branch. You can also "rub" a commit onto another commit to squash
-them together. You can rub a commit onto a branch to move that commit.
-You can rub a file from one commit to another.
+For example, you can "rub" a file onto a branch to stage that file to the branch. You can also "rub"
+a commit onto another commit to squash them together. You can rub a commit onto a branch to move
+that commit. You can rub a file from one commit to another.
 
-## Operations Matrix
+Operations Matrix
 
 Each cell shows what happens when you rub SOURCE → TARGET:
 
-```text
-SOURCE ↓ / TARGET →  │ zz (unassigned) │ Commit     │ Branch      │ Stack
-─────────────────────┼─────────────────┼────────────┼─────────────┼────────────
-File/Hunk            │ Unstage         │ Amend      │ Stage       │ Stage
-Commit               │ Undo            │ Squash     │ Move        │ -
-Branch (all changes) │ Unstage all     │ Amend all  │ Reassign    │ Reassign
-Stack (all changes)  │ Unstage all     │ -          │ Reassign    │ Reassign
-Unassigned (zz)      │ -               │ Amend all  │ Stage all   │ Stage all
-File-in-Commit       │ Uncommit        │ Move       │ Uncommit to │ -
-```
+  SOURCE ↓ / TARGET →  │ zz (unassigned) │ Commit     │ Branch      │ Stack
+  ─────────────────────┼─────────────────┼────────────┼─────────────┼────────────
+  File/Hunk            │ Unstage         │ Amend      │ Stage       │ Stage
+  Commit               │ Undo            │ Squash     │ Move        │ -
+  Branch (all changes) │ Unstage all     │ Amend all  │ Reassign    │ Reassign
+  Stack (all changes)  │ Unstage all     │ -          │ Reassign    │ Reassign
+  Unassigned (zz)      │ -               │ Amend all  │ Stage all   │ Stage all
+  File-in-Commit       │ Uncommit        │ Move       │ Uncommit to │ -
 
 Legend:
-- `zz` is a special target meaning "unassigned" (no branch)
-- `-` means the operation is not supported
+
+- zz is a special target meaning "unassigned" (no branch)
+- - means the operation is not supported
 - "all changes" / "all" refers to all uncommitted changes from that source
 
-## Examples
+Examples
 
 Squashing two commits into one (combining the commit messages):
 
-```text
-but rub 3868155 abe3f53f
-```
+  but rub 3868155 abe3f53f
 
 Amending a commit with the contents of a modified file:
 
-```text
-but rub README.md abe3f53f
-```
+  but rub README.md abe3f53f
 
 Moving a commit from one branch to another:
 
-```text
-but rub 3868155 feature-branch
-```
+  but rub 3868155 feature-branch
+
 
 Usage: but rub [OPTIONS] <SOURCE> <TARGET>
 
@@ -93,7 +86,7 @@ Options:
 
 "#]]);
     env.but("rub -h").assert().success().stdout_eq(str![[r#"
-Combines two entities together to perform an operation like amend, squash, stage, or move.
+Combines two entities together to perform an operation like amend, squash, stage, or move
 
 Usage: but rub [OPTIONS] <SOURCE> <TARGET>
 


### PR DESCRIPTION
All commands output raw (verbatim) doc comments, which looks like all heckin' heck when using the CLI. It's probably there to facilitate docs generation for the website (through `but-clap`).

This commit feature gates the raw doc comments s.t. normal builds of the CLI has the doc comments pas through clap's Markdown formatter, and raw doc comments are only output when passing the `raw-clap-docs` feature flag.

For the CLI usage itself, this PR takes it from this raw hellscape:
<img width="1916" height="1145" alt="config_verbatim" src="https://github.com/user-attachments/assets/51ea46c0-b2e4-4db8-b308-74a90e89341d" />

To this formatted paradise:
<img width="1850" height="876" alt="config_formatted" src="https://github.com/user-attachments/assets/14a86892-785e-4b07-ae40-991537233b26" />