### PR TITLE
skill: warn agents off committing to merged-leftover branches; surface but pr

### DIFF
--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -17,6 +17,8 @@ Use GitButler CLI (`but`) as the default version-control interface.
 4. Use CLI IDs from `but diff` / `but status -fv` / `but show`; never hardcode IDs.
 5. Do not run `but status` or `but status -fv` as routine preflight for selected dirty-file or hunk commits. Start with `but diff`; use `but status -fv` when existing branch, stack, commit, conflict, or history state matters.
 6. For "commit these selected changes on a new branch", prefer one command: `but commit <branch> -c -m "<msg>" --changes <ids>`.
+7. **Choose the commit target deliberately.** A branch in `but status -fv` is a stack of changes, not "the current branch you're on." Multiple branches are applied at once and any of them can be a stale leftover — an already-merged PR, a prior-session WIP, work that belongs to a different task. New work goes to a new branch (`but commit <new-name> -c -m "<msg>" --changes <ids>`) unless the user named an existing branch this turn or the work is the next step on a still-open PR for that branch. When in doubt, a new branch is the safe default.
+8. **Never use `gh` / `glab` for PR write operations.** Use `but pr new`, `but pr set-draft`, `but pr set-ready`, `but pr auto-merge`. Read-only inspection with `gh pr view` is fine for state the `but` commands don't surface (e.g. checking whether a branch already has a merged PR before reusing it).
 
 ## Choose Inspection By Task
 
@@ -113,6 +115,27 @@ but move feature/logging zz
 
 **Note:** branch stack/tear-off operations use branch **names** (like `feature/frontend`) or branch CLI IDs, while commit reordering uses commit **IDs** (like `c3`). Do NOT use `but undo` to unstack — it may revert more than intended and lose commits.
 
+### Create a PR (or merge request) for a branch
+
+```bash
+but pr new <branch> --draft -F pr-body.md    # multi-line body from file (recommended for non-trivial PRs)
+but pr new <branch> --draft -m "Title..."    # short inline message
+but pr new <branch> --draft -t               # single-commit branch: use the commit message
+```
+
+`but pr new` pushes the branch as part of the operation; do not run `but push` first. Default to `--draft` and flip with `but pr set-ready` once the review is ready. Other forge subcommands: `but pr set-draft`, `but pr set-ready`, `but pr auto-merge`.
+
+Do not reach for `gh pr create` / `glab mr create` (see Non-Negotiable Rule 8). `gh pr view` is fine for read-only checks the `but` commands don't surface.
+
+### Reusing an existing applied branch
+
+Default answer: don't. A branch appearing in `but status -fv` does not mean it's the right target for the next commit — the workspace is a stack of independent staging areas, and any applied branch can be a merged leftover or someone else's WIP. Reuse only when:
+
+- The user pointed you at that branch by name in this turn, **or**
+- The new work is the documented next step on a still-open PR for that branch.
+
+If you're unsure whether a branch is still active or already integrated upstream, verify the review state before committing (`gh pr view <branch> --json state,mergedAt` read-only) or just open a new branch. The cost of one unused branch is zero; the cost of pushing onto a merged branch is forcing the user to clean it up on the remote.
+
 ### Stacked dependency / commit-lock recovery
 
 A **dependency lock** occurs when a file was originally committed on branch A, but you're trying to commit changes to it on branch B. Symptoms:
@@ -154,6 +177,9 @@ If `but move` causes conflicts (conflicted commits in status):
 | `git rebase -i` | `but move`, `but squash`, `but reword` |
 | `git rebase --onto` | `but move <branch> <new-base>` |
 | `git cherry-pick` | `but pick` |
+| `gh pr create` / `glab mr create` | `but pr new <branch>` |
+| `gh pr ready` / `gh pr edit --draft` | `but pr set-ready` / `but pr set-draft` |
+| `gh pr merge --auto` | `but pr auto-merge` |
 
 ## Notes
 


### PR DESCRIPTION
## Motivation

Two related agent failure modes I keep hitting with the current `SKILL.md`. Both came up while I was using `but` from a Claude-style agent to make changes against my own (non-gitbutler) project; reporting them here because the skill is the artifact that's supposed to prevent them.

### 1. Committing to a merged-leftover branch

I treat `but status -fv` as "what branch am I currently on" — pure git mental model — and commit new, unrelated work onto whatever applied branch happens to be at the top of the workspace. In one case that branch had already had its PR merged upstream; my commit got pushed to the merged remote ref and the user had to clean it up manually.

The current rules say to make a new branch *"when needed"* (rule 5 in the installed v0.20.0 build, rule 6 in current master) — but "when needed" is doing all the heavy lifting. Agents read it generously and treat any in-workspace branch as a valid commit target. There's no rule or recipe explicitly addressing "is this branch still a live target, or is it a stale leftover?"

### 2. Using `gh pr create` instead of `but pr new`

`SKILL.md` never mentions any `but pr` subcommand — they live in `references/reference.md` and `examples.md` — so agents fall back to the `gh pr create` invocation they already know. The Git-to-But Map has no `gh` row to redirect them either.

## What this PR changes

`SKILL.md` only. No `references/` or `examples.md` changes — the material for both is already there, just not surfaced in the main file.

- **Two new non-negotiable rules** (7 + 8):
  - "Choose the commit target deliberately" — explicit framing that a branch's presence in `but status -fv` is not evidence it's the right target. New work goes to a new branch unless the user named an existing one this turn or the new work is the next step on a still-open PR for it.
  - "Never use `gh` / `glab` for PR write operations" — with `gh pr view` carved out as still OK for read-only state (specifically, "did this branch already merge?" checks the `but` commands don't surface).
- **Two new Task Recipes**:
  - "Create a PR (or merge request) for a branch" — surfaces `but pr new <branch> --draft -F …` and the `set-draft` / `set-ready` / `auto-merge` subcommands. Notes that `but pr new` auto-pushes.
  - "Reusing an existing applied branch" — encodes the default-to-new-branch rule with concrete reuse criteria and a `gh pr view --json state,mergedAt` escape hatch for verification.
- **Three new Git-to-But Map rows** for the `gh pr create` / `gh pr ready` / `gh pr merge --auto` mappings.

Resulting `SKILL.md` is 198 lines, still under the 250-line budget noted in `RESEARCH.md`.

## What I deliberately did not change

- I considered claiming the `◐` glyph or `(no changes)` annotation in `but status -fv` is a merged-status signal, but [the source](https://github.com/gitbutlerapp/gitbutler/blob/master/crates/but/src/command/legacy/status/mod.rs#L1320-L1325) shows `◐` is `CommitClassification::Modified` (modified vs. upstream) and `(no changes)` only means "no file changes assigned to this commit." The actual `Integrated` classification renders as `●` in a different theme color — agents reading plain-text capture can't reliably detect it. So the "reusing an applied branch" recipe deliberately doesn't claim a text-detectable merged signal; it relies on mental-model framing plus the `gh pr view` escape hatch.
- No `examples.md` change. The existing PR examples (`but pr new bu`) are already correct; this PR is about surfacing them in the right place in `SKILL.md`.
- No `concepts.md` change. The workspace-model section already covers parallel branches well; my additions are about the "what to do with that model when committing" gap, which belongs in `SKILL.md`.

## Re: `CONTRIBUTING.md` discussion-first norm

I know `CONTRIBUTING.md` asks for discussion before opening PRs against features the maintainers might disagree with. I went straight to a PR because this is a small, additive `SKILL.md` doc change driven by a specific observed failure mode, and I figured the concrete patch was easier to react to than a prose issue. Happy to convert this to an issue and close the PR if that's the preferred path.
