### PR TITLE
feat(but): allow commit by path prefix for `commit2`

### DIFF
--- a/crates/but/src/args/atoms/cli_id.rs
+++ b/crates/but/src/args/atoms/cli_id.rs
@@ -1,3 +1,4 @@
+use nonempty::NonEmpty;
 use serde::Serialize;
 
 use crate::{
@@ -150,7 +151,7 @@ impl CliIdArg {
         &self,
         repo: &gix::Repository,
         id_map: &IdMap,
-    ) -> CliResult<Option<UncommittedCliId>> {
+    ) -> CliResult<Option<Vec<UncommittedCliId>>> {
         let Some(id) = try_resolve_cli_id(
             self,
             repo,
@@ -162,7 +163,25 @@ impl CliIdArg {
             return Ok(None);
         };
         match id {
-            CliId::Uncommitted(uncommitted) => Ok(Some(uncommitted)),
+            CliId::Uncommitted(uncommitted) => Ok(Some(vec![uncommitted])),
+            CliId::PathPrefix {
+                id: _,
+                hunk_assignments,
+            } => Ok(Some(
+                hunk_assignments
+                    .into_iter()
+                    .map(|(id, assignment)| UncommittedCliId {
+                        id,
+                        hunk_assignments: NonEmpty::new(assignment),
+                        // In a world without staging, all these hunk assignments should be turned
+                        // into "entire file" assignments for every file under the given PathPrefix.
+                        // However, currently, already assigned changes are not resolved by
+                        // PathPrefix. This should all be fixed at the level of resolving the
+                        // PathPrefix rather than here, though.
+                        is_entire_file: false,
+                    })
+                    .collect(),
+            )),
             other => Err(self.wrong_kind_error(&other, "uncommitted change")),
         }
     }
@@ -172,7 +191,7 @@ impl CliIdArg {
         &self,
         repo: &gix::Repository,
         id_map: &IdMap,
-    ) -> CliResult<UncommittedCliId> {
+    ) -> CliResult<Vec<UncommittedCliId>> {
         if let Some(uncommitted) = self.try_resolve_uncommitted(repo, id_map)? {
             Ok(uncommitted)
         } else {

--- a/crates/but/src/command/legacy/commit2.rs
+++ b/crates/but/src/command/legacy/commit2.rs
@@ -180,7 +180,8 @@ fn resolve(
         let changes = changes
             .into_iter()
             .map(|change| change.resolve_uncommitted(&*ctx.repo.get()?, id_map))
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<CliResult<Vec<Vec<UncommittedCliId>>>>()?;
+        let changes = changes.into_iter().flatten().collect();
         let Some(changes) = NonEmpty::from_vec(changes) else {
             return Err(bad_input("No changes to commit")
                 .hint("Run `but status` to show applicable targets")

--- a/crates/but/src/utils/diff_specs.rs
+++ b/crates/but/src/utils/diff_specs.rs
@@ -232,13 +232,11 @@ impl<'a> DiffSpecBuilder<'a> {
                 _ => None,
             };
 
-            diff_spec_order.insert(
-                DiffSpecKey {
-                    path: change.path_bytes.as_bstr(),
-                    previous_path,
-                },
-                i,
-            );
+            let key = DiffSpecKey {
+                path: change.path_bytes.as_bstr(),
+                previous_path,
+            };
+            diff_spec_order.insert(key, i);
         }
 
         self.diff_specs.sort_by_key(|item| {

--- a/crates/but/tests/but/command/commit2.rs
+++ b/crates/but/tests/but/command/commit2.rs
@@ -1267,6 +1267,148 @@ Error: Invalid uncommitted change. 'A' is a branch
 }
 
 #[test]
+fn can_commit_with_path_prefix() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    env.file("path/to/first.txt", "first");
+    env.file("path/to/second.txt", "second");
+    env.file("path/other/to/third.txt", "third");
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes]
+┊   om A path/other/to/third.txt
+┊   ms A path/to/first.txt
+┊   rr A path/to/second.txt
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+
+"#]]);
+
+    env.but("commit2 path/to/ --no-message").assert().success();
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes]
+┊   om A path/other/to/third.txt
+┊
+┊╭┄g0 [A]
+┊●   e1c5473 (no commit message)
+┊│     e1:ms A path/to/first.txt
+┊│     e1:rr A path/to/second.txt
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+
+"#]]);
+}
+
+#[test]
+fn path_prefix_with_mix_of_modifications() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    env.file("dir/to_modify.txt", "first");
+    env.file("dir/to_delete.txt", "second");
+    env.file("dir/to_empty.txt", "third");
+
+    env.but("commit2 --no-message").assert().success();
+
+    std::fs::remove_file(env.projects_root().join("dir/to_delete.txt")).unwrap();
+    env.file("dir/to_empty.txt", "");
+    env.file(
+        env.projects_root().join("dir/to_modify.txt"),
+        "first\nnew line",
+    );
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes]
+┊   lm D dir/to_delete.txt
+┊   no M dir/to_empty.txt
+┊   xv M dir/to_modify.txt
+┊
+┊╭┄g0 [A]
+┊●   d199c17 (no commit message)
+┊│     d1:lm A dir/to_delete.txt
+┊│     d1:no A dir/to_empty.txt
+┊│     d1:xv A dir/to_modify.txt
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+
+"#]]);
+
+    env.but("commit2 dir/ --no-message").assert().success();
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   d1a6de8 (no commit message)
+┊│     d1a:lm D dir/to_delete.txt
+┊│     d1a:no M dir/to_empty.txt
+┊│     d1a:xv M dir/to_modify.txt
+┊●   d199c17 (no commit message)
+┊│     d19:lm A dir/to_delete.txt
+┊│     d19:no A dir/to_empty.txt
+┊│     d19:xv A dir/to_modify.txt
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("diff d1a")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+───────────────────╮
+D dir/to_delete.txt│
+───────────────────╯
+   1  │-second
+──────────────────╮
+M dir/to_empty.txt│
+──────────────────╯
+   1  │-third
+───────────────────╮
+M dir/to_modify.txt│
+───────────────────╯
+   1 1│ first
+     2│+new line
+
+"#]]);
+}
+
+#[test]
 fn requires_specifying_stack_when_there_are_multiple() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
     env.setup_metadata(&["A", "B"]);


### PR DESCRIPTION
## 🧢 Changes
Adds committing by path prefix for `commit2`.

This is _pretty_ rough as `PathPrefix` currently resolves into individual hunks, rather than entire files. It does this as it excludes hunks that are already assigned. Once we've nuked assignments for `but`, we should revise `PathPrefix` s.t. it resolves into entire files rather than individual hunks, or at the very least retains file-level information (file ID etc) so we can create `is_entire_file=true` uncommitted changes.

## ☕️ Reasoning