### PR TITLE
fix: allow gpg.ssh.program to use tilde

### DIFF
--- a/crates/but-core/src/commit/mod.rs
+++ b/crates/but-core/src/commit/mod.rs
@@ -1,6 +1,4 @@
-use std::{
-    borrow::Cow, collections::HashSet, io::Write, path::Path, path::PathBuf, process::Stdio,
-};
+use std::{collections::HashSet, io::Write, path::Path, path::PathBuf, process::Stdio};
 
 use anyhow::{Context as _, bail};
 use bstr::{BStr, BString, ByteSlice};
@@ -337,13 +335,10 @@ pub fn sign_buffer(repo: &gix::Repository, buffer: &[u8]) -> anyhow::Result<BStr
         signature_storage.write_all(buffer)?;
         let buffer_file_to_sign_path = signature_storage.into_temp_path();
 
-        let gpg_program = config
-            .trusted_program("gpg.ssh.program")
-            .filter(|program| !program.is_empty())
-            .map_or_else(
-                || Path::new("ssh-keygen").into(),
-                |program| Cow::Owned(program.into_owned().into()),
-            );
+        let gpg_program = match config.trusted_path("gpg.ssh.program").transpose()? {
+            Some(program) if !program.as_os_str().is_empty() => program,
+            _ => Path::new("ssh-keygen").into(),
+        };
 
         let mut signing_cmd = prepare_with_shell_on_windows(gpg_program.into_owned())
             .args(["-Y", "sign", "-n", "git", "-f"]);
@@ -393,13 +388,10 @@ pub fn sign_buffer(repo: &gix::Repository, buffer: &[u8]) -> anyhow::Result<BStr
             bail!("Failed to sign SSH: {stdout} {stderr}");
         }
     } else {
-        let gpg_program = config
-            .trusted_program("gpg.program")
-            .filter(|program| !program.is_empty())
-            .map_or_else(
-                || Path::new("gpg").into(),
-                |program| Cow::Owned(program.into_owned().into()),
-            );
+        let gpg_program = match config.trusted_path("gpg.program").transpose()? {
+            Some(program) if !program.as_os_str().is_empty() => program,
+            _ => Path::new("gpg").into(),
+        };
 
         let mut cmd = into_command(
             prepare_with_shell_on_windows(gpg_program.as_ref())


### PR DESCRIPTION
## 🧢 Changes

Updates gpg program to use `trusted_path` rather than `trusted_program` so that gpg signing works with a path containing a tilde.

It would appear to me the underlying functions are quite similar and both do a filter on `filter_config_section` but transparently this is my first time reading gitoxide and it's definitely possible I am overlooking something

1. https://github.com/GitoxideLabs/gitoxide/blob/a507ee0e9b7023598516a1ada1d99e8b622acdde/gix/src/config/snapshot/access.rs#L63-L83
2. https://github.com/GitoxideLabs/gitoxide/blob/main/gix/src/config/cache/access.rs#L260
3. https://github.com/GitoxideLabs/gitoxide/blob/main/gix/src/config/cache/access.rs#L528

## ☕️ Reasoning

I use a script in my dotfiles repo that will act differently depending on my machine. On my Mac it will use 1password. In my virtual machines and servers it will sign without 1password since there is no GUI. These machines do not always use the same username so an absolute path is not always the same. 

**Before**

<img width="845" height="811" alt="image" src="https://github.com/user-attachments/assets/fdcfe288-96e6-437f-bc6f-a3af0cc946d6" />

**After**

<img width="860" height="828" alt="image" src="https://github.com/user-attachments/assets/f2e1814b-6504-40e7-b8bf-24b99f43131a" />