### PR TITLE
tree: remove entries before upserting

### DIFF
--- a/crates/but-core/src/tree/mod.rs
+++ b/crates/but-core/src/tree/mod.rs
@@ -201,6 +201,15 @@ pub fn apply_worktree_changes<'repo>(
     let mut current_worktree = Vec::new();
 
     let work_dir = repo.workdir().expect("non-bare repo");
+    for possible_change in changes.iter() {
+        let change_request = match possible_change {
+            Ok(change) => change,
+            Err(_) => continue,
+        };
+        if let Some(previous_path) = change_request.previous_path.as_ref().map(|p| p.as_bstr()) {
+            base_tree_editor.remove(previous_path)?;
+        }
+    }
     'each_change: for possible_change in changes.iter_mut() {
         let change_request = match possible_change {
             Ok(change) => change,
@@ -215,10 +224,6 @@ pub fn apply_worktree_changes<'repo>(
             }
             Err(err) => return Err(err.into()),
         };
-        // NOTE: See copy below!
-        if let Some(previous_path) = change_request.previous_path.as_ref().map(|p| p.as_bstr()) {
-            base_tree_editor.remove(previous_path)?;
-        }
         if change_request.hunk_headers.is_empty() {
             let rela_path = change_request.path.as_bstr();
             match pipeline.worktree_file_to_object(rela_path, &index)? {

--- a/crates/but-core/tests/core/main.rs
+++ b/crates/but-core/tests/core/main.rs
@@ -10,5 +10,6 @@ mod ref_metadata;
 mod settings;
 mod snapshot;
 mod sync;
+mod tree;
 mod unified_diff;
 mod worktree;

--- a/crates/but-core/tests/core/tree.rs
+++ b/crates/but-core/tests/core/tree.rs
@@ -1,0 +1,73 @@
+use but_core::DiffSpec;
+use but_testsupport::writable_scenario;
+use gix::object::tree::EntryKind;
+
+/// Regression test for data loss when a file is renamed and a *new directory* is committed at the
+/// file's old path in the same commit.
+///
+/// Base tree (stand-in for `HEAD`) has a blob `A`. In the worktree, `A` is renamed to `B` and a new
+/// directory `A/` (with files) is created at the old path. Committing all of this once dropped the
+/// directory: changes are processed in path-sorted order (`A/one`, `A/two`, then the rename
+/// `B` <- `A`), and the rename's unconditional source-removal `remove("A")` pruned the
+/// freshly-built `A/` subtree.
+#[test]
+fn rename_with_new_directory_at_old_path_keeps_directory() -> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario("unborn-empty");
+    let work_dir = repo.workdir().expect("non-bare repo").to_owned();
+
+    // Base tree: a single blob at path `A`.
+    let mut base = repo.empty_tree().edit()?;
+    base.upsert("A", EntryKind::Blob, repo.write_blob("a\n")?.detach())?;
+    let base_tree = base.write()?.detach();
+
+    // Worktree: `A` renamed to `B`, plus a brand-new `A/` directory at the old path.
+    std::fs::write(work_dir.join("B"), "a\n")?;
+    std::fs::create_dir(work_dir.join("A"))?;
+    std::fs::write(work_dir.join("A").join("one"), "one\n")?;
+    std::fs::write(work_dir.join("A").join("two"), "two\n")?;
+
+    // The order `but` actually feeds in, sorted by destination path: the rename comes last.
+    let mut changes = vec![
+        Ok(spec(None, "A/one")),
+        Ok(spec(None, "A/two")),
+        Ok(spec(Some("A"), "B")),
+    ];
+
+    let (new_tree, _base) =
+        but_core::tree::apply_worktree_changes(base_tree, &repo, &mut changes, 0)?;
+
+    assert!(
+        changes.iter().all(|c| c.is_ok()),
+        "no change should be rejected: {changes:?}"
+    );
+
+    let tree = new_tree.object()?.into_tree();
+    assert!(
+        tree.lookup_entry_by_path("A/one")?.is_some(),
+        "A/one must survive the commit"
+    );
+    assert!(
+        tree.lookup_entry_by_path("A/two")?.is_some(),
+        "A/two must survive the commit"
+    );
+    assert!(
+        tree.lookup_entry_by_path("B")?.is_some(),
+        "the renamed file B must exist"
+    );
+    let a = tree
+        .lookup_entry_by_path("A")?
+        .expect("`A` must exist as the new directory");
+    assert!(
+        a.mode().is_tree(),
+        "`A` must be a directory, not a leftover blob"
+    );
+    Ok(())
+}
+
+fn spec(previous_path: Option<&str>, path: &str) -> DiffSpec {
+    DiffSpec {
+        previous_path: previous_path.map(Into::into),
+        path: path.into(),
+        hunk_headers: vec![],
+    }
+}


### PR DESCRIPTION
When applying worktree changes, some tree entries need to be deleted, but performing those deletions in the same pass as adding new entries may cause newly added entries to be deleted. This was observed when an entry of the form "A/one" was added, and "A" subsequently deleted (thus deleting the newly added "A/one"). Fix this by making two separate passes - first deletion, then addition.

In order to prevent issues like this from happening in the future, ideally gix would have an API to delete a leaf entry (returning an error if the entry to be deleted was a non-leaf - in the example above, deleting "A" when "A/one" is present would be an error), but looking at its documentation, I don't think such an API exists.

I did not reproduce the comment "NOTE: See copy below!". It was added in 0aa9e0ff46 (allow DiffSpecs with hunks even when untracked., 2025-02-26) with a paired "NOTE: See copy above!", but the latter was removed in e8edb62723 (Support for hunk-selections when committing and amending, 2025-03-30), so the comment no longer seems necessary.
