### PR TITLE
fix(but-action): use configured model instead of hardcoded gpt-5-mini

### DIFF
--- a/crates/but-action/src/generate.rs
+++ b/crates/but-action/src/generate.rs
@@ -30,8 +30,9 @@ unified diff:
     );
 
     let chat_messages = vec![ChatMessage::User(user_message)];
+    let model = llm.model_or_default();
     let response = llm
-        .structured_output::<StructuredOutput>(&system_message, chat_messages, "gpt-5-mini")?
+        .structured_output::<StructuredOutput>(&system_message, chat_messages, &model)?
         .context("Failed to generate structured content for commit message")?;
 
     Ok(response.commit_message)
@@ -83,12 +84,9 @@ pub fn branch_name(
     );
 
     let chat_messages = vec![ChatMessage::User(user_message)];
+    let model = llm.model_or_default();
     let response = llm
-        .structured_output::<GenerateBranchNameOutput>(
-            &system_message,
-            chat_messages,
-            "gpt-5-mini",
-        )?
+        .structured_output::<GenerateBranchNameOutput>(&system_message, chat_messages, &model)?
         .context("Failed to generate structured content for commit message")?;
 
     Ok(response.branch_name)

--- a/crates/but-llm/src/lib.rs
+++ b/crates/but-llm/src/lib.rs
@@ -238,6 +238,24 @@ impl LLMProvider {
         }
     }
 
+    /// Returns the configured model, or a per-provider default when none is set.
+    ///
+    /// Callers that need a concrete model name (e.g. structured output) must not
+    /// hardcode a provider-specific model, as it would 404 against other providers.
+    /// This returns the configured model when available, otherwise a sensible
+    /// default for the active provider: `claude-haiku-4-5` for Anthropic (so the
+    /// proxied path, which carries no model name, still hits a real model) and
+    /// `gpt-5-mini` for everything else.
+    pub fn model_or_default(&self) -> String {
+        if let Some(model) = self.model() {
+            return model;
+        }
+        match &self.client {
+            LLMClientType::Anthropic(_) => "claude-haiku-4-5".to_string(),
+            _ => "gpt-5-mini".to_string(),
+        }
+    }
+
     /// Creates a default OpenAI LLM provider using environment-based credentials.
     ///
     /// This is a convenience method that attempts to create an OpenAI provider


### PR DESCRIPTION
Fixes #13400.

### Problem

`but-action/src/generate.rs` (`commit_message` / `branch_name`) passed a hardcoded `"gpt-5-mini"` to `structured_output` regardless of the configured provider. For Anthropic / Ollama / other providers `gpt-5-mini` is not a valid model, so the request returns `404` and the raw prompt ends up as the commit title.

### Fix

Add `LLMProvider::model_or_default()` which returns the configured model, or a per-provider default when none is set:

- **Anthropic** → `claude-haiku-4-5` (so the proxied path, which carries no model name, still hits a real model)
- **everything else** → `gpt-5-mini` (unchanged)

`generate.rs` now uses `model_or_default()` for both commit message and branch name generation instead of the hardcoded string.

This is scoped to the `generate.rs` path per the discussion in the issue. The other `default_openai()` / hardcoded-model sites (`legacy/ai.rs`, `branch/show.rs`) can follow separately.

### Before / after

To show the effect, model selection was run against a live OpenAI-compatible provider where `gpt-5-mini` is just as invalid as on Anthropic:

- **Before** — hardcoded `gpt-5-mini`: `404, not found`.
- **After** — the resolved model: a real commit message (e.g. `Add hello world print to main()`).