### PR TITLE
upstream integration: stack squash-merge detection

### DIFF
--- a/apps/desktop/src/lib/upstream/types.test.ts
+++ b/apps/desktop/src/lib/upstream/types.test.ts
@@ -36,9 +36,11 @@ function commit(id: string, hasConflicts = false): Commit {
 function segment({
 	name,
 	commits = [],
+	pushStatus = "unpushedCommits",
 }: {
 	name?: string;
 	commits?: Commit[];
+	pushStatus?: Segment["pushStatus"];
 } = {}): Segment {
 	return {
 		refName: name
@@ -53,7 +55,7 @@ function segment({
 		commitsOutside: null,
 		metadata: null,
 		isEntrypoint: false,
-		pushStatus: "unpushedCommits",
+		pushStatus,
 		base: null,
 	};
 }
@@ -168,6 +170,34 @@ describe("upstream integration types", () => {
 		expect(statuses[0]).toMatchObject({
 			status: "integrated",
 			fullyIntegrated: true,
+		});
+	});
+
+	test("keeps already integrated branch status even when preview still contains conflicts", () => {
+		const statuses = deriveUpstreamIntegrationStatuses(
+			[
+				stack([
+					segment({
+						name: "feature/squashed",
+						commits: [commit("local-tip")],
+						pushStatus: "integrated",
+					}),
+				]),
+			],
+			refInfo([
+				stack([
+					segment({
+						name: "feature/squashed",
+						commits: [commit("preview-conflict", true)],
+					}),
+				]),
+			]),
+		);
+
+		expect(statuses[0]).toMatchObject({
+			status: "integrated",
+			fullyIntegrated: true,
+			branchStatuses: [{ name: "feature/squashed", status: "integrated" }],
 		});
 	});
 });

--- a/apps/desktop/src/lib/upstream/types.ts
+++ b/apps/desktop/src/lib/upstream/types.ts
@@ -100,6 +100,13 @@ function deriveBranchStatus(
 	segment: Segment,
 	previewSegments: Map<string, Segment>,
 ): UpstreamIntegrationBranchStatus {
+	if (segment.pushStatus === "integrated") {
+		return {
+			name: branchDisplayName(segment),
+			status: "integrated",
+		};
+	}
+
 	const key = refNameKey(segment);
 	if (!key) {
 		return {

--- a/crates/but-workspace/src/changeset.rs
+++ b/crates/but-workspace/src/changeset.rs
@@ -339,44 +339,82 @@ pub(crate) struct SimilarityByCommitIds {
     pub(crate) matches_by_workspace_commit: HashMap<gix::ObjectId, gix::ObjectId>,
 }
 
-/// Compute upstream similarity for the provided workspace commits without depending on [`RefInfo`].
+/// Similarity lookup for one upstream-integration operation.
 ///
-/// The returned matches use the same cheap and optional expensive checks as [`RefInfo::compute_similarity`]
-/// for upstream integration: change IDs are skipped, while commit data and changeset IDs are considered.
-pub(crate) fn compute_similarity_by_commit_ids(
-    repo: &gix::Repository,
-    upstream_commit_ids: &[gix::ObjectId],
-    workspace_commit_ids: &[gix::ObjectId],
-    expensive: bool,
-) -> anyhow::Result<SimilarityByCommitIds> {
-    let cost_info = (
-        upstream_commit_ids.len(),
-        repo.index_or_empty()?.entries().len(),
-    );
-    let upstream_lut = create_similarity_lut(
-        repo,
-        upstream_commit_ids
-            .iter()
-            .filter_map(|id| commit_from_id(repo, *id).ok()),
-        cost_info,
-        expensive,
-    )?;
+/// Building the upstream lookup can require changeset computation for incoming
+/// upstream commits, so callers should create this once and reuse it for every
+/// workspace commit and stack-level squash check in the same operation. It is
+/// intentionally not persisted across calls: the lookup is tied to the current
+/// repository state and the current set of incoming upstream commits.
+pub(crate) struct UpstreamSimilarity {
+    upstream_lut: Identity,
+}
 
-    let mut time_used = std::time::Duration::default();
-    let mut matches_by_workspace_commit = HashMap::new();
-    for workspace_commit_id in workspace_commit_ids {
-        let commit = commit_from_id(repo, *workspace_commit_id)?;
-        let expensive = changeset_identifier(repo, expensive.then_some(&commit), &mut time_used)?;
-        if let Some(upstream_commit_id) =
-            lookup_similar(&upstream_lut, &commit, expensive.as_ref(), ChangeId::Skip)
-        {
-            matches_by_workspace_commit.insert(*workspace_commit_id, *upstream_commit_id);
-        }
+impl UpstreamSimilarity {
+    pub(crate) fn new(
+        repo: &gix::Repository,
+        upstream_commit_ids: &[gix::ObjectId],
+        expensive: bool,
+    ) -> anyhow::Result<Self> {
+        let cost_info = (
+            upstream_commit_ids.len(),
+            repo.index_or_empty()?.entries().len(),
+        );
+        let upstream_lut = create_similarity_lut(
+            repo,
+            upstream_commit_ids
+                .iter()
+                .filter_map(|id| commit_from_id(repo, *id).ok()),
+            cost_info,
+            expensive,
+        )?;
+
+        Ok(Self { upstream_lut })
     }
 
-    Ok(SimilarityByCommitIds {
-        matches_by_workspace_commit,
-    })
+    pub(crate) fn compute_similarity_by_commit_ids(
+        &self,
+        repo: &gix::Repository,
+        workspace_commit_ids: &[gix::ObjectId],
+        expensive: bool,
+    ) -> anyhow::Result<SimilarityByCommitIds> {
+        let mut time_used = std::time::Duration::default();
+        let mut matches_by_workspace_commit = HashMap::new();
+        for workspace_commit_id in workspace_commit_ids {
+            let commit = commit_from_id(repo, *workspace_commit_id)?;
+            let expensive =
+                changeset_identifier(repo, expensive.then_some(&commit), &mut time_used)?;
+            if let Some(upstream_commit_id) = lookup_similar(
+                &self.upstream_lut,
+                &commit,
+                expensive.as_ref(),
+                ChangeId::Skip,
+            ) {
+                matches_by_workspace_commit.insert(*workspace_commit_id, *upstream_commit_id);
+            }
+        }
+
+        Ok(SimilarityByCommitIds {
+            matches_by_workspace_commit,
+        })
+    }
+
+    /// Return the upstream commit whose changeset matches the aggregate diff
+    /// from `lhs` to `rhs`.
+    pub(crate) fn matching_changeset(
+        &self,
+        repo: &gix::Repository,
+        lhs: Option<gix::ObjectId>,
+        rhs: gix::ObjectId,
+    ) -> anyhow::Result<Option<gix::ObjectId>> {
+        let Some(changeset_id) = id_for_tree_diff(repo, lhs, rhs)? else {
+            return Ok(None);
+        };
+        Ok(self
+            .upstream_lut
+            .get(&Identifier::ChangesetId(changeset_id))
+            .cloned())
+    }
 }
 
 fn commit_from_id(

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -15,7 +15,7 @@ use but_rebase::{
     },
 };
 
-use crate::changeset::compute_similarity_by_commit_ids;
+use crate::changeset::UpstreamSimilarity;
 use crate::graph_manipulation::traverse_nodes;
 
 /// Whether a bottom most commit should be rebased, or a merge commit should be
@@ -453,27 +453,29 @@ fn collect_stacks<'ws, 'meta, M: RefMetadata>(
     for stack in &output_stacks {
         workspace_selectors.extend(stack.nodes.keys());
     }
-    let integration = compute_similarity_by_commit_ids(
+    // The upstream similarity lookup can require expensive changeset
+    // computation for incoming commits. Build it once for this integration
+    // operation and reuse it for both per-commit matching and stack-level
+    // squash detection below.
+    let upstream_similarity = UpstreamSimilarity::new(editor.repo(), &upstream_commits, true)?;
+    let integration = upstream_similarity.compute_similarity_by_commit_ids(
         editor.repo(),
-        &upstream_commits,
         &commit_ids(editor, workspace_selectors)?,
         true,
     )?;
 
     for stack in &mut output_stacks {
-        let Stack { nodes, bottoms, .. } = stack;
-
-        for node in nodes.keys() {
+        for node in stack.nodes.keys() {
             if editor
                 .direct_parents(*node)?
                 .iter()
-                .all(|(p, _)| !nodes.contains_key(p))
+                .all(|(p, _)| !stack.nodes.contains_key(p))
             {
-                bottoms.insert(*node);
+                stack.bottoms.insert(*node);
             }
         }
 
-        for (node, attrs) in nodes.iter_mut() {
+        for (node, attrs) in stack.nodes.iter_mut() {
             if from_target_ref.contains(node) {
                 attrs.historically_integrated = true;
             }
@@ -483,6 +485,12 @@ fn collect_stacks<'ws, 'meta, M: RefMetadata>(
             if let Step::Pick(Pick { id, .. }) = node
                 && integration.matches_by_workspace_commit.contains_key(&id)
             {
+                attrs.content_integrated = true;
+            }
+        }
+
+        if squashed_stack_upstream_match(editor, stack, &upstream_similarity)?.is_some() {
+            for attrs in stack.nodes.values_mut() {
                 attrs.content_integrated = true;
             }
         }
@@ -556,6 +564,48 @@ fn collect_stacks<'ws, 'meta, M: RefMetadata>(
     }
 
     Ok(output_stacks)
+}
+
+fn squashed_stack_upstream_match<M: RefMetadata>(
+    editor: &Editor<'_, '_, M>,
+    stack: &Stack,
+    upstream_similarity: &UpstreamSimilarity,
+) -> Result<Option<gix::ObjectId>> {
+    // Stack-level squash detection only has an unambiguous range for linear
+    // stacks with one head and one bottom. Multi-branch stacks keep their
+    // existing per-commit integration behavior until branch-level squash
+    // semantics are introduced.
+    if stack.heads.len() != 1 || stack.bottoms.len() != 1 {
+        return Ok(None);
+    }
+    let head = stack.heads.iter().next().copied().context("head exists")?;
+    let bottom = stack
+        .bottoms
+        .iter()
+        .next()
+        .copied()
+        .context("bottom exists")?;
+    let Some(head_id) = selector_commit_id(editor, head)? else {
+        return Ok(None);
+    };
+    let mut base_ids = Vec::new();
+    for (parent, _) in editor.direct_parents(bottom)? {
+        if stack.nodes.contains_key(&parent) {
+            continue;
+        }
+        if let Some(parent_id) = selector_commit_id(editor, parent)? {
+            base_ids.push(parent_id);
+        }
+    }
+    let [base_id] = base_ids.as_slice() else {
+        return Ok(None);
+    };
+
+    // A squash merge upstream turns all stack commits into one upstream commit.
+    // Individual commit matching cannot see that, so compare the aggregate
+    // stack diff, from the stack's external base to its head, against the
+    // precomputed upstream changeset lookup.
+    upstream_similarity.matching_changeset(editor.repo(), Some(*base_id), head_id)
 }
 
 /// Convert a list of selectors into their current commit ids.

--- a/crates/but-workspace/tests/fixtures/scenario/fully-squash-integrated-single-branch-target-advanced.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/fully-squash-integrated-single-branch-target-advanced.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A stack has commits B and A above old target C. The target ref has the same
+# B/A changes in a single squash commit, plus X on top.
+git init
+commit-file C.txt C
+setup_target_to_match_main
+
+git checkout -b A
+commit-file B.txt B
+commit-file A.txt A
+
+git checkout main
+git merge --squash A
+git commit -m "Squash A into base"
+commit-file X.txt X
+git update-ref refs/remotes/origin/main main
+
+git checkout A
+create_workspace_commit_once A

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -1437,6 +1437,50 @@ fn orphan_reparent_content_integrated_stack_to_target_tip() -> Result<()> {
 }
 
 #[test]
+fn orphan_reparent_squash_integrated_stack_to_target_tip() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) = named_writable_scenario_with_description(
+        "fully-squash-integrated-single-branch-target-advanced",
+    )?;
+    let target_sha = repo.rev_parse_single("main~2")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    add_stack(&mut meta, 1, "A", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta(&meta)?,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+    let mut workspace = graph.into_workspace()?;
+
+    integrate_and_materialize(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A^")?.detach()),
+        }],
+    )?;
+
+    assert_eq!(
+        workspace_first_parent(&repo)?,
+        repo.rev_parse_single("origin/main")?.detach(),
+        "orphaned workspace commit should be reparented to the advanced target tip after squash integration"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn content_integrated_stack_does_not_reparent_while_stack_parent_remains() -> Result<()> {
     let (_tmp, repo, mut meta, _description) = named_writable_scenario_with_description(
         "content-integrated-stack-with-remaining-stack-target-advanced",

--- a/e2e/playwright/scripts/squash-upstream-branch-to-base.sh
+++ b/e2e/playwright/scripts/squash-upstream-branch-to-base.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "GIT CONFIG $GIT_CONFIG_GLOBAL"
+echo "DATA DIR $E2E_TEST_APP_DATA_DIR"
+echo "BUT $BUT"
+echo "BRANCH TO SQUASH: $1"
+
+# Squash the upstream branch into master and delete the upstream branch.
+pushd remote-project
+  git checkout master
+  git merge --squash "$1"
+  git commit -m "Squashing upstream branch $1 into base"
+  git branch -D "$1"
+popd

--- a/e2e/playwright/tests/upstreamIntegration.spec.ts
+++ b/e2e/playwright/tests/upstreamIntegration.spec.ts
@@ -55,6 +55,10 @@ function git(pathToRepo: string, args: string[]): string {
 	}).trim();
 }
 
+function integrationSeriesRow(page: Page, branchName: string) {
+	return getByTestId(page, "integrate-upstream-series-row").filter({ hasText: branchName });
+}
+
 test("should handle the update of workspace with one conflicting branch gracefully", async ({
 	page,
 	gitbutler,
@@ -96,6 +100,27 @@ test("should handle the update of workspace with integrated branch gracefully", 
 
 	await gitbutler.runScript("merge-upstream-branch-to-base.sh", ["branch1"]);
 	await syncAndIntegrate(page);
+
+	await waitForTestIdToNotExist(page, "stack");
+});
+
+test("should handle a stack whose branch was squash merged into the target", async ({
+	page,
+	gitbutler,
+}) => {
+	await gitbutler.runScript("project-with-remote-branches.sh");
+	await applyUpstream(gitbutler, "branch1");
+	await openWorkspace(page);
+
+	await expect(stack(page)).toHaveCount(1);
+
+	await gitbutler.runScript("squash-upstream-branch-to-base.sh", ["branch1"]);
+	await clickByTestId(page, "sync-button");
+	await clickByTestId(page, "integrate-upstream-commits-button");
+
+	await expect(integrationSeriesRow(page, "branch1")).toContainText("Integrated");
+
+	await clickByTestId(page, "integrate-upstream-action-button");
 
 	await waitForTestIdToNotExist(page, "stack");
 });
@@ -158,9 +183,7 @@ test("should handle the update of workspace with integrated parent branch in sta
 	await clickByTestId(page, "sync-button");
 	await clickByTestId(page, "integrate-upstream-commits-button");
 
-	const branch1Row = page.locator('[data-integration-row-branch-name="branch1"]').first();
-	const statusBadge = branch1Row.getByTestId("integrate-upstream-series-row-status-badge");
-	await expect(statusBadge).toHaveText("Integrated");
+	await expect(integrationSeriesRow(page, "branch1")).toContainText("Integrated");
 
 	await clickByTestId(page, "integrate-upstream-action-button");
 


### PR DESCRIPTION
Detect the stack-wide integration by squash-merge. Limited to single-branch stacks for now due to complexity reasons.

---    

### Changes

The main change is in `changeset.rs`: `UpstreamSimilarity` now builds the upstream similarity lookup once for a single integration operation, then reuses it for both:

- per-commit content matching
- aggregate stack squash matching

Then `upstream_integration.rs` uses one `UpstreamSimilarity` after collecting incoming upstream commits and passes it into `squashed_stack_upstream_match()`.

### Issues

fixes https://github.com/gitbutlerapp/gitbutler/issues/14298

