### PR TITLE
test(cli): unwrap `Result`s in test helpers

### DIFF
--- a/crates/but-hunk-dependency/tests/hunk_dependency/workspace_dependencies.rs
+++ b/crates/but-hunk-dependency/tests/hunk_dependency/workspace_dependencies.rs
@@ -1,5 +1,5 @@
 #[test]
-fn every_commit_is_independent() -> anyhow::Result<()> {
+fn every_commit_is_independent() {
     let actual = worktree_ranges_digest_for_workspace_separated("independent-commits");
     // Nothing to see here, there is no worktree change.
     insta::assert_debug_snapshot!(actual, @r#"
@@ -84,11 +84,10 @@ fn every_commit_is_independent() -> anyhow::Result<()> {
         },
     )
     "#);
-    Ok(())
 }
 
 #[test]
-fn multiple_stacks_with_multiple_branches_each() -> anyhow::Result<()> {
+fn multiple_stacks_with_multiple_branches_each() {
     let actual = worktree_ranges_digest_for_workspace_separated("independent-commits-multi-stack");
     // Nothing to see here, there is no worktree change.
     insta::assert_debug_snapshot!(actual, @r#"
@@ -245,11 +244,10 @@ fn multiple_stacks_with_multiple_branches_each() -> anyhow::Result<()> {
         },
     )
     "#);
-    Ok(())
 }
 
 #[test]
-fn every_commit_is_sequentially_dependent() -> anyhow::Result<()> {
+fn every_commit_is_sequentially_dependent() {
     let actual = worktree_ranges_digest_for_workspace_separated("sequentially-dependent-commits");
     insta::assert_debug_snapshot!(actual, @r#"
     Ok(
@@ -273,11 +271,10 @@ fn every_commit_is_sequentially_dependent() -> anyhow::Result<()> {
         },
     )
     "#);
-    Ok(())
 }
 
 #[test]
-fn every_commit_is_sequentially_dependent_multi_stack() -> anyhow::Result<()> {
+fn every_commit_is_sequentially_dependent_multi_stack() {
     let actual = worktree_ranges_digest_for_workspace_separated(
         "sequentially-dependent-commits-multi-stack",
     );
@@ -315,7 +312,6 @@ fn every_commit_is_sequentially_dependent_multi_stack() -> anyhow::Result<()> {
         },
     )
     "#);
-    Ok(())
 }
 
 #[test]

--- a/crates/but-testsupport/src/sandbox.rs
+++ b/crates/but-testsupport/src/sandbox.rs
@@ -53,24 +53,22 @@ impl Sandbox {
     /// Create a new instance with empty everything, except for basic application settings that prevent the app to break out.
     ///
     /// Change these if you want to test something specific on top of that.
-    pub fn empty() -> anyhow::Result<Sandbox> {
+    pub fn empty() -> Sandbox {
         #[cfg_attr(not(feature = "sandbox-but-api"), allow(unused_mut))]
         let mut sandbox = Sandbox {
-            project_root: Some(tempfile::TempDir::new()?),
+            project_root: Some(tempfile::TempDir::new().unwrap()),
             #[cfg(feature = "sandbox-but-api")]
-            app_root: Some(tempfile::TempDir::new()?),
+            app_root: Some(tempfile::TempDir::new().unwrap()),
             #[cfg(feature = "sandbox-but-api")]
             app_settings: None,
         };
         #[cfg(feature = "sandbox-but-api")]
-        sandbox.set_default_settings()?;
-        Ok(sandbox)
+        sandbox.set_default_settings();
+        sandbox
     }
 
     /// A utility to init a scenario if the legacy feature is set, or open a repo otherwise.
-    pub fn open_or_init_scenario_with_target_and_default_settings(
-        name: &str,
-    ) -> anyhow::Result<Sandbox> {
+    pub fn open_or_init_scenario_with_target_and_default_settings(name: &str) -> Sandbox {
         Self::open_or_init_scenario_with_target_inner(
             name,
             Creation::CopyFromReadOnly,
@@ -79,7 +77,7 @@ impl Sandbox {
     }
 
     /// Open a repository without any additional setup and default application settings.
-    pub fn open_with_default_settings(name: &str) -> anyhow::Result<Sandbox> {
+    pub fn open_with_default_settings(name: &str) -> Sandbox {
         Self::open_or_init_scenario_with_target_inner(
             name,
             Creation::CopyFromReadOnly,
@@ -93,7 +91,7 @@ impl Sandbox {
     /// Prefer to use [`Self::open_scenario_with_target_and_default_settings()`] instead for less side-effects
     /// TODO: we shouldn't have to add the project for interaction - it's only useful for listing.
     /// TODO: there should be no need for the target.
-    pub fn init_scenario_with_target_and_default_settings(name: &str) -> anyhow::Result<Sandbox> {
+    pub fn init_scenario_with_target_and_default_settings(name: &str) -> Sandbox {
         Self::open_or_init_scenario_with_target_inner(
             name,
             Creation::CopyFromReadOnly,
@@ -102,7 +100,7 @@ impl Sandbox {
     }
 
     /// Provide a scenario with `name` for writing, with target added.
-    pub fn open_scenario_with_target_and_default_settings(name: &str) -> anyhow::Result<Sandbox> {
+    pub fn open_scenario_with_target_and_default_settings(name: &str) -> Sandbox {
         Self::open_or_init_scenario_with_target_inner(
             name,
             Creation::CopyFromReadOnly,
@@ -112,9 +110,7 @@ impl Sandbox {
 
     /// Like [`Self::init_scenario_with_target_and_default_settings`], Execute the script at `name` instead of
     /// copying it - necessary if Git places absolute paths.
-    pub fn init_scenario_with_target_and_default_settings_slow(
-        name: &str,
-    ) -> anyhow::Result<Sandbox> {
+    pub fn init_scenario_with_target_and_default_settings_slow(name: &str) -> Sandbox {
         Self::open_or_init_scenario_with_target_inner(name, Creation::Execute, InitMetadata::Allow)
     }
 
@@ -122,29 +118,32 @@ impl Sandbox {
         name: &str,
         script_creation: Creation,
         meta_mode: InitMetadata,
-    ) -> anyhow::Result<Sandbox> {
+    ) -> Sandbox {
         let repo_dir = gix_testtools::scripted_fixture_writable_with_args(
             format!("scenario/{name}.sh"),
             None::<String>,
             script_creation,
         )
-        .map_err(anyhow::Error::from_boxed)?;
+        .map_err(anyhow::Error::from_boxed)
+        .unwrap();
         #[cfg_attr(not(feature = "sandbox-but-api"), allow(unused_mut))]
         let mut sandbox = Sandbox {
             project_root: Some(repo_dir),
             #[cfg(feature = "sandbox-but-api")]
-            app_root: Some(tempfile::TempDir::new()?),
+            app_root: Some(tempfile::TempDir::new().unwrap()),
             #[cfg(feature = "sandbox-but-api")]
             app_settings: None,
         };
-        let repo = sandbox.open_repo()?;
+        let repo = sandbox.open_repo();
 
         // This can fail on unborn repos, let it, see if we can handle unborn.
         if matches!(meta_mode, InitMetadata::Allow)
             && let Ok(commit_id) = repo.rev_parse_single("origin/main")
         {
             sandbox.file(
-                repo.gitbutler_storage_path()?.join("virtual_branches.toml"),
+                repo.gitbutler_storage_path()
+                    .unwrap()
+                    .join("virtual_branches.toml"),
                 r#"
 [default_target]
 branchName = "main"
@@ -161,8 +160,8 @@ pushRemoteName = "origin"
             );
         }
         #[cfg(feature = "sandbox-but-api")]
-        sandbox.set_default_settings()?;
-        Ok(sandbox)
+        sandbox.set_default_settings();
+        sandbox
     }
 }
 
@@ -231,25 +230,24 @@ impl Sandbox {
     }
 
     /// Open a repository on the projects-directory.
-    pub fn open_repo(&self) -> anyhow::Result<gix::Repository> {
-        Ok(gix::open_opts(
-            self.projects_root(),
-            gix::open::Options::isolated(),
-        )?)
+    pub fn open_repo(&self) -> gix::Repository {
+        gix::open_opts(self.projects_root(), gix::open::Options::isolated()).unwrap()
     }
 
     /// Create a metadata instance on the project.
-    pub fn meta(&self) -> anyhow::Result<impl but_core::RefMetadata> {
+    pub fn meta(&self) -> impl but_core::RefMetadata {
         VirtualBranchesTomlMetadata::from_path(
-            self.open_repo()?
-                .gitbutler_storage_path()?
+            self.open_repo()
+                .gitbutler_storage_path()
+                .unwrap()
                 .join("virtual_branches.toml"),
         )
+        .unwrap()
     }
 
     /// Read project-scoped metadata, falling back to legacy workspace metadata.
-    pub fn project_meta(&self) -> anyhow::Result<ProjectMeta> {
-        ProjectMeta::resolve(&self.open_repo()?, &self.meta()?)
+    pub fn project_meta(&self) -> ProjectMeta {
+        ProjectMeta::resolve(&self.open_repo(), &self.meta()).unwrap()
     }
 
     /// Return a fully isolated context configured to interact with this repository.
@@ -258,52 +256,54 @@ impl Sandbox {
     ///
     /// This feature is only meant for higher-level Client or API tests. Plumbing crates must not use the [`but_ctx::Context`].
     #[cfg(feature = "sandbox-but-api")]
-    pub fn context(&self) -> anyhow::Result<but_ctx::Context> {
-        but_ctx::Context::from_repo(self.open_repo()?).map(but_ctx::Context::with_memory_app_cache)
+    pub fn context(&self) -> but_ctx::Context {
+        but_ctx::Context::from_repo(self.open_repo())
+            .map(but_ctx::Context::with_memory_app_cache)
+            .unwrap()
     }
 
     /// Return the graph at `HEAD`, along with the `(graph, repo, meta)` repository and metadata used to create it.
     pub fn graph_at_head(
         &self,
-    ) -> anyhow::Result<(
+    ) -> (
         but_graph::Graph,
         gix::Repository,
         impl but_core::RefMetadata,
-    )> {
-        let repo = self.open_repo()?;
-        let meta = self.meta()?;
+    ) {
+        let repo = self.open_repo();
+        let meta = self.meta();
         let graph = but_graph::Graph::from_head(
             &repo,
             &meta,
-            self.project_meta()?,
+            self.project_meta(),
             but_graph::init::Options::default(),
-        )?;
-        Ok((graph, repo, meta))
+        )
+        .unwrap();
+        (graph, repo, meta)
     }
 
     /// Return a worktree visualisation, freshly read from [Self::graph_at_head()].
-    pub fn workspace_debug_at_head(&self) -> anyhow::Result<String> {
-        let (graph, _repo, _meta) = self.graph_at_head()?;
-        Ok(graph_workspace_determinisitcally(&graph.into_workspace()?).to_string())
+    pub fn workspace_debug_at_head(&self) -> String {
+        let (graph, _repo, _meta) = self.graph_at_head();
+        graph_workspace_determinisitcally(&graph.into_workspace().unwrap()).to_string()
     }
 
     /// Open the graph at `HEAD` as SVG for debugging.
     #[cfg(unix)]
-    pub fn open_graph_at_head_as_svg(&self) -> anyhow::Result<()> {
-        let (graph, _repo, _meta) = self.graph_at_head()?;
+    pub fn open_graph_at_head_as_svg(&self) {
+        let (graph, _repo, _meta) = self.graph_at_head();
         graph.open_as_svg();
-        Ok(())
     }
 
     /// Show a git log for all refs.
-    pub fn git_log(&self) -> anyhow::Result<String> {
-        Ok(visualize_commit_graph_all_from_dir(self.projects_root())?)
+    pub fn git_log(&self) -> String {
+        visualize_commit_graph_all_from_dir(self.projects_root()).unwrap()
     }
 
     /// Show the `git status` as string.
-    pub fn git_status(&self) -> anyhow::Result<String> {
-        let repo = self.open_repo()?;
-        Ok(git_status(&repo)?)
+    pub fn git_status(&self) -> String {
+        let repo = self.open_repo();
+        git_status(&repo).unwrap()
     }
 
     /// Return app settings if these were initialized.
@@ -433,9 +433,9 @@ impl Sandbox {
     // TODO: in most cases, this shouldn't be necessary as single-branch mode is a thing.
     //       Review each usage, try without.
     /// Create stack metadata for `branch_names` and return its StackIds, one per item in the input slice, in order.
-    pub fn setup_metadata(&self, branch_names: &[&str]) -> anyhow::Result<Vec<StackId>> {
-        let mut meta = self.meta()?;
-        let mut ws = meta.workspace(r(WORKSPACE_REF_NAME))?;
+    pub fn setup_metadata(&self, branch_names: &[&str]) -> Vec<StackId> {
+        let mut meta = self.meta();
+        let mut ws = meta.workspace(r(WORKSPACE_REF_NAME)).unwrap();
         let ws_data: &mut but_core::ref_metadata::Workspace = ws.deref_mut();
         for (stable_id, branch_name) in (0_u128..).zip(branch_names.iter()) {
             ws_data.add_or_insert_new_stack_if_not_present(
@@ -447,34 +447,36 @@ impl Sandbox {
         }
         let out = ws_data.stacks.iter().map(|s| s.id).collect();
         let project_meta = ws.project_meta();
-        meta.set_workspace(&ws)?;
-        project_meta.persist_to_local_config(&self.open_repo()?)?;
+        meta.set_workspace(&ws).unwrap();
+        project_meta
+            .persist_to_local_config(&self.open_repo())
+            .unwrap();
 
-        Ok(out)
+        out
     }
 
     /// Set target sha to a given refspec
     ///
     /// Returns the target sha we ended up setting.
-    pub fn set_target_sha(&self, spec: &str) -> anyhow::Result<gix::ObjectId> {
-        let mut meta = self.meta()?;
-        let mut ws = meta.workspace(r(WORKSPACE_REF_NAME))?;
-        let repo = self.open_repo()?;
-        let target_sha = repo.rev_parse_single(spec)?;
+    pub fn set_target_sha(&self, spec: &str) -> gix::ObjectId {
+        let mut meta = self.meta();
+        let mut ws = meta.workspace(r(WORKSPACE_REF_NAME)).unwrap();
+        let repo = self.open_repo();
+        let target_sha = repo.rev_parse_single(spec).unwrap();
         let mut project_meta = ws.project_meta();
         project_meta.target_commit_id = Some(target_sha.detach());
         ws.set_project_meta(project_meta);
         let project_meta = ws.project_meta();
-        meta.set_workspace(&ws)?;
-        project_meta.persist_to_local_config(&repo)?;
+        meta.set_workspace(&ws).unwrap();
+        project_meta.persist_to_local_config(&repo).unwrap();
 
-        Ok(target_sha.detach())
+        target_sha.detach()
     }
 }
 
 impl Sandbox {
     #[cfg(feature = "sandbox-but-api")]
-    fn set_default_settings(&mut self) -> anyhow::Result<()> {
+    fn set_default_settings(&mut self) {
         use but_settings::{
             AppSettings,
             app_settings::{
@@ -547,9 +549,10 @@ impl Sandbox {
                 },
             },
         };
-        settings.save(&self.app_data_dir().join("gitbutler/settings.json"), None)?;
+        settings
+            .save(&self.app_data_dir().join("gitbutler/settings.json"), None)
+            .unwrap();
         self.app_settings = Some(settings);
-        Ok(())
     }
 }
 

--- a/crates/but-transaction/src/tests.rs
+++ b/crates/but-transaction/src/tests.rs
@@ -15,7 +15,6 @@ use crate::{DynamicOutcome, with_transaction};
 #[track_caller]
 fn ref_target(env: &Sandbox, ref_name: &gix::refs::FullNameRef) -> Option<ObjectId> {
     env.open_repo()
-        .unwrap()
         .try_find_reference(ref_name)
         .unwrap()
         .map(|mut reference| reference.peel_to_id().unwrap().detach())
@@ -25,7 +24,7 @@ fn ref_target(env: &Sandbox, ref_name: &gix::refs::FullNameRef) -> Option<Object
 
 #[track_caller]
 fn find_commits<const N: usize>(env: &Sandbox, commits: [&str; N]) -> [ObjectId; N] {
-    let repo = env.open_repo().unwrap();
+    let repo = env.open_repo();
     commits.map(|commit| repo.rev_parse_single(commit).unwrap().detach())
 }
 
@@ -41,8 +40,8 @@ fn assert_num_snapshots(ctx: &Context, expected: usize) {
 
 #[test]
 fn squashing_three_commits() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let [three, two, one] = find_commits(&env, ["1e25c58", "9b3b3d5", "dbdbcea"]);
 
@@ -80,7 +79,7 @@ fn squashing_three_commits() {
     .unwrap();
 
     snapbox::assert_data_eq!(
-        env.git_log().unwrap(),
+        env.git_log(),
         snapbox::str![[r#"
 * ec6f55f (HEAD -> gitbutler/workspace) GitButler Workspace Commit
 * a2fc6dc (branch) squashed
@@ -94,8 +93,8 @@ fn squashing_three_commits() {
 
 #[test]
 fn rollback() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let [three, two, one] = find_commits(&env, ["1e25c58", "9b3b3d5", "dbdbcea"]);
 
@@ -124,7 +123,7 @@ fn rollback() {
     .unwrap();
 
     snapbox::assert_data_eq!(
-        env.git_log().unwrap(),
+        env.git_log(),
         snapbox::str![[r#"
 * ebaef69 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
 * 1e25c58 (branch) add file-three
@@ -140,8 +139,8 @@ fn rollback() {
 
 #[test]
 fn create_reference_without_creating_commits() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let [three] = find_commits(&env, ["1e25c58"]);
 
@@ -182,8 +181,8 @@ fn create_reference_without_creating_commits() {
 
 #[test]
 fn create_reference_relative_to_various_anchors() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let [three, two, base] = find_commits(&env, ["1e25c58", "9b3b3d5", "6674d4f"]);
 
@@ -249,8 +248,8 @@ fn create_reference_relative_to_various_anchors() {
 
 #[test]
 fn create_reference_then_remove_it_in_same_transaction() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let [three] = find_commits(&env, ["1e25c58"]);
 
@@ -292,8 +291,8 @@ fn create_reference_then_remove_it_in_same_transaction() {
 
 #[test]
 fn create_reference_then_commit_below_anchor_keeps_commit_in_workspace() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let [three, base] = find_commits(&env, ["1e25c58", "6674d4f"]);
 
@@ -333,7 +332,7 @@ fn create_reference_then_commit_below_anchor_keeps_commit_in_workspace() {
 
     assert_eq!(Some(new_commit), ref_target(&env, refname.as_ref()));
 
-    let repo = env.open_repo().unwrap();
+    let repo = env.open_repo();
     let mut branch_commit = ref_target(&env, branch.as_ref()).unwrap();
     let mut commits_above_new_branch = 0;
     while branch_commit != new_commit {
@@ -363,8 +362,8 @@ fn create_reference_then_commit_below_anchor_keeps_commit_in_workspace() {
 
 #[test]
 fn create_reference_then_commit_relative_to_it() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let [three] = find_commits(&env, ["1e25c58"]);
 
@@ -410,8 +409,8 @@ fn create_reference_then_commit_relative_to_it() {
 
 #[test]
 fn create_reference_is_removed_on_rollback() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let [three] = find_commits(&env, ["1e25c58"]);
 
@@ -453,8 +452,8 @@ fn create_reference_is_removed_on_rollback() {
 
 #[test]
 fn dynamic_rollback() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let [three, two, one] = find_commits(&env, ["1e25c58", "9b3b3d5", "dbdbcea"]);
 
@@ -489,7 +488,7 @@ fn dynamic_rollback() {
     assert!(matches!(outcome, DynamicOutcome::Rollback(2)));
 
     snapbox::assert_data_eq!(
-        env.git_log().unwrap(),
+        env.git_log(),
         snapbox::str![[r#"
 * ebaef69 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
 * 1e25c58 (branch) add file-three
@@ -505,11 +504,11 @@ fn dynamic_rollback() {
 
 #[test]
 fn discarding_three_commits() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     snapbox::assert_data_eq!(
-        env.git_log().unwrap(),
+        env.git_log(),
         snapbox::str![[r#"
 * ebaef69 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
 * 1e25c58 (branch) add file-three
@@ -548,7 +547,7 @@ fn discarding_three_commits() {
     .unwrap();
 
     snapbox::assert_data_eq!(
-        env.git_log().unwrap(),
+        env.git_log(),
         snapbox::str![[r#"
 * 8413d71 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
 * 6674d4f (origin/main, origin/HEAD, main, gitbutler/target, branch) add random-file
@@ -561,11 +560,11 @@ fn discarding_three_commits() {
 
 #[test]
 fn remove_references() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     snapbox::assert_data_eq!(
-        env.git_log().unwrap(),
+        env.git_log(),
         snapbox::str![[r#"
 * ebaef69 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
 * 1e25c58 (branch) add file-three
@@ -606,7 +605,7 @@ fn remove_references() {
     .unwrap();
 
     snapbox::assert_data_eq!(
-        env.git_log().unwrap(),
+        env.git_log(),
         snapbox::str![[r#"
 * 8413d71 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
 * 6674d4f (origin/main, origin/HEAD, main, gitbutler/target) add random-file

--- a/crates/but-worktrees/tests/worktree/worktree_new.rs
+++ b/crates/but-worktrees/tests/worktree/worktree_new.rs
@@ -1,18 +1,18 @@
 use crate::util::{test_ctx, worktree_new};
 
 #[test]
-fn can_create_worktree_from_feature_a() -> anyhow::Result<()> {
-    can_create_worktree_from("refs/heads/feature-a")
+fn can_create_worktree_from_feature_a() {
+    can_create_worktree_from("refs/heads/feature-a").unwrap();
 }
 
 #[test]
-fn can_create_worktree_from_feature_b() -> anyhow::Result<()> {
-    can_create_worktree_from("refs/heads/feature-b")
+fn can_create_worktree_from_feature_b() {
+    can_create_worktree_from("refs/heads/feature-b").unwrap();
 }
 
 #[test]
-fn can_create_worktree_from_feature_c() -> anyhow::Result<()> {
-    can_create_worktree_from("refs/heads/feature-c")
+fn can_create_worktree_from_feature_c() {
+    can_create_worktree_from("refs/heads/feature-c").unwrap();
 }
 
 fn can_create_worktree_from(refname: &str) -> anyhow::Result<()> {

--- a/crates/but/src/command/legacy/status/tui/tests/branch_picker_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/branch_picker_tests.rs
@@ -6,8 +6,8 @@ use crate::command::legacy::status::tui::tests::utils::test_tui;
 
 #[test]
 fn opens_branch_picker_popup_layout() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -20,8 +20,8 @@ fn opens_branch_picker_popup_layout() {
 
 #[test]
 fn branch_picker_filters_and_highlights_matches() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -37,8 +37,8 @@ fn branch_picker_filters_and_highlights_matches() {
 
 #[test]
 fn branch_picker_cursor_movement_updates_selected_row() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -52,8 +52,8 @@ fn branch_picker_cursor_movement_updates_selected_row() {
 
 #[test]
 fn esc_closes_branch_picker_without_changing_selection() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -68,8 +68,8 @@ fn esc_closes_branch_picker_without_changing_selection() {
 
 #[test]
 fn confirm_selects_highlighted_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -83,8 +83,8 @@ fn confirm_selects_highlighted_branch() {
 
 #[test]
 fn confirm_with_no_matches_keeps_picker_open() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -99,8 +99,8 @@ fn confirm_with_no_matches_keeps_picker_open() {
 
 #[test]
 fn pick_and_goto_noop_when_commit_file_list_open() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -119,8 +119,8 @@ fn pick_and_goto_noop_when_commit_file_list_open() {
 
 #[test]
 fn goto_unassigned_changes() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 

--- a/crates/but/src/command/legacy/status/tui/tests/branch_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/branch_tests.rs
@@ -6,8 +6,8 @@ use crate::command::legacy::status::tui::tests::utils::test_tui;
 
 #[test]
 fn branch_key_from_unassigned_creates_new_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -20,8 +20,8 @@ fn branch_key_from_unassigned_creates_new_branch() {
 
 #[test]
 fn branch_key_from_commit_is_noop() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -34,8 +34,8 @@ fn branch_key_from_commit_is_noop() {
 
 #[test]
 fn branch_key_from_branch_creates_new_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -48,8 +48,8 @@ fn branch_key_from_branch_creates_new_branch() {
 
 #[test]
 fn branch_key_keeps_global_file_list_open() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -67,8 +67,8 @@ fn branch_key_keeps_global_file_list_open() {
 
 #[test]
 fn focus_reload_preserves_branch_selection() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -81,8 +81,8 @@ fn focus_reload_preserves_branch_selection() {
 
 #[test]
 fn deleted_branch_name_can_be_reused_without_restoring_old_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -119,8 +119,8 @@ fn deleted_branch_name_can_be_reused_without_restoring_old_branch() {
 
 #[test]
 fn focus_reload_preserves_merge_base_selection() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -136,8 +136,8 @@ fn focus_reload_preserves_merge_base_selection() {
 
 #[test]
 fn inline_branch_reword_confirm_renames_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -166,8 +166,8 @@ fn inline_branch_reword_confirm_renames_branch() {
 
 #[test]
 fn inline_branch_reword_esc_cancels() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -186,8 +186,8 @@ fn inline_branch_reword_esc_cancels() {
 
 #[test]
 fn inline_branch_reword_preserves_selection_after_reload_with_multiple_branches() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -212,8 +212,8 @@ fn inline_branch_reword_preserves_selection_after_reload_with_multiple_branches(
 
 #[test]
 fn inline_branch_reword_space_before_close_bracket() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 

--- a/crates/but/src/command/legacy/status/tui/tests/command_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/command_tests.rs
@@ -6,8 +6,8 @@ use super::utils::test_tui;
 
 #[test]
 fn command_mode_runs_successful_command_and_returns_to_normal_mode() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -23,8 +23,8 @@ fn command_mode_runs_successful_command_and_returns_to_normal_mode() {
 
 #[test]
 fn command_mode_keeps_input_when_command_exits_non_zero() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 

--- a/crates/but/src/command/legacy/status/tui/tests/commit_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/commit_tests.rs
@@ -9,8 +9,8 @@ const TEST_EDITOR_MESSAGE: &str = "commit from tui test";
 
 #[test]
 fn commit_mode_enter_and_escape() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -32,8 +32,8 @@ fn commit_mode_enter_and_escape() {
 
 #[test]
 fn commit_confirm_on_source_is_noop() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -54,8 +54,8 @@ fn commit_confirm_on_source_is_noop() {
 
 #[test]
 fn commiting_with_no_unassigned_changes() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -93,8 +93,8 @@ fn commiting_with_no_unassigned_changes() {
 
 #[test]
 fn commit_from_unstaged_changes_creates_commit_visible_in_tui() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file(
         "editor.sh",
@@ -130,8 +130,8 @@ fn commit_from_unstaged_changes_creates_commit_visible_in_tui() {
 
 #[test]
 fn commit_from_unstaged_changes_to_new_branch_creates_branch_and_commit() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file(
         "editor.sh",
@@ -167,8 +167,8 @@ fn commit_from_unstaged_changes_to_new_branch_creates_branch_and_commit() {
 
 #[test]
 fn commit_from_unstaged_changes_with_multiple_hunks_in_same_file_commits_all_changes() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file(
         ".git/editor.sh",
@@ -239,8 +239,8 @@ fn commit_from_unstaged_changes_with_multiple_hunks_in_same_file_commits_all_cha
 
 #[test]
 fn commit_mode_shows_commit_below_on_commit_rows() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -261,8 +261,8 @@ fn commit_mode_shows_commit_below_on_commit_rows() {
 
 #[test]
 fn commit_to_commit_above_creates_commit_visible_in_tui() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file(
         "editor.sh",
@@ -305,8 +305,8 @@ fn commit_to_commit_above_creates_commit_visible_in_tui() {
 
 #[test]
 fn commit_to_commit_below_creates_commit_visible_in_tui() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file(
         "editor.sh",
@@ -346,8 +346,8 @@ fn commit_to_commit_below_creates_commit_visible_in_tui() {
 
 #[test]
 fn commit_mode_from_staged_changes_stays_within_current_stack() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -393,8 +393,8 @@ fn commit_mode_from_staged_changes_stays_within_current_stack() {
 
 #[test]
 fn commit_with_inline_reword() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -441,8 +441,8 @@ fn commit_with_inline_reword() {
 
 #[test]
 fn commit_moved_file_from_unassigned_changes_line() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -481,8 +481,8 @@ fn commit_moved_file_from_unassigned_changes_line() {
 
 #[test]
 fn commit_moved_file_from_file_line() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -523,8 +523,8 @@ fn commit_moved_file_from_file_line() {
 
 #[test]
 fn commit_moved_and_modified_file() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -568,8 +568,8 @@ fn commit_moved_and_modified_file() {
 
 #[test]
 fn cannot_select_unassigned_files_with_commits_marked() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -595,8 +595,8 @@ fn cannot_select_unassigned_files_with_commits_marked() {
 
 #[test]
 fn cannot_select_committed_files_with_commits_marked() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -618,8 +618,8 @@ fn cannot_select_committed_files_with_commits_marked() {
 
 #[test]
 fn cannot_select_committed_files_from_global_listing_with_commits_marked() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -648,8 +648,8 @@ fn cannot_select_committed_files_from_global_listing_with_commits_marked() {
 
 #[test]
 fn escape_from_commit_mode_preserves_marks() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -668,8 +668,8 @@ fn escape_from_commit_mode_preserves_marks() {
 
 #[test]
 fn mark_and_commit_multiple_uncommitted_files() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -698,8 +698,8 @@ fn mark_and_commit_multiple_uncommitted_files() {
 
 #[test]
 fn committing_above_below() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -716,8 +716,8 @@ fn committing_above_below() {
 
 #[test]
 fn cannot_commit_to_new_branch_from_commit_line() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -737,8 +737,8 @@ fn cannot_commit_to_new_branch_from_commit_line() {
 
 #[test]
 fn commit_to_new_branch_from_unassigned() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     let mut tui = test_tui(env);
 

--- a/crates/but/src/command/legacy/status/tui/tests/details_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/details_tests.rs
@@ -9,8 +9,8 @@ use crate::command::legacy::status::tui::tests::utils::{
 
 #[test]
 fn toggle_details_view_for_commit() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -26,8 +26,8 @@ fn toggle_details_view_for_commit() {
 
 #[test]
 fn details_view_updates_with_selection_changes() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -49,8 +49,8 @@ fn details_view_updates_with_selection_changes() {
 
 #[test]
 fn details_view_supports_scroll_controls() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let file_contents = (1..=120)
         .map(|line| format!("line-{line:03}\n"))
@@ -109,8 +109,8 @@ fn details_view_supports_scroll_controls() {
 
 #[test]
 fn commit_message_wraps_in_details_view() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui_with_options(
         env,
@@ -150,8 +150,8 @@ fn commit_message_wraps_in_details_view() {
 
 #[test]
 fn details_view_renders_multiple_hunks_and_files() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let first_file = (1..=8)
         .map(|line| format!("alpha-{line}\n"))
@@ -180,8 +180,8 @@ fn details_view_renders_multiple_hunks_and_files() {
 
 #[test]
 fn details_diff_svg_shows_plus_and_minus_backgrounds() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("A", "A-changed\n");
 
@@ -202,8 +202,8 @@ fn details_diff_svg_shows_plus_and_minus_backgrounds() {
 
 #[test]
 fn toggling_details_off_and_on_resets_scroll_position() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
     let file_contents = (1..=80)
         .map(|line| format!("line-{line:03}\n"))
         .collect::<String>();
@@ -241,8 +241,8 @@ fn toggling_details_off_and_on_resets_scroll_position() {
 
 #[test]
 fn details_view_syntax_highlighting_survives_scrolling() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let rust_code = (1..=120)
         .map(|line| {
@@ -280,8 +280,8 @@ fn details_view_syntax_highlighting_survives_scrolling() {
 
 #[test]
 fn details_view_can_grow_and_shrink() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui_with_options(
         env,
@@ -299,8 +299,8 @@ fn details_view_can_grow_and_shrink() {
 
 #[test]
 fn details_view_resize_clamps_to_max_and_min_width() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui_with_options(
         env,
@@ -321,8 +321,8 @@ fn details_view_resize_clamps_to_max_and_min_width() {
 
 #[test]
 fn details_cursor_stays_visible_after_resizing() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let long_lines = (1..=80)
         .map(|line| format!("this is a deliberately long line in alpha.txt #{line:03} that should wrap in narrow detail panes\n"))
@@ -353,8 +353,8 @@ fn details_cursor_stays_visible_after_resizing() {
 
 #[test]
 fn toggle_full_screen_details_view() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("file.txt", "content");
 
@@ -433,8 +433,8 @@ fn toggle_full_screen_details_view() {
 
 #[test]
 fn full_screen_details_scrolls_selected_hunk_to_include_final_line() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let first_file_contents = (1..=4)
         .map(|line| format!("first-{line:02}\n"))
@@ -468,8 +468,8 @@ fn full_screen_details_scrolls_selected_hunk_to_include_final_line() {
 
 #[test]
 fn rubbing_from_full_screen_details() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("file.txt", "content");
 
@@ -501,8 +501,8 @@ fn rubbing_from_full_screen_details() {
 
 #[test]
 fn rubbing_from_split_details() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("file.txt", "content");
 
@@ -528,8 +528,8 @@ fn rubbing_from_split_details() {
 
 #[test]
 fn details_view_with_no_changes() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -541,8 +541,8 @@ fn details_view_with_no_changes() {
 
 #[test]
 fn unfocusing_split_details_with_escape() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("file.txt", "content");
 
@@ -561,8 +561,8 @@ fn unfocusing_split_details_with_escape() {
 
 #[test]
 fn close_split_details_with_escape() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("file.txt", "content");
 
@@ -579,8 +579,8 @@ fn close_split_details_with_escape() {
 
 #[test]
 fn escape_after_toggling_split_details_closed_does_not_reopen_details() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("file.txt", "content");
 
@@ -597,8 +597,8 @@ fn escape_after_toggling_split_details_closed_does_not_reopen_details() {
 
 #[test]
 fn escape_after_toggling_full_screen_details_closed_does_not_reopen_details() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("file.txt", "content");
 
@@ -615,8 +615,8 @@ fn escape_after_toggling_full_screen_details_closed_does_not_reopen_details() {
 
 #[test]
 fn open_and_focus_details_split_can_be_closed_with_esc() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("file.txt", "content");
 
@@ -637,8 +637,8 @@ fn open_and_focus_details_split_can_be_closed_with_esc() {
 
 #[test]
 fn viewing_empty_file() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     env.file("empty file", "");
 

--- a/crates/but/src/command/legacy/status/tui/tests/discard_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/discard_tests.rs
@@ -6,8 +6,8 @@ use crate::command::legacy::status::tui::tests::utils::test_tui;
 
 #[test]
 fn discard_prompt_can_be_cancelled() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -29,8 +29,8 @@ fn discard_prompt_can_be_cancelled() {
 
 #[test]
 fn discard_unassigned_confirm_yes_discards_changes() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -57,8 +57,8 @@ fn discard_unassigned_confirm_yes_discards_changes() {
 
 #[test]
 fn discard_unassigned_cancel_keeps_changes() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -88,8 +88,8 @@ fn discard_unassigned_cancel_keeps_changes() {
 
 #[test]
 fn discard_commit_confirm_yes_removes_commit() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -116,8 +116,8 @@ fn discard_commit_confirm_yes_removes_commit() {
 
 #[test]
 fn discard_top_commit_selects_next_commit_in_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -142,8 +142,8 @@ fn discard_top_commit_selects_next_commit_in_branch() {
 
 #[test]
 fn discard_stack_confirm_yes_discards_staged_changes() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -186,8 +186,8 @@ fn discard_stack_confirm_yes_discards_staged_changes() {
 
 #[test]
 fn discard_branch_confirm_yes_removes_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -218,8 +218,8 @@ fn discard_branch_confirm_yes_removes_branch() {
 
 #[test]
 fn discard_branch_cancel_keeps_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -250,8 +250,8 @@ fn discard_branch_cancel_keeps_branch() {
 
 #[test]
 fn discard_on_committed_file_row_is_noop() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -270,8 +270,8 @@ fn discard_on_committed_file_row_is_noop() {
 
 #[test]
 fn discard_multiple_commits() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     let mut tui = test_tui(env);
 
@@ -300,8 +300,8 @@ fn discard_multiple_commits() {
 
 #[test]
 fn mark_and_discard_uncommitted_files() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     env.file("one", "");
     env.file("two", "");

--- a/crates/but/src/command/legacy/status/tui/tests/marking_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/marking_tests.rs
@@ -6,8 +6,8 @@ use crate::command::legacy::status::tui::{BackstackEntry, tests::utils::test_tui
 
 #[test]
 fn marking_individual_commit_toggles_mark_indicator() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -26,8 +26,8 @@ fn marking_individual_commit_toggles_mark_indicator() {
 
 #[test]
 fn marking_branch_toggles_all_commits_in_that_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -46,7 +46,7 @@ fn marking_branch_toggles_all_commits_in_that_branch() {
 
 #[test]
 fn marking_unassigned_toggles_all_unassigned_files() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.file("a.txt", "content");
     env.file("b.txt", "content");
 
@@ -73,8 +73,8 @@ fn marking_unassigned_toggles_all_unassigned_files() {
 
 #[test]
 fn multi_squash_marked_commits_into_selected_marked_target() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -105,8 +105,8 @@ fn multi_squash_marked_commits_into_selected_marked_target() {
 
 #[test]
 fn marks_still_show_in_split_details() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     env.file("one", "content of one");
     env.file("two", "content of two");

--- a/crates/but/src/command/legacy/status/tui/tests/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/mod.rs
@@ -59,8 +59,8 @@ fn assert_cursor_context_rows(
 
 #[test]
 fn shows_full_error_when_message_wraps() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -78,8 +78,8 @@ fn shows_full_error_when_message_wraps() {
 
 #[test]
 fn shows_full_error_cause_chain_with_multiple_contexts() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -102,8 +102,8 @@ fn shows_full_error_cause_chain_with_multiple_contexts() {
 
 #[test]
 fn narrow_hotbar_prioritizes_help_and_quit() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui_with_options(
         env,
@@ -121,8 +121,8 @@ fn narrow_hotbar_prioritizes_help_and_quit() {
 
 #[test]
 fn narrow_hotbar_keeps_help_and_quit_visible_in_modal_modes() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui_with_options(
         env,
@@ -141,8 +141,8 @@ fn narrow_hotbar_keeps_help_and_quit_visible_in_modal_modes() {
 
 #[test]
 fn help_popup_opens_over_status_view() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -155,8 +155,8 @@ fn help_popup_opens_over_status_view() {
 
 #[test]
 fn help_popup_scrolls() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui_with_options(
         env,
@@ -182,8 +182,8 @@ fn help_popup_scrolls() {
 
 #[test]
 fn undo_opens_confirm_for_latest_snapshot() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
     let mut tui = test_tui(env);
 
     tui.env().file("test.txt", "content");
@@ -232,8 +232,8 @@ fn format_error_for_tui_shows_single_message_for_leaf_error() {
 
 #[test]
 fn basic_cursor_movement() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -273,8 +273,8 @@ fn basic_cursor_movement() {
 
 #[test]
 fn movement_aliases_j_k() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -296,8 +296,8 @@ fn movement_aliases_j_k() {
 
 #[test]
 fn section_jumps_shift_j_k() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -319,8 +319,8 @@ fn section_jumps_shift_j_k() {
 
 #[test]
 fn shift_k_from_commit_moves_to_current_section_header_first() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -339,8 +339,8 @@ fn shift_k_from_commit_moves_to_current_section_header_first() {
 
 #[test]
 fn shift_k_from_second_stack_commit_moves_to_its_header() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -362,8 +362,8 @@ fn shift_k_from_second_stack_commit_moves_to_its_header() {
 
 #[test]
 fn cursor_movement_scrolls_viewport_down() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui_with_options(
         env,
@@ -389,8 +389,8 @@ fn cursor_movement_scrolls_viewport_down() {
 
 #[test]
 fn cursor_movement_scrolls_viewport_up() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui_with_options(
         env,
@@ -416,8 +416,8 @@ fn cursor_movement_scrolls_viewport_up() {
 
 #[test]
 fn scrolling_keeps_three_rows_of_context_when_possible() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui_with_options(
         env,
@@ -445,8 +445,8 @@ fn scrolling_keeps_three_rows_of_context_when_possible() {
 
 #[test]
 fn section_jumps_scroll_viewport_when_target_is_offscreen() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui_with_options(
         env,
@@ -478,8 +478,8 @@ fn section_jumps_scroll_viewport_when_target_is_offscreen() {
 
 #[test]
 fn moving_to_merge_base_scrolls_to_keep_selection_visible() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui_with_options(
         env,
@@ -502,8 +502,8 @@ fn moving_to_merge_base_scrolls_to_keep_selection_visible() {
 
 #[test]
 fn reload_preserves_visible_selection_when_scrolled() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui_with_options(
         env,
@@ -528,8 +528,8 @@ fn reload_preserves_visible_selection_when_scrolled() {
 
 #[test]
 fn inline_reword_renders_on_visible_row_when_scrolled() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui_with_options(
         env,
@@ -555,8 +555,8 @@ fn inline_reword_renders_on_visible_row_when_scrolled() {
 
 #[test]
 fn creating_empty_commits() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -578,8 +578,8 @@ fn creating_empty_commits() {
 
 #[test]
 fn inline_reword() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -607,8 +607,8 @@ fn inline_reword() {
 
 #[test]
 fn inline_reword_open_editor_keeps_inline_message_when_editor_makes_no_changes() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file(".git/editor.sh", "exit 0\n");
     let editor_path = env.projects_root().join(".git/editor.sh");
@@ -631,8 +631,8 @@ fn inline_reword_open_editor_keeps_inline_message_when_editor_makes_no_changes()
 
 #[test]
 fn esc_leaves_rub_mode() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -656,8 +656,8 @@ fn esc_leaves_rub_mode() {
 
 #[test]
 fn mode_key_r_enters_and_escape_leaves_rub_mode() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -680,8 +680,8 @@ fn mode_key_r_enters_and_escape_leaves_rub_mode() {
 
 #[test]
 fn rub_mode_shift_j_lands_on_first_selectable_in_next_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -701,8 +701,8 @@ fn rub_mode_shift_j_lands_on_first_selectable_in_next_branch() {
 
 #[test]
 fn rub_mode_shift_j_can_jump_between_branches() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -725,8 +725,8 @@ fn rub_mode_shift_j_can_jump_between_branches() {
 
 #[test]
 fn rub_mode_shift_k_jumps_to_first_selectable_in_previous_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -752,8 +752,8 @@ fn rub_mode_shift_k_jumps_to_first_selectable_in_previous_branch() {
 
 #[test]
 fn mode_key_c_enters_and_escape_leaves_commit_mode() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -773,8 +773,8 @@ fn mode_key_c_enters_and_escape_leaves_commit_mode() {
 
 #[test]
 fn mode_key_m_enters_and_escape_leaves_move_mode() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -793,8 +793,8 @@ fn mode_key_m_enters_and_escape_leaves_move_mode() {
 
 #[test]
 fn key_b_creates_new_branch_from_selected_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -807,8 +807,8 @@ fn key_b_creates_new_branch_from_selected_branch() {
 
 #[test]
 fn rubbing() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -866,8 +866,8 @@ fn rubbing() {
 
 #[test]
 fn global_file_list_does_not_restrict_cursor() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -889,8 +889,8 @@ fn global_file_list_does_not_restrict_cursor() {
 
 #[test]
 fn commit_file_list_scopes_cursor_to_files_in_selected_commit() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -912,8 +912,8 @@ fn commit_file_list_scopes_cursor_to_files_in_selected_commit() {
 
 #[test]
 fn commit_file_toggle_on_commit_without_files_is_noop() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui_with_options(
         env,
@@ -946,8 +946,8 @@ fn commit_file_toggle_on_commit_without_files_is_noop() {
 
 #[test]
 fn commit_file_list_rub_esc_leaves_rub_and_closes_file_list() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -972,8 +972,8 @@ fn commit_file_list_rub_esc_leaves_rub_and_closes_file_list() {
 
 #[test]
 fn confirm_rub_keeps_commit_file_list_open() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -995,8 +995,8 @@ fn confirm_rub_keeps_commit_file_list_open() {
 
 #[test]
 fn esc_in_normal_mode_closes_global_file_list() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -1018,8 +1018,8 @@ fn esc_in_normal_mode_closes_global_file_list() {
 
 #[test]
 fn esc_in_normal_mode_closes_commit_file_list() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -1038,8 +1038,8 @@ fn esc_in_normal_mode_closes_commit_file_list() {
 
 #[test]
 fn commit_file_toggle_off_from_commit_row_preserves_commit_selection() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -1058,8 +1058,8 @@ fn commit_file_toggle_off_from_commit_row_preserves_commit_selection() {
 
 #[test]
 fn pick_changes_mode() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     env.file("one", "content of one");
     env.file("two", "content of two");
@@ -1096,8 +1096,8 @@ fn pick_changes_mode() {
 
 #[test]
 fn stays_in_pick_change_mode_after_full_screen_details() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     env.file("one", "content of one");
     env.file("two", "content of two");
@@ -1159,8 +1159,8 @@ fn stays_in_pick_change_mode_after_full_screen_details() {
 
 #[test]
 fn pick_changes_mode_supports_focusing_details_view() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     env.file("one", "content of one");
     env.file("two", "content of two");
@@ -1181,8 +1181,8 @@ fn pick_changes_mode_supports_focusing_details_view() {
 
 #[test]
 fn consistent_commit_shas_in_tests() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     let mut tui = test_tui(env);
 
@@ -1193,8 +1193,8 @@ fn consistent_commit_shas_in_tests() {
 
 #[test]
 fn jumping_up_down() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -1217,8 +1217,8 @@ fn jumping_up_down() {
 
 #[test]
 fn jumping_up_down_non_normal_mode() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("file", "");
 

--- a/crates/but/src/command/legacy/status/tui/tests/move_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/move_tests.rs
@@ -9,8 +9,8 @@ use crate::command::legacy::status::tui::{
 
 #[test]
 fn esc_leaves_move_mode() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -30,8 +30,8 @@ fn esc_leaves_move_mode() {
 
 #[test]
 fn move_mode_keeps_selected_commit_and_extension_visible_when_scrolled() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui_with_options(
         env,
@@ -68,8 +68,8 @@ fn move_mode_keeps_selected_commit_and_extension_visible_when_scrolled() {
 
 #[test]
 fn move_commit_above_other_commit_reorders_tui() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -108,8 +108,8 @@ fn move_commit_above_other_commit_reorders_tui() {
 
 #[test]
 fn move_commit_down_from_source_selects_next_commit() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -137,9 +137,8 @@ fn move_commit_down_from_source_selects_next_commit() {
 fn move_commit_up_from_top_commit_selects_source_branch() {
     let env = Sandbox::open_or_init_scenario_with_target_and_default_settings(
         "two-stacks-one-single-and-ready-to-mingle-one-double",
-    )
-    .unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    );
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -161,9 +160,8 @@ fn move_commit_up_from_top_commit_selects_source_branch() {
 fn move_branch_onto_other_branch_reorders_stacks() {
     let env = Sandbox::open_or_init_scenario_with_target_and_default_settings(
         "two-stacks-one-single-and-ready-to-mingle-one-double",
-    )
-    .unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    );
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -192,9 +190,8 @@ fn move_branch_onto_other_branch_reorders_stacks() {
 fn move_branch_to_merge_base_tears_off_branch() {
     let env = Sandbox::open_or_init_scenario_with_target_and_default_settings(
         "two-stacks-one-single-and-ready-to-mingle-one-double",
-    )
-    .unwrap();
-    env.setup_metadata(&["A", "C", "B"]).unwrap();
+    );
+    env.setup_metadata(&["A", "C", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -230,8 +227,8 @@ fn move_branch_to_merge_base_tears_off_branch() {
 
 #[test]
 fn moving_multiple_commits() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 

--- a/crates/but/src/command/legacy/status/tui/tests/rub_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/rub_tests.rs
@@ -7,8 +7,8 @@ use crate::command::legacy::status::tui::tests::utils::test_tui;
 // Tests RubOperation::UnassignedToCommit.
 #[test]
 fn rub_api_unassigned_to_commit() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -47,8 +47,8 @@ fn rub_api_unassigned_to_commit() {
 
 #[test]
 fn rub_api_unassigned_to_commit_preserves_global_file_list() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -79,8 +79,8 @@ fn rub_api_unassigned_to_commit_preserves_global_file_list() {
 // Tests RubOperation::UnassignUncommitted.
 #[test]
 fn rub_api_unassign_uncommitted_operation() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -102,8 +102,8 @@ fn rub_api_unassign_uncommitted_operation() {
 // Tests RubOperation::UncommittedToCommit.
 #[test]
 fn rub_api_uncommitted_to_commit_operation() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -124,8 +124,8 @@ fn rub_api_uncommitted_to_commit_operation() {
 
 #[test]
 fn mark_and_rub_multiple_uncommitted_files() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -155,8 +155,8 @@ fn mark_and_rub_multiple_uncommitted_files() {
 // Ensure rub mode does not offer branch destinations.
 #[test]
 fn rub_api_cannot_rub_into_branches() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -175,8 +175,8 @@ fn rub_api_cannot_rub_into_branches() {
 // Tests RubMessage::StartReverse on a commit when unassigned has changes.
 #[test]
 fn rub_api_reverse_rub_uses_unassigned_source_when_unassigned_has_changes() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -202,8 +202,8 @@ fn rub_api_reverse_rub_uses_unassigned_source_when_unassigned_has_changes() {
 // Tests RubMessage::StartReverse with unassigned source when stack has no assigned changes.
 #[test]
 fn rub_api_reverse_rub_uses_unassigned_source_when_stack_has_no_assigned_changes() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -225,8 +225,8 @@ fn rub_api_reverse_rub_uses_unassigned_source_when_stack_has_no_assigned_changes
 // Tests RubMessage::StartReverse is a no-op when not selecting a commit.
 #[test]
 fn rub_api_reverse_rub_is_noop_on_non_commit_selection() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -240,8 +240,8 @@ fn rub_api_reverse_rub_is_noop_on_non_commit_selection() {
 // Tests RubOperation::UndoCommit.
 #[test]
 fn rub_api_undo_commit_operation() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -263,8 +263,8 @@ fn rub_api_undo_commit_operation() {
 // Tests RubOperation::SquashCommits.
 #[test]
 fn rub_api_squash_commits_operation() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -283,8 +283,8 @@ fn rub_api_squash_commits_operation() {
 
 #[test]
 fn rub_api_squash_commits_toggles_message_strategy_labels() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -314,8 +314,8 @@ fn rub_api_squash_commits_toggles_message_strategy_labels() {
 
 #[test]
 fn rub_api_squash_commits_can_keep_target_message() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -337,8 +337,8 @@ fn rub_api_squash_commits_can_keep_target_message() {
 
 #[test]
 fn rub_api_squash_commits_can_keep_source_message() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -363,8 +363,8 @@ fn rub_api_squash_commits_can_keep_source_message() {
 // Tests RubOperation::CommittedFileToCommit.
 #[test]
 fn rub_api_committed_file_to_commit_operation() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -390,8 +390,8 @@ fn rub_api_committed_file_to_commit_operation() {
 // Tests RubOperation::CommittedFileToUnassigned.
 #[test]
 fn rub_api_committed_file_to_unassigned_operation() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -419,8 +419,8 @@ fn rub_api_committed_file_to_unassigned_operation() {
 // Tests RubOperation::UnassignedToStack.
 #[test]
 fn rub_api_unassigned_to_stack_operation() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -446,8 +446,8 @@ fn rub_api_unassigned_to_stack_operation() {
 // Tests RubOperation::UncommittedToStack.
 #[test]
 fn rub_api_uncommitted_to_stack_operation() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -473,8 +473,8 @@ fn rub_api_uncommitted_to_stack_operation() {
 // Tests RubOperation::StackToUnassigned.
 #[test]
 fn rub_api_stack_to_unassigned_operation() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -499,8 +499,8 @@ fn rub_api_stack_to_unassigned_operation() {
 // Tests RubOperation::StackToStack.
 #[test]
 fn rub_api_stack_to_stack_operation() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let mut tui = test_tui(env);
 
@@ -554,8 +554,8 @@ fn rub_api_stack_to_stack_operation() {
 
 #[test]
 fn rub_multiple_commits_into_unassigned() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     let mut tui = test_tui(env);
 

--- a/crates/but/src/command/legacy/status/tui/tests/stack_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/stack_tests.rs
@@ -6,8 +6,8 @@ use crate::command::legacy::status::tui::tests::utils::test_tui;
 
 #[test]
 fn unapply_stack() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -36,8 +36,8 @@ fn unapply_stack() {
 
 #[test]
 fn enter_stack_mode_from_commits() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let mut tui = test_tui(env);
 
@@ -49,8 +49,8 @@ fn enter_stack_mode_from_commits() {
 
 #[test]
 fn moving_stacks() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     let mut tui = test_tui(env);
 
@@ -89,8 +89,8 @@ fn moving_stacks() {
 
 #[test]
 fn applying_stacks() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     let mut tui = test_tui(env);
 

--- a/crates/but/src/command/legacy/status/tui/tests/utils.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/utils.rs
@@ -84,7 +84,7 @@ pub(super) fn test_tui_with_options(env: Sandbox, options: TestTuiOptions) -> Te
     env.invoke_git("config gitoxide.commit.committerDate '2000-01-01 00:00:00 +0000'");
     env.invoke_git("config gitbutler.testing.changeId 1");
 
-    let mut ctx = env.context().expect("failed to create context");
+    let mut ctx = env.context();
     let mode = but_api::legacy::modes::operating_mode(&ctx)
         .expect("failed to get operating mode")
         .operating_mode;
@@ -190,7 +190,7 @@ impl TestTui {
         let mut other_messages = Vec::new();
 
         with_stable_commit_env(|| {
-            let mut ctx = self.env().context().expect("failed to create context");
+            let mut ctx = self.env().context();
             let mut out = TestTuiInputOutputChannel(&mut self.out);
             render_loop_once(
                 &mut self.app,

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -7,7 +7,7 @@ use but_testsupport::{hex_to_id, hunk_header};
 use crate::{CliId, IdMap, id::id_usage::UintId};
 
 #[test]
-fn uint_id_from_short_id() -> anyhow::Result<()> {
+fn uint_id_from_short_id() {
     assert_eq!(UintId::from_name(b"a".as_slice()), None);
     assert_eq!(UintId::from_name(b"a0".as_slice()), None);
     assert_eq!(UintId::from_name(b"--".as_slice()), None);
@@ -19,11 +19,10 @@ fn uint_id_from_short_id() -> anyhow::Result<()> {
     assert_eq!(UintId::from_name(b"gz0".as_slice()), Some(UintId(1420)));
     assert_eq!(UintId::from_name(b"zzz".as_slice()), Some(UintId(26639)));
     assert_eq!(UintId::from_name(b"g000".as_slice()), None);
-    Ok(())
 }
 
 #[test]
-fn uint_id_to_short_id() -> anyhow::Result<()> {
+fn uint_id_to_short_id() {
     assert_eq!(UintId(0).to_short_id(), "g0");
     assert_eq!(UintId(19).to_short_id(), "z0");
     assert_eq!(UintId(700).to_short_id(), "gz");
@@ -41,7 +40,6 @@ fn uint_id_to_short_id() -> anyhow::Result<()> {
         "00",
         "too big always yields this"
     );
-    Ok(())
 }
 
 #[test]

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -16,9 +16,9 @@ fn find_unassigned_cli_id(status: &serde_json::Value, path: &str) -> Option<Stri
 
 #[test]
 fn uncommitted_file() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata_at_target(&["A", "B"], "origin/main")?;
+    env.setup_metadata_at_target(&["A", "B"], "origin/main");
     commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
 
     env.but("--format json status -f")
@@ -56,7 +56,7 @@ Hint: you can run `but undo` to undo these changes
         .stderr_eq(str![""]);
 
     // Change was absorbed
-    let repo = env.open_repo()?;
+    let repo = env.open_repo();
     let blob = repo.rev_parse_single(b"A:a.txt")?.object()?;
     insta::assert_snapshot!(blob.data.as_bstr(), @"
     firsta
@@ -88,9 +88,9 @@ Hint: you can run `but undo` to undo these changes
 
 #[test]
 fn uncommitted_hunk() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata_at_target(&["A", "B"], "origin/main")?;
+    env.setup_metadata_at_target(&["A", "B"], "origin/main");
     commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
 
     // Verify that the first hunk is j0, and absorb it.
@@ -134,7 +134,7 @@ Hint: you can run `but undo` to undo these changes
         .stderr_eq(str![""]);
 
     // Change was partially absorbed
-    let repo = env.open_repo()?;
+    let repo = env.open_repo();
     let blob = repo.rev_parse_single(b"A:a.txt")?.object()?;
     insta::assert_snapshot!(blob.data.as_bstr(), @"
     firsta
@@ -172,9 +172,9 @@ Hint: you can run `but undo` to undo these changes
 
 #[test]
 fn committed_hunk() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata_at_target(&["A", "B"], "origin/main")?;
+    env.setup_metadata_at_target(&["A", "B"], "origin/main");
     commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
 
     // Verify that the first hunk is j0, and commit it.
@@ -377,7 +377,7 @@ Hint: run `but help` for all commands
 "#]]);
 
     // Change was full absorbed
-    let repo = env.open_repo()?;
+    let repo = env.open_repo();
     let blob = repo.rev_parse_single(b"A:a.txt")?.object()?;
     insta::assert_snapshot!(blob.data.as_bstr(), @"
     first new
@@ -396,8 +396,8 @@ Hint: run `but help` for all commands
 
 #[test]
 fn concurrent_absorb_of_independent_files_succeeds() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
     commit_file_with_worktree_changes_as_two_hunks(&env, "B", "b.txt");
@@ -438,9 +438,9 @@ fn concurrent_absorb_of_independent_files_succeeds() -> anyhow::Result<()> {
 
 #[test]
 fn dry_run_shows_plan_without_changes() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata_at_target(&["A", "B"], "origin/main")?;
+    env.setup_metadata_at_target(&["A", "B"], "origin/main");
     commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
 
     // Get initial status
@@ -479,7 +479,7 @@ Dry run complete. No changes were made.
     );
 
     // Also verify the workspace commit did NOT change during dry-run
-    let repo = env.open_repo()?;
+    let repo = env.open_repo();
     let ws_id = repo.rev_parse_single(b"gitbutler/workspace")?.detach();
     // Re-run dry-run and confirm workspace is still the same
     env.but("absorb i0 --dry-run").assert().success();
@@ -487,7 +487,7 @@ Dry run complete. No changes were made.
     assert_eq!(ws_id, ws_id_after, "dry-run must not touch workspace HEAD");
 
     // Verify the file content wasn't actually changed
-    let repo = env.open_repo()?;
+    let repo = env.open_repo();
     let blob = repo.rev_parse_single(b"A:a.txt")?.object()?;
     insta::assert_snapshot!(blob.data.as_bstr(), @"
     first
@@ -529,13 +529,13 @@ Dry run complete. No changes were made.
 /// an up-to-date synthetic commit rather than a stale one.
 #[test]
 fn workspace_head_is_refreshed_after_absorb() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata_at_target(&["A", "B"], "origin/main")?;
+    env.setup_metadata_at_target(&["A", "B"], "origin/main");
     commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
 
     // Record the workspace commit *before* absorb.
-    let repo = env.open_repo()?;
+    let repo = env.open_repo();
     let ws_before = repo.rev_parse_single(b"gitbutler/workspace")?.detach();
 
     env.but("absorb i0").assert().success().stderr_eq(str![""]);

--- a/crates/but/tests/but/command/alias.rs
+++ b/crates/but/tests/but/command/alias.rs
@@ -4,8 +4,8 @@ use crate::utils::Sandbox;
 use snapbox::str;
 
 #[test]
-fn local_alias_roundtrip_uses_repo_config() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+fn local_alias_roundtrip_uses_repo_config() {
+    let env = Sandbox::empty();
     env.invoke_bash("git init repo");
 
     env.invoke_git_fails(
@@ -23,13 +23,11 @@ fn local_alias_roundtrip_uses_repo_config() -> anyhow::Result<()> {
         "-C repo config --local --get but.alias.st",
         "local alias should be removed from repo config",
     );
-
-    Ok(())
 }
 
 #[test]
-fn global_alias_roundtrip_uses_global_config() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+fn global_alias_roundtrip_uses_global_config() {
+    let env = Sandbox::empty();
     env.invoke_bash("git init repo");
     let global_config = env.projects_root().join("global.gitconfig");
 
@@ -54,15 +52,13 @@ fn global_alias_roundtrip_uses_global_config() -> anyhow::Result<()> {
         "config --file global.gitconfig --get but.alias.st",
         "global alias should be removed from the configured global file",
     );
-
-    Ok(())
 }
 
 #[cfg(feature = "legacy")]
 #[test]
-fn can_invoke_alias() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn can_invoke_alias() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("alias add b branch").assert().success();
 
@@ -74,15 +70,13 @@ active  ✓ *A          26y ago    author
 
 "#]])
         .stderr_eq(str![[]]);
-
-    Ok(())
 }
 
 #[cfg(feature = "legacy")]
 #[test]
 fn can_invoke_alias_with_root_flags() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("alias add b branch").assert().success();
 
@@ -110,8 +104,8 @@ fn can_invoke_alias_with_root_flags() -> anyhow::Result<()> {
 #[cfg(feature = "legacy")]
 #[test]
 fn can_invoke_alias_with_root_flags_with_args() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("alias add b branch").assert().success();
     let log_file_path = env.projects_root().join("log_file.txt");
@@ -145,8 +139,8 @@ fn can_invoke_alias_that_shadows_external_command() -> anyhow::Result<()> {
 
     use tempfile::tempdir;
 
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let bin = tempdir()?;
     let helper = bin.path().join("but-b");
@@ -185,8 +179,8 @@ active  ✓ *A          26y ago    author
 #[cfg(unix)]
 #[cfg(feature = "legacy")]
 #[test]
-fn alias_expansion_failure_falls_back_to_original_args() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+fn alias_expansion_failure_falls_back_to_original_args() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
 
     env.but("alias add bad").arg("'").assert().success();
 
@@ -205,8 +199,6 @@ Usage: but [OPTIONS] [COMMAND]
 For more information, try '--help'.
 
 "#]]);
-
-    Ok(())
 }
 
 #[cfg(unix)]
@@ -219,8 +211,8 @@ For more information, try '--help'.
 /// it impossible as known subcommands should not be parsed as external commands, and the alias
 /// expansion itself should bail if a known subcommand is passed in.
 fn alias_of_known_subcommand_is_not_expanded() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.invoke_git("config --local but.alias.branch help");
 

--- a/crates/but/tests/but/command/amend.rs
+++ b/crates/but/tests/but/command/amend.rs
@@ -30,20 +30,22 @@ fn branch_commits_contain_file(
 }
 
 #[test]
-fn amend_accepts_comma_separated_uncommitted_changes() -> anyhow::Result<()> {
+fn amend_accepts_comma_separated_uncommitted_changes() {
     assert_multiple_amend(|target_commit| {
         format!("amend {target_commit} --changes one.txt,two.txt")
     })
+    .unwrap();
 }
 
 #[test]
-fn amend_legacy_form_still_accepts_comma_separated_uncommitted_changes() -> anyhow::Result<()> {
+fn amend_legacy_form_still_accepts_comma_separated_uncommitted_changes() {
     assert_multiple_amend(|target_commit| format!("amend one.txt,two.txt {target_commit}"))
+        .unwrap();
 }
 
 #[test]
-fn amend_without_changes_prints_new_usage_hint() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+fn amend_without_changes_prints_new_usage_hint() {
+    let env = Sandbox::empty();
 
     env.but("amend c3")
         .assert()
@@ -53,13 +55,11 @@ fn amend_without_changes_prints_new_usage_hint() -> anyhow::Result<()> {
 Error: Missing --changes <file-or-hunk>. Usage: but amend <commit> --changes <id>[,<id>]
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn amend_with_changes_rejects_extra_positional() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+fn amend_with_changes_rejects_extra_positional() {
+    let env = Sandbox::empty();
 
     env.but("amend c3 --changes a1 b2")
         .assert()
@@ -69,13 +69,11 @@ fn amend_with_changes_rejects_extra_positional() -> anyhow::Result<()> {
 Error: Unexpected extra argument 'b2'. Use comma-separated --changes values: but amend <commit> --changes <id>[,<id>]
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn amend_with_changes_rejects_empty_change_ids() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+fn amend_with_changes_rejects_empty_change_ids() {
+    let env = Sandbox::empty();
 
     env.but("amend c3 --changes a1,,b2")
         .assert()
@@ -85,13 +83,11 @@ fn amend_with_changes_rejects_empty_change_ids() -> anyhow::Result<()> {
 Error: Empty --changes value. Use comma-separated file or hunk IDs: but amend <commit> --changes <id>[,<id>]
 
 "#]]);
-
-    Ok(())
 }
 
 fn assert_multiple_amend(args: impl FnOnce(&str) -> String) -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     env.file("one.txt", "one\n");
     env.file("two.txt", "two\n");

--- a/crates/but/tests/but/command/branch/apply.rs
+++ b/crates/but/tests/but/command/branch/apply.rs
@@ -7,8 +7,8 @@ use crate::utils::{CommandExt, Sandbox};
 #[cfg(not(feature = "legacy"))]
 #[test]
 fn single_branch() -> anyhow::Result<()> {
-    let env = Sandbox::open_with_default_settings("one-fork")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
+    let env = Sandbox::open_with_default_settings("one-fork");
+    insta::assert_snapshot!(env.git_log(), @r"
     * bf53300 (A) add A
     | * b1540e5 (HEAD -> main) M
     |/  
@@ -37,7 +37,7 @@ Applied branch 'A' to workspace
             └── ·b1540e5 (🏘️)
     ");
 
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log(), @r"
     *   d87b903 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * bf53300 (A) add A
@@ -70,7 +70,7 @@ Applied remote branch 'origin/B' to workspace
     ");
 
     // TODO: should be success and create a local tracking branch.
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log(), @r"
     *-.   7bcf528 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\ \  
     | | * 0e391b2 (origin/B, B) add B
@@ -88,15 +88,15 @@ use utils::create_local_branch_with_commit;
 use crate::command::branch::apply::utils::create_local_branch_with_commit_with_message;
 
 #[test]
-fn local_branch() -> anyhow::Result<()> {
-    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @"
+fn local_branch() {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
+    insta::assert_snapshot!(env.git_log(), @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     let branch_name = "feature-branch";
     create_local_branch_with_commit(&env, branch_name);
@@ -123,7 +123,7 @@ refs/heads/feature-branch
 "#]]);
 
     // It actually applied the branch, by merging it in.
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log(), @r"
     *   9d5d9e5 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * 9f9d5a6 (feature-branch) Add feature
@@ -131,20 +131,18 @@ refs/heads/feature-branch
     |/  
     * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
     ");
-
-    Ok(())
 }
 
 #[test]
-fn local_branch_with_json_output() -> anyhow::Result<()> {
-    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @"
+fn local_branch_with_json_output() {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
+    insta::assert_snapshot!(env.git_log(), @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     create_local_branch_with_commit(&env, "feature-branch");
 
@@ -192,7 +190,7 @@ fn local_branch_with_json_output() -> anyhow::Result<()> {
 "#]])
         .stderr_eq(str![]);
 
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log(), @r"
     *   9d5d9e5 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * 9f9d5a6 (feature-branch) Add feature
@@ -200,20 +198,18 @@ fn local_branch_with_json_output() -> anyhow::Result<()> {
     |/  
     * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
     ");
-
-    Ok(())
 }
 
 #[test]
-fn remote_branch_creates_local_tracking_branch_automatically() -> anyhow::Result<()> {
-    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @"
+fn remote_branch_creates_local_tracking_branch_automatically() {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
+    insta::assert_snapshot!(env.git_log(), @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     // Create a remote branch reference
     env.invoke_bash(
@@ -236,7 +232,7 @@ Applied remote branch 'origin/remote-feature' to workspace
 "#]]);
 
     // It created a local tracking branch.
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log(), @r"
     *   1bb7daf (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * ba02e5f (origin/remote-feature, remote-feature) Add remote feature
@@ -244,20 +240,18 @@ Applied remote branch 'origin/remote-feature' to workspace
     |/  
     * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
     ");
-
-    Ok(())
 }
 
 #[test]
-fn remote_branch_short_name_resolves_to_unique_remote_tracking_branch() -> anyhow::Result<()> {
-    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @"
+fn remote_branch_short_name_resolves_to_unique_remote_tracking_branch() {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
+    insta::assert_snapshot!(env.git_log(), @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     // Create a remote-only branch reference.
     env.invoke_bash(
@@ -280,7 +274,7 @@ Applied remote branch 'origin/remote-feature' to workspace
 "#]]);
 
     // It created the same local tracking branch as the qualified form.
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log(), @r"
     *   1bb7daf (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * ba02e5f (origin/remote-feature, remote-feature) Add remote feature
@@ -288,21 +282,18 @@ Applied remote branch 'origin/remote-feature' to workspace
     |/  
     * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
     ");
-
-    Ok(())
 }
 
 #[test]
-fn remote_branch_short_name_requires_disambiguation_across_multiple_remotes() -> anyhow::Result<()>
-{
-    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @"
+fn remote_branch_short_name_requires_disambiguation_across_multiple_remotes() {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
+    insta::assert_snapshot!(env.git_log(), @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     // Create two configured remotes that both expose the same short branch name.
     env.invoke_bash(
@@ -334,7 +325,7 @@ Applied remote branch 'origin/remote-feature' to workspace
 
 "#]]);
 
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log(), @r"
     *   1bb7daf (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * ba02e5f (upstream/remote-feature, origin/remote-feature, remote-feature) Add remote feature
@@ -342,14 +333,12 @@ Applied remote branch 'origin/remote-feature' to workspace
     |/  
     * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
     ");
-
-    Ok(())
 }
 
 #[test]
 fn concurrent_apply_of_independent_branches_succeeds() -> anyhow::Result<()> {
-    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     create_local_branch_with_commit(&env, "feature-branch-a");
     create_local_branch_with_commit_with_message(&env, "feature-branch-b", "Add other feature");
@@ -379,8 +368,8 @@ fn concurrent_apply_of_independent_branches_succeeds() -> anyhow::Result<()> {
 }
 
 #[test]
-fn nonexistent_branch() -> anyhow::Result<()> {
-    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
+fn nonexistent_branch() {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
 
     // Try to apply a branch that doesn't exist
     env.but("apply nonexistent-branch")
@@ -391,13 +380,11 @@ Failed to apply branch. The reference 'nonexistent-branch' did not exist
 
 "#]])
         .stdout_eq(str![""]);
-
-    Ok(())
 }
 
 #[test]
-fn nonexistent_branch_with_json() -> anyhow::Result<()> {
-    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
+fn nonexistent_branch_with_json() {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
 
     // Try to apply a branch that doesn't exist with JSON output
     env.but("--format json apply nonexistent-branch")
@@ -410,20 +397,18 @@ Failed to apply branch. The reference 'nonexistent-branch' did not exist
 "#]]);
     // Note: Currently the apply function doesn't output anything with JSON when branch not found
     // This might be improved to output an error in JSON format
-
-    Ok(())
 }
 
 #[test]
-fn multiple_branches_sequentially() -> anyhow::Result<()> {
-    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @"
+fn multiple_branches_sequentially() {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
+    insta::assert_snapshot!(env.git_log(), @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     let f1 = "feature-1";
     create_local_branch_with_commit_with_message(&env, f1, "Add feature 1");
@@ -451,7 +436,7 @@ Applied branch 'feature-2' to workspace
 "#]])
         .stderr_eq(str![]);
 
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log(), @r"
     *-.   7044ae9 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\ \  
     | | * 4e81b31 (feature-2) Add feature 2
@@ -461,19 +446,18 @@ Applied branch 'feature-2' to workspace
     |/  
     * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
     ");
-    Ok(())
 }
 
 #[test]
-fn apply_branch_conflicting_with_workspace_reports_error() -> anyhow::Result<()> {
-    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @"
+fn apply_branch_conflicting_with_workspace_reports_error() {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
+    insta::assert_snapshot!(env.git_log(), @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     env.invoke_bash(
         r#"
@@ -495,8 +479,6 @@ Failed to apply branch. 'conflicting-branch' conflicts with existing stack in th
 
 "#]])
         .stdout_eq(str![""]);
-
-    Ok(())
 }
 
 mod utils {

--- a/crates/but/tests/but/command/branch/delete.rs
+++ b/crates/but/tests/but/command/branch/delete.rs
@@ -2,9 +2,9 @@ use crate::utils::Sandbox;
 use snapbox::str;
 
 #[test]
-fn rejects_non_existent_branch_name() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn rejects_non_existent_branch_name() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("branch delete no-such-branch")
         .assert()
@@ -14,14 +14,12 @@ Error: Could not find branch: 'no-such-branch'
 
 "#]])
         .stdout_eq(str![[]]);
-
-    Ok(())
 }
 
 #[test]
-fn can_delete_branch_with_commits() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A"])?;
+fn can_delete_branch_with_commits() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A"]);
 
     env.but("branch delete A")
         .assert()
@@ -47,16 +45,14 @@ Deleted branch A
 Hint: run `but help` for all commands
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn can_delete_branch_with_commits_in_the_bottom_of_a_stack() -> anyhow::Result<()> {
+fn can_delete_branch_with_commits_in_the_bottom_of_a_stack() {
     let env = Sandbox::init_scenario_with_target_and_default_settings(
         "one-stack-three-dependent-branches",
-    )?;
-    env.setup_metadata(&["A", "B", "C"])?;
+    );
+    env.setup_metadata(&["A", "B", "C"]);
 
     env.but("branch delete A")
         .assert()
@@ -85,16 +81,14 @@ Deleted branch A
 Hint: run `but help` for all commands
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn can_delete_branch_with_commits_in_the_middle_of_a_stack() -> anyhow::Result<()> {
+fn can_delete_branch_with_commits_in_the_middle_of_a_stack() {
     let env = Sandbox::init_scenario_with_target_and_default_settings(
         "one-stack-three-dependent-branches",
-    )?;
-    env.setup_metadata(&["A", "B", "C"])?;
+    );
+    env.setup_metadata(&["A", "B", "C"]);
 
     env.but("branch delete B")
         .assert()
@@ -123,16 +117,14 @@ Deleted branch B
 Hint: run `but help` for all commands
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn can_delete_branch_with_commits_in_the_top_of_a_stack() -> anyhow::Result<()> {
+fn can_delete_branch_with_commits_in_the_top_of_a_stack() {
     let env = Sandbox::init_scenario_with_target_and_default_settings(
         "one-stack-three-dependent-branches",
-    )?;
-    env.setup_metadata(&["A", "B", "C"])?;
+    );
+    env.setup_metadata(&["A", "B", "C"]);
 
     env.but("branch delete C")
         .assert()
@@ -161,16 +153,14 @@ Deleted branch C
 Hint: run `but help` for all commands
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn can_delete_branches_via_short_code() -> anyhow::Result<()> {
+fn can_delete_branches_via_short_code() {
     let env = Sandbox::init_scenario_with_target_and_default_settings(
         "one-stack-three-dependent-branches",
-    )?;
-    env.setup_metadata(&["A", "B", "C"])?;
+    );
+    env.setup_metadata(&["A", "B", "C"]);
 
     env.but("branch delete g0")
         .assert()
@@ -199,6 +189,4 @@ Deleted branch C
 Hint: run `but help` for all commands
 
 "#]]);
-
-    Ok(())
 }

--- a/crates/but/tests/but/command/branch/list.rs
+++ b/crates/but/tests/but/command/branch/list.rs
@@ -3,8 +3,8 @@ use crate::utils::{CommandExt, Sandbox};
 /// Hide empty applied branches by default and show them again with `--empty`.
 #[test]
 fn list_hides_empty_applied_branches_by_default() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks-one-empty")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks-one-empty");
+    env.setup_metadata(&["A", "B"]);
 
     let result = env.but("--format json branch list").allow_json().output()?;
     assert!(result.status.success());
@@ -47,9 +47,9 @@ fn list_hides_empty_applied_branches_by_default() -> anyhow::Result<()> {
 }
 
 #[test]
-fn list_truncates_results_if_they_exceed_default_limit() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn list_truncates_results_if_they_exceed_default_limit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
     let default_limit = 20;
 
     for i in 0..default_limit {
@@ -124,6 +124,4 @@ local   ✓ branch-8  ↑1     26y ago    author
 
 "#]])
         .stderr_eq(snapbox::str![[]]);
-
-    Ok(())
 }

--- a/crates/but/tests/but/command/branch/new.rs
+++ b/crates/but/tests/but/command/branch/new.rs
@@ -3,15 +3,15 @@ use snapbox::str;
 use crate::utils::{CommandExt, Sandbox};
 
 #[test]
-fn outputs_branch_name() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @"
+fn outputs_branch_name() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    insta::assert_snapshot!(env.git_log(), @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     env.but("branch new my-feature")
         .assert()
@@ -30,13 +30,12 @@ fn outputs_branch_name() -> anyhow::Result<()> {
 ✓ Created branch my-anchored-feature stacked on [..]
 
 "#]]);
-    Ok(())
 }
 
 #[test]
-fn rejects_head() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn rejects_head() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("branch new HEAD")
         .assert()
@@ -47,14 +46,12 @@ Error: Bad input 'HEAD'
 Invalid branch name: Could not turn "HEAD" into a valid reference name
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn rejects_name_that_normalizes_to_head() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn rejects_name_that_normalizes_to_head() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("branch new HEAD-")
         .assert()
@@ -65,14 +62,12 @@ Error: Bad input 'HEAD-'
 Invalid branch name: Could not turn "HEAD-" into a valid reference name
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn rejects_name_that_normalizes_to_something_else_and_suggests_alternative() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn rejects_name_that_normalizes_to_something_else_and_suggests_alternative() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("branch new 'my branch'")
         .assert()
@@ -85,14 +80,12 @@ Invalid branch name
 Hint: Try 'my-branch' instead
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn rejects_branch_name_already_applied_in_workspace() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn rejects_branch_name_already_applied_in_workspace() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("branch new A")
         .assert()
@@ -101,14 +94,12 @@ fn rejects_branch_name_already_applied_in_workspace() -> anyhow::Result<()> {
 Error: A branch named 'A' is already applied
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn rejects_name_that_exists_outside_workspace() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn rejects_name_that_exists_outside_workspace() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
     env.but("unapply A").assert().success();
 
     env.but("branch new A")
@@ -118,20 +109,18 @@ fn rejects_name_that_exists_outside_workspace() -> anyhow::Result<()> {
 Error: A branch named 'A' exists but is not applied
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn with_json_output() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @"
+fn with_json_output() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    insta::assert_snapshot!(env.git_log(), @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     // Test JSON output without anchor
     env.but("--format json branch new my-feature")
@@ -163,13 +152,12 @@ fn with_json_output() -> anyhow::Result<()> {
     // TODO: on error
     // On error, we indicate this both by exit code and by json output to stdout
     // so tools would be able to detect it that way.
-    Ok(())
 }
 
 #[test]
 fn handles_path_prefix_collision() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // As ref A already exists, A/new collides with A due to the need to create a directory called A
     env.but("branch new A/new/branch")

--- a/crates/but/tests/but/command/branch/show.rs
+++ b/crates/but/tests/but/command/branch/show.rs
@@ -3,8 +3,8 @@ use crate::utils::{CommandExt, Sandbox};
 /// Show branch details for an applied branch using JSON output.
 #[test]
 fn show_lists_commits_ahead_for_applied_branch() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied")?;
-    env.setup_metadata(&["applied-branch"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied");
+    env.setup_metadata(&["applied-branch"]);
 
     let result = env
         .but("--format json branch show applied-branch")
@@ -26,8 +26,8 @@ fn show_lists_commits_ahead_for_applied_branch() -> anyhow::Result<()> {
 /// Report merge-check information for an applied branch using JSON output.
 #[test]
 fn show_check_reports_clean_merge_for_applied_branch() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied")?;
-    env.setup_metadata(&["applied-branch"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied");
+    env.setup_metadata(&["applied-branch"]);
 
     let result = env
         .but("--format json branch show applied-branch --check")
@@ -49,9 +49,9 @@ fn show_check_reports_clean_merge_for_applied_branch() -> anyhow::Result<()> {
 }
 
 #[test]
-fn show_works_for_unapplied_branches() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn show_works_for_unapplied_branches() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("branch show A")
         .assert()
@@ -84,14 +84,12 @@ Branch: A (1 commits ahead)
     1 file changed, 1 insertion, 0 deletions
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn supports_short_codes() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn supports_short_codes() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("branch show g0")
         .assert()
@@ -104,14 +102,12 @@ Branch: A (1 commits ahead)
     1 file changed, 1 insertion, 0 deletions
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn show_works_for_remote_only_branches() -> anyhow::Result<()> {
-    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn show_works_for_remote_only_branches() {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.invoke_bash(
         r#"
@@ -145,17 +141,14 @@ ba02e5f Add remote feature
     0 files changed, 0 insertions, 0 deletions
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
 fn showing_branch_that_isnt_top_of_stack() {
     let env = Sandbox::init_scenario_with_target_and_default_settings(
         "one-stack-three-dependent-branches",
-    )
-    .unwrap();
-    env.setup_metadata(&["A", "B", "C"]).unwrap();
+    );
+    env.setup_metadata(&["A", "B", "C"]);
 
     env.but("status")
         .assert()
@@ -232,9 +225,8 @@ Branch: A (1 commits ahead)
 fn checking_merge_status_of_branch_that_isnt_top_of_stack() {
     let env = Sandbox::init_scenario_with_target_and_default_settings(
         "one-stack-three-dependent-branches",
-    )
-    .unwrap();
-    env.setup_metadata(&["A", "B", "C"]).unwrap();
+    );
+    env.setup_metadata(&["A", "B", "C"]);
 
     env.but("status")
         .assert()

--- a/crates/but/tests/but/command/branch/unapply.rs
+++ b/crates/but/tests/but/command/branch/unapply.rs
@@ -8,15 +8,15 @@ use crate::{
 };
 
 #[test]
-fn single_branch() -> anyhow::Result<()> {
-    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @"
+fn single_branch() {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
+    insta::assert_snapshot!(env.git_log(), @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     let branch_name = "feature-branch";
     create_local_branch_with_commit(&env, branch_name);
@@ -24,7 +24,7 @@ fn single_branch() -> anyhow::Result<()> {
     // First apply the branch
     env.but("apply").arg(branch_name).assert().success();
 
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log(), @r"
     *   9d5d9e5 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * 9f9d5a6 (feature-branch) Add feature
@@ -45,27 +45,25 @@ Unapplied stack with branches 'feature-branch' from workspace
 "#]]);
 
     // Verify the branch is removed from workspace
-    insta::assert_snapshot!(env.git_log()?, @"
+    insta::assert_snapshot!(env.git_log(), @"
     * 9f9d5a6 (feature-branch) Add feature
     | * 0bbfbfd (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     | * 9477ae7 (A) add A
     |/  
     * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
     ");
-
-    Ok(())
 }
 
 #[test]
-fn unapply_with_json_output() -> anyhow::Result<()> {
-    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @"
+fn unapply_with_json_output() {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
+    insta::assert_snapshot!(env.git_log(), @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     let branch_name = "feature-branch";
     create_local_branch_with_commit(&env, branch_name);
@@ -81,21 +79,19 @@ fn unapply_with_json_output() -> anyhow::Result<()> {
         .success()
         .stderr_eq(str![]);
 
-    insta::assert_snapshot!(env.git_log()?, @"
+    insta::assert_snapshot!(env.git_log(), @"
     * 9f9d5a6 (feature-branch) Add feature
     | * 0bbfbfd (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     | * 9477ae7 (A) add A
     |/  
     * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
     ");
-
-    Ok(())
 }
 
 #[test]
-fn unapply_idempotent() -> anyhow::Result<()> {
-    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn unapply_idempotent() {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let branch_name = "feature-branch";
     create_local_branch_with_commit(&env, branch_name);
@@ -115,14 +111,12 @@ Failed to unapply branch. Branch 'feature-branch' not found in any applied stack
 
 "#]])
         .stdout_eq(str![]);
-
-    Ok(())
 }
 
 #[test]
-fn unapply_shell_format() -> anyhow::Result<()> {
-    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn unapply_shell_format() {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let branch_name = "feature-branch";
     create_local_branch_with_commit(&env, branch_name);
@@ -142,13 +136,11 @@ fn unapply_shell_format() -> anyhow::Result<()> {
 feature-branch
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn unapply_nonexistent_branch() -> anyhow::Result<()> {
-    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
+fn unapply_nonexistent_branch() {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
 
     // Try to unapply a branch that doesn't exist - should fail with the new command
     env.but("unapply nonexistent-branch")
@@ -159,27 +151,23 @@ Failed to unapply branch. Branch 'nonexistent-branch' not found in any applied s
 
 "#]])
         .stdout_eq(str![]);
-
-    Ok(())
 }
 
 #[test]
-fn unapply_nonexistent_branch_with_json() -> anyhow::Result<()> {
-    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
+fn unapply_nonexistent_branch_with_json() {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
 
     // Try to unapply a branch that doesn't exist with JSON output - should fail
     env.but("--format json unapply nonexistent-branch")
         .allow_json()
         .assert()
         .failure();
-
-    Ok(())
 }
 
 #[test]
-fn unapply_branch_not_in_workspace() -> anyhow::Result<()> {
-    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn unapply_branch_not_in_workspace() {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let branch_name = "feature-branch";
     create_local_branch_with_commit(&env, branch_name);
@@ -194,20 +182,18 @@ Failed to unapply branch. Branch 'feature-branch' not found in any applied stack
 
 "#]])
         .stdout_eq(str![]);
-
-    Ok(())
 }
 
 #[test]
-fn unapply_remote_tracking_branch() -> anyhow::Result<()> {
-    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @"
+fn unapply_remote_tracking_branch() {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
+    insta::assert_snapshot!(env.git_log(), @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     // Create a remote branch reference
     env.invoke_bash(
@@ -222,7 +208,7 @@ fn unapply_remote_tracking_branch() -> anyhow::Result<()> {
     // Apply the remote branch
     env.but("apply origin/remote-feature").assert().success();
 
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log(), @r"
     *   1bb7daf (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * ba02e5f (origin/remote-feature, remote-feature) Add remote feature
@@ -242,21 +228,19 @@ Unapplied stack with branches 'remote-feature' from workspace
 "#]]);
 
     // Verify it was removed from workspace
-    insta::assert_snapshot!(env.git_log()?, @"
+    insta::assert_snapshot!(env.git_log(), @"
     * 0bbfbfd (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     | * ba02e5f (origin/remote-feature, remote-feature) Add remote feature
     |/  
     * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
     ");
-
-    Ok(())
 }
 
 #[test]
 fn concurrent_unapply_of_independent_branches_succeeds() -> anyhow::Result<()> {
-    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     create_local_branch_with_commit(&env, "feature-branch-a");
 
@@ -294,8 +278,8 @@ fn concurrent_unapply_of_independent_branches_succeeds() -> anyhow::Result<()> {
 
 #[test]
 fn unapply_using_cli_branch_id() -> anyhow::Result<()> {
-    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let branch_name = "feature-branch";
     utils::create_local_branch_with_commit(&env, branch_name);
@@ -360,8 +344,8 @@ Unapplied stack with branches 'feature-branch' from workspace
 
 #[test]
 fn unapply_using_cli_stack_id() -> anyhow::Result<()> {
-    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let branch_name = "feature-branch";
     utils::create_local_branch_with_commit(&env, branch_name);
@@ -406,8 +390,8 @@ Unapplied stack with branches 'feature-branch' from workspace
 
 #[test]
 fn unapply_json_output_validation() -> anyhow::Result<()> {
-    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let branch_name = "feature-branch";
     utils::create_local_branch_with_commit(&env, branch_name);

--- a/crates/but/tests/but/command/branch/update.rs
+++ b/crates/but/tests/but/command/branch/update.rs
@@ -24,9 +24,9 @@ fn install_editor_script(env: &Sandbox, script: &str) -> anyhow::Result<()> {
 
 #[test]
 fn integrate_pull_rebase_applies_and_snapshots_before_and_after() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("branch-integrate-diverged")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("branch-integrate-diverged");
 
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log(), @r"
     *   a952a0b (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * 643ade3 (A) add only-on-local
@@ -77,7 +77,7 @@ Updated branch A.
 
 "#]]);
 
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log(), @r"
     *   6a3496e (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * 74faa12 (A) add only-on-local
@@ -124,9 +124,9 @@ Updated branch A.
 #[test]
 fn integrate_smart_squash_applies_matching_change_ids() -> anyhow::Result<()> {
     let env =
-        Sandbox::init_scenario_with_target_and_default_settings("branch-integrate-smart-squash")?;
+        Sandbox::init_scenario_with_target_and_default_settings("branch-integrate-smart-squash");
 
-    insta::assert_snapshot!(env.git_log()?, @"
+    insta::assert_snapshot!(env.git_log(), @"
     * 2662ee8 (HEAD -> gitbutler/workspace, A) add only-on-local
     | * c42227a (origin/A) add only-on-remote
     |/  
@@ -149,7 +149,7 @@ Updated branch A.
 
 "#]]);
 
-    insta::assert_snapshot!(env.git_log()?, @"
+    insta::assert_snapshot!(env.git_log(), @"
     * bf02b24 (HEAD -> gitbutler/workspace, A) add only-on-remote
     | * c42227a (origin/A) add only-on-remote
     |/  
@@ -168,8 +168,8 @@ Updated branch A.
 
 #[test]
 fn integrate_dry_run_shows_preview_without_changing_repo() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("branch-integrate-diverged")?;
-    let before_log = env.git_log()?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("branch-integrate-diverged");
+    let before_log = env.git_log();
     let before_status = pretty_status(&env)?;
 
     env.but("branch update A --dry-run")
@@ -227,7 +227,7 @@ o 0dc3733
       }
     }
     "#);
-    assert_eq!(env.git_log()?, before_log, "dry-run must not rewrite refs");
+    assert_eq!(env.git_log(), before_log, "dry-run must not rewrite refs");
     assert_eq!(
         pretty_status(&env)?,
         before_status,
@@ -239,8 +239,8 @@ o 0dc3733
 
 #[test]
 fn integrate_dry_run_verbose_shows_divergence_before_preview() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("branch-integrate-diverged")?;
-    let before_log = env.git_log()?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("branch-integrate-diverged");
+    let before_log = env.git_log();
     let before_status = pretty_status(&env)?;
 
     env.but("branch update A --dry-run --verbose")
@@ -267,7 +267,7 @@ o 0dc3733
 "#]]);
 
     assert_eq!(
-        env.git_log()?,
+        env.git_log(),
         before_log,
         "verbose dry-run must not rewrite refs"
     );
@@ -281,10 +281,10 @@ o 0dc3733
 }
 
 #[test]
-fn integrate_merge_dry_run_marks_conflicted_preview_commits() -> anyhow::Result<()> {
+fn integrate_merge_dry_run_marks_conflicted_preview_commits() {
     let env = Sandbox::init_scenario_with_target_and_default_settings_slow(
         "branch-integrate-conflicting",
-    )?;
+    );
 
     env.but("branch update A -s merge --dry-run")
         .assert()
@@ -299,13 +299,11 @@ Preview
 o 6a997fd
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
 fn integrate_interactive_unchanged_script_applies_generated_plan() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("branch-integrate-diverged")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("branch-integrate-diverged");
     install_editor_script(&env, "#!/usr/bin/env bash\n: \"$1\"\n")?;
 
     env.but("branch update A --interactive")
@@ -318,7 +316,7 @@ Updated branch A.
 
 "#]]);
 
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log(), @r"
     *   6a3496e (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * 74faa12 (A) add only-on-local
@@ -332,9 +330,9 @@ Updated branch A.
 
 #[test]
 fn integrate_interactive_dry_run_keeps_repo_unchanged() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("branch-integrate-diverged")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("branch-integrate-diverged");
     install_editor_script(&env, "#!/usr/bin/env bash\n: \"$1\"\n")?;
-    let before_log = env.git_log()?;
+    let before_log = env.git_log();
     let before_status = pretty_status(&env)?;
 
     env.but("branch update A --interactive --dry-run")
@@ -353,7 +351,7 @@ o 0dc3733
 "#]]);
 
     assert_eq!(
-        env.git_log()?,
+        env.git_log(),
         before_log,
         "interactive dry-run must not rewrite refs"
     );
@@ -368,7 +366,7 @@ o 0dc3733
 
 #[test]
 fn integrate_interactive_applies_edited_merge_plan() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("branch-integrate-diverged")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("branch-integrate-diverged");
     install_editor_script(
         &env,
         r#"#!/usr/bin/env bash
@@ -385,7 +383,7 @@ EOF
         .success()
         .stderr_eq(str![]);
 
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log(), @r"
     *   9e0c28c (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | *   30a8d17 (A) Merge 28baf9a2794d7722ceff84f2967b5186545b8a48 into previous commit
@@ -403,14 +401,14 @@ EOF
 
 #[test]
 fn integrate_interactive_fails_on_parse_error() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("branch-integrate-diverged")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("branch-integrate-diverged");
     install_editor_script(
         &env,
         r#"#!/usr/bin/env bash
 printf 'drop 643ade3\n' > "$1"
 "#,
     )?;
-    let before_log = env.git_log()?;
+    let before_log = env.git_log();
 
     env.but("branch update A --interactive")
         .env("GIT_EDITOR", "bash editor.sh")
@@ -423,7 +421,7 @@ Error: line 1: unknown command 'drop'
 "#]]);
 
     assert_eq!(
-        env.git_log()?,
+        env.git_log(),
         before_log,
         "parse failures must not rewrite refs"
     );
@@ -433,14 +431,14 @@ Error: line 1: unknown command 'drop'
 
 #[test]
 fn integrate_interactive_fails_on_out_of_scope_commit() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("branch-integrate-diverged")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("branch-integrate-diverged");
     install_editor_script(
         &env,
         r#"#!/usr/bin/env bash
 printf 'pick 0dc3733\n' > "$1"
 "#,
     )?;
-    let before_log = env.git_log()?;
+    let before_log = env.git_log();
 
     env.but("branch update A --interactive")
         .env("GIT_EDITOR", "bash editor.sh")
@@ -453,7 +451,7 @@ Error: line 1: invalid pick commit: commit '0dc3733' is not part of the editable
 "#]]);
 
     assert_eq!(
-        env.git_log()?,
+        env.git_log(),
         before_log,
         "validation failures must not rewrite refs"
     );
@@ -464,8 +462,8 @@ Error: line 1: invalid pick commit: commit '0dc3733' is not part of the editable
 #[test]
 fn integrate_errors_cleanly_without_tracking_branch() -> anyhow::Result<()> {
     let env =
-        Sandbox::init_scenario_with_target_and_default_settings("branch-integrate-no-tracking")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
+        Sandbox::init_scenario_with_target_and_default_settings("branch-integrate-no-tracking");
+    insta::assert_snapshot!(env.git_log(), @r"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M

--- a/crates/but/tests/but/command/clean.rs
+++ b/crates/but/tests/but/command/clean.rs
@@ -3,9 +3,9 @@ use snapbox::str;
 use crate::utils::{CommandExt, Sandbox};
 
 #[test]
-fn no_empty_branches() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata_at_target(&["A"], "origin/main")?;
+fn no_empty_branches() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
 
     env.but("clean")
         .assert()
@@ -15,13 +15,12 @@ fn no_empty_branches() -> anyhow::Result<()> {
 No empty branches found.
 
 "#]]);
-    Ok(())
 }
 
 #[test]
-fn removes_empty_branch() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata_at_target(&["A"], "origin/main")?;
+fn removes_empty_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
 
     env.but("branch new empty-branch").assert().success();
 
@@ -34,13 +33,12 @@ fn removes_empty_branch() -> anyhow::Result<()> {
 ✓ Deleted 1 empty branch(es)
 
 "#]]);
-    Ok(())
 }
 
 #[test]
-fn dry_run_does_not_delete() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata_at_target(&["A"], "origin/main")?;
+fn dry_run_does_not_delete() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
 
     env.but("branch new empty-branch").assert().success();
 
@@ -63,26 +61,24 @@ Would delete branch: empty-branch
 Found 1 empty branch(es)
 
 "#]]);
-    Ok(())
 }
 
 #[test]
-fn does_not_remove_branch_with_commits() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn does_not_remove_branch_with_commits() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // A has a commit, so clean should find nothing
     env.but("clean").assert().success().stdout_eq(str![[r#"
 No empty branches found.
 
 "#]]);
-    Ok(())
 }
 
 #[test]
-fn json_output() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata_at_target(&["A"], "origin/main")?;
+fn json_output() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
 
     env.but("branch new empty-branch").assert().success();
 
@@ -102,13 +98,12 @@ fn json_output() -> anyhow::Result<()> {
 }
 
 "#]]);
-    Ok(())
 }
 
 #[test]
-fn json_output_dry_run() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata_at_target(&["A"], "origin/main")?;
+fn json_output_dry_run() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
 
     env.but("branch new empty-branch").assert().success();
 
@@ -128,13 +123,12 @@ fn json_output_dry_run() -> anyhow::Result<()> {
 }
 
 "#]]);
-    Ok(())
 }
 
 #[test]
-fn json_output_no_empty_branches() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata_at_target(&["A"], "origin/main")?;
+fn json_output_no_empty_branches() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
 
     env.but("--format json clean")
         .allow_json()
@@ -148,13 +142,12 @@ fn json_output_no_empty_branches() -> anyhow::Result<()> {
 }
 
 "#]]);
-    Ok(())
 }
 
 #[test]
-fn does_not_remove_branch_with_assigned_changes() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn does_not_remove_branch_with_assigned_changes() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Create a new empty branch
     env.but("branch new my-branch").assert().success();
@@ -168,13 +161,12 @@ fn does_not_remove_branch_with_assigned_changes() -> anyhow::Result<()> {
 No empty branches found.
 
 "#]]);
-    Ok(())
 }
 
 #[test]
 fn creates_oplog_entry() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("branch new empty-branch").assert().success();
     env.but("clean").assert().success();

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -4,15 +4,15 @@ use super::util;
 use crate::utils::Sandbox;
 
 #[test]
-fn commit_with_message_from_file() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @"
+fn commit_with_message_from_file() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    insta::assert_snapshot!(env.git_log(), @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     // Create a change in the worktree
     env.file("new-file.txt", "test content");
@@ -33,17 +33,15 @@ fn commit_with_message_from_file() -> anyhow::Result<()> {
 "#]]);
 
     // Verify the commit was created with the correct message
-    let log = env.git_log()?;
+    let log = env.git_log();
     assert!(log.contains("Add new file from message file"));
-
-    Ok(())
 }
 
 #[test]
-fn commit_with_message_file_not_found() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+fn commit_with_message_file_not_found() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     // Create a change in the worktree
     env.file("new-file.txt", "test content");
@@ -59,20 +57,18 @@ Caused by:
     No such file or directory (os error 2)
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn commit_with_message_flag() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @"
+fn commit_with_message_flag() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    insta::assert_snapshot!(env.git_log(), @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     // Create a change in the worktree
     env.file("new-file.txt", "test content");
@@ -87,16 +83,14 @@ fn commit_with_message_flag() -> anyhow::Result<()> {
 "#]]);
 
     // Verify the commit was created
-    let log = env.git_log()?;
+    let log = env.git_log();
     assert!(log.contains("Add new file"));
-
-    Ok(())
 }
 
 #[test]
-fn commit_with_git_all_flag_prints_hint() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn commit_with_git_all_flag_prints_hint() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
     env.file("new-file.txt", "test content");
 
     env.but("commit -am 'Add new file'")
@@ -108,16 +102,14 @@ no need for -a here my friend...
 
 "#]]);
 
-    let log = env.git_log()?;
+    let log = env.git_log();
     assert!(log.contains("Add new file"));
-
-    Ok(())
 }
 
 #[test]
-fn commit_with_branch_hint() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
+fn commit_with_branch_hint() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    insta::assert_snapshot!(env.git_log(), @r"
     *   c128bce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * 9477ae7 (A) add A
@@ -126,7 +118,7 @@ fn commit_with_branch_hint() -> anyhow::Result<()> {
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
 
     // Create a change
     env.file("file-for-b.txt", "content for B");
@@ -140,16 +132,14 @@ fn commit_with_branch_hint() -> anyhow::Result<()> {
 
 "#]]);
 
-    let log = env.git_log()?;
+    let log = env.git_log();
     assert!(log.contains("Change for B"));
-
-    Ok(())
 }
 
 #[test]
-fn commit_with_nonexistent_branch_fails() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
+fn commit_with_nonexistent_branch_fails() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    insta::assert_snapshot!(env.git_log(), @r"
     *   c128bce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * 9477ae7 (A) add A
@@ -158,7 +148,7 @@ fn commit_with_nonexistent_branch_fails() -> anyhow::Result<()> {
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata_at_target(&["A", "B"], "origin/main")?;
+    env.setup_metadata_at_target(&["A", "B"], "origin/main");
 
     env.file("file.txt", "content");
 
@@ -169,14 +159,12 @@ fn commit_with_nonexistent_branch_fails() -> anyhow::Result<()> {
 Error: Branch 'nonexistent' not found
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn commit_with_create_flag_creates_new_branch() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
+fn commit_with_create_flag_creates_new_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    insta::assert_snapshot!(env.git_log(), @r"
     *   c128bce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * 9477ae7 (A) add A
@@ -185,7 +173,7 @@ fn commit_with_create_flag_creates_new_branch() -> anyhow::Result<()> {
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata_at_target(&["A", "B"], "origin/main")?;
+    env.setup_metadata_at_target(&["A", "B"], "origin/main");
 
     env.file("new-feature.txt", "new feature");
 
@@ -211,13 +199,12 @@ Operations History
 [SHORTHASH] 2000-01-02 00:00:00 [BRANCH] Created branch
 
 "#]]);
-    Ok(())
 }
 
 #[test]
-fn commit_with_create_and_position_fails() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn commit_with_create_and_position_fails() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
     env.file("new-file.txt", "new feature");
 
     env.but("commit -m 'New feature' -c feature-x --before A")
@@ -227,14 +214,12 @@ fn commit_with_create_and_position_fails() -> anyhow::Result<()> {
 Error: --create cannot be used with --before/--after.
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
 fn commit_with_position_on_different_branch_fails() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
     env.file("new-file.txt", "content");
 
     let output = env
@@ -251,9 +236,9 @@ fn commit_with_position_on_different_branch_fails() -> anyhow::Result<()> {
 }
 
 #[test]
-fn commit_empty_default() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn commit_empty_default() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("status").assert().success().stdout_eq(str![[r#"
 ╭┄zz [unassigned changes] (no changes)
@@ -289,14 +274,12 @@ Created blank commit at the tip of branch 'A'
 Hint: run `but help` for all commands
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
 fn commit_empty_with_message() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let output = env
         .but("commit empty -m 'Plan empty slot' --format json")
@@ -314,10 +297,10 @@ fn commit_empty_with_message() -> anyhow::Result<()> {
 }
 
 #[test]
-fn commit_empty_rejects_empty_message() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
-    let log_before = env.git_log()?;
+fn commit_empty_rejects_empty_message() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+    let log_before = env.git_log();
 
     env.but("commit empty -m '   '")
         .assert()
@@ -327,21 +310,19 @@ Error: Aborting commit due to empty commit message.
 
 "#]]);
 
-    assert_eq!(env.git_log()?, log_before);
-
-    Ok(())
+    assert_eq!(env.git_log(), log_before);
 }
 
 #[test]
-fn commit_empty_with_before_flag() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @"
+fn commit_empty_with_before_flag() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    insta::assert_snapshot!(env.git_log(), @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     // Get the commit ID from the CLI ID map
     // Use the short git hash for the commit on branch A
@@ -354,23 +335,21 @@ Created blank commit before commit 9477ae7
 "#]]);
 
     // Verify a new commit was created
-    let log = env.git_log()?;
+    let log = env.git_log();
     // Should have one more commit than before
     assert!(log.lines().filter(|l| l.starts_with("*")).count() > 3);
-
-    Ok(())
 }
 
 #[test]
-fn commit_empty_with_positional_target_defaults_to_before() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @"
+fn commit_empty_with_positional_target_defaults_to_before() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    insta::assert_snapshot!(env.git_log(), @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     // Use positional argument without flag (should default to --before behavior)
     env.but("commit empty 9477ae7")
@@ -382,11 +361,9 @@ Created blank commit before commit 9477ae7
 "#]]);
 
     // Verify a new commit was created
-    let log = env.git_log()?;
+    let log = env.git_log();
     // Should have one more commit than before
     assert!(log.lines().filter(|l| l.starts_with("*")).count() > 3);
-
-    Ok(())
 }
 
 #[test]
@@ -396,8 +373,8 @@ Created blank commit before commit 9477ae7
 /// We intend to support this together with the `--create` flag once `but commit empty` is migrated
 /// up to `but commit --empty`.
 fn commit_empty_after_stack_head_is_disallowed() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("status").assert().success().stdout_eq(str![[r#"
 ╭┄zz [unassigned changes] (no changes)
@@ -428,9 +405,9 @@ Hint: Use '--before' to insert at the tip of the stack
 }
 
 #[test]
-fn commit_after_branch_is_disallowed() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn commit_after_branch_is_disallowed() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
     env.file("new-file.txt", "content");
 
     env.but("commit -m 'test' --after A")
@@ -444,18 +421,16 @@ Cannot insert commit after a branch
 Hint: Use a commit ID with '--after', or use '--before <branch>' to insert at the branch tip
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
 fn commit_empty_after_branch_for_non_stack_head() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     env.but("branch new bottom")
         .arg("-a")
-        .arg(env.open_repo()?.rev_parse("A~")?.to_string())
+        .arg(env.open_repo().rev_parse("A~")?.to_string())
         .assert()
         .success();
 
@@ -505,9 +480,9 @@ Hint: run `but help` for all commands
 }
 
 #[test]
-fn commit_empty_with_before_branch() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn commit_empty_with_before_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("status").assert().success().stdout_eq(str![[r#"
 ╭┄zz [unassigned changes] (no changes)
@@ -543,20 +518,18 @@ Created blank commit at the tip of branch 'A'
 Hint: run `but help` for all commands
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn commit_empty_with_after_commit() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @"
+fn commit_empty_with_after_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    insta::assert_snapshot!(env.git_log(), @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     // Insert empty commit after a specific commit
     env.but("commit empty --after 9477ae7")
@@ -568,17 +541,15 @@ Created blank commit after commit 9477ae7
 "#]]);
 
     // Verify a new commit was created
-    let log = env.git_log()?;
+    let log = env.git_log();
     // Should have one more commit than before
     assert!(log.lines().filter(|l| l.starts_with("*")).count() > 3);
-
-    Ok(())
 }
 
 #[test]
-fn commit_empty_without_branches_fails() -> anyhow::Result<()> {
+fn commit_empty_without_branches_fails() {
     // This test uses a scenario with no GitButler branches to verify error handling
-    let env = Sandbox::init_scenario_with_target_and_default_settings("first-commit")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("first-commit");
 
     // Try to run without any arguments when there are no branches
     env.but("commit empty")
@@ -588,14 +559,12 @@ fn commit_empty_without_branches_fails() -> anyhow::Result<()> {
 Error: No branches found. Create a branch first or specify a target explicitly.
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn commit_empty_rejects_both_flags() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn commit_empty_rejects_both_flags() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Try to use both --before and --after
     env.but("commit empty --before A --after A")
@@ -609,14 +578,12 @@ Usage: but commit empty --before <BEFORE> [TARGET]
 For more information, try '--help'.
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn commit_empty_with_nonexistent_target() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn commit_empty_with_nonexistent_target() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Try to insert before a nonexistent target
     env.but("commit empty --before nonexistent")
@@ -626,14 +593,12 @@ fn commit_empty_with_nonexistent_target() -> anyhow::Result<()> {
 Error: Could not find target: 'nonexistent'
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn commit_empty_rejects_parent_message_flag() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn commit_empty_rejects_parent_message_flag() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Try to use parent --message with empty subcommand
     env.but("commit -m 'test' empty --before A")
@@ -643,14 +608,12 @@ fn commit_empty_rejects_parent_message_flag() -> anyhow::Result<()> {
 Error: --message must be passed after 'empty'. Use `but commit empty -m "message"`.
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn commit_empty_rejects_file_flag() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn commit_empty_rejects_file_flag() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
     env.file("msg.txt", "test message");
 
     // Try to use --message-file with empty subcommand
@@ -661,14 +624,12 @@ fn commit_empty_rejects_file_flag() -> anyhow::Result<()> {
 Error: --message-file cannot be used with 'commit empty'. Use `but commit empty -m "message"`.
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn commit_empty_rejects_branch_argument() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn commit_empty_rejects_branch_argument() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Try to use branch argument with empty subcommand
     env.but("commit A empty --before A")
@@ -678,14 +639,12 @@ fn commit_empty_rejects_branch_argument() -> anyhow::Result<()> {
 Error: branch argument cannot be used with 'commit empty'. Use the target positional argument or --before/--after flags.
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn commit_empty_rejects_only_flag() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn commit_empty_rejects_only_flag() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Try to use --only with empty subcommand
     env.but("commit --only empty --before A")
@@ -695,14 +654,12 @@ fn commit_empty_rejects_only_flag() -> anyhow::Result<()> {
 Error: --only cannot be used with 'commit empty'.
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn commit_empty_rejects_create_flag() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn commit_empty_rejects_create_flag() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Try to use --create with empty subcommand
     env.but("commit --create empty --before A")
@@ -712,14 +669,12 @@ fn commit_empty_rejects_create_flag() -> anyhow::Result<()> {
 Error: --create cannot be used with 'commit empty'.
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn commit_empty_rejects_parent_position_flags() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn commit_empty_rejects_parent_position_flags() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("commit --before A empty")
         .assert()
@@ -728,14 +683,12 @@ fn commit_empty_rejects_parent_position_flags() -> anyhow::Result<()> {
 Error: --before/--after must be passed after 'empty'. Use `but commit empty --before <target>`.
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn commit_empty_rejects_no_hooks_flag() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn commit_empty_rejects_no_hooks_flag() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Try to use --no-hooks with empty subcommand
     env.but("commit --no-hooks empty --before A")
@@ -745,14 +698,12 @@ fn commit_empty_rejects_no_hooks_flag() -> anyhow::Result<()> {
 Error: --no-hooks cannot be used with 'commit empty'.
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn commit_ai_conflicts_with_message() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn commit_ai_conflicts_with_message() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
     env.file("new-file.txt", "test content");
 
     // Try to use both --ai and -m
@@ -767,14 +718,12 @@ Usage: but commit --ai[=<AI>] [BRANCH]
 For more information, try '--help'.
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn commit_ai_conflicts_with_message_file() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn commit_ai_conflicts_with_message_file() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
     env.file("new-file.txt", "test content");
     env.file("msg.txt", "commit message");
 
@@ -790,14 +739,12 @@ Usage: but commit --ai[=<AI>] [BRANCH]
 For more information, try '--help'.
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn commit_empty_rejects_ai_flag() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn commit_empty_rejects_ai_flag() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Try to use --ai with empty subcommand
     // Note: Using -i= (with explicit empty value) to avoid clap treating "empty" as the flag's value
@@ -808,14 +755,12 @@ fn commit_empty_rejects_ai_flag() -> anyhow::Result<()> {
 Error: --ai cannot be used with 'commit empty'.
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn commit_changes_conflicts_with_only() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn commit_changes_conflicts_with_only() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
     env.file("file.txt", "content");
 
     // Try to use both --changes and --only
@@ -830,14 +775,12 @@ Usage: but commit --message <MESSAGE> --changes <CHANGES> [BRANCH]
 For more information, try '--help'.
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
 fn commit_empty_rejects_changes_flag() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Try to use --changes with empty subcommand
     // --changes is not a valid flag for the empty subcommand, so clap rejects it
@@ -856,9 +799,9 @@ fn commit_empty_rejects_changes_flag() -> anyhow::Result<()> {
 }
 
 #[test]
-fn commit_json_mode_requires_message_or_file() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn commit_json_mode_requires_message_or_file() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Create a change in the worktree
     env.file("new-file.txt", "test content");
@@ -871,14 +814,12 @@ fn commit_json_mode_requires_message_or_file() -> anyhow::Result<()> {
 Error: Either --message (-m), --message-file, or --ai (-i) must be specified for this output format
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
 fn commit_json_mode_with_message_succeeds() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Create a change in the worktree
     env.file("new-file.txt", "test content");
@@ -906,8 +847,8 @@ fn commit_json_mode_with_message_succeeds() -> anyhow::Result<()> {
 
 #[test]
 fn commit_json_mode_with_file_succeeds() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Create a change in the worktree
     env.file("new-file.txt", "test content");
@@ -937,9 +878,9 @@ fn commit_json_mode_with_file_succeeds() -> anyhow::Result<()> {
 }
 
 #[test]
-fn commit_json_mode_multiple_branches_requires_branch() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata_at_target(&["A", "B"], "origin/main")?;
+fn commit_json_mode_multiple_branches_requires_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata_at_target(&["A", "B"], "origin/main");
 
     // Create a change
     env.file("new-file.txt", "test content");
@@ -952,14 +893,12 @@ fn commit_json_mode_multiple_branches_requires_branch() -> anyhow::Result<()> {
 Error: Multiple branches found. Specify a branch to commit to using the branch argument
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
 fn commit_json_mode_multiple_branches_with_branch_succeeds() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     // Create a change
     env.file("new-file.txt", "test content");
@@ -987,8 +926,8 @@ fn commit_json_mode_multiple_branches_with_branch_succeeds() -> anyhow::Result<(
 
 #[test]
 fn commit_json_positioned_omits_branch_tip() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
     env.file("new-file.txt", "test content");
 
     let output = env
@@ -1006,8 +945,8 @@ fn commit_json_positioned_omits_branch_tip() -> anyhow::Result<()> {
 
 #[test]
 fn commit_with_specific_file_ids() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Create two files
     env.file("file1.txt", "content 1");
@@ -1042,7 +981,7 @@ fn commit_with_specific_file_ids() -> anyhow::Result<()> {
 "#]]);
 
     // Verify file1 was committed
-    let log = env.git_log()?;
+    let log = env.git_log();
     assert!(log.contains("Add file1 only"));
 
     // Verify file2 is still uncommitted
@@ -1065,8 +1004,8 @@ fn commit_with_specific_file_ids() -> anyhow::Result<()> {
 
 #[test]
 fn commit_with_multiple_file_ids() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Create three files
     env.file("file1.txt", "content 1");
@@ -1126,8 +1065,8 @@ fn commit_with_multiple_file_ids() -> anyhow::Result<()> {
 
 #[test]
 fn commit_with_short_changes_flag() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Create two files
     env.file("file1.txt", "content 1");
@@ -1185,9 +1124,9 @@ fn commit_with_short_changes_flag() -> anyhow::Result<()> {
 }
 
 #[test]
-fn commit_with_invalid_file_id_fails() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata_at_target(&["A"], "origin/main")?;
+fn commit_with_invalid_file_id_fails() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
 
     // Create a file so we have something to potentially commit
     env.file("file.txt", "content");
@@ -1201,14 +1140,12 @@ Error: Invalid file ID(s):
   'zq' not found. Run 'but status' to see available file IDs.
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn commit_with_wrong_entity_type_fails() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata_at_target(&["A"], "origin/main")?;
+fn commit_with_wrong_entity_type_fails() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
 
     // Create a file
     env.file("file.txt", "content");
@@ -1223,14 +1160,12 @@ Error: Invalid file ID(s):
   'A' is a branch but must be an uncommitted file or hunk
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
 fn commit_with_file_assigned_to_different_stack_fails() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     // Create a file
     env.file("file.txt", "content");
@@ -1256,8 +1191,8 @@ fn commit_with_file_assigned_to_different_stack_fails() -> anyhow::Result<()> {
 
 #[test]
 fn commit_with_empty_file_list_uses_all_files() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Create two files
     env.file("file1.txt", "content 1");
@@ -1288,8 +1223,8 @@ fn commit_with_empty_file_list_uses_all_files() -> anyhow::Result<()> {
 
 #[test]
 fn commit_with_multiple_hunk_ids_from_same_file() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Create a file with content that will result in multiple hunks when modified
     env.file(
@@ -1362,8 +1297,8 @@ fn commit_with_multiple_hunk_ids_from_same_file() -> anyhow::Result<()> {
 
 #[test]
 fn commit_single_hunk_leaves_other_hunks_uncommitted() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Create a file with content that will result in multiple hunks when modified
     env.file(
@@ -1427,8 +1362,8 @@ fn commit_single_hunk_leaves_other_hunks_uncommitted() -> anyhow::Result<()> {
 
 #[test]
 fn committing_to_existing_branch_with_same_name_as_file() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // create a file with the same name as the branch
     env.file("A", "data");
@@ -1445,8 +1380,8 @@ fn committing_to_existing_branch_with_same_name_as_file() {
 
 #[test]
 fn committing_to_new_branch_with_same_name_as_file() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("foo", "data");
 
@@ -1464,8 +1399,8 @@ Created new independent branch 'foo'
 
 #[test]
 fn committing_to_existing_branch_via_short_id() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("file.txt", "data");
 
@@ -1481,8 +1416,8 @@ fn committing_to_existing_branch_via_short_id() {
 
 #[test]
 fn commit_batch_creates_multiple_selected_commits() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("one.txt", "one");
     env.file("two.txt", "two");
@@ -1524,8 +1459,8 @@ fn commit_batch_creates_multiple_selected_commits() -> anyhow::Result<()> {
 
 #[test]
 fn commit_batch_with_position_on_different_branch_fails() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
     env.file("new-file.txt", "content");
 
     let status = util::status_json(&env)?;
@@ -1549,8 +1484,8 @@ fn commit_batch_with_position_on_different_branch_fails() -> anyhow::Result<()> 
 
 #[test]
 fn commit_batch_after_commit_preserves_batch_order() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("one.txt", "one");
     env.file("two.txt", "two");
@@ -1578,8 +1513,8 @@ fn commit_batch_after_commit_preserves_batch_order() -> anyhow::Result<()> {
 
 #[test]
 fn commit_batch_json_outputs_single_document() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("one.txt", "one");
     env.file("two.txt", "two");
@@ -1609,9 +1544,9 @@ fn commit_batch_json_outputs_single_document() -> anyhow::Result<()> {
 }
 
 #[test]
-fn commit_batch_json_mode_multiple_branches_requires_branch() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata_at_target(&["A", "B"], "origin/main")?;
+fn commit_batch_json_mode_multiple_branches_requires_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata_at_target(&["A", "B"], "origin/main");
 
     env.file("new-file.txt", "test content");
 
@@ -1622,8 +1557,6 @@ fn commit_batch_json_mode_multiple_branches_requires_branch() -> anyhow::Result<
 Error: Multiple branches found. Specify a branch to commit to using the branch argument
 
 "#]]);
-
-    Ok(())
 }
 
 /// Helper to build an isolated `std::process::Command` for `but` with the same
@@ -1732,8 +1665,8 @@ mod concurrent_commits {
     /// succeed without errors or lost data.
     #[test]
     fn concurrent_commits_to_independent_branches() -> anyhow::Result<()> {
-        let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-        env.setup_metadata(&["A"])?;
+        let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+        env.setup_metadata(&["A"]);
 
         // Create two more independent branches
         env.but("branch new branchB").assert().success();
@@ -1820,8 +1753,8 @@ mod concurrent_commits {
     /// it can work if done in serial, if there is definitely no race.
     #[test]
     fn serialized_commits_to_independent_branches() -> anyhow::Result<()> {
-        let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-        env.setup_metadata(&["A"])?;
+        let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+        env.setup_metadata(&["A"]);
 
         // Create two more independent branches
         env.but("branch new branchB").assert().success();

--- a/crates/but/tests/but/command/commit2.rs
+++ b/crates/but/tests/but/command/commit2.rs
@@ -2,8 +2,8 @@ use crate::utils::Sandbox;
 
 #[test]
 fn no_message_nothing_to_commit() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("commit2 --no-message").assert().success();
 
@@ -27,8 +27,8 @@ Hint: run `but help` for all commands
 
 #[test]
 fn no_args_single_head_no_message_human_output() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("file.txt", "Some text");
 
@@ -60,8 +60,8 @@ Hint: run `but help` for all commands
 
 #[test]
 fn no_args_single_head_no_message_shell_output() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("file.txt", "Some text");
 
@@ -76,8 +76,8 @@ fn no_args_single_head_no_message_shell_output() {
 
 #[test]
 fn no_args_single_head_no_message_json_output() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("file.txt", "Some text");
 
@@ -94,8 +94,8 @@ fn no_args_single_head_no_message_json_output() {
 
 #[test]
 fn no_args_single_head_message_from_editor() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // TODO: move this into Sandbox
     env.file("editor.sh", "printf 'commit from editor\\n' > \"$1\"\n");
@@ -129,8 +129,8 @@ Hint: run `but help` for all commands
 
 #[test]
 fn single_head_with_message() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("file.txt", "Some text");
 
@@ -156,8 +156,8 @@ Hint: run `but help` for all commands
 
 #[test]
 fn can_repeat_message() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("file.txt", "Some text");
 
@@ -208,8 +208,8 @@ Files changed:
 
 #[test]
 fn editor_user_writes_no_message() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("editor.sh", "printf '' > \"$1\"\n");
     let editor_path = env.projects_root().join("editor.sh");
@@ -242,8 +242,8 @@ Hint: run `but help` for all commands
 
 #[test]
 fn editor_fails() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("editor.sh", "false");
     let editor_path = env.projects_root().join("editor.sh");
@@ -264,8 +264,8 @@ Error: Editor exited with non-zero status
 
 #[test]
 fn create_commit_on_new_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     env.file("file.txt", "Some text");
 
@@ -290,8 +290,8 @@ Hint: run `but help` for all commands
 
 #[test]
 fn create_commit_on_user_provided_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     env.file("first", "Some text");
 
@@ -394,8 +394,8 @@ Hint: run `but help` for all commands
 
 #[test]
 fn create_commit_on_new_branch_with_canned_name() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("file.txt", "Some text");
 
@@ -424,8 +424,8 @@ Hint: run `but help` for all commands
 
 #[test]
 fn create_commit_on_branch_that_is_not_applied_fails() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     env.invoke_git("branch existing");
 
@@ -444,8 +444,8 @@ Hint: Run `but apply existing` to apply the branch first
 
 #[test]
 fn bails_on_rejected_specs() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     env.file("first", "Some text");
 
@@ -464,8 +464,8 @@ Error: Couldn't commit all changes
 
 #[test]
 fn newly_created_branches_are_included_in_json_output() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     env.file("first", "Some text");
 
@@ -483,8 +483,8 @@ fn newly_created_branches_are_included_in_json_output() {
 
 #[test]
 fn empty_flag_to_force_empty_commit_when_changes_exist() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&["A"]);
 
     env.file(
         "changes",
@@ -515,9 +515,8 @@ Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage 
 
 #[test]
 fn commit_empty_above_commit() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     env.but("status")
         .assert()
@@ -561,9 +560,8 @@ Hint: run `but help` for all commands
 
 #[test]
 fn commit_empty_below_commit() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     env.but("status")
         .assert()
@@ -607,9 +605,8 @@ Hint: run `but help` for all commands
 
 #[test]
 fn commit_above_commit() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     env.file("file.txt", "Some changes");
 
@@ -656,8 +653,8 @@ Hint: run `but help` for all commands
 
 #[test]
 fn commit_above_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("file.txt", "Some changes");
 
@@ -704,9 +701,8 @@ Hint: run `but help` for all commands
 
 #[test]
 fn commit_below_commit() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     env.file("file.txt", "Some changes");
 
@@ -753,8 +749,8 @@ Hint: run `but help` for all commands
 
 #[test]
 fn commit_below_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("file.txt", "Some changes");
 
@@ -801,9 +797,8 @@ Hint: run `but help` for all commands
 
 #[test]
 fn commit_below_branch_with_multiple_commits_treats_branch_as_bucket() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     env.file("file.txt", "Some changes");
 
@@ -852,9 +847,8 @@ Hint: run `but help` for all commands
 
 #[test]
 fn commit_above_refuses_on_conflicts() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     env.but("status")
         .assert()
@@ -886,9 +880,8 @@ Error: Couldn't commit all changes
 
 #[test]
 fn commit_below_refuses_on_conflicts() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     env.but("status")
         .assert()
@@ -920,8 +913,8 @@ Error: Couldn't commit all changes
 
 #[test]
 fn refuses_above_and_below() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&["A"]);
 
     env.but("commit2 --above dontcare --below dontcare")
         .assert()
@@ -938,8 +931,8 @@ For more information, try '--help'.
 
 #[test]
 fn refuses_above_and_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&["A"]);
 
     env.but("commit2 --above dontcare -b")
         .assert()
@@ -956,8 +949,8 @@ For more information, try '--help'.
 
 #[test]
 fn refuses_below_and_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&["A"]);
 
     env.but("commit2 --below dontcare -b")
         .assert()
@@ -974,8 +967,8 @@ For more information, try '--help'.
 
 #[test]
 fn above_branch_not_in_workspace_returns_bad_input() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     env.but("unapply B").assert().success();
 
@@ -992,8 +985,8 @@ Hint: Target must be an applied branch or commit. Run `but status` for applicabl
 
 #[test]
 fn above_commit_not_in_workspace_returns_bad_input() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     env.but("status")
         .assert()
@@ -1030,8 +1023,8 @@ Hint: Target must be an applied branch or commit. Run `but status` for applicabl
 
 #[test]
 fn above_non_branch_non_commit_target_returns_bad_input() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     env.but("commit2 --above zz")
         .assert()
@@ -1046,8 +1039,8 @@ Hint: Run `but status` to show applicable targets
 
 #[test]
 fn committing_specific_cli_ids() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("one", "content");
     env.file("two", "content");
@@ -1095,8 +1088,8 @@ Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage 
 
 #[test]
 fn hunks_within_file_are_not_order_dependent() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let original_data = "enough\nlines\nto\ncreate\nmultiple\nhunks\nwhen\nediting";
 
@@ -1178,8 +1171,8 @@ Hint: run `but help` for all commands
 
 #[test]
 fn overlapping_changes_to_modified_file_are_deduplicated() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let original_data = "enough\nlines\nto\ncreate\nmultiple\nhunks\nwhen\nediting";
 
@@ -1261,8 +1254,8 @@ Hint: run `but help` for all commands
 
 #[test]
 fn committing_something_that_isnt_a_cli_id() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("commit2 --no-message A")
         .assert()
@@ -1275,8 +1268,8 @@ Error: Invalid uncommitted change. 'A' is a branch
 
 #[test]
 fn requires_specifying_stack_when_there_are_multiple() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     env.but("commit2 --empty --no-message")
         .assert()
@@ -1291,8 +1284,8 @@ Hint: You can specify where to commit with `--branch [<BRANCH>]`
 
 #[test]
 fn committing_above_an_empty_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     env.file("one", "one content");
 
@@ -1322,8 +1315,8 @@ Hint: run `but help` for all commands
 
 #[test]
 fn committing_below_empty_branch_with_empty_branch_below() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     env.file("one", "one content");
 
@@ -1356,8 +1349,8 @@ Hint: run `but help` for all commands
 
 #[test]
 fn committing_below_non_top_empty_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     env.file("one", "one content");
     env.file("two", "two content");
@@ -1399,8 +1392,8 @@ Hint: run `but help` for all commands
 
 #[test]
 fn committing_below_an_empty_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     env.file("one", "one content");
     env.file("two", "two content");
@@ -1477,8 +1470,8 @@ Hint: run `but help` for all commands
 
 #[test]
 fn gives_good_error_when_your_terminal_doesnt_support_input() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     env.but("commit2 --interactive")
         .assert()

--- a/crates/but/tests/but/command/config.rs
+++ b/crates/but/tests/but/command/config.rs
@@ -2,8 +2,8 @@ use crate::utils::{CommandExt as _, Sandbox};
 use snapbox::str;
 
 #[test]
-fn ai_openai_defaults_to_global_config() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+fn ai_openai_defaults_to_global_config() {
+    let env = Sandbox::empty();
     env.invoke_bash("git init repo");
     let global_config = env.projects_root().join("global.gitconfig");
 
@@ -29,13 +29,11 @@ fn ai_openai_defaults_to_global_config() -> anyhow::Result<()> {
         "-C repo config --local --get gitbutler.aiModelProvider",
         "default AI config should not write repo-local keys",
     );
-
-    Ok(())
 }
 
 #[test]
-fn ai_ollama_local_writes_repo_config() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+fn ai_ollama_local_writes_repo_config() {
+    let env = Sandbox::empty();
     env.invoke_bash("git init repo");
     #[cfg(feature = "legacy")]
     env.but("-C repo setup").assert().success();
@@ -56,13 +54,11 @@ fn ai_ollama_local_writes_repo_config() -> anyhow::Result<()> {
         env.invoke_git("-C repo config --local --get gitbutler.aiOllamaModelName"),
         "llama3.1"
     );
-
-    Ok(())
 }
 
 #[test]
-fn ai_global_config_works_outside_repository() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+fn ai_global_config_works_outside_repository() {
+    let env = Sandbox::empty();
     let global_config = env.projects_root().join("global.gitconfig");
 
     env.but("config ai lmstudio --endpoint http://localhost:1234/v1 --model local-model")
@@ -82,13 +78,11 @@ fn ai_global_config_works_outside_repository() -> anyhow::Result<()> {
         env.invoke_git("config --file global.gitconfig --get gitbutler.aiLMStudioModelName"),
         "local-model"
     );
-
-    Ok(())
 }
 
 #[test]
 fn ai_show_outputs_current_global_configuration_json() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+    let env = Sandbox::empty();
     let global_config = env.projects_root().join("global.gitconfig");
 
     env.but("config ai openai --key-option butler-api --model gpt-5.4-nano")
@@ -112,7 +106,7 @@ fn ai_show_outputs_current_global_configuration_json() -> anyhow::Result<()> {
 
 #[test]
 fn ai_show_outputs_current_local_configuration_json() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+    let env = Sandbox::empty();
     env.invoke_bash("git init repo");
     #[cfg(feature = "legacy")]
     env.but("-C repo setup").assert().success();
@@ -135,8 +129,8 @@ fn ai_show_outputs_current_local_configuration_json() -> anyhow::Result<()> {
 }
 
 #[test]
-fn ai_show_outputs_current_global_configuration_human() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+fn ai_show_outputs_current_global_configuration_human() {
+    let env = Sandbox::empty();
     let global_config = env.projects_root().join("global.gitconfig");
 
     env.but("config ai openai --key-option butler-api --model gpt-5.4-nano")
@@ -163,13 +157,11 @@ AI Configuration (global)
   LM Studio model: (not set)
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
 fn ai_openai_byok_without_api_key_fails_non_interactive() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+    let env = Sandbox::empty();
     let global_config = env.projects_root().join("global.gitconfig");
 
     let output = env
@@ -196,7 +188,7 @@ fn ai_openai_byok_without_api_key_fails_non_interactive() -> anyhow::Result<()> 
 
 #[test]
 fn ai_anthropic_byok_without_api_key_fails_non_interactive() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+    let env = Sandbox::empty();
     let global_config = env.projects_root().join("global.gitconfig");
 
     let output = env

--- a/crates/but/tests/but/command/diff.rs
+++ b/crates/but/tests/but/command/diff.rs
@@ -1,10 +1,10 @@
 use crate::utils::Sandbox;
 
 #[test]
-fn path_prefix() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+fn path_prefix() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
     env.file("prefixx", "don't show this\n");
     env.file("prefix/a", "we want this\n");
     env.file("prefix/b", "we also want this\n");
@@ -23,5 +23,4 @@ m0 prefix/b│
      1│+we also want this
 
 "#]]);
-    Ok(())
 }

--- a/crates/but/tests/but/command/discard.rs
+++ b/crates/but/tests/but/command/discard.rs
@@ -17,8 +17,8 @@ fn find_unassigned_cli_id(status: &serde_json::Value, path_contains: &str) -> Op
 
 #[test]
 fn discard_removes_selected_change() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("src/discard-me.ts", "export const value = true;\n");
 
@@ -42,8 +42,8 @@ fn discard_removes_selected_change() -> anyhow::Result<()> {
 
 #[test]
 fn concurrent_discard_to_independent_files_succeeds() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("src/a/discard.ts", "export const a = true;\n");
     env.file("src/b/discard.ts", "export const b = true;\n");
@@ -84,8 +84,8 @@ fn concurrent_discard_to_independent_files_succeeds() -> anyhow::Result<()> {
 
 #[test]
 fn discard_reverts_simple_rename() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("src/rename-source.ts", "export const source = true;\n");
     env.but("commit A -m 'seed rename source'")
@@ -122,8 +122,8 @@ fn discard_reverts_simple_rename() -> anyhow::Result<()> {
 
 #[test]
 fn discard_rename_does_not_discard_unrelated_changes() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("src/rename-source-only.ts", "export const source = 1;\n");
     env.but("commit A -m 'seed rename source only'")
@@ -180,8 +180,8 @@ fn discard_rename_does_not_discard_unrelated_changes() -> anyhow::Result<()> {
 
 #[test]
 fn discard_the_whole_unassigned_changes() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("src/rename-source-only.ts", "export const source = 1;\n");
     env.but("commit A -m 'seed rename source only'")
@@ -230,8 +230,8 @@ fn discard_the_whole_unassigned_changes() -> anyhow::Result<()> {
 
 #[test]
 fn discarding_multiple_hunks_in_a_file_works() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let content = "1\n2\n3\n4\n5\n6\n7";
     let file_path = "src/some_file.txt";

--- a/crates/but/tests/but/command/external.rs
+++ b/crates/but/tests/but/command/external.rs
@@ -8,7 +8,7 @@ use crate::utils::Sandbox;
 
 #[test]
 fn delegates_plain_name_to_but_prefixed_executable() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+    let env = Sandbox::empty();
     let bin = env.projects_root().join("external-cmd-bin");
     fs::create_dir_all(&bin)?;
     let helper = bin.join("but-forecast");
@@ -38,7 +38,7 @@ args: one two
 
 #[test]
 fn prefers_builtin_command_when_external_command_clashes() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     let bin = env.projects_root().join("external-cmd-bin");
     fs::create_dir_all(&bin)?;
     let helper = bin.join("but-alias");
@@ -72,7 +72,7 @@ Default aliases (overridable):
 
 #[test]
 fn propagates_reasonable_error_when_program_is_not_executable() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+    let env = Sandbox::empty();
     let bin = env.projects_root().join("external-cmd-bin");
     fs::create_dir_all(&bin)?;
     let helper = bin.join("but-forecast");
@@ -102,7 +102,7 @@ Caused by:
 
 #[test]
 fn refuses_to_execute_command_with_forward_slash() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+    let env = Sandbox::empty();
 
     env.but("bad/command")
             .assert()
@@ -121,7 +121,7 @@ Hint: Are you trying to write an extension command 'but-<command>'? Make sure th
 
 #[test]
 fn refuses_to_execute_command_with_dot() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+    let env = Sandbox::empty();
 
     env.but("bad.command")
             .assert()
@@ -139,8 +139,8 @@ Hint: Are you trying to write an extension command 'but-<command>'? Make sure th
 }
 
 #[test]
-fn friendly_error_when_no_such_command_exists() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+fn friendly_error_when_no_such_command_exists() {
+    let env = Sandbox::empty();
 
     env.but("comit").assert().failure().stderr_eq(str![[r#"
 error: unrecognized subcommand 'comit'
@@ -152,6 +152,4 @@ Usage: but [OPTIONS] [COMMAND]
 For more information, try '--help'.
 
 "#]]);
-
-    Ok(())
 }

--- a/crates/but/tests/but/command/format.rs
+++ b/crates/but/tests/but/command/format.rs
@@ -1,10 +1,10 @@
 use crate::utils::Sandbox;
 
 #[test]
-fn json_flag_can_be_placed_before_or_after_subcommand() -> anyhow::Result<()> {
+fn json_flag_can_be_placed_before_or_after_subcommand() {
     // TODO: use an actual repository here, but single-branch mode isn't really supported yet
     //       so everything fails anyway.
-    let env = Sandbox::empty()?;
+    let env = Sandbox::empty();
 
     // Test that --format json flag works in both positions with help command (doesn't need a valid repo)
     env.but("--format json completions --help")
@@ -43,14 +43,12 @@ Please run 'but setup' to initialize the project.
 
 "#]]);
     }
-
-    Ok(())
 }
 
 #[test]
 #[cfg(feature = "legacy")]
 fn default_command_respects_c_flag_for_setup_checks() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+    let env = Sandbox::empty();
     env.invoke_bash("git init repo");
 
     env.but("-C repo")
@@ -67,7 +65,7 @@ Error: Setup required: No GitButler project found at repo - run `but setup` to c
 #[test]
 #[cfg(feature = "legacy")]
 fn default_alias_can_provide_c_flag_for_implicit_default_command() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+    let env = Sandbox::empty();
     env.invoke_bash(
         r#"
 git init .
@@ -87,7 +85,7 @@ Error: Setup required: No GitButler project found at repo - run `but setup` to c
 #[test]
 #[cfg(feature = "legacy")]
 fn explicit_c_flag_overrides_default_alias_c_flag() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+    let env = Sandbox::empty();
     env.invoke_bash(
         r#"
 git init .

--- a/crates/but/tests/but/command/gui.rs
+++ b/crates/but/tests/but/command/gui.rs
@@ -3,8 +3,8 @@ use snapbox::str;
 use crate::utils::Sandbox;
 
 #[test]
-fn good_error_message_for_non_directories() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+fn good_error_message_for_non_directories() {
+    let env = Sandbox::empty();
 
     env.file("not-a-dir", "content-does-not-matter");
 
@@ -16,5 +16,4 @@ fn good_error_message_for_non_directories() -> anyhow::Result<()> {
 Error: Can only open the GUI on directories: './not-a-dir'
 
 "#]]);
-    Ok(())
 }

--- a/crates/but/tests/but/command/help.rs
+++ b/crates/but/tests/but/command/help.rs
@@ -5,8 +5,8 @@ use crate::utils::Sandbox;
 
 #[cfg(feature = "legacy")]
 #[test]
-fn rub_looks_good() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+fn rub_looks_good() {
+    let env = Sandbox::empty();
 
     // Assert on plain help text so the test doesn't drift on ANSI-to-SVG styling differences.
     env.but("rub --help").assert().success().stdout_eq(str![[r#"
@@ -100,12 +100,11 @@ Options:
   -h, --help             Print help (see more with '--help')
 
 "#]]);
-    Ok(())
 }
 
 #[test]
-fn nonexistent_comman_shows_friendly_error() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+fn nonexistent_comman_shows_friendly_error() {
+    let env = Sandbox::empty();
 
     env.but("no-such-command")
         .assert()
@@ -119,14 +118,12 @@ Usage: but [OPTIONS] [COMMAND]
 For more information, try '--help'.
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
 /// We want the output of `help --help` to be the same as `help`.
 fn help_help_should_be_help() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+    let env = Sandbox::empty();
 
     let help = env.but("help").output()?.stdout;
     env.but("help --help")
@@ -139,7 +136,7 @@ fn help_help_should_be_help() -> anyhow::Result<()> {
 
 #[test]
 fn top_level_help_honors_agent_format_after_help_flag() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+    let env = Sandbox::empty();
     let help = env.but("help --format agent").output()?.stdout;
 
     env.but("--help --format agent")

--- a/crates/but/tests/but/command/merge.rs
+++ b/crates/but/tests/but/command/merge.rs
@@ -4,7 +4,7 @@ use crate::utils::{CommandExt, Sandbox};
 
 #[test]
 fn merge_first_branch_into_gb_local_and_verify_rebase() -> anyhow::Result<()> {
-    let env = Sandbox::open_with_default_settings("merge-gb-local-two-branches")?;
+    let env = Sandbox::open_with_default_settings("merge-gb-local-two-branches");
 
     // Run setup to create gb-local remote
     env.but("setup").assert().success();
@@ -33,7 +33,7 @@ fn merge_first_branch_into_gb_local_and_verify_rebase() -> anyhow::Result<()> {
         .success();
 
     // Verify git log shows both branches before merge
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log(), @r"
     *   71ae247 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * edca1cd (second-branch) second commit on branch B
@@ -118,7 +118,7 @@ To undo this operation:
     );
 
     // Verify git log shows the rebased structure
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log(), @r"
     * c7f0f9d (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * e8d7818 (second-branch) second commit on branch B
     *   61888c9 (gb-local/main, gb-local/HEAD, main) Merge branch 'first-branch'
@@ -138,7 +138,7 @@ To undo this operation:
 
 #[test]
 fn pull_integrates_branch_when_gb_local_target_points_at_branch_head() -> anyhow::Result<()> {
-    let env = Sandbox::open_with_default_settings("merge-gb-local-two-branches")?;
+    let env = Sandbox::open_with_default_settings("merge-gb-local-two-branches");
 
     env.but("setup").assert().success();
     env.but("branch new first-branch").assert().success();

--- a/crates/but/tests/but/command/move.rs
+++ b/crates/but/tests/but/command/move.rs
@@ -12,9 +12,9 @@ use crate::{
 
 #[test]
 fn move_commit_before_another_commit() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     // Create three commits
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
@@ -58,9 +58,9 @@ Moved 23e1bf8 → before fce8ecc
 
 #[test]
 fn move_commit_after_another_commit() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     // Create three commits
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
@@ -97,9 +97,9 @@ Moved fce8ecc → after 23e1bf8
 
 #[test]
 fn move_multiple_commits_before_another_commit() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     // Create three commits
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
@@ -175,9 +175,9 @@ Hint: run `but help` for all commands
 
 #[test]
 fn move_multiple_commits_after_another_commit() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     // Create three commits
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
@@ -253,9 +253,9 @@ Hint: run `but help` for all commands
 
 #[test]
 fn move_multiple_commits_from_different_branches() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("three-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("three-stacks");
 
-    env.setup_metadata(&["A", "B", "C"])?;
+    env.setup_metadata(&["A", "B", "C"]);
 
     env.but("st")
         .assert()
@@ -397,9 +397,9 @@ Hint: run `but help` for all commands
 
 #[test]
 fn move_multiple_commits_from_different_branches_after() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("three-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("three-stacks");
 
-    env.setup_metadata(&["A", "B", "C"])?;
+    env.setup_metadata(&["A", "B", "C"]);
 
     env.but("st")
         .assert()
@@ -541,9 +541,9 @@ Hint: run `but help` for all commands
 
 #[test]
 fn move_commit_to_branch() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
 
     // Create a commit on branch A
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "commit on A");
@@ -580,10 +580,10 @@ Moved [..] → [B]
 }
 
 #[test]
-fn move_commit_with_invalid_source() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+fn move_commit_with_invalid_source() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
 
@@ -594,15 +594,13 @@ fn move_commit_with_invalid_source() -> anyhow::Result<()> {
 Failed to move commit. Source 'nonexistent' not found. If you just performed a Git operation, try running 'but status' to refresh.
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
 fn move_commit_with_after_flag_and_branch_target() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
 
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "commit on A");
 
@@ -628,9 +626,9 @@ When moving to a branch, the commit is placed at the top of the stack by default
 
 #[test]
 fn move_same_commit_to_itself() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
 
@@ -655,9 +653,9 @@ Source and target are the same commit. Nothing to do.
 
 #[test]
 fn move_commit_with_invalid_target() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
 
@@ -681,9 +679,9 @@ Failed to move commit. Target 'nonexistent' not found. If you just performed a G
 
 #[test]
 fn move_cross_stack_works_yay() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
 
     // Create commits on both branches
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "commit on A");
@@ -714,9 +712,9 @@ Moved c629281 → before ae3978a
 
 #[test]
 fn move_committed_file_to_another_commit() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     // Create two commits with different files
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
@@ -781,9 +779,9 @@ Moved files between commits!
 fn move_branch_by_name_from_top_level_move() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings(
         "two-stacks-one-single-and-ready-to-mingle-one-double",
-    )?;
+    );
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
 
     env.but("st")
         .assert()
@@ -849,7 +847,7 @@ Hint: run `but help` for all commands
 
 #[test]
 fn move_empty_branch_on_top_of_empty_branch_by_cli_id() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
 
     env.invoke_git("branch A main");
     env.invoke_git("branch B main");
@@ -907,9 +905,9 @@ Hint: run `but help` for all commands
 fn move_branch_onto_itself_fails_without_deleting_branch() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings(
         "two-stacks-one-single-and-ready-to-mingle-one-double",
-    )?;
+    );
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
 
     env.but("move C C").assert().failure().stderr_eq(str![[r#"
 Failed to move branch. Cannot move branch refs/heads/C onto itself
@@ -934,9 +932,9 @@ Failed to move branch. Cannot move branch refs/heads/C onto itself
 fn move_branch_by_cli_id_from_top_level_move() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings(
         "two-stacks-one-single-and-ready-to-mingle-one-double",
-    )?;
+    );
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
 
     env.but("st")
         .assert()
@@ -1015,9 +1013,9 @@ Hint: run `but help` for all commands
 fn tear_off_branch_with_top_level_move_to_zz() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings(
         "two-stacks-one-single-and-ready-to-mingle-one-double",
-    )?;
+    );
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
 
     env.but("st")
         .assert()
@@ -1096,12 +1094,12 @@ Hint: run `but help` for all commands
 }
 
 #[test]
-fn move_branch_with_after_flag_fails_from_top_level_move() -> anyhow::Result<()> {
+fn move_branch_with_after_flag_fails_from_top_level_move() {
     let env = Sandbox::init_scenario_with_target_and_default_settings(
         "two-stacks-one-single-and-ready-to-mingle-one-double",
-    )?;
+    );
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
 
     env.but("st")
         .assert()
@@ -1158,7 +1156,6 @@ Failed to move branch. The --after flag only makes sense when moving a commit to
 Hint: run `but help` for all commands
 
 "#]]);
-    Ok(())
 }
 
 fn status_json(env: &Sandbox) -> anyhow::Result<serde_json::Value> {
@@ -1188,7 +1185,7 @@ fn stack_branch_layout(status_json: &serde_json::Value) -> anyhow::Result<Vec<Ve
 }
 
 fn setup_single_stack_metadata(env: &Sandbox, branch_names: &[&str]) -> anyhow::Result<()> {
-    let mut meta = env.meta()?;
+    let mut meta = env.meta();
     let mut workspace = meta.workspace(but_core::WORKSPACE_REF_NAME.try_into()?)?;
     workspace.stacks = vec![WorkspaceStack {
         id: StackId::from_number_for_testing(0),

--- a/crates/but/tests/but/command/onboarding.rs
+++ b/crates/but/tests/but/command/onboarding.rs
@@ -2,7 +2,7 @@ use crate::utils::{CommandExt as _, Sandbox};
 
 #[test]
 fn first_run_shows_metrics_message() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+    let env = Sandbox::empty();
 
     // The sandbox sets onboarding_complete: true by default to avoid polluting other tests.
     // Delete the settings file to simulate a fresh install (will be recreated with defaults).
@@ -23,7 +23,7 @@ GitButler uses metrics to help us know what is useful and improve it. Configure 
 
 #[test]
 fn second_run_is_silent() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+    let env = Sandbox::empty();
 
     // The sandbox sets onboarding_complete: true by default.
     // Delete the settings file to simulate a fresh install.
@@ -48,7 +48,7 @@ GitButler uses metrics to help us know what is useful and improve it. Configure 
 
 #[test]
 fn json_mode_is_silent_but_marks_complete() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+    let env = Sandbox::empty();
 
     // The sandbox sets onboarding_complete: true by default.
     // Delete the settings file to simulate a fresh install.

--- a/crates/but/tests/but/command/pick.rs
+++ b/crates/but/tests/but/command/pick.rs
@@ -31,9 +31,9 @@ fn branch_has_commit_message(env: &Sandbox, branch_name: &str, message_contains:
 // === Success cases ===
 
 #[test]
-fn pick_by_full_sha() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied")?;
-    env.setup_metadata(&["applied-branch"])?;
+fn pick_by_full_sha() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied");
+    env.setup_metadata(&["applied-branch"]);
 
     let sha = get_commit_sha(&env, "refs/gitbutler/pickable-first");
     env.but(format!("pick {sha} applied-branch"))
@@ -45,13 +45,12 @@ fn pick_by_full_sha() -> anyhow::Result<()> {
         "applied-branch",
         "first pickable commit"
     ));
-    Ok(())
 }
 
 #[test]
-fn pick_by_short_sha() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied")?;
-    env.setup_metadata(&["applied-branch"])?;
+fn pick_by_short_sha() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied");
+    env.setup_metadata(&["applied-branch"]);
 
     let short_sha = &get_commit_sha(&env, "refs/gitbutler/pickable-first")[..7];
     env.but(format!("pick {short_sha} applied-branch"))
@@ -63,13 +62,12 @@ fn pick_by_short_sha() -> anyhow::Result<()> {
         "applied-branch",
         "first pickable commit"
     ));
-    Ok(())
 }
 
 #[test]
-fn pick_by_branch_name() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied")?;
-    env.setup_metadata(&["applied-branch"])?;
+fn pick_by_branch_name() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied");
+    env.setup_metadata(&["applied-branch"]);
 
     // When picking by branch name in non-interactive mode, picks the head commit
     env.but("pick unapplied-branch applied-branch")
@@ -81,13 +79,12 @@ fn pick_by_branch_name() -> anyhow::Result<()> {
         "applied-branch",
         "second pickable commit"
     ));
-    Ok(())
 }
 
 #[test]
-fn pick_auto_selects_single_stack() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied")?;
-    env.setup_metadata(&["applied-branch"])?;
+fn pick_auto_selects_single_stack() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied");
+    env.setup_metadata(&["applied-branch"]);
 
     let sha = get_commit_sha(&env, "refs/gitbutler/pickable-first");
 
@@ -96,26 +93,23 @@ fn pick_auto_selects_single_stack() -> anyhow::Result<()> {
     let stdout = String::from_utf8_lossy(&result.get_output().stdout);
 
     assert!(stdout.contains("into branch applied-branch"));
-    Ok(())
 }
 
 #[test]
-fn pick_target_is_case_insensitive() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied")?;
-    env.setup_metadata(&["applied-branch"])?;
+fn pick_target_is_case_insensitive() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied");
+    env.setup_metadata(&["applied-branch"]);
 
     let sha = get_commit_sha(&env, "refs/gitbutler/pickable-first");
     env.but(format!("pick {sha} APPLIED-BRANCH"))
         .assert()
         .success();
-
-    Ok(())
 }
 
 #[test]
 fn pick_json_output() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied")?;
-    let stack_ids = env.setup_metadata(&["applied-branch"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied");
+    let stack_ids = env.setup_metadata(&["applied-branch"]);
 
     let sha = get_commit_sha(&env, "refs/gitbutler/pickable-first");
     let result = env
@@ -136,9 +130,9 @@ fn pick_json_output() -> anyhow::Result<()> {
 // === Error cases ===
 
 #[test]
-fn pick_invalid_source_fails() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied")?;
-    env.setup_metadata(&["applied-branch"])?;
+fn pick_invalid_source_fails() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied");
+    env.setup_metadata(&["applied-branch"]);
 
     env.but("pick nonexistent-thing applied-branch")
         .assert()
@@ -148,14 +142,12 @@ Failed to pick commit. Source 'nonexistent-thing' is not a valid commit ID, CLI 
 Run 'but status' to see available CLI IDs, or 'but branch list' to see branches.
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn pick_invalid_target_fails() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied")?;
-    env.setup_metadata(&["applied-branch"])?;
+fn pick_invalid_target_fails() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied");
+    env.setup_metadata(&["applied-branch"]);
 
     let sha = get_commit_sha(&env, "refs/gitbutler/pickable-first");
     env.but(format!("pick {sha} nonexistent-branch"))
@@ -166,6 +158,4 @@ Failed to pick commit. Target branch 'nonexistent-branch' not found among applie
 Available stacks: applied-branch
 
 "#]]);
-
-    Ok(())
 }

--- a/crates/but/tests/but/command/push.rs
+++ b/crates/but/tests/but/command/push.rs
@@ -4,8 +4,8 @@ use super::util::find_branch;
 use crate::utils::{CommandExt, Sandbox};
 
 fn repo_with_unpushed_branch() -> anyhow::Result<Sandbox> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let remote_git = env.app_data_dir().join("origin.git");
     let remote_git = remote_git.display();
@@ -96,8 +96,8 @@ fn push_dry_run_agent_reports_human_summary() -> anyhow::Result<()> {
 
 #[test]
 fn push_refuses_conflicted_commits() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata_at_target(&["A"], "origin/main")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
 
     let remote_git = env.app_data_dir().join("origin.git");
     let remote_git = remote_git.display();

--- a/crates/but/tests/but/command/resolve.rs
+++ b/crates/but/tests/but/command/resolve.rs
@@ -5,7 +5,7 @@ use super::util::enter_edit_mode_with_conflicted_commit;
 use crate::utils::Sandbox;
 
 fn current_branch_name(env: &Sandbox) -> anyhow::Result<String> {
-    let repo = env.open_repo()?;
+    let repo = env.open_repo();
     repo.rev_parse_single("HEAD")
         .context("HEAD should resolve")?;
     repo.head_name()?
@@ -15,7 +15,7 @@ fn current_branch_name(env: &Sandbox) -> anyhow::Result<String> {
 
 #[test]
 fn resolve_status_and_finish_work_in_edit_mode() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     enter_edit_mode_with_conflicted_commit(&env)?;
 
     env.but("resolve status")
@@ -37,7 +37,7 @@ fn resolve_status_and_finish_work_in_edit_mode() -> anyhow::Result<()> {
 
 #[test]
 fn resolve_cancel_works_in_edit_mode() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     enter_edit_mode_with_conflicted_commit(&env)?;
 
     env.but("resolve cancel --force")
@@ -50,7 +50,7 @@ fn resolve_cancel_works_in_edit_mode() -> anyhow::Result<()> {
 
 #[test]
 fn resolve_cancel_requires_force_when_changes_were_made() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     enter_edit_mode_with_conflicted_commit(&env)?;
 
     env.file("test-file.txt", "resolved content with additional edits\n");

--- a/crates/but/tests/but/command/reword.rs
+++ b/crates/but/tests/but/command/reword.rs
@@ -4,15 +4,15 @@ use snapbox::str;
 use crate::utils::Sandbox;
 
 #[test]
-fn reword_commit_with_message_flag() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @"
+fn reword_commit_with_message_flag() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    insta::assert_snapshot!(env.git_log(), @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     // Use reword with -m flag to change commit message (using commit ID)
     env.but("reword 9477ae7 -m 'Updated commit message'")
@@ -23,25 +23,23 @@ Updated commit message for [..] (now [..])
 
 "#]]);
 
-    insta::assert_snapshot!(env.git_log()?, @"
+    insta::assert_snapshot!(env.git_log(), @"
     * 8c69cf9 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 2f7c570 (A) Updated commit message
     * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
     ");
-
-    Ok(())
 }
 
 #[test]
 fn reword_commit_with_multiline_message() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @"
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    insta::assert_snapshot!(env.git_log(), @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     // Use reword with multiline message
     env.but("reword 9477ae7 -m 'First line\n\n\tSecond paragraph with details'")
@@ -53,13 +51,13 @@ Updated commit message for [..] (now [..])
 "#]]);
 
     // Verify the commit message was updated with multiline content
-    insta::assert_snapshot!(env.git_log()?, @"
+    insta::assert_snapshot!(env.git_log(), @"
     * e6bde18 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * cdf2c74 (A) First line
     * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
     ");
 
-    let repo = env.open_repo()?;
+    let repo = env.open_repo();
     assert_eq!(
         repo.rev_parse_single(":/First line")?
             .object()?
@@ -75,11 +73,10 @@ Updated commit message for [..] (now [..])
 // branch names ("A") which don't meet the 2-character minimum requirement for CLI IDs.
 // The branch rename functionality with -m flag is tested manually and works correctly.
 #[test]
-fn reword_branch_from_editor_trims_trailing_newlines_in_confirmation_output() -> anyhow::Result<()>
-{
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+fn reword_branch_from_editor_trims_trailing_newlines_in_confirmation_output() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
     env.but("branch new branch-to-rename-123")
         .assert()
         .success();
@@ -96,14 +93,12 @@ fn reword_branch_from_editor_trims_trailing_newlines_in_confirmation_output() ->
 Renamed branch 'branch-to-rename-123' to 'renamed-branch'
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn reword_branch_rejects_head() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn reword_branch_rejects_head() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("branch new branch-to-rename").assert().success();
 
@@ -116,14 +111,12 @@ Error: Bad input 'HEAD'
 Invalid branch name: Could not turn "HEAD" into a valid reference name
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn reword_branch_rejects_non_normalized_name() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn reword_branch_rejects_non_normalized_name() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("reword A -m /B")
         .assert()
@@ -137,14 +130,12 @@ Invalid branch name
 Hint: Try 'B' instead
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn reword_branch_rejects_branch_name_that_already_exists() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn reword_branch_rejects_branch_name_that_already_exists() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("branch new existing").assert().success();
 
@@ -156,14 +147,12 @@ fn reword_branch_rejects_branch_name_that_already_exists() -> anyhow::Result<()>
 Error: A branch named 'existing' is already applied
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn reword_branch_allows_rewording_to_same_name() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn reword_branch_allows_rewording_to_same_name() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("reword A -m A")
         .assert()
@@ -173,20 +162,18 @@ Branch already named 'A' - nothing to do
 
 "#]])
         .stderr_eq(str![[]]);
-
-    Ok(())
 }
 
 #[test]
-fn reword_commit_with_same_message_succeeds_as_noop() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @"
+fn reword_commit_with_same_message_succeeds_as_noop() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    insta::assert_snapshot!(env.git_log(), @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     // Try to reword with the same message
     env.but("reword 9477ae7 -m 'add A'")
@@ -196,20 +183,18 @@ fn reword_commit_with_same_message_succeeds_as_noop() -> anyhow::Result<()> {
 No changes to commit message - nothing to be done
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn reword_commit_with_json_flag() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @"
+fn reword_commit_with_json_flag() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    insta::assert_snapshot!(env.git_log(), @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     // Use reword with -m flag to change commit message (using commit ID)
     env.but("reword 9477ae7 -m 'Updated commit message' --format json")
@@ -221,11 +206,9 @@ fn reword_commit_with_json_flag() -> anyhow::Result<()> {
 
 "#]]);
 
-    insta::assert_snapshot!(env.git_log()?, @"
+    insta::assert_snapshot!(env.git_log(), @"
     * 8c69cf9 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 2f7c570 (A) Updated commit message
     * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
     ");
-
-    Ok(())
 }

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -10,9 +10,9 @@ use crate::{
 };
 
 fn assigned_uncommitted_file_env() -> anyhow::Result<Sandbox> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
     env.file("a.txt", "arbitrary text\n");
     env.but("rub zz:a.txt A").assert().success();
     Ok(env)
@@ -147,10 +147,10 @@ j0 a.txt│
 }
 
 #[test]
-fn uncommitted_file_to_branch() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+fn uncommitted_file_to_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
     commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
 
     env.but("rub a.txt A")
@@ -161,15 +161,13 @@ Staged all hunks in a.txt in the unassigned area → [A].
 
 "#]])
         .stderr_eq(str![""]);
-
-    Ok(())
 }
 
 #[test]
-fn uncommitted_file_by_path_prefix_to_branch() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+fn uncommitted_file_by_path_prefix_to_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
     commit_file_with_worktree_changes_as_two_hunks(&env, "A", "path/a.txt");
 
     env.but("rub path/ A")
@@ -180,15 +178,13 @@ Staged hunk(s) → [A].
 
 "#]])
         .stderr_eq(str![""]);
-
-    Ok(())
 }
 
 #[test]
 fn committed_file_to_unassigned() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "second commit");
 
@@ -349,9 +345,9 @@ Uncommitted changes
 
 #[test]
 fn shorthand_uncommitted_hunk_to_unassigned() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
     commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
 
     // Assign the change to A.
@@ -429,10 +425,10 @@ Unstaged a hunk in a.txt in a stack
 
 #[test]
 fn uncommitted_hunk_to_branch() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
     // Must set metadata to match the scenario
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
 
     commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
 
@@ -510,10 +506,10 @@ Staged a hunk in a.txt in the unassigned area → [A].
 // Before the fix, "my-file.txt" would be split on '-' and treated as a range
 // from "my" to "file.txt", which would fail.
 #[test]
-fn filename_with_dash_not_treated_as_range() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+fn filename_with_dash_not_treated_as_range() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
     env.file("my-file.txt", "arbitrary text\n");
 
     // Staging by filename should work — the dash should NOT be interpreted as a range separator
@@ -525,17 +521,15 @@ Staged the only hunk in my-file.txt in the unassigned area → [A].
 
 "#]])
         .stderr_eq(str![""]);
-
-    Ok(())
 }
 
 // Tests for convenience commands
 
 #[test]
 fn uncommit_command_on_commit() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
 
     // Get the commit ID from status
@@ -582,9 +576,9 @@ fn uncommit_command_on_commit() -> anyhow::Result<()> {
 #[test]
 fn uncommit_diff_json_keeps_mutation_result_and_diff() -> anyhow::Result<()> {
     fn run(agent: bool) -> anyhow::Result<()> {
-        let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+        let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-        env.setup_metadata(&["A", "B"])?;
+        env.setup_metadata(&["A", "B"]);
         commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
 
         let before = status_json(&env)?;
@@ -634,10 +628,10 @@ fn uncommit_diff_json_keeps_mutation_result_and_diff() -> anyhow::Result<()> {
 }
 
 #[test]
-fn uncommit_command_validation() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+fn uncommit_command_validation() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
     commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
 
     // Test that uncommit rejects uncommitted files
@@ -654,15 +648,13 @@ Failed to uncommit. Cannot uncommit a.txt - it is an uncommitted file or hunk. O
 Failed to uncommit. Cannot uncommit A - it is a branch. Only commits and files-in-commits can be uncommitted.
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
 fn uncommit_command_with_discard_on_commit() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
 
     let before = status_json(&env)?;
@@ -744,9 +736,9 @@ Hint: run `but help` for all commands
 
 #[test]
 fn uncommit_command_with_discard_on_committed_file() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
 
     let before = status_json(&env)?;
@@ -827,7 +819,7 @@ Hint: run `but help` for all commands
 
 #[test]
 fn uncommit_help_mentions_discard_flag() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+    let env = Sandbox::empty();
 
     let output = env.but("uncommit --help").output()?;
     assert!(output.status.success());
@@ -847,9 +839,9 @@ fn uncommit_help_mentions_discard_flag() -> anyhow::Result<()> {
 
 #[test]
 fn agent_uncommit_discard_multiple_sources_writes_single_json_with_status() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "second commit");
 
@@ -889,9 +881,9 @@ fn agent_uncommit_discard_multiple_sources_writes_single_json_with_status() -> a
 
 #[test]
 fn stage_command() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
     commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
 
     // Test stage command
@@ -923,10 +915,10 @@ fn stage_command() -> anyhow::Result<()> {
 }
 
 #[test]
-fn stage_command_path_prefix() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+fn stage_command_path_prefix() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
     env.file("path/a.txt", "text\n");
     env.but("stage path/ A")
         .assert()
@@ -936,14 +928,13 @@ fn stage_command_path_prefix() -> anyhow::Result<()> {
 Staged hunk(s) → [A].
 
 "#]]);
-    Ok(())
 }
 
 #[test]
-fn stage_command_missing_source_hints_to_refresh_cli_ids() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+fn stage_command_missing_source_hints_to_refresh_cli_ids() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
     env.but("stage missing-file A")
         .assert()
         .failure()
@@ -955,15 +946,13 @@ Source 'missing-file' not found. If you just performed a Git operation (squash, 
 Hint: Run `but status --format json -f` to refresh CLI IDs, then retry with a file or hunk cliId from the output
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn stage_command_missing_branch_hints_to_refresh_cli_ids() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+fn stage_command_missing_branch_hints_to_refresh_cli_ids() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
     env.file("a.txt", "text\n");
 
     env.but("stage a.txt missing-branch")
@@ -977,15 +966,13 @@ Branch 'missing-branch' not found. If you just performed a Git operation (squash
 Hint: Use a branch name or branch cliId from `but status --format json -f`
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn stage_command_non_branch_target_hints_to_use_branch() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+fn stage_command_non_branch_target_hints_to_use_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
     env.file("a.txt", "text\n");
 
     env.but("stage a.txt zz")
@@ -999,15 +986,13 @@ Cannot stage to zz - it is the unassigned area. Target must be a branch.
 Hint: Use a branch name or branch cliId from `but status --format json -f`
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
 fn unstage_command() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
     commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
 
     // First stage the file to A
@@ -1064,10 +1049,10 @@ fn unstage_command() -> anyhow::Result<()> {
 }
 
 #[test]
-fn unstage_command_path_prefix() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+fn unstage_command_path_prefix() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
     env.file("path/a.txt", "text\n");
 
     // First stage the file to A
@@ -1082,14 +1067,13 @@ fn unstage_command_path_prefix() -> anyhow::Result<()> {
 Unstaged hunk(s)
 
 "#]]);
-    Ok(())
 }
 
 #[test]
 fn unstage_command_with_branch() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
     commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
 
     // Stage the file to A
@@ -1121,9 +1105,9 @@ fn unstage_command_with_branch() -> anyhow::Result<()> {
 
 #[test]
 fn unstage_command_validation() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
 
     // Get the commit ID from status
@@ -1159,8 +1143,8 @@ Failed to unstage. Cannot unstage from fc - it is a commit. Target must be a bra
 
 #[test]
 fn rub_matrix_uncommitted_to_commit_smoke() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     env.file("uncommitted-to-commit.txt", "content\n");
 
@@ -1191,8 +1175,8 @@ Amended [..] → [..]
 
 #[test]
 fn rub_matrix_uncommitted_to_stack_smoke() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     env.file("uncommitted-to-stack.txt", "content\n");
 
@@ -1216,8 +1200,8 @@ Staged the only hunk in uncommitted-to-stack.txt in the unassigned area → stac
 
 #[test]
 fn rub_matrix_unassigned_to_branch_smoke() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     env.file("zz-to-branch.txt", "content\n");
 
@@ -1245,8 +1229,8 @@ Staged all unstaged changes to [A].
 
 #[test]
 fn rub_matrix_unassigned_to_commit_smoke() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     env.file("zz-to-commit.txt", "content\n");
 
@@ -1277,8 +1261,8 @@ Amended unassigned files → [..]
 
 #[test]
 fn rub_matrix_unassigned_to_commit_consumes_renames() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let original = (1..=120)
         .map(|line| line.to_string())
@@ -1327,8 +1311,8 @@ Amended unassigned files → [..]
 
 #[test]
 fn rub_matrix_unassigned_file_to_commit_consumes_renames() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     let original = (1..=120)
         .map(|line| line.to_string())
@@ -1380,8 +1364,8 @@ Amended the only hunk in rename-target-single.txt in the unassigned area → [..
 
 #[test]
 fn rub_unassigned_deleted_file_to_commit_keeps_unrelated_deleted_file() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     env.file("a.txt", "a\n");
     env.file("b.txt", "b\n");
@@ -1438,8 +1422,8 @@ Amended the only hunk in a.txt in the unassigned area → [..]
 
 #[test]
 fn rub_matrix_unassigned_to_stack_smoke() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     env.file("zz-to-stack.txt", "content\n");
 
@@ -1467,8 +1451,8 @@ Staged all unstaged changes to [A].
 
 #[test]
 fn rub_matrix_commit_to_unassigned_smoke() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
 
@@ -1508,8 +1492,8 @@ Uncommitted [..]
 
 #[test]
 fn rub_matrix_commit_to_commit_smoke() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "second commit");
@@ -1540,9 +1524,9 @@ Squashed [..] → [..]
 }
 
 #[test]
-fn rub_commit_without_message_to_commit() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn rub_commit_without_message_to_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("one.txt", "one.txt contents");
     env.but("commit -m 'add one.txt'").assert().success();
@@ -1596,14 +1580,12 @@ fn rub_commit_without_message_to_commit() -> anyhow::Result<()> {
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
 fn rub_commit_to_commit_without_message() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.file("one.txt", "one.txt contents");
     env.but("commit -m 'add one.txt'").assert().success();
@@ -1633,8 +1615,8 @@ fn rub_commit_to_commit_without_message() -> anyhow::Result<()> {
 
 #[test]
 fn rub_matrix_commit_to_branch_smoke() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
 
@@ -1663,8 +1645,8 @@ Moved [..] → [B]
 
 #[test]
 fn rub_matrix_commit_to_stack_smoke() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
 
@@ -1697,8 +1679,8 @@ Uncommitted [..] to [B]
 
 #[test]
 fn rub_matrix_branch_to_unassigned_smoke() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     env.file("branch-to-zz.txt", "content\n");
     env.but("rub branch-to-zz.txt A")
@@ -1730,8 +1712,8 @@ Unstaged all [A] changes.
 
 #[test]
 fn rub_matrix_branch_to_stack_smoke() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     env.file("branch-to-stack.txt", "content\n");
     env.but("rub branch-to-stack.txt A")
@@ -1763,8 +1745,8 @@ Staged all [A] changes to [B].
 
 #[test]
 fn rub_matrix_branch_to_commit_smoke() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     env.file("branch-to-commit.txt", "content\n");
     env.but("rub branch-to-commit.txt A")
@@ -1799,8 +1781,8 @@ Amended assigned files [A] → [..]
 
 #[test]
 fn rub_matrix_branch_to_branch_smoke() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     env.file("branch-to-branch.txt", "content\n");
     env.but("rub branch-to-branch.txt A")
@@ -1832,8 +1814,8 @@ Staged all [A] changes to [B].
 
 #[test]
 fn rub_matrix_stack_to_unassigned_smoke() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     env.file("stack-to-zz.txt", "content\n");
     env.but("rub stack-to-zz.txt A")
@@ -1865,8 +1847,8 @@ Unstaged all [A] changes.
 
 #[test]
 fn rub_matrix_stack_to_stack_smoke() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     env.file("stack-to-stack.txt", "content\n");
     env.but("rub stack-to-stack.txt A")
@@ -1898,8 +1880,8 @@ Staged all [A] changes to [B].
 
 #[test]
 fn rub_matrix_stack_to_branch_smoke() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     env.file("stack-to-branch.txt", "content\n");
     env.but("rub stack-to-branch.txt A")
@@ -1931,8 +1913,8 @@ Staged all [A] changes to [B].
 
 #[test]
 fn rub_matrix_stack_to_commit_smoke() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     env.file("stack-to-commit.txt", "content\n");
     env.but("rub stack-to-commit.txt A")
@@ -1971,8 +1953,8 @@ Amended files assigned to [A] → [..]
 
 #[test]
 fn rub_matrix_committed_file_to_branch_smoke() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
 
@@ -1999,8 +1981,8 @@ Uncommitted changes
 
 #[test]
 fn rub_matrix_committed_file_to_commit_smoke() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     commit_two_files_as_two_hunks_each(&env, "A", "source-a.txt", "source-b.txt", "source commit");
     commit_two_files_as_two_hunks_each(&env, "A", "target-a.txt", "target-b.txt", "target commit");
@@ -2031,8 +2013,8 @@ Moved files between commits!
 
 #[test]
 fn rub_matrix_invalid_pairs_smoke() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "invalid matrix setup");
     env.file("invalid-a.txt", "content\n");
@@ -2075,9 +2057,9 @@ Rubbed the wrong way. Operation doesn't make sense.[..]
 
 #[test]
 fn agent_json_wraps_mutation_and_status() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
     env.file("a.txt", "arbitrary text\n");
 
     let output = env
@@ -2120,9 +2102,9 @@ fn agent_json_wraps_mutation_and_status() -> anyhow::Result<()> {
 
 #[test]
 fn agent_invocation_enables_status_after_for_mutations() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
     env.file("agent.txt", "content\n");
 
     let output = env
@@ -2149,9 +2131,9 @@ fn agent_invocation_enables_status_after_for_mutations() -> anyhow::Result<()> {
 fn agent_json_success_has_no_status_error_field() -> anyhow::Result<()> {
     // Verifies that on a successful agent mutation, the combined JSON output
     // contains {result, status} but NOT status_error.
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
     env.file("b.txt", "content\n");
 
     let output = env
@@ -2174,8 +2156,8 @@ fn agent_json_success_has_no_status_error_field() -> anyhow::Result<()> {
 
 #[test]
 fn rubbing_modified_and_renamed_file() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     env.file("file", "content");
     env.file("file-2", "content-2");
@@ -2245,8 +2227,8 @@ Hint: run `but help` for all commands
 
 #[test]
 fn committing_modified_and_renamed_file() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     env.file("file", "content");
     env.file("file-2", "content-2");

--- a/crates/but/tests/but/command/setup.rs
+++ b/crates/but/tests/but/command/setup.rs
@@ -3,8 +3,8 @@ use serde_json::json;
 use crate::utils::{CommandExt as _, Sandbox};
 
 #[test]
-fn not_a_git_repository() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+fn not_a_git_repository() {
+    let env = Sandbox::empty();
 
     env.but("setup")
         .assert()
@@ -13,13 +13,11 @@ fn not_a_git_repository() -> anyhow::Result<()> {
 Error: No git repository found - run `but setup --init` to initialize a new repository.
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn no_remote_creates_gb_local() -> anyhow::Result<()> {
-    let env = Sandbox::open_with_default_settings("repo-no-remote")?;
+fn no_remote_creates_gb_local() {
+    let env = Sandbox::open_with_default_settings("repo-no-remote");
 
     // Verify initial state - no remotes
     let output = env.invoke_git("remote");
@@ -86,13 +84,11 @@ Learn more at https://docs.gitbutler.com/cli-overview
     // Verify remote HEAD was created
     let output = env.invoke_git("symbolic-ref refs/remotes/gb-local/HEAD");
     assert_eq!(output, "refs/remotes/gb-local/main");
-
-    Ok(())
 }
 
 #[test]
-fn no_remote_with_non_standard_branch() -> anyhow::Result<()> {
-    let env = Sandbox::open_with_default_settings("repo-no-remote-no-main-or-master")?;
+fn no_remote_with_non_standard_branch() {
+    let env = Sandbox::open_with_default_settings("repo-no-remote-no-main-or-master");
 
     // Run setup - should use the current branch name (development)
     env.but("setup")
@@ -151,13 +147,11 @@ Learn more at https://docs.gitbutler.com/cli-overview
     // Verify gb-local remote was created with development branch
     let output = env.invoke_git("symbolic-ref refs/remotes/gb-local/HEAD");
     assert_eq!(output, "refs/remotes/gb-local/development");
-
-    Ok(())
 }
 
 #[test]
-fn remote_exists_but_no_remote_head() -> anyhow::Result<()> {
-    let env = Sandbox::open_with_default_settings("repo-with-remote-no-head")?;
+fn remote_exists_but_no_remote_head() {
+    let env = Sandbox::open_with_default_settings("repo-with-remote-no-head");
 
     // Verify remote exists but no HEAD
     let output = env.invoke_git("remote");
@@ -221,13 +215,11 @@ Learn more at https://docs.gitbutler.com/cli-overview
 
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn remote_exists_with_head() -> anyhow::Result<()> {
-    let env = Sandbox::open_with_default_settings("repo-with-remote-and-head")?;
+fn remote_exists_with_head() {
+    let env = Sandbox::open_with_default_settings("repo-with-remote-and-head");
 
     // Verify remote exists with HEAD
     let output = env.invoke_git("remote");
@@ -287,13 +279,11 @@ Learn more at https://docs.gitbutler.com/cli-overview
 
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn already_setup() -> anyhow::Result<()> {
-    let env = Sandbox::open_with_default_settings("repo-already-setup")?;
+fn already_setup() {
+    let env = Sandbox::open_with_default_settings("repo-already-setup");
 
     // Run setup once to initialize
     env.but("setup").assert().success();
@@ -334,13 +324,11 @@ Learn more at https://docs.gitbutler.com/cli-overview
 
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn json_output_new_setup() -> anyhow::Result<()> {
-    let env = Sandbox::open_with_default_settings("repo-with-remote-and-head")?;
+fn json_output_new_setup() {
+    let env = Sandbox::open_with_default_settings("repo-with-remote-and-head");
 
     env.but("--format json setup")
         .allow_json()
@@ -359,13 +347,11 @@ fn json_output_new_setup() -> anyhow::Result<()> {
 }
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn json_output_already_setup() -> anyhow::Result<()> {
-    let env = Sandbox::open_with_default_settings("repo-already-setup")?;
+fn json_output_already_setup() {
+    let env = Sandbox::open_with_default_settings("repo-already-setup");
 
     // Run setup once to initialize
     env.but("setup").assert().success();
@@ -388,13 +374,11 @@ fn json_output_already_setup() -> anyhow::Result<()> {
 }
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn json_output_gb_local() -> anyhow::Result<()> {
-    let env = Sandbox::open_with_default_settings("repo-no-remote")?;
+fn json_output_gb_local() {
+    let env = Sandbox::open_with_default_settings("repo-no-remote");
 
     env.but("--format json setup")
         .allow_json()
@@ -413,13 +397,11 @@ fn json_output_gb_local() -> anyhow::Result<()> {
 }
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn json_output_non_standard_branch() -> anyhow::Result<()> {
-    let env = Sandbox::open_with_default_settings("repo-no-remote-no-main-or-master")?;
+fn json_output_non_standard_branch() {
+    let env = Sandbox::open_with_default_settings("repo-no-remote-no-main-or-master");
 
     env.but("--format json setup")
         .allow_json()
@@ -438,13 +420,11 @@ fn json_output_non_standard_branch() -> anyhow::Result<()> {
 }
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn json_output_remote_no_head_fallback() -> anyhow::Result<()> {
-    let env = Sandbox::open_with_default_settings("repo-with-remote-no-head")?;
+fn json_output_remote_no_head_fallback() {
+    let env = Sandbox::open_with_default_settings("repo-with-remote-no-head");
 
     env.but("--format json setup")
         .allow_json()
@@ -463,13 +443,11 @@ fn json_output_remote_no_head_fallback() -> anyhow::Result<()> {
 }
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn json_output_not_a_git_repo() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+fn json_output_not_a_git_repo() {
+    let env = Sandbox::empty();
 
     env.but("--format json setup")
         .allow_json()
@@ -480,13 +458,11 @@ Error: No git repository found - run `but setup --init` to initialize a new repo
 
 "#]])
         .stdout_eq(snapbox::str![]);
-
-    Ok(())
 }
 
 #[test]
 fn init_flag_creates_repo() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+    let env = Sandbox::empty();
 
     // Verify no git repo exists
     env.invoke_git_fails(
@@ -565,8 +541,8 @@ Learn more at https://docs.gitbutler.com/cli-overview
 }
 
 #[test]
-fn init_flag_json_output() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+fn init_flag_json_output() {
+    let env = Sandbox::empty();
 
     env.but("--format json setup --init")
         .allow_json()
@@ -589,13 +565,11 @@ fn init_flag_json_output() -> anyhow::Result<()> {
     // Verify git repo was created
     let output = env.invoke_git("rev-parse --git-dir");
     assert!(!output.is_empty());
-
-    Ok(())
 }
 
 #[test]
-fn init_flag_with_existing_repo() -> anyhow::Result<()> {
-    let env = Sandbox::open_with_default_settings("repo-no-remote")?;
+fn init_flag_with_existing_repo() {
+    let env = Sandbox::open_with_default_settings("repo-no-remote");
 
     // Should work the same as without --init when repo exists
     env.but("setup --init")
@@ -650,13 +624,11 @@ Learn more at https://docs.gitbutler.com/cli-overview
 
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
 fn setup_called_on_unmigrated_projects_json() -> anyhow::Result<()> {
-    let env = Sandbox::open_with_default_settings("repo-no-remote")?;
+    let env = Sandbox::open_with_default_settings("repo-no-remote");
 
     // Run first to create the metadata in `projects.json` which we then mutate
     // to create the "legacy" metadata scenario.

--- a/crates/but/tests/but/command/skill.rs
+++ b/crates/but/tests/but/command/skill.rs
@@ -15,8 +15,8 @@ fn path_ends_with_gitbutler_agents_dir(path: &str) -> bool {
 }
 
 #[test]
-fn skill_check_local_outside_repo_fails() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+fn skill_check_local_outside_repo_fails() {
+    let env = Sandbox::empty();
 
     env.but("skill check --local")
         .assert()
@@ -27,12 +27,11 @@ Error: Cannot check local installations: not in a git repository.
 Use --global to check global installations, or run from within a repository.
 
 "#]]);
-    Ok(())
 }
 
 #[test]
 fn skill_check_json_output_is_valid() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+    let env = Sandbox::empty();
 
     // Check with --global to avoid needing a repo context
     // The JSON output should always be valid even if no skills are found
@@ -60,8 +59,8 @@ fn skill_check_json_output_is_valid() -> anyhow::Result<()> {
 }
 
 #[test]
-fn skill_install_json_outside_repo_requires_path_instead_of_repo_context() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+fn skill_install_json_outside_repo_requires_path_instead_of_repo_context() {
+    let env = Sandbox::empty();
 
     env.but("skill install --format json")
         .allow_json()
@@ -72,13 +71,11 @@ fn skill_install_json_outside_repo_requires_path_instead_of_repo_context() -> an
 Error: In non-interactive mode, you must specify --path or --detect. Use --path <path> to specify where to install the skill, or --detect to update an existing installation.
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn skill_install_path_outside_repo_requires_global() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+fn skill_install_path_outside_repo_requires_global() {
+    let env = Sandbox::empty();
     let install_path = relative_agent_skill_path(".claude");
 
     env.but("")
@@ -96,13 +93,11 @@ Error: Cannot use relative --path outside a git repository unless --global is sp
 Use --global --path <path> for a global installation, use an absolute path, or run from within a repository for local installation.
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
 fn skill_install_absolute_path_outside_repo_does_not_require_global() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+    let env = Sandbox::empty();
     let install_dir = env.projects_root().join("abs-skill-install");
 
     let output = env
@@ -132,7 +127,7 @@ fn skill_install_absolute_path_outside_repo_does_not_require_global() -> anyhow:
 
 #[test]
 fn skill_install_agent_outputs_success_message() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+    let env = Sandbox::empty();
     let install_dir = env.projects_root().join("agent-skill-install");
 
     let output = env
@@ -164,7 +159,7 @@ fn skill_install_agent_outputs_success_message() -> anyhow::Result<()> {
 
 #[test]
 fn skill_check_detects_agent_skills_installation_in_repo() -> anyhow::Result<()> {
-    let env = Sandbox::open_with_default_settings("repo-no-remote")?;
+    let env = Sandbox::open_with_default_settings("repo-no-remote");
     let install_path = relative_agent_skill_path(".agents");
 
     env.but("")
@@ -209,7 +204,7 @@ fn skill_check_detects_agent_skills_installation_in_repo() -> anyhow::Result<()>
 
 #[test]
 fn skill_install_detect_finds_agent_skills_installation_in_repo() -> anyhow::Result<()> {
-    let env = Sandbox::open_with_default_settings("repo-no-remote")?;
+    let env = Sandbox::open_with_default_settings("repo-no-remote");
     let install_path = relative_agent_skill_path(".agents");
 
     env.but("")
@@ -244,7 +239,7 @@ fn skill_install_detect_finds_agent_skills_installation_in_repo() -> anyhow::Res
 
 #[test]
 fn skill_install_surfaces_non_repo_discovery_errors() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+    let env = Sandbox::empty();
     let invalid_dir = env.projects_root().join("not-a-directory");
     std::fs::write(&invalid_dir, "not a dir")?;
 

--- a/crates/but/tests/but/command/squash.rs
+++ b/crates/but/tests/but/command/squash.rs
@@ -29,8 +29,8 @@ fn branch_commit_count(env: &Sandbox, branch: &str) -> anyhow::Result<usize> {
 
 #[test]
 fn squash_requires_at_least_two_commits() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Only one commit exists (from scenario)
     // Try to squash a single commit - should fail
@@ -47,8 +47,8 @@ Failed to squash commits. No matching branch or commit found for 'c0'
 
 #[test]
 fn squash_branch_with_single_commit_fails() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Branch A has only 1 commit from the scenario
     // Try to squash branch with single commit - should fail
@@ -65,8 +65,8 @@ Failed to squash commits. Branch 'A' has only one commit, nothing to squash
 
 #[test]
 fn squash_nonexistent_commit_fails() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     setup_branch_with_commits(&env, "A", 1);
 
@@ -87,8 +87,8 @@ Failed to squash commits. No matching commit found for 'nonexistent'
 
 #[test]
 fn squash_branch_by_name_succeeds() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Create more commits on branch A (scenario already has 1)
     setup_branch_with_commits(&env, "A", 2);
@@ -105,8 +105,8 @@ fn squash_branch_by_name_succeeds() -> anyhow::Result<()> {
 
 #[test]
 fn squash_with_drop_message_flag_succeeds() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Create 1 more commit (scenario has 1, so we'll have 2 total)
     setup_branch_with_commits(&env, "A", 1);
@@ -122,8 +122,8 @@ fn squash_with_drop_message_flag_succeeds() -> anyhow::Result<()> {
 
 #[test]
 fn squash_with_custom_message_succeeds() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Create 1 more commit
     setup_branch_with_commits(&env, "A", 1);
@@ -141,8 +141,8 @@ fn squash_with_custom_message_succeeds() -> anyhow::Result<()> {
 
 #[test]
 fn squash_mutually_exclusive_flags_fails() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     setup_branch_with_commits(&env, "A", 1);
 
@@ -159,8 +159,8 @@ fn squash_mutually_exclusive_flags_fails() -> anyhow::Result<()> {
 
 #[test]
 fn squash_with_invalid_range_format_fails() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     setup_branch_with_commits(&env, "A", 2);
 
@@ -181,8 +181,8 @@ Failed to squash commits. Range format should be 'start..end', got 'c0..c1..c2'
 
 #[test]
 fn squash_with_empty_range_part_fails() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     setup_branch_with_commits(&env, "A", 2);
 
@@ -197,8 +197,8 @@ fn squash_with_empty_range_part_fails() -> anyhow::Result<()> {
 
 #[test]
 fn squash_comma_list_with_nonexistent_commit_fails() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Try comma-separated list with only nonexistent commits
     // This tests the comma parsing path without needing real commit IDs
@@ -218,8 +218,8 @@ Failed to squash commits. Commit 'nonexistent1' not found
 
 #[test]
 fn squash_range_with_nonexistent_endpoint_fails() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Try range with nonexistent endpoints
     // This tests the range parsing path without needing real commit IDs
@@ -239,8 +239,8 @@ Failed to squash commits. Start of range 'nonexistent1' must match exactly one c
 
 #[test]
 fn squash_ai_conflicts_with_message() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     setup_branch_with_commits(&env, "A", 1);
 
@@ -265,8 +265,8 @@ For more information, try '--help'.
 
 #[test]
 fn squash_ai_conflicts_with_drop_message() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     setup_branch_with_commits(&env, "A", 1);
 
@@ -291,8 +291,8 @@ For more information, try '--help'.
 
 #[test]
 fn concurrent_squashes_on_independent_branches_succeed() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("branch new branchB").assert().success();
     setup_branch_with_commits(&env, "A", 1);
@@ -326,8 +326,8 @@ fn concurrent_squashes_on_independent_branches_succeed() -> anyhow::Result<()> {
 
 #[test]
 fn squash_multiple_commits_from_list_succeeds() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     setup_branch_with_commits(&env, "A", 3);
 
@@ -375,11 +375,11 @@ Squashed 2 commits → [..]
 
 #[test]
 fn squash_list_with_bottom_target_keeps_target_message_first() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
     setup_branch_with_commits(&env, "A", 3);
 
-    insta::assert_snapshot!(env.git_log()?, @"
+    insta::assert_snapshot!(env.git_log(), @"
     * ec2758d (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 8a1f552 (A) commit 3
     * 39dd878 commit 2
@@ -411,7 +411,7 @@ fn squash_list_with_bottom_target_keeps_target_message_first() -> anyhow::Result
     let working_directory_after = util::working_directory_snapshot(&env)?;
     assert_eq!(working_directory_before, working_directory_after);
 
-    let log_after = env.git_log()?;
+    let log_after = env.git_log();
     assert!(
         log_after.contains("(A) commit 1"),
         "expected squashed branch tip message to be target-first (commit 1), got:\n{log_after}"
@@ -422,11 +422,11 @@ fn squash_list_with_bottom_target_keeps_target_message_first() -> anyhow::Result
 
 #[test]
 fn squash_list_with_middle_target_keeps_target_message_first() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
     setup_branch_with_commits(&env, "A", 3);
 
-    insta::assert_snapshot!(env.git_log()?, @"
+    insta::assert_snapshot!(env.git_log(), @"
     * ec2758d (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 8a1f552 (A) commit 3
     * 39dd878 commit 2
@@ -462,7 +462,7 @@ Squashed 2 commits → [..]
     let working_directory_after = util::working_directory_snapshot(&env)?;
     assert_eq!(working_directory_before, working_directory_after);
 
-    let log_after = env.git_log()?;
+    let log_after = env.git_log();
     assert!(
         log_after.contains("(A) commit 2"),
         "expected squashed branch tip message to be target-first (commit 2), got:\n{log_after}"
@@ -473,11 +473,11 @@ Squashed 2 commits → [..]
 
 #[test]
 fn squash_multiple_commits_keeps_squashed_commit_content() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
     setup_branch_with_commits(&env, "A", 3);
 
-    insta::assert_snapshot!(env.git_log()?, @"
+    insta::assert_snapshot!(env.git_log(), @"
     * ec2758d (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 8a1f552 (A) commit 3
     * 39dd878 commit 2
@@ -536,7 +536,7 @@ fn squash_multiple_commits_keeps_squashed_commit_content() -> anyhow::Result<()>
         format!("{target_message_before}\n\n{source_top_message}\n\n{source_second_message}")
     );
 
-    let repo = env.open_repo()?;
+    let repo = env.open_repo();
     let first_blob = repo.rev_parse_single(b"A:A-file1.txt")?.object()?;
     let second_blob = repo.rev_parse_single(b"A:A-file2.txt")?.object()?;
     let third_blob = repo.rev_parse_single(b"A:A-file3.txt")?.object()?;
@@ -545,7 +545,7 @@ fn squash_multiple_commits_keeps_squashed_commit_content() -> anyhow::Result<()>
     insta::assert_snapshot!(second_blob.data.as_bstr(), @"content for commit 2");
     insta::assert_snapshot!(third_blob.data.as_bstr(), @"content for commit 3");
 
-    let log_after = env.git_log()?;
+    let log_after = env.git_log();
     assert!(
         log_after.contains("(A) commit 1"),
         "expected squashed A tip message to start with target commit message, got:\n{log_after}"
@@ -558,8 +558,8 @@ fn squash_multiple_commits_keeps_squashed_commit_content() -> anyhow::Result<()>
 fn squash_multiple_commits_from_different_branches_on_same_stack_succeeds() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings(
         "two-stacks-one-single-and-ready-to-mingle-one-double",
-    )?;
-    env.setup_metadata(&["A", "B"])?;
+    );
+    env.setup_metadata(&["A", "B"]);
 
     env.file("c-extra.txt", "another change on C\n");
     env.but("commit C -m 'extra on C'").assert().success();
@@ -618,10 +618,10 @@ Squashed 2 commits → [..]
 
 #[test]
 fn squash_branch_c_in_three_stacks_keeps_content_and_updates_graph() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("three-stacks")?;
-    env.setup_metadata(&["A", "B", "C"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("three-stacks");
+    env.setup_metadata(&["A", "B", "C"]);
 
-    let normalized_log = env.git_log()?.replace("  \n", "\n");
+    let normalized_log = env.git_log().replace("  \n", "\n");
     insta::assert_snapshot!(normalized_log, @r"
     *-.   205e798 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\ \
@@ -648,7 +648,7 @@ fn squash_branch_c_in_three_stacks_keeps_content_and_updates_graph() -> anyhow::
         .context("Missing commits for branch C after squash")?;
     assert_eq!(commits_after.len(), 1);
 
-    let repo = env.open_repo()?;
+    let repo = env.open_repo();
     let new_file_blob = repo.rev_parse_single(b"C:new-file")?.object()?;
     insta::assert_snapshot!(new_file_blob.data.as_bstr(), @"
     1
@@ -683,7 +683,7 @@ fn squash_branch_c_in_three_stacks_keeps_content_and_updates_graph() -> anyhow::
     30
     ");
 
-    let normalized_log = env.git_log()?.replace("  \n", "\n");
+    let normalized_log = env.git_log().replace("  \n", "\n");
     assert!(
         normalized_log.contains("(C) C: new file with 10 lines"),
         "expected squashed C tip message to begin with target commit message, got:\n{normalized_log}"
@@ -694,8 +694,8 @@ fn squash_branch_c_in_three_stacks_keeps_content_and_updates_graph() -> anyhow::
 
 #[test]
 fn squash_all_c_commits_into_second_commit_of_b_keeps_new_file_content() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("three-stacks")?;
-    env.setup_metadata(&["A", "B", "C"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("three-stacks");
+    env.setup_metadata(&["A", "B", "C"]);
 
     let status_before = util::status_json(&env)?;
     let branch_b_before = util::find_branch(&status_before, "B")?;
@@ -730,7 +730,7 @@ fn squash_all_c_commits_into_second_commit_of_b_keeps_new_file_content() -> anyh
     let working_directory_after = util::working_directory_snapshot(&env)?;
     assert_eq!(working_directory_before, working_directory_after);
 
-    let repo = env.open_repo()?;
+    let repo = env.open_repo();
     let new_file_blob = repo.rev_parse_single(b"B:new-file")?.object()?;
     insta::assert_snapshot!(new_file_blob.data.as_bstr(), @"
     1

--- a/crates/but/tests/but/command/squash2.rs
+++ b/crates/but/tests/but/command/squash2.rs
@@ -2,8 +2,8 @@ use crate::utils::Sandbox;
 
 // TODO: make fixture for this
 fn one_branch_three_commits() -> Sandbox {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks").unwrap();
-    env.setup_metadata(&[]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
 
     env.file("one", "content of one");
     env.file("two", "content of two");

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -2,9 +2,9 @@ use super::util::{enter_edit_mode_with_conflicted_commit, status_json};
 use crate::utils::{CommandExt as _, Sandbox};
 
 #[test]
-fn worktrees() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings_slow("two-worktrees")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
+fn worktrees() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings_slow("two-worktrees");
+    insta::assert_snapshot!(env.git_log(), @r"
     *   063d8c1 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * 3e01e28 (B) B
@@ -19,7 +19,7 @@ fn worktrees() -> anyhow::Result<()> {
     ");
 
     // Must set metadata to match the scenario, or else the old APIs used here won't deliver.
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
 
     env.but("status")
         .with_color_for_svg()
@@ -38,13 +38,12 @@ fn worktrees() -> anyhow::Result<()> {
         .stdout_eq(snapbox::file![
             "snapshots/status/two-worktrees/status-with-worktrees-verbose.stdout.term.svg"
         ]);
-    Ok(())
 }
 
 #[test]
-fn unborn() -> anyhow::Result<()> {
-    let env = Sandbox::open_scenario_with_target_and_default_settings("unborn")?;
-    insta::assert_snapshot!(env.git_log()?, @"");
+fn unborn() {
+    let env = Sandbox::open_scenario_with_target_and_default_settings("unborn");
+    insta::assert_snapshot!(env.git_log(), @"");
 
     // TODO: make this work
     env.but("status --verbose")
@@ -54,13 +53,12 @@ fn unborn() -> anyhow::Result<()> {
 Error: Setup required: No GitButler project found at . - run `but setup` to configure the project
 
 "#]]);
-    Ok(())
 }
 
 #[test]
-fn first_commit_no_workspace() -> anyhow::Result<()> {
-    let env = Sandbox::open_scenario_with_target_and_default_settings("first-commit")?;
-    insta::assert_snapshot!(env.git_log()?, @"* 85efbe4 (HEAD -> main) M");
+fn first_commit_no_workspace() {
+    let env = Sandbox::open_scenario_with_target_and_default_settings("first-commit");
+    insta::assert_snapshot!(env.git_log(), @"* 85efbe4 (HEAD -> main) M");
 
     // TODO: make this work
     env.but("status --verbose")
@@ -70,16 +68,14 @@ fn first_commit_no_workspace() -> anyhow::Result<()> {
 Error: Setup required: No GitButler project found at . - run `but setup` to configure the project
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn remote_and_local_files() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("remote-local-divergence")?;
+fn remote_and_local_files() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("remote-local-divergence");
 
     // Must set metadata to match the scenario, or else the old APIs used here won't deliver.
-    env.setup_metadata(&["main", "A"])?;
+    env.setup_metadata(&["main", "A"]);
 
     // Under branch A, remote-only and local-only commits and files are shown.
     // CLI IDs are shown only for local-only files.
@@ -91,16 +87,14 @@ fn remote_and_local_files() -> anyhow::Result<()> {
         .stdout_eq(snapbox::file![
             "snapshots/status/remote-and-local-files.stdout.term.svg"
         ]);
-
-    Ok(())
 }
 
 #[test]
-fn json_shows_paths_as_strings() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+fn json_shows_paths_as_strings() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
     // Must set metadata to match the scenario, or else the old APIs used here won't deliver.
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
 
     // Create a new file to ensure we have file assignments
     env.file("test-file.txt", "test content");
@@ -204,8 +198,6 @@ fn json_shows_paths_as_strings() -> anyhow::Result<()> {
 }
 
 "#]]);
-
-    Ok(())
 }
 
 // TODO This test demonstrates how IDs are assigned to uncommitted and committed
@@ -214,10 +206,10 @@ fn json_shows_paths_as_strings() -> anyhow::Result<()> {
 // is tested.
 #[test]
 fn uncommitted_and_committed_file_cli_ids() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
     // Must set metadata to match the scenario, or else the old APIs used here won't deliver.
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
 
     env.file("a.txt", format!("first\n{}last\n", "line\n".repeat(100)));
     env.file("b.txt", "only\n");
@@ -286,11 +278,11 @@ fn uncommitted_and_committed_file_cli_ids() -> anyhow::Result<()> {
 }
 
 #[test]
-fn long_file_cli_ids_are_aligned() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("commits-with-same-prefix")?;
+fn long_file_cli_ids_are_aligned() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("commits-with-same-prefix");
 
     // Must set metadata to match the scenario, or else the old APIs used here won't deliver.
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     // foo1 has a CLI ID of length 2; the others have length 3
     env.file("foo1", "contents");
@@ -306,16 +298,14 @@ fn long_file_cli_ids_are_aligned() -> anyhow::Result<()> {
         .stdout_eq(snapbox::file![
             "snapshots/status/long-file-cli-ids-are-aligned.stdout.term.svg"
         ]);
-
-    Ok(())
 }
 
 #[test]
-fn long_cli_ids() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("commits-with-same-prefix")?;
+fn long_cli_ids() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("commits-with-same-prefix");
 
     // Must set metadata to match the scenario, or else the old APIs used here won't deliver.
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     // For "add A13" and "add A3", the IDs have 3 characters. The others have 2.
     env.but("status")
@@ -326,16 +316,14 @@ fn long_cli_ids() -> anyhow::Result<()> {
         .stdout_eq(snapbox::file![
             "snapshots/status/long-cli-ids.stdout.term.svg"
         ]);
-
-    Ok(())
 }
 
 #[test]
 fn long_cli_ids_json() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("commits-with-same-prefix")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("commits-with-same-prefix");
 
     // Must set metadata to match the scenario, or else the old APIs used here won't deliver.
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     // Assert a handful of commits to show that the commit CLI IDs become longer
     // if a short ID would be ambiguous, but remain at 2 characters otherwise.
@@ -389,9 +377,9 @@ fn long_cli_ids_json() -> anyhow::Result<()> {
 }
 
 #[test]
-fn status_hint_with_uncommitted_changes() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn status_hint_with_uncommitted_changes() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
     env.file("new-file.txt", "content");
 
     env.but("status")
@@ -402,14 +390,12 @@ fn status_hint_with_uncommitted_changes() -> anyhow::Result<()> {
         .stdout_eq(snapbox::file![
             "snapshots/status/hints/status-hint-with-uncommitted-changes.stdout.term.svg"
         ]);
-
-    Ok(())
 }
 
 #[test]
-fn status_hint_clean_workspace() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn status_hint_clean_workspace() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("status")
         .with_color_for_svg()
@@ -419,14 +405,12 @@ fn status_hint_clean_workspace() -> anyhow::Result<()> {
         .stdout_eq(snapbox::file![
             "snapshots/status/hints/status-hint-clean-workspace.stdout.term.svg"
         ]);
-
-    Ok(())
 }
 
 #[test]
-fn status_hint_when_no_branches() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn status_hint_when_no_branches() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("unapply A").assert().success();
 
@@ -438,14 +422,12 @@ fn status_hint_when_no_branches() -> anyhow::Result<()> {
         .stdout_eq(snapbox::file![
             "snapshots/status/hints/status-hint-no-branches.stdout.term.svg"
         ]);
-
-    Ok(())
 }
 
 #[test]
-fn status_no_hint_flag_suppresses_hint() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn status_no_hint_flag_suppresses_hint() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("status --no-hint")
         .with_color_for_svg()
@@ -455,14 +437,12 @@ fn status_no_hint_flag_suppresses_hint() -> anyhow::Result<()> {
         .stdout_eq(snapbox::file![
             "snapshots/status/hints/status-no-hint.stdout.term.svg"
         ]);
-
-    Ok(())
 }
 
 #[test]
-fn status_shows_no_commits_label_for_empty_branch() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks-one-empty")?;
-    env.setup_metadata(&["A", "B"])?;
+fn status_shows_no_commits_label_for_empty_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks-one-empty");
+    env.setup_metadata(&["A", "B"]);
 
     env.but("status")
         .with_color_for_svg()
@@ -472,14 +452,12 @@ fn status_shows_no_commits_label_for_empty_branch() -> anyhow::Result<()> {
         .stdout_eq(snapbox::file![
             "snapshots/status/classification/status-shows-no-commits-label.stdout.term.svg"
         ]);
-
-    Ok(())
 }
 
 #[test]
-fn status_upstream_merge_status_empty() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks-one-empty")?;
-    env.setup_metadata(&["A", "B"])?;
+fn status_upstream_merge_status_empty() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks-one-empty");
+    env.setup_metadata(&["A", "B"]);
 
     env.but("status --upstream")
         .env("NO_BG_TASKS", "1")
@@ -490,14 +468,12 @@ fn status_upstream_merge_status_empty() -> anyhow::Result<()> {
         .stdout_eq(snapbox::file![
             "snapshots/status/upstream/status-upstream-merge-status-empty.stdout.term.svg"
         ]);
-
-    Ok(())
 }
 
 #[test]
-fn status_upstream_summary_without_flag() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("upstream-many-commits")?;
-    env.setup_metadata(&["A"])?;
+fn status_upstream_summary_without_flag() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("upstream-many-commits");
+    env.setup_metadata(&["A"]);
 
     env.but("status")
         .env("NO_BG_TASKS", "1")
@@ -508,14 +484,12 @@ fn status_upstream_summary_without_flag() -> anyhow::Result<()> {
         .stdout_eq(snapbox::file![
             "snapshots/status/upstream/status-upstream-summary.stdout.term.svg"
         ]);
-
-    Ok(())
 }
 
 #[test]
-fn status_upstream_detailed_with_flag() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("upstream-many-commits")?;
-    env.setup_metadata_at_target(&["A"], "refs/heads/base")?;
+fn status_upstream_detailed_with_flag() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("upstream-many-commits");
+    env.setup_metadata_at_target(&["A"], "refs/heads/base");
 
     env.but("status --upstream")
         .env("NO_BG_TASKS", "1")
@@ -526,14 +500,12 @@ fn status_upstream_detailed_with_flag() -> anyhow::Result<()> {
         .stdout_eq(snapbox::file![
             "snapshots/status/upstream/status-upstream-detailed.stdout.term.svg"
         ]);
-
-    Ok(())
 }
 
 #[test]
-fn status_upstream_detailed_truncates_after_8() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("upstream-many-commits")?;
-    env.setup_metadata_at_target(&["A"], "refs/heads/base")?;
+fn status_upstream_detailed_truncates_after_8() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("upstream-many-commits");
+    env.setup_metadata_at_target(&["A"], "refs/heads/base");
 
     env.but("status --upstream")
         .env("NO_BG_TASKS", "1")
@@ -544,14 +516,12 @@ fn status_upstream_detailed_truncates_after_8() -> anyhow::Result<()> {
         .stdout_eq(snapbox::file![
             "snapshots/status/upstream/status-upstream-truncates-after-8.stdout.term.svg"
         ]);
-
-    Ok(())
 }
 
 #[test]
-fn status_upstream_and_merge_base_messages_truncate_when_unpaged() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("upstream-long-messages")?;
-    env.setup_metadata_at_target(&["A"], "refs/heads/base")?;
+fn status_upstream_and_merge_base_messages_truncate_when_unpaged() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("upstream-long-messages");
+    env.setup_metadata_at_target(&["A"], "refs/heads/base");
 
     env.but("status --upstream")
         .env("NO_BG_TASKS", "1")
@@ -573,16 +543,13 @@ fn status_upstream_and_merge_base_messages_truncate_when_unpaged() -> anyhow::Re
 Hint: run `but help` for all commands
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn status_upstream_merge_status_integrated() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings(
-        "upstream-integrated-with-updates",
-    )?;
-    env.setup_metadata_at_target(&["A", "B"], "refs/heads/base")?;
+fn status_upstream_merge_status_integrated() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("upstream-integrated-with-updates");
+    env.setup_metadata_at_target(&["A", "B"], "refs/heads/base");
 
     env.but("status --upstream")
         .env("NO_BG_TASKS", "1")
@@ -593,8 +560,6 @@ fn status_upstream_merge_status_integrated() -> anyhow::Result<()> {
         .stdout_eq(snapbox::file![
             "snapshots/status/upstream/status-upstream-merge-status-integrated.stdout.term.svg"
         ]);
-
-    Ok(())
 }
 
 /// Like `status_upstream_merge_status_integrated`, but the fixture adds two
@@ -611,12 +576,12 @@ fn status_upstream_merge_status_integrated() -> anyhow::Result<()> {
 ///
 /// Expected: both extra branches are pruned entirely.
 #[test]
-fn status_upstream_prunes_untracked_integrated_branch() -> anyhow::Result<()> {
+fn status_upstream_prunes_untracked_integrated_branch() {
     let env = Sandbox::init_scenario_with_target_and_default_settings_slow(
         "upstream-integrated-with-extra-branch",
-    )?;
+    );
     // Only register A and B — `extra-untracked` is deliberately omitted.
-    env.setup_metadata_at_target(&["A", "B"], "refs/heads/base")?;
+    env.setup_metadata_at_target(&["A", "B"], "refs/heads/base");
 
     env.but("status --upstream")
         .env("NO_BG_TASKS", "1")
@@ -643,8 +608,6 @@ fn status_upstream_prunes_untracked_integrated_branch() -> anyhow::Result<()> {
 Hint: run `but help` for all commands
 
 "#]]);
-
-    Ok(())
 }
 
 /// Same fixture as `status_upstream_prunes_untracked_integrated_branch`, but
@@ -654,13 +617,13 @@ Hint: run `but help` for all commands
 /// Expected: `extra-untracked` is kept (metadata-tracked), `extra-untracked-2`
 /// is pruned (not tracked).
 #[test]
-fn status_upstream_prunes_metadata_tracked_integrated_branches() -> anyhow::Result<()> {
+fn status_upstream_prunes_metadata_tracked_integrated_branches() {
     let env = Sandbox::init_scenario_with_target_and_default_settings_slow(
         "upstream-integrated-with-extra-branch",
-    )?;
+    );
     // Register A, B, and extra-untracked (simulating auto-discovery).
     // extra-untracked-2 remains unregistered.
-    env.setup_metadata_at_target(&["A", "B", "extra-untracked"], "refs/heads/base")?;
+    env.setup_metadata_at_target(&["A", "B", "extra-untracked"], "refs/heads/base");
 
     env.but("status --upstream")
         .env("NO_BG_TASKS", "1")
@@ -690,8 +653,6 @@ fn status_upstream_prunes_metadata_tracked_integrated_branches() -> anyhow::Resu
 Hint: run `but help` for all commands
 
 "#]]);
-
-    Ok(())
 }
 
 /// Two branches with different merge bases against the target.
@@ -706,13 +667,13 @@ Hint: run `but help` for all commands
 /// not pruned — `M1` and `M2` appear in B's stack as integrated commits,
 /// to be cleaned up by `integrate_upstream`.
 #[test]
-fn status_upstream_prunes_with_different_bases() -> anyhow::Result<()> {
+fn status_upstream_prunes_with_different_bases() {
     let env =
-        Sandbox::init_scenario_with_target_and_default_settings_slow("upstream-different-bases")?;
-    env.setup_metadata(&["A", "B"])?;
+        Sandbox::init_scenario_with_target_and_default_settings_slow("upstream-different-bases");
+    env.setup_metadata(&["A", "B"]);
     // This test wants the target sha to be the common ancestor ancestor of the
     // workspace.
-    env.set_target_sha("refs/heads/base")?;
+    env.set_target_sha("refs/heads/base");
 
     env.but("status --upstream")
         .env("NO_BG_TASKS", "1")
@@ -743,8 +704,6 @@ fn status_upstream_prunes_with_different_bases() -> anyhow::Result<()> {
 Hint: run `but help` for all commands
 
 "#]]);
-
-    Ok(())
 }
 
 /// Simulate a `git fetch` that advances `origin/main` after the workspace
@@ -765,15 +724,15 @@ Hint: run `but help` for all commands
 fn status_upstream_advanced_target_does_not_leak_branches() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings_slow(
         "upstream-advanced-after-workspace",
-    )?;
-    env.setup_metadata(&["A", "B"])?;
+    );
+    env.setup_metadata(&["A", "B"]);
 
     // Add old-integrated to A's stack in metadata, simulating auto-discovery
     // before the branch was integrated upstream.
     {
         use but_core::RefMetadata;
         use std::ops::DerefMut;
-        let mut meta = env.meta()?;
+        let mut meta = env.meta();
         let ws_ref: &gix::refs::FullNameRef = but_core::WORKSPACE_REF_NAME.try_into()?;
         let mut ws = meta.workspace(ws_ref)?;
         ws.deref_mut()
@@ -800,9 +759,9 @@ fn status_upstream_advanced_target_does_not_leak_branches() -> anyhow::Result<()
 }
 
 #[test]
-fn status_upstream_merge_status_conflicted() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("upstream-conflicted")?;
-    env.setup_metadata_at_target(&["A"], "refs/heads/base")?;
+fn status_upstream_merge_status_conflicted() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("upstream-conflicted");
+    env.setup_metadata_at_target(&["A"], "refs/heads/base");
 
     env.but("status --upstream")
         .env("NO_BG_TASKS", "1")
@@ -813,14 +772,12 @@ fn status_upstream_merge_status_conflicted() -> anyhow::Result<()> {
         .stdout_eq(snapbox::file![
             "snapshots/status/upstream/status-upstream-merge-status-conflicted.stdout.term.svg"
         ]);
-
-    Ok(())
 }
 
 #[test]
-fn status_shows_pushed_commit_marker() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("status-pushed")?;
-    env.setup_metadata(&["A"])?;
+fn status_shows_pushed_commit_marker() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("status-pushed");
+    env.setup_metadata(&["A"]);
 
     env.but("status")
         .with_color_for_svg()
@@ -830,14 +787,12 @@ fn status_shows_pushed_commit_marker() -> anyhow::Result<()> {
         .stdout_eq(snapbox::file![
             "snapshots/status/classification/status-shows-pushed-commit-marker.stdout.term.svg"
         ]);
-
-    Ok(())
 }
 
 #[test]
-fn status_shows_rewritten_branch_with_remote_and_local_commits() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("status-modified")?;
-    env.setup_metadata(&["A"])?;
+fn status_shows_rewritten_branch_with_remote_and_local_commits() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("status-modified");
+    env.setup_metadata(&["A"]);
 
     env.but("status")
         .with_color_for_svg()
@@ -847,13 +802,11 @@ fn status_shows_rewritten_branch_with_remote_and_local_commits() -> anyhow::Resu
         .stdout_eq(snapbox::file![
             "snapshots/status/classification/status-shows-rewritten-branch-with-remote-and-local-commits.stdout.term.svg"
         ]);
-
-    Ok(())
 }
 
 #[test]
 fn status_in_edit_mode_delegates_to_resolve_status() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     enter_edit_mode_with_conflicted_commit(&env)?;
 
     env.but("status")
@@ -870,8 +823,8 @@ fn status_in_edit_mode_delegates_to_resolve_status() -> anyhow::Result<()> {
 
 #[test]
 fn status_shows_marked_stack() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     let status = status_json(&env)?;
     let branch_cli_id = status["stacks"][0]["branches"][0]["cliId"]

--- a/crates/but/tests/but/command/switch.rs
+++ b/crates/but/tests/but/command/switch.rs
@@ -218,8 +218,8 @@ fn rejects_non_branch_cli_id() -> anyhow::Result<()> {
 }
 
 fn switch_env() -> anyhow::Result<crate::utils::Sandbox> {
-    let env = crate::utils::Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = crate::utils::Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
     Ok(env)
 }
 

--- a/crates/but/tests/but/command/teardown.rs
+++ b/crates/but/tests/but/command/teardown.rs
@@ -5,15 +5,15 @@ use crate::utils::{CommandExt, Sandbox};
 /// Test 1: Simple case of a single branch
 /// - Teardown should return HEAD to that branch
 #[test]
-fn single_branch_simple_teardown() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @"
+fn single_branch_simple_teardown() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    insta::assert_snapshot!(env.git_log(), @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata(&["A"])?;
+    env.setup_metadata(&["A"]);
 
     // Run teardown
     env.but("teardown")
@@ -45,8 +45,6 @@ To return to GitButler mode, run:
     // Verify we're on branch A
     let output = env.invoke_git("rev-parse --abbrev-ref HEAD");
     assert_eq!(output, "A");
-
-    Ok(())
 }
 
 /// Test 2: Multiple branches
@@ -54,9 +52,9 @@ To return to GitButler mode, run:
 /// - Removes other branches' work from working directory
 /// - Preserves virtual branch state
 #[test]
-fn multiple_branches_preserves_state() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
+fn multiple_branches_preserves_state() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    insta::assert_snapshot!(env.git_log(), @r"
     *   c128bce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * 9477ae7 (A) add A
@@ -65,7 +63,7 @@ fn multiple_branches_preserves_state() -> anyhow::Result<()> {
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
 
     // Run teardown
     env.but("teardown")
@@ -108,8 +106,6 @@ To return to GitButler mode, run:
         !file_b.exists(),
         "File B should not exist in working directory after teardown"
     );
-
-    Ok(())
 }
 
 /// Test 3: User has committed on top of gitbutler/workspace
@@ -118,8 +114,8 @@ To return to GitButler mode, run:
 #[test]
 #[ignore = "flaky test - needs investigation"]
 fn dangling_commit_on_workspace() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     // Create a dangling commit on top of workspace
     env.file("UserFile", "user content");
@@ -191,8 +187,8 @@ To return to GitButler mode, run:
 #[test]
 #[ignore = "flaky test - needs investigation"]
 fn dangling_commit_spanning_multiple_branches() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     // Create a dangling commit touching files from both branches
     let git_dir = env.projects_root();
@@ -271,9 +267,9 @@ To return to GitButler mode, run:
 #[test]
 fn two_dangling_commits_different_branches() -> anyhow::Result<()> {
     let env =
-        Sandbox::init_scenario_with_target_and_default_settings("teardown-two-dangling-commits")?;
+        Sandbox::init_scenario_with_target_and_default_settings("teardown-two-dangling-commits");
     // Initial state: user has made two commits on top of workspace
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log(), @r"
     * fc13bfb (HEAD -> gitbutler/workspace) add FileForB
     * 091c8f9 add FileForA
     *   c128bce GitButler Workspace Commit
@@ -284,7 +280,7 @@ fn two_dangling_commits_different_branches() -> anyhow::Result<()> {
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
 
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
 
     // Run teardown - should cherry-pick both commits to first branch
     // Note: In the current implementation, ALL dangling commits are cherry-picked
@@ -350,9 +346,9 @@ To return to GitButler mode, run:
 
 /// Test: JSON output format
 #[test]
-fn json_output_single_branch() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn json_output_single_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("--format json teardown")
         .allow_json()
@@ -370,16 +366,14 @@ fn json_output_single_branch() -> anyhow::Result<()> {
     // check the current git branch is A
     let output = env.invoke_git("rev-parse --abbrev-ref HEAD");
     assert_eq!(output, "A");
-
-    Ok(())
 }
 
 /// Test: JSON output with dangling commits
 #[test]
-fn json_output_with_dangling_commits() -> anyhow::Result<()> {
+fn json_output_with_dangling_commits() {
     let env =
-        Sandbox::init_scenario_with_target_and_default_settings("teardown-dangling-single-commit")?;
-    env.setup_metadata(&["A"])?;
+        Sandbox::init_scenario_with_target_and_default_settings("teardown-dangling-single-commit");
+    env.setup_metadata(&["A"]);
 
     env.but("--format json teardown")
         .allow_json()
@@ -397,14 +391,12 @@ fn json_output_with_dangling_commits() -> anyhow::Result<()> {
     // check the current git branch is A
     let output = env.invoke_git("rev-parse --abbrev-ref HEAD");
     assert_eq!(output, "A");
-
-    Ok(())
 }
 
 #[test]
-fn teardown_informs_of_checkout_to_when_there_are_no_stacks() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn teardown_informs_of_checkout_to_when_there_are_no_stacks() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
     env.but("unapply A").assert().success();
 
     env.but("teardown")
@@ -414,14 +406,12 @@ fn teardown_informs_of_checkout_to_when_there_are_no_stacks() -> anyhow::Result<
 Error: Failed to determine checkout target branch. Specify a target branch with `--checkout-to <branch>`.
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
 fn teardown_checks_out_to_branch_override() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
     env.but("unapply A").assert().success();
 
     env.but("--format json teardown")
@@ -453,8 +443,8 @@ fn teardown_checks_out_to_branch_override() -> anyhow::Result<()> {
 
 #[test]
 fn teardown_checks_out_to_branch_override_with_qualified_ref_name() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
     env.but("unapply A").assert().success();
 
     env.but("--format json teardown")
@@ -485,9 +475,9 @@ fn teardown_checks_out_to_branch_override_with_qualified_ref_name() -> anyhow::R
 }
 
 #[test]
-fn teardown_checkout_to_handles_missing_branch() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn teardown_checkout_to_handles_missing_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("teardown")
         .arg("--checkout-to")
@@ -502,14 +492,12 @@ The reference 'no-such-branch' did not exist
 
 "#
         ]);
-
-    Ok(())
 }
 
 #[test]
-fn teardown_checkout_to_handles_malformed_branch_name() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn teardown_checkout_to_handles_malformed_branch_name() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("teardown")
         .arg("--checkout-to")
@@ -524,14 +512,12 @@ Invalid ref name: not a branch
 
 "#
         ]);
-
-    Ok(())
 }
 
 #[test]
-fn teardown_checkout_to_disallows_non_branch_ref() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn teardown_checkout_to_disallows_non_branch_ref() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("teardown")
         .arg("--checkout-to")
@@ -544,14 +530,12 @@ Error: Bad input for '--checkout-to'
 Invalid ref for checkout: 'HEAD' is not a local branch
 
 "#]]);
-
-    Ok(())
 }
 
 #[test]
-fn teardown_checkout_to_disallows_non_local_branch_ref() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn teardown_checkout_to_disallows_non_local_branch_ref() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("teardown")
         .arg("--checkout-to")
@@ -564,6 +548,4 @@ Error: Bad input for '--checkout-to'
 Invalid ref for checkout: 'origin/main' is not a local branch
 
 "#]]);
-
-    Ok(())
 }

--- a/crates/but/tests/but/command/undo.rs
+++ b/crates/but/tests/but/command/undo.rs
@@ -82,8 +82,8 @@ where
 
 #[test]
 fn can_undo_discard() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
     let path = "new-file.txt";
     env.file(path, "content");
 
@@ -98,37 +98,33 @@ fn can_undo_discard() {
 }
 
 #[test]
-fn can_undo_but_discard_file_modifications() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits")?;
-    env.setup_metadata(&["A"])?;
+fn can_undo_but_discard_file_modifications() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     env.file("first", "This is new stuff");
 
     run_mutate_undo_roundtrip_test(&env, |env| {
         env.but("discard zz").assert().success();
     });
-
-    Ok(())
 }
 
 #[test]
-fn can_undo_but_discard_new_file() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits")?;
-    env.setup_metadata(&["A"])?;
+fn can_undo_but_discard_new_file() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     env.file("totally_new_file", "This is new stuff");
 
     run_mutate_undo_roundtrip_test(&env, |env| {
         env.but("discard zz").assert().success();
     });
-
-    Ok(())
 }
 
 #[test]
-fn can_undo_but_discard_deletion() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits")?;
-    env.setup_metadata(&["A"])?;
+fn can_undo_but_discard_deletion() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     let filepath = env.projects_root().join("first");
     std::fs::remove_file(&filepath).expect("must be able to delete file");
@@ -136,14 +132,12 @@ fn can_undo_but_discard_deletion() -> anyhow::Result<()> {
     run_mutate_undo_roundtrip_test(&env, |env| {
         env.but("discard zz").assert().success();
     });
-
-    Ok(())
 }
 
 #[test]
-fn can_undo_but_discard_rename() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits")?;
-    env.setup_metadata(&["A"])?;
+fn can_undo_but_discard_rename() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     let filepath = env.projects_root().join("first");
     let new_filepath = env.projects_root().join("first_renamed");
@@ -152,15 +146,13 @@ fn can_undo_but_discard_rename() -> anyhow::Result<()> {
     run_mutate_undo_roundtrip_test(&env, |env| {
         env.but("discard zz").assert().success();
     });
-
-    Ok(())
 }
 
 #[test]
 #[ignore = "Test harness runs with cv3 feature flag, and but_core::worktree::safe_checkout_from_head does not restore the worktree file A for some reason. https://linear.app/gitbutler/issue/GB-1403/run-test-both-with-and-without-cv3-feature-flag"]
 fn can_undo_unapply() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     run_mutate_undo_roundtrip_test(&env, |env| {
         env.but("unapply A")
@@ -174,8 +166,8 @@ fn can_undo_unapply() {
 #[test]
 #[ignore = "Test harness runs with cv3 feature flag, and but_core::worktree::safe_checkout_from_head does not remove the worktree file A for some reason. https://linear.app/gitbutler/issue/GB-1403/run-test-both-with-and-without-cv3-feature-flag"]
 fn can_undo_clean_apply() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
     env.but("unapply A").assert().success();
 
     run_mutate_undo_roundtrip_test(&env, |env| {
@@ -189,9 +181,8 @@ fn can_undo_clean_apply() {
 
 #[test]
 fn can_undo_rewording_commit() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     run_mutate_undo_roundtrip_test(&env, |env| {
         env.but("reword")
@@ -205,9 +196,8 @@ fn can_undo_rewording_commit() {
 
 #[test]
 fn can_undo_rewording_branch() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     run_mutate_undo_roundtrip_test(&env, |env| {
         env.but("reword")
@@ -221,9 +211,8 @@ fn can_undo_rewording_branch() {
 
 #[test]
 fn can_undo_but_branch_new_at_base() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     run_mutate_undo_roundtrip_test(&env, |env| {
         env.but("branch").args(["new", "foo"]).assert().success();
@@ -232,9 +221,8 @@ fn can_undo_but_branch_new_at_base() {
 
 #[test]
 fn can_undo_but_branch_in_stack() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     env.but("branch").args(["new", "foo"]).assert().success();
 
@@ -248,9 +236,8 @@ fn can_undo_but_branch_in_stack() {
 
 #[test]
 fn can_undo_but_branch_delete() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     env.but("branch").args(["new", "foo"]).assert().success();
 
@@ -261,9 +248,8 @@ fn can_undo_but_branch_delete() {
 
 #[test]
 fn can_undo_but_branch_delete_in_stack() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     env.but("branch").args(["new", "foo"]).assert().success();
     env.but("branch")
@@ -278,9 +264,8 @@ fn can_undo_but_branch_delete_in_stack() {
 
 #[test]
 fn can_undo_but_absorb() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     env.file("first", "This is new stuff");
 
@@ -291,9 +276,8 @@ fn can_undo_but_absorb() {
 
 #[test]
 fn can_undo_but_squash_with_two_commits() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     let commit_one = commit_empty_with_message(&env, "one");
     let commit_two = commit_empty_with_message(&env, "two");
@@ -324,9 +308,8 @@ af394f9 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 #[test]
 fn can_undo_but_squash_with_three_commits() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     let commit_one = commit_empty_with_message(&env, "one");
     let commit_two = commit_empty_with_message(&env, "two");
@@ -360,9 +343,8 @@ af394f9 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 #[test]
 fn can_undo_but_squash_with_range_of_commits() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     let commit_one = commit_empty_with_message(&env, "one");
     commit_empty_with_message(&env, "two");
@@ -400,9 +382,8 @@ af394f9 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 #[test]
 fn can_undo_but_squash_with_two_commits_with_message() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     let commit_one = commit_empty_with_message(&env, "one");
     let commit_two = commit_empty_with_message(&env, "two");
@@ -435,9 +416,8 @@ af394f9 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 #[test]
 fn can_undo_but_squash_with_branch() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     commit_empty_with_message(&env, "one");
     commit_empty_with_message(&env, "two");
@@ -466,9 +446,8 @@ af394f9 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 #[test]
 fn can_undo_but_squash_with_branch_and_drop_message() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     commit_empty_with_message(&env, "one");
     commit_empty_with_message(&env, "two");

--- a/crates/but/tests/but/command/undo/undo_commit.rs
+++ b/crates/but/tests/but/command/undo/undo_commit.rs
@@ -31,8 +31,8 @@ pub(super) fn commit_empty_with_message(env: &Sandbox, message: &str) -> String 
 
 #[test]
 fn can_undo_but_commit() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata_at_target(&["A"], "origin/main").unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
     let path = "new-file.txt";
     env.file(path, "content");
 
@@ -43,8 +43,8 @@ fn can_undo_but_commit() {
 
 #[test]
 fn can_undo_but_commit_on_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata_at_target(&["A"], "origin/main").unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
     let path = "new-file.txt";
     env.file(path, "content");
 
@@ -55,8 +55,8 @@ fn can_undo_but_commit_on_branch() {
 
 #[test]
 fn can_undo_but_commit_dash_dash_create() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata_at_target(&["A"], "origin/main").unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
     let path = "new-file.txt";
     env.file(path, "content");
 
@@ -70,8 +70,8 @@ fn can_undo_but_commit_dash_dash_create() {
 
 #[test]
 fn can_undo_but_commit_dash_dash_create_new_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata_at_target(&["A"], "origin/main").unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
     let path = "new-file.txt";
     env.file(path, "content");
 
@@ -87,8 +87,8 @@ fn can_undo_but_commit_dash_dash_create_new_branch() {
 
 #[test]
 fn can_undo_but_commit_dash_dash_create_existing_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata_at_target(&["A"], "origin/main").unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
     let path = "new-file.txt";
     env.file(path, "content");
 
@@ -102,8 +102,8 @@ fn can_undo_but_commit_dash_dash_create_existing_branch() {
 #[test]
 #[ignore = "undoing assignments dont work. https://linear.app/gitbutler/issue/GB-1468/undoing-but-commit-only-to-commit-only-assigned-changes-doesnt-work"]
 fn can_undo_but_commit_dash_dash_only() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata_at_target(&["A"], "origin/main").unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
 
     env.file("assigned.txt", "assigned content");
     env.but("rub assigned.txt A").assert().success();
@@ -117,8 +117,8 @@ fn can_undo_but_commit_dash_dash_only() {
 
 #[test]
 fn can_undo_but_commit_dash_dash_changes() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata_at_target(&["A"], "origin/main").unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
 
     env.file("new-file.txt", "content");
     env.file("other-new-file.txt", "content");
@@ -132,8 +132,8 @@ fn can_undo_but_commit_dash_dash_changes() {
 
 #[test]
 fn can_undo_but_commit_empty() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata_at_target(&["A"], "origin/main").unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
 
     run_mutate_undo_roundtrip_test(&env, |env| {
         env.but("commit empty").assert().success();
@@ -142,8 +142,8 @@ fn can_undo_but_commit_empty() {
 
 #[test]
 fn can_undo_but_commit_empty_with_message() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata_at_target(&["A"], "origin/main").unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
 
     run_mutate_undo_roundtrip_test(&env, |env| {
         env.but("commit empty -m 'Plan empty slot'")
@@ -154,8 +154,8 @@ fn can_undo_but_commit_empty_with_message() {
 
 #[test]
 fn can_undo_but_commit_empty_target() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata_at_target(&["A"], "origin/main").unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
 
     env.file("new-file.txt", "content");
 
@@ -168,8 +168,8 @@ fn can_undo_but_commit_empty_target() {
 
 #[test]
 fn can_undo_but_commit_empty_dash_dash_before() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata_at_target(&["A"], "origin/main").unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
 
     env.file("new-file.txt", "content");
 
@@ -186,8 +186,8 @@ fn can_undo_but_commit_empty_dash_dash_before() {
 
 #[test]
 fn can_undo_but_commit_empty_dash_dash_after() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata_at_target(&["A"], "origin/main").unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
 
     env.file("new-file.txt", "content");
 

--- a/crates/but/tests/but/command/undo/undo_redo.rs
+++ b/crates/but/tests/but/command/undo/undo_redo.rs
@@ -90,9 +90,8 @@ Workspace has been restored to the selected snapshot.
 
 #[test]
 fn can_undo_repeatedly() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     let (status_one, new_commit) = reword(&env, "9ac4652", "one");
     let (status_two, new_commit) = reword(&env, &new_commit, "two");
@@ -185,9 +184,8 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 #[test]
 fn can_undo_explicit_restore() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     let (_, new_commit) = reword(&env, "9ac4652", "one");
     let (status_two, new_commit) = reword(&env, &new_commit, "two");
@@ -251,9 +249,8 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 #[test]
 fn can_undo_perform_operation_then_undo_again() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     let (_, new_commit) = reword(&env, "9ac4652", "one");
     let (status_two, new_commit) = reword(&env, &new_commit, "two");
@@ -333,9 +330,8 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 #[test]
 fn undoing_past_end_of_oplog() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     let status_zero = env.but("status").output().unwrap();
     let (status_one, new_commit) = reword(&env, "9ac4652", "one");
@@ -402,9 +398,8 @@ Operations History
 
 #[test]
 fn can_redo() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     let (_, new_commit) = reword(&env, "9ac4652", "one");
     let (_, new_commit) = reword(&env, &new_commit, "two");
@@ -478,9 +473,8 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 #[test]
 fn can_mix_undo_and_redo() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     let (status_one, new_commit) = reword(&env, "9ac4652", "one");
     let (status_two, new_commit) = reword(&env, &new_commit, "two");
@@ -692,9 +686,8 @@ e637109 2000-01-02 00:00:00 [REWORD] Updated commit message
 
 #[test]
 fn cannot_redo_without_undoing_first() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     reword(&env, "9ac4652", "one");
 

--- a/crates/but/tests/but/command/undo/undo_rub.rs
+++ b/crates/but/tests/but/command/undo/undo_rub.rs
@@ -12,9 +12,8 @@ use crate::{
 // RubOperation::SquashCommits
 #[test]
 fn undo_squash_commits() {
-    let env =
-        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
 
     run_mutate_undo_roundtrip_test(&env, |env| {
         env.but("rub")
@@ -31,8 +30,8 @@ fn undo_squash_commits() {
 #[test]
 #[ignore = "undo currently does not restore hunk assignment metadata for rub operations that only move changes between unassigned, branch, and stack buckets. https://linear.app/gitbutler/issue/GB-1435/cannot-undo-rub-operations-that-deal-with-uncommitted-changes"]
 fn undo_unassign_uncommitted() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
     env.file("unassign-uncommitted.txt", "content\n");
     env.but("rub unassign-uncommitted.txt A").assert().success();
 
@@ -48,8 +47,8 @@ fn undo_unassign_uncommitted() {
 // RubOperation::UncommittedToCommit
 #[test]
 fn undo_uncommitted_to_commit() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
     env.file("uncommitted-to-commit.txt", "content\n");
     let target_commit = branch_commit_ids(&status_json(&env).unwrap(), "A")[0].clone();
 
@@ -66,8 +65,8 @@ fn undo_uncommitted_to_commit() {
 #[test]
 #[ignore = "undo currently does not restore hunk assignment metadata for rub operations that only move changes between unassigned, branch, and stack buckets. https://linear.app/gitbutler/issue/GB-1435/cannot-undo-rub-operations-that-deal-with-uncommitted-changes"]
 fn undo_uncommitted_to_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
     env.file("uncommitted-to-branch.txt", "content\n");
 
     run_mutate_undo_roundtrip_test(&env, |env| {
@@ -85,8 +84,8 @@ fn undo_uncommitted_to_branch() {
 #[test]
 #[ignore = "undo currently does not restore hunk assignment metadata for rub operations that only move changes between unassigned, branch, and stack buckets. https://linear.app/gitbutler/issue/GB-1435/cannot-undo-rub-operations-that-deal-with-uncommitted-changes"]
 fn undo_uncommitted_to_stack() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
     env.file("uncommitted-to-stack.txt", "content\n");
 
     run_mutate_undo_roundtrip_test(&env, |env| {
@@ -102,8 +101,8 @@ fn undo_uncommitted_to_stack() {
 #[test]
 #[ignore = "undo currently does not restore hunk assignment metadata for rub operations that only move changes between unassigned, branch, and stack buckets. https://linear.app/gitbutler/issue/GB-1435/cannot-undo-rub-operations-that-deal-with-uncommitted-changes"]
 fn undo_stack_to_unassigned() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
     env.file("stack-to-unassigned.txt", "content\n");
     env.but("rub stack-to-unassigned.txt A").assert().success();
 
@@ -120,8 +119,8 @@ fn undo_stack_to_unassigned() {
 #[test]
 #[ignore = "undo currently does not restore hunk assignment metadata for rub operations that only move changes between unassigned, branch, and stack buckets. https://linear.app/gitbutler/issue/GB-1435/cannot-undo-rub-operations-that-deal-with-uncommitted-changes"]
 fn undo_stack_to_stack() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
     env.file("stack-to-stack.txt", "content\n");
     env.but("rub stack-to-stack.txt A").assert().success();
 
@@ -138,8 +137,8 @@ fn undo_stack_to_stack() {
 #[test]
 #[ignore = "undo currently does not restore hunk assignment metadata for rub operations that only move changes between unassigned, branch, and stack buckets. https://linear.app/gitbutler/issue/GB-1435/cannot-undo-rub-operations-that-deal-with-uncommitted-changes"]
 fn undo_stack_to_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
     env.file("stack-to-branch.txt", "content\n");
     env.but("rub stack-to-branch.txt A").assert().success();
 
@@ -155,8 +154,8 @@ fn undo_stack_to_branch() {
 // RubOperation::StackToCommit
 #[test]
 fn undo_stack_to_commit() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
     env.file("stack-to-commit.txt", "content\n");
     env.but("rub stack-to-commit.txt A").assert().success();
     let target_commit = branch_commit_ids(&status_json(&env).unwrap(), "A")[0].clone();
@@ -173,8 +172,8 @@ fn undo_stack_to_commit() {
 // RubOperation::UnassignedToCommit
 #[test]
 fn undo_unassigned_to_commit() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
     env.file("unassigned-to-commit.txt", "content\n");
     let target_commit = branch_commit_ids(&status_json(&env).unwrap(), "A")[0].clone();
 
@@ -191,8 +190,8 @@ fn undo_unassigned_to_commit() {
 #[test]
 #[ignore = "undo currently does not restore hunk assignment metadata for rub operations that only move changes between unassigned, branch, and stack buckets. https://linear.app/gitbutler/issue/GB-1435/cannot-undo-rub-operations-that-deal-with-uncommitted-changes"]
 fn undo_unassigned_to_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
     env.file("unassigned-to-branch.txt", "content\n");
 
     run_mutate_undo_roundtrip_test(&env, |env| {
@@ -208,8 +207,8 @@ fn undo_unassigned_to_branch() {
 #[test]
 #[ignore = "undo currently does not restore hunk assignment metadata for rub operations that only move changes between unassigned, branch, and stack buckets. https://linear.app/gitbutler/issue/GB-1435/cannot-undo-rub-operations-that-deal-with-uncommitted-changes"]
 fn undo_unassigned_to_stack() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
     env.file("unassigned-to-stack.txt", "content\n");
 
     run_mutate_undo_roundtrip_test(&env, |env| {
@@ -224,8 +223,8 @@ fn undo_unassigned_to_stack() {
 // RubOperation::CommitToUnassigned
 #[test]
 fn undo_commit_to_unassigned() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
     commit_two_files_as_two_hunks_each(
         &env,
         "A",
@@ -247,8 +246,8 @@ fn undo_commit_to_unassigned() {
 // RubOperation::CommitToStack
 #[test]
 fn undo_commit_to_stack() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
     commit_two_files_as_two_hunks_each(
         &env,
         "A",
@@ -270,8 +269,8 @@ fn undo_commit_to_stack() {
 // RubOperation::MoveCommitToBranch
 #[test]
 fn undo_move_commit_to_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
     commit_two_files_as_two_hunks_each(
         &env,
         "A",
@@ -294,8 +293,8 @@ fn undo_move_commit_to_branch() {
 #[test]
 #[ignore = "undo currently does not restore hunk assignment metadata for rub operations that only move changes between unassigned, branch, and stack buckets. https://linear.app/gitbutler/issue/GB-1435/cannot-undo-rub-operations-that-deal-with-uncommitted-changes"]
 fn undo_branch_to_unassigned() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
     env.file("branch-to-unassigned.txt", "content\n");
     env.but("rub branch-to-unassigned.txt A").assert().success();
 
@@ -312,8 +311,8 @@ fn undo_branch_to_unassigned() {
 #[test]
 #[ignore = "undo currently does not restore hunk assignment metadata for rub operations that only move changes between unassigned, branch, and stack buckets. https://linear.app/gitbutler/issue/GB-1435/cannot-undo-rub-operations-that-deal-with-uncommitted-changes"]
 fn undo_branch_to_stack() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
     env.file("branch-to-stack.txt", "content\n");
     env.but("rub branch-to-stack.txt A").assert().success();
 
@@ -329,8 +328,8 @@ fn undo_branch_to_stack() {
 // RubOperation::BranchToCommit
 #[test]
 fn undo_branch_to_commit() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
     env.file("branch-to-commit.txt", "content\n");
     env.but("rub branch-to-commit.txt A").assert().success();
     let target_commit = branch_commit_ids(&status_json(&env).unwrap(), "A")[0].clone();
@@ -348,8 +347,8 @@ fn undo_branch_to_commit() {
 #[test]
 #[ignore = "undo currently does not restore hunk assignment metadata for rub operations that only move changes between unassigned, branch, and stack buckets. https://linear.app/gitbutler/issue/GB-1435/cannot-undo-rub-operations-that-deal-with-uncommitted-changes"]
 fn undo_branch_to_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
     env.file("branch-to-branch.txt", "content\n");
     env.but("rub branch-to-branch.txt A").assert().success();
 
@@ -365,8 +364,8 @@ fn undo_branch_to_branch() {
 // RubOperation::CommittedFileToBranch
 #[test]
 fn undo_committed_file_to_branch() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
     commit_two_files_as_two_hunks_each(
         &env,
         "A",
@@ -388,8 +387,8 @@ fn undo_committed_file_to_branch() {
 // RubOperation::CommittedFileToCommit
 #[test]
 fn undo_committed_file_to_commit() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata(&["A"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
     commit_two_files_as_two_hunks_each(&env, "A", "source-a.txt", "source-b.txt", "source");
     commit_two_files_as_two_hunks_each(&env, "A", "target-a.txt", "target-b.txt", "target");
     let status = status_json_with_files(&env).unwrap();
@@ -408,8 +407,8 @@ fn undo_committed_file_to_commit() {
 // RubOperation::CommittedFileToUnassigned
 #[test]
 fn undo_committed_file_to_unassigned() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
-    env.setup_metadata(&["A", "B"]).unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
     commit_two_files_as_two_hunks_each(&env, "A", "file-to-zz-a.txt", "file-to-zz-b.txt", "first");
     let source_commit = branch_commit_ids(&status_json(&env).unwrap(), "A")[0].clone();
 

--- a/crates/but/tests/but/command/undo/undo_uncommit.rs
+++ b/crates/but/tests/but/command/undo/undo_uncommit.rs
@@ -2,8 +2,8 @@ use crate::{command::undo::run_mutate_undo_roundtrip_test, utils::Sandbox};
 
 #[test]
 fn can_undo_but_uncommit_commit_add() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata_at_target(&["A"], "origin/main").unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
     let path = "new-file.txt";
     env.file(path, "content");
 
@@ -16,8 +16,8 @@ fn can_undo_but_uncommit_commit_add() {
 
 #[test]
 fn can_undo_but_uncommit_commit_modify() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata_at_target(&["A"], "origin/main").unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
     let path = "new-file.txt";
     env.file(path, "content");
 
@@ -35,8 +35,8 @@ fn can_undo_but_uncommit_commit_modify() {
 
 #[test]
 fn can_undo_but_uncommit_commit_delete() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata_at_target(&["A"], "origin/main").unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
     let path = "new-file.txt";
     env.file(path, "content");
 
@@ -53,8 +53,8 @@ fn can_undo_but_uncommit_commit_delete() {
 
 #[test]
 fn can_undo_but_uncommit_file_add() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata_at_target(&["A"], "origin/main").unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
     let path = "new-file.txt";
     env.file(path, "content");
 
@@ -67,8 +67,8 @@ fn can_undo_but_uncommit_file_add() {
 
 #[test]
 fn can_undo_but_uncommit_file_modify() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata_at_target(&["A"], "origin/main").unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
     let path = "new-file.txt";
     env.file(path, "content");
 
@@ -84,8 +84,8 @@ fn can_undo_but_uncommit_file_modify() {
 
 #[test]
 fn can_undo_but_uncommit_file_delete() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
-    env.setup_metadata_at_target(&["A"], "origin/main").unwrap();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
     let path = "new-file.txt";
     env.file(path, "content");
 

--- a/crates/but/tests/but/command/worktree.rs
+++ b/crates/but/tests/but/command/worktree.rs
@@ -6,8 +6,8 @@ use crate::utils::Sandbox;
 /// work there, then squash-integrate the result back into the workspace.
 #[test]
 fn journey_new_list_integrate() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    insta::assert_snapshot!(env.git_log(), @r"
     *   c128bce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * 9477ae7 (A) add A
@@ -15,7 +15,7 @@ fn journey_new_list_integrate() -> anyhow::Result<()> {
     |/  
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
 
     env.but("worktree new A")
         .assert()
@@ -68,7 +68,7 @@ Target: refs/heads/A
 
 "#]]);
 
-    let log = env.git_log()?;
+    let log = env.git_log();
     assert!(
         log.contains("(A) Integrated worktree"),
         "the worktree work is squashed into a commit on the branch it was created from: {log}"
@@ -95,8 +95,8 @@ Target: refs/heads/A
 
 #[test]
 fn destroy_by_name_and_by_reference() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     env.but("worktree new A").assert().success();
     let a_id = single_worktree_id(&env);
@@ -139,9 +139,9 @@ No worktrees found
 }
 
 #[test]
-fn integrate_dry_run_reports_worktree_without_changes() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    env.setup_metadata(&["A", "B"])?;
+fn integrate_dry_run_reports_worktree_without_changes() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
     env.but("worktree new A").assert().success();
     let wt_id = single_worktree_id(&env);
@@ -156,8 +156,6 @@ Target: refs/heads/A
 Status: Nothing to integrate - the worktree has no changes
 
 "#]]);
-
-    Ok(())
 }
 
 fn worktrees_dir(env: &Sandbox) -> std::path::PathBuf {
@@ -181,7 +179,7 @@ fn single_worktree_id(env: &Sandbox) -> String {
 
 /// All local branches under the private worktree namespace.
 fn worktree_private_branches(env: &Sandbox) -> anyhow::Result<Vec<String>> {
-    let repo = env.open_repo()?;
+    let repo = env.open_repo();
     let refs = repo.references()?;
     Ok(refs
         .prefixed(b"refs/heads/gitbutler/worktree/".as_ref())?

--- a/crates/but/tests/but/journey.rs
+++ b/crates/but/tests/but/journey.rs
@@ -5,9 +5,9 @@ use crate::utils::Sandbox;
 
 #[cfg(not(feature = "legacy"))]
 #[test]
-fn from_unborn() -> anyhow::Result<()> {
-    let env = Sandbox::open_with_default_settings("unborn")?;
-    insta::assert_snapshot!(env.git_log()?, @r"");
+fn from_unborn() {
+    let env = Sandbox::open_with_default_settings("unborn");
+    insta::assert_snapshot!(env.git_log(), @r"");
 
     env.but("branch apply main")
         .assert()
@@ -18,14 +18,13 @@ Error: The reference 'main' did not exist
 "#]]);
 
     // TODO: we should be able to use the CLI to create a commit
-    Ok(())
 }
 
 // TODO: maybe this should be a non-legacy journey only as we start out without workspace?
 #[cfg(feature = "legacy")]
 #[test]
-fn from_empty() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
+fn from_empty() {
+    let env = Sandbox::empty();
 
     env.but("status").assert().failure().stderr_eq(str![[r#"
 Error: No git repository found at .
@@ -153,18 +152,16 @@ Hint: run `but branch new` to create a new branch to work on
 
 "#]])
         .stderr_eq(str![""]);
-
-    Ok(())
 }
 
 #[cfg(feature = "legacy")]
 #[test]
-fn from_workspace() -> anyhow::Result<()> {
+fn from_workspace() {
     use snapbox::file;
 
     use crate::utils::CommandExt;
-    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    insta::assert_snapshot!(env.git_log(), @r"
     *   c128bce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * 9477ae7 (A) add A
@@ -172,10 +169,10 @@ fn from_workspace() -> anyhow::Result<()> {
     |/  
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
-    insta::assert_snapshot!(env.git_status()?, @"");
+    insta::assert_snapshot!(env.git_status(), @"");
 
     // Must set metadata to match the scenario, or else the old APIs used here won't deliver.
-    env.setup_metadata(&["A", "B"])?;
+    env.setup_metadata(&["A", "B"]);
 
     env.but("status")
         .with_color_for_svg()
@@ -206,5 +203,4 @@ fn from_workspace() -> anyhow::Result<()> {
         .stdout_eq(file!["snapshots/from-workspace/branch01.stdout.term.svg"]);
 
     // TODO: more operations on the repository!
-    Ok(())
 }

--- a/crates/but/tests/but/utils.rs
+++ b/crates/but/tests/but/utils.rs
@@ -32,21 +32,19 @@ impl DerefMut for Sandbox {
 /// Lifecycle
 impl Sandbox {
     /// Create a new instance with empty everything.
-    pub fn empty() -> anyhow::Result<Sandbox> {
-        Ok(Sandbox {
-            inner: but_testsupport::Sandbox::empty()?,
-        })
+    pub fn empty() -> Sandbox {
+        Sandbox {
+            inner: but_testsupport::Sandbox::empty(),
+        }
     }
 
     /// A utility to init a scenario if the legacy feature is set, or open a repo otherwise.
-    pub fn open_or_init_scenario_with_target_and_default_settings(
-        name: &str,
-    ) -> anyhow::Result<Sandbox> {
+    pub fn open_or_init_scenario_with_target_and_default_settings(name: &str) -> Sandbox {
         let inner =
-            but_testsupport::Sandbox::open_or_init_scenario_with_target_and_default_settings(name)?;
+            but_testsupport::Sandbox::open_or_init_scenario_with_target_and_default_settings(name);
         let this = Sandbox { inner };
         this.run_but_init_if_needed();
-        Ok(this)
+        this
     }
 
     fn run_but_init_if_needed(&self) {
@@ -59,10 +57,10 @@ impl Sandbox {
     }
 
     /// Open a repository without any additional setup and default application settings.
-    pub fn open_with_default_settings(name: &str) -> anyhow::Result<Sandbox> {
-        Ok(Sandbox {
-            inner: but_testsupport::Sandbox::open_with_default_settings(name)?,
-        })
+    pub fn open_with_default_settings(name: &str) -> Sandbox {
+        Sandbox {
+            inner: but_testsupport::Sandbox::open_with_default_settings(name),
+        }
     }
 
     /// Provide a scenario with `name` for writing, and `but setup` already invoked to add the project,
@@ -71,30 +69,28 @@ impl Sandbox {
     /// Prefer to use [`Self::open_scenario_with_target_and_default_settings()`] instead for less side-effects
     /// TODO: we shouldn't have to add the project for interaction - it's only useful for listing.
     /// TODO: there should be no need for the target.
-    pub fn init_scenario_with_target_and_default_settings(name: &str) -> anyhow::Result<Sandbox> {
-        let inner = but_testsupport::Sandbox::init_scenario_with_target_and_default_settings(name)?;
+    pub fn init_scenario_with_target_and_default_settings(name: &str) -> Sandbox {
+        let inner = but_testsupport::Sandbox::init_scenario_with_target_and_default_settings(name);
         let this = Sandbox { inner };
         this.run_but_init_if_needed();
-        Ok(this)
+        this
     }
 
     /// Provide a scenario with `name` for writing, with target added.
-    pub fn open_scenario_with_target_and_default_settings(name: &str) -> anyhow::Result<Sandbox> {
-        Ok(Sandbox {
-            inner: but_testsupport::Sandbox::open_scenario_with_target_and_default_settings(name)?,
-        })
+    pub fn open_scenario_with_target_and_default_settings(name: &str) -> Sandbox {
+        Sandbox {
+            inner: but_testsupport::Sandbox::open_scenario_with_target_and_default_settings(name),
+        }
     }
 
     /// Like [`Self::init_scenario_with_target_and_default_settings`], Execute the script at `name` instead of
     /// copying it - necessary if Git places absolute paths.
-    pub fn init_scenario_with_target_and_default_settings_slow(
-        name: &str,
-    ) -> anyhow::Result<Sandbox> {
+    pub fn init_scenario_with_target_and_default_settings_slow(name: &str) -> Sandbox {
         let inner =
-            but_testsupport::Sandbox::init_scenario_with_target_and_default_settings_slow(name)?;
+            but_testsupport::Sandbox::init_scenario_with_target_and_default_settings_slow(name);
         let this = Sandbox { inner };
         this.run_but_init_if_needed();
-        Ok(this)
+        this
     }
 }
 
@@ -110,10 +106,10 @@ impl Sandbox {
         &self,
         branch_names: &[&str],
         target_spec: &str,
-    ) -> anyhow::Result<Vec<but_core::ref_metadata::StackId>> {
-        let stack_ids = self.inner.setup_metadata(branch_names)?;
-        self.inner.set_target_sha(target_spec)?;
-        Ok(stack_ids)
+    ) -> Vec<but_core::ref_metadata::StackId> {
+        let stack_ids = self.inner.setup_metadata(branch_names);
+        self.inner.set_target_sha(target_spec);
+        stack_ids
     }
 }
 


### PR DESCRIPTION
Changes `but-testsupport` to not return `Result` but instead unwrap internally. It makes the code easier to use and improves backtraces.