### PR TITLE
test(but): reproduce commit failure on move + directory creation

### DIFF
--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -4,6 +4,22 @@ use super::util;
 use crate::utils::Sandbox;
 
 #[test]
+fn commit_moved_file_replaced_by_directory() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    std::fs::rename(env.projects_root().join("A"), env.projects_root().join("B")).unwrap();
+    env.file("A/file", "some other stuff");
+
+    env.but("commit -m 'Commit everything'").assert().success();
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#""#]]);
+}
+
+#[test]
 fn commit_with_message_from_file() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     insta::assert_snapshot!(env.git_log(), @"


### PR DESCRIPTION
## 🧢 Changes
Test case that reproduces a failure to commit when a file is moved and the file's original path is replaced with a directory. The end result is that the directory is removed (including any content) and committing crashes with an error message.