### PR TITLE
fix(but): reconcile hunks for `commit2`

### DIFF
--- a/crates/but/src/command/legacy/commit2.rs
+++ b/crates/but/src/command/legacy/commit2.rs
@@ -260,6 +260,8 @@ fn run(
                 for change in *changes {
                     builder.push_changes_from_uncommitted(&change)?;
                 }
+
+                builder.reconcile_worktree_diff_specs()?;
             }
             CommitSelection::Nothing => {}
         }

--- a/crates/but/src/utils/diff_specs.rs
+++ b/crates/but/src/utils/diff_specs.rs
@@ -194,6 +194,88 @@ impl<'a> DiffSpecBuilder<'a> {
         but_workspace::flatten_diff_specs(self.diff_specs)
     }
 
+    /// Reconciles the builder's [`DiffSpec`]s by sorting, coalescing and deduplicating all of the
+    /// specs based on worktree changes. This only works reliably if the [`DiffSpec`]s are sourced
+    /// from the worktree changes. The end result is that there is at most one [`DiffSpec`] per file
+    /// and no duplicated hunks.
+    ///
+    /// WARNING: Does not support overlapping hunks - results may get very strange if such hunks are
+    /// in the specs. The implementation naively assumes that hunk equality checks are sufficient
+    /// for reconciling changes, whereas with overlapping hunks that is not the case.
+    #[cfg(feature = "but-2")]
+    pub fn reconcile_worktree_diff_specs(&mut self) -> anyhow::Result<()> {
+        use std::collections::HashMap;
+
+        // This looks a bit odd, but we need to populate the worktree_changes cache without holding
+        // onto the mut self reference. Otherwise we cant sort the diff_specs later.
+        self.worktree_changes()?;
+        let worktree_changes = self
+            .worktree_changes
+            .as_deref()
+            .expect("BUG: worktree_changes cache should be populated!");
+
+        #[derive(Hash, Eq, PartialEq)]
+        struct DiffSpecKey<'a> {
+            path: &'a BStr,
+            previous_path: Option<&'a BStr>,
+        }
+
+        let mut diff_spec_order: HashMap<DiffSpecKey<'_>, usize> = HashMap::new();
+        for (i, change) in worktree_changes.iter().enumerate() {
+            use but_core::ui::TreeStatus;
+
+            let previous_path = match &change.status {
+                TreeStatus::Rename {
+                    previous_path_bytes,
+                    ..
+                } => Some(previous_path_bytes.as_bstr()),
+                _ => None,
+            };
+
+            diff_spec_order.insert(
+                DiffSpecKey {
+                    path: change.path_bytes.as_bstr(),
+                    previous_path,
+                },
+                i,
+            );
+        }
+
+        self.diff_specs.sort_by_key(|item| {
+            let key = DiffSpecKey {
+                path: item.path.as_bstr(),
+                previous_path: item.previous_path.as_ref().map(|p| p.as_bstr()),
+            };
+            *diff_spec_order
+                .get(&key)
+                .expect("BUG: diff_spec_order did not contain all DiffSpecs")
+        });
+
+        let mut reconciled_changes: Vec<DiffSpec> = vec![];
+        for change in self.diff_specs.iter() {
+            match reconciled_changes.last_mut() {
+                Some(last) if last.path == change.path => {
+                    for hunk in change.hunk_headers.iter() {
+                        match last.hunk_headers.binary_search(hunk) {
+                            Ok(_) => (),
+                            Err(i) => last.hunk_headers.insert(i, *hunk),
+                        }
+                    }
+                }
+                Some(_) | None => {
+                    let mut change = change.clone();
+                    change.hunk_headers.sort();
+                    change.hunk_headers.dedup();
+                    reconciled_changes.push(change)
+                }
+            }
+        }
+
+        self.diff_specs = reconciled_changes;
+
+        Ok(())
+    }
+
     fn worktree_changes(&mut self) -> anyhow::Result<&[but_core::ui::TreeChange]> {
         if self.worktree_changes.is_none() {
             self.worktree_changes = Some(but_core::diff::ui::worktree_changes(self.repo)?.changes);

--- a/crates/but/tests/but/command/commit2.rs
+++ b/crates/but/tests/but/command/commit2.rs
@@ -255,8 +255,7 @@ fn editor_fails() {
         .env("GIT_EDITOR", editor_command)
         .assert()
         .failure()
-        .stdout_eq(snapbox::str![[r#"
-"#]])
+        .stdout_eq(snapbox::str![""])
         .stderr_eq(snapbox::str![[r#"
 Error: Editor exited with non-zero status
 
@@ -1090,6 +1089,172 @@ Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage 
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
 Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+
+"#]]);
+}
+
+#[test]
+fn hunks_within_file_are_not_order_dependent() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    let original_data = "enough\nlines\nto\ncreate\nmultiple\nhunks\nwhen\nediting";
+
+    env.file("file", original_data);
+
+    env.but("commit2 --no-message").assert().success();
+
+    env.file("file", format!("first hunk\n{original_data}\nlast hunk"));
+
+    env.but("diff")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+───────╮
+i0 file│
+───────╯
+     1│+first hunk
+   1 2│ enough
+   2 3│ lines
+   3 4│ to
+───────╮
+j0 file│
+───────╯
+    6  7│ hunks
+    7  8│ when
+    8  9│ editing
+      10│+last hunk
+
+"#]]);
+
+    env.but("commit2 --no-message i0 j0").assert().success();
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   f0a3edc (no commit message)
+┊│     f0:qs M file
+┊●   21b345e (no commit message)
+┊│     21:qs A file
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("undo").assert().success();
+
+    env.but("commit2 --no-message j0 i0").assert().success();
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   f0a3edc (no commit message)
+┊│     f0:qs M file
+┊●   21b345e (no commit message)
+┊│     21:qs A file
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn overlapping_changes_to_modified_file_are_deduplicated() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    let original_data = "enough\nlines\nto\ncreate\nmultiple\nhunks\nwhen\nediting";
+
+    env.file("file", original_data);
+
+    env.but("commit2 --no-message").assert().success();
+
+    env.file("file", format!("first hunk\n{original_data}\nlast hunk"));
+
+    env.but("diff")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+───────╮
+i0 file│
+───────╯
+     1│+first hunk
+   1 2│ enough
+   2 3│ lines
+   3 4│ to
+───────╮
+j0 file│
+───────╯
+    6  7│ hunks
+    7  8│ when
+    8  9│ editing
+      10│+last hunk
+
+"#]]);
+
+    env.but("commit2 --no-message i0 j0 i0").assert().success();
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   f0a3edc (no commit message)
+┊│     f0:qs M file
+┊●   21b345e (no commit message)
+┊│     21:qs A file
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("undo").assert().success();
+
+    env.but("commit2 --no-message file j0").assert().success();
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   f0a3edc (no commit message)
+┊│     f0:qs M file
+┊●   21b345e (no commit message)
+┊│     21:qs A file
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
 
 "#]]);
 }


### PR DESCRIPTION
The user shouldn't have to care about the order in which they pass CLI IDs, or if they accidentally duplicate them. So we reconcile hunks by coalescing into one `DiffSpec` per path, and deduplicating hunks.

Sorting is performed using the same order as `worktree_changes()`.

Note that this does not necessarily work if there are overlapping hunks. For that situation we need to actually coalesce the hunks themselves and I'm not entirely sure how to go about that. As the CLI currently can only specify entire hunks, it's a problem for later.