### PR TITLE
gitlab CI refinements

### DIFF
--- a/apps/desktop/src/components/forge/CIChecksBadge.svelte
+++ b/apps/desktop/src/components/forge/CIChecksBadge.svelte
@@ -103,6 +103,17 @@
 				};
 			}
 
+			if (checks.completed && checks.actionRequired) {
+				const checksList = checks.actionRequiredChecks.join(", ");
+				return {
+					style: "warning",
+					icon: "warning",
+					text: "Action required",
+					reducedText: "Action",
+					tooltip: checksList ? `Action required: ${checksList}` : "Action required.",
+				};
+			}
+
 			// Merge conflicts can prevent checks from running at all.
 			if (mergeableState === "dirty") {
 				return {

--- a/apps/desktop/src/lib/forge/checksMonitor.svelte.ts
+++ b/apps/desktop/src/lib/forge/checksMonitor.svelte.ts
@@ -49,6 +49,7 @@ function parseChecks(checks: CiCheck[]): ChecksStatus | null {
 	let actionRequiredCount = 0;
 	let allCompleted = true;
 	const failedNames: string[] = [];
+	const actionRequiredNames: string[] = [];
 	const startTimestamps: number[] = [];
 
 	for (const check of checks) {
@@ -65,6 +66,7 @@ function parseChecks(checks: CiCheck[]): ChecksStatus | null {
 				failedNames.push(check.name);
 			} else if (conclusion === "actionRequired") {
 				actionRequiredCount++;
+				actionRequiredNames.push(check.name);
 			}
 		}
 	}
@@ -75,7 +77,14 @@ function parseChecks(checks: CiCheck[]): ChecksStatus | null {
 	const startedAt =
 		startTimestamps.length > 0 ? new Date(Math.min(...startTimestamps)).toISOString() : null;
 
-	return { startedAt, completed, success, failedChecks: failedNames };
+	return {
+		startedAt,
+		completed,
+		success,
+		failedChecks: failedNames,
+		actionRequired: actionRequiredCount > 0,
+		actionRequiredChecks: actionRequiredNames,
+	};
 }
 
 function injectEndpoints(api: BackendApi) {

--- a/apps/desktop/src/lib/forge/interface/types.ts
+++ b/apps/desktop/src/lib/forge/interface/types.ts
@@ -127,6 +127,8 @@ export type ChecksStatus = {
 	completed: boolean;
 	success: boolean;
 	failedChecks: string[];
+	actionRequired: boolean;
+	actionRequiredChecks: string[];
 };
 
 export enum MergeMethod {

--- a/crates/but-forge/src/ci.rs
+++ b/crates/but-forge/src/ci.rs
@@ -242,10 +242,13 @@ impl From<but_gitlab::GitLabPipelineJob> for CiCheck {
                 },
                 completed_at,
             },
-            "running" => CiStatus::InProgress,
-            "pending" | "created" | "waiting_for_resource" | "preparing" | "scheduled" => {
-                CiStatus::Queued
-            }
+            "running" | "canceling" => CiStatus::InProgress,
+            "pending"
+            | "created"
+            | "waiting_for_resource"
+            | "waiting_for_callback"
+            | "preparing"
+            | "scheduled" => CiStatus::Queued,
             _ => CiStatus::Unknown,
         };
 
@@ -395,5 +398,19 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn maps_canceling_jobs_to_in_progress_status() {
+        let check = CiCheck::from(job("canceling", Some("https://example.com/job")));
+
+        assert!(matches!(check.status, CiStatus::InProgress));
+    }
+
+    #[test]
+    fn maps_waiting_for_callback_jobs_to_queued_status() {
+        let check = CiCheck::from(job("waiting_for_callback", Some("https://example.com/job")));
+
+        assert!(matches!(check.status, CiStatus::Queued));
     }
 }

--- a/crates/but-gitlab/src/client.rs
+++ b/crates/but-gitlab/src/client.rs
@@ -505,10 +505,9 @@ impl GitLabClient {
         })
     }
 
-    /// Fetch pipeline jobs for a given branch reference.
+    /// Fetch pipeline jobs for the latest commit on a given branch reference.
     ///
-    /// Fetches the latest pipeline for the ref, then returns all jobs in that pipeline.
-    /// Returns an empty vec if no pipelines exist for the ref.
+    /// Returns an empty vec if GitLab has no pipeline for the latest commit on the ref.
     pub async fn list_pipeline_jobs_for_ref(
         &self,
         project_id: GitLabProjectId,
@@ -521,29 +520,33 @@ impl GitLabClient {
             web_url: Option<String>,
         }
 
-        let url = format!("{}/projects/{}/pipelines", self.base_url, project_id);
+        let url = format!("{}/projects/{}/pipelines/latest", self.base_url, project_id);
         let response = self
             .client
             .get(&url)
-            .query(&[("ref", reference), ("per_page", "1")])
+            .query(&[("ref", reference)])
             .send()
             .await
-            .with_context(|| format!("Failed to list GitLab pipelines for ref '{reference}'"))?;
+            .with_context(|| {
+                format!("Failed to get latest GitLab pipeline for ref '{reference}'")
+            })?;
 
         if !response.status().is_success() {
-            bail!("Failed to list pipelines for ref: {}", response.status());
+            let status = response.status();
+            if status == reqwest::StatusCode::FORBIDDEN || status == reqwest::StatusCode::NOT_FOUND
+            {
+                return Ok(Vec::new());
+            }
+            bail!("Failed to get latest pipeline for ref: {status}");
         }
 
-        let pipelines: Vec<GitLabPipelineResponse> = response
+        let pipeline: GitLabPipelineResponse = response
             .json()
             .await
-            .with_context(|| format!("Failed to parse GitLab pipelines for ref '{reference}'"))?;
-        let Some(pipeline) = pipelines.first() else {
-            return Ok(Vec::new());
-        };
+            .with_context(|| format!("Failed to parse GitLab pipeline for ref '{reference}'"))?;
 
-        let pipeline_web_url = pipeline.web_url.clone();
-        let pipeline_status = Some(pipeline.status.clone());
+        let pipeline_web_url = pipeline.web_url;
+        let pipeline_status = Some(pipeline.status);
 
         let jobs_url = format!(
             "{}/projects/{}/pipelines/{}/jobs",


### PR DESCRIPTION
- desktop extend forge types includeRequired and actionChecks so checks can indicate human action.
- desktop: propagate action-required names/counts in checksMonitor, and show a warning-style badge in CIChecksBadge when checks require action,
 including a tooltip listing the specific checks.
- but-forge: map additional GitLab job states to CI statuses:
 treat "canceling" In and "waiting_for_callback" asued; add unit tests these.
- but-gitlab: pipeline listing to call /pipelines/latest for a ref,
 simplify response, and return empty result whenLab responds with403404; improve context messages failures.