### PR TITLE
Support ad-hoc dependent branch ordering

### DIFF
--- a/crates/but-api/src/legacy/stack.rs
+++ b/crates/but-api/src/legacy/stack.rs
@@ -3,9 +3,10 @@ use std::borrow::Cow;
 use anyhow::{Context as _, Result, anyhow};
 use but_api_macros::but_api;
 use but_core::{
-    DryRun, branch,
+    DryRun, RefMetadata, branch,
     ref_metadata::StackId,
     sync::{RepoExclusive, RepoShared},
+    update_head_reference,
 };
 use but_ctx::Context;
 use but_oplog::legacy::{OperationKind, SnapshotDetails, Trailer};
@@ -237,6 +238,23 @@ pub fn remove_branch_only(
     let ref_name = Category::LocalBranch
         .to_full_name(branch_name)
         .map_err(anyhow::Error::from)?;
+    if let Some(replacement_ref) = checked_out_ad_hoc_replacement(ctx, ref_name.as_ref())? {
+        let repo = ctx.repo.get()?;
+        let mut reference = repo.find_reference(replacement_ref.as_ref())?;
+        let target = reference.peel_to_id()?.detach();
+        let parent_count = repo.find_commit(target)?.parent_ids().count();
+        update_head_reference(
+            &repo,
+            gix::refs::Target::Symbolic(replacement_ref.clone()),
+            false,
+            "checkout",
+            replacement_ref.as_bstr(),
+            parent_count,
+        )?;
+        drop(repo);
+        ctx.reload_repo_and_invalidate_workspace(perm)?;
+    }
+
     let mut meta = ctx.meta()?;
     let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let new_ws = but_workspace::branch::remove_reference(
@@ -254,6 +272,39 @@ pub fn remove_branch_only(
         *ws = new_ws;
     }
     Ok(())
+}
+
+fn checked_out_ad_hoc_replacement(
+    ctx: &Context,
+    ref_name: &gix::refs::FullNameRef,
+) -> Result<Option<gix::refs::FullName>> {
+    let repo = ctx.repo.get()?;
+    if repo
+        .head_name()?
+        .as_ref()
+        .is_none_or(|head_name| head_name.as_ref() != ref_name)
+    {
+        return Ok(None);
+    }
+
+    let meta = ctx.meta()?;
+    let Some(order) = meta.branch_stack_order(ref_name)? else {
+        return Ok(None);
+    };
+    let Some(idx) = order.iter().position(|branch| branch.as_ref() == ref_name) else {
+        return Ok(None);
+    };
+    let replacement_ref = order
+        .get(idx + 1)
+        .or_else(|| idx.checked_sub(1).and_then(|idx| order.get(idx)))
+        .cloned();
+    let Some(replacement_ref) = replacement_ref else {
+        return Ok(None);
+    };
+    if repo.try_find_reference(replacement_ref.as_ref())?.is_none() {
+        return Ok(None);
+    }
+    Ok(Some(replacement_ref))
 }
 
 /// Remove a branch from a stack.

--- a/crates/but-api/tests/api/branch_checkout.rs
+++ b/crates/but-api/tests/api/branch_checkout.rs
@@ -1,4 +1,167 @@
+use but_core::RefMetadata;
 use snapbox::IntoData;
+
+#[test]
+fn legacy_create_reference_below_checked_out_empty_branch_is_visible_in_head_info()
+-> anyhow::Result<()> {
+    let (repo, _tmp) = single_branch_repo()?;
+    persist_origin_main_target(&repo)?;
+    let mut ctx = but_ctx::Context::from_repo(repo)?.with_memory_app_cache();
+
+    but_api::branch::branch_create(
+        &mut ctx,
+        Some(gix::refs::FullName::try_from("refs/heads/empty-top")?),
+        but_api::branch::json::BranchCreatePlacement::Dependent {
+            relative_to: but_api::commit::json::RelativeTo::Reference(
+                gix::refs::FullName::try_from("refs/heads/main")?,
+            ),
+            side: but_rebase::graph_rebase::mutate::InsertSide::Above,
+        },
+    )?;
+
+    let repo = ctx.repo.get()?;
+    let head_name = repo
+        .head_name()?
+        .expect("creating above the checked-out branch checks out the new ref");
+    assert_eq!(head_name.as_bstr(), "refs/heads/empty-top");
+    drop(repo);
+
+    but_api::legacy::stack::create_reference(
+        &mut ctx,
+        but_api::legacy::stack::create_reference::Request {
+            new_name: "bm-branch-1".into(),
+            anchor: Some(
+                but_api::legacy::stack::create_reference::Anchor::AtReference {
+                    short_name: "empty-top".into(),
+                    position: but_workspace::branch::create_reference::Position::Below,
+                },
+            ),
+        },
+    )?;
+
+    let repo = ctx.repo.get()?;
+    assert!(
+        repo.try_find_reference("refs/heads/bm-branch-1")?.is_some(),
+        "legacy API should create the inserted branch ref"
+    );
+    drop(repo);
+
+    let main_ref = gix::refs::FullName::try_from("refs/heads/main")?;
+    let branch_order = ctx
+        .meta()?
+        .branch_stack_order(main_ref.as_ref())?
+        .expect("legacy API should persist ad-hoc branch order");
+    assert_eq!(
+        branch_order,
+        vec![
+            gix::refs::FullName::try_from("refs/heads/empty-top")?,
+            gix::refs::FullName::try_from("refs/heads/bm-branch-1")?,
+            gix::refs::FullName::try_from("refs/heads/main")?,
+        ]
+    );
+
+    let repo = ctx.repo.get()?;
+    let meta = ctx.meta()?;
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        ctx.project_meta()?,
+        but_graph::init::Options::limited(),
+    )?;
+    let graph_tree = but_testsupport::graph_tree(&graph).to_string();
+    assert!(
+        graph_tree.contains("bm-branch-1"),
+        "graph should include inserted branch before workspace projection:\n{graph_tree}"
+    );
+    drop(meta);
+    drop(repo);
+
+    let head_info = but_api::legacy::workspace::head_info(&ctx)?;
+    let rendered = format!("{head_info:#?}");
+    let empty_top_idx = rendered
+        .find("empty-top")
+        .expect("head info should include the checked-out empty top branch");
+    let inserted_idx = rendered.find("bm-branch-1").unwrap_or_else(|| {
+        panic!("head info should include the inserted empty branch:\n{rendered}")
+    });
+    let main_idx = rendered
+        .find("main")
+        .expect("head info should include the bottom branch");
+    assert!(
+        empty_top_idx < inserted_idx && inserted_idx < main_idx,
+        "head_info should preserve ad-hoc branch order, got:\n{rendered}"
+    );
+
+    but_api::legacy::stack::remove_branch(
+        &mut ctx,
+        but_core::ref_metadata::StackId::single_branch_id(),
+        "empty-top".into(),
+    )?;
+    let repo = ctx.repo.get()?;
+    let head_name = repo
+        .head_name()?
+        .expect("removing checked-out empty top should switch to the branch below");
+    assert_eq!(head_name.as_bstr(), "refs/heads/bm-branch-1");
+    assert!(repo.try_find_reference("refs/heads/empty-top")?.is_none());
+    drop(repo);
+
+    let main_ref = gix::refs::FullName::try_from("refs/heads/main")?;
+    assert_eq!(
+        ctx.meta()?.branch_stack_order(main_ref.as_ref())?,
+        Some(vec![
+            gix::refs::FullName::try_from("refs/heads/bm-branch-1")?,
+            main_ref,
+        ])
+    );
+
+    Ok(())
+}
+
+fn persist_origin_main_target(repo: &gix::Repository) -> anyhow::Result<gix::ObjectId> {
+    let target_commit_id = repo.rev_parse_single("refs/remotes/origin/main")?.detach();
+    but_core::ref_metadata::ProjectMeta {
+        target_ref: Some("refs/remotes/origin/main".try_into()?),
+        target_commit_id: Some(target_commit_id),
+        push_remote: Some("origin".into()),
+    }
+    .persist_to_local_config(repo)?;
+    Ok(target_commit_id)
+}
+
+fn single_branch_repo() -> anyhow::Result<(gix::Repository, tempfile::TempDir)> {
+    let tmp = tempfile::tempdir()?;
+    git(tmp.path(), ["init", "-b", "main"])?;
+    git(tmp.path(), ["config", "user.name", "GitButler"])?;
+    git(
+        tmp.path(),
+        ["config", "user.email", "gitbutler@example.com"],
+    )?;
+    std::fs::write(tmp.path().join("base.txt"), "base\n")?;
+    git(tmp.path(), ["add", "base.txt"])?;
+    git(tmp.path(), ["commit", "-m", "base"])?;
+    git(
+        tmp.path(),
+        ["update-ref", "refs/remotes/origin/main", "HEAD"],
+    )?;
+
+    for name in ["first", "second", "third"] {
+        std::fs::write(tmp.path().join(format!("{name}.txt")), format!("{name}\n"))?;
+        git(tmp.path(), ["add", "."])?;
+        git(tmp.path(), ["commit", "-m", name])?;
+    }
+
+    Ok((gix::open(tmp.path())?, tmp))
+}
+
+fn git<const N: usize>(cwd: &std::path::Path, args: [&str; N]) -> anyhow::Result<()> {
+    let status = std::process::Command::new("git")
+        .args(["-c", "commit.gpgsign=false"])
+        .args(args)
+        .current_dir(cwd)
+        .status()?;
+    anyhow::ensure!(status.success(), "git command failed");
+    Ok(())
+}
 
 #[test]
 fn checkout_returns_head_info_matching_fresh_head_info() -> anyhow::Result<()> {

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -762,7 +762,10 @@ impl Context {
 
     fn workspace_from_head(&self) -> anyhow::Result<but_graph::Workspace> {
         let repo = self.repo.get()?;
-        let meta = self.meta_inner_read_only()?;
+        let meta = but_meta::BranchOrderMetadata::from_paths_read_only(
+            self.project_data_dir().join("virtual_branches.toml"),
+            self.project_data_dir(),
+        )?;
         let graph = but_graph::Graph::from_head(
             &repo,
             &meta,
@@ -857,9 +860,19 @@ impl Context {
     //            reads. For a correct implementation, this would also have to hold on to
     //            `_read_only`.
     pub fn meta(&self) -> anyhow::Result<impl but_core::RefMetadata + 'static> {
-        but_meta::VirtualBranchesTomlMetadata::from_path(
+        let mut meta = but_meta::BranchOrderMetadata::from_paths(
             self.project_data_dir().join("virtual_branches.toml"),
-        )
+            self.project_data_dir(),
+        )?;
+        let repo = self.repo.get()?;
+        let local_branch_refs = repo
+            .references()?
+            .prefixed("refs/heads/")?
+            .filter_map(Result::ok)
+            .map(|reference| reference.name().to_owned())
+            .collect::<Vec<_>>();
+        meta.remove_missing_branch_stack_order_references(&local_branch_refs)?;
+        Ok(meta)
     }
 
     /// Copy all copyable values into an instance to pass across thread boundaries.

--- a/crates/but-rebase/src/graph_rebase/mod.rs
+++ b/crates/but-rebase/src/graph_rebase/mod.rs
@@ -314,6 +314,11 @@ impl<'ws, 'meta, M: RefMetadata> SuccessfulRebase<'ws, 'meta, M> {
         &self.repo
     }
 
+    /// Return the metadata handle that will be carried into materialization.
+    pub fn meta_mut(&mut self) -> &mut M {
+        self.meta
+    }
+
     /// Returns a preview of what the but-graph will look like after
     /// materialization.
     ///

--- a/crates/but-workspace/src/branch/create_reference.rs
+++ b/crates/but-workspace/src/branch/create_reference.rs
@@ -186,10 +186,11 @@ pub(super) mod function {
         let existing_ref_target_in_workspace = existing_ref_target_id
             .filter(|id| workspace.find_owner_indexes_by_commit_id(*id).is_some());
 
-        let (check_if_id_in_workspace, ref_target_id, instruction): (
+        let (check_if_id_in_workspace, ref_target_id, instruction, branch_stack_order): (
             _,
             _,
             Option<Instruction<'_>>,
+            Option<Vec<gix::refs::FullName>>,
         ) = {
             match anchor {
                 None => {
@@ -214,6 +215,7 @@ pub(super) mod function {
                             true, // expect the target id to be in the workspace
                             existing_ref_target_id,
                             instruction,
+                            None,
                         )
                     } else {
                         // The target tip (e.g. `origin/main`) can be advanced *past* the
@@ -252,6 +254,7 @@ pub(super) mod function {
                             false,
                             base,
                             Some(Instruction::Independent),
+                            None,
                         )
                     }
                 }
@@ -281,7 +284,7 @@ pub(super) mod function {
                         })
                         .transpose()?;
 
-                    (validate_id, ref_target_id, instruction)
+                    (validate_id, ref_target_id, instruction, None)
                 }
                 Some(Anchor::AtSegment { ref_name, position }) => {
                     let mut validate_id = true;
@@ -322,36 +325,76 @@ pub(super) mod function {
                         validate_id,
                         ref_target_id,
                         Some(Instruction::Dependent { ref_name, position }),
+                        None,
                     )
                 }
                 Some(Anchor::AtReference {
                     ref_name: anchor_ref,
                     position,
                 }) => {
-                    if !workspace.has_metadata() {
+                    if !workspace.has_metadata()
+                        && anchor_ref.category() != Some(gix::refs::Category::LocalBranch)
+                    {
                         bail_precondition!(
-                            "Cannot position '{new}' relative to reference '{anchor}' without a managed workspace",
+                            "Cannot position '{new}' relative to non-local reference '{anchor}' without a managed workspace",
                             new = ref_name.shorten(),
                             anchor = anchor_ref.shorten()
                         );
                     }
-                    let (stack_idx, seg_idx) =
-                        workspace.try_find_segment_owner_indexes_by_refname(anchor_ref.as_ref())?;
-                    let segment = &workspace.stacks[stack_idx].segments[seg_idx];
-                    let ref_target_id = workspace
-                        .tip_commit_by_segment_id(segment.id)
-                        .map(|commit| commit.id)
-                        .context(
-                            "BUG: we should always see through to the base or eligible commits",
-                        )?;
-                    (
-                        Some(ref_target_id) != ws_base,
-                        ref_target_id,
-                        Some(Instruction::Dependent {
-                            ref_name: anchor_ref,
-                            position,
-                        }),
-                    )
+                    if workspace.has_metadata() {
+                        let (stack_idx, seg_idx) = workspace
+                            .try_find_segment_owner_indexes_by_refname(anchor_ref.as_ref())?;
+                        let segment = &workspace.stacks[stack_idx].segments[seg_idx];
+                        let ref_target_id = workspace
+                            .tip_commit_by_segment_id(segment.id)
+                            .map(|commit| commit.id)
+                            .context(
+                                "BUG: we should always see through to the base or eligible commits",
+                            )?;
+                        (
+                            Some(ref_target_id) != ws_base,
+                            ref_target_id,
+                            Some(Instruction::Dependent {
+                                ref_name: anchor_ref,
+                                position,
+                            }),
+                            None,
+                        )
+                    } else {
+                        if !meta.can_persist_branch_stack_order() {
+                            bail_precondition!(
+                                "Cannot position '{new}' relative to local reference '{anchor}' without branch order metadata",
+                                new = ref_name.shorten(),
+                                anchor = anchor_ref.shorten()
+                            );
+                        }
+                        let ref_target_id = repo
+                            .find_reference(anchor_ref.as_ref())?
+                            .peel_to_id()?
+                            .detach();
+                        let mut branch_stack_order = meta
+                            .branch_stack_order(anchor_ref.as_ref())?
+                            .unwrap_or_else(|| vec![anchor_ref.as_ref().to_owned()]);
+                        if !branch_stack_order
+                            .iter()
+                            .any(|branch| branch.as_ref() == anchor_ref.as_ref())
+                        {
+                            branch_stack_order.push(anchor_ref.as_ref().to_owned());
+                        }
+                        branch_stack_order.retain(|branch| branch.as_ref() != ref_name);
+                        let anchor_idx = branch_stack_order
+                            .iter()
+                            .position(|branch| branch.as_ref() == anchor_ref.as_ref())
+                            .context("BUG: anchor ref was just ensured in branch stack order")?;
+                        branch_stack_order.insert(
+                            match position {
+                                Position::Above => anchor_idx,
+                                Position::Below => anchor_idx + 1,
+                            },
+                            ref_name.to_owned(),
+                        );
+                        (false, ref_target_id, None, Some(branch_stack_order))
+                    }
                 }
             }
         };
@@ -374,25 +417,28 @@ pub(super) mod function {
             let mut branch_md = meta.branch(ref_name)?;
             update_branch_metadata(ref_name, repo, &mut branch_md)?;
 
-            workspace.graph.redo_traversal_with_overlay(
-                repo,
-                meta,
-                but_graph::init::Overlay::default()
-                    .with_references_if_new(Some(gix::refs::Reference {
-                        name: ref_name.into(),
-                        target: gix::refs::Target::Object(ref_target_id),
-                        peeled: None,
-                    }))
-                    .with_branch_metadata_override(Some((
-                        branch_md.as_ref().to_owned(),
-                        (*branch_md).clone(),
-                    )))
-                    .with_workspace_metadata_override(
-                        updated_ws_meta
-                            .as_ref()
-                            .map(|ws| (ws.as_ref().to_owned(), (*ws).clone())),
-                    ),
-            )?
+            let mut overlay = but_graph::init::Overlay::default()
+                .with_references_if_new(Some(gix::refs::Reference {
+                    name: ref_name.into(),
+                    target: gix::refs::Target::Object(ref_target_id),
+                    peeled: None,
+                }))
+                .with_branch_metadata_override(Some((
+                    branch_md.as_ref().to_owned(),
+                    (*branch_md).clone(),
+                )))
+                .with_workspace_metadata_override(
+                    updated_ws_meta
+                        .as_ref()
+                        .map(|ws| (ws.as_ref().to_owned(), (*ws).clone())),
+                );
+            if let Some(branch_stack_order) = branch_stack_order.clone() {
+                overlay = overlay.with_branch_stack_order_override(branch_stack_order);
+            }
+
+            workspace
+                .graph
+                .redo_traversal_with_overlay(repo, meta, overlay)?
         };
 
         let updated_workspace = graph_with_new_ref.into_workspace()?;
@@ -458,6 +504,9 @@ pub(super) mod function {
         } else if let Some(existing) = existing_ws_meta {
             // TODO: overwrite stored information with reality in new graph.
             meta.set_workspace(&existing)?;
+        }
+        if let Some(branch_stack_order) = branch_stack_order {
+            meta.set_branch_stack_order(&branch_stack_order)?;
         }
 
         // Always re-obtain the branch as `set_workspace` has created another version of it, possibly.

--- a/crates/but-workspace/src/branch/remove_reference.rs
+++ b/crates/but-workspace/src/branch/remove_reference.rs
@@ -15,6 +15,7 @@ pub struct Options {
 use anyhow::{Context as _, bail};
 use but_core::RefMetadata;
 use but_error::bail_precondition;
+use but_graph::workspace::WorkspaceKind;
 use gix::refs::transaction::PreviousValue;
 
 /// Remove the workspace reference `ref_name` (if it still exists),
@@ -34,12 +35,21 @@ pub fn remove_reference(
         keep_metadata,
     }: Options,
 ) -> anyhow::Result<Option<but_graph::Workspace>> {
-    // We assume the stack-idx can't change by deleting
-    let Some((stack, _segment)) = workspace.find_segment_and_stack_by_refname(ref_name) else {
-        return Ok(None);
-    };
+    // We assume the stack-idx can't change by deleting.
+    let stack_id =
+        if let Some((stack, _segment)) = workspace.find_segment_and_stack_by_refname(ref_name) {
+            Some(stack.id)
+        } else {
+            let ordered_ad_hoc_ref = matches!(workspace.kind, WorkspaceKind::AdHoc)
+                && meta.branch_stack_order(ref_name)?.is_some();
+            if !ordered_ad_hoc_ref {
+                return Ok(None);
+            }
+            None
+        };
 
     if avoid_anonymous_stacks
+        && let Some((stack, _segment)) = workspace.find_segment_and_stack_by_refname(ref_name)
         && (stack
             .segments
             .iter()
@@ -83,12 +93,11 @@ pub fn remove_reference(
         return Ok(None);
     }
 
-    let stack_id = stack.id;
     let mut graph = workspace
         .graph
         .redo_traversal_with_overlay(repo, meta, Default::default())?;
     let ws = graph.into_workspace()?;
-    if avoid_anonymous_stacks {
+    if avoid_anonymous_stacks && let Some(stack_id) = stack_id {
         let Some(stack) = ws.stacks.iter().find(|s| s.id == stack_id) else {
             // The whole stack is gone, so nothing that could be anonymous.
             return Ok(Some(ws));

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -219,6 +219,9 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
     let mut stacks = collect_stacks(
         head_commit,
         head_is_workspace_commit,
+        direct_checkout_head_ref_name
+            .as_ref()
+            .map(|ref_name| ref_name.as_ref()),
         &editor,
         from_target_sha,
         from_target_ref,
@@ -282,6 +285,8 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
         .transpose()?;
     let mut fully_integrated_workspace_parents = HashSet::new();
     let mut direct_checkout_replacement_ref: Option<(Selector, gix::refs::FullName)> = None;
+    let mut preserved_empty_direct_checkout_ref: Option<Selector> = None;
+    let mut refs_to_prune_from_branch_order = Vec::new();
     for stack in &stacks {
         let is_selected = stack.nodes.values().any(|attrs| attrs.to_rebase)
             || stack.to_merge
@@ -297,10 +302,38 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
         }
 
         if is_fully_integrated {
+            if !head_is_workspace_commit
+                && preserved_empty_direct_checkout_ref.is_none()
+                && let Some(head_ref_name) = direct_checkout_head_ref_name.as_ref()
+                && head_ref_name.as_ref().category() == Some(gix::refs::Category::LocalBranch)
+            {
+                let head_ref_selector = head_ref_name.as_ref().to_selector(&editor)?;
+                if stack.nodes.contains_key(&head_ref_selector)
+                    && direct_reference_parents(&editor, head_ref_selector)?
+                        .iter()
+                        .any(|(_selector, ref_name)| {
+                            ref_name.category() == Some(gix::refs::Category::LocalBranch)
+                        })
+                {
+                    editor.disconnect_segment_from(
+                        SegmentDelimiter {
+                            child: head_ref_selector,
+                            parent: head_ref_selector,
+                        },
+                        SelectorSet::All,
+                        SelectorSet::All,
+                        false,
+                    )?;
+                    preserve_pick_parents(&mut editor, target_ref_commit_selector)?;
+                    editor.add_edge(head_ref_selector, target_ref_commit_selector, 0)?;
+                    preserved_empty_direct_checkout_ref = Some(head_ref_selector);
+                }
+            }
             // If we're not in the managed workspace, we haven't determined a
             // ref replacement yet and we were checked out on a local branch.
             if !head_is_workspace_commit
                 && direct_checkout_replacement_ref.is_none()
+                && preserved_empty_direct_checkout_ref.is_none()
                 && let Some(head_ref_name) = direct_checkout_head_ref_name.as_ref()
                 && head_ref_name.as_ref().category() == Some(gix::refs::Category::LocalBranch)
             {
@@ -329,7 +362,18 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
         // Remove integrated refs from the workspace and from git.
         // TODO: allow to keep some references.
         for (selector, attrs) in &stack.nodes {
-            if let Some(ref_name) = attrs.reference_integrated.as_ref() {
+            if let Some(ref_name) = attrs.reference_integrated.as_ref()
+                && should_delete_integrated_local_branch(ref_name.as_ref())
+            {
+                if direct_checkout_replacement_ref
+                    .as_ref()
+                    .is_some_and(|(replacement_selector, _)| replacement_selector == selector)
+                    || preserved_empty_direct_checkout_ref == Some(*selector)
+                {
+                    continue;
+                }
+                editor.replace(*selector, Step::None)?;
+                refs_to_prune_from_branch_order.push(ref_name.clone());
                 if let Some(ws_meta) = ws_meta.as_mut() {
                     ws_meta.remove_segment(ref_name.as_ref());
                 }
@@ -453,10 +497,15 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
 
     let mut project_meta = project_meta;
     project_meta.target_commit_id = Some(target_ref_commit.detach());
+    let mut rebase = editor.rebase()?;
+    for ref_name in refs_to_prune_from_branch_order {
+        remove_ref_from_branch_stack_order(rebase.meta_mut(), ref_name.as_ref())?;
+    }
+
     Ok(IntegrateUpstreamOutcome {
         ws_meta,
         project_meta,
-        rebase: editor.rebase()?,
+        rebase,
     })
 }
 
@@ -464,6 +513,7 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
 fn collect_stacks<'ws, 'meta, M: RefMetadata>(
     head_commit: gix::Commit<'_>,
     head_is_workspace_commit: bool,
+    direct_checkout_head_ref_name: Option<&gix::refs::FullNameRef>,
     editor: &Editor<'ws, 'meta, M>,
     from_target_sha: HashSet<Selector>,
     from_target_ref: HashSet<Selector>,
@@ -484,7 +534,10 @@ fn collect_stacks<'ws, 'meta, M: RefMetadata>(
             })
             .collect()
     } else {
-        let c = editor.select_commit(head_commit.id)?;
+        let c = direct_checkout_head_ref_name
+            .map(|ref_name| ref_name.to_selector(editor))
+            .transpose()?
+            .unwrap_or(editor.select_commit(head_commit.id)?);
         vec![Stack {
             to_merge: false,
             nodes: HashMap::from([(c, AnnotatedNode::new())]),
@@ -893,6 +946,45 @@ fn selector_commit_id<M: RefMetadata>(
         ),
         Step::None => None,
     })
+}
+
+fn direct_reference_parents<M: RefMetadata>(
+    editor: &Editor<'_, '_, M>,
+    selector: Selector,
+) -> Result<Vec<(Selector, gix::refs::FullName)>> {
+    editor
+        .direct_parents(selector)?
+        .into_iter()
+        .filter_map(|(parent, _)| {
+            editor
+                .lookup_step(parent)
+                .map(|step| match step {
+                    Step::Reference { refname } => Some((parent, refname)),
+                    _ => None,
+                })
+                .transpose()
+        })
+        .collect()
+}
+
+fn remove_ref_from_branch_stack_order<M: RefMetadata>(
+    meta: &mut M,
+    ref_name: &gix::refs::FullNameRef,
+) -> Result<()> {
+    let Some(mut branch_stack_order) = meta.branch_stack_order(ref_name)? else {
+        return Ok(());
+    };
+    let original_len = branch_stack_order.len();
+    branch_stack_order.retain(|branch| branch.as_ref() != ref_name);
+    if branch_stack_order.len() == original_len {
+        return Ok(());
+    }
+    if branch_stack_order.is_empty() {
+        meta.remove(ref_name)?;
+    } else {
+        meta.set_branch_stack_order(&branch_stack_order)?;
+    }
+    Ok(())
 }
 
 /// Replace a fully integrated direct-checkout branch with a new canned local branch at the

--- a/crates/but-workspace/tests/fixtures/scenario/integrated-bottom-empty-top-no-workspace.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/integrated-bottom-empty-top-no-workspace.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A single stack in single-branch mode where the checked-out top branch A is
+# empty and points at the same commit as the bottom branch B. The bottom branch B
+# is historically integrated into the target, and origin/main has advanced one
+# commit past B.
+git init
+commit M1
+setup_target_to_match_main
+
+git checkout -b B
+commit-file B.txt B1
+git branch A
+
+git checkout -b upstream-main B
+commit-file X.txt X1
+git update-ref refs/remotes/origin/main upstream-main
+
+git checkout A
+git branch -D upstream-main

--- a/crates/but-workspace/tests/workspace/branch/create_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/create_reference.rs
@@ -1,14 +1,14 @@
-use std::borrow::Cow;
-
 use bstr::ByteSlice;
 use but_core::{
     RefMetadata,
     ref_metadata::{StackId, ValueInfo},
 };
 use but_graph::init::Options;
+use but_meta::BranchOrderMetadata;
 use but_testsupport::{graph_workspace, id_at, id_by_rev, visualize_commit_graph_all};
 use but_workspace::branch::create_reference::{Anchor, Position::*};
 use gix::refs::transaction::PreviousValue;
+use std::borrow::Cow;
 
 use crate::{
     ref_info::with_workspace_commit::utils::{
@@ -25,6 +25,10 @@ fn project_meta(meta: &impl RefMetadata) -> but_core::ref_metadata::ProjectMeta 
     )
     .map(|workspace| workspace.project_meta())
     .unwrap_or_default()
+}
+
+fn branch_order_meta(repo: &gix::Repository) -> anyhow::Result<BranchOrderMetadata> {
+    BranchOrderMetadata::from_paths(repo.path().join("virtual-branches.toml"), repo.path())
 }
 
 mod with_workspace {
@@ -1994,43 +1998,152 @@ fn errors() -> anyhow::Result<()> {
 }
 
 #[test]
-fn at_reference_requires_managed_workspace() -> anyhow::Result<()> {
-    let (repo, mut meta) =
-        named_read_only_in_memory_scenario("with-remotes-no-workspace", "remote")?;
-    let graph =
-        but_graph::Graph::from_head(&repo, &*meta, project_meta(&*meta), Options::limited())?;
+fn at_reference_in_ad_hoc_workspace_orders_local_branches_only() -> anyhow::Result<()> {
+    let (_tmp, repo, legacy_meta) = named_writable_scenario("single-branch-with-3-commits")?;
+    let project_meta = project_meta(&legacy_meta);
+    let mut meta = branch_order_meta(&repo)?;
+    let graph = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?;
     let ws = graph.into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @"
-    ⌂:0:main[🌳] <> ✓! on c166d42
+    ⌂:0:main[🌳] <> ✓! on 281da94
     └── ≡:0:main[🌳] {1}
         └── :0:main[🌳]
     ");
 
-    let new_name = r("refs/heads/new");
     let main_ref = r("refs/heads/main");
-    for position in [Above, Below] {
-        // Without workspace metadata there is no way to order two references
-        // on the same commit, so this refuses to do anything.
-        let err = but_workspace::branch::create_reference(
-            new_name,
-            Anchor::at_reference(main_ref, position),
-            &repo,
-            &ws,
-            &mut *meta,
-            stack_id_for_name,
-            None,
-        )
-        .unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "Cannot position 'new' relative to reference 'main' without a managed workspace"
+    let main_id = repo.find_reference(main_ref)?.id();
+    let below_ref = r("refs/heads/new-below");
+    but_workspace::branch::create_reference(
+        below_ref,
+        Anchor::at_reference(main_ref, Below),
+        &repo,
+        &ws,
+        &mut meta,
+        stack_id_for_name,
+        None,
+    )?;
+    assert_eq!(
+        meta.branch_stack_order(main_ref)?,
+        Some(vec![main_ref.to_owned(), below_ref.to_owned()]),
+        "GitButler-created same-tip local branches should have durable ad-hoc order"
+    );
+    assert_eq!(repo.find_reference(below_ref)?.id(), main_id);
+
+    let remote_ref = r("refs/remotes/origin/main");
+    repo.reference(
+        remote_ref,
+        main_id,
+        PreviousValue::Any,
+        "test remote anchor",
+    )?;
+    let err = but_workspace::branch::create_reference(
+        r("refs/heads/new-remote-anchor"),
+        Anchor::at_reference(remote_ref, Above),
+        &repo,
+        &ws,
+        &mut meta,
+        stack_id_for_name,
+        None,
+    )
+    .unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Cannot position 'new-remote-anchor' relative to non-local reference 'origin/main' without a managed workspace"
+    );
+    Ok(())
+}
+
+#[test]
+fn at_reference_in_ad_hoc_workspace_requires_branch_order_metadata() -> anyhow::Result<()> {
+    let (_tmp, repo, mut meta) = named_writable_scenario("single-branch-with-3-commits")?;
+    let graph = but_graph::Graph::from_head(&repo, &meta, project_meta(&meta), Options::limited())?;
+    let ws = graph.into_workspace()?;
+
+    let new_ref = r("refs/heads/new");
+    let err = but_workspace::branch::create_reference(
+        new_ref,
+        Anchor::at_reference(r("refs/heads/main"), Above),
+        &repo,
+        &ws,
+        &mut meta,
+        stack_id_for_name,
+        None,
+    )
+    .unwrap_err();
+
+    assert_eq!(
+        err.to_string(),
+        "Cannot position 'new' relative to local reference 'main' without branch order metadata"
+    );
+    assert!(
+        repo.try_find_reference(new_ref)?.is_none(),
+        "unsupported metadata must fail before creating the ref"
+    );
+    Ok(())
+}
+
+#[test]
+fn ad_hoc_reference_below_empty_branch_between_empty_branches() -> anyhow::Result<()> {
+    let (_tmp, repo, legacy_meta) = named_writable_scenario("single-branch-with-3-commits")?;
+    let project_meta = project_meta(&legacy_meta);
+    let mut meta = branch_order_meta(&repo)?;
+    let graph =
+        but_graph::Graph::from_head(&repo, &meta, project_meta.clone(), Options::limited())?;
+    let ws = graph.into_workspace()?;
+
+    let middle_ref = r("refs/heads/empty-middle");
+    let inserted_ref = r("refs/heads/inserted-below-middle");
+    let bottom_ref = r("refs/heads/empty-bottom");
+    let main_ref = r("refs/heads/main");
+    let mut ws = Cow::Owned(ws);
+
+    for (ref_name, anchor_ref, position) in [
+        (bottom_ref, main_ref, Below),
+        (middle_ref, main_ref, Below),
+        (inserted_ref, middle_ref, Below),
+    ] {
+        ws = Cow::Owned(
+            but_workspace::branch::create_reference(
+                ref_name,
+                Anchor::AtReference {
+                    ref_name: Cow::Borrowed(anchor_ref),
+                    position,
+                },
+                &repo,
+                &ws,
+                &mut meta,
+                stack_id_for_name,
+                None,
+            )?
+            .into_owned(),
         );
-        assert!(
-            repo.try_find_reference(new_name)?.is_none(),
-            "the reference isn't physically available"
-        );
-        assert!(meta.branch(new_name)?.is_default(), "no data was stored");
     }
+
+    assert_eq!(
+        meta.branch_stack_order(main_ref)?,
+        Some(vec![
+            main_ref.to_owned(),
+            middle_ref.to_owned(),
+            inserted_ref.to_owned(),
+            bottom_ref.to_owned(),
+        ]),
+        "the new branch should be spliced below the empty middle branch"
+    );
+
+    let graph = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?;
+    let ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    ⌂:1:main[🌳] <> ✓! on 281da94
+    └── ≡:1:main[🌳] {1}
+        ├── :1:main[🌳]
+        ├── 📙:2:empty-middle
+        ├── 📙:3:inserted-below-middle
+        └── 📙:0:empty-bottom
+            ├── ·281da94
+            ├── ·12995d7
+            └── ·3d57fc1
+    ");
+
     Ok(())
 }
 
@@ -2255,6 +2368,94 @@ fn existing_git_ref_inside_workspace_is_adopted() -> anyhow::Result<()> {
         └── 📙:3:created-with-git
             └── ·6fdab32 (🏘️)
     ");
+
+    Ok(())
+}
+
+#[test]
+fn ad_hoc_reference_above_checked_out_branch_is_rejected_if_not_projected() -> anyhow::Result<()> {
+    let (_tmp, repo, legacy_meta) = named_writable_scenario("single-branch-with-3-commits")?;
+    let mut meta = branch_order_meta(&repo)?;
+    let graph =
+        but_graph::Graph::from_head(&repo, &meta, project_meta(&legacy_meta), Options::limited())?;
+    let ws = graph.into_workspace()?;
+
+    let top_ref = r("refs/heads/empty-top");
+    let main_ref = r("refs/heads/main");
+    let err = but_workspace::branch::create_reference(
+        top_ref,
+        Anchor::AtReference {
+            ref_name: Cow::Borrowed(main_ref),
+            position: Above,
+        },
+        &repo,
+        &ws,
+        &mut meta,
+        stack_id_for_name,
+        None,
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("Branch 'empty-top' cannot be created"),
+        "creating a branch above the current ad-hoc entrypoint should fail because it would not be projected: {err}"
+    );
+    assert!(
+        repo.try_find_reference(top_ref)?.is_none(),
+        "the invisible branch should not be created"
+    );
+    assert!(
+        meta.branch_stack_order(main_ref)?.is_none(),
+        "failed projection should not persist branch-order metadata"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn ad_hoc_reference_below_checked_out_branch_is_projected() -> anyhow::Result<()> {
+    let (_tmp, repo, legacy_meta) = named_writable_scenario("single-branch-with-3-commits")?;
+    let project_meta = project_meta(&legacy_meta);
+    let mut meta = branch_order_meta(&repo)?;
+    let graph =
+        but_graph::Graph::from_head(&repo, &meta, project_meta.clone(), Options::limited())?;
+    let ws = graph.into_workspace()?;
+
+    let bottom_ref = r("refs/heads/empty-bottom");
+    let main_ref = r("refs/heads/main");
+    but_workspace::branch::create_reference(
+        bottom_ref,
+        Anchor::AtReference {
+            ref_name: Cow::Borrowed(main_ref),
+            position: Below,
+        },
+        &repo,
+        &ws,
+        &mut meta,
+        stack_id_for_name,
+        None,
+    )?;
+
+    let graph = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?;
+    let ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    ⌂:1:main[🌳] <> ✓! on 281da94
+    └── ≡:1:main[🌳] {1}
+        ├── :1:main[🌳]
+        └── 📙:0:empty-bottom
+            ├── ·281da94
+            ├── ·12995d7
+            └── ·3d57fc1
+    ");
+    assert!(
+        repo.try_find_reference(bottom_ref)?.is_some(),
+        "the ordered lower ref should exist"
+    );
+    assert_eq!(
+        meta.branch_stack_order(main_ref)?,
+        Some(vec![main_ref.to_owned(), bottom_ref.to_owned()]),
+        "the durable order should record the projected lower ref below the checked-out branch"
+    );
 
     Ok(())
 }

--- a/crates/but-workspace/tests/workspace/branch/remove_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/remove_reference.rs
@@ -1,16 +1,386 @@
-use but_core::RefMetadata;
-use but_testsupport::{graph_workspace, visualize_commit_graph_all};
+use but_core::{RefMetadata, ref_metadata::StackId};
+use but_graph::init::Options as GraphOptions;
+use but_meta::BranchOrderMetadata;
+use but_testsupport::{graph_tree, graph_workspace, visualize_commit_graph_all};
+use but_workspace::branch::create_reference::{Anchor, Position::*};
 use but_workspace::branch::remove_reference;
 use gix::refs::{Category, transaction::PreviousValue};
 
 use crate::{
     ref_info::with_workspace_commit::utils::{
-        StackState, add_stack_with_segments,
+        StackState, add_stack_with_segments, named_writable_scenario,
         named_writable_scenario_with_args_and_description_and_graph,
         named_writable_scenario_with_description_and_graph,
     },
     utils::r,
 };
+
+fn project_meta(meta: &impl RefMetadata) -> but_core::ref_metadata::ProjectMeta {
+    meta.workspace(
+        but_core::WORKSPACE_REF_NAME
+            .try_into()
+            .expect("valid workspace ref"),
+    )
+    .map(|workspace| workspace.project_meta())
+    .unwrap_or_default()
+}
+
+fn branch_order_meta(repo: &gix::Repository) -> anyhow::Result<BranchOrderMetadata> {
+    BranchOrderMetadata::from_paths(repo.path().join("virtual-branches.toml"), repo.path())
+}
+
+fn branch_order_meta_read_only(repo: &gix::Repository) -> anyhow::Result<BranchOrderMetadata> {
+    BranchOrderMetadata::from_paths_read_only(
+        repo.path().join("virtual-branches.toml"),
+        repo.path(),
+    )
+}
+
+fn stack_id_for_name(_rn: &gix::refs::FullNameRef) -> StackId {
+    StackId::generate()
+}
+
+fn workspace_from_head(
+    repo: &gix::Repository,
+    meta: &impl RefMetadata,
+    project_meta: but_core::ref_metadata::ProjectMeta,
+) -> anyhow::Result<but_graph::Workspace> {
+    but_graph::Graph::from_head(repo, meta, project_meta, GraphOptions::limited())?.into_workspace()
+}
+
+fn checkout_branch(
+    repo: &gix::Repository,
+    ref_name: &gix::refs::FullNameRef,
+) -> anyhow::Result<()> {
+    but_core::update_head_reference(
+        repo,
+        gix::refs::Target::Symbolic(ref_name.to_owned()),
+        false,
+        "checkout",
+        ref_name.as_bstr(),
+        1,
+    )
+    .map(|_| ())
+}
+
+fn create_ad_hoc_reference(
+    repo: &gix::Repository,
+    ws: &but_graph::Workspace,
+    meta: &mut impl RefMetadata,
+    ref_name: &gix::refs::FullNameRef,
+    anchor_ref: &gix::refs::FullNameRef,
+    position: but_workspace::branch::create_reference::Position,
+) -> anyhow::Result<()> {
+    but_workspace::branch::create_reference(
+        ref_name,
+        Anchor::AtReference {
+            ref_name: std::borrow::Cow::Borrowed(anchor_ref),
+            position,
+        },
+        repo,
+        ws,
+        meta,
+        stack_id_for_name,
+        None,
+    )?;
+    Ok(())
+}
+
+fn delete_reference_externally(
+    repo: &gix::Repository,
+    ref_name: &gix::refs::FullNameRef,
+) -> anyhow::Result<()> {
+    let reference = repo.find_reference(ref_name)?;
+    reference.delete()?;
+    Ok(())
+}
+
+fn assert_workspace_order(workspace: &but_graph::Workspace, refs: &[&str]) {
+    let rendered = graph_workspace(workspace).to_string();
+    let mut previous_idx = None;
+    for ref_name in refs {
+        let short_name = ref_name.trim_start_matches("refs/heads/");
+        let idx = rendered
+            .find(short_name)
+            .unwrap_or_else(|| panic!("workspace should include {short_name}:\n{rendered}"));
+        if let Some(previous_idx) = previous_idx {
+            assert!(
+                previous_idx < idx,
+                "{short_name} should appear after the previous expected ref:\n{rendered}"
+            );
+        }
+        previous_idx = Some(idx);
+    }
+}
+
+#[test]
+fn ad_hoc_remove_empty_branch_from_top_of_two_branch_stack() -> anyhow::Result<()> {
+    let (_tmp, repo, legacy_meta) = named_writable_scenario("single-branch-with-3-commits")?;
+    let project_meta = project_meta(&legacy_meta);
+    let mut meta = branch_order_meta(&repo)?;
+    let ws = workspace_from_head(&repo, &meta, project_meta.clone())?;
+
+    let top_ref = r("refs/heads/empty-top");
+    let bottom_ref = r("refs/heads/empty-bottom");
+    let main_ref = r("refs/heads/main");
+    create_ad_hoc_reference(&repo, &ws, &mut meta, top_ref, main_ref, Above)?;
+    create_ad_hoc_reference(&repo, &ws, &mut meta, bottom_ref, top_ref, Below)?;
+    checkout_branch(&repo, bottom_ref)?;
+    let ws = workspace_from_head(&repo, &meta, project_meta.clone())?;
+
+    let ws = but_workspace::branch::remove_reference(
+        top_ref,
+        &repo,
+        &ws,
+        &mut meta,
+        remove_reference::Options::default(),
+    )?
+    .expect("the ordered empty top branch should be removed");
+
+    assert!(repo.try_find_reference(top_ref)?.is_none());
+    assert_eq!(
+        meta.branch_stack_order(main_ref)?,
+        Some(vec![bottom_ref.to_owned(), main_ref.to_owned()])
+    );
+    let ws = ws.graph.into_workspace_of_redone_traversal(&repo, &meta)?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    ⌂:1:empty-bottom[🌳] <> ✓! on 281da94
+    └── ≡📙:1:empty-bottom[🌳] {1}
+        ├── 📙:1:empty-bottom[🌳]
+        └── :0:main
+            ├── ·281da94
+            ├── ·12995d7
+            └── ·3d57fc1
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn external_delete_of_ordered_top_branch_does_not_break_workspace_load() -> anyhow::Result<()> {
+    let (_tmp, repo, legacy_meta) = named_writable_scenario("single-branch-with-3-commits")?;
+    let project_meta = project_meta(&legacy_meta);
+    let mut meta = branch_order_meta(&repo)?;
+    let ws = workspace_from_head(&repo, &meta, project_meta.clone())?;
+
+    let top_ref = r("refs/heads/empty-top");
+    let bottom_ref = r("refs/heads/empty-bottom");
+    let main_ref = r("refs/heads/main");
+    create_ad_hoc_reference(&repo, &ws, &mut meta, top_ref, main_ref, Above)?;
+    create_ad_hoc_reference(&repo, &ws, &mut meta, bottom_ref, top_ref, Below)?;
+
+    checkout_branch(&repo, main_ref)?;
+    delete_reference_externally(&repo, top_ref)?;
+    drop(meta);
+    let read_only_meta = branch_order_meta_read_only(&repo)?;
+    assert_eq!(
+        read_only_meta.branch_stack_order(main_ref)?,
+        Some(vec![
+            top_ref.to_owned(),
+            bottom_ref.to_owned(),
+            main_ref.to_owned()
+        ]),
+        "read-only metadata should still see the stale persisted order before graph filtering"
+    );
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &read_only_meta,
+        project_meta.clone(),
+        GraphOptions::limited(),
+    )?;
+    let rendered_graph = graph_tree(&graph).to_string();
+    assert!(
+        rendered_graph.contains("empty-bottom"),
+        "graph should include surviving ordered ref before projection:\n{rendered_graph}"
+    );
+    let ws = graph.into_workspace()?;
+
+    assert_workspace_order(&ws, &["refs/heads/empty-bottom", "refs/heads/main"]);
+    let rendered = graph_workspace(&ws).to_string();
+    assert!(
+        !rendered.contains("empty-top"),
+        "stale metadata should not keep deleted top branch visible:\n{rendered}"
+    );
+    Ok(())
+}
+
+#[test]
+fn ad_hoc_remove_empty_branch_from_middle_of_three_branch_stack() -> anyhow::Result<()> {
+    let (_tmp, repo, legacy_meta) = named_writable_scenario("single-branch-with-3-commits")?;
+    let project_meta = project_meta(&legacy_meta);
+    let mut meta = branch_order_meta(&repo)?;
+    let ws = workspace_from_head(&repo, &meta, project_meta.clone())?;
+
+    let top_ref = r("refs/heads/empty-top");
+    let middle_ref = r("refs/heads/empty-middle");
+    let bottom_ref = r("refs/heads/empty-bottom");
+    let main_ref = r("refs/heads/main");
+    create_ad_hoc_reference(&repo, &ws, &mut meta, top_ref, main_ref, Above)?;
+    create_ad_hoc_reference(&repo, &ws, &mut meta, middle_ref, top_ref, Below)?;
+    create_ad_hoc_reference(&repo, &ws, &mut meta, bottom_ref, middle_ref, Below)?;
+    checkout_branch(&repo, top_ref)?;
+    let ws = workspace_from_head(&repo, &meta, project_meta.clone())?;
+
+    let ws = but_workspace::branch::remove_reference(
+        middle_ref,
+        &repo,
+        &ws,
+        &mut meta,
+        remove_reference::Options::default(),
+    )?
+    .expect("the empty middle branch should be removed");
+
+    assert!(repo.try_find_reference(middle_ref)?.is_none());
+    assert_eq!(
+        meta.branch_stack_order(main_ref)?,
+        Some(vec![
+            top_ref.to_owned(),
+            bottom_ref.to_owned(),
+            main_ref.to_owned()
+        ])
+    );
+    let ws = ws.graph.into_workspace_of_redone_traversal(&repo, &meta)?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    ⌂:1:empty-top[🌳] <> ✓! on 281da94
+    └── ≡📙:1:empty-top[🌳] {1}
+        ├── 📙:1:empty-top[🌳]
+        ├── 📙:2:empty-bottom
+        └── :0:main
+            ├── ·281da94
+            ├── ·12995d7
+            └── ·3d57fc1
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn external_delete_of_ordered_middle_branch_does_not_break_workspace_load() -> anyhow::Result<()> {
+    let (_tmp, repo, legacy_meta) = named_writable_scenario("single-branch-with-3-commits")?;
+    let project_meta = project_meta(&legacy_meta);
+    let mut meta = branch_order_meta(&repo)?;
+    let ws = workspace_from_head(&repo, &meta, project_meta.clone())?;
+
+    let top_ref = r("refs/heads/empty-top");
+    let middle_ref = r("refs/heads/empty-middle");
+    let bottom_ref = r("refs/heads/empty-bottom");
+    let main_ref = r("refs/heads/main");
+    create_ad_hoc_reference(&repo, &ws, &mut meta, top_ref, main_ref, Above)?;
+    create_ad_hoc_reference(&repo, &ws, &mut meta, middle_ref, top_ref, Below)?;
+    create_ad_hoc_reference(&repo, &ws, &mut meta, bottom_ref, middle_ref, Below)?;
+
+    checkout_branch(&repo, main_ref)?;
+    delete_reference_externally(&repo, middle_ref)?;
+    drop(meta);
+    let read_only_meta = branch_order_meta_read_only(&repo)?;
+    let ws = workspace_from_head(&repo, &read_only_meta, project_meta)?;
+
+    assert_workspace_order(
+        &ws,
+        &[
+            "refs/heads/empty-top",
+            "refs/heads/empty-bottom",
+            "refs/heads/main",
+        ],
+    );
+    let rendered = graph_workspace(&ws).to_string();
+    assert!(
+        !rendered.contains("empty-middle"),
+        "stale metadata should not keep deleted middle branch visible:\n{rendered}"
+    );
+    Ok(())
+}
+
+#[test]
+fn ad_hoc_remove_empty_branch_from_bottom_of_two_branch_stack() -> anyhow::Result<()> {
+    let (_tmp, repo, legacy_meta) = named_writable_scenario("single-branch-with-3-commits")?;
+    let project_meta = project_meta(&legacy_meta);
+    let mut meta = branch_order_meta(&repo)?;
+    let ws = workspace_from_head(&repo, &meta, project_meta.clone())?;
+
+    let top_ref = r("refs/heads/empty-top");
+    let bottom_ref = r("refs/heads/empty-bottom");
+    let main_ref = r("refs/heads/main");
+    create_ad_hoc_reference(&repo, &ws, &mut meta, top_ref, main_ref, Above)?;
+    create_ad_hoc_reference(&repo, &ws, &mut meta, bottom_ref, top_ref, Below)?;
+    checkout_branch(&repo, top_ref)?;
+    let ws = workspace_from_head(&repo, &meta, project_meta.clone())?;
+
+    let ws = but_workspace::branch::remove_reference(
+        bottom_ref,
+        &repo,
+        &ws,
+        &mut meta,
+        remove_reference::Options::default(),
+    )?
+    .expect("the empty bottom branch should be removed");
+
+    assert!(repo.try_find_reference(bottom_ref)?.is_none());
+    assert_eq!(
+        meta.branch_stack_order(main_ref)?,
+        Some(vec![top_ref.to_owned(), main_ref.to_owned()])
+    );
+    let ws = ws.graph.into_workspace_of_redone_traversal(&repo, &meta)?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    ⌂:1:empty-top[🌳] <> ✓! on 281da94
+    └── ≡📙:1:empty-top[🌳] {1}
+        ├── 📙:1:empty-top[🌳]
+        └── :0:main
+            ├── ·281da94
+            ├── ·12995d7
+            └── ·3d57fc1
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn external_delete_of_ordered_bottom_branch_does_not_break_workspace_load() -> anyhow::Result<()> {
+    let (_tmp, repo, legacy_meta) = named_writable_scenario("single-branch-with-3-commits")?;
+    let project_meta = project_meta(&legacy_meta);
+    let mut meta = branch_order_meta(&repo)?;
+    let ws = workspace_from_head(&repo, &meta, project_meta.clone())?;
+
+    let top_ref = r("refs/heads/empty-top");
+    let bottom_ref = r("refs/heads/empty-bottom");
+    let main_ref = r("refs/heads/main");
+    create_ad_hoc_reference(&repo, &ws, &mut meta, top_ref, main_ref, Above)?;
+    create_ad_hoc_reference(&repo, &ws, &mut meta, bottom_ref, top_ref, Below)?;
+
+    checkout_branch(&repo, main_ref)?;
+    delete_reference_externally(&repo, bottom_ref)?;
+    drop(meta);
+    let read_only_meta = branch_order_meta_read_only(&repo)?;
+    let ws = workspace_from_head(&repo, &read_only_meta, project_meta)?;
+
+    assert_workspace_order(&ws, &["refs/heads/empty-top", "refs/heads/main"]);
+    let rendered = graph_workspace(&ws).to_string();
+    assert!(
+        !rendered.contains("empty-bottom"),
+        "stale metadata should not keep deleted bottom branch visible:\n{rendered}"
+    );
+    Ok(())
+}
+
+#[test]
+fn metadata_only_ordered_ref_does_not_create_phantom_branch() -> anyhow::Result<()> {
+    let (_tmp, repo, legacy_meta) = named_writable_scenario("single-branch-with-3-commits")?;
+    let project_meta = project_meta(&legacy_meta);
+    let mut meta = branch_order_meta(&repo)?;
+    let phantom_ref = r("refs/heads/phantom");
+    let main_ref = r("refs/heads/main");
+    meta.set_branch_stack_order(&[phantom_ref.to_owned(), main_ref.to_owned()])?;
+
+    let read_only_meta = branch_order_meta_read_only(&repo)?;
+    let ws = workspace_from_head(&repo, &read_only_meta, project_meta)?;
+    let rendered = graph_workspace(&ws).to_string();
+
+    assert!(
+        !rendered.contains("phantom"),
+        "metadata without a Git ref should not create a projected branch:\n{rendered}"
+    );
+    Ok(())
+}
 
 #[test]
 fn no_errors_due_to_idempotency_in_empty_workspace() -> anyhow::Result<()> {

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -2,9 +2,12 @@ use anyhow::{Context, Result};
 use bstr::ByteSlice;
 use but_core::{Commit, RefMetadata};
 use but_graph::init::{Options, Tip};
+use but_meta::BranchOrderMetadata;
 use but_meta::virtual_branches_legacy_types::Target;
 use but_rebase::graph_rebase::mutate::RelativeTo;
-use but_testsupport::{CommandExt, git, graph_workspace, visualize_commit_graph_all};
+use but_testsupport::{
+    CommandExt, git, graph_workspace, visualize_commit_graph_all as visualize_commit_graph_all_raw,
+};
 use but_workspace::{
     BottomUpdate, BottomUpdateKind, ReviewIntegrationHint, integrate_upstream,
     integrate_upstream_with_hints, worktree_conflicts_for_rebase,
@@ -15,11 +18,24 @@ use gix::refs::transaction::PreviousValue;
 use crate::ref_info::with_workspace_commit::utils::{
     StackState, add_stack, add_stack_with_segments, named_writable_scenario_with_description,
 };
+use crate::utils::{r, rc};
 
 fn project_meta(meta: &impl RefMetadata) -> Result<but_core::ref_metadata::ProjectMeta> {
     Ok(meta
         .workspace(but_core::WORKSPACE_REF_NAME.try_into()?)?
         .project_meta())
+}
+
+fn branch_order_meta(repo: &gix::Repository) -> Result<BranchOrderMetadata> {
+    BranchOrderMetadata::from_paths(repo.path().join("virtual-branches.toml"), repo.path())
+}
+
+fn visualize_commit_graph_all(repo: &gix::Repository) -> Result<String> {
+    Ok(visualize_commit_graph_all_raw(repo)?
+        .lines()
+        .map(str::trim_end)
+        .collect::<Vec<_>>()
+        .join("\n"))
 }
 
 #[test]
@@ -49,18 +65,18 @@ fn diamond_partially_historically_integrated_rebase() -> Result<()> {
     * 61ee5f5 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 972cf74 (E) E
     *   9e74c75 (C) C
-    |\  
+    |\
     | * d6a7004 (D) D
     | | * 7de2393 (origin/master, master) o4
     | | *   7d62953 (o3) o3
-    | | |\  
-    | |_|/  
-    |/| |   
+    | | |\
+    | |_|/
+    |/| |
     * | | ffb801b (B) B
-    |/ /  
+    |/ /
     * | 448b195 (A) A
     | * d1b2089 o2
-    |/  
+    |/
     * 85aa44b (o1) o1
     ");
 
@@ -84,16 +100,16 @@ fn diamond_partially_historically_integrated_rebase() -> Result<()> {
     * 996b85e (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 2eb4a8c (E) E
     *   aecdc68 (C) C
-    |\  
+    |\
     | * 020d090 (D) D
-    |/  
+    |/
     * 7de2393 (origin/master, master) o4
     *   7d62953 (o3) o3
-    |\  
+    |\
     | * ffb801b B
     | * 448b195 A
     * | d1b2089 o2
-    |/  
+    |/
     * 85aa44b (o1) o1
     ");
 
@@ -132,18 +148,18 @@ fn diamond_partially_historically_integrated_merge() -> Result<()> {
     * 61ee5f5 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 972cf74 (E) E
     *   9e74c75 (C) C
-    |\  
+    |\
     | * d6a7004 (D) D
     | | * 7de2393 (origin/master, master) o4
     | | *   7d62953 (o3) o3
-    | | |\  
-    | |_|/  
-    |/| |   
+    | | |\
+    | |_|/
+    |/| |
     * | | ffb801b (B) B
-    |/ /  
+    |/ /
     * | 448b195 (A) A
     | * d1b2089 o2
-    |/  
+    |/
     * 85aa44b (o1) o1
     ");
 
@@ -165,21 +181,21 @@ fn diamond_partially_historically_integrated_merge() -> Result<()> {
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     * 292b0b3 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     *   ed5f276 (E) Merge refs/remotes/origin/master into merge
-    |\  
+    |\
     | * 7de2393 (origin/master, master) o4
     | *   7d62953 (o3) o3
-    | |\  
+    | |\
     | * | d1b2089 o2
     * | | 972cf74 E
     * | |   9e74c75 (C) C
-    |\ \ \  
-    | |_|/  
-    |/| |   
+    |\ \ \
+    | |_|/
+    |/| |
     | * | d6a7004 (D) D
     * | | ffb801b B
-    |/ /  
+    |/ /
     * / 448b195 A
-    |/  
+    |/
     * 85aa44b (o1) o1
     ");
 
@@ -213,16 +229,16 @@ fn diamond_partially_content_integrated_rebase() -> Result<()> {
     * 3e02fbd (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * a6588cf (E) E
     *   4827d2f (C) C
-    |\  
+    |\
     | * d8d0970 (D) D
     * | 3d3bfa7 (B) B
-    |/  
+    |/
     * f5b02d3 (A) A
     | * 162b064 (origin/master, master) o4
     | * dd87d69 (o3) B
     | * 5c0b375 A
     | * d1b2089 o2
-    |/  
+    |/
     * 85aa44b (o1) o1
     ");
 
@@ -257,9 +273,9 @@ fn diamond_partially_content_integrated_rebase() -> Result<()> {
     * 8b48706 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * cb866ec (E) E
     *   c7b32b8 (C) C
-    |\  
+    |\
     | * e05e7c1 (D) D
-    |/  
+    |/
     * 162b064 (origin/master, master) o4
     * dd87d69 (o3) B
     * 5c0b375 A
@@ -297,16 +313,16 @@ fn diamond_partially_content_integrated_merge() -> Result<()> {
     * 3e02fbd (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * a6588cf (E) E
     *   4827d2f (C) C
-    |\  
+    |\
     | * d8d0970 (D) D
     * | 3d3bfa7 (B) B
-    |/  
+    |/
     * f5b02d3 (A) A
     | * 162b064 (origin/master, master) o4
     | * dd87d69 (o3) B
     | * 5c0b375 A
     | * d1b2089 o2
-    |/  
+    |/
     * 85aa44b (o1) o1
     ");
 
@@ -328,19 +344,19 @@ fn diamond_partially_content_integrated_merge() -> Result<()> {
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     * ebd6fa2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     *   0a395ba (E) Merge refs/remotes/origin/master into merge
-    |\  
+    |\
     | * 162b064 (origin/master, master) o4
     | * dd87d69 (o3) B
     | * 5c0b375 A
     | * d1b2089 o2
     * | a6588cf E
     * |   4827d2f (C) C
-    |\ \  
+    |\ \
     | * | d8d0970 (D) D
     * | | 3d3bfa7 B
-    |/ /  
+    |/ /
     * / f5b02d3 A
-    |/  
+    |/
     * 85aa44b (o1) o1
     ");
 
@@ -381,7 +397,7 @@ fn integrated_bottom_branch_no_workspace_rebase() -> Result<()> {
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * e792f40 (HEAD -> A) add A1
     | * 8c8a843 (origin/main) add X1
-    |/  
+    |/
     * b38b04b (B) add B1
     * 3183e43 (main) M1
     ");
@@ -495,6 +511,85 @@ fn integrated_bottom_branch_does_not_delete_local_main_or_master() -> Result<()>
 }
 
 #[test]
+fn integrated_bottom_empty_top_no_workspace_rebase() -> Result<()> {
+    let (_tmp, repo, mut legacy_meta, _description) =
+        named_writable_scenario_with_description("integrated-bottom-empty-top-no-workspace")?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+
+    legacy_meta.set_default_target(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    })?;
+    drop(legacy_meta);
+    let mut meta = branch_order_meta(&repo)?;
+    meta.set_branch_stack_order(&[
+        rc("refs/heads/A").into_owned(),
+        rc("refs/heads/B").into_owned(),
+    ])?;
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta(&meta)?,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * 8c8a843 (origin/main) add X1
+    * b38b04b (HEAD -> A, B) add B1
+    * 3183e43 (main) M1
+    ");
+
+    let mut workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    ⌂:3:A[🌳] <> ✓refs/remotes/origin/main⇣2 on 3183e43
+    └── ≡:3:A[🌳] on 3183e43 {1}
+        ├── :3:A[🌳]
+        └── :0:B
+            └── ·b38b04b
+    ");
+    let project_meta = workspace.graph.project_meta.clone();
+    let but_workspace::IntegrateUpstreamOutcome { rebase, .. } = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        project_meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("B")?.detach()),
+        }],
+    )?;
+
+    rebase.materialize()?;
+
+    assert!(
+        repo.try_find_reference("B")?.is_none(),
+        "the integrated bottom branch should be removed from the refs after rebase integration"
+    );
+    assert_eq!(
+        repo.head_name()?.as_ref().map(|name| name.as_bstr()),
+        Some(r("refs/heads/A").as_bstr()),
+        "the empty top branch should remain checked out"
+    );
+    assert_eq!(
+        repo.rev_parse_single("A")?.detach(),
+        repo.rev_parse_single("origin/main")?.detach(),
+        "the empty top branch should move to the integrated target tip"
+    );
+    assert_eq!(
+        meta.branch_stack_order(r("refs/heads/A"))?,
+        Some(vec![rc("refs/heads/A").into_owned()]),
+        "removing the integrated bottom branch should prune it from ad-hoc branch order"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn integrated_bottom_branch_no_workspace_merge() -> Result<()> {
     let (_tmp, repo, mut meta, _description) =
         named_writable_scenario_with_description("integrated-bottom-branch-no-workspace")?;
@@ -528,7 +623,7 @@ fn integrated_bottom_branch_no_workspace_merge() -> Result<()> {
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * e792f40 (HEAD -> A) add A1
     | * 8c8a843 (origin/main) add X1
-    |/  
+    |/
     * b38b04b (B) add B1
     * 3183e43 (main) M1
     ");
@@ -558,10 +653,10 @@ fn integrated_bottom_branch_no_workspace_merge() -> Result<()> {
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     *   7ce831c (HEAD -> A) Merge refs/remotes/origin/main into merge
-    |\  
+    |\
     | * 8c8a843 (origin/main) add X1
     * | e792f40 add A1
-    |/  
+    |/
     * b38b04b add B1
     * 3183e43 (main) M1
     ");
@@ -614,7 +709,7 @@ fn merge_upstream_with_conflicting_target_materializes_conflicted_merge_commit()
     * 8fd8fb6 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 61c4a24 (A) local change in A 1
     | * f03fc2c (origin/A, new-origin) remote change in A 1
-    |/  
+    |/
     * 2b73dee (origin/main, main) init-integration
     ");
 
@@ -636,10 +731,10 @@ fn merge_upstream_with_conflicting_target_materializes_conflicted_merge_commit()
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     * 379fa91 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     *   9b4efdf (A) [conflict] Merge refs/remotes/origin/A into merge
-    |\  
+    |\
     | * f03fc2c (origin/A, new-origin) remote change in A 1
     * | 61c4a24 local change in A 1
-    |/  
+    |/
     * 2b73dee (origin/main, main) init-integration
     ");
 
@@ -704,10 +799,10 @@ fn fully_historically_integrated_branch_leaves_workspace_shape() -> Result<()> {
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     *   9d7da88 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    |\  
+    |\
     | * 905d6e5 (origin/main, A) add A1
     * | b38b04b (B) add B1
-    |/  
+    |/
     * 3183e43 (main) M1
     ");
 
@@ -843,7 +938,7 @@ fn fully_integrated_single_branch_reparents_workspace_commit_to_advanced_target(
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 9de7db5 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     | * 6b20716 (origin/main) add X
-    |/  
+    |/
     * ffde79e (A) add A
     * 86b55e6 add B
     * 8d5739f (main) add C
@@ -975,12 +1070,12 @@ fn fully_integrated_single_branch_reparents_workspace_commit_to_advanced_merge_t
     * 9de7db5 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     | * f27db86 (origin/main) add X
     | *   4f5589a D
-    | |\  
-    | |/  
-    |/|   
+    | |\
+    | |/
+    |/|
     * | ffde79e (A) add A
     * | 86b55e6 add B
-    |/  
+    |/
     * 8d5739f (main) add C
     ");
 
@@ -1011,10 +1106,10 @@ fn fully_integrated_single_branch_reparents_workspace_commit_to_advanced_merge_t
     * d60856a (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * f27db86 (origin/main) add X
     *   4f5589a D
-    |\  
+    |\
     | * ffde79e add A
     | * 86b55e6 add B
-    |/  
+    |/
     * 8d5739f (main) add C
     ");
 
@@ -1285,12 +1380,12 @@ fn workspace_target_parent_updates_while_stack_parent_remains_anonymous_segment_
     )?;
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     *   e854d6a (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    |\  
+    |\
     | * 90d25da (A) add A
     * | 0d97cc1 add C2
-    |/  
+    |/
     | * 20a5ffc (origin/main, main) add X
-    |/  
+    |/
     * fe9ae6e (target-sha) add C1
     ");
 
@@ -1328,11 +1423,11 @@ fn workspace_target_parent_updates_while_stack_parent_remains_anonymous_segment_
     ");
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     *   06beb96 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    |\  
+    |\
     | * c529875 (A) add A
     | * 20a5ffc (origin/main, main) add X
     * | 0d97cc1 add C2
-    |/  
+    |/
     * fe9ae6e (target-sha) add C1
     ");
     assert_eq!(
@@ -1475,11 +1570,11 @@ fn partially_integrated_branch_leaves_multi_branch_stack() -> Result<()> {
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     *   cf53402 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    |\  
+    |\
     | * 44c9428 (A) add A1
     | * f1e7451 (origin/main, C) add C1
     * | b38b04b (B) add B1
-    |/  
+    |/
     * 3183e43 (main) M1
     ");
 
@@ -1526,10 +1621,10 @@ fn partially_integrated_branch_leaves_multi_branch_stack() -> Result<()> {
     ");
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     *   780946b (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    |\  
+    |\
     | * 44c9428 (A) add A1
     * | a27415e (B) add B1
-    |/  
+    |/
     * f1e7451 (origin/main) add C1
     * 3183e43 (main) M1
     ");
@@ -1563,11 +1658,11 @@ fn fully_integrated_multi_branch_stack_leaves_workspace_shape() -> Result<()> {
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     *   cf53402 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    |\  
+    |\
     | * 44c9428 (origin/main, A) add A1
     | * f1e7451 (C) add C1
     * | b38b04b (B) add B1
-    |/  
+    |/
     * 3183e43 (main) M1
     ");
 
@@ -1646,17 +1741,17 @@ fn fully_integrated_two_stacks_leave_workspace_shape() -> Result<()> {
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     *   9d7da88 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    |\  
+    |\
     | | *   5f7d45e (origin/main, main) Merging B into base
-    | | |\  
-    | |_|/  
-    |/| |   
+    | | |\
+    | |_|/
+    |/| |
     * | | b38b04b (B) add B1
     | | * 1f7670a Merging A into base
-    | |/| 
-    |/|/  
+    | |/|
+    |/|/
     | * 905d6e5 (A) add A1
-    |/  
+    |/
     * 3183e43 M1
     ");
 
@@ -1694,14 +1789,14 @@ fn fully_integrated_two_stacks_leave_workspace_shape() -> Result<()> {
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     * b44fd24 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     *   5f7d45e (origin/main, main) Merging B into base
-    |\  
+    |\
     | * b38b04b add B1
     * |   1f7670a Merging A into base
-    |\ \  
-    | |/  
-    |/|   
+    |\ \
+    | |/
+    |/|
     | * 905d6e5 add A1
-    |/  
+    |/
     * 3183e43 M1
     ");
 
@@ -2340,13 +2435,13 @@ fn review_hint_integrates_squashed_two_commit_stack_in_managed_workspace() -> Re
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     *   b96a78e (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    |\  
+    |\
     | * ad1d22b (A) add A2
     | * fe98e29 add A1
     * | b38b04b (B) add B1
-    |/  
+    |/
     | * 56057f2 (origin/main) squash A
-    |/  
+    |/
     * 3183e43 (main) M1
     ");
 
@@ -2391,7 +2486,7 @@ fn review_hint_integrates_squashed_two_commit_stack_in_managed_workspace() -> Re
     * e4abb28 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * b38b04b (B) add B1
     | * 56057f2 (origin/main) squash A
-    |/  
+    |/
     * 3183e43 (main) M1
     ");
 
@@ -2445,7 +2540,7 @@ fn review_hint_integrates_squashed_two_commit_direct_checkout_branch() -> Result
     * ad1d22b (HEAD -> A) add A2
     * fe98e29 add A1
     | * 56057f2 (origin/main) squash A
-    |/  
+    |/
     * 3183e43 (main) M1
     ");
 
@@ -2532,7 +2627,7 @@ fn review_hint_integrates_squashed_prefix_and_keeps_extra_commit_in_managed_work
     * ad1d22b add A2
     * fe98e29 add A1
     | * e2f5892 (origin/main) squash A1 and A2
-    |/  
+    |/
     * 3183e43 (main) M1
     ");
 
@@ -2615,7 +2710,7 @@ fn review_hint_integrates_squashed_prefix_and_keeps_extra_commit_in_direct_check
     * ad1d22b add A2
     * fe98e29 add A1
     | * e2f5892 (origin/main) squash A1 and A2
-    |/  
+    |/
     * 3183e43 (main) M1
     ");
 

--- a/crates/but/tests/fixtures/scenario/pull-branch-and-dirty-worktree-conflict.sh
+++ b/crates/but/tests/fixtures/scenario/pull-branch-and-dirty-worktree-conflict.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git-init-frozen
+
+echo base >shared.txt
+git add shared.txt
+git commit -m "base"
+setup_target_to_match_main
+git remote set-url origin .
+
+git checkout -b A
+echo local >shared.txt
+git add shared.txt
+git commit -m "local change"
+
+create_workspace_commit_once A
+
+git checkout main
+echo upstream >shared.txt
+git add shared.txt
+git commit -m "upstream change"
+git update-ref refs/remotes/origin/main main
+
+git checkout gitbutler/workspace

--- a/crates/but/tests/fixtures/scenario/pull-conflict-in-lower-branch-of-stack.sh
+++ b/crates/but/tests/fixtures/scenario/pull-conflict-in-lower-branch-of-stack.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git-init-frozen
+
+echo base >shared.txt
+git add shared.txt
+git commit -m "base"
+setup_target_to_match_main
+git remote set-url origin .
+
+git checkout -b B
+echo bottom >shared.txt
+git add shared.txt
+git commit -m "bottom change"
+
+git checkout -b A
+echo top >top.txt
+git add top.txt
+git commit -m "top change"
+
+create_workspace_commit_once A
+
+git checkout main
+echo upstream >shared.txt
+git add shared.txt
+git commit -m "upstream change"
+git update-ref refs/remotes/origin/main main
+
+git checkout gitbutler/workspace

--- a/crates/but/tests/fixtures/scenario/pull-conflicts-in-both-branches-of-stack.sh
+++ b/crates/but/tests/fixtures/scenario/pull-conflicts-in-both-branches-of-stack.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git-init-frozen
+
+echo base >bottom.txt
+echo base >top.txt
+git add bottom.txt top.txt
+git commit -m "base"
+setup_target_to_match_main
+git remote set-url origin .
+
+git checkout -b B
+echo bottom >bottom.txt
+git add bottom.txt
+git commit -m "bottom change"
+
+git checkout -b A
+echo top >top.txt
+git add top.txt
+git commit -m "top change"
+
+create_workspace_commit_once A
+
+git checkout main
+echo upstream >bottom.txt
+echo upstream >top.txt
+git add bottom.txt top.txt
+git commit -m "upstream change"
+git update-ref refs/remotes/origin/main main
+
+git checkout gitbutler/workspace

--- a/crates/but/tests/fixtures/scenario/pull-one-of-two-stacks-integrated.sh
+++ b/crates/but/tests/fixtures/scenario/pull-one-of-two-stacks-integrated.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git-init-frozen
+
+commit-file M
+setup_target_to_match_main
+git remote set-url origin .
+
+git checkout -b A main
+commit-file A
+
+git checkout -b B main
+commit-file B
+
+create_workspace_commit_once A B
+
+git checkout main
+git merge --no-ff -m "merge A" A
+commit-file upstream
+git update-ref refs/remotes/origin/main main
+
+git checkout gitbutler/workspace

--- a/crates/but/tests/fixtures/scenario/pull-partially-integrated-multi-branch-stack.sh
+++ b/crates/but/tests/fixtures/scenario/pull-partially-integrated-multi-branch-stack.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git-init-frozen
+
+commit-file M
+setup_target_to_match_main
+git remote set-url origin .
+git update-ref refs/heads/base main
+
+git checkout -b C main
+commit-file C
+
+git checkout -b A
+commit-file A
+
+create_workspace_commit_once A
+
+git checkout main
+git merge --no-ff -m "merge C" C
+commit-file upstream
+git update-ref refs/remotes/origin/main main
+
+git checkout gitbutler/workspace

--- a/crates/but/tests/fixtures/scenario/pull-two-integrated-stacks.sh
+++ b/crates/but/tests/fixtures/scenario/pull-two-integrated-stacks.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git-init-frozen
+
+commit-file M
+setup_target_to_match_main
+git remote set-url origin .
+
+git checkout -b A main
+commit-file A
+
+git checkout -b B main
+commit-file B
+
+create_workspace_commit_once A B
+
+git checkout main
+git merge --no-ff -m "merge A" A
+git merge --no-ff -m "merge B" B
+commit-file upstream
+git update-ref refs/remotes/origin/main main
+
+git checkout gitbutler/workspace

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -1,5 +1,7 @@
 use anyhow::{Context as _, Result};
-use but_core::{RepositoryExt, extract_remote_name_and_short_name, ref_metadata::StackId};
+use but_core::{
+    RefMetadata as _, RepositoryExt, extract_remote_name_and_short_name, ref_metadata::StackId,
+};
 use but_ctx::{Context, access::RepoShared};
 use gitbutler_git::{GitContextExt as _, PushResult};
 use gitbutler_operating_modes::ensure_open_workspace_mode;
@@ -102,6 +104,12 @@ pub fn update_branch_name_with_perm(
         .context("Requires an open workspace mode")?;
     let mut stack = ctx.virtual_branches().get_stack(stack_id)?;
     let normalized_head_name = normalize_branch_name(&new_name)?;
+    let old_ref_name = Category::LocalBranch
+        .to_full_name(branch_name.as_str())
+        .map_err(anyhow::Error::from)?;
+    let new_ref_name = Category::LocalBranch
+        .to_full_name(normalized_head_name.as_str())
+        .map_err(anyhow::Error::from)?;
     stack.update_branch(
         ctx,
         branch_name,
@@ -109,6 +117,13 @@ pub fn update_branch_name_with_perm(
             name: Some(normalized_head_name.clone()),
         },
     )?;
+    ctx.reload_repo_and_invalidate_workspace(perm)?;
+    let mut meta = but_meta::BranchOrderMetadata::from_paths(
+        ctx.project_data_dir().join("virtual_branches.toml"),
+        ctx.project_data_dir(),
+    )?;
+    meta.rename_branch_stack_order_reference(old_ref_name.as_ref(), new_ref_name.as_ref())?;
+    ctx.invalidate_workspace_cache()?;
     Ok(normalized_head_name)
 }
 

--- a/crates/gitbutler-branch-actions/tests/branch-actions/main.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/main.rs
@@ -1,6 +1,7 @@
 mod branch;
 mod driverless;
 mod hooks;
+mod rename_branch;
 mod support;
 mod virtual_branches;
 mod workspace_commit;

--- a/crates/gitbutler-branch-actions/tests/branch-actions/rename_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/rename_branch.rs
@@ -1,0 +1,68 @@
+use anyhow::Result;
+use but_core::{RefMetadata, ref_metadata::StackId};
+
+#[test]
+fn update_branch_name_renames_branch_order_metadata() -> Result<()> {
+    let (mut ctx, _tmp) = crate::driverless::writable_context(
+        "for-listing.sh",
+        "one-vbranch-in-workspace-one-commit",
+    )?;
+    let virtual_ref = gix::refs::FullName::try_from("refs/heads/virtual")?;
+    let workspace_ref = gix::refs::FullName::try_from("refs/heads/gitbutler/workspace")?;
+    let renamed_ref = gix::refs::FullName::try_from("refs/heads/renamed-virtual")?;
+
+    {
+        let mut meta = ctx.meta()?;
+        meta.set_branch_stack_order(&[virtual_ref.clone(), workspace_ref.clone()])?;
+    }
+
+    gitbutler_branch_actions::stack::update_branch_name(
+        &mut ctx,
+        StackId::from_number_for_testing(1),
+        "virtual".into(),
+        "renamed-virtual".into(),
+    )?;
+
+    assert_eq!(
+        ctx.meta()?.branch_stack_order(renamed_ref.as_ref())?,
+        Some(vec![renamed_ref.clone(), workspace_ref.clone()]),
+        "branch-order metadata should follow the renamed branch ref"
+    );
+    assert!(
+        ctx.meta()?
+            .branch_stack_order(virtual_ref.as_ref())?
+            .is_none(),
+        "old branch ref should not retain order metadata after rename"
+    );
+    Ok(())
+}
+
+#[test]
+fn failed_update_branch_name_leaves_branch_order_metadata_unchanged() -> Result<()> {
+    let (mut ctx, _tmp) =
+        crate::driverless::writable_context("for-listing.sh", "one-vbranch-in-workspace")?;
+    let virtual_ref = gix::refs::FullName::try_from("refs/heads/virtual")?;
+    let workspace_ref = gix::refs::FullName::try_from("refs/heads/gitbutler/workspace")?;
+
+    {
+        let mut meta = ctx.meta()?;
+        meta.set_branch_stack_order(&[virtual_ref.clone(), workspace_ref.clone()])?;
+    }
+
+    assert!(
+        gitbutler_branch_actions::stack::update_branch_name(
+            &mut ctx,
+            StackId::from_number_for_testing(1),
+            "virtual".into(),
+            "gitbutler/workspace".into(),
+        )
+        .is_err(),
+        "renaming onto an existing local branch should fail before metadata is rewritten"
+    );
+    assert_eq!(
+        ctx.meta()?.branch_stack_order(virtual_ref.as_ref())?,
+        Some(vec![virtual_ref, workspace_ref]),
+        "failed rename should leave branch-order metadata unchanged"
+    );
+    Ok(())
+}

--- a/single-branch-ad-hoc-metadata-notes.md
+++ b/single-branch-ad-hoc-metadata-notes.md
@@ -1,0 +1,219 @@
+# Single-Branch Ad-Hoc Metadata Notes
+
+## Motivation
+
+Single-branch mode can create multiple local branch refs that all point at the same commit. Without additional metadata, Git alone cannot express which empty branch should appear above or below another empty branch in the UI.
+
+The work on `single-branch-ad-hoc-metadata` adds persisted ad-hoc branch ordering so the app can keep same-tip empty branches in a stable stack order. The follow-up Playwright work covers the user-visible Tauri app flows for creating and removing these empty branches in single-branch mode.
+
+## Relevant Concepts
+
+- `branch_order` database table: stores ad-hoc branch order as a parent chain, from top branch toward the base branch.
+- `BranchOrderMetadata`: bridges legacy metadata with DB-backed ad-hoc ordering.
+- `Anchor::AtReference`: creates a branch at the same commit as the anchor ref, using the requested position only for ordering.
+- Ad-hoc workspace: a single-branch workspace without managed workspace metadata, where the checked-out local branch is treated as the workspace entrypoint.
+- Empty branch segment: a graph/workspace segment with a ref but no commits. These must be preserved if they are part of persisted ad-hoc ordering.
+- Projection pruning: workspace projection removes integrated commits and normally prunes empty branches; DB-ordered ad-hoc empty branches need to survive that pruning.
+- Checked-out branch deletion: Git refuses to delete a checked-out ref, so removing a checked-out empty ad-hoc branch must first move `HEAD` to a surviving neighboring branch.
+
+## Testing
+
+Backend and graph coverage:
+
+- Added/updated Rust coverage for creating a branch below an empty branch between empty branches.
+- Added/updated Rust coverage for removing empty branches from the top, middle, and bottom of ad-hoc stacks.
+- Added a `but-api` regression test that exercises the legacy `create_reference` path used by the app and verifies `head_info` includes the inserted empty branch.
+- Extended that API test to verify deleting a checked-out empty top branch switches `HEAD` to the next branch before deletion.
+
+Tauri app e2e coverage:
+
+- Added Playwright single-branch tests for:
+  - Adding a branch below an empty branch in between empty branches.
+  - Removing an empty branch from the top of a two-branch stack.
+  - Removing an empty branch from the middle of a three-branch stack.
+  - Removing an empty branch from the bottom of a two-branch stack.
+
+Validation run:
+
+- `cargo fmt --check`
+- `cargo check -p but-graph -p but-workspace -p but-api`
+- `cargo clippy -p but-graph -p but-workspace -p but-api --all-targets`
+- `cargo build -p but-server -p but`
+- targeted `but-workspace` tests for create/remove scenarios
+- targeted `but-api` regression test
+- targeted Playwright run for the four new single-branch scenarios
+- `corepack pnpm exec prettier --check ...`
+- `git diff --check`
+
+Known validation caveat:
+
+- `corepack pnpm --filter @gitbutler/e2e exec tsc --noEmit` still fails on existing PostCSS config typing errors in `packages/shared/postcss.config.js` and `packages/ui/postcss.config.js`.
+
+## Risks
+
+- The graph post-processing and workspace projection changes are subtle; they affect how same-tip local refs become empty stack segments in ad-hoc workspaces.
+- Preserving DB-ordered empty segments during projection pruning must not accidentally keep unrelated empty branches alive.
+- Switching `HEAD` before deleting a checked-out empty branch changes user-visible state. It is intended for ordered ad-hoc empty branches, but reviewers should confirm this behavior is acceptable for all single-branch deletion flows.
+- The frontend now uses `atReference` from the branch header context menu. This is correct for same-tip empty ordering, but reviewers should confirm no managed-workspace branch-header flow depended on `atSegment` semantics there.
+- Cache invalidation was broadened for create/remove reference flows; this should keep the UI accurate, but may cause extra workspace refetches.
+
+## Open Questions
+
+- Should checked-out ad-hoc branch deletion always move to the branch below, or should the UI/API choose the nearest surviving branch by explicit policy?
+- Should `remove_reference` itself own the checked-out-ref replacement behavior, or is keeping it in the legacy API boundary the right layering?
+- Should the app expose clearer UI state for deleting the currently checked-out empty branch, since it may switch `HEAD`?
+- Are there multi-worktree edge cases where switching `HEAD` in the current worktree is insufficient or surprising?
+- Should all branch-header create operations use `atReference`, or should managed workspaces keep a separate `atSegment` path?
+
+## Critique: Flaws and Testing Gaps
+
+The following review covers correctness bugs, robustness/design issues, testing gaps,
+and minor cleanups. File:line references point at the current branch state.
+
+### Critical correctness issues
+
+1. **Renaming an ordered ad-hoc branch silently corrupts the order table.**
+   The `branch_order` table keys rows by full ref-name *strings*, but no rename path
+   updates it. The UI Rename action → `updateBranchName` →
+   `gitbutler_branch_actions::stack::update_branch_name`
+   (`crates/but-action/src/rename_branch.rs:46`); a grep across `but-workspace`,
+   `but-api`, and `but-meta` shows nothing touches `branch_order` outside the trait
+   methods themselves. For a chain `[A, B, C]` where `B` is renamed to `B'`:
+   - The stale rows `(A→B)`/`(B→C)` persist; `order_for_reference` keeps returning the
+     dead name `B`.
+   - In `ad_hoc_branch_stack_upgrades`, `try_find_reference(B)` returns `None` and `B`
+     is skipped (`crates/but-graph/src/init/post.rs:1519`), so the renamed branch `B'`
+     loses its position and reverts to default placement.
+   - Subsequent `set_order`/`remove_reference` operate on a chain containing a phantom
+     ref.
+
+   This is a real, user-reachable data-integrity bug with no test coverage.
+
+2. **HEAD switch on delete does not touch the worktree — only safe by luck.**
+   `checked_out_ad_hoc_replacement` → `update_head_reference`
+   (`crates/but-core/src/repo_ext.rs:26`) calls only `repo.edit_reference("HEAD", …)`
+   with `deref=false`. It rewrites the symbolic ref and a reflog entry; it does *not*
+   update the index or working tree. This works today only because all same-tip ad-hoc
+   refs point at the same commit (same tree). `checked_out_ad_hoc_replacement`
+   (`crates/but-api/src/legacy/stack.rs:277`) never verifies the replacement is at the
+   same commit — it peels the target purely to compose the reflog `num_parents`. If the
+   persisted order ever contains a branch at a different commit (divergence is not
+   prevented), HEAD moves without a checkout and the worktree is left on the old tree →
+   spurious uncommitted diffs. Needs an explicit same-commit guard (or a real checkout)
+   and a test.
+
+3. **No atomicity across Git + DB + metadata.**
+   `create_reference` creates the Git ref and re-traverses, persists workspace metadata,
+   then finally `set_branch_stack_order`
+   (`crates/but-workspace/src/branch/create_reference.rs`, tail). If the DB write fails
+   (locked/IO), the ref exists in Git but ordering is never persisted → inconsistent
+   state on next load. Symmetrically on delete, `legacy/stack.rs` switches HEAD and
+   reloads *before* `remove_reference`; a failure after the HEAD switch leaves HEAD moved
+   but the branch undeleted. No compensating rollback exists.
+
+4. **Cycle/corruption in the order table hard-fails the whole workspace load.**
+   `order_for_reference` returns `Err(rusqlite::Error::InvalidQuery)` on a detected cycle
+   (`crates/but-db/src/table/branch_order.rs:77,87`). That error propagates through
+   `branch_stack_order` → `ad_hoc_branch_stack_upgrades` → graph construction with `?`,
+   so a single corrupt chain breaks workspace projection entirely. Contrast with the
+   missing-table case, deliberately downgraded to `Ok(None)`
+   (`crates/but-db/src/table/branch_order.rs:128`). Ordering is a presentation nicety; it
+   should degrade gracefully, not brick the view.
+
+### Robustness / design issues
+
+5. **`set_order` silently drops chain members not in the list.**
+   `DELETE FROM branch_order WHERE branch_ref_name = ?1 OR parent_ref_name = ?1`
+   (`crates/but-db/src/table/branch_order.rs:158`) runs per branch. If an existing row
+   `(P→A)` exists where `A` is in the new list but `P` is not, `P` is deleted and
+   vanishes from ordering. Masked in practice because callers pass the full chain from
+   `branch_stack_order(anchor)`, but it is a sharp edge with no guard and no test.
+
+6. **No garbage collection of stale order rows.**
+   Externally deleted branches (`git branch -d`) leave their `branch_order` rows forever.
+   Nothing reconciles the table against real refs. `VirtualBranchesTomlMetadata` has a
+   `garbage_collect`; the branch-order table has no equivalent. Cruft accumulates and
+   feeds back into projection (`keep_empty_segment_ids`, `is_ordered_ad_hoc_lower_bound`)
+   via dead names.
+
+7. **The recorded order influences projection even when no segments were rebuilt.**
+   `ad_hoc_branch_stack_upgrades` pushes `branch_order.clone()` into
+   `graph.ad_hoc_branch_stack_orders` at `crates/but-graph/src/init/post.rs:1491` —
+   before the `matching_refs.len() < 2` early return at
+   `crates/but-graph/src/init/post.rs:1543`. So when a chain exists but no empty segments
+   were materialized (e.g. branches diverged), the order still drives
+   `keep_empty_segment_ids` and `is_ordered_ad_hoc_lower_bound` in projection
+   (`crates/but-graph/src/projection/workspace/init.rs:435,1151`). The "recorded order"
+   and "actually restructured" states can disagree.
+
+8. **`keep_empty_segment_ids` flattens *all* orders.**
+   It collects ordered refs from `ad_hoc_branch_stack_orders.iter().flatten()`
+   (`crates/but-graph/src/projection/workspace/init.rs:1151`) with no scoping to the
+   current stack — exactly the risk the notes call out ("must not accidentally keep
+   unrelated empty branches alive"). Single-branch likely has one chain so it is latent,
+   but the code permits cross-chain leakage.
+
+9. **Success criterion checks the graph, not the projection.**
+   In `create_reference`, the ad-hoc path sets `has_new_ref_as_standalone_segment` by
+   scanning raw `graph.node_weights()` rather than `find_segment_and_stack_by_refname`.
+   A graph node can exist while projection pruning drops it from the workspace stacks —
+   so the op can "succeed" while the UI shows nothing. The two pruning fixes are meant to
+   prevent that, but the success signal and the display path are now decoupled and can
+   drift.
+
+10. **HEAD-switch layering is split and inconsistent.**
+    Delete-side HEAD switching lives in `but-api/legacy/stack.rs`; create-side checkout
+    lives in `but-api/branch.rs` (`branch_create_with_perm` drops all guards then calls
+    `branch_checkout_with_perm`). Neither lives in `but-workspace`. Two API modules
+    independently reason about "is this ref checked out," with duplicated `head_name()`
+    logic. Also: `branch_create_with_perm` computes
+    `WorkspaceState::from_workspace(&new_ws, …)` unconditionally and discards it whenever
+    `checkout_after_create` is true (wasted work), and the auto-checkout's oplog/undo
+    granularity (create + checkout as one snapshot or two?) is unspecified and untested.
+
+### Testing gaps
+
+Existing coverage is decent for happy paths (create-below-between-empties; remove
+top/middle/bottom; one API regression). Missing:
+
+- **Rename of an ordered empty branch** (issue 1) — untested and broken.
+- **Persistence across a cold reload** — all e2e runs are one session. No test that the
+  order is re-derived after a fresh `Graph::from_head` / app restart.
+- **Auto-checkout-on-create-above** is only unit-tested
+  (`crates/but-api/src/branch.rs:1390`), never e2e; and never with a *dirty worktree*
+  (does `branch_checkout` carry/refuse WIP changes?).
+- **Deleting the checked-out *middle* branch** — the API test only covers deleting the
+  checked-out *top*. The replacement-prefers-below logic for a middle deletion is
+  unverified.
+- **Replacement at a different commit** (issue 2) — no test; this is where the
+  worktree-safety bug bites.
+- **Cycle / corrupt order row** (issue 4) — no test that load degrades gracefully.
+- **Diverged branches in a chain** (`matching_refs < 2` path) — untested.
+- **Multiple independent chains** in one project — untested; relevant to issue 8.
+- **Reordering** an existing chain (`set_order` rewriting) and the orphan-drop edge
+  (issue 5) — untested.
+- **DB-write-failure / partial failure** (issue 3) — untested.
+- The notes' own caveat: `tsc --noEmit` for `@gitbutler/e2e` still fails (pre-existing
+  PostCSS typing). Pre-existing, but it means the new TS tests are not type-checked by
+  that gate.
+
+### Minor / cleanliness
+
+- `AddDependentBranchModal` keeps `stackId` in its props type and `BranchList` still
+  passes it, but the modal no longer uses it — dead prop. It also hardcodes
+  `side: "above"`, so the modal can only ever create above.
+- `branchReference` (TextDecoder over `fullNameBytes`) is duplicated in
+  `BranchList.svelte` and `BranchHeaderContextMenu.svelte` — candidate for a shared
+  helper.
+- Broadened invalidation (`invalidatesList(StackDetails)` etc. in `stackEndpoints.ts`)
+  trades correctness for extra refetches; acceptable but already flagged.
+- `order_for_reference` issues 2N point queries per chain (fine at current scale).
+
+### Highest-priority fixes
+
+1. Keep `branch_order` in sync on rename (and ideally on external deletion via GC) —
+   issue 1.
+2. Guard the HEAD-switch replacement to same-commit, or perform a real checkout —
+   issue 2.
+3. Downgrade the cycle error to graceful `Ok(None)` like the missing-table case —
+   issue 4.

--- a/single-branch-ad-hoc-metadata-pr-plan.md
+++ b/single-branch-ad-hoc-metadata-pr-plan.md
@@ -1,0 +1,554 @@
+# Single-Branch Ad-Hoc Metadata PR Plan
+
+## Goal
+
+Land single-branch ad-hoc branch ordering incrementally, without introducing a large backend rewrite or a broad UI/API migration in one review.
+
+The core invariant for the series:
+
+> Ad-hoc branch-order metadata may improve display and branch operations, but invalid, stale, or externally changed metadata must never prevent the workspace from loading or corrupt Git state.
+
+## Motivation
+
+Single-branch mode can create multiple local branch refs at the same commit. Git alone cannot express a stable visual order for those empty same-tip branches, so GitButler needs additional metadata.
+
+The current branch adds DB-backed `branch_order` metadata and uses it during graph/projection to keep empty branches ordered and visible. That solves the immediate UI problem, but the critique identified several flaws:
+
+- stale metadata after rename or external deletion
+- corrupt/cyclic metadata breaking workspace load
+- unsafe `HEAD` switching assumptions during checked-out branch deletion
+- projection behavior that can preserve too much or rely on metadata that was not actually materialized
+- split checkout/delete logic across legacy and newer API surfaces
+- insufficient API and e2e coverage for reloads, rename, divergence, corruption, and checked-out deletion variants
+
+The plan below breaks the work into PR-sized phases with narrow review surfaces.
+
+## Phase 0: Baseline And Scope Lock
+
+### Purpose
+
+Make the current branch easy to review before changing behavior further.
+
+### Scope
+
+- Keep existing implementation changes unamended until inspected.
+- Capture the current failing/passing validation state.
+- Confirm the minimum user-visible flows this feature must support:
+  - create empty branch above/below another empty branch
+  - remove empty branch from top/middle/bottom of an ordered stack
+  - reload and preserve order
+  - rename ordered branch without losing order
+  - tolerate external branch deletion
+
+### Tests / Validation
+
+- Re-run the already targeted Rust tests.
+- Re-run the targeted Playwright single-branch tests.
+- Record known unrelated `@gitbutler/e2e` TypeScript caveat if still present.
+
+### Non-Goals
+
+- No new APIs.
+- No frontend migration.
+- No metadata schema change unless required by later phases.
+
+### Review Boundary
+
+This can be a documentation-only PR or an internal checkpoint before implementation PRs.
+
+## Phase 1: Harden Metadata Loading And Failure Behavior
+
+### Purpose
+
+Make existing `branch_order` metadata safe to read. This should land before expanding API usage.
+
+### Scope
+
+- Treat cyclic/corrupt branch-order chains as invalid ordering, not as fatal workspace-load errors.
+- Tolerate missing refs in an order chain.
+- Ensure stale rows do not cause graph/projection construction to fail.
+- Add logging/tracing where helpful so corruption can be diagnosed without breaking the UI.
+
+### Candidate Code Areas
+
+- `crates/but-db/src/table/branch_order.rs`
+- `crates/but-graph/src/init/post.rs`
+- `crates/but-graph/src/projection/workspace/init.rs`
+
+### Tests
+
+- `but-db` or `but-workspace` test: cycle in `branch_order` degrades to no order.
+- `but-workspace` test: ordered ref missing from Git does not fail workspace load.
+- `but-workspace` test: externally deleted middle branch produces a stable remaining projection.
+- Optional snapshot/assertion: no phantom branch is shown when only metadata remains.
+
+### Validation
+
+- `cargo test -p but-db`
+- targeted `cargo test -p but-workspace`
+- `cargo check -p but-db -p but-graph -p but-workspace`
+- `cargo clippy -p but-db -p but-graph -p but-workspace --all-targets`
+- `cargo fmt --check`
+
+### Non-Goals
+
+- Do not add rename support yet.
+- Do not introduce new API endpoints.
+- Do not change frontend behavior.
+
+### Review Boundary
+
+Reviewers should only need to answer: "Can invalid metadata still break workspace load?"
+
+## Phase 2: Reconcile Metadata With Git Refs
+
+### Purpose
+
+Define and implement what happens when Git refs change outside the metadata writer.
+
+### Scope
+
+- Add a reconciliation or garbage-collection path for `branch_order`.
+- Remove or ignore rows for refs that no longer exist.
+- Decide whether reconciliation happens:
+  - opportunistically during metadata read,
+  - explicitly during workspace load,
+  - or through a metadata maintenance call.
+- Ensure reconciliation is conservative and does not delete valid order when refs are temporarily unavailable.
+
+### Candidate Code Areas
+
+- `crates/but-db/src/table/branch_order.rs`
+- metadata abstraction around `BranchOrderMetadata`
+- workspace/graph initialization code that already has access to real refs
+
+### Tests
+
+- External deletion of top/middle/bottom ordered branch.
+- Cold reload after external deletion.
+- Stale lower-bound row does not keep unrelated empty branches alive.
+- Multiple independent stale chains do not affect the active stack.
+
+### Validation
+
+- targeted `but-db` tests
+- targeted `but-workspace` tests
+- `cargo check -p but-db -p but-workspace -p but-graph`
+- `cargo clippy -p but-db -p but-workspace -p but-graph --all-targets`
+- `cargo fmt --check`
+
+### Non-Goals
+
+- No UI changes.
+- No rename API yet, except possibly low-level helper tests that make rename support possible.
+
+### Review Boundary
+
+Reviewers should only need to answer: "Does metadata stay harmless and eventually clean when Git refs disappear?"
+
+## Phase 3: Rename-Safe Branch Order
+
+### Purpose
+
+Fix the known data-integrity bug where renaming an ordered ad-hoc branch leaves stale branch-order rows behind.
+
+### Scope
+
+- Add a metadata operation for ref rename, for example `rename_reference(old, new)`.
+- Update all rows where either `branch_ref_name` or `parent_ref_name` matches the old full ref name.
+- Ensure rename preserves order for top, middle, bottom, and checked-out branches.
+- Wire the existing rename path to update branch-order metadata.
+
+### Candidate Code Areas
+
+- `crates/but-db/src/table/branch_order.rs`
+- `crates/but-action/src/rename_branch.rs`
+- related metadata trait/adapter code
+
+### Tests
+
+- Rename top branch in ordered stack.
+- Rename middle branch in ordered stack.
+- Rename bottom branch in ordered stack.
+- Cold reload after rename preserves order.
+- Rename of an unordered branch does not create metadata.
+- Rename collision/error path does not partially rewrite metadata.
+
+### Validation
+
+- targeted `but-action` or integration tests around rename
+- targeted `but-workspace` reload/projection tests
+- `cargo check -p but-action -p but-workspace -p but-db`
+- `cargo clippy -p but-action -p but-workspace -p but-db --all-targets`
+- `cargo fmt --check`
+
+### Non-Goals
+
+- Do not introduce the new non-legacy rename API in this phase unless the existing path cannot be fixed cleanly.
+- Do not migrate frontend rename calls.
+
+### Review Boundary
+
+Reviewers should only need to answer: "Does branch-order metadata remain correct after existing rename operations?"
+
+## Phase 4: Projection Semantics And Stack Scoping
+
+### Purpose
+
+Make graph/projection behavior consistently informed by valid branch-order metadata, without cross-chain leakage.
+
+### Scope
+
+- Scope preserved empty segments to the active ad-hoc stack/order, not every known order.
+- Only let metadata affect projection when the ordered chain is valid enough to materialize.
+- Ensure success criteria for branch creation/removal match projected workspace state, not only raw graph node presence.
+- Clarify diverged-chain behavior:
+  - same-tip refs may be ordered as empty branches
+  - diverged refs should not be forced into the same empty stack
+  - invalid order should degrade to normal placement
+
+### Candidate Code Areas
+
+- `crates/but-graph/src/init/post.rs`
+- `crates/but-graph/src/projection/workspace/init.rs`
+- `crates/but-workspace/src/branch/create_reference.rs`
+- branch remove/reference tests under `crates/but-workspace/tests`
+
+### Tests
+
+- Same-tip ordered empty stack projects in persisted order.
+- Diverged branch in the chain does not get forced into the empty stack.
+- Multiple independent chains do not keep each other's empty segments alive.
+- Create-reference success requires the new ref to appear in projected workspace output.
+- Cold reload preserves the same projected order.
+
+### Validation
+
+- targeted `cargo test -p but-graph`
+- targeted `cargo test -p but-workspace`
+- `cargo check -p but-graph -p but-workspace`
+- `cargo clippy -p but-graph -p but-workspace --all-targets`
+- `cargo fmt --check`
+
+### Non-Goals
+
+- No frontend changes.
+- No API migration.
+- No new storage format unless existing metadata cannot support correct scoping.
+
+### Review Boundary
+
+Reviewers should only need to answer: "Does projection preserve exactly the ordered empty branches it should, and no more?"
+
+## Phase 5: Shared Checkout And Checked-Out Deletion Primitive
+
+### Purpose
+
+Centralize the logic for changing the checked-out branch during create/remove operations.
+
+### Scope
+
+- Introduce one shared backend helper for safe checked-out ref replacement.
+- Require same-commit replacement for symbolic `HEAD` updates.
+- Use a real checkout, or reject the operation, when replacement points at a different commit.
+- Define replacement policy for deletion:
+  - top deletion prefers next branch below
+  - middle deletion prefers below, unless policy chooses nearest surviving branch
+  - bottom deletion prefers branch above
+- Define oplog/undo expectations for create+checkout and remove+checkout.
+
+### Candidate Code Areas
+
+- `crates/but-api/src/legacy/stack.rs`
+- `crates/but-api/src/branch.rs`
+- possible shared helper in `but-workspace` or a lower-level crate
+- `crates/but-core/src/repo_ext.rs`
+
+### Tests
+
+- Delete checked-out top branch.
+- Delete checked-out middle branch.
+- Delete checked-out bottom branch.
+- Replacement at same commit updates `HEAD` without worktree diff.
+- Replacement at different commit is rejected or performs a real checkout, depending on chosen policy.
+- Dirty worktree behavior is explicit and tested.
+
+### Validation
+
+- targeted `cargo test -p but-api`
+- targeted `cargo test -p but-workspace`
+- `cargo check -p but-api -p but-workspace -p but-core`
+- `cargo clippy -p but-api -p but-workspace -p but-core --all-targets`
+- `cargo fmt --check`
+
+### Non-Goals
+
+- Do not add new public branch APIs in this phase.
+- Do not migrate frontend calls yet.
+
+### Review Boundary
+
+Reviewers should only need to answer: "Is checked-out branch movement safe, consistent, and tested?"
+
+## Phase 6: Non-Legacy Rename API
+
+### Purpose
+
+Add the first modern API that is explicitly compatible with single-branch ad-hoc metadata.
+
+### Scope
+
+- Add or update a non-legacy rename API.
+- Use the rename-safe metadata operation from Phase 3.
+- Use shared checkout behavior if renaming the checked-out branch needs it.
+- Return enough workspace/head state for the frontend to update consistently.
+
+### Tests
+
+- API rename preserves ordered stack.
+- API rename checked-out branch preserves `HEAD`.
+- API rename followed by cold reload preserves order.
+- API rename fails cleanly on collision without partial metadata changes.
+
+### Validation
+
+- targeted `cargo test -p but-api`
+- `cargo check -p but-api`
+- `cargo clippy -p but-api --all-targets`
+- `cargo fmt --check`
+
+### Non-Goals
+
+- Do not migrate every frontend rename call unless the API is ready and the diff stays small.
+- Do not add remove/create API changes here.
+
+### Review Boundary
+
+Reviewers should only need to answer: "Is the new rename API correct for ordered single-branch stacks?"
+
+## Phase 7: Non-Legacy Remove API
+
+### Purpose
+
+Add a modern remove API that safely handles ordered ad-hoc branches and checked-out deletion.
+
+### Scope
+
+- Add or update a non-legacy remove/delete branch API.
+- Use the shared checked-out deletion primitive from Phase 5.
+- Remove or reconcile branch-order metadata atomically enough for the current storage design.
+- Return projected workspace/head state after deletion.
+
+### Tests
+
+- Remove top/middle/bottom ordered empty branch through API.
+- Remove checked-out top/middle/bottom ordered empty branch through API.
+- Remove unordered branch does not mutate unrelated order.
+- Failure after `HEAD` replacement or metadata update is handled or documented.
+
+### Validation
+
+- targeted `cargo test -p but-api`
+- targeted `cargo test -p but-workspace`
+- `cargo check -p but-api -p but-workspace`
+- `cargo clippy -p but-api -p but-workspace --all-targets`
+- `cargo fmt --check`
+
+### Non-Goals
+
+- No frontend migration unless kept to a separate very small PR.
+- No remote branch handling.
+
+### Review Boundary
+
+Reviewers should only need to answer: "Does the new remove API update Git, metadata, HEAD, and projected state consistently?"
+
+## Phase 8: Non-Legacy Create / Move / Remote APIs
+
+### Purpose
+
+Expand modern API coverage after metadata, projection, rename, remove, and checkout semantics are already hardened.
+
+### Scope
+
+- Add or update create branch API for single-branch ad-hoc ordering.
+- Add move/reorder support if it is user-facing and needed for the feature.
+- Add remote-related API behavior only after local ordering semantics are stable.
+- Ensure all APIs share the same metadata writer and checkout primitive.
+
+### Tests
+
+- Create above/below same-tip empty branch.
+- Create below an empty branch between empty branches.
+- Create with checkout-after-create.
+- Move/reorder existing ordered branches, if supported.
+- Remote branch behavior, if added:
+  - applying remote branch does not corrupt local ad-hoc order
+  - deleting/renaming local branch with upstream metadata is safe
+
+### Validation
+
+- targeted `cargo test -p but-api`
+- targeted `cargo test -p but-workspace`
+- `cargo check -p but-api -p but-workspace -p but-graph`
+- `cargo clippy -p but-api -p but-workspace -p but-graph --all-targets`
+- `cargo fmt --check`
+
+### Non-Goals
+
+- Do not combine all create/move/remote work if each can stand alone.
+- Prefer one operation per PR if the implementation is not obviously mechanical.
+
+### Review Boundary
+
+Reviewers should only need to answer: "Does this specific new API operation preserve the established invariants?"
+
+## Phase 9: Frontend Migration And Cache Invalidation
+
+### Purpose
+
+Move the desktop app to the hardened API surface with minimal behavioral changes.
+
+### Scope
+
+- Replace legacy calls one flow at a time.
+- Keep branch-header create semantics explicit:
+  - `Anchor::AtReference` for same-tip empty branch ordering
+  - preserve managed-workspace behavior if it still requires `AtSegment`
+- Tighten cache invalidation to the minimum needed after each operation.
+- Remove dead props/helpers exposed by the earlier branch-header changes.
+
+### Candidate Code Areas
+
+- `apps/desktop/src/components/branch/BranchHeaderContextMenu.svelte`
+- `apps/desktop/src/lib/stacks/stackEndpoints.ts`
+- any branch rename/remove/create frontend API wrappers
+
+### Tests
+
+- Unit or component tests if existing patterns support them.
+- Prettier check for touched Svelte/TS files.
+- TypeScript check where possible, documenting unrelated known failures if still present.
+
+### Validation
+
+- `corepack pnpm exec prettier --check <touched files>`
+- targeted package typecheck if available
+- targeted Playwright smoke tests for migrated flows
+
+### Non-Goals
+
+- Do not add broad e2e coverage in the same PR if API migration is already non-trivial.
+- Do not redesign branch UI.
+
+### Review Boundary
+
+Reviewers should only need to answer: "Did the frontend switch to the new safe API without changing unrelated UI behavior?"
+
+## Phase 10: Playwright E2E Coverage
+
+### Purpose
+
+Verify the user-visible Tauri app behavior after backend invariants and frontend calls are stable.
+
+### Scope
+
+- Add Playwright tests for primary single-branch empty-stack flows.
+- Keep tests focused on user-visible outcomes:
+  - branch appears in the expected order
+  - branch is removed
+  - checked-out branch changes when expected
+  - order survives reload/reopen
+
+### Tests
+
+- Add branch below an empty branch between empty branches.
+- Remove empty branch from top of two-branch stack.
+- Remove empty branch from middle of three-branch stack.
+- Remove empty branch from bottom of two-branch stack.
+- Rename ordered empty branch.
+- Delete checked-out top/middle/bottom empty branch.
+- Reload/reopen app preserves ordered stack.
+- Optional dirty-worktree scenario if the UI permits the operation.
+
+### Validation
+
+- targeted Playwright run for the new single-branch tests
+- rebuild `but-server` before Playwright when backend changed
+- `corepack pnpm exec prettier --check <touched e2e files>`
+- document existing `tsc --noEmit` caveat if unchanged
+
+### Non-Goals
+
+- Do not use Playwright to prove low-level corruption behavior.
+- Do not combine with backend correctness changes.
+
+### Review Boundary
+
+Reviewers should only need to answer: "Does the app behave correctly for the supported single-branch workflows?"
+
+## Suggested PR Grouping
+
+If we want the fewest PRs while staying reviewable:
+
+1. Metadata hardening and reconciliation: Phases 1-2.
+2. Rename-safe metadata: Phase 3.
+3. Projection correctness: Phase 4.
+4. Shared checkout/delete primitive: Phase 5.
+5. New APIs, split by operation: Phases 6-8, likely 2-3 PRs.
+6. Frontend migration: Phase 9.
+7. Playwright coverage: Phase 10.
+
+If we want maximum review clarity:
+
+1. Phase 1 only.
+2. Phase 2 only.
+3. Phase 3 only.
+4. Phase 4 only.
+5. Phase 5 only.
+6. Phase 6 only.
+7. Phase 7 only.
+8. Phase 8 split into create, move, and remote PRs.
+9. Phase 9 only.
+10. Phase 10 only.
+
+## Cross-Phase Design Decisions
+
+These should be decided before or during the first implementation PR that needs them:
+
+- Should invalid branch-order metadata be deleted immediately, or ignored until explicit GC?
+- Should checked-out deletion prefer the branch below, above, or nearest surviving ordered branch?
+- Should different-commit replacement perform a real checkout or reject the operation?
+- Should metadata writes be best-effort, transactional with DB only, or compensated when Git operations succeed and DB operations fail?
+- Should `branch_order` store full ref names permanently, or eventually use a more resilient identifier?
+- Should managed workspaces continue using `Anchor::AtSegment` while ad-hoc branch-header flows use `Anchor::AtReference`?
+
+## General Validation Gate Per Backend PR
+
+Use the narrowest package set that covers touched code, but the expected baseline is:
+
+- `cargo fmt --check`
+- targeted `cargo test`
+- targeted `cargo check`
+- targeted `cargo clippy --all-targets`
+
+For PRs touching the Tauri app or e2e tests:
+
+- rebuild `but-server` when backend behavior changed
+- targeted Playwright run
+- Prettier check for touched Svelte/TypeScript files
+- TypeScript check when the package gate is healthy, otherwise document known unrelated failures
+
+## Landing Strategy
+
+Prefer landing the safety phases before feature expansion:
+
+1. Make metadata harmless.
+2. Make metadata consistent.
+3. Make projection precise.
+4. Make checkout/delete shared and safe.
+5. Add modern APIs.
+6. Migrate UI.
+7. Prove the full user journey with e2e tests.
+
+This keeps each review centered on one question and avoids turning a UI ordering feature into a single high-risk backend migration.


### PR DESCRIPTION
## Summary

- persist ad-hoc single-branch stack order in a dedicated `branch_order` project DB table
- model the order as refname parent pointers, without stack IDs or legacy virtual branch rows
- keep the metadata API backed by legacy TOML for existing workspace data, but read and write branch order through the DB
- preserve empty dependent branches above integrated lower branches during create and upstream-integration flows

## Why

Single-branch mode needs to support dependent branches even when a newly-created dependent branch is empty and points at the same commit as the branch below it. Git alone cannot distinguish the intended top-to-bottom order for same-tip refs, so GitButler needs durable metadata for explicit GitButler-created ordering.

This version keeps that metadata self-contained in the project database. Each row stores one branch ref and its parent ref; a branch with no parent is the bottom of its stack. Looking up any branch walks child links upward and parent links downward to recover the full tip-to-base order.

## Notes

- This avoids reusing `virtual_branches.toml` or existing legacy DB tables for new ordering metadata.
- No stack ID is stored. The relationship graph itself defines the stack.
- Removing a branch from the metadata splices its child directly to its parent, preserving the remaining order.
- Externally-created same-tip refs remain ambiguous; V1 only records explicit GitButler-created dependent branch ordering.

## Validation

- `cargo fmt`
- `cargo test -p but-db branch_order`
- `cargo check -p but-meta -p but-ctx -p but-workspace`
- `cargo test -p but-workspace at_reference_in_ad_hoc_workspace_orders_local_branches_only`
- `cargo test -p but-workspace ad_hoc_reference_above_checked_out_branch_becomes_empty_top_segment`
- `cargo test -p but-workspace integrated_bottom_empty_top_no_workspace_rebase`
- `corepack pnpm --filter @gitbutler/e2e exec playwright test --config ./playwright/playwright.config.ts --tsconfig ./playwright/tsconfig.json playwright/tests/singleBranch/commitActions.spec.ts playwright/tests/singleBranch/upstreamIntegration.spec.ts -g "can create an empty dependent branch above the checked-out branch and commit to it|keeps an empty top branch when the checked-out lower branch is integrated"`

