### PR TITLE
fix: moving empty branches

### DIFF
--- a/crates/but-workspace/src/branch/move_branch.rs
+++ b/crates/but-workspace/src/branch/move_branch.rs
@@ -176,7 +176,6 @@ pub(super) mod function {
 
         let successful_rebase = editor.rebase()?;
         let workspace = successful_rebase.overlayed_graph()?.into_workspace()?;
-        let mut editor = successful_rebase.into_editor();
 
         let (source, destination) =
             retrieve_branches_and_containers(&workspace, subject_branch_name, target_branch_name)?;
@@ -205,6 +204,20 @@ pub(super) mod function {
 
         let (source_stack, subject_segment) = source;
         let (_, target_segment) = destination;
+        if subject_segment.commits.is_empty()
+            && target_segment.commits.is_empty()
+            && ws_meta.is_some()
+        {
+            if let Some(ws_meta) = ws_meta.as_mut() {
+                move_branch_in_metadata(ws_meta, subject_branch_name, target_branch_name);
+            }
+            return Ok(Outcome {
+                rebase: successful_rebase,
+                ws_meta,
+            });
+        }
+
+        let mut editor = successful_rebase.into_editor();
         let target_segment_ref_name = target_segment
             .ref_name()
             .context("Target segment doesn't have a ref")?;
@@ -240,23 +253,7 @@ pub(super) mod function {
         // Keep workspace metadata aligned with the graph move outcome for all move cases.
         // We remove the subject branch from its current location and reinsert it above the target.
         if let Some(ws_meta) = ws_meta.as_mut() {
-            ws_meta.remove_segment(subject_branch_name);
-            if ws_meta
-                .insert_new_segment_above_anchor_if_not_present(
-                    subject_branch_name,
-                    target_branch_name,
-                )
-                .is_none()
-            {
-                // If metadata doesn't know the target anchor (stale metadata),
-                // keep the moved branch represented as a stack tip.
-                ws_meta.add_or_insert_new_stack_if_not_present(
-                    subject_branch_name,
-                    None,
-                    but_core::ref_metadata::WorkspaceCommitRelation::Merged,
-                    |_| StackId::generate(),
-                );
-            }
+            move_branch_in_metadata(ws_meta, subject_branch_name, target_branch_name);
         };
 
         Ok(Outcome {
@@ -322,5 +319,26 @@ pub(super) mod function {
             );
         };
         Ok((own_context(source), own_context(destination)))
+    }
+
+    fn move_branch_in_metadata(
+        ws_meta: &mut but_core::ref_metadata::Workspace,
+        subject_branch_name: &FullNameRef,
+        target_branch_name: &FullNameRef,
+    ) {
+        ws_meta.remove_segment(subject_branch_name);
+        if ws_meta
+            .insert_new_segment_above_anchor_if_not_present(subject_branch_name, target_branch_name)
+            .is_none()
+        {
+            // If metadata doesn't know the target anchor (stale metadata),
+            // keep the moved branch represented as a stack tip.
+            ws_meta.add_or_insert_new_stack_if_not_present(
+                subject_branch_name,
+                None,
+                but_core::ref_metadata::WorkspaceCommitRelation::Merged,
+                |_| StackId::generate(),
+            );
+        }
     }
 }

--- a/crates/but-workspace/tests/workspace/branch/move_branch.rs
+++ b/crates/but-workspace/tests/workspace/branch/move_branch.rs
@@ -1,10 +1,12 @@
 use but_core::RefMetadata;
 use but_core::ref_metadata::StackKind;
+use but_graph::init::Options;
 use but_rebase::graph_rebase::Editor;
-use but_testsupport::{graph_workspace, visualize_commit_graph_all};
+use but_testsupport::{graph_workspace, invoke_bash, visualize_commit_graph_all};
 
 use crate::ref_info::with_workspace_commit::utils::{
-    StackState, add_stack_with_segments, named_writable_scenario_with_description_and_graph,
+    StackState, add_stack_with_segments, named_writable_scenario_with_description,
+    named_writable_scenario_with_description_and_graph,
 };
 
 #[test]
@@ -509,6 +511,122 @@ fn move_branch_on_top_of_empty_branch() -> anyhow::Result<()> {
         │   └── ·09d8e52 (🏘️)
         └── 📙:4:B
     ");
+    Ok(())
+}
+
+#[test]
+fn move_empty_branch_on_top_of_empty_branch_in_same_stack() -> anyhow::Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("empty-workspace-target-advanced")?;
+    invoke_bash(
+        "git branch A gitbutler/target\ngit branch B gitbutler/target\n",
+        &repo,
+    );
+    add_stack_with_segments(&mut meta, 1, "B", StackState::InWorkspace, &["A"]);
+
+    let project_meta = meta
+        .workspace(but_core::WORKSPACE_REF_NAME.try_into()?)?
+        .project_meta();
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta,
+        Options {
+            extra_target_commit_id: repo
+                .rev_parse_single("gitbutler/target")
+                .ok()
+                .map(|id| id.detach()),
+            ..Options::limited()
+        },
+    )?;
+
+    let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+    └── ≡📙:4:B on 3183e43 {1}
+        ├── 📙:4:B
+        └── 📙:5:A
+    ");
+
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
+        but_workspace::branch::move_branch(
+            editor,
+            "refs/heads/A".try_into()?,
+            "refs/heads/B".try_into()?,
+        )?;
+
+    rebase.materialize()?;
+    set_workspace_metadata(&mut meta, &ws, ws_meta)?;
+    let project_meta = ws.graph.project_meta.clone();
+    ws.refresh_from_head(&repo, &meta, project_meta)?;
+
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+    └── ≡📙:4:A on 3183e43 {1}
+        ├── 📙:4:A
+        └── 📙:5:B
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn move_empty_branch_on_top_of_empty_branch_across_stacks() -> anyhow::Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("empty-workspace-target-advanced")?;
+    invoke_bash(
+        "git branch A gitbutler/target\ngit branch B gitbutler/target\n",
+        &repo,
+    );
+    add_stack_with_segments(&mut meta, 1, "A", StackState::InWorkspace, &[]);
+    add_stack_with_segments(&mut meta, 2, "B", StackState::InWorkspace, &[]);
+
+    let project_meta = meta
+        .workspace(but_core::WORKSPACE_REF_NAME.try_into()?)?
+        .project_meta();
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta,
+        Options {
+            extra_target_commit_id: repo
+                .rev_parse_single("gitbutler/target")
+                .ok()
+                .map(|id| id.detach()),
+            ..Options::limited()
+        },
+    )?;
+
+    let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+    ├── ≡📙:4:A on 3183e43 {1}
+    │   └── 📙:4:A
+    └── ≡📙:5:B on 3183e43 {2}
+        └── 📙:5:B
+    ");
+
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
+        but_workspace::branch::move_branch(
+            editor,
+            "refs/heads/A".try_into()?,
+            "refs/heads/B".try_into()?,
+        )?;
+
+    rebase.materialize()?;
+    set_workspace_metadata(&mut meta, &ws, ws_meta)?;
+    let project_meta = ws.graph.project_meta.clone();
+    ws.refresh_from_head(&repo, &meta, project_meta)?;
+
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+    └── ≡📙:4:A on 3183e43 {2}
+        ├── 📙:4:A
+        └── 📙:5:B
+    ");
+
     Ok(())
 }
 

--- a/crates/but/tests/but/command/move.rs
+++ b/crates/but/tests/but/command/move.rs
@@ -1,4 +1,8 @@
 use anyhow::Context as _;
+use but_core::{
+    RefMetadata,
+    ref_metadata::{StackId, WorkspaceCommitRelation, WorkspaceStack, WorkspaceStackBranch},
+};
 use snapbox::str;
 
 use crate::{
@@ -844,6 +848,62 @@ Hint: run `but help` for all commands
 }
 
 #[test]
+fn move_empty_branch_on_top_of_empty_branch_by_cli_id() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks")?;
+
+    env.invoke_git("branch A main");
+    env.invoke_git("branch B main");
+    setup_single_stack_metadata(&env, &["B", "A"])?;
+
+    let initial_status = status_json(&env)?;
+    assert_eq!(
+        stack_branch_layout(&initial_status)?,
+        vec![vec!["B".to_string(), "A".to_string()]]
+    );
+
+    let source_branch_id = initial_status["stacks"][0]["branches"][1]["cliId"]
+        .as_str()
+        .context("Missing source branch cliId")?;
+    let target_branch_id = initial_status["stacks"][0]["branches"][0]["cliId"]
+        .as_str()
+        .context("Missing target branch cliId")?;
+
+    env.but(format!("move {source_branch_id} {target_branch_id}"))
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Moved branch A on top of B.
+
+"#]]);
+
+    let status_json = status_json(&env)?;
+    assert_eq!(
+        stack_branch_layout(&status_json)?,
+        vec![vec!["A".to_string(), "B".to_string()]]
+    );
+
+    env.but("st")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A] (no commits)
+┊│
+┊├┄h0 [B] (no commits)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
 fn move_branch_onto_itself_fails_without_deleting_branch() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings(
         "two-stacks-one-single-and-ready-to-mingle-one-double",
@@ -1125,4 +1185,24 @@ fn stack_branch_layout(status_json: &serde_json::Value) -> anyhow::Result<Vec<Ve
                 .collect::<anyhow::Result<Vec<_>>>()
         })
         .collect()
+}
+
+fn setup_single_stack_metadata(env: &Sandbox, branch_names: &[&str]) -> anyhow::Result<()> {
+    let mut meta = env.meta()?;
+    let mut workspace = meta.workspace(but_core::WORKSPACE_REF_NAME.try_into()?)?;
+    workspace.stacks = vec![WorkspaceStack {
+        id: StackId::from_number_for_testing(0),
+        branches: branch_names
+            .iter()
+            .map(|branch_name| {
+                Ok(WorkspaceStackBranch {
+                    ref_name: format!("refs/heads/{branch_name}").try_into()?,
+                    archived: false,
+                })
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?,
+        workspacecommit_relation: WorkspaceCommitRelation::Merged,
+    }];
+    meta.set_workspace(&workspace)?;
+    Ok(())
 }


### PR DESCRIPTION
Moving and reordering empty branches should work as well and now it does

fixes GB-1297