### PR TITLE
Reject reftable repositories when adding projects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4129,6 +4129,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
+ "temp-env",
  "tempfile",
  "tracing",
 ]

--- a/apps/desktop/src/lib/project/project.ts
+++ b/apps/desktop/src/lib/project/project.ts
@@ -62,6 +62,9 @@ export type AddProjectOutcome =
 			type: "noDotGitDirectory";
 	  }
 	| {
+			type: "reftableRefFormatUnsupported";
+	  }
+	| {
 			type: "notAGitRepository";
 			/**
 			 * The error message received
@@ -125,6 +128,12 @@ export function handleAddProjectOutcome(
 				"The specified path does not contain a .git directory.",
 				undefined,
 				TestId.AddProjectNoDotGitDirectoryModal,
+			);
+			return true;
+		case "reftableRefFormatUnsupported":
+			showWarning(
+				"Unsupported reference format",
+				"GitButler does not support repositories using the reftable reference format yet.",
 			);
 			return true;
 		case "notAGitRepository":

--- a/crates/but/src/command/legacy/setup.rs
+++ b/crates/but/src/command/legacy/setup.rs
@@ -255,6 +255,10 @@ pub(crate) fn repo(
             "The repository at {} has no .git directory. GitButler requires a .git directory.",
             repo_path.display()
         )),
+        gitbutler_project::AddProjectOutcome::ReftableRefFormatUnsupported => Err(anyhow::anyhow!(
+            "The repository at {} uses the currently unsupported reftable reference format.",
+            repo_path.display()
+        )),
         gitbutler_project::AddProjectOutcome::NotAGitRepository(_) => Err(anyhow::anyhow!(
             "The path {} is not a git repository.",
             repo_path.display()

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -1197,19 +1197,22 @@ async fn match_subcommand(
         }
         #[cfg(feature = "legacy")]
         Subcommands::Setup { init } => {
-            let repo =
-                match but_api::legacy::projects::add_project_best_effort(args.current_dir.clone())?
-                {
-                    gitbutler_project::AddProjectOutcome::Added(project)
-                    | gitbutler_project::AddProjectOutcome::AlreadyExists(project) => {
-                        gix::open(project.git_dir())?
-                    }
-                    _ => command::legacy::setup::find_or_initialize_repo(
-                        &args.current_dir,
-                        out,
-                        init,
-                    )?,
-                };
+            let repo = match but_api::legacy::projects::add_project_best_effort(
+                args.current_dir.clone(),
+            )? {
+                gitbutler_project::AddProjectOutcome::Added(project)
+                | gitbutler_project::AddProjectOutcome::AlreadyExists(project) => {
+                    gix::open(project.git_dir())?
+                }
+                gitbutler_project::AddProjectOutcome::ReftableRefFormatUnsupported => {
+                    return Err(anyhow::anyhow!(
+                            "The repository at {} uses the currently unsupported reftable reference format.",
+                            args.current_dir.display()
+                        )
+                        .into());
+                }
+                _ => command::legacy::setup::find_or_initialize_repo(&args.current_dir, out, init)?,
+            };
             let mut ctx = but_ctx::Context::from_repo(repo)?;
             let mut guard = ctx.exclusive_worktree_access();
             command::legacy::setup::repo(&mut ctx, &args.current_dir, out, guard.write_permission())

--- a/crates/gitbutler-project/Cargo.toml
+++ b/crates/gitbutler-project/Cargo.toml
@@ -40,6 +40,7 @@ schemars = { workspace = true, optional = true }
 but-testsupport.workspace = true
 tempfile.workspace = true
 insta.workspace = true
+temp-env = "0.3"
 
 [lints]
 workspace = true

--- a/crates/gitbutler-project/src/controller.rs
+++ b/crates/gitbutler-project/src/controller.rs
@@ -17,10 +17,22 @@ struct ResolvedProjectRepo {
     worktree_dir: PathBuf,
 }
 
+/// Validates that a repository can be added as a project and returns its worktree directory.
 #[expect(clippy::result_large_err)]
 fn normalize_project_repo(
     repo: gix::Repository,
 ) -> std::result::Result<ResolvedProjectRepo, AddProjectOutcome> {
+    if repo
+        .config_snapshot()
+        .plumbing()
+        .string_filter("extensions.refStorage", |metadata| {
+            metadata.source == gix::config::Source::Local
+        })
+        .is_some_and(|value| value.as_ref().eq_ignore_ascii_case(b"reftable"))
+    {
+        return Err(AddProjectOutcome::ReftableRefFormatUnsupported);
+    }
+
     if repo.is_bare() {
         return Err(AddProjectOutcome::BareRepository);
     }

--- a/crates/gitbutler-project/src/project.rs
+++ b/crates/gitbutler-project/src/project.rs
@@ -356,6 +356,7 @@ pub enum AddProjectOutcome {
     NonMainWorktree,
     NoWorkdir,
     NoDotGitDirectory,
+    ReftableRefFormatUnsupported,
     NotAGitRepository(String),
 }
 
@@ -390,6 +391,9 @@ impl AddProjectOutcome {
             AddProjectOutcome::NoDotGitDirectory => {
                 Err(anyhow::anyhow!("no .git directory found in repository"))
             }
+            AddProjectOutcome::ReftableRefFormatUnsupported => Err(anyhow::anyhow!(
+                "unsupported repository reference format: reftable"
+            )),
             AddProjectOutcome::NotAGitRepository(msg) => {
                 Err(anyhow::anyhow!("not a git repository: {msg}"))
             }

--- a/crates/gitbutler-project/tests/project/main.rs
+++ b/crates/gitbutler-project/tests/project/main.rs
@@ -323,6 +323,71 @@ mod add {
                 gitbutler_project::add_at_app_data_dir(data_dir.path(), &worktree_dir).unwrap();
             assert!(matches!(outcome, AddProjectOutcome::NonMainWorktree));
         }
+
+        #[test]
+        fn reftable_ref_format_is_rejected() {
+            let data_dir = support::data_dir();
+            let tmp = tempfile::tempdir().unwrap();
+            let repo_dir = tmp.path().join("reftable");
+
+            let init_output = git_at_dir(tmp.path())
+                .args(["init", "--ref-format=reftable"])
+                .arg(&repo_dir)
+                .output()
+                .expect("git can be invoked");
+            if !init_output.status.success() {
+                eprintln!(
+                    "Skipping reftable rejection test because this Git cannot initialize a reftable repository: {}",
+                    String::from_utf8_lossy(&init_output.stderr)
+                );
+                return;
+            }
+
+            let outcome =
+                gitbutler_project::add_at_app_data_dir(data_dir.path(), &repo_dir).unwrap();
+            assert!(matches!(
+                outcome,
+                AddProjectOutcome::ReftableRefFormatUnsupported
+            ));
+        }
+
+        #[test]
+        fn global_reftable_ref_format_does_not_affect_project_add() {
+            let data_dir = support::data_dir();
+            let tmp = tempfile::tempdir().unwrap();
+            let repo_dir = tmp.path().join("repo");
+            let global_config = tmp.path().join("global.gitconfig");
+
+            git_at_dir(tmp.path()).args(["init"]).arg(&repo_dir).run();
+            std::fs::write(&global_config, "[extensions]\n\trefStorage = reftable\n").unwrap();
+
+            let outcome = temp_env::with_var("GIT_CONFIG_GLOBAL", Some(&global_config), || {
+                gitbutler_project::add_at_app_data_dir(data_dir.path(), &repo_dir).unwrap()
+            });
+            assert!(
+                matches!(outcome, AddProjectOutcome::Added(_)),
+                "only the repo's own configuration decides reftables"
+            );
+        }
+
+        #[test]
+        fn worktree_reftable_ref_format_does_not_affect_project_add() {
+            let data_dir = support::data_dir();
+            let tmp = tempfile::tempdir().unwrap();
+            let repo_dir = tmp.path().join("repo");
+
+            git_at_dir(tmp.path()).args(["init"]).arg(&repo_dir).run();
+            git_at_dir(&repo_dir)
+                .args(["config", "extensions.worktreeConfig", "true"])
+                .run();
+            git_at_dir(&repo_dir)
+                .args(["config", "--worktree", "extensions.refStorage", "reftable"])
+                .run();
+
+            let outcome =
+                gitbutler_project::add_at_app_data_dir(data_dir.path(), &repo_dir).unwrap();
+            assert!(matches!(outcome, AddProjectOutcome::Added(_)));
+        }
     }
 }
 

--- a/crates/gitbutler-project/tests/project/main.rs
+++ b/crates/gitbutler-project/tests/project/main.rs
@@ -362,7 +362,8 @@ mod add {
             std::fs::write(&global_config, "[extensions]\n\trefStorage = reftable\n").unwrap();
 
             let outcome = temp_env::with_var("GIT_CONFIG_GLOBAL", Some(&global_config), || {
-                gitbutler_project::add_at_app_data_dir(data_dir.path(), &repo_dir).unwrap()
+                gitbutler_project::add_with_best_effort_at_app_data_dir(data_dir.path(), &repo_dir)
+                    .unwrap()
             });
             assert!(
                 matches!(outcome, AddProjectOutcome::Added(_)),
@@ -386,7 +387,10 @@ mod add {
 
             let outcome =
                 gitbutler_project::add_at_app_data_dir(data_dir.path(), &repo_dir).unwrap();
-            assert!(matches!(outcome, AddProjectOutcome::Added(_)));
+            assert!(
+                matches!(outcome, AddProjectOutcome::Added(_)),
+                "worktree configuration doesn't say that reftables should be used, only the common config"
+            );
         }
     }
 }


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

Plain-text report: When adding a project, also check if the ref-format is reftable, and reject it explicitly based on that. It's acceptable that repositories that were migrated to reftables after adding them as a project will appear to have no refs or fail because HEAD is invalid.

Related issue comment: https://github.com/gitbutlerapp/gitbutler/issues/12741#issuecomment-4765156493

## Summary

- Added an explicit `UnsupportedRefFormat("reftable")` add-project outcome when the repository-local common config declares `extensions.refStorage = reftable`.
- Threaded the new outcome through legacy CLI setup paths and the desktop add-project UI warning.
- Added regression coverage for real reftable repositories, plus global and worktree-specific config false positives.

## Git Baseline

Git 2.50.1 supports `git init --ref-format=reftable`, reports it through `git rev-parse --show-ref-format`, and upstream Git `t/t0001-init.sh` covers `extensions.refStorage` and ref-format initialization behavior.

## Validation

- `cargo test -p gitbutler-project reftable -- --nocapture`
- `cargo test -p gitbutler-project`
- `cargo check -p but --all-targets`
- `cargo fmt`
- `cargo machete`
- `git diff --check`
- `codex review --commit f5c5e224e778dc4ef59a6d62dafcc95db3bc9ac3`

JS formatting/type checks were attempted but unavailable in this worktree because `node_modules` is not installed (`prettier` and `svelte-check` were missing).