### PR TITLE
API: Add a function to initialize the application namespace

### DIFF
--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -83,6 +83,7 @@ import {
 	workspaceIntegrateUpstream,
 	askpassInit,
 	askpassSubmitPromptResponse,
+	initApplicationNamespace,
 } from "@gitbutler/but-sdk";
 import {
 	app,
@@ -571,6 +572,7 @@ const createMainWindow = async (): Promise<void> => {
 
 app.enableSandbox(); // forces sandboxing for all renderers, even if they try to launch without
 void app.whenReady().then(async () => {
+	await initApplicationNamespace(null);
 	configureAskpass();
 
 	if (app.isPackaged) {

--- a/crates/but-api/src/platform.rs
+++ b/crates/but-api/src/platform.rs
@@ -29,3 +29,15 @@ pub fn build_type() -> Result<String> {
 
     Ok(build_type.to_string())
 }
+
+/// Initialize the secret namespace used by build-kind scoped credentials.
+///
+/// Applications embedding the SDK should call this once during startup before
+/// invoking APIs that read or write forge credentials. If `identifier` is
+/// `None`, the namespace defaults to the SDK's compiled GitButler app channel.
+#[but_api(napi)]
+pub fn init_application_namespace(identifier: Option<String>) -> Result<()> {
+    let identifier = identifier.unwrap_or_else(|| but_path::identifier().to_string());
+    but_secret::secret::set_application_namespace(identifier);
+    Ok(())
+}

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -308,6 +308,15 @@ export declare function getUndoTargetSnapshot(projectId: string): Promise<Snapsh
 
 export declare function headInfo(projectId: string): Promise<RefInfo>
 
+/**
+ * Initialize the secret namespace used by build-kind scoped credentials.
+ *
+ * Applications embedding the SDK should call this once during startup before
+ * invoking APIs that read or write forge credentials. If `identifier` is
+ * `None`, the namespace defaults to the SDK's compiled GitButler app channel.
+ */
+export declare function initApplicationNamespace(identifier: string | null): Promise<void>
+
 /** Get the list of review template paths for the given project. */
 export declare function listAvailableReviewTemplates(projectId: string): Promise<Array<string>>
 

--- a/packages/but-sdk/src/generated/index.js
+++ b/packages/but-sdk/src/generated/index.js
@@ -579,7 +579,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { absorb, absorptionPlan, apply, applyBranchIntegration, assignHunk, branchCheckout, branchCheckoutNew, branchCreate, branchDetails, branchDiff, changesInWorktree, changesInWorktreeWithPerm, commitAmend, commitCreate, commitDetailsWithLineStats, commitDiscard, commitDiscardChanges, commitInsertBlank, commitMove, commitMoveChangesBetween, commitReword, commitSquash, commitUncommit, commitUncommitChanges, discardWorktreeChanges, forgeCompareBranchUrl, forgeInfo, forgeProvider, getInitialBranchIntegration, getRedoTargetSnapshot, getRepoInfo, getReview, getReviewBaseRepoUrl, getReviewMergeStatus, getUndoTargetSnapshot, headInfo, listAvailableReviewTemplates, listBranches, listCiChecks, listEditors, listProjectsStateless, listReviews, listReviewsForBranch, mergeReview, moveBranch, openInEditor, peelRestoreSnapshot, publishReview, pushStack, removeBranch, restoreSnapshotWithKind, reviewTemplate, setReviewAutoMerge, setReviewDraftiness, setReviewTemplate, tearOffBranch, treeChangeDiffs, unapplyStack, updateBranchName, updateReview, updateReviewFooters, warmCiChecksCache, workspaceBranchAndAncestorsPush, workspaceIntegrateUpstream, WatcherHandle, askpassInit, askpassSubmitPromptResponse, watcherStart } = nativeBinding
+const { absorb, absorptionPlan, apply, applyBranchIntegration, assignHunk, branchCheckout, branchCheckoutNew, branchCreate, branchDetails, branchDiff, changesInWorktree, changesInWorktreeWithPerm, commitAmend, commitCreate, commitDetailsWithLineStats, commitDiscard, commitDiscardChanges, commitInsertBlank, commitMove, commitMoveChangesBetween, commitReword, commitSquash, commitUncommit, commitUncommitChanges, discardWorktreeChanges, forgeCompareBranchUrl, forgeInfo, forgeProvider, getInitialBranchIntegration, getRedoTargetSnapshot, getRepoInfo, getReview, getReviewBaseRepoUrl, getReviewMergeStatus, getUndoTargetSnapshot, headInfo, initApplicationNamespace, listAvailableReviewTemplates, listBranches, listCiChecks, listEditors, listProjectsStateless, listReviews, listReviewsForBranch, mergeReview, moveBranch, openInEditor, peelRestoreSnapshot, publishReview, pushStack, removeBranch, restoreSnapshotWithKind, reviewTemplate, setReviewAutoMerge, setReviewDraftiness, setReviewTemplate, tearOffBranch, treeChangeDiffs, unapplyStack, updateBranchName, updateReview, updateReviewFooters, warmCiChecksCache, workspaceBranchAndAncestorsPush, workspaceIntegrateUpstream, WatcherHandle, askpassInit, askpassSubmitPromptResponse, watcherStart } = nativeBinding
 export { absorb }
 export { absorptionPlan }
 export { apply }
@@ -616,6 +616,7 @@ export { getReviewBaseRepoUrl }
 export { getReviewMergeStatus }
 export { getUndoTargetSnapshot }
 export { headInfo }
+export { initApplicationNamespace }
 export { listAvailableReviewTemplates }
 export { listBranches }
 export { listCiChecks }


### PR DESCRIPTION
We need to initialize the application namespace in order to be able to access the right secrets 🤫 

fixes GB-1639