### PR TITLE
chore: fix some module level doc comments

### DIFF
--- a/crates/but-debugging/src/lib.rs
+++ b/crates/but-debugging/src/lib.rs
@@ -1,6 +1,8 @@
-/// But Debugging contains utilities that aid in debugging gitbutler.
-/// Utilities defined inside of but-debugging should not be relied upon in
-/// tests or used in production code.
+//! But Debugging contains utilities that aid in debugging gitbutler.
+//!
+//! Utilities defined inside of but-debugging should not be relied upon in
+//! tests or used in production code.
+
 use std::{path::Path, process::Command};
 
 /// Options passed to `git log`

--- a/crates/but-hunk-assignment/src/state.rs
+++ b/crates/but-hunk-assignment/src/state.rs
@@ -1,4 +1,5 @@
-/// The name of the file holding our state, useful for watching for changes.
+//! The name of the file holding our state, useful for watching for changes.
+
 use anyhow::Result;
 use but_db::{HunkAssignmentsHandle, HunkAssignmentsHandleMut};
 

--- a/crates/but-rebase/tests/rebase/graph_rebase/rebase_identities.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/rebase_identities.rs
@@ -1,5 +1,6 @@
-/// These tests demonstrate that if none of the steps are changed, the same
-/// graphs are returned.
+//! These tests demonstrate that if none of the steps are changed, the same
+//! graphs are returned.
+
 use anyhow::Result;
 use but_graph::Graph;
 use but_rebase::graph_rebase::Editor;

--- a/crates/but-rebase/tests/rebase/graph_rebase/signing_preferences.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/signing_preferences.rs
@@ -1,4 +1,5 @@
-/// These tests cover the signing behavior on the Step::Pick.
+//! These tests cover the signing behavior on the Step::Pick.
+
 use anyhow::Result;
 use but_core::commit::SignCommit;
 use but_graph::Graph;

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -1,11 +1,13 @@
-/// Command-line argument parsing for GitButler CLI.
-/// Uses `clap` for defining commands and options.
-///
-/// This module defines the main `Args` struct which represents the top-level
-/// command-line interface, along with its subcommands and options.
-///
-/// Nearly all documentation for the CLI is defined here using `clap` attributes,
-/// which are then used to generate help messages and online documentation.
+//! Command-line argument parsing for GitButler CLI.
+//!
+//! Uses `clap` for defining commands and options.
+//!
+//! This module defines the main `Args` struct which represents the top-level
+//! command-line interface, along with its subcommands and options.
+//!
+//! Nearly all documentation for the CLI is defined here using `clap` attributes,
+//! which are then used to generate help messages and online documentation.
+
 use std::ffi::OsString;
 use std::path::PathBuf;
 


### PR DESCRIPTION
`//!` should be used for module level doc comments, not `///`.