### PR TITLE
tree_expression: refactor into its own file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,6 +1103,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "smallvec",
  "tempfile",
  "toml 0.9.12+spec-1.1.0",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -311,6 +311,7 @@ unicode-segmentation = "1.13.2"
 urlencoding = "2.1"
 inventory = "0.3"
 git-meta-lib = { git = "https://github.com/git-meta/git-meta", rev = "b40c108514a992abea2f739889376334481af1a3" }
+smallvec = "1.15.1"
 
 [patch.crates-io]
 # Keep workspace crates that use the `gix 0.84` line on the same git revision.

--- a/crates/but-core/Cargo.toml
+++ b/crates/but-core/Cargo.toml
@@ -38,6 +38,7 @@ gix = { workspace = true, features = [
     "status",
     "merge",
 ] }
+smallvec.workspace = true
 # for V1 conflict commits
 toml.workspace = true
 chardetng = "0.1.17"

--- a/crates/but-core/src/commit/mod.rs
+++ b/crates/but-core/src/commit/mod.rs
@@ -9,10 +9,11 @@ use gix::objs::WriteTo;
 use gix::objs::tree::EntryKind;
 use gix::prelude::ObjectIdExt;
 use serde::{Deserialize, Serialize};
+use smallvec::{SmallVec, smallvec};
 
 use crate::{
     ChangeId, Commit, CommitOwned, GitConfigSettings, RepositoryExt,
-    cmd::prepare_with_shell_on_windows,
+    cmd::prepare_with_shell_on_windows, commit::tree_expression::TreeExpression,
 };
 
 /// A collection of all the extra information we keep in the headers of a commit.
@@ -636,13 +637,13 @@ impl<'repo> Commit<'repo> {
         Ok(ids)
     }
 
-    /// If the commit is not conflicted, returns the commit's tree as a single-element vec..
-    pub fn side_tree_ids(&self) -> anyhow::Result<Vec<gix::ObjectId>> {
+    /// If the commit is not conflicted, returns the commit's tree as a single-element SmallVec.
+    pub fn side_tree_ids(&self) -> anyhow::Result<SmallVec<[gix::ObjectId; 1]>> {
         if !self.is_conflicted() {
-            return Ok(vec![self.inner.tree]);
+            return Ok(smallvec![self.inner.tree]);
         }
         let tree = self.inner.tree.attach(self.id.repo).object()?.into_tree();
-        let mut ids = Vec::new();
+        let mut ids = SmallVec::new();
         let mut i = 0;
         while let Some(entry) = tree.find_entry(format!(".conflict-side-{i}")) {
             ids.push(entry.id().detach());
@@ -816,6 +817,7 @@ pub use conflict::{
     add_conflict_markers, is_conflicted, message_is_conflicted,
     rewrite_conflict_markers_on_message_change, strip_conflict_markers,
 };
+pub mod tree_expression;
 
 /// Write a GitButler conflicted tree that wraps `resolved_tree_id` together
 /// with the conflict base trees, the conflict side trees, and the conflict
@@ -827,33 +829,25 @@ pub use conflict::{
 /// - `resolved_tree_id` - is the visible auto-resolved tree that callers want to
 ///   present as the conflicted commit's main tree.
 ///
-/// - `base_tree_ids` - are the base trees. A conflict from a 3-way merge will
-///   have 1 base.
-///
-/// - `side_tree_ids` - are the side trees. A conflict from a 3-way merge will
-///   have 2 sides, the first side being "ours" and the second side being
-///   "theirs".
-///
-/// - `theirs_tree_id` - is the incoming tree on the "theirs" side of the conflict.
+/// - `tree_expression` - represents the trees involved in the conflict.
 ///
 /// - `conflict_entries` - lists the paths that should be recorded as conflicted in
 ///   the synthetic GitButler tree metadata.
 pub fn write_conflicted_tree(
     repo: &gix::Repository,
     resolved_tree_id: gix::ObjectId,
-    base_tree_ids: impl IntoIterator<Item = gix::ObjectId>,
-    side_tree_ids: impl IntoIterator<Item = gix::ObjectId>,
+    tree_expression: &TreeExpression,
     conflict_entries: &ConflictEntries,
 ) -> anyhow::Result<gix::ObjectId> {
     let conflicted_files_string = toml::to_string(conflict_entries)?;
     let conflicted_files_blob = repo.write_blob(conflicted_files_string.as_bytes())?;
 
     let mut tree = repo.find_tree(resolved_tree_id)?.edit()?;
-    for (i, tree_id) in base_tree_ids.into_iter().enumerate() {
-        tree.upsert(format!(".conflict-base-{i}"), EntryKind::Tree, tree_id)?;
+    for (i, tree_id) in tree_expression.base_tree_ids.iter().enumerate() {
+        tree.upsert(format!(".conflict-base-{i}"), EntryKind::Tree, *tree_id)?;
     }
-    for (i, tree_id) in side_tree_ids.into_iter().enumerate() {
-        tree.upsert(format!(".conflict-side-{i}"), EntryKind::Tree, tree_id)?;
+    for (i, tree_id) in tree_expression.side_tree_ids.iter().enumerate() {
+        tree.upsert(format!(".conflict-side-{i}"), EntryKind::Tree, *tree_id)?;
     }
     tree.upsert(
         TreeKind::AutoResolution.as_tree_entry_name(),

--- a/crates/but-core/src/commit/tree_expression.rs
+++ b/crates/but-core/src/commit/tree_expression.rs
@@ -1,0 +1,153 @@
+//! Expressions of the form "sum of side tree IDs minus sum of base tree IDs".
+
+use std::collections::VecDeque;
+
+use crate::repo_ext::RepositoryExt as _;
+use anyhow::Context as _;
+use smallvec::{SmallVec, smallvec};
+
+/// Sum of sides minus sum of bases. All functions enforce the invariant that
+/// the count of sides is exactly one more than the count of bases.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TreeExpression {
+    /// Base tree IDs.
+    pub base_tree_ids: Vec<gix::ObjectId>,
+    /// Side tree IDs.
+    pub side_tree_ids: SmallVec<[gix::ObjectId; 1]>,
+}
+
+impl TryFrom<&crate::Commit<'_>> for TreeExpression {
+    type Error = anyhow::Error;
+
+    fn try_from(commit: &crate::Commit<'_>) -> Result<Self, Self::Error> {
+        let base_tree_ids = commit.base_tree_ids()?;
+        let side_tree_ids = commit.side_tree_ids()?;
+        if base_tree_ids.len() + 1 != side_tree_ids.len() {
+            anyhow::bail!(
+                "in commit {}, number of sides ({}) is not exactly one more than number of bases ({})",
+                commit.id.to_hex(),
+                side_tree_ids.len(),
+                base_tree_ids.len()
+            );
+        }
+        Ok(Self {
+            base_tree_ids,
+            side_tree_ids,
+        })
+    }
+}
+
+impl From<gix::ObjectId> for TreeExpression {
+    fn from(side: gix::ObjectId) -> Self {
+        Self {
+            base_tree_ids: Vec::new(),
+            side_tree_ids: smallvec![side],
+        }
+    }
+}
+
+/// Arithmetic
+impl TreeExpression {
+    /// Subtracts `base` then adds `side`. This extends self's bases with the
+    /// sides of `base` and the bases of `side`, and then extends self's sides
+    /// with the bases of `base` and the sides of `side`.
+    pub fn subtract_add(&mut self, base: &TreeExpression, side: &TreeExpression) {
+        self.base_tree_ids
+            .extend(base.side_tree_ids.iter().copied());
+        self.base_tree_ids
+            .extend(side.base_tree_ids.iter().copied());
+        self.side_tree_ids
+            .extend(base.base_tree_ids.iter().copied());
+        self.side_tree_ids
+            .extend(side.side_tree_ids.iter().copied());
+    }
+}
+
+/// Outcome of [TreeExpression::merge].
+pub enum MergeOutcome<'repo> {
+    /// There were no merge conflicts.
+    Unconflicted {
+        /// The lone tree after simplifications and merges.
+        tree_id: gix::ObjectId,
+    },
+    /// There was at least one merge conflict.
+    Conflicted {
+        /// The tree as returned by the last merge (which resulted in a
+        /// conflict).
+        tree_id: gix::ObjectId,
+        /// The outcome of the last merge (which resulted in a conflict).
+        merge: Box<gix::merge::tree::Outcome<'repo>>,
+        /// The tree expression representing the parts that could not be merged
+        /// without conflict (after possibly some successful simplifications
+        /// and/or merges).
+        tree_expression: TreeExpression,
+    },
+}
+
+/// Simplification
+impl TreeExpression {
+    /// Cancel out terms in the bases and sides wherever possible, then
+    /// repeatedly merge until only one side remains or a conflict is
+    /// encountered.
+    pub fn merge<'repo>(
+        self,
+        repo: &'repo gix::Repository,
+        merge_options: gix::merge::tree::Options,
+    ) -> anyhow::Result<MergeOutcome<'repo>> {
+        let (mut bases, mut sides) = {
+            let Self {
+                base_tree_ids,
+                side_tree_ids,
+            } = self;
+            (
+                VecDeque::from(base_tree_ids),
+                VecDeque::from(side_tree_ids.into_vec()),
+            )
+        };
+        for i in (0..bases.len()).rev() {
+            if let Some(position) = sides.iter().position(|side| *side == bases[i]) {
+                sides.remove(position);
+                bases.remove(i);
+            }
+        }
+
+        let conflict_kind = gix::merge::tree::TreatAsUnresolved::forced_resolution();
+        let mut ours = sides
+            .pop_front()
+            .context("BUG: side count invariant not enforced (should have at least 1 side)")?;
+        while let Some(base) = bases.pop_front() {
+            let theirs = sides.pop_front().context(
+                "BUG: side count invariant not enforced (no corresponding side to popped base)",
+            )?;
+            let mut merge = repo.merge_trees(
+                base,
+                ours,
+                theirs,
+                repo.default_merge_labels(),
+                merge_options.clone(),
+            )?;
+            let merged_tree_id = merge.tree.write()?.detach();
+
+            if merge.has_unresolved_conflicts(conflict_kind) {
+                // Push back the things that conflict when merged. Note that
+                // "ours" needs to be the frontmost, so we push "theirs" then
+                // "ours".
+                sides.push_front(theirs);
+                sides.push_front(ours);
+                bases.push_front(base);
+                return Ok(MergeOutcome::Conflicted {
+                    tree_id: merged_tree_id,
+                    merge: Box::new(merge),
+                    tree_expression: TreeExpression {
+                        base_tree_ids: bases.into(),
+                        side_tree_ids: Vec::from(sides).into(),
+                    },
+                });
+            }
+
+            ours = merged_tree_id;
+        }
+
+        Ok(MergeOutcome::Unconflicted { tree_id: ours })
+    }
+}

--- a/crates/but-rebase/src/graph_rebase/merge_commit_changes.rs
+++ b/crates/but-rebase/src/graph_rebase/merge_commit_changes.rs
@@ -1,9 +1,9 @@
 #![doc = include_str!("../../docs/merge_commit_changes.md")]
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet};
 
 use anyhow::{Context, Result, bail};
-use but_core::{RefMetadata, RepositoryExt};
+use but_core::{RefMetadata, commit::tree_expression::TreeExpression};
 use gix::prelude::ObjectIdExt;
 use petgraph::Direction;
 
@@ -41,10 +41,8 @@ pub struct MergeCommitChangesOutcome {
 /// merged change-range result.
 #[derive(Debug, Clone, PartialEq)]
 pub struct MergeCommitChangesConflict {
-    /// The merge base trees for the conflicted merge step.
-    pub base_tree_ids: Vec<gix::ObjectId>,
-    /// The merge side trees for the conflicted merge step.
-    pub side_tree_ids: Vec<gix::ObjectId>,
+    /// The tree expression for the conflicted merge step.
+    pub tree_expression: TreeExpression,
     /// The paths that remained conflicted after auto-resolution.
     pub conflict_entries: but_core::commit::ConflictEntries,
 }
@@ -65,71 +63,44 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
         let merge_plan =
             self.plan_commit_changes_for_merge(target_commit_id, subject_commit_ids)?;
 
-        let mut bases = VecDeque::from(target_commit.base_tree_ids()?);
-        let mut sides = VecDeque::from(target_commit.side_tree_ids()?);
+        let mut tree_expression = TreeExpression::try_from(&target_commit)?;
         for change in merge_plan {
-            bases.push_back(change.base_tree_id);
             let commit = but_core::Commit::from_id(change.commit_id.attach(&self.repo))?;
-            bases.extend(commit.base_tree_ids()?);
-            sides.extend(commit.side_tree_ids()?);
+            tree_expression.subtract_add(
+                &TreeExpression::from(change.base_tree_id),
+                &TreeExpression::try_from(&commit)?,
+            );
         }
 
-        // Simplify: a base and a side that are identical cancel each other out
-        for i in (0..bases.len()).rev() {
-            if let Some(position) = sides.iter().position(|side| *side == bases[i]) {
-                sides.remove(position);
-                bases.remove(i);
+        Ok(match tree_expression.merge(&self.repo, merge_options)? {
+            but_core::commit::tree_expression::MergeOutcome::Unconflicted { tree_id } => {
+                MergeCommitChangesOutcome {
+                    tree_id,
+                    conflict: None,
+                }
             }
-        }
-
-        let conflict_kind = gix::merge::tree::TreatAsUnresolved::forced_resolution();
-        let mut ours = sides
-            .pop_front()
-            .context("BUG: target_commit should have at least one side")?;
-        while let Some(base) = bases.pop_front() {
-            let theirs = sides
-                .pop_front()
-                .context("attempting to merge commit with unbalanced bases and sides")?;
-            let mut merge = self.repo.merge_trees(
-                base,
-                ours,
-                theirs,
-                self.repo.default_merge_labels(),
-                merge_options.clone(),
-            )?;
-            let merged_tree_id = merge.tree.write()?.detach();
-
-            if merge.has_unresolved_conflicts(conflict_kind) {
-                // Push back the things that conflict when merged. Note that
-                // "ours" needs to be the frontmost, so we push "theirs" then
-                // "ours".
-                sides.push_front(theirs);
-                sides.push_front(ours);
-                bases.push_front(base);
+            but_core::commit::tree_expression::MergeOutcome::Conflicted {
+                tree_id,
+                merge,
+                tree_expression,
+            } => {
+                let conflict_kind = gix::merge::tree::TreatAsUnresolved::forced_resolution();
                 let conflict = Some(MergeCommitChangesConflict {
-                    base_tree_ids: bases.into(),
-                    side_tree_ids: sides.into(),
+                    tree_expression,
                     conflict_entries: but_core::commit::conflict_entries_from_merge_outcome(
                         &self.repo,
-                        merged_tree_id,
+                        tree_id,
                         &merge,
                         conflict_kind,
                     )?,
                 });
-                return Ok(MergeCommitChangesOutcome {
+                MergeCommitChangesOutcome {
                     // As described in the module-level documentation, we stop
                     // at the first unresolved merge conflict.
-                    tree_id: merged_tree_id,
+                    tree_id,
                     conflict,
-                });
+                }
             }
-
-            ours = merged_tree_id;
-        }
-
-        Ok(MergeCommitChangesOutcome {
-            tree_id: ours,
-            conflict: None,
         })
     }
 

--- a/crates/but-rebase/tests/rebase/graph_rebase/merge_commit_changes.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/merge_commit_changes.rs
@@ -163,11 +163,11 @@ fn reports_conflicts() -> Result<()> {
         .conflict
         .expect("conflicting merge should report conflict metadata");
     assert_eq!(
-        conflict.base_tree_ids,
+        conflict.tree_expression.base_tree_ids,
         vec![repo.rev_parse_single("A~1^{tree}")?.detach()]
     );
     assert_eq!(
-        conflict.side_tree_ids,
+        conflict.tree_expression.side_tree_ids.into_vec(),
         vec![
             repo.rev_parse_single("A^{tree}")?.detach(),
             repo.rev_parse_single("B^{tree}")?.detach()

--- a/crates/but-workspace/src/branch/integrate_branch_upstream/plan.rs
+++ b/crates/but-workspace/src/branch/integrate_branch_upstream/plan.rs
@@ -312,8 +312,7 @@ fn apply_merge_commit_changes_outcome(
         commit.tree = write_conflicted_tree(
             repo,
             outcome.tree_id,
-            conflict.base_tree_ids,
-            conflict.side_tree_ids,
+            &conflict.tree_expression,
             &conflict.conflict_entries,
         )?;
         commit.message = add_conflict_markers(BStr::new(&message));


### PR DESCRIPTION
Refactor the tree expression code to make it easier for other code to reuse it.

I have a PR in progress that uses the result of the refactor.
