### PR TITLE
upstream-integration-sbm-e2e

### DIFF
--- a/apps/desktop/src/components/upstream/IntegrateUpstreamModal.svelte
+++ b/apps/desktop/src/components/upstream/IntegrateUpstreamModal.svelte
@@ -73,6 +73,11 @@
 	$effect(() => {
 		if (!modal?.imports.open) return;
 
+		if (integratingUpstream !== "inert") {
+			statusRequest++;
+			return;
+		}
+
 		if (!baseLoaded) {
 			statusRequest++;
 			integrationStatuses = undefined;

--- a/apps/desktop/src/lib/upstream/upstreamIntegrationService.test.ts
+++ b/apps/desktop/src/lib/upstream/upstreamIntegrationService.test.ts
@@ -2,9 +2,20 @@ import { UpstreamIntegrationService } from "$lib/upstream/upstreamIntegrationSer
 import { describe, expect, test, vi } from "vitest";
 import type { RefInfo, Segment, Stack } from "@gitbutler/but-sdk";
 
-function segment(): Segment {
+const encoder = new TextEncoder();
+
+function bytes(value: string): number[] {
+	return [...encoder.encode(value)];
+}
+
+function segment(name?: string): Segment {
 	return {
-		refName: null,
+		refName: name
+			? {
+					fullNameBytes: bytes(`refs/heads/${name}`),
+					displayName: name,
+				}
+			: null,
 		remoteTrackingRefName: null,
 		commits: [],
 		commitsOnRemote: [],
@@ -44,7 +55,7 @@ describe("UpstreamIntegrationService", () => {
 				changes: [],
 				replacedCommits: {},
 			},
-			worktreeConflicts: [],
+			worktreeConflicts: ["conflicting.txt"],
 		});
 		const service = new UpstreamIntegrationService(
 			{
@@ -68,11 +79,69 @@ describe("UpstreamIntegrationService", () => {
 		});
 		expect(statuses).toMatchObject({
 			updates: [],
-			worktreeConflicts: [],
+			worktreeConflicts: ["conflicting.txt"],
 			subject: [
 				{
 					status: "clear",
 					fullyIntegrated: false,
+				},
+			],
+		});
+	});
+
+	test("previews non-empty update sets through the backend", async () => {
+		const stacks = [stack([segment("feature")])];
+		const mutate = vi.fn().mockResolvedValue({
+			workspaceState: {
+				headInfo: refInfo([]),
+				changes: [],
+				replacedCommits: {},
+			},
+			worktreeConflicts: [],
+		});
+		const service = new UpstreamIntegrationService(
+			{
+				endpoints: {
+					workspaceIntegrateUpstream: {
+						mutate,
+					},
+				},
+			} as any,
+			{
+				fetchStacks: vi.fn().mockResolvedValue(stacks),
+			} as any,
+		);
+
+		const statuses = await service.upstreamStatuses("project-1");
+
+		expect(mutate).toHaveBeenCalledWith({
+			projectId: "project-1",
+			updates: [
+				{
+					kind: "rebase",
+					selector: {
+						type: "referenceBytes",
+						subject: bytes("refs/heads/feature"),
+					},
+				},
+			],
+			dryRun: true,
+		});
+		expect(statuses).toMatchObject({
+			updates: [
+				{
+					kind: "rebase",
+					selector: {
+						type: "referenceBytes",
+						subject: bytes("refs/heads/feature"),
+					},
+				},
+			],
+			worktreeConflicts: [],
+			subject: [
+				{
+					status: "integrated",
+					fullyIntegrated: true,
 				},
 			],
 		});

--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -2,7 +2,7 @@
 
 use crate::WorkspaceState;
 use but_api_macros::but_api;
-use but_core::{DryRun, RefMetadata, sync::RepoExclusive};
+use but_core::{DryRun, RefMetadata, is_workspace_ref_name, sync::RepoExclusive};
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
 use but_serde::BStringForFrontend;
 use but_workspace::IntegrateUpstreamOutcome;
@@ -213,6 +213,7 @@ pub fn workspace_integrate_upstream_only_with_perm(
 
         if let Some(ref_name) = materialized.workspace.ref_name()
             && let Some(ws_meta) = ws_meta
+            && is_workspace_ref_name(ref_name)
         {
             let mut md = materialized.meta.workspace(ref_name)?;
             *md = ws_meta;

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -4,14 +4,14 @@ use std::collections::{HashMap, HashSet};
 
 use anyhow::{Context, Result, bail};
 
-use but_core::{RefMetadata, ref_metadata::ProjectMeta};
+use but_core::{RefMetadata, branch::unique_canned_refname, ref_metadata::ProjectMeta};
 use but_graph::workspace::commit::is_managed_workspace_by_message;
 use but_rebase::{
     commit::DateMode,
     graph_rebase::{
         Editor, ExtraRef, GraphEditorOptions, LookupStep, Pick, Selector, Step, SuccessfulRebase,
         ToSelector,
-        mutate::{InsertSide, RelativeTo},
+        mutate::{InsertSide, RelativeTo, SegmentDelimiter, SelectorSet},
     },
 };
 
@@ -154,6 +154,9 @@ pub fn integrate_upstream<'ws, 'meta, M: RefMetadata>(
     let head_commit = repo.find_commit(head_commit.id)?;
     let head_commit_id = head_commit.id;
     let head_is_workspace_commit = is_managed_workspace_by_message(head_commit.message_raw()?);
+    let direct_checkout_head_ref_name = (!head_is_workspace_commit)
+        .then(|| workspace.ref_name().map(ToOwned::to_owned))
+        .flatten();
 
     let editor_options = GraphEditorOptions {
         extra_refs: vec![ExtraRef::immutable(target_ref.ref_name.as_ref())],
@@ -168,6 +171,7 @@ pub fn integrate_upstream<'ws, 'meta, M: RefMetadata>(
 
     let target_ref_selector = target_ref.ref_name.to_selector(&editor)?;
     let target_sha_selector = target_sha.to_selector(&editor)?;
+    let target_ref_commit_selector = target_ref_commit.detach().to_selector(&editor)?;
 
     let from_target_ref = traverse_nodes(&editor, target_ref_selector)?;
     let mut from_target_sha = traverse_nodes(&editor, target_sha_selector)?;
@@ -234,6 +238,7 @@ pub fn integrate_upstream<'ws, 'meta, M: RefMetadata>(
         .then(|| editor.select_commit(head_commit_id))
         .transpose()?;
     let mut fully_integrated_workspace_parents = HashSet::new();
+    let mut direct_checkout_replacement_ref: Option<(Selector, gix::refs::FullName)> = None;
     for stack in &stacks {
         let is_selected = stack.nodes.values().any(|attrs| attrs.to_rebase) || stack.to_merge;
         let is_fully_integrated = stack.nodes.values().all(|attrs| {
@@ -246,6 +251,20 @@ pub fn integrate_upstream<'ws, 'meta, M: RefMetadata>(
         }
 
         if is_fully_integrated {
+            // If we're not in the managed workspace, we haven't determined a
+            // ref replacement yet and we were checked out on a local branch.
+            if !head_is_workspace_commit
+                && direct_checkout_replacement_ref.is_none()
+                && let Some(head_ref_name) = direct_checkout_head_ref_name.as_ref()
+                && head_ref_name.as_ref().category() == Some(gix::refs::Category::LocalBranch)
+            {
+                direct_checkout_replacement_ref = Some(replace_direct_checkout_ref_with_fallback(
+                    &mut editor,
+                    repo,
+                    head_ref_name.as_ref(),
+                    target_ref_commit_selector,
+                )?);
+            }
             // TODO: Look into what happens when the head is an irrelevant
             // reference like the target_sha or a remote reference. In these
             // cases, we should look to see if it has a relevant reference
@@ -267,6 +286,12 @@ pub fn integrate_upstream<'ws, 'meta, M: RefMetadata>(
             if let Some(ref_name) = attrs.reference_integrated.as_ref()
                 && ref_name.category() == Some(gix::refs::Category::LocalBranch)
             {
+                if direct_checkout_replacement_ref
+                    .as_ref()
+                    .is_some_and(|(replacement_selector, _)| replacement_selector == selector)
+                {
+                    continue;
+                }
                 editor.replace(*selector, Step::None)?;
                 if let Some(ws_meta) = ws_meta.as_mut() {
                     ws_meta.remove_segment(ref_name.as_ref());
@@ -597,4 +622,46 @@ fn selector_commit_id<M: RefMetadata>(
         ),
         Step::None => None,
     })
+}
+
+/// Replace a fully integrated direct-checkout branch with a new canned local branch at the
+/// latest target tip.
+///
+/// In a managed workspace, a fully integrated stack can simply be detached from the workspace
+/// commit and the workspace commit is reparented to the target. A direct checkout has no
+/// workspace commit to keep `HEAD` alive, so deleting the checked-out branch would leave `HEAD`
+/// pointing at a missing ref. Instead, reuse the checkout reference step for a fresh branch name
+/// and point it at the latest target commit.
+///
+/// The old checkout reference can be on the target ancestry path. Before repointing the step to
+/// the target tip, `disconnect_segment_from()` rewires its children around the old reference to
+/// preserve the existing graph and avoid introducing a cycle.
+fn replace_direct_checkout_ref_with_fallback<M: RefMetadata>(
+    editor: &mut Editor<'_, '_, M>,
+    repo: &gix::Repository,
+    head_ref_name: &gix::refs::FullNameRef,
+    target_tip_selector: Selector,
+) -> Result<(Selector, gix::refs::FullName)> {
+    let head_ref_selector = head_ref_name.to_selector(editor)?;
+    let fallback_ref_name = unique_canned_refname(repo)?;
+
+    editor.replace(
+        head_ref_selector,
+        Step::Reference {
+            refname: fallback_ref_name.clone(),
+        },
+    )?;
+
+    editor.disconnect_segment_from(
+        SegmentDelimiter {
+            child: head_ref_selector,
+            parent: head_ref_selector,
+        },
+        SelectorSet::All,
+        SelectorSet::All,
+        false,
+    )?;
+    editor.add_edge(head_ref_selector, target_tip_selector, 0)?;
+
+    Ok((head_ref_selector, fallback_ref_name))
 }

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -154,9 +154,11 @@ pub fn integrate_upstream<'ws, 'meta, M: RefMetadata>(
     let head_commit = repo.find_commit(head_commit.id)?;
     let head_commit_id = head_commit.id;
     let head_is_workspace_commit = is_managed_workspace_by_message(head_commit.message_raw()?);
-    let direct_checkout_head_ref_name = (!head_is_workspace_commit)
-        .then(|| workspace.ref_name().map(ToOwned::to_owned))
-        .flatten();
+    let direct_checkout_head_ref_name = if head_is_workspace_commit {
+        None
+    } else {
+        repo.head_name()?
+    };
 
     let editor_options = GraphEditorOptions {
         extra_refs: vec![ExtraRef::immutable(target_ref.ref_name.as_ref())],
@@ -661,7 +663,26 @@ fn replace_direct_checkout_ref_with_fallback<M: RefMetadata>(
         SelectorSet::All,
         false,
     )?;
+    preserve_pick_parents(editor, target_tip_selector)?;
     editor.add_edge(head_ref_selector, target_tip_selector, 0)?;
 
     Ok((head_ref_selector, fallback_ref_name))
+}
+
+fn preserve_pick_parents<M: RefMetadata>(
+    editor: &mut Editor<'_, '_, M>,
+    selector: Selector,
+) -> Result<()> {
+    let Step::Pick(mut pick) = editor.lookup_step(selector)? else {
+        bail!("Expected target tip selector to point to a pick");
+    };
+    let commit = editor.find_commit(pick.id)?;
+    // TODO: Teach but-rebase to treat immutable reference parents as object
+    // anchors. Until then, preserve the target tip's original parents here so
+    // graph-rebase materializes the fallback branch at the exact target ref
+    // object instead of replaying merge-based target history into an equivalent
+    // local rewrite.
+    pick.preserved_parents = Some(commit.inner.parents.iter().copied().collect());
+    editor.replace(selector, Step::Pick(pick))?;
+    Ok(())
 }

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -962,6 +962,93 @@ fn fully_integrated_direct_checkout_creates_unique_canned_branch_at_target_tip()
 }
 
 #[test]
+fn fully_integrated_direct_checkout_creates_canned_branch_at_merge_target_tip() -> Result<()> {
+    let (_tmp, mut repo, mut meta, _description) = named_writable_scenario_with_description(
+        "fully-integrated-single-branch-target-advanced-through-merge",
+    )?;
+    force_prefixless_canned_branch_name(&mut repo)?;
+    git(&repo).args(["checkout", "A"]).run();
+    remove_managed_workspace_ref(&repo)?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+    let target_tip = repo.rev_parse_single("origin/main")?.detach();
+    let target_tip_parent = repo
+        .find_commit(target_tip)?
+        .parent_ids()
+        .next()
+        .context("target tip should have a parent")?
+        .detach();
+    assert_eq!(
+        repo.find_commit(target_tip_parent)?.parent_ids().count(),
+        2,
+        "this fixture must exercise a target tip based on a merge commit"
+    );
+    let branch_1: gix::refs::FullName = "refs/heads/branch-1".try_into()?;
+    let branch_2: gix::refs::FullName = "refs/heads/branch-2".try_into()?;
+
+    repo.reference(
+        branch_1.as_ref(),
+        target_tip,
+        PreviousValue::MustNotExist,
+        "reserve first canned branch name",
+    )?;
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta(&meta)?,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+    let mut workspace = graph.into_workspace()?;
+    let project_meta = workspace.graph.project_meta.clone();
+
+    let but_workspace::IntegrateUpstreamOutcome { rebase, .. } = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        project_meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A^")?.detach()),
+        }],
+    )?;
+
+    let preview = rebase.overlayed_graph()?.into_workspace()?;
+    assert_eq!(
+        preview.ref_name(),
+        Some(branch_2.as_ref()),
+        "dry-run overlay should show the replacement canned branch as the checked-out branch"
+    );
+    drop(preview);
+
+    rebase.materialize()?;
+
+    assert!(
+        repo.try_find_reference("A")?.is_none(),
+        "fully integrated checked-out branch should be removed"
+    );
+    assert_eq!(
+        repo.find_reference(branch_2.as_ref())?.id(),
+        target_tip,
+        "replacement canned branch should point at the exact merge target tip, not a replayed merge"
+    );
+    assert_eq!(
+        repo.head_name()?,
+        Some(branch_2),
+        "HEAD should stay attached to the replacement canned branch"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn empty_workspace_reparents_workspace_commit_to_advanced_target() -> Result<()> {
     let (_tmp, repo, mut meta, _description) =
         named_writable_scenario_with_description("empty-workspace-target-advanced")?;

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -8,6 +8,7 @@ use but_workspace::{
     BottomUpdate, BottomUpdateKind, integrate_upstream, worktree_conflicts_for_rebase,
 };
 use gix::prelude::ObjectIdExt;
+use gix::refs::transaction::PreviousValue;
 
 use crate::ref_info::with_workspace_commit::utils::{
     StackState, add_stack, add_stack_with_segments, named_writable_scenario_with_description,
@@ -877,6 +878,90 @@ fn fully_integrated_single_branch_reparents_workspace_commit_to_advanced_merge_t
 }
 
 #[test]
+fn fully_integrated_direct_checkout_creates_unique_canned_branch_at_target_tip() -> Result<()> {
+    let (_tmp, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description("fully-integrated-single-branch-target-advanced")?;
+    force_prefixless_canned_branch_name(&mut repo)?;
+    git(&repo).args(["checkout", "A"]).run();
+    remove_managed_workspace_ref(&repo)?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+    let target_tip = repo.rev_parse_single("origin/main")?.detach();
+    let branch_1: gix::refs::FullName = "refs/heads/branch-1".try_into()?;
+    let branch_2: gix::refs::FullName = "refs/heads/branch-2".try_into()?;
+
+    repo.reference(
+        branch_1.as_ref(),
+        target_tip,
+        PreviousValue::MustNotExist,
+        "reserve first canned branch name",
+    )?;
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta(&meta)?,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+    let mut workspace = graph.into_workspace()?;
+    let project_meta = workspace.graph.project_meta.clone();
+
+    let but_workspace::IntegrateUpstreamOutcome { rebase, .. } = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        project_meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A^")?.detach()),
+        }],
+    )?;
+
+    let preview = rebase.overlayed_graph()?.into_workspace()?;
+    assert_eq!(
+        preview.ref_name(),
+        Some(branch_2.as_ref()),
+        "dry-run overlay should show the replacement canned branch as the checked-out branch"
+    );
+    assert!(
+        repo.try_find_reference(branch_2.as_ref())?.is_none(),
+        "dry-run preview should not create the replacement branch on disk"
+    );
+    drop(preview);
+
+    rebase.materialize()?;
+
+    assert!(
+        repo.try_find_reference("A")?.is_none(),
+        "fully integrated checked-out branch should be removed"
+    );
+    assert_eq!(
+        repo.find_reference(branch_1.as_ref())?.id(),
+        target_tip,
+        "the pre-existing canned branch collision should be left untouched"
+    );
+    assert_eq!(
+        repo.find_reference(branch_2.as_ref())?.id(),
+        target_tip,
+        "replacement canned branch should point at the latest target tip"
+    );
+    assert_eq!(
+        repo.head_name()?,
+        Some(branch_2),
+        "HEAD should stay attached to the replacement canned branch"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn empty_workspace_reparents_workspace_commit_to_advanced_target() -> Result<()> {
     let (_tmp, repo, mut meta, _description) =
         named_writable_scenario_with_description("empty-workspace-target-advanced")?;
@@ -1714,4 +1799,18 @@ fn workspace_parent_count(repo: &gix::Repository) -> Result<usize> {
     let workspace_commit =
         repo.find_commit(repo.rev_parse_single("gitbutler/workspace")?.detach())?;
     Ok(workspace_commit.parent_ids().count())
+}
+
+fn force_prefixless_canned_branch_name(repo: &mut gix::Repository) -> Result<()> {
+    let mut config = repo.config_snapshot_mut();
+    config.raw_values_mut(&"author.name")?.delete_all();
+    config.raw_values_mut(&"author.email")?.delete_all();
+    Ok(())
+}
+
+fn remove_managed_workspace_ref(repo: &gix::Repository) -> Result<()> {
+    if let Some(reference) = repo.try_find_reference(but_core::WORKSPACE_REF_NAME)? {
+        reference.delete()?;
+    }
+    Ok(())
 }

--- a/e2e/playwright/scripts/project-in-single-branch-upstream-integration.sh
+++ b/e2e/playwright/scripts/project-in-single-branch-upstream-integration.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "GIT CONFIG $GIT_CONFIG_GLOBAL"
+echo "DATA DIR $E2E_TEST_APP_DATA_DIR"
+echo "BUT $BUT"
+echo "SCENARIO: $1"
+
+scenario="$1"
+
+mkdir remote-project
+pushd remote-project
+git init -b master --object-format=sha1
+echo "base line 1" >> a_file
+echo "base line 2" >> a_file
+echo "base line 3" >> a_file
+git add a_file
+git commit -m "base: initial commit"
+
+case "$scenario" in
+  fully-integrated)
+    git checkout -b fully-integrated-branch
+    echo "fully integrated commit 1" > fully_integrated_first.txt
+    git add fully_integrated_first.txt
+    git commit -m "fully-integrated: first commit"
+    echo "fully integrated commit 2" > fully_integrated_second.txt
+    git add fully_integrated_second.txt
+    git commit -m "fully-integrated: second commit"
+    git checkout master
+    ;;
+  partial-stack)
+    git checkout -b partial-stack-base
+    echo "partial stack base" > partial_stack_base.txt
+    git add partial_stack_base.txt
+    git commit -m "partial-stack-base: first commit"
+
+    git checkout -b partial-stack-top
+    echo "partial stack top" > partial_stack_top.txt
+    git add partial_stack_top.txt
+    git commit -m "partial-stack-top: first commit"
+    git checkout master
+    ;;
+  rebase)
+    ;;
+  *)
+    echo "Unknown scenario: $scenario" >&2
+    exit 1
+    ;;
+esac
+popd
+
+git clone remote-project local-clone
+pushd local-clone
+git checkout master
+
+if [ "$scenario" = "rebase" ]; then
+  git checkout -b rebased-single-branch master
+  echo "rebased branch commit 1" > rebased_single_first.txt
+  git add rebased_single_first.txt
+  git commit -m "rebased-single-branch: first commit"
+  echo "rebased branch commit 2" > rebased_single_second.txt
+  git add rebased_single_second.txt
+  git commit -m "rebased-single-branch: second commit"
+  git checkout master
+fi
+
+"$BUT" setup
+
+case "$scenario" in
+  fully-integrated)
+    "$BUT" apply fully-integrated-branch
+    git checkout fully-integrated-branch
+    ;;
+  partial-stack)
+    "$BUT" apply partial-stack-base
+    "$BUT" apply partial-stack-top
+    git checkout partial-stack-top
+    ;;
+  rebase)
+    "$BUT" apply rebased-single-branch
+    git checkout rebased-single-branch
+    ;;
+esac
+popd

--- a/e2e/playwright/tests/singleBranch/upstreamIntegration.spec.ts
+++ b/e2e/playwright/tests/singleBranch/upstreamIntegration.spec.ts
@@ -1,0 +1,220 @@
+import { expectCurrentBranchChip, openSingleBranchWorkspace } from "./helpers.ts";
+import { assertBranch, assertCleanWorktree, assertCommitSubjects } from "../../src/branch.ts";
+import { test } from "../../src/test.ts";
+import {
+	clickByTestId,
+	commitRow,
+	getByTestId,
+	stack,
+	waitForTestIdToNotExist,
+} from "../../src/util.ts";
+import { expect, type Page } from "@playwright/test";
+import { execFileSync } from "node:child_process";
+
+const FULLY_INTEGRATED_BRANCH = "fully-integrated-branch";
+const PARTIAL_STACK_BASE = "partial-stack-base";
+const PARTIAL_STACK_TOP = "partial-stack-top";
+const REBASED_SINGLE_BRANCH = "rebased-single-branch";
+const TARGET_BRANCH = "master";
+const TARGET_REMOTE_BRANCH = "origin/master";
+const ERROR_TOAST_PATTERN = /API error:|error/i;
+
+test.use({
+	gitbutlerOptions: {
+		config: {
+			onboardingComplete: true,
+			featureFlags: { singleBranch: true },
+		},
+	},
+});
+
+async function syncAndIntegrateWorkspace(page: Page) {
+	await clickByTestId(page, "sync-button");
+	await expectNoErrorToast(page);
+	await clickByTestId(page, "integrate-upstream-commits-button");
+	await expectNoErrorToast(page);
+	await clickByTestId(page, "integrate-upstream-action-button");
+	await expectNoErrorToast(page);
+}
+
+async function expectNoErrorToast(page: Page) {
+	await expect(
+		page.getByTestId("toast-info-message").filter({ hasText: ERROR_TOAST_PATTERN }),
+	).toHaveCount(0);
+}
+
+async function expectBranchParentToBeOriginMaster(pathToRepo: string, branchName: string) {
+	await expect
+		.poll(() => git(pathToRepo, ["rev-parse", `${branchName}~2`]), {
+			message: `Expected ${branchName} to be rebased onto origin/master`,
+			intervals: [100, 200, 500, 1000],
+		})
+		.toBe(git(pathToRepo, ["rev-parse", "origin/master"]));
+}
+
+async function expectBranchFirstParentToBeOriginMaster(pathToRepo: string, branchName: string) {
+	await expect
+		.poll(() => git(pathToRepo, ["rev-parse", `${branchName}^`]), {
+			message: `Expected ${branchName} to be parented to origin/master`,
+			intervals: [100, 200, 500, 1000],
+		})
+		.toBe(git(pathToRepo, ["rev-parse", "origin/master"]));
+}
+
+async function expectLocalBranchNotToExist(pathToRepo: string, branchName: string) {
+	await expect
+		.poll(() => gitSucceeds(pathToRepo, ["show-ref", "--verify", `refs/heads/${branchName}`]), {
+			message: `Expected local branch ${branchName} to be deleted`,
+			intervals: [100, 200, 500, 1000],
+		})
+		.toBe(false);
+}
+
+async function replacementBranchAtTarget(pathToRepo: string): Promise<string> {
+	await expect
+		.poll(() => findReplacementBranchAtTarget(pathToRepo), {
+			message: `Expected a new local branch at ${TARGET_REMOTE_BRANCH}`,
+			intervals: [100, 200, 500, 1000],
+		})
+		.not.toBeUndefined();
+	const replacementBranch = findReplacementBranchAtTarget(pathToRepo);
+	expect(replacementBranch).toBeDefined();
+	return replacementBranch!;
+}
+
+function findReplacementBranchAtTarget(pathToRepo: string): string | undefined {
+	const targetCommit = git(pathToRepo, ["rev-parse", TARGET_REMOTE_BRANCH]);
+	return git(pathToRepo, ["for-each-ref", "--format=%(refname:short) %(objectname)", "refs/heads"])
+		.split("\n")
+		.map((line) => line.trim().split(" "))
+		.find(([branchName, commitId]) => {
+			return (
+				!branchName.startsWith("gitbutler/") &&
+				branchName !== TARGET_BRANCH &&
+				branchName !== FULLY_INTEGRATED_BRANCH &&
+				commitId === targetCommit
+			);
+		})?.[0];
+}
+
+function git(pathToRepo: string, args: string[]): string {
+	return execFileSync("git", args, {
+		cwd: pathToRepo,
+		encoding: "utf8",
+	}).trim();
+}
+
+function gitSucceeds(pathToRepo: string, args: string[]): boolean {
+	try {
+		git(pathToRepo, args);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+test("creates a new branch on top of the advanced target after branch is fully integrated", async ({
+	page,
+	gitbutler,
+}) => {
+	await gitbutler.runScript("project-in-single-branch-upstream-integration.sh", [
+		"fully-integrated",
+	]);
+	await openSingleBranchWorkspace(page);
+
+	const localClone = gitbutler.pathInWorkdir("local-clone");
+	await assertBranch(FULLY_INTEGRATED_BRANCH, localClone);
+	await expectCurrentBranchChip(page, FULLY_INTEGRATED_BRANCH);
+	await expect(commitRow(page, "fully-integrated: second commit")).toBeVisible();
+
+	await gitbutler.runScript("merge-upstream-branch-to-base.sh", [FULLY_INTEGRATED_BRANCH]);
+	await syncAndIntegrateWorkspace(page);
+
+	await expectLocalBranchNotToExist(localClone, FULLY_INTEGRATED_BRANCH);
+	const replacementBranch = await replacementBranchAtTarget(localClone);
+	await expect(stack(page)).toHaveCount(1);
+	await expect(getByTestId(page, "branch-card")).toContainText(replacementBranch);
+	await assertBranch(replacementBranch, localClone);
+	await expectCurrentBranchChip(page, replacementBranch);
+	expect(git(localClone, ["rev-parse", replacementBranch])).toBe(
+		git(localClone, ["rev-parse", TARGET_REMOTE_BRANCH]),
+	);
+	await assertCleanWorktree(localClone);
+	await expectNoErrorToast(page);
+});
+
+test("keeps the top branch when its lower stack segment is integrated", async ({
+	page,
+	gitbutler,
+}) => {
+	await gitbutler.runScript("project-in-single-branch-upstream-integration.sh", ["partial-stack"]);
+	await openSingleBranchWorkspace(page);
+
+	const localClone = gitbutler.pathInWorkdir("local-clone");
+	await assertBranch(PARTIAL_STACK_TOP, localClone);
+	await expect(stack(page)).toHaveCount(1);
+	await expect(getByTestId(page, "branch-card")).toHaveCount(2);
+	await expect(
+		getByTestId(page, "branch-card").filter({ hasText: PARTIAL_STACK_BASE }),
+	).toBeVisible();
+	await expect(
+		getByTestId(page, "branch-card").filter({ hasText: PARTIAL_STACK_TOP }),
+	).toBeVisible();
+
+	await gitbutler.runScript("merge-upstream-branch-to-base.sh", [PARTIAL_STACK_BASE]);
+	await clickByTestId(page, "sync-button");
+	await expectNoErrorToast(page);
+	await clickByTestId(page, "integrate-upstream-commits-button");
+	await expectNoErrorToast(page);
+
+	const baseRow = page
+		.locator(`[data-integration-row-branch-name="${PARTIAL_STACK_BASE}"]`)
+		.first();
+	await expect(baseRow.getByTestId("integrate-upstream-series-row-status-badge")).toHaveText(
+		"Integrated",
+	);
+
+	await clickByTestId(page, "integrate-upstream-action-button");
+	await expectNoErrorToast(page);
+
+	await expect(stack(page)).toHaveCount(1);
+	await expect(getByTestId(page, "branch-card")).toHaveCount(1);
+	await expect(getByTestId(page, "branch-card")).toContainText(PARTIAL_STACK_TOP);
+	await expect(getByTestId(page, "branch-card")).not.toContainText(PARTIAL_STACK_BASE);
+	await assertBranch(PARTIAL_STACK_TOP, localClone);
+	await expectCurrentBranchChip(page, PARTIAL_STACK_TOP);
+	await assertCommitSubjects(
+		["partial-stack-top: first commit", `Merging upstream branch ${PARTIAL_STACK_BASE} into base`],
+		localClone,
+	);
+	await expectBranchFirstParentToBeOriginMaster(localClone, PARTIAL_STACK_TOP);
+	await assertCleanWorktree(localClone);
+	await expectNoErrorToast(page);
+});
+
+test("rebases the checked-out branch when the target advances", async ({ page, gitbutler }) => {
+	await gitbutler.runScript("project-in-single-branch-upstream-integration.sh", ["rebase"]);
+	await openSingleBranchWorkspace(page);
+
+	const localClone = gitbutler.pathInWorkdir("local-clone");
+	await assertBranch(REBASED_SINGLE_BRANCH, localClone);
+	await expectCurrentBranchChip(page, REBASED_SINGLE_BRANCH);
+
+	await gitbutler.runScript("project-with-remote-branches__add-commit-to-base.sh");
+	await syncAndIntegrateWorkspace(page);
+
+	await waitForTestIdToNotExist(page, "integrate-upstream-commits-button");
+	await assertBranch(REBASED_SINGLE_BRANCH, localClone);
+	await expectCurrentBranchChip(page, REBASED_SINGLE_BRANCH);
+	await assertCommitSubjects(
+		[
+			"rebased-single-branch: second commit",
+			"rebased-single-branch: first commit",
+			"commit in base",
+		],
+		localClone,
+	);
+	await expectBranchParentToBeOriginMaster(localClone, REBASED_SINGLE_BRANCH);
+	await assertCleanWorktree(localClone);
+	await expectNoErrorToast(page);
+});


### PR DESCRIPTION
Integrate upstream changes for-branch mode (SBM) end-to-end flow.

### Changes
- After full SBM integration checkout a new empty branch.
- Avoid writing metadata when operating outside the managed workspace
- Preserve parent commits during upstream integration.

### E2E tests
 - Full integration checks out new empty branch
 - Partial integration behavior
 - No-integration leaves the branch in the workspace