### PR TITLE
Lite: don't transform commit button to amend when alt is held

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
@@ -1721,7 +1721,6 @@ const Changes: FC<{
 		worktreeChanges.changes.length > 0 &&
 		headInfo &&
 		resolveRelativeTo({ headInfo, relativeTo: commitTarget.relativeTo }) !== null;
-	const canCommitOrAmend = canAmend || canCommit;
 
 	const [open, setOpen] = useState(false);
 
@@ -1905,7 +1904,7 @@ const Changes: FC<{
 						</Tooltip.Root>
 						<Button
 							focusableWhenDisabled
-							disabled={!canCommitOrAmend}
+							disabled={!(canAmend || canCommit)}
 							aria-label="Commit options"
 							className={getButtonClassName({ iconOnly: true })}
 							onClick={(event) => {

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
@@ -89,7 +89,6 @@ import {
 	useHotkey,
 	UseHotkeyDefinition,
 	useHotkeys,
-	useKeyHold,
 } from "@tanstack/react-hotkeys";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
@@ -1713,9 +1712,6 @@ const Changes: FC<{
 	);
 
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
-	const isAltHeld = useKeyHold("Alt");
-	// TODO: bug: false positive when holding alt e.g. inside commit reword input
-	const isAmendMode = isAltHeld;
 	const isCommitOrAmendPending = commitCreateMutation.isPending || commitAmendMutation.isPending;
 	const canCommitOrAmendBase = isDefaultMode && commitTarget !== null && !isCommitOrAmendPending;
 	const canCommit = canCommitOrAmendBase;
@@ -1725,7 +1721,7 @@ const Changes: FC<{
 		worktreeChanges.changes.length > 0 &&
 		headInfo &&
 		resolveRelativeTo({ headInfo, relativeTo: commitTarget.relativeTo }) !== null;
-	const canCommitOrAmend = isAmendMode ? canAmend : canCommit;
+	const canCommitOrAmend = canAmend || canCommit;
 
 	const [open, setOpen] = useState(false);
 
@@ -1765,11 +1761,6 @@ const Changes: FC<{
 	};
 	const submit: SubmitEventHandler = (event) => {
 		event.preventDefault();
-
-		if (isAmendMode) {
-			amendCommit();
-			return;
-		}
 
 		createCommit();
 	};
@@ -1899,31 +1890,15 @@ const Changes: FC<{
 								className={getButtonClassName({})}
 								// We pass `disabled` here because we want to disable the button, not
 								// the tooltip. Other props should be passed above.
-								render={<Button focusableWhenDisabled type="submit" disabled={!canCommitOrAmend} />}
+								render={<Button focusableWhenDisabled type="submit" disabled={!canCommit} />}
 							>
-								{isAmendMode ? "Amend" : "Commit"}
-								<Kbd
-									hotkey={
-										isAmendMode ? changesHotkeys.amendCommit.hotkey : changesHotkeys.commit.hotkey
-									}
-								/>
+								Commit
+								<Kbd hotkey={changesHotkeys.commit.hotkey} />
 							</Tooltip.Trigger>
 							<Tooltip.Portal>
 								<Tooltip.Positioner sideOffset={4}>
-									<Tooltip.Popup
-										render={
-											<TooltipPopup
-												kbd={
-													isAmendMode
-														? changesHotkeys.amendCommit.hotkey
-														: changesHotkeys.commit.hotkey
-												}
-											/>
-										}
-									>
-										{isAmendMode
-											? changesHotkeys.amendCommit.meta.name
-											: changesHotkeys.commit.meta.name}
+									<Tooltip.Popup render={<TooltipPopup kbd={changesHotkeys.commit.hotkey} />}>
+										{changesHotkeys.commit.meta.name}
 									</Tooltip.Popup>
 								</Tooltip.Positioner>
 							</Tooltip.Portal>


### PR DESCRIPTION
Fixes https://discord.com/channels/1060193121130000425/1481308709001891961/1518029747144102008

Keyboard users still have an amend hotkey and mouse users still have an amend button in the dropdown.

At first I attempted to fix this with https://github.com/gitbutlerapp/gitbutler/pull/14343, but at that point we may as well just stop transforming the button.