### PR TITLE
Follow-up to 14312

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4339,7 +4339,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.84.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "gix-actor",
  "gix-attributes",
@@ -4400,7 +4400,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.41.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "gix-date",
@@ -4411,7 +4411,7 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.33.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -4428,7 +4428,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.3.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "gix-error",
 ]
@@ -4436,7 +4436,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.7.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "gix-error",
 ]
@@ -4444,7 +4444,7 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.9.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "gix-path 0.12.1",
@@ -4456,7 +4456,7 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.37.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -4470,7 +4470,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.57.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -4487,7 +4487,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.18.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
@@ -4499,7 +4499,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.38.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4517,7 +4517,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.15.4"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "gix-error",
@@ -4529,7 +4529,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.64.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -4552,7 +4552,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.26.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "gix-discover",
@@ -4571,7 +4571,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.52.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "dunce",
@@ -4585,7 +4585,7 @@ dependencies = [
 [[package]]
 name = "gix-error"
 version = "0.2.4"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
 ]
@@ -4593,7 +4593,7 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.48.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -4613,7 +4613,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -4633,7 +4633,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.21.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4646,7 +4646,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.26.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
@@ -4658,7 +4658,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.25.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -4671,7 +4671,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.15.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "gix-hash",
  "hashbrown 0.17.1",
@@ -4681,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.21.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -4694,16 +4694,16 @@ dependencies = [
 [[package]]
 name = "gix-imara-diff"
 version = "0.2.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
 name = "gix-index"
 version = "0.52.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
@@ -4731,7 +4731,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "23.0.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -4741,7 +4741,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.33.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4753,7 +4753,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4778,7 +4778,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.32.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bitflags 2.11.1",
  "gix-commitgraph",
@@ -4791,7 +4791,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.61.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4810,7 +4810,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.81.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "arc-swap",
  "gix-features",
@@ -4831,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.71.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "clru",
  "gix-chunk",
@@ -4853,7 +4853,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.21.5"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4876,7 +4876,7 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.12.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "gix-trace 0.1.20",
@@ -4887,7 +4887,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.18.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
@@ -4901,7 +4901,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.15.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -4913,7 +4913,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.62.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -4939,7 +4939,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.7.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "gix-error",
@@ -4949,7 +4949,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.64.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -4969,7 +4969,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.42.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "gix-error",
@@ -4984,7 +4984,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.46.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
@@ -5003,7 +5003,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.32.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -5018,7 +5018,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.14.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bitflags 2.11.1",
  "gix-path 0.12.1",
@@ -5030,7 +5030,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.12.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -5043,7 +5043,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "filetime",
@@ -5065,7 +5065,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "gix-config",
@@ -5079,7 +5079,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "23.0.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "dashmap",
  "gix-fs",
@@ -5093,7 +5093,7 @@ dependencies = [
 [[package]]
 name = "gix-testtools"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "crc",
@@ -5121,7 +5121,7 @@ checksum = "6f23569e55f2ffaf958617353b9734a7d52a7c19c439eeaa5e3efc217fd2270e"
 [[package]]
 name = "gix-trace"
 version = "0.1.20"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "tracing",
 ]
@@ -5129,7 +5129,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.57.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -5148,7 +5148,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.58.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bitflags 2.11.1",
  "gix-commitgraph",
@@ -5164,7 +5164,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.36.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "gix-path 0.12.1",
@@ -5176,7 +5176,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "fastrand",
@@ -5196,7 +5196,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.11.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
 ]
@@ -5204,7 +5204,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.53.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -5222,7 +5222,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
  "gix-features",
@@ -5239,7 +5239,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-stream"
 version = "0.33.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=4f089fce944ce8b3a8f3417441ed3c02cabcac26#4f089fce944ce8b3a8f3417441ed3c02cabcac26"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "gix-attributes",
  "gix-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,10 +214,10 @@ bstr = "1.12.1"
 zip = { version = "4", default-features = false, features = ["bzip2"] }
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
 # When adjusting this, update `gix-testtools` as well!
-gix = { version = "0.84.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "4f089fce944ce8b3a8f3417441ed3c02cabcac26", default-features = false, features = [
+gix = { version = "0.84.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "66f70f3063724b4145b21c6691c4f57892c7a74e", default-features = false, features = [
     "sha1", "sha256"
 ] }
-gix-testtools = { version = "0.19.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "4f089fce944ce8b3a8f3417441ed3c02cabcac26" }
+gix-testtools = { version = "0.19.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "66f70f3063724b4145b21c6691c4f57892c7a74e" }
 
 
 insta = { version = "1.47.2", features = ["json"] }
@@ -315,7 +315,7 @@ smallvec = "1.15.1"
 
 [patch.crates-io]
 # Keep workspace crates that use the `gix 0.84` line on the same git revision.
-gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "4f089fce944ce8b3a8f3417441ed3c02cabcac26" }
+gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "66f70f3063724b4145b21c6691c4f57892c7a74e" }
 
 [workspace.lints.clippy]
 # Note that `all` doesn't include everything, so extra lints should be added here.

--- a/crates/but-core/src/tree/mod.rs
+++ b/crates/but-core/src/tree/mod.rs
@@ -207,7 +207,7 @@ pub fn apply_worktree_changes<'repo>(
             Err(_) => continue,
         };
         if let Some(previous_path) = change_request.previous_path.as_ref().map(|p| p.as_bstr()) {
-            base_tree_editor.remove(previous_path)?;
+            base_tree_editor.remove_leaf(previous_path)?;
         }
     }
     'each_change: for possible_change in changes.iter_mut() {
@@ -219,7 +219,7 @@ pub fn apply_worktree_changes<'repo>(
         let md = match gix::index::fs::Metadata::from_path_no_follow(&path) {
             Ok(md) => md,
             Err(err) if gix::fs::io_err::is_not_found(err.kind(), err.raw_os_error()) => {
-                base_tree_editor.remove(change_request.path.as_bstr())?;
+                base_tree_editor.remove_leaf(change_request.path.as_bstr())?;
                 continue;
             }
             Err(err) => return Err(err.into()),


### PR DESCRIPTION
This is a follow-up to #14312 which uses `remove_leaf()` instead of `remove()` for added control.

Doing so would have prevented the bug we were seeing automatically.

Please note that I refrained from putting it into more places, despite having found some, because I'd have to think really hard if `remove_leaf()` is truly correct there 😅.

There is also [a uboot](https://github.com/GitoxideLabs/gitoxide/pull/2604) that greatly improves the performance of `packedrefs` file reading, a contribution that speeds up the AUR package repo by 4 seconds (of a 12s fetch operation). This performance optimisation will be most noticeable when there are 100k+ refs I suppose.
