### PR TITLE
Bump design-core and update list item CSS vars

### DIFF
--- a/apps/lite/package.json
+++ b/apps/lite/package.json
@@ -126,7 +126,7 @@
 		"@base-ui/react": "^1.6.0",
 		"@base-ui/utils": "^0.3.1",
 		"@gitbutler/but-sdk": "workspace:*",
-		"@gitbutler/design-core": "3.5.1",
+		"@gitbutler/design-core": "3.6.1",
 		"@pierre/diffs": "^1.2.4",
 		"@reduxjs/toolkit": "catalog:redux",
 		"@suspensive/react-query": "npm:@suspensive/react-query-5@^3.21.2",

--- a/apps/lite/ui/src/components/PickerDialog.module.css
+++ b/apps/lite/ui/src/components/PickerDialog.module.css
@@ -161,7 +161,7 @@
 	user-select: none;
 
 	&[data-highlighted] {
-		background-color: var(--button-ghost-hover-bg);
+		background-color: var(--list-item-hover-bg);
 	}
 }
 

--- a/apps/lite/ui/src/global.css
+++ b/apps/lite/ui/src/global.css
@@ -3,7 +3,7 @@
 :root {
 	color-scheme: light dark;
 
-	--button-ghost-hover-bg: color-mix(var(--fill-gray-bg) 6%, transparent);
+	--list-item-hover-bg: color-mix(var(--fill-gray-bg) var(--opacity-bg-hover), transparent);
 	--panel-padding: 16px;
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceItemRow.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceItemRow.module.css
@@ -13,12 +13,12 @@
 	border-radius: var(--radius-m);
 
 	&:where(:hover) {
-		background-color: var(--button-ghost-hover-bg);
+		background-color: var(--list-item-hover-bg);
 	}
 }
 
 .containerSelected {
-	background-color: color-mix(var(--fill-gray-bg) 13%, transparent);
+	background-color: color-mix(var(--fill-gray-bg) var(--opacity-bg-selected-blur), transparent);
 
 	&:has(:is(textarea, input):focus),
 	[data-selection-scope]:focus & {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -411,8 +411,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/but-sdk
       '@gitbutler/design-core':
-        specifier: 3.5.1
-        version: 3.5.1
+        specifier: 3.6.1
+        version: 3.6.1
       '@pierre/diffs':
         specifier: ^1.2.4
         version: 1.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1922,8 +1922,8 @@ packages:
   '@gitbutler/design-core@2.2.2':
     resolution: {integrity: sha512-oPPnYjwsKxwoTY6wK/fT9ylwhSIBgQxCOGJzYefbM8WFr2OuJePH9MnDnZ3K9UQlb94p+NR7m/QCFzhbDVRwxw==}
 
-  '@gitbutler/design-core@3.5.1':
-    resolution: {integrity: sha512-+XqQQuyLrrmRMD7KIgab4NNTRsDRwBQnoS4RX9U4EMMw2mOFxj+OeISc9HhAqcnQOc6dlZRpig6rFFKB9ZxTsw==}
+  '@gitbutler/design-core@3.6.1':
+    resolution: {integrity: sha512-SA6PexaODqL5eXwmNK3c71KcHjcXkS8sQSTMsk64cyUYeQtyQKXeqSZSSlTGefcphw6zAosjf86ShumOdYX11A==}
 
   '@hapi/address@5.1.1':
     resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
@@ -10625,7 +10625,7 @@ snapshots:
 
   '@gitbutler/design-core@2.2.2': {}
 
-  '@gitbutler/design-core@3.5.1': {}
+  '@gitbutler/design-core@3.6.1': {}
 
   '@hapi/address@5.1.1':
     dependencies:


### PR DESCRIPTION
In Figma, I started using `list item hover` and `selected but not in focus` opacity states in several places, so I converted them into variables for better consistency.
This PR hooks those same variables up in the code, pulling them from the `design-core` package.