### PR TITLE
Fix data loss when committing a new directory at a renamed file's old path

### DIFF
--- a/crates/but-core/src/tree/mod.rs
+++ b/crates/but-core/src/tree/mod.rs
@@ -217,7 +217,15 @@ pub fn apply_worktree_changes<'repo>(
         };
         // NOTE: See copy below!
         if let Some(previous_path) = change_request.previous_path.as_ref().map(|p| p.as_bstr()) {
-            base_tree_editor.remove(previous_path)?;
+            // A sibling change in this batch may have turned `previous_path` into a directory
+            // (e.g. `A` renamed to `B` while a new `A/` is committed at the old path). Those
+            // upserts already replaced the old blob, so only remove the source if it's still a leaf.
+            if base_tree_editor
+                .get(previous_path)
+                .is_none_or(|e| !e.mode().is_tree())
+            {
+                base_tree_editor.remove(previous_path)?;
+            }
         }
         if change_request.hunk_headers.is_empty() {
             let rela_path = change_request.path.as_bstr();

--- a/crates/but-core/tests/core/main.rs
+++ b/crates/but-core/tests/core/main.rs
@@ -10,5 +10,6 @@ mod ref_metadata;
 mod settings;
 mod snapshot;
 mod sync;
+mod tree;
 mod unified_diff;
 mod worktree;

--- a/crates/but-core/tests/core/tree.rs
+++ b/crates/but-core/tests/core/tree.rs
@@ -1,0 +1,73 @@
+use but_core::DiffSpec;
+use but_testsupport::writable_scenario;
+use gix::object::tree::EntryKind;
+
+/// Regression test for data loss when a file is renamed and a *new directory* is committed at the
+/// file's old path in the same commit.
+///
+/// Base tree (stand-in for `HEAD`) has a blob `A`. In the worktree, `A` is renamed to `B` and a new
+/// directory `A/` (with files) is created at the old path. Committing all of this once dropped the
+/// directory: changes are processed in path-sorted order (`A/one`, `A/two`, then the rename
+/// `B` <- `A`), and the rename's unconditional source-removal `remove("A")` pruned the
+/// freshly-built `A/` subtree.
+#[test]
+fn rename_with_new_directory_at_old_path_keeps_directory() -> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario("unborn-empty");
+    let work_dir = repo.workdir().expect("non-bare repo").to_owned();
+
+    // Base tree: a single blob at path `A`.
+    let mut base = repo.empty_tree().edit()?;
+    base.upsert("A", EntryKind::Blob, repo.write_blob("a\n")?.detach())?;
+    let base_tree = base.write()?.detach();
+
+    // Worktree: `A` renamed to `B`, plus a brand-new `A/` directory at the old path.
+    std::fs::write(work_dir.join("B"), "a\n")?;
+    std::fs::create_dir(work_dir.join("A"))?;
+    std::fs::write(work_dir.join("A").join("one"), "one\n")?;
+    std::fs::write(work_dir.join("A").join("two"), "two\n")?;
+
+    // The order `but` actually feeds in, sorted by destination path: the rename comes last.
+    let mut changes = vec![
+        Ok(spec(None, "A/one")),
+        Ok(spec(None, "A/two")),
+        Ok(spec(Some("A"), "B")),
+    ];
+
+    let (new_tree, _base) =
+        but_core::tree::apply_worktree_changes(base_tree, &repo, &mut changes, 0)?;
+
+    assert!(
+        changes.iter().all(|c| c.is_ok()),
+        "no change should be rejected: {changes:?}"
+    );
+
+    let tree = new_tree.object()?.into_tree();
+    assert!(
+        tree.lookup_entry_by_path("A/one")?.is_some(),
+        "A/one must survive the commit"
+    );
+    assert!(
+        tree.lookup_entry_by_path("A/two")?.is_some(),
+        "A/two must survive the commit"
+    );
+    assert!(
+        tree.lookup_entry_by_path("B")?.is_some(),
+        "the renamed file B must exist"
+    );
+    let a = tree
+        .lookup_entry_by_path("A")?
+        .expect("`A` must exist as the new directory");
+    assert!(
+        a.mode().is_tree(),
+        "`A` must be a directory, not a leftover blob"
+    );
+    Ok(())
+}
+
+fn spec(previous_path: Option<&str>, path: &str) -> DiffSpec {
+    DiffSpec {
+        previous_path: previous_path.map(Into::into),
+        path: path.into(),
+        hunk_headers: vec![],
+    }
+}


### PR DESCRIPTION
## The problem

Committing can silently delete files when, in a single commit, a tracked file is renamed away from a path and a new directory is created at that same path.

### Reproduction

1. Commit a file `A`.
2. Rename `A` → `B`.
3. Create a new directory `A/` and put one or more files in it.
4. Commit all changes.

The directory `A/` and its contents disappear from the commit. Worse, `but undo` then breaks and cannot recover them — the files survive only in the raw snapshot, not via GitButler.

### Why it happens

When GitButler builds the committed tree, it applies the changes in path-sorted order — for this scenario that's `A/one`, `A/two`, and finally the rename `B` ← `A`. The new directory entries are written first, which turns the old path `A` into a directory in the tree being built. The rename of `A` → `B` then removes the old source path `A`. By that point `A` is no longer the original blob; it is the freshly-built directory, so removing it prunes the entire `A/` subtree and drops its files from the commit.

The bug is specific to a file→directory transition combined with rename detection:

- A plain deletion of `A` (without a rename) does not trigger it.
- It reproduces consistently because the rename's destination (`B`) sorts after the new directory's children (`A/...`), so the directory is built before the source removal runs.

### Impact

- **Silent data loss** — committed directory contents vanish with no error.
- **Broken recovery** — `but undo` fails afterward, so the loss is not recoverable through normal GitButler operations.