### PR TITLE
fix(desktop): preserve commit reword drafts across navigation

### DIFF
--- a/apps/desktop/src/components/commit/CommitView.svelte
+++ b/apps/desktop/src/components/commit/CommitView.svelte
@@ -6,6 +6,7 @@
 	import { isLocalAndRemoteCommit } from "$components/lib";
 	import Drawer from "$components/shared/Drawer.svelte";
 	import { splitMessage } from "$lib/commits/commitMessage";
+	import { applyEditDraftUpdate, resolveEditDraft } from "$lib/commits/editCommitDraft";
 	import { rewrapCommitMessage } from "$lib/config/uiFeatureFlags";
 	import { commitUrl, FORGE_INFO_SERVICE } from "$lib/forge/forgeInfo.svelte";
 	import { MODE_SERVICE } from "$lib/mode/modeService";
@@ -81,6 +82,20 @@
 
 	const parsedMessage = $derived(splitMessage(commit.message));
 
+	const originalMessage = $derived({
+		title: parsedMessage?.title || "",
+		description: parsedMessage?.description || "",
+	});
+	const editorSeed = $derived(
+		resolveEditDraft(laneState.editCommitMessage.current, commit.id, originalMessage),
+	);
+
+	function persistDraft(update: { title?: string; description?: string }) {
+		laneState.editCommitMessage.set(
+			applyEditDraftUpdate(laneState.editCommitMessage.current, commit.id, originalMessage, update),
+		);
+	}
+
 	function combineParts(title?: string, description?: string): string {
 		if (!title) {
 			return "";
@@ -112,6 +127,7 @@
 		if (stackId) {
 			uiState.lane(stackId).selection.set({ branchName, commitId: newCommitId, previewOpen: true });
 		}
+		laneState.editCommitMessage.set(undefined);
 		setMode("view");
 	}
 
@@ -138,6 +154,11 @@
 	let drawer = $state<ReturnType<typeof Drawer>>();
 
 	function cancelEdit() {
+		setMode("view");
+	}
+
+	function discardEdit() {
+		laneState.editCommitMessage.set(undefined);
 		setMode("view");
 	}
 </script>
@@ -231,12 +252,13 @@
 					{stackId}
 					action={({ title, description }) => saveCommitMessage(title, description)}
 					actionLabel="Save changes"
-					onCancel={cancelEdit}
+					onChange={persistDraft}
+					onCancel={discardEdit}
 					floatingBoxHeader="Reword commit"
 					loading={messageUpdateQuery.current.isLoading}
 					existingCommitId={commit.id}
-					title={parsedMessage?.title || ""}
-					description={parsedMessage?.description || ""}
+					title={editorSeed.title}
+					description={editorSeed.description}
 				/>
 			</div>
 		{:else}

--- a/apps/desktop/src/lib/commits/editCommitDraft.test.ts
+++ b/apps/desktop/src/lib/commits/editCommitDraft.test.ts
@@ -1,0 +1,60 @@
+import { applyEditDraftUpdate, resolveEditDraft } from "$lib/commits/editCommitDraft";
+import { describe, expect, test } from "vitest";
+
+const original = { title: "Original title", description: "Original body" };
+
+describe("resolveEditDraft", () => {
+	test("uses the original message when there is no draft", () => {
+		expect(resolveEditDraft(undefined, "c1", original)).toEqual(original);
+	});
+
+	test("uses the original message when the draft is for another commit", () => {
+		const draft = { commitId: "c2", title: "Other", description: "Other body" };
+		expect(resolveEditDraft(draft, "c1", original)).toEqual(original);
+	});
+
+	test("uses the draft when it belongs to the commit", () => {
+		const draft = { commitId: "c1", title: "Draft title", description: "Draft body" };
+		expect(resolveEditDraft(draft, "c1", original)).toEqual({
+			title: "Draft title",
+			description: "Draft body",
+		});
+	});
+});
+
+describe("applyEditDraftUpdate", () => {
+	test("seeds from the original message on the first change", () => {
+		expect(applyEditDraftUpdate(undefined, "c1", original, { title: "New title" })).toEqual({
+			commitId: "c1",
+			title: "New title",
+			description: "Original body",
+		});
+	});
+
+	test("merges a description-only change, keeping the existing title", () => {
+		const draft = { commitId: "c1", title: "A", description: "B" };
+		expect(applyEditDraftUpdate(draft, "c1", original, { description: "B2" })).toEqual({
+			commitId: "c1",
+			title: "A",
+			description: "B2",
+		});
+	});
+
+	test("restarts from the original when the draft is for another commit", () => {
+		const draft = { commitId: "c2", title: "A", description: "B" };
+		expect(applyEditDraftUpdate(draft, "c1", original, { title: "New" })).toEqual({
+			commitId: "c1",
+			title: "New",
+			description: "Original body",
+		});
+	});
+
+	test("keeps an explicitly cleared (empty) field", () => {
+		const draft = { commitId: "c1", title: "A", description: "B" };
+		expect(applyEditDraftUpdate(draft, "c1", original, { title: "" })).toEqual({
+			commitId: "c1",
+			title: "",
+			description: "B",
+		});
+	});
+});

--- a/apps/desktop/src/lib/commits/editCommitDraft.ts
+++ b/apps/desktop/src/lib/commits/editCommitDraft.ts
@@ -1,0 +1,44 @@
+/**
+ * In-progress reword draft for a single commit. Persisted in lane UI state so it
+ * survives navigating away from the commit and back, instead of living only in
+ * the editor component's local state. See issue #13287.
+ */
+export type EditCommitMessage = {
+	commitId: string;
+	title: string;
+	description: string;
+};
+
+/**
+ * Picks the title/description to seed the reword editor with: the persisted
+ * draft when it belongs to `commitId`, otherwise the commit's own message.
+ */
+export function resolveEditDraft(
+	draft: EditCommitMessage | undefined,
+	commitId: string,
+	original: { title: string; description: string },
+): { title: string; description: string } {
+	if (draft?.commitId === commitId) {
+		return { title: draft.title, description: draft.description };
+	}
+	return original;
+}
+
+/**
+ * Merges a partial editor change into the draft for `commitId`. The editor emits
+ * one field at a time, so the untouched field is carried over from the existing
+ * draft, or seeded from the original message when starting fresh.
+ */
+export function applyEditDraftUpdate(
+	draft: EditCommitMessage | undefined,
+	commitId: string,
+	original: { title: string; description: string },
+	update: { title?: string; description?: string },
+): EditCommitMessage {
+	const base = draft?.commitId === commitId ? draft : { commitId, ...original };
+	return {
+		commitId,
+		title: update.title ?? base.title,
+		description: update.description ?? base.description,
+	};
+}

--- a/apps/desktop/src/lib/state/uiState.svelte.ts
+++ b/apps/desktop/src/lib/state/uiState.svelte.ts
@@ -3,6 +3,7 @@ import { InjectionToken } from "@gitbutler/core/context";
 import { reactive } from "@gitbutler/shared/reactiveUtils.svelte";
 import { type Reactive } from "@gitbutler/shared/storeUtils";
 import { createEntityAdapter, createSlice, type EntityState } from "@reduxjs/toolkit";
+import type { EditCommitMessage } from "$lib/commits/editCommitDraft";
 import type { TerminalService } from "$lib/settings/terminalService";
 import type { AppDispatch } from "$lib/state/clientState.svelte";
 import type { ScrollbarVisilitySettings } from "@gitbutler/ui";
@@ -50,6 +51,7 @@ export type NewCommitMessage = {
 export type StackState = {
 	selection: StackSelection | undefined;
 	newCommitMessage: NewCommitMessage;
+	editCommitMessage: EditCommitMessage | undefined;
 };
 
 export type ExclusiveAction =
@@ -217,6 +219,7 @@ export class UiState {
 	readonly lane = this.buildScopedProps<StackState>(this.scopesCache.lanes, {
 		selection: undefined,
 		newCommitMessage: { title: "", description: "" },
+		editCommitMessage: undefined,
 	});
 
 	/** Properties scoped to a specific project. */


### PR DESCRIPTION
Reword (edit commit message) drafts were lost on context switch — start editing a commit's message, navigate to another commit/branch/repo, come back, and the draft is gone. New-commit drafts already survive.

**Cause:** `CommitView.svelte` mounted the reword editor seeded from the original message with no `onChange`, so the draft lived only in the editor's local state and was destroyed when the editor unmounted on context switch. `NewCommitView` avoids this by persisting into `lane.newCommitMessage` (redux).

**Fix:** mirror that, scoped to reword — persist the draft per-commit in lane UI state, seed the editor from it, clear it on save or explicit cancel:
- `lib/commits/editCommitDraft.ts` — pure `resolveEditDraft` / `applyEditDraftUpdate` helpers (+ `EditCommitMessage` type), with unit tests.
- `lib/state/uiState.svelte.ts` — add `editCommitMessage` to lane `StackState`.
- `components/commit/CommitView.svelte` — seed from the draft, persist on change, clear on save + explicit cancel.

Behavior: navigate away / close the drawer → draft preserved; return → restored; Cancel → discarded; Save → cleared. (`RichTextEditor` only seeds when empty, so restore happens on remount and there's no caret reset while typing.)

Two design points worth a maintainer call (cc @PavelLaptev, per the issue thread):
1. Editor **Cancel/Escape discard**, but **Drawer close / navigation preserve** — biased toward preserving so navigation reliably keeps the draft. Happy to make Drawer-close discard too if preferred.
2. One reword draft per lane, keyed by commit — starting to edit a second commit before returning overwrites the first's draft.

`prettier`, `eslint`, `svelte-check` (0 errors / 0 warnings), and the new vitest suite (7 cases) pass locally.

Fixes #13287