### PR TITLE
but-rebase: materialize updates head

### DIFF
--- a/crates/but-rebase/src/graph_rebase/materialize.rs
+++ b/crates/but-rebase/src/graph_rebase/materialize.rs
@@ -7,6 +7,10 @@ use but_core::{
         safe_checkout_from_head,
     },
 };
+use gix::refs::{
+    Target,
+    transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog},
+};
 
 use crate::graph_rebase::{
     Checkout, MaterializeOutcome, Pick, Step, SuccessfulRebase, util::collect_ordered_parents,
@@ -20,6 +24,7 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
             memory.persist(self.repo)?;
         }
 
+        let mut head_reference_update = None;
         for checkout in self.checkouts {
             match checkout {
                 Checkout::Head {
@@ -29,19 +34,20 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
                     let selector = self.history.normalize_selector(selector)?;
                     let step = self.graph[selector.id].clone();
 
-                    let new_head = match step {
+                    let (new_head, new_head_refname) = match step {
                         Step::None => bail!("Checkout selector is pointing to none"),
-                        Step::Pick(Pick { id, .. }) => id,
-                        Step::Reference { .. } => {
+                        Step::Pick(Pick { id, .. }) => (id, None),
+                        Step::Reference { refname } => {
                             let parents = collect_ordered_parents(&self.graph, selector.id);
                             let parent_step_id =
                                 parents.first().context("No first parent to reference")?;
                             let Step::Pick(Pick { id, .. }) = self.graph[*parent_step_id] else {
                                 bail!("collect_ordered_parents should always return a commit pick");
                             };
-                            id
+                            (id, Some(refname))
                         }
                     };
+                    head_reference_update = new_head_refname;
 
                     // If the head has changed (which means it's in the
                     // commit mapping), perform a safe checkout.
@@ -59,7 +65,30 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
             }
         }
 
-        repo.edit_references(self.ref_edits.clone())?;
+        let mut ref_edits = self.ref_edits.clone();
+        if let Some(refname) = head_reference_update
+            && repo.head_name()?.as_ref() != Some(&refname)
+        {
+            let ref_short_name = refname.shorten().to_owned();
+            ref_edits.push(RefEdit {
+                change: Change::Update {
+                    log: LogChange {
+                        mode: RefLog::AndReference,
+                        force_create_reflog: false,
+                        message: gix::reference::log::message(
+                            "safe checkout",
+                            ref_short_name.as_ref(),
+                            0,
+                        ),
+                    },
+                    expected: PreviousValue::Any,
+                    new: Target::Symbolic(refname),
+                },
+                name: "HEAD".try_into().expect("root refs are always valid"),
+                deref: false,
+            });
+        }
+        repo.edit_references(ref_edits)?;
 
         let project_meta = self.workspace.graph.project_meta.clone();
         self.workspace

--- a/crates/but-rebase/tests/rebase/graph_rebase/materialize.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/materialize.rs
@@ -216,6 +216,100 @@ fn both_methods_update_references_identically() -> Result<()> {
 }
 
 #[test]
+fn materialize_repoints_head_when_checkout_reference_is_replaced() -> Result<()> {
+    let (repo, _tmpdir, mut meta) = fixture_writable("four-commits")?;
+    let replacement_ref = gix::refs::FullName::try_from("refs/heads/replacement")?;
+    let head_before = repo.rev_parse_single("HEAD")?.detach();
+
+    let graph =
+        Graph::from_head(&repo, &*meta, project_meta(&*meta), standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let main_selector = editor.select_reference("refs/heads/main".try_into()?)?;
+    editor.replace(
+        main_selector,
+        Step::Reference {
+            refname: replacement_ref.clone(),
+        },
+    )?;
+
+    let outcome = editor.rebase()?;
+    let overlayed = graph_tree(&outcome.overlayed_graph()?).to_string();
+    insta::assert_snapshot!(overlayed, @"
+
+    └── 👉►:0[0]:replacement[🌳]
+        ├── ·120e3a9 (⌂|1)
+        ├── ·a96434e (⌂|1)
+        ├── ·d591dfe (⌂|1)
+        └── 🏁·35b8235 (⌂|1)
+    ");
+    assert_eq!(
+        repo.head_name()?,
+        Some(gix::refs::FullName::try_from("refs/heads/main")?),
+        "overlay preview should not repoint HEAD before materialization"
+    );
+
+    let outcome = outcome.materialize()?;
+    assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
+    assert_eq!(
+        repo.head_name()?,
+        Some(replacement_ref.clone()),
+        "materialize should keep HEAD attached to the replacement checkout reference"
+    );
+    assert_eq!(
+        repo.find_reference(replacement_ref.as_ref())?.id(),
+        head_before,
+        "replacement branch should point at the previous checkout commit"
+    );
+    assert!(
+        repo.try_find_reference("refs/heads/main")?.is_none(),
+        "replaced checkout branch should be deleted"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn materialize_without_checkout_does_not_repoint_head_when_checkout_reference_is_replaced()
+-> Result<()> {
+    let (repo, _tmpdir, mut meta) = fixture_writable("four-commits")?;
+    let replacement_ref = gix::refs::FullName::try_from("refs/heads/replacement")?;
+
+    let graph =
+        Graph::from_head(&repo, &*meta, project_meta(&*meta), standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let main_selector = editor.select_reference("refs/heads/main".try_into()?)?;
+    editor.replace(
+        main_selector,
+        Step::Reference {
+            refname: replacement_ref.clone(),
+        },
+    )?;
+
+    let outcome = editor.rebase()?;
+    outcome.materialize_without_checkout()?;
+
+    assert_eq!(
+        repo.head_name()?,
+        Some(gix::refs::FullName::try_from("refs/heads/main")?),
+        "materialize_without_checkout should leave the symbolic HEAD target untouched"
+    );
+    assert!(
+        repo.try_find_reference(replacement_ref.as_ref())?.is_some(),
+        "reference edits should still create the replacement branch"
+    );
+    assert!(
+        repo.try_find_reference("refs/heads/main")?.is_none(),
+        "reference edits should still delete the replaced branch"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn materialize_keeps_immutable_extra_refs_unchanged_while_updating_local_refs() -> Result<()> {
     let (repo, _tmpdir, mut meta) = fixture_writable("workspace-with-empty-stack")?;
     add_stack_with_segments(&mut meta, 1, "stack-1", StackState::InWorkspace, &[]);


### PR DESCRIPTION
If we update the ref pointed by head through an edit, we should also update head.