### PR TITLE
fix: integration steps picked the wrong order

### DIFF
--- a/crates/but-workspace/src/graph_manipulation.rs
+++ b/crates/but-workspace/src/graph_manipulation.rs
@@ -297,11 +297,16 @@ pub(crate) fn selected_edges_from_set<M: RefMetadata>(
 /// selectors.
 ///
 /// `children` are the previously captured child edges that should point back to
-/// `delimiter.child` with their original order.
+/// `delimiter.child`. If the child is already connected to `delimiter.child`, no
+/// new edge is added. Otherwise, the original edge order is reused when
+/// available, or the next free order is used when another parent already
+/// occupies it.
 ///
 /// `parents` are the previously captured parent edges that should be restored
 /// from `delimiter.parent`, with fresh order values appended after any existing
-/// parents already connected there.
+/// parents already connected there. If a parent is already connected to
+/// `delimiter.parent`, no new edge is added. Otherwise, the appended order is
+/// reused when available, or advanced to the next free order on collision.
 ///
 /// Returns `Ok(())` after the captured child and parent edges have been
 /// reattached to the rebuilt segment.
@@ -312,7 +317,18 @@ pub(crate) fn connect_segment_to_edges<M: RefMetadata>(
     parents: &[(Selector, usize)],
 ) -> Result<()> {
     for (child, order) in children {
-        editor.add_edge(*child, delimiter.child, *order)?;
+        let direct_parents = editor.direct_parents(*child)?;
+        if direct_parents
+            .iter()
+            .any(|(parent, _)| *parent == delimiter.child)
+        {
+            continue;
+        }
+        editor.add_edge(
+            *child,
+            delimiter.child,
+            next_available_order(direct_parents.iter().map(|(_, order)| *order), *order),
+        )?;
     }
 
     let parent_order_offset = editor
@@ -324,10 +340,39 @@ pub(crate) fn connect_segment_to_edges<M: RefMetadata>(
         .unwrap_or(0);
 
     for (parent, order) in parents {
-        editor.add_edge(delimiter.parent, *parent, parent_order_offset + *order)?;
+        let direct_parents = editor.direct_parents(delimiter.parent)?;
+        if direct_parents
+            .iter()
+            .any(|(existing_parent, _)| *existing_parent == *parent)
+        {
+            continue;
+        }
+        let desired_order = parent_order_offset + *order;
+        editor.add_edge(
+            delimiter.parent,
+            *parent,
+            next_available_order(
+                direct_parents
+                    .iter()
+                    .map(|(_, existing_order)| *existing_order),
+                desired_order,
+            ),
+        )?;
     }
 
     Ok(())
+}
+
+fn next_available_order(
+    existing_orders: impl Iterator<Item = usize>,
+    desired_order: usize,
+) -> usize {
+    let used_orders = existing_orders.collect::<HashSet<_>>();
+    let mut order = desired_order;
+    while used_orders.contains(&order) {
+        order += 1;
+    }
+    order
 }
 
 /// Return a direct parent of `child` when `step` refers to a pick that is already connected.

--- a/crates/but-workspace/tests/fixtures/scenario/remote-advanced-with-empty-top-branch.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/remote-advanced-with-empty-top-branch.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A workspace has a local branch whose upstream has advanced, and a parallel
+# empty branch. This mirrors `but apply feature-foo` followed by
+# `but branch new empty-branch`.
+git init
+echo "A remote-advanced branch with a parallel empty branch" >.git/description
+
+commit "add main.txt"
+setup_target_to_match_main
+
+git checkout -b feature-foo main
+commit "add foo.txt"
+remote_tracking_caught_up feature-foo
+
+git checkout -b new-origin-feature-foo feature-foo
+commit "update foo.txt (remote)"
+setup_remote_tracking new-origin-feature-foo feature-foo 'move'
+
+git checkout main
+git branch empty-branch
+git checkout feature-foo
+create_workspace_commit_once feature-foo

--- a/crates/but-workspace/tests/workspace/branch/integrate_branch_upstream.rs
+++ b/crates/but-workspace/tests/workspace/branch/integrate_branch_upstream.rs
@@ -1754,6 +1754,75 @@ fn integrate_upstream_commits_when_remote_is_ahead_of_local() -> Result<()> {
 }
 
 #[test]
+fn integrate_remote_advanced_branch_with_parallel_empty_branch() -> Result<()> {
+    let (_tmp, graph, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "remote-advanced-with-empty-top-branch",
+            |meta| {
+                add_stack_with_segments(meta, 1, "feature-foo", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "empty-branch", StackState::InWorkspace, &[]);
+            },
+        )?;
+
+    insta::assert_snapshot!(normalized_graph_snapshot(&repo)?, @"
+    * cd9798c (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    | * 412aade (origin/feature-foo) update foo.txt (remote)
+    |/
+    * f0c6d1c (feature-foo) add foo.txt
+    * da7bed3 (origin/main, main, empty-branch) add main.txt
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    configure_tracking_for_branch(&mut repo, "feature-foo")?;
+
+    let initial = get_initial_integration_steps_for_branch(
+        r("refs/heads/feature-foo"),
+        BranchIntegrationStrategy::PullRebase,
+        &mut ws,
+        &mut meta,
+        &repo,
+    )?;
+
+    let remote_commit = repo.rev_parse_single("origin/feature-foo")?.detach();
+    let local_commit = repo.rev_parse_single("feature-foo")?.detach();
+    let labels = [
+        (remote_commit, "remote-commit"),
+        (local_commit, "local-commit"),
+    ];
+
+    insta::assert_snapshot!(
+        labeled_integration_snapshot(&initial.integration, &labels),
+        @"
+    merge-base local-commit
+    pick remote-commit
+    "
+    );
+
+    let rebase = integrate_branch_with_steps(
+        r("refs/heads/feature-foo"),
+        initial.integration,
+        &mut ws,
+        &mut meta,
+        &repo,
+    )?;
+    rebase.materialize()?;
+
+    insta::assert_snapshot!(
+        labeled_graph_snapshot(&repo, &labels)?,
+        @"
+    *   abcd9a1 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\\
+    | * remote-commit (origin/feature-foo, feature-foo) update foo.txt (remote)
+    | * local-commit add foo.txt
+    |/
+    * da7bed3 (origin/main, main, empty-branch) add main.txt
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
 fn initial_pull_rebase_plan_includes_workspace_local_commits_above_branch_ref() -> Result<()> {
     let (_tmp, graph, mut repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph(
@@ -2710,14 +2779,21 @@ fn initial_steps_example_3_keeps_integrated_upstream_commits_editable() -> Resul
 }
 
 fn configure_tracking_for_branch_a(repo: &mut gix::Repository) -> Result<()> {
+    configure_tracking_for_branch(repo, "A")
+}
+
+fn configure_tracking_for_branch(repo: &mut gix::Repository, branch: &str) -> Result<()> {
     let mut cfg = repo.config_snapshot_mut();
     cfg.set_raw_value(
         "remote.origin.fetch",
         gix::bstr::BStr::new(b"+refs/heads/*:refs/remotes/origin/*"),
     )?;
     cfg.set_raw_value("remote.origin.url", gix::bstr::BStr::new(b"."))?;
-    cfg.set_raw_value("branch.A.remote", gix::bstr::BStr::new(b"origin"))?;
-    cfg.set_raw_value("branch.A.merge", gix::bstr::BStr::new(b"refs/heads/A"))?;
+    let remote_key = format!("branch.{branch}.remote");
+    cfg.set_raw_value(&remote_key, gix::bstr::BStr::new(b"origin"))?;
+    let merge_key = format!("branch.{branch}.merge");
+    let merge_value = format!("refs/heads/{branch}");
+    cfg.set_raw_value(&merge_key, gix::bstr::BStr::new(merge_value.as_bytes()))?;
     Ok(())
 }
 

--- a/e2e/playwright/scripts/project-with-diverged-branch-and-parallel-empty-branch.sh
+++ b/e2e/playwright/scripts/project-with-diverged-branch-and-parallel-empty-branch.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+git init -b main local-clone
+pushd local-clone
+echo "line 1" >> main.txt
+git add main.txt
+git commit -m "add main.txt"
+
+REMOTE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/test-remote-XXXXXX")"
+trap 'rm -rf "$REMOTE_DIR"' EXIT
+git init --bare "$REMOTE_DIR"
+git remote add origin "$REMOTE_DIR"
+git push -u origin main
+
+git checkout -b feature-foo
+echo "line 1" >> foo.txt
+git add foo.txt
+git commit -m "add foo.txt"
+git push -u origin feature-foo
+
+git switch --detach origin/feature-foo
+echo "line 2" >> foo.txt
+git add foo.txt
+git commit -m "update foo.txt (remote)"
+git push origin HEAD:feature-foo
+
+git checkout main
+"$BUT" setup
+"$BUT" apply feature-foo
+"$BUT" branch new empty-branch
+popd

--- a/e2e/playwright/tests/branches.spec.ts
+++ b/e2e/playwright/tests/branches.spec.ts
@@ -75,6 +75,21 @@ test("should be able to apply a remote branch and integrate the remote changes -
 	await expect(commitRow(page)).toHaveCount(3);
 });
 
+test("should preview branch integration for a diverged branch with a parallel empty branch", async ({
+	page,
+	gitbutler,
+}) => {
+	await gitbutler.runScript("project-with-diverged-branch-and-parallel-empty-branch.sh");
+	await openWorkspace(page);
+
+	await clickByTestId(page, "sync-button");
+	await clickByTestId(page, "upstream-commits-integrate-button");
+
+	await waitForTestId(page, "branch-integration-modal");
+	await expect(getByTestId(page, "branch-integration-preview-row").first()).toBeVisible();
+	await expect(getByTestId(page, "branch-integration-error")).toHaveCount(0);
+});
+
 test("should be able to apply a remote branch and integrate the remote changes - create commit", async ({
 	page,
 	gitbutler,


### PR DESCRIPTION
Ensuere that we always pick the next available edge when building<br>the editor graph for integration or remote changes into the remote

fixes [GB-1586](https://linear.app/gitbutler/issue/GB-1586/error-when-resolving-branch-divergence-an-edge-with-desired-order-o)