### PR TITLE
grit transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,7 +538,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
@@ -2262,6 +2262,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2882,6 +2888,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2899,6 +2911,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
+ "const-oid",
  "crypto-common 0.2.1",
 ]
 
@@ -3845,7 +3858,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "time",
 ]
@@ -4032,6 +4045,7 @@ dependencies = [
  "file-id 0.2.3 (git+https://github.com/notify-rs/notify?rev=978fe719b066a8ce76b9a9d346546b1569eecfb6)",
  "futures",
  "gix",
+ "grit-lib",
  "nix 0.30.1",
  "rand 0.9.4",
  "serde",
@@ -4697,7 +4711,7 @@ version = "0.2.2"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -5331,6 +5345,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "grit-lib"
+version = "0.5.0"
+dependencies = [
+ "base64 0.22.1",
+ "encoding_rs",
+ "filetime",
+ "flate2",
+ "hex",
+ "icu_normalizer",
+ "imara-diff",
+ "libc",
+ "merge3",
+ "nix 0.31.3",
+ "regex",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "shell-words",
+ "similar 3.1.1",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "unicode-width",
+ "ureq",
+ "url",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "gtk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5766,6 +5808,9 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
  "zerovec",
 ]
 
@@ -5874,6 +5919,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "imara-diff"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f01d462f766df78ab820dd06f5eb700233c51f0f4c2e846520eaf4ba6aa5c5c"
+dependencies = [
+ "hashbrown 0.15.5",
+ "memchr",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5953,7 +6008,7 @@ dependencies = [
  "console",
  "once_cell",
  "serde",
- "similar",
+ "similar 2.7.0",
  "tempfile",
 ]
 
@@ -6636,6 +6691,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "merge3"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3e8ff44de522626e1cb360cdc0b29041f3a3d2694dddb90ecfdac59245a2bd"
+dependencies = [
+ "clap",
+ "difflib",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6886,6 +6951,18 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -7949,7 +8026,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha1",
+ "sha1 0.10.6",
  "tokio",
  "tracing",
  "uuid",
@@ -8823,6 +8900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -9365,13 +9443,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha1-checked"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
 dependencies = [
  "digest 0.10.7",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -9508,6 +9597,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "similar"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9546,7 +9644,7 @@ dependencies = [
  "normalize-line-endings",
  "regex",
  "serde_json",
- "similar",
+ "similar 2.7.0",
  "snapbox-macros",
 ]
 
@@ -11127,7 +11225,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
 ]
 
@@ -11279,6 +11377,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11316,10 +11443,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
 name = "utf8-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -11705,6 +11844,15 @@ name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -12476,6 +12624,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12642,7 +12796,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_repr",
- "sha1",
+ "sha1 0.10.6",
  "static_assertions",
  "tracing",
  "uds_windows",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,10 @@ edition = "2024"
 rust-version = "1.95"
 
 [workspace.dependencies]
+# In-process Git transport stack (fetch/push/clone without shelling out to the
+# `git` binary), gated behind the `gitbutler.grit` config flag in `gitbutler-git`.
+# Patched to a local checkout below; see `[patch.crates-io]`.
+grit-lib = { version = "0.5", features = ["http-ureq"] }
 but-debug = { path = "crates/but-debug" }
 but = { path = "crates/but" }
 but-debugging = { path = "crates/but-debugging" }
@@ -316,6 +320,7 @@ smallvec = "1.15.1"
 [patch.crates-io]
 # Keep workspace crates that use the `gix 0.84` line on the same git revision.
 gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "66f70f3063724b4145b21c6691c4f57892c7a74e" }
+grit-lib = { path = "../grit/grit-lib" }
 
 [workspace.lints.clippy]
 # Note that `all` doesn't include everything, so extra lints should be added here.

--- a/crates/gitbutler-git/Cargo.toml
+++ b/crates/gitbutler-git/Cargo.toml
@@ -42,6 +42,7 @@ rand.workspace = true
 futures.workspace = true
 sysinfo = { workspace = true, features = ["system"] }
 gix.workspace = true
+grit-lib.workspace = true
 serde.workspace = true
 
 [target."cfg(unix)".dependencies]

--- a/crates/gitbutler-git/src/error.rs
+++ b/crates/gitbutler-git/src/error.rs
@@ -36,4 +36,9 @@ pub enum Error<BE: std::error::Error + core::fmt::Debug + Send + Sync + 'static>
         "the force push was blocked because the remote branch contains commits that would be overwritten"
     )]
     ForcePushProtection(BE),
+    /// The in-process `grit-lib` transport backend (selected by the
+    /// `gitbutler.grit` config flag) failed. The string carries the
+    /// backend's formatted error chain.
+    #[error("grit transport error: {0}")]
+    Grit(String),
 }

--- a/crates/gitbutler-git/src/grit.rs
+++ b/crates/gitbutler-git/src/grit.rs
@@ -1,0 +1,613 @@
+//! In-process Git transport backed by [`grit-lib`](https://github.com/gitbutlerapp/grit).
+//!
+//! When the `gitbutler.grit` configuration flag is set — or when no `git`
+//! binary is available on the system, in which case this is the fallback —
+//! fetch/push/clone are performed entirely in-process over grit-lib's transport
+//! stack instead of shelling out to the `git` binary. The transport (and the
+//! authentication) is inferred from the remote URL scheme, mirroring grit's own
+//! `gritx-fetch`/`gritx-push` examples:
+//!
+//! * `http(s)://` — smart HTTP; credentials come from the configured
+//!   `credential.helper` programs (filled on a `401` and retried as Basic).
+//! * `ssh://` / `git@host:path` — SSH; auth is the `ssh` child process's job.
+//! * `git://` — anonymous Git daemon; no auth.
+//! * `file://` / local path — a local repository; no auth.
+//!
+//! Unlike the `git`-CLI path, this backend never opens a TTY/askpass prompt: a
+//! missing credential surfaces as a typed error.
+//!
+//! # Limitations
+//!
+//! [`clone`] is a deliberately minimal reimplementation (init + remote config +
+//! fetch + checkout). It does **not** handle submodules, sparse-checkout,
+//! shallow clones, or `.gitattributes` smudge filters/CRLF conversion.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context as _, Result, anyhow, bail};
+use grit_lib::config::ConfigSet;
+use grit_lib::credentials::HelperCredentialProvider;
+use grit_lib::fetch::{NoProgress, fetch_remote};
+use grit_lib::objects::{ObjectId, ObjectKind, parse_tree};
+use grit_lib::odb::Odb;
+use grit_lib::push::{push_http, push_remote};
+use grit_lib::push_report::PushRefStatus;
+use grit_lib::transfer::{
+    self, FetchOptions, FetchOutcome, PushOptions, PushOutcome, PushRefSpec, TagMode,
+};
+use grit_lib::transport::http::http_fetch;
+use grit_lib::transport::http::ureq_client::UreqHttpClient;
+use grit_lib::transport::{
+    ConnectOptions, GitDaemonTransport, Service, SshTransport, Transport as _,
+};
+
+use crate::RefSpec;
+
+/// Whether to use the in-process grit transport for `repo` instead of shelling
+/// out to `git`. True when the `gitbutler.grit` flag is set in the repository
+/// configuration, **or** when no `git` binary is available on this system (in
+/// which case grit is the fallback, since the CLI path cannot run).
+pub fn is_enabled(repo: &gix::Repository) -> bool {
+    config_flag(repo) || !git_binary_available()
+}
+
+/// Like [`is_enabled`], but reads only the global/system Git configuration. Used
+/// by [`clone`], which runs before the target repository exists.
+pub fn is_enabled_global() -> bool {
+    config_flag_global() || !git_binary_available()
+}
+
+/// The `gitbutler.grit` flag from `repo`'s configuration.
+fn config_flag(repo: &gix::Repository) -> bool {
+    repo.config_snapshot()
+        .boolean("gitbutler.grit")
+        .unwrap_or(false)
+}
+
+/// The `gitbutler.grit` flag from global/system Git configuration.
+fn config_flag_global() -> bool {
+    gix::config::File::from_globals()
+        .ok()
+        .and_then(|cfg| cfg.boolean("gitbutler.grit").and_then(Result::ok))
+        .unwrap_or(false)
+}
+
+/// Whether the external `git` binary can be found and run on this system.
+///
+/// Probed once and cached: it shells out to `git --version` (using the same
+/// executable resolution the executor uses) only when needed, i.e. only when the
+/// `gitbutler.grit` flag is not already set.
+fn git_binary_available() -> bool {
+    use std::sync::OnceLock;
+    static AVAILABLE: OnceLock<bool> = OnceLock::new();
+    *AVAILABLE.get_or_init(|| {
+        let git = gix::path::env::exe_invocation();
+        std::process::Command::new(git)
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
+    })
+}
+
+/// How a remote URL is reached, and therefore what authentication it implies.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum RemoteKind {
+    /// `http(s)://` — smart HTTP; auth via configured credential helpers.
+    Http,
+    /// `git://` — anonymous Git daemon; no auth.
+    GitDaemon,
+    /// `ssh://`, `git+ssh://`, or scp-style `host:path`; auth via SSH keys/agent.
+    Ssh,
+    /// `file://` or a local filesystem path; no auth.
+    Local,
+}
+
+impl RemoteKind {
+    fn classify(url: &str) -> Self {
+        if url.starts_with("http://") || url.starts_with("https://") {
+            Self::Http
+        } else if url.starts_with("git://") {
+            Self::GitDaemon
+        } else if grit_lib::transport::is_ssh_url(url) {
+            Self::Ssh
+        } else {
+            Self::Local
+        }
+    }
+}
+
+/// A resolved remote: the URL to use, the transport kind, and the fetch refspecs.
+struct ResolvedRemote {
+    url: String,
+    kind: RemoteKind,
+    fetch_refspecs: Vec<String>,
+}
+
+/// Fetch from `remote` into `repo` using its configured fetch refspecs, over the
+/// transport implied by the remote URL. Writes refs and objects directly into
+/// the local repository (grit-lib drives the negotiation and pack ingest).
+pub fn fetch(repo: &gix::Repository, remote: &str) -> Result<()> {
+    let git_dir = repo.git_dir().to_owned();
+    let resolved = resolve_remote(repo, remote, false)?;
+    let opts = FetchOptions {
+        refspecs: resolved.fetch_refspecs.clone(),
+        ..Default::default()
+    };
+    run_fetch(&git_dir, &resolved, &opts)?;
+    Ok(())
+}
+
+/// Push `refspec` to `remote` from `repo`, over the transport implied by the
+/// remote URL. Returns an empty string on success (the `git`-CLI path returns
+/// the remote's stderr; grit-lib has none to surface).
+pub fn push(
+    repo: &gix::Repository,
+    remote: &str,
+    refspec: &RefSpec,
+    force: bool,
+    force_with_lease: bool,
+) -> Result<String> {
+    let git_dir = repo.git_dir().to_owned();
+    let resolved = resolve_remote(repo, remote, true)?;
+    let pushspec = build_push_refspec(repo, remote, refspec, force, force_with_lease)?;
+    let outcome = run_push(&git_dir, &resolved, &[pushspec], &PushOptions::default())?;
+    summarize_push(&outcome)
+}
+
+/// Minimal in-process clone of `url` into `target_dir`: init a repository,
+/// configure `origin`, fetch, set up the default branch + `HEAD`, and check out
+/// the working tree. See the module-level limitations.
+pub fn clone(url: &str, target_dir: &Path) -> Result<()> {
+    if dir_is_non_empty(target_dir) {
+        bail!(
+            "target directory '{}' already exists and is not an empty directory",
+            target_dir.display()
+        );
+    }
+
+    // 1. Initialise a fresh (non-bare) repository. The initial branch is a
+    //    placeholder; the real default branch is taken from the remote below.
+    let repo = grit_lib::repo::init_repository(target_dir, false, "main", None, "files")
+        .map_err(|e| anyhow!("failed to initialise repository: {e}"))?;
+    let git_dir = repo.git_dir.clone();
+
+    let fetch_refspec = "+refs/heads/*:refs/remotes/origin/*".to_owned();
+    let resolved = ResolvedRemote {
+        url: url.to_owned(),
+        kind: RemoteKind::classify(url),
+        fetch_refspecs: vec![fetch_refspec.clone()],
+    };
+
+    // 2. Configure the `origin` remote so the clone is usable afterwards.
+    append_config_sections(
+        &git_dir,
+        &[(
+            "remote \"origin\"".to_owned(),
+            vec![
+                ("url".to_owned(), url.to_owned()),
+                ("fetch".to_owned(), fetch_refspec),
+            ],
+        )],
+    )?;
+
+    // 3. Fetch all branches into `refs/remotes/origin/*`.
+    let opts = FetchOptions {
+        refspecs: resolved.fetch_refspecs.clone(),
+        tags: TagMode::Following,
+        ..Default::default()
+    };
+    let outcome = run_fetch(&git_dir, &resolved, &opts)?;
+
+    // 4. Pick the default branch (remote `HEAD` symref, else `main`).
+    let branch = outcome.default_branch.clone().unwrap_or_else(|| {
+        // Fall back to the first branch we fetched, else "main".
+        outcome
+            .updates
+            .iter()
+            .find_map(|u| {
+                u.local_ref
+                    .as_deref()
+                    .and_then(|r| r.strip_prefix("refs/remotes/origin/"))
+                    .map(str::to_owned)
+            })
+            .unwrap_or_else(|| "main".to_owned())
+    });
+
+    // 5. Materialise the local branch + HEAD + tracking config.
+    let head_oid = grit_lib::refs::resolve_ref(&git_dir, &format!("refs/remotes/origin/{branch}"))
+        .ok();
+    if let Some(oid) = &head_oid {
+        grit_lib::refs::write_ref(&git_dir, &format!("refs/heads/{branch}"), oid)
+            .map_err(|e| anyhow!("failed to write refs/heads/{branch}: {e}"))?;
+    }
+    grit_lib::refs::write_symbolic_ref(&git_dir, "HEAD", &format!("refs/heads/{branch}"))
+        .map_err(|e| anyhow!("failed to write HEAD: {e}"))?;
+    append_config_sections(
+        &git_dir,
+        &[(
+            format!("branch \"{branch}\""),
+            vec![
+                ("remote".to_owned(), "origin".to_owned()),
+                ("merge".to_owned(), format!("refs/heads/{branch}")),
+            ],
+        )],
+    )?;
+
+    // 6. Check out the working tree (best-effort; no filters/submodules).
+    if let Some(oid) = head_oid {
+        checkout_worktree(&git_dir, target_dir, &oid)?;
+    }
+    Ok(())
+}
+
+// --- transport dispatch -----------------------------------------------------
+
+fn run_fetch(
+    git_dir: &Path,
+    resolved: &ResolvedRemote,
+    opts: &FetchOptions,
+) -> Result<FetchOutcome> {
+    let v2 = ConnectOptions {
+        protocol_version: 2,
+        ..Default::default()
+    };
+    let outcome = match resolved.kind {
+        RemoteKind::Http => {
+            let client = http_client(git_dir, Some("version=2"));
+            http_fetch(&client, git_dir, &resolved.url, opts, &mut NoProgress)?
+        }
+        RemoteKind::GitDaemon => {
+            let mut conn =
+                GitDaemonTransport::new().connect(&resolved.url, Service::UploadPack, &v2)?;
+            fetch_remote(git_dir, &mut *conn, opts, &mut NoProgress)?
+        }
+        RemoteKind::Ssh => {
+            let mut conn = SshTransport::new().connect(&resolved.url, Service::UploadPack, &v2)?;
+            fetch_remote(git_dir, &mut *conn, opts, &mut NoProgress)?
+        }
+        RemoteKind::Local => {
+            transfer::fetch_local(git_dir, &local_git_dir(&resolved.url), opts)?
+        }
+    };
+    Ok(outcome)
+}
+
+fn run_push(
+    git_dir: &Path,
+    resolved: &ResolvedRemote,
+    refs: &[PushRefSpec],
+    opts: &PushOptions,
+) -> Result<PushOutcome> {
+    // Push uses protocol v0/v1 (there is no v2 receive-pack).
+    let v0 = ConnectOptions::default();
+    let outcome = match resolved.kind {
+        RemoteKind::Http => {
+            let client = http_client(git_dir, None);
+            push_http(&client, git_dir, &resolved.url, refs, opts, &mut NoProgress)?
+        }
+        RemoteKind::GitDaemon => {
+            let mut conn =
+                GitDaemonTransport::new().connect(&resolved.url, Service::ReceivePack, &v0)?;
+            push_remote(git_dir, &mut *conn, refs, opts, &mut NoProgress)?
+        }
+        RemoteKind::Ssh => {
+            let mut conn = SshTransport::new().connect(&resolved.url, Service::ReceivePack, &v0)?;
+            push_remote(git_dir, &mut *conn, refs, opts, &mut NoProgress)?
+        }
+        RemoteKind::Local => {
+            transfer::push_local(git_dir, &local_git_dir(&resolved.url), refs, opts)?
+        }
+    };
+    Ok(outcome)
+}
+
+/// Build an HTTP client honoring request-shaping config (`http.proxy`,
+/// cookies, `http.extraHeader`) and wired with a config-driven
+/// [`HelperCredentialProvider`] so `credential.helper` programs satisfy a `401`.
+fn http_client(git_dir: &Path, git_protocol: Option<&str>) -> UreqHttpClient {
+    let client = match ConfigSet::load(Some(git_dir), true) {
+        Ok(config) => {
+            let provider = HelperCredentialProvider::new(config.clone());
+            match UreqHttpClient::from_config(&config) {
+                Ok(c) => c.with_credential_provider(Box::new(provider)),
+                Err(_) => UreqHttpClient::with_credentials(Box::new(provider)),
+            }
+        }
+        Err(_) => UreqHttpClient::new(),
+    };
+    match git_protocol {
+        Some(v) => client.with_git_protocol(v.to_owned()),
+        None => client,
+    }
+}
+
+// --- remote/refspec resolution ----------------------------------------------
+
+fn resolve_remote(repo: &gix::Repository, remote: &str, for_push: bool) -> Result<ResolvedRemote> {
+    let r = repo
+        .find_remote(remote)
+        .with_context(|| format!("remote '{remote}' not found"))?;
+    let direction = if for_push {
+        gix::remote::Direction::Push
+    } else {
+        gix::remote::Direction::Fetch
+    };
+    let url = r
+        .url(direction)
+        .map(ToString::to_string)
+        .filter(|u| !u.trim().is_empty())
+        .ok_or_else(|| anyhow!("remote '{remote}' has no configured URL"))?;
+    let fetch_refspecs = fetch_refspecs_for(&r, remote);
+    let kind = RemoteKind::classify(&url);
+    Ok(ResolvedRemote {
+        url,
+        kind,
+        fetch_refspecs,
+    })
+}
+
+fn fetch_refspecs_for(remote: &gix::Remote<'_>, name: &str) -> Vec<String> {
+    let specs: Vec<String> = remote
+        .refspecs(gix::remote::Direction::Fetch)
+        .iter()
+        .map(|spec| spec.to_ref().to_bstring().to_string())
+        .collect();
+    if specs.is_empty() {
+        vec![format!("+refs/heads/*:refs/remotes/{name}/*")]
+    } else {
+        specs
+    }
+}
+
+fn build_push_refspec(
+    repo: &gix::Repository,
+    remote: &str,
+    refspec: &RefSpec,
+    force: bool,
+    force_with_lease: bool,
+) -> Result<PushRefSpec> {
+    let dst = refspec
+        .destination
+        .clone()
+        .ok_or_else(|| anyhow!("push refspec has no destination"))?;
+    let delete = refspec.source.is_none();
+    let src = match &refspec.source {
+        None => None,
+        Some(s) => Some(resolve_to_oid(repo, s)?),
+    };
+    // Force-with-lease: expect the remote ref to still match our last-known value
+    // (the remote-tracking ref). If we cannot resolve it, fall back to no lease.
+    let expected_old = if force_with_lease && !delete {
+        lease_oid(repo, remote, &dst)
+    } else {
+        None
+    };
+    Ok(PushRefSpec {
+        src,
+        dst,
+        force: force || refspec.update_non_fastforward,
+        delete,
+        expected_old,
+        expect_absent: false,
+    })
+}
+
+/// Resolve a refspec source (an object id or a revision) to a grit [`ObjectId`].
+fn resolve_to_oid(repo: &gix::Repository, spec: &str) -> Result<ObjectId> {
+    if let Ok(oid) = ObjectId::from_hex(spec) {
+        return Ok(oid);
+    }
+    let id = repo
+        .rev_parse_single(spec)
+        .with_context(|| format!("failed to resolve push source '{spec}'"))?;
+    ObjectId::from_bytes(id.as_bytes()).map_err(|e| anyhow!("invalid object id for '{spec}': {e}"))
+}
+
+/// The remote-tracking ref value used as the force-with-lease expectation.
+fn lease_oid(repo: &gix::Repository, remote: &str, dst: &str) -> Option<ObjectId> {
+    let branch = dst.strip_prefix("refs/heads/").unwrap_or(dst);
+    let name = format!("refs/remotes/{remote}/{branch}");
+    let mut reference = repo.try_find_reference(&name).ok().flatten()?;
+    let id = reference.peel_to_id().ok()?.detach();
+    ObjectId::from_bytes(id.as_bytes()).ok()
+}
+
+fn summarize_push(outcome: &PushOutcome) -> Result<String> {
+    let rejected: Vec<String> = outcome
+        .results
+        .iter()
+        .filter(|r| !matches!(r.status, PushRefStatus::Ok))
+        .map(|r| {
+            let reason = r
+                .message
+                .clone()
+                .unwrap_or_else(|| format!("{:?}", r.status));
+            format!("{} ({reason})", r.remote_ref)
+        })
+        .collect();
+    if rejected.is_empty() {
+        Ok(String::new())
+    } else {
+        Err(anyhow!("push rejected: {}", rejected.join(", ")))
+    }
+}
+
+// --- clone helpers ----------------------------------------------------------
+
+fn dir_is_non_empty(path: &Path) -> bool {
+    std::fs::read_dir(path)
+        .map(|mut entries| entries.next().is_some())
+        .unwrap_or(false)
+}
+
+/// Append well-formed config sections to the (freshly created) `<git_dir>/config`.
+/// Each section is `(header, [(key, value)])`, e.g. `("remote \"origin\"", ...)`.
+fn append_config_sections(git_dir: &Path, sections: &[(String, Vec<(String, String)>)]) -> Result<()> {
+    use std::fmt::Write as _;
+    let path = git_dir.join("config");
+    let mut content = std::fs::read_to_string(&path).unwrap_or_default();
+    if !content.is_empty() && !content.ends_with('\n') {
+        content.push('\n');
+    }
+    for (header, entries) in sections {
+        let _ = writeln!(content, "[{header}]");
+        for (key, value) in entries {
+            let _ = writeln!(content, "\t{key} = {value}");
+        }
+    }
+    std::fs::write(&path, content).with_context(|| format!("writing {}", path.display()))?;
+    Ok(())
+}
+
+/// Recursively write the tree of `commit_oid` into `work_tree` and build a basic
+/// index. No smudge filters, CRLF conversion, or submodule handling.
+fn checkout_worktree(git_dir: &Path, work_tree: &Path, commit_oid: &ObjectId) -> Result<()> {
+    let odb = Odb::new(&git_dir.join("objects"));
+
+    let commit = odb
+        .read(commit_oid)
+        .map_err(|e| anyhow!("reading commit {}: {e}", commit_oid.to_hex()))?;
+    if commit.kind != ObjectKind::Commit {
+        bail!("HEAD does not point at a commit");
+    }
+    let commit_data =
+        grit_lib::objects::parse_commit(&commit.data).map_err(|e| anyhow!("parsing commit: {e}"))?;
+
+    let mut entries = Vec::new();
+    write_tree_recursive(&odb, work_tree, &commit_data.tree, "", &mut entries)?;
+
+    let mut index = grit_lib::index::Index::new();
+    index.entries = entries;
+    index.sort();
+    index
+        .write(&git_dir.join("index"))
+        .map_err(|e| anyhow!("writing index: {e}"))?;
+    Ok(())
+}
+
+fn write_tree_recursive(
+    odb: &Odb,
+    work_tree: &Path,
+    tree_oid: &ObjectId,
+    prefix: &str,
+    entries: &mut Vec<grit_lib::index::IndexEntry>,
+) -> Result<()> {
+    let tree = odb
+        .read(tree_oid)
+        .map_err(|e| anyhow!("reading tree {}: {e}", tree_oid.to_hex()))?;
+    if tree.kind != ObjectKind::Tree {
+        bail!("expected a tree object at {}", tree_oid.to_hex());
+    }
+    for entry in parse_tree(&tree.data).map_err(|e| anyhow!("parsing tree: {e}"))? {
+        let name = String::from_utf8_lossy(&entry.name);
+        let rel = if prefix.is_empty() {
+            name.to_string()
+        } else {
+            format!("{prefix}/{name}")
+        };
+        let abs = work_tree.join(&rel);
+
+        match entry.mode {
+            0o040000 => {
+                std::fs::create_dir_all(&abs)
+                    .with_context(|| format!("creating directory {}", abs.display()))?;
+                write_tree_recursive(odb, work_tree, &entry.oid, &rel, entries)?;
+                continue;
+            }
+            // Submodule (gitlink): no submodule support in the minimal clone.
+            0o160000 => continue,
+            _ => {}
+        }
+
+        if let Some(parent) = abs.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating directory {}", parent.display()))?;
+        }
+        let blob = odb
+            .read(&entry.oid)
+            .map_err(|e| anyhow!("reading blob {}: {e}", entry.oid.to_hex()))?;
+
+        if entry.mode == 0o120000 {
+            write_symlink(&abs, &blob.data)?;
+        } else {
+            std::fs::write(&abs, &blob.data)
+                .with_context(|| format!("writing {}", abs.display()))?;
+            #[cfg(unix)]
+            if entry.mode == 0o100755 {
+                use std::os::unix::fs::PermissionsExt as _;
+                let perms = std::fs::Permissions::from_mode(0o755);
+                let _ = std::fs::set_permissions(&abs, perms);
+            }
+        }
+
+        entries.push(index_entry(&abs, rel.as_bytes(), entry.mode, entry.oid));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn write_symlink(path: &Path, target: &[u8]) -> Result<()> {
+    use std::os::unix::ffi::OsStrExt as _;
+    let target = std::ffi::OsStr::from_bytes(target);
+    std::os::unix::fs::symlink(target, path)
+        .with_context(|| format!("creating symlink {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn write_symlink(path: &Path, target: &[u8]) -> Result<()> {
+    // No symlink support: write the link text as a regular file.
+    std::fs::write(path, target).with_context(|| format!("writing {}", path.display()))
+}
+
+/// Build an index entry for a just-written working-tree file, filling the stat
+/// cache from disk so `git status` is clean after the clone.
+fn index_entry(abs: &Path, rel: &[u8], mode: u32, oid: ObjectId) -> grit_lib::index::IndexEntry {
+    let flags = (rel.len().min(0xFFF)) as u16;
+    let mut entry = grit_lib::index::IndexEntry {
+        ctime_sec: 0,
+        ctime_nsec: 0,
+        mtime_sec: 0,
+        mtime_nsec: 0,
+        dev: 0,
+        ino: 0,
+        mode,
+        uid: 0,
+        gid: 0,
+        size: 0,
+        oid,
+        flags,
+        flags_extended: None,
+        path: rel.to_vec(),
+        base_index_pos: 0,
+    };
+    if let Ok(meta) = std::fs::symlink_metadata(abs) {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt as _;
+            entry.ctime_sec = meta.ctime() as u32;
+            entry.ctime_nsec = meta.ctime_nsec() as u32;
+            entry.mtime_sec = meta.mtime() as u32;
+            entry.mtime_nsec = meta.mtime_nsec() as u32;
+            entry.dev = meta.dev() as u32;
+            entry.ino = meta.ino() as u32;
+            entry.uid = meta.uid();
+            entry.gid = meta.gid();
+            entry.size = meta.size() as u32;
+        }
+        #[cfg(not(unix))]
+        {
+            entry.size = meta.len() as u32;
+        }
+    }
+    entry
+}
+
+fn local_git_dir(url: &str) -> PathBuf {
+    let raw = url.strip_prefix("file://").unwrap_or(url);
+    let path = PathBuf::from(raw);
+    let dot_git = path.join(".git");
+    if dot_git.is_dir() { dot_git } else { path }
+}

--- a/crates/gitbutler-git/src/lib.rs
+++ b/crates/gitbutler-git/src/lib.rs
@@ -13,6 +13,8 @@ mod context;
 mod error;
 /// utilities to execute a command
 pub mod executor;
+/// In-process Git transport via `grit-lib`, used when `gitbutler.grit` is set.
+pub mod grit;
 mod refspec;
 mod repository;
 

--- a/crates/gitbutler-git/src/repository.rs
+++ b/crates/gitbutler-git/src/repository.rs
@@ -434,6 +434,14 @@ where
         path: repo_path.to_owned(),
         source,
     })?;
+
+    // When `gitbutler.grit` is set, fetch in-process over grit-lib's transport
+    // stack instead of shelling out to the `git` binary.
+    if crate::grit::is_enabled(&repo) {
+        return crate::grit::fetch(&repo, remote)
+            .map_err(|err| crate::Error::Grit(format!("{err:#}")));
+    }
+
     let refspecs = fetch_refspecs(&repo, remote).map_err(|source| {
         let remote_not_found =
             matches!(source, gix::remote::find::existing::Error::NotFound { .. });
@@ -524,6 +532,26 @@ where
     F: FnMut(String) -> Fut,
     Fut: std::future::Future<Output = Option<String>>,
 {
+    // When `gitbutler.grit` is set, push in-process over grit-lib's transport
+    // stack instead of shelling out to the `git` binary.
+    {
+        let repo_path = repo_path.as_ref();
+        let repo = gix::open(repo_path).map_err(|source| Error::<E>::RepositoryOpen {
+            path: repo_path.to_owned(),
+            source,
+        })?;
+        if crate::grit::is_enabled(&repo) {
+            return crate::grit::push(
+                &repo,
+                remote,
+                &refspec,
+                force,
+                force && force_push_protection,
+            )
+            .map_err(|err| crate::Error::Grit(format!("{err:#}")));
+        }
+    }
+
     let mut args = vec!["push", "--quiet", "--no-verify"];
 
     let refspec = refspec.to_string();
@@ -605,6 +633,13 @@ where
     Fut: std::future::Future<Output = Option<String>>,
 {
     let target_dir = target_dir.as_ref();
+
+    // When `gitbutler.grit` is set (in global/system config, since no repository
+    // exists yet), clone in-process over grit-lib instead of the `git` binary.
+    if crate::grit::is_enabled_global() {
+        return crate::grit::clone(repository_url, target_dir)
+            .map_err(|err| crate::Error::Grit(format!("{err:#}")));
+    }
 
     // For clone, we run from the parent directory of the target
     let work_dir = target_dir.parent().unwrap_or(Path::new("."));

--- a/crates/gitbutler-git/tests/git/grit.rs
+++ b/crates/gitbutler-git/tests/git/grit.rs
@@ -1,0 +1,131 @@
+//! Integration coverage for the in-process `grit-lib` transport backend, using
+//! a `file://` remote so no network or authentication is involved.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// A self-cleaning temporary directory under the system temp dir.
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn new(tag: &str) -> Self {
+        let base = std::env::temp_dir().join(format!(
+            "gitbutler-grit-test-{}-{tag}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).expect("create temp dir");
+        Self(base)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn git(cwd: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .current_dir(cwd)
+        .args(args)
+        .env("GIT_AUTHOR_NAME", "test")
+        .env("GIT_AUTHOR_EMAIL", "test@example.com")
+        .env("GIT_COMMITTER_NAME", "test")
+        .env("GIT_COMMITTER_EMAIL", "test@example.com")
+        .status()
+        .expect("run git");
+    assert!(status.success(), "git {args:?} failed");
+}
+
+/// Create a source repository with a single commit on `main` containing
+/// `hello.txt`, and return its path.
+fn make_source(root: &Path) -> PathBuf {
+    let src = root.join("source");
+    std::fs::create_dir_all(&src).unwrap();
+    git(&src, &["init", "-q", "-b", "main"]);
+    std::fs::write(src.join("hello.txt"), b"hello from grit\n").unwrap();
+    std::fs::create_dir_all(src.join("nested")).unwrap();
+    std::fs::write(src.join("nested/file.txt"), b"nested\n").unwrap();
+    git(&src, &["add", "."]);
+    git(&src, &["commit", "-q", "-m", "initial"]);
+    src
+}
+
+fn file_url(path: &Path) -> String {
+    format!("file://{}", path.display())
+}
+
+// cargo test --package gitbutler-git --test git grit_clone_local
+#[test]
+fn grit_clone_local() {
+    let tmp = TempDir::new("clone");
+    let src = make_source(tmp.path());
+    let dest = tmp.path().join("dest");
+
+    gitbutler_git::grit::clone(&file_url(&src), &dest).expect("grit clone");
+
+    // The working tree was checked out.
+    assert_eq!(
+        std::fs::read_to_string(dest.join("hello.txt")).unwrap(),
+        "hello from grit\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dest.join("nested/file.txt")).unwrap(),
+        "nested\n"
+    );
+
+    // HEAD points at the remote's default branch and an index was written.
+    let head = std::fs::read_to_string(dest.join(".git/HEAD")).unwrap();
+    assert_eq!(head.trim(), "ref: refs/heads/main");
+    assert!(dest.join(".git/index").exists(), "index was written");
+
+    // The clone is a valid repository with a clean status (via real git).
+    let status = Command::new("git")
+        .current_dir(&dest)
+        .args(["status", "--porcelain"])
+        .output()
+        .expect("git status");
+    assert!(status.status.success());
+    assert!(
+        status.stdout.is_empty(),
+        "expected clean status, got: {}",
+        String::from_utf8_lossy(&status.stdout)
+    );
+}
+
+// cargo test --package gitbutler-git --test git grit_fetch_local
+#[test]
+fn grit_fetch_local() {
+    let tmp = TempDir::new("fetch");
+    let src = make_source(tmp.path());
+
+    // A destination repo with `origin` pointing at the source via file://.
+    let dest = tmp.path().join("dest");
+    std::fs::create_dir_all(&dest).unwrap();
+    git(&dest, &["init", "-q", "-b", "main"]);
+    git(&dest, &["remote", "add", "origin", &file_url(&src)]);
+
+    let repo = gix::open(&dest).expect("open dest");
+    gitbutler_git::grit::fetch(&repo, "origin").expect("grit fetch");
+
+    // The remote-tracking ref now exists and matches the source's `main`.
+    let src_main = Command::new("git")
+        .current_dir(&src)
+        .args(["rev-parse", "main"])
+        .output()
+        .unwrap();
+    let src_oid = String::from_utf8_lossy(&src_main.stdout).trim().to_owned();
+
+    let tracked = Command::new("git")
+        .current_dir(&dest)
+        .args(["rev-parse", "refs/remotes/origin/main"])
+        .output()
+        .unwrap();
+    assert!(tracked.status.success(), "tracking ref should exist");
+    assert_eq!(String::from_utf8_lossy(&tracked.stdout).trim(), src_oid);
+}

--- a/crates/gitbutler-git/tests/git/main.rs
+++ b/crates/gitbutler-git/tests/git/main.rs
@@ -1,3 +1,4 @@
+mod grit;
 mod refspec;
 
 #[cfg(test)]


### PR DESCRIPTION
This adds a `gitbutler.grit` config setting that uses the Grit transport library for push/fetch operations instead of fork/exec'ing out to Git.

While slower and Claude'd, it seems to work. Using it as a fallback option if `git` is not present may not be the _wurst_ approach.

```
❯ time GRIT_NET_DEBUG=1 butd fetch                                                              took 12s
Assuming you meant to check for upstream work, running `but pull --check`
Fetching from upstream remotes...
[grit-net] ssh connect git@github.com:gitbutlerapp/gitbutler.git (service=git-upload-pack, request protocol v2)
[grit-net] ssh connected: protocol v0, 14483 ref(s) advertised
[grit-net] fetch_remote: begin — protocol v0, 1 refspec(s), tags=Following, depth=None
[grit-net] fetch_remote: remote advertised 14483 ref(s) (v0/v1 advertisement)
[grit-net] fetch_remote: 2879 matched ref(s), want 0 object(s) [+56.764917ms since begin]
[grit-net] fetch_remote: retain_following_tags 304.36475ms
[grit-net] fetch_remote: apply 113.8285ms — repo_open 74.292µs, prune 42ns, packed_load 14.390667ms, resolve 66.587611ms, classify 32.396972ms (19 ancestry-checked), write 0ns (0 written)
[grit-net] fetch_remote: done — 2865 ref update(s), default branch 'master' [+474.99775ms total]
Checking integration statuses...
Checking base branch status...

Base branch:    origin/master
Upstream:       13 new commits on origin/master

  280a3b9fc4 Merge pull request #14351 from tobeycodes/fix/allow-gpg-ssh-program-to-u
  8ffb540ccf Merge pull request #14354 from gitbutlerapp/uncommit-diff-output  Add di
  73b850ed65 Merge pull request #14348 from tobeycodes/patch-1  fix: typo in readme.m
  ... (10 more)

Run `but pull` to update your branches
GRIT_NET_DEBUG=1 butd fetch  2.67s user 0.27s system 63% cpu 4.629 total
```