### PR TITLE
Demo of how rub that shouldn't work works

### DIFF
--- a/crates/but-rebase/src/graph_rebase/cherry_pick.rs
+++ b/crates/but-rebase/src/graph_rebase/cherry_pick.rs
@@ -62,6 +62,25 @@ pub enum PickMode {
     Force,
 }
 
+fn debug_tree(repo: &gix::Repository, tree_id: gix::ObjectId) -> Result<()> {
+    eprintln!("start of {:?}", tree_id);
+    let tree = repo.find_tree(tree_id)?;
+    for entry in tree.iter() {
+        let entry = entry?;
+        if let Ok(blob) = repo.find_blob(entry.inner.oid) {
+            eprintln!(
+                " entry {} contents {:?}",
+                entry.inner.filename,
+                str::from_utf8(&blob.data)
+            );
+        } else {
+            eprintln!(" entry {}", entry.inner.filename);
+        }
+    }
+    eprintln!("end of {:?}", tree_id);
+    Ok(())
+}
+
 /// Cherry pick, but supports cherry-picking merge commits.
 ///
 /// When cherry-picking a commit onto two or more commits, we first find the
@@ -117,11 +136,21 @@ pub fn cherry_pick(
         return Ok(CherryPickOutcome::Identity(target.id.detach()));
     }
 
+    eprintln!("merging target {:?} ontos {:?}", target, ontos);
+    debug_tree(repo, target.tree)?;
     let base_t = find_base_tree(&target, tree_merge_mode)?;
     // We always want the "theirs-ist" side of the target if it's conflicted.
     let target_t = find_real_tree(&target, TreeKind::Theirs)?;
     // We want to cherry-pick onto the merge result.
     let onto_t = merged_tree_from_commits(repo, ontos, tree_merge_mode, TreeKind::AutoResolution)?;
+    eprintln!("base {:?} target {:?} onto {:?}", base_t, target_t, onto_t);
+    if let MergeOutcome::Success(tree_id) = base_t {
+        debug_tree(repo, tree_id)?;
+    }
+    debug_tree(repo, target_t.detach())?;
+    if let MergeOutcome::Success(tree_id) = onto_t {
+        debug_tree(repo, tree_id)?;
+    }
 
     match (&base_t, &onto_t) {
         (MergeOutcome::NoCommit, MergeOutcome::NoCommit) if pick_mode == PickMode::Force => {

--- a/crates/but-rebase/src/graph_rebase/rebase.rs
+++ b/crates/but-rebase/src/graph_rebase/rebase.rs
@@ -72,6 +72,7 @@ impl<'ws, 'graph, M: RefMetadata> Editor<'ws, 'graph, M> {
                             .collect::<Result<Vec<_>>>()?,
                     };
 
+                    eprintln!("cherrypicking...");
                     let outcome = cherry_pick(
                         &self.repo,
                         pick.id,
@@ -80,6 +81,7 @@ impl<'ws, 'graph, M: RefMetadata> Editor<'ws, 'graph, M> {
                         pick.tree_merge_mode,
                         pick.sign_commit,
                     )?;
+                    eprintln!("cherrypicking outcome is {:?}", outcome);
 
                     if matches!(outcome, CherryPickOutcome::ConflictedCommit(_))
                         && !pick.conflictable

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -185,7 +185,7 @@ Staged hunk(s) → [A].
 }
 
 #[test]
-fn committed_file_to_unassigned() -> anyhow::Result<()> {
+fn jonathansdemo() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
 
     env.setup_metadata(&["A", "B"])?;
@@ -254,6 +254,43 @@ fn committed_file_to_unassigned() -> anyhow::Result<()> {
 
 "#]]);
 
+    env.but("diff fc:b.txt")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+───────╮
+A b.txt│
+───────╯
+       1│+first commit
+       2│+line
+       3│+line
+       4│+line
+       5│+line
+       6│+line
+       7│+line
+       8│+line
+       9│+last
+
+"#]])
+        .stderr_eq(str![""]);
+
+    env.but("diff e8:b.txt")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+───────╮
+M b.txt│
+───────╯
+   1  │-first commit
+     1│+second commit
+   2 2│ line
+   3 3│ line
+   4 4│ line
+
+"#]])
+        .stderr_eq(str![""]);
+
+    eprintln!("before rub");
     env.but("rub fc:b.txt zz")
         .assert()
         .success()
@@ -262,6 +299,7 @@ Uncommitted changes
 
 "#]])
         .stderr_eq(str![""]);
+    eprintln!("after rub");
 
     // Verify that `status` reflects the move.
     env.but("--format json status -f")


### PR DESCRIPTION
Notice that we're rubbing fc:b.txt away to the unassigned area, but one of its lines ("first commit") is subsequently modified by fc's child (e8).

As can be seen from the screenshot below, two non-trivial cherrypicks occur. The first one is the change from "first commit" (on the base) to "second commit" (on the target) in b.txt, a file that does not exist on the "onto". A conflicted commit `fd6ff4` is written as expected, with the autoresolution tree favoring the "onto" tree (https://github.com/gitbutlerapp/gitbutler/blob/master/crates/but-rebase/src/graph_rebase/cherry_pick.rs#L192 ).

The second one is cherrypicking the workspace commit onto 2 commits, one of them being the conflicted commit generated above (`fd6ff4`). The "onto" tree is generated by merging these 2 commits. `fd6ff4` has the "conflicted" flag, but that flag is only used to indicate that the commit's tree should not be taken directly (instead, the autoresolution tree is taken); after that, that flag is ignored. (Remember that the autoresolution tree does not have conflict markers because we favored the "onto" side during the merge.) All subsequent merges happen without conflict, so no conflict is detected.

With my code in progress (not in this PR), conflicts are not swept under the rug, so the workspace commit would be conflicted.

<img width="3834" height="1620" alt="image" src="https://github.com/user-attachments/assets/d3febad9-dabc-4807-beeb-0b911f58c167" />

```
        1 + cherrypicking...
        2 + cherrypicking outcome is Identity(Sha1(0dc37334a458df421bf67ea806103bf5004845dd))
        3 + cherrypicking...
        4 + cherrypicking outcome is Identity(Sha1(d3e2ba36c529fbdce8de90593e22aceae21f9b17))
        5 + cherrypicking...
        6 + cherrypicking outcome is Identity(Sha1(9477ae721ab521d9d0174f70e804ce3ff9f6fb56))
        7 + cherrypicking...
        8 + cherrypicking outcome is Identity(Sha1(993513d3d109de0dcfe0424c1aa403a9d2aafff8))
        9 + cherrypicking...
       10 + merging target Commit { id: Sha1(e8818283e5e0b903cefc4a27b77b1fec084ea268), inner: Commit { tree: Sha1(f73a4061169f087e439a22229cdbeff589bcc1f6), parents: [Sha1(fce8eccc1ef1036c727dcd33e3190075154c7c64)], author: Signature { name: "author", email: "author@example.com", time: Time { seconds: 946684800, offset: 0 } }, committer: Signature { name: "committer", email: "committer@example.com", time: Time { seconds: 946771200, offset: 0 } }, encoding: None, message: "create a.txt and b.txt", extra_headers: [("gitbutler-headers-version", "2"), ("change-id", "1")] } } ontos [Sha1(993513d3d109de0dcfe0424c1aa403a9d2aafff8)]
       11 + start of Sha1(f73a4061169f087e439a22229cdbeff589bcc1f6)
       12 +  entry A contents Ok("A/n")
       13 +  entry M contents Ok("M/n")
       14 +  entry a.txt contents Ok("second commit/nline/nline/nline/nline/nline/nline/nline/nlast/n")
       15 +  entry b.txt contents Ok("second commit/nline/nline/nline/nline/nline/nline/nline/nlast/n")
       16 + end of Sha1(f73a4061169f087e439a22229cdbeff589bcc1f6)
       17 + base Success(Sha1(a81b0dab654d056015f145323f3c88dd188f08c1)) target Sha1(f73a4061169f087e439a22229cdbeff589bcc1f6) onto Success(Sha1(2502026512fc6b40bd33d75772e1d3909a02b74c))
       18 + start of Sha1(a81b0dab654d056015f145323f3c88dd188f08c1)
       19 +  entry A contents Ok("A/n")
       20 +  entry M contents Ok("M/n")
       21 +  entry a.txt contents Ok("first commit/nline/nline/nline/nline/nline/nline/nline/nlast/n")
       22 +  entry b.txt contents Ok("first commit/nline/nline/nline/nline/nline/nline/nline/nlast/n")
       23 + end of Sha1(a81b0dab654d056015f145323f3c88dd188f08c1)
       24 + start of Sha1(f73a4061169f087e439a22229cdbeff589bcc1f6)
       25 +  entry A contents Ok("A/n")
       26 +  entry M contents Ok("M/n")
       27 +  entry a.txt contents Ok("second commit/nline/nline/nline/nline/nline/nline/nline/nlast/n")
       28 +  entry b.txt contents Ok("second commit/nline/nline/nline/nline/nline/nline/nline/nlast/n")
       29 + end of Sha1(f73a4061169f087e439a22229cdbeff589bcc1f6)
       30 + start of Sha1(2502026512fc6b40bd33d75772e1d3909a02b74c)
       31 +  entry A contents Ok("A/n")
       32 +  entry M contents Ok("M/n")
       33 +  entry a.txt contents Ok("first commit/nline/nline/nline/nline/nline/nline/nline/nlast/n")
       34 + end of Sha1(2502026512fc6b40bd33d75772e1d3909a02b74c)
       35 + cherrypicking outcome is ConflictedCommit(Sha1(fd6ff45576302a381ada939bc73cd409dc24c9c2))
       36 + cherrypicking...
       37 + merging target Commit { id: Sha1(ce2efed46eec592ef285fedc431325a9e87a3002), inner: Commit { tree: Sha1(ba0178df5fd85fe0a62a36f38aa54abf5d6db68a), parents: [Sha1(d3e2ba36c529fbdce8de90593e22aceae21f9b17), Sha1(e8818283e5e0b903cefc4a27b77b1fec084ea268)], author: Signature { name: "author", email: "author@example.com", time: Time { seconds: 946684800, offset: 0 } }, committer: Signature { name: "committer", email: "committer@example.com", time: Time { seconds: 946771200, offset: 0 } }, encoding: None, message: "GitButler Workspace Commit/n", extra_headers: [("gitbutler-headers-version", "2"), ("change-id", "vyuxvluwtxzwqoymknuulxkztmnmmqmx")] } } ontos [Sha1(d3e2ba36c529fbdce8de90593e22aceae21f9b17), Sha1(fd6ff45576302a381ada939bc73cd409dc24c9c2)]
       38 + start of Sha1(ba0178df5fd85fe0a62a36f38aa54abf5d6db68a)
       39 +  entry A contents Ok("A/n")
       40 +  entry B contents Ok("B/n")
       41 +  entry M contents Ok("M/n")
       42 +  entry a.txt contents Ok("second commit/nline/nline/nline/nline/nline/nline/nline/nlast/n")
       43 +  entry b.txt contents Ok("second commit/nline/nline/nline/nline/nline/nline/nline/nlast/n")
       44 + end of Sha1(ba0178df5fd85fe0a62a36f38aa54abf5d6db68a)
       45 + base Success(Sha1(ba0178df5fd85fe0a62a36f38aa54abf5d6db68a)) target Sha1(ba0178df5fd85fe0a62a36f38aa54abf5d6db68a) onto Success(Sha1(6d3580459055ee78557803e877216824022d34b3))
       46 + start of Sha1(ba0178df5fd85fe0a62a36f38aa54abf5d6db68a)
       47 +  entry A contents Ok("A/n")
       48 +  entry B contents Ok("B/n")
       49 +  entry M contents Ok("M/n")
       50 +  entry a.txt contents Ok("second commit/nline/nline/nline/nline/nline/nline/nline/nlast/n")
       51 +  entry b.txt contents Ok("second commit/nline/nline/nline/nline/nline/nline/nline/nlast/n")
       52 + end of Sha1(ba0178df5fd85fe0a62a36f38aa54abf5d6db68a)
       53 + start of Sha1(ba0178df5fd85fe0a62a36f38aa54abf5d6db68a)
       54 +  entry A contents Ok("A/n")
       55 +  entry B contents Ok("B/n")
       56 +  entry M contents Ok("M/n")
       57 +  entry a.txt contents Ok("second commit/nline/nline/nline/nline/nline/nline/nline/nlast/n")
       58 +  entry b.txt contents Ok("second commit/nline/nline/nline/nline/nline/nline/nline/nlast/n")
       59 + end of Sha1(ba0178df5fd85fe0a62a36f38aa54abf5d6db68a)
       60 + start of Sha1(6d3580459055ee78557803e877216824022d34b3)
       61 +  entry A contents Ok("A/n")
       62 +  entry B contents Ok("B/n")
       63 +  entry M contents Ok("M/n")
       64 +  entry a.txt contents Ok("second commit/nline/nline/nline/nline/nline/nline/nline/nlast/n")
       65 + end of Sha1(6d3580459055ee78557803e877216824022d34b3)
       66 + cherrypicking outcome is Commit(Sha1(112004b6bff7a0d86076998910cc0fa616e73021))
```