### PR TITLE
Increase drag region size

### DIFF
--- a/apps/lite/ui/src/routes/RootLayout.module.css
+++ b/apps/lite/ui/src/routes/RootLayout.module.css
@@ -7,11 +7,12 @@
 }
 
 .dragRegion {
+	z-index: 0;
 	position: absolute;
 	top: 0;
 	right: 0;
 	left: 0;
-	height: 16px;
+	height: 40px;
 	app-region: drag;
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.module.css
@@ -62,9 +62,12 @@
 
 .workspaceControlsActions {
 	display: flex;
+	z-index: 1;
+	position: relative;
 	align-items: center;
 	margin-inline-start: auto;
 	gap: 4px;
+	app-region: no-drag;
 }
 
 .workspaceName {


### PR DESCRIPTION
Yo! I increased the drag area so it's easier to grab the window. In Electron, you can actually adjust this pretty easily even if there are buttons in the way https://www.electronjs.org/docs/latest/tutorial/custom-window-interactions

The extra thing I added here is a `z-index`. With `static` positioning, it was technically working but visually sitting behind the drag area. I threw that in just to ensure the layering is right.


https://github.com/user-attachments/assets/5d282d8c-3463-439d-a4c4-2f3d07bad07e

