### PR TITLE
Align SVG glyph stroke opacity

### DIFF
--- a/apps/lite/ui/src/components/GraphSegment.tsx
+++ b/apps/lite/ui/src/components/GraphSegment.tsx
@@ -79,7 +79,7 @@ export const GraphSegment: FC<GraphSegmentProps> = ({ glyph, className, status, 
 			) : glyph === "group" ? (
 				groupGlyph
 			) : (
-				<path d={glyphPaths[glyph]} opacity="0.5" stroke="currentColor" strokeWidth="1.5" />
+				<path d={glyphPaths[glyph]} opacity="0.4" stroke="currentColor" strokeWidth="1.5" />
 			)}
 		</svg>
 
@@ -93,7 +93,7 @@ export const GraphSegment: FC<GraphSegmentProps> = ({ glyph, className, status, 
 				aria-hidden="true"
 				focusable="false"
 			>
-				<path d={glyphPaths.parent} opacity="0.5" stroke="currentColor" strokeWidth="1.5" />
+				<path d={glyphPaths.parent} opacity="0.4" stroke="currentColor" strokeWidth="1.5" />
 			</svg>
 		)}
 	</div>


### PR DESCRIPTION
There was a mismatch between a few of the graphs

<img width="866" height="821" alt="image" src="https://github.com/user-attachments/assets/8e3771ed-fcbe-4c5e-8dfd-31a70edf3b0d" />
