### PR TITLE
Add `conflictingStacks` to `ApplyOutcome`

### DIFF
--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -148,7 +148,22 @@ pub mod json {
         pub applied_branches: Vec<crate::json::FullRefName>,
         /// Whether the workspace reference had to be created.
         pub workspace_ref_created: bool,
+        /// Stacks that conflicted while applying the branch.
+        pub conflicting_stacks: Vec<ConflictingStack>,
     }
+
+    /// A stack that conflicted while applying a branch.
+    #[derive(Debug, Serialize)]
+    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+    #[serde(rename_all = "camelCase")]
+    pub struct ConflictingStack {
+        /// The tip branch name of the stack.
+        pub ref_name: crate::json::FullRefName,
+        /// The shortened tip branch name, matching CLI display.
+        pub short_name: String,
+    }
+    #[cfg(feature = "export-schema")]
+    but_schemars::register_sdk_type!(ConflictingStack);
     #[cfg(feature = "export-schema")]
     but_schemars::register_sdk_type!(ApplyOutcome);
 
@@ -160,13 +175,23 @@ pub mod json {
                 applied_branches,
                 workspace_ref_created,
                 workspace_merge: _,
-                conflicting_stacks: _,
+                conflicting_stacks,
             } = value;
 
             ApplyOutcome {
                 workspace_changed,
                 applied_branches: applied_branches.into_iter().map(Into::into).collect(),
                 workspace_ref_created,
+                conflicting_stacks: conflicting_stacks
+                    .into_iter()
+                    .map(|stack| {
+                        let short_name = stack.ref_name.shorten().to_string();
+                        ConflictingStack {
+                            ref_name: stack.ref_name.into(),
+                            short_name,
+                        }
+                    })
+                    .collect(),
             }
         }
     }

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -621,6 +621,8 @@ export type ApplyOutcome = {
   appliedBranches: Array<FullRefName>;
   /** Whether the workspace reference had to be created. */
   workspaceRefCreated: boolean;
+  /** Stacks that conflicted while applying the branch. */
+  conflictingStacks: Array<ConflictingStack>;
 };
 
 /** Represents the author of a commit. */
@@ -1101,6 +1103,14 @@ export type ConflictEntryPresence = {
   ours: boolean;
   theirs: boolean;
   ancestor: boolean;
+};
+
+/** A stack that conflicted while applying a branch. */
+export type ConflictingStack = {
+  /** The tip branch name of the stack. */
+  refName: FullRefName;
+  /** The shortened tip branch name, matching CLI display. */
+  shortName: string;
 };
 
 export type CreateForgeReviewParams = {


### PR DESCRIPTION
So Lite can show an error like the CLI:

```
$ but apply conflict-test-b
Failed to apply branch. 'conflict-test-b' conflicts with existing stack in the workspace: conflict-test-a
```

Related Discord thread: https://discord.com/channels/1060193121130000425/1481308709001891961/1517555311513178253

This was fully written by AI. Feel free to take over the PR or shoot me down. 🙈