### PR TITLE
fix: don't tell agents to use cargo-nextest

### DIFF
--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -105,9 +105,8 @@ vendored, or fixture data unless the task is specifically about that code.
 
 ## Testing and Validation
 
-- Run the narrowest relevant test or check first, for example `cargo nextest run
-  -p <crate> <test-name>` or `cargo check -p <crate> --all-targets`. If
-  `cargo nextest` is unavailable, use targeted `cargo test -p <crate>`.
+- Run the narrowest relevant test or check first, for example `cargo test
+  -p <crate> <test-name>` or `cargo check -p <crate> --all-targets`.
 - Use existing test-support crates and fixtures; prefer read-only fixtures for
   read-only behavior.
 - For graph, rebase, or workspace behavior, prefer fixture-backed before/after

--- a/crates/but/AGENTS.md
+++ b/crates/but/AGENTS.md
@@ -44,7 +44,7 @@ permission-taking helper.
   with `.stdout_eq(snapbox::str![...])` and
   `.stderr_eq(snapbox::str![...])`; use `[..]` or `...` wildcards for unstable
   portions instead of weakening the assertion.
-- Update CLI snapshots with `SNAPSHOTS=overwrite cargo nextest run -p but`,
+- Update CLI snapshots with `SNAPSHOTS=overwrite cargo test -p but`,
   scoped to a test name when possible. For colored terminal output, assert
   against `snapbox::file!["snapshots/<test-name>/<invocation>.stdout.term.svg"]`
   and update with the same command.


### PR DESCRIPTION
I'm having issues with cargo-nextest where tests run way slower. They're both
slower to get started and each individual test is also slower. `cargo clean`
fixes it but I don't wanna loose the cache every few days.

`cargo test` doesn't have those issues for some reason.