### PR TITLE
tests: make "rub" test less controversial

### DIFF
--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -254,7 +254,7 @@ fn committed_file_to_unassigned() -> anyhow::Result<()> {
 
 "#]]);
 
-    env.but("rub fc:b.txt zz")
+    env.but("rub e8:b.txt zz")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -275,7 +275,7 @@ Uncommitted changes
     {
       "cliId": "pn",
       "filePath": "b.txt",
-      "changeType": "added"
+      "changeType": "modified"
     }
   ],
   "stacks": [
@@ -291,7 +291,7 @@ Uncommitted changes
 ...
               "changes": [
                 {
-                  "cliId": "fd:nk",
+                  "cliId": "ce:nk",
                   "filePath": "a.txt",
                   "changeType": "modified"
                 }
@@ -301,8 +301,13 @@ Uncommitted changes
 ...
               "changes": [
                 {
-                  "cliId": "99:nk",
+                  "cliId": "fc:nk",
                   "filePath": "a.txt",
+                  "changeType": "added"
+                },
+                {
+                  "cliId": "fc:pn",
+                  "filePath": "b.txt",
                   "changeType": "added"
                 }
               ]


### PR DESCRIPTION
The current test creates a conflict and then rebases the workspace commit on top of it. The rebase engine currently does not flag rebasing onto a conflicted commit as automatically being conflicted itself (so the test passes), but we might want to change that in the future. In any case, this test is not about conflicts but about the ability to move file changes around, so change it to be a non-conflicting one.

A discussion of the existing behavior (of how rebasing onto a conflicted commit does not automatically mark the result as conflicted) is here: https://github.com/gitbutlerapp/gitbutler/pull/14262

