### PR TITLE
Lite: implement new designs for "add new branch" button

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.module.css
@@ -14,6 +14,10 @@
 	text-align: center;
 
 	&:not([data-disabled]):hover {
+		background-color: light-dark(
+			color-mix(in srgb, var(--fill-gray-bg) 5%, var(--bg-2)),
+			color-mix(in srgb, var(--fill-gray-bg) 12%, var(--bg-2))
+		);
 		color: color-mix(in srgb, var(--text-2) 50%, var(--text-1));
 	}
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.module.css
@@ -14,7 +14,7 @@
 	text-align: center;
 
 	&:not([data-disabled]):hover {
-		background-color: var(--bg-3);
+		color: color-mix(in srgb, var(--text-2) 50%, var(--text-1));
 	}
 
 	& > * {

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.module.css
@@ -4,6 +4,32 @@
 	background-color: var(--bg-2);
 }
 
+.addNewBranchButton {
+	display: grid;
+	padding-inline: 12px;
+	padding-block: 10px;
+	border-radius: var(--radius-l);
+	background-color: var(--bg-2);
+	color: var(--text-2);
+	text-align: center;
+
+	&:not([data-disabled]):hover {
+		background-color: var(--bg-3);
+	}
+
+	& > * {
+		grid-area: 1 / 1;
+	}
+
+	[data-icon] {
+		justify-self: right;
+	}
+
+	&[data-disabled] {
+		opacity: 0.5;
+	}
+}
+
 .tree {
 	display: grid;
 	grid-template-rows: auto minmax(0, 1fr);

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
@@ -773,7 +773,7 @@ export const OutlineTree: FC<
 							<div className={styles.stacks}>
 								<Tooltip.Root>
 									<Tooltip.Trigger
-										className={getButtonClassName({})}
+										className={classes("text-13", "text-semibold", styles.addNewBranchButton)}
 										onClick={createIndependentBranch}
 										render={<Button focusableWhenDisabled disabled={!canCreateIndependentBranch} />}
 									>
@@ -782,7 +782,7 @@ export const OutlineTree: FC<
 										) : (
 											<Icon name="plus" />
 										)}
-										Add new branch
+										<span>Add new branch</span>
 									</Tooltip.Trigger>
 									<Tooltip.Portal>
 										<Tooltip.Positioner sideOffset={4}>


### PR DESCRIPTION
I kept the copy as "add new branch" rather than "new branch" because I think it's important we emphasise this will _apply_ a new branch rather than _switch_ to a new branch. On that note, we probably need to continue the discussion on switch vs apply.

As mentioned previously, I feel conflicted about this design because it blurs keyboard selection, i.e. it looks like something that can be selected and it widens the gap between things that can be selected ("Changes" and stacks). But maybe it's okay.