### PR TITLE
feat(but): prepend but-2 commands with `_` to reduce discoverability

### DIFF
--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -258,13 +258,13 @@ pub enum Subcommands {
 
     #[cfg(all(feature = "legacy", feature = "but-2"))]
     #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
-    #[clap(hide = true)]
-    Commit2(commit2::Platform),
+    #[clap(hide = true, name = "_commit2")]
+    _Commit2(commit2::Platform),
 
     #[cfg(all(feature = "legacy", feature = "but-2"))]
     #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
-    #[clap(hide = true)]
-    Squash2(squash2::Platform),
+    #[clap(hide = true, name = "_squash2")]
+    _Squash2(squash2::Platform),
 
     /// Stages a file or hunk to a specific branch.
     ///

--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -88,7 +88,7 @@ fn print_grouped_with_truncation(
                 #[cfg(feature = "legacy")]
                 SubcommandDiscriminant::Commit => Group::BranchingAndCommitting,
                 #[cfg(all(feature = "legacy", feature = "but-2"))]
-                SubcommandDiscriminant::Commit2 => Group::BranchingAndCommitting,
+                SubcommandDiscriminant::_Commit2 => Group::BranchingAndCommitting,
                 #[cfg(feature = "legacy")]
                 SubcommandDiscriminant::Stage => Group::BranchingAndCommitting,
                 SubcommandDiscriminant::Branch => Group::BranchingAndCommitting,
@@ -135,7 +135,7 @@ fn print_grouped_with_truncation(
                 #[cfg(feature = "legacy")]
                 SubcommandDiscriminant::Squash => Group::EditingCommits,
                 #[cfg(all(feature = "legacy", feature = "but-2"))]
-                SubcommandDiscriminant::Squash2 => Group::EditingCommits,
+                SubcommandDiscriminant::_Squash2 => Group::EditingCommits,
                 SubcommandDiscriminant::Move => Group::EditingCommits,
 
                 #[cfg(feature = "legacy")]

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -1097,7 +1097,7 @@ async fn match_subcommand(
             result
         }
         #[cfg(all(feature = "legacy", feature = "but-2"))]
-        Subcommands::Commit2(commit_args) => {
+        Subcommands::_Commit2(commit_args) => {
             use crate::utils::{IntermediateChannel, OutputChannelExt};
 
             let status_after = args.status_after;
@@ -1121,7 +1121,7 @@ async fn match_subcommand(
             Ok(())
         }
         #[cfg(all(feature = "legacy", feature = "but-2"))]
-        Subcommands::Squash2(squash_args) => {
+        Subcommands::_Squash2(squash_args) => {
             use crate::utils::{IntermediateChannel, OutputChannelExt};
 
             let status_after = args.status_after;

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -130,7 +130,7 @@ impl Subcommands {
                 Some(crate::args::commit::Subcommands::Empty { .. }) => CommitEmpty,
             },
             #[cfg(all(feature = "legacy", feature = "but-2"))]
-            Subcommands::Commit2(..) => Commit2,
+            Subcommands::_Commit2(..) => Commit2,
             #[cfg(feature = "legacy")]
             Subcommands::Push(_) => Push,
             #[cfg(feature = "legacy")]
@@ -210,7 +210,7 @@ impl Subcommands {
             #[cfg(feature = "legacy")]
             Subcommands::Squash { .. } => Squash,
             #[cfg(all(feature = "legacy", feature = "but-2"))]
-            Subcommands::Squash2(..) => Squash2,
+            Subcommands::_Squash2(..) => Squash2,
             #[cfg(feature = "legacy")]
             Subcommands::Merge { .. } => Merge,
             Subcommands::Move { .. } => Move,

--- a/crates/but/tests/but/command/commit2.rs
+++ b/crates/but/tests/but/command/commit2.rs
@@ -5,7 +5,7 @@ fn no_message_nothing_to_commit() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.setup_metadata(&["A"]);
 
-    env.but("commit2 --no-message").assert().success();
+    env.but("_commit2 --no-message").assert().success();
 
     env.but("status")
         .assert()
@@ -32,7 +32,7 @@ fn no_args_single_head_no_message_human_output() {
 
     env.file("file.txt", "Some text");
 
-    env.but("commit2 --no-message")
+    env.but("_commit2 --no-message")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -65,7 +65,7 @@ fn no_args_single_head_no_message_shell_output() {
 
     env.file("file.txt", "Some text");
 
-    env.but("commit2 --no-message --format shell")
+    env.but("_commit2 --no-message --format shell")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -81,7 +81,7 @@ fn no_args_single_head_no_message_json_output() {
 
     env.file("file.txt", "Some text");
 
-    env.but("commit2 --no-message --format json")
+    env.but("_commit2 --no-message --format json")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -104,7 +104,7 @@ fn no_args_single_head_message_from_editor() {
 
     env.file("file.txt", "Some text");
 
-    env.but("commit2")
+    env.but("_commit2")
         .env("GIT_EDITOR", editor_command)
         .assert()
         .success();
@@ -134,7 +134,7 @@ fn single_head_with_message() {
 
     env.file("file.txt", "Some text");
 
-    env.but("commit2 -m 'add file.txt'").assert().success();
+    env.but("_commit2 -m 'add file.txt'").assert().success();
 
     env.but("status")
         .assert()
@@ -161,7 +161,7 @@ fn can_repeat_message() {
 
     env.file("file.txt", "Some text");
 
-    env.but("commit2 -m 'add file.txt' -m 'with more' -m 'text lines'")
+    env.but("_commit2 -m 'add file.txt' -m 'with more' -m 'text lines'")
         .assert()
         .success();
 
@@ -217,7 +217,7 @@ fn editor_user_writes_no_message() {
 
     env.file("file.txt", "Some text");
 
-    env.but("commit2")
+    env.but("_commit2")
         .env("GIT_EDITOR", editor_command)
         .assert()
         .success();
@@ -251,7 +251,7 @@ fn editor_fails() {
 
     env.file("file.txt", "Some text");
 
-    env.but("commit2")
+    env.but("_commit2")
         .env("GIT_EDITOR", editor_command)
         .assert()
         .failure()
@@ -269,7 +269,7 @@ fn create_commit_on_new_branch() {
 
     env.file("file.txt", "Some text");
 
-    env.but("commit2 --no-message").assert().success();
+    env.but("_commit2 --no-message").assert().success();
 
     env.but("status")
         .assert()
@@ -295,7 +295,9 @@ fn create_commit_on_user_provided_branch() {
 
     env.file("first", "Some text");
 
-    env.but("commit2 -m 'add first' -b file").assert().success();
+    env.but("_commit2 -m 'add first' -b file")
+        .assert()
+        .success();
 
     env.but("status")
         .assert()
@@ -315,7 +317,7 @@ Hint: run `but help` for all commands
 
     env.file("second", "change file");
 
-    env.but("commit2 -m 'add second' -b file")
+    env.but("_commit2 -m 'add second' -b file")
         .assert()
         .success();
 
@@ -338,7 +340,7 @@ Hint: run `but help` for all commands
 
     env.file("third", "change file");
 
-    env.but("commit2 -m 'add third' -b other")
+    env.but("_commit2 -m 'add third' -b other")
         .assert()
         .success();
 
@@ -365,7 +367,7 @@ Hint: run `but help` for all commands
 
     env.file("fourth", "change file");
 
-    env.but("commit2 -m 'add fourth' -b other")
+    env.but("_commit2 -m 'add fourth' -b other")
         .assert()
         .success();
 
@@ -399,7 +401,7 @@ fn create_commit_on_new_branch_with_canned_name() {
 
     env.file("file.txt", "Some text");
 
-    env.but("commit2 -m 'add file.txt' -b").assert().success();
+    env.but("_commit2 -m 'add file.txt' -b").assert().success();
 
     env.but("status")
         .assert()
@@ -431,7 +433,7 @@ fn create_commit_on_branch_that_is_not_applied_fails() {
 
     env.file("first", "Some text");
 
-    env.but("commit2 -m 'add first' -b existing")
+    env.but("_commit2 -m 'add first' -b existing")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
@@ -449,11 +451,11 @@ fn bails_on_rejected_specs() {
 
     env.file("first", "Some text");
 
-    env.but("commit2 -m 'add first' -b foo").assert().success();
+    env.but("_commit2 -m 'add first' -b foo").assert().success();
 
     env.file("first", "changes");
 
-    env.but("commit2 -m 'add first' -b bar")
+    env.but("_commit2 -m 'add first' -b bar")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
@@ -469,7 +471,7 @@ fn newly_created_branches_are_included_in_json_output() {
 
     env.file("first", "Some text");
 
-    env.but("commit2 -m 'add first' -b foo --format json")
+    env.but("_commit2 -m 'add first' -b foo --format json")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -491,7 +493,7 @@ fn empty_flag_to_force_empty_commit_when_changes_exist() {
         "Some changes that will not be included in commit",
     );
 
-    env.but("commit2 -m 'empty commit despite changes in worktree' --empty")
+    env.but("_commit2 -m 'empty commit despite changes in worktree' --empty")
         .assert()
         .success();
 
@@ -535,7 +537,7 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("commit2 --no-message --above fe")
+    env.but("_commit2 --no-message --above fe")
         .assert()
         .success();
 
@@ -580,7 +582,7 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("commit2 --no-message --below fe")
+    env.but("_commit2 --no-message --below fe")
         .assert()
         .success();
 
@@ -628,7 +630,7 @@ Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage 
 
 "#]]);
 
-    env.but("commit2 -m 'add file.txt' --above fe")
+    env.but("_commit2 -m 'add file.txt' --above fe")
         .assert()
         .success();
 
@@ -675,7 +677,7 @@ Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage 
 
 "#]]);
 
-    env.but("commit2 -m 'add file.txt' --above g0")
+    env.but("_commit2 -m 'add file.txt' --above g0")
         .assert()
         .success();
 
@@ -724,7 +726,7 @@ Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage 
 
 "#]]);
 
-    env.but("commit2 -m 'add file.txt' --below fe")
+    env.but("_commit2 -m 'add file.txt' --below fe")
         .assert()
         .success();
 
@@ -771,7 +773,7 @@ Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage 
 
 "#]]);
 
-    env.but("commit2 -m 'add file.txt' --below g0")
+    env.but("_commit2 -m 'add file.txt' --below g0")
         .assert()
         .success();
 
@@ -820,7 +822,7 @@ Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage 
 
 "#]]);
 
-    env.but("commit2 -m 'add file.txt' --below g0")
+    env.but("_commit2 -m 'add file.txt' --below g0")
         .assert()
         .success();
 
@@ -869,7 +871,7 @@ Hint: run `but help` for all commands
 
     env.file("second", "Conflicting with commit 9ac4652");
 
-    env.but("commit2 -m 'add second' --above fe")
+    env.but("_commit2 -m 'add second' --above fe")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
@@ -902,7 +904,7 @@ Hint: run `but help` for all commands
 
     env.file("second", "Conflicting with commit 9ac4652");
 
-    env.but("commit2 -m 'add second' --below 9a")
+    env.but("_commit2 -m 'add second' --below 9a")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
@@ -916,13 +918,13 @@ fn refuses_above_and_below() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
     env.setup_metadata(&["A"]);
 
-    env.but("commit2 --above dontcare --below dontcare")
+    env.but("_commit2 --above dontcare --below dontcare")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
 error: the argument '--above <BRANCH_OR_COMMIT>' cannot be used with '--below <BRANCH_OR_COMMIT>'
 
-Usage: but commit2 --above <BRANCH_OR_COMMIT> [CHANGES]...
+Usage: but _commit2 --above <BRANCH_OR_COMMIT> [CHANGES]...
 
 For more information, try '--help'.
 
@@ -934,13 +936,13 @@ fn refuses_above_and_branch() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
     env.setup_metadata(&["A"]);
 
-    env.but("commit2 --above dontcare -b")
+    env.but("_commit2 --above dontcare -b")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
 error: the argument '--above <BRANCH_OR_COMMIT>' cannot be used with '--branch [<BRANCH>]'
 
-Usage: but commit2 --above <BRANCH_OR_COMMIT> [CHANGES]...
+Usage: but _commit2 --above <BRANCH_OR_COMMIT> [CHANGES]...
 
 For more information, try '--help'.
 
@@ -952,13 +954,13 @@ fn refuses_below_and_branch() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
     env.setup_metadata(&["A"]);
 
-    env.but("commit2 --below dontcare -b")
+    env.but("_commit2 --below dontcare -b")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
 error: the argument '--below <BRANCH_OR_COMMIT>' cannot be used with '--branch [<BRANCH>]'
 
-Usage: but commit2 --below <BRANCH_OR_COMMIT> [CHANGES]...
+Usage: but _commit2 --below <BRANCH_OR_COMMIT> [CHANGES]...
 
 For more information, try '--help'.
 
@@ -972,7 +974,7 @@ fn above_branch_not_in_workspace_returns_bad_input() {
 
     env.but("unapply B").assert().success();
 
-    env.but("commit2 --above B")
+    env.but("_commit2 --above B")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
@@ -1010,7 +1012,7 @@ Hint: run `but help` for all commands
 
     env.but("unapply B").assert().success();
 
-    env.but("commit2 --above d3")
+    env.but("_commit2 --above d3")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
@@ -1026,7 +1028,7 @@ fn above_non_branch_non_commit_target_returns_bad_input() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
     env.setup_metadata(&[]);
 
-    env.but("commit2 --above zz")
+    env.but("_commit2 --above zz")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
@@ -1063,7 +1065,7 @@ Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage 
 
 "#]]);
 
-    env.but("commit2 --no-message kl").assert().success();
+    env.but("_commit2 --no-message kl").assert().success();
 
     env.but("status -f")
         .assert()
@@ -1095,7 +1097,7 @@ fn hunks_within_file_are_not_order_dependent() {
 
     env.file("file", original_data);
 
-    env.but("commit2 --no-message").assert().success();
+    env.but("_commit2 --no-message").assert().success();
 
     env.file("file", format!("first hunk\n{original_data}\nlast hunk"));
 
@@ -1120,7 +1122,7 @@ j0 file│
 
 "#]]);
 
-    env.but("commit2 --no-message i0 j0").assert().success();
+    env.but("_commit2 --no-message i0 j0").assert().success();
 
     env.but("status -f")
         .assert()
@@ -1145,7 +1147,7 @@ Hint: run `but help` for all commands
 
     env.but("undo").assert().success();
 
-    env.but("commit2 --no-message j0 i0").assert().success();
+    env.but("_commit2 --no-message j0 i0").assert().success();
 
     env.but("status -f")
         .assert()
@@ -1178,7 +1180,7 @@ fn overlapping_changes_to_modified_file_are_deduplicated() {
 
     env.file("file", original_data);
 
-    env.but("commit2 --no-message").assert().success();
+    env.but("_commit2 --no-message").assert().success();
 
     env.file("file", format!("first hunk\n{original_data}\nlast hunk"));
 
@@ -1203,7 +1205,7 @@ j0 file│
 
 "#]]);
 
-    env.but("commit2 --no-message i0 j0 i0").assert().success();
+    env.but("_commit2 --no-message i0 j0 i0").assert().success();
 
     env.but("status -f")
         .assert()
@@ -1228,7 +1230,7 @@ Hint: run `but help` for all commands
 
     env.but("undo").assert().success();
 
-    env.but("commit2 --no-message file j0").assert().success();
+    env.but("_commit2 --no-message file j0").assert().success();
 
     env.but("status -f")
         .assert()
@@ -1257,7 +1259,7 @@ fn committing_something_that_isnt_a_cli_id() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.setup_metadata(&["A"]);
 
-    env.but("commit2 --no-message A")
+    env.but("_commit2 --no-message A")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
@@ -1294,7 +1296,7 @@ Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage 
 
 "#]]);
 
-    env.but("commit2 path/to/ --no-message").assert().success();
+    env.but("_commit2 path/to/ --no-message").assert().success();
 
     env.but("status -f")
         .assert()
@@ -1327,7 +1329,7 @@ fn path_prefix_with_mix_of_modifications() {
     env.file("dir/to_delete.txt", "second");
     env.file("dir/to_empty.txt", "third");
 
-    env.but("commit2 --no-message").assert().success();
+    env.but("_commit2 --no-message").assert().success();
 
     std::fs::remove_file(env.projects_root().join("dir/to_delete.txt")).unwrap();
     env.file("dir/to_empty.txt", "");
@@ -1360,7 +1362,7 @@ Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage 
 
 "#]]);
 
-    env.but("commit2 dir/ --no-message").assert().success();
+    env.but("_commit2 dir/ --no-message").assert().success();
 
     env.but("status -f")
         .assert()
@@ -1413,7 +1415,7 @@ fn requires_specifying_stack_when_there_are_multiple() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
     env.setup_metadata(&["A", "B"]);
 
-    env.but("commit2 --empty --no-message")
+    env.but("_commit2 --empty --no-message")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
@@ -1432,7 +1434,7 @@ fn committing_above_an_empty_branch() {
     env.file("one", "one content");
 
     env.but("branch new top").assert().success();
-    env.but("commit2 one -m 'add one' --above top")
+    env.but("_commit2 one -m 'add one' --above top")
         .assert()
         .success();
 
@@ -1464,7 +1466,7 @@ fn committing_below_empty_branch_with_empty_branch_below() {
 
     env.but("branch new middle").assert().success();
     env.but("branch new --anchor middle top").assert().success();
-    env.but("commit2 one -m 'add one' --below top")
+    env.but("_commit2 one -m 'add one' --below top")
         .assert()
         .success();
 
@@ -1497,14 +1499,14 @@ fn committing_below_non_top_empty_branch() {
     env.file("one", "one content");
     env.file("two", "two content");
 
-    env.but("commit2 one -m 'add one' -b bottom")
+    env.but("_commit2 one -m 'add one' -b bottom")
         .assert()
         .success();
     env.but("branch new --anchor bottom middle")
         .assert()
         .success();
     env.but("branch new --anchor middle top").assert().success();
-    env.but("commit2 two -m 'add two' --below middle")
+    env.but("_commit2 two -m 'add two' --below middle")
         .assert()
         .success();
 
@@ -1559,7 +1561,7 @@ Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage 
 
 "#]]);
 
-    env.but("commit2 one -m 'add one' --below top")
+    env.but("_commit2 one -m 'add one' --below top")
         .assert()
         .success();
 
@@ -1584,7 +1586,7 @@ Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage 
 
     env.but("reword a-branch-1 -m bottom").assert().success();
 
-    env.but("commit2 two -m 'add two' --below top")
+    env.but("_commit2 two -m 'add two' --below top")
         .assert()
         .success();
 
@@ -1615,7 +1617,7 @@ fn gives_good_error_when_your_terminal_doesnt_support_input() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
     env.setup_metadata(&[]);
 
-    env.but("commit2 --interactive")
+    env.but("_commit2 --interactive")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"

--- a/crates/but/tests/but/command/squash2.rs
+++ b/crates/but/tests/but/command/squash2.rs
@@ -9,9 +9,9 @@ fn one_branch_three_commits() -> Sandbox {
     env.file("two", "content of two");
     env.file("three", "content of three");
 
-    env.but("commit2 -m 'add one' one").assert().success();
-    env.but("commit2 -m 'add two' two").assert().success();
-    env.but("commit2 -m 'add three' three").assert().success();
+    env.but("_commit2 -m 'add one' one").assert().success();
+    env.but("_commit2 -m 'add two' two").assert().success();
+    env.but("_commit2 -m 'add three' three").assert().success();
 
     env
 }
@@ -43,7 +43,7 @@ Hint: run `but help` for all commands
 
     // TODO(david): handle --message
 
-    env.but("squash2 f55169f --target f63361f --message 'squashed'")
+    env.but("_squash2 f55169f --target f63361f --message 'squashed'")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -73,7 +73,7 @@ Hint: run `but help` for all commands
 
     env.but("undo").assert().success();
 
-    env.but("squash2 f55169f --target f63361f --message 'squashed' --format json")
+    env.but("_squash2 f55169f --target f63361f --message 'squashed' --format json")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -85,7 +85,7 @@ Hint: run `but help` for all commands
 
     env.but("undo").assert().success();
 
-    env.but("squash2 f55169f --target f63361f --message 'squashed' --format shell")
+    env.but("_squash2 f55169f --target f63361f --message 'squashed' --format shell")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -98,7 +98,7 @@ Hint: run `but help` for all commands
 fn squash_multiple_sources() {
     let env = one_branch_three_commits();
 
-    env.but("squash2 f55169f f63361f --target ea345ba --message 'squashed'")
+    env.but("_squash2 f55169f f63361f --target ea345ba --message 'squashed'")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -130,7 +130,7 @@ Hint: run `but help` for all commands
 fn use_target_message() {
     let env = one_branch_three_commits();
 
-    env.but("squash2 f55169f --target f63361f --use-target-message")
+    env.but("_squash2 f55169f --target f63361f --use-target-message")
         .assert()
         .success();
 
@@ -161,7 +161,7 @@ Hint: run `but help` for all commands
 fn use_source_message() {
     let env = one_branch_three_commits();
 
-    env.but("squash2 f55169f --target f63361f --use-source-message")
+    env.but("_squash2 f55169f --target f63361f --use-source-message")
         .assert()
         .success();
 
@@ -192,7 +192,7 @@ Hint: run `but help` for all commands
 fn squash_whole_branch() {
     let env = one_branch_three_commits();
 
-    env.but("squash2 a-branch-1 -m 'squashed a branch'")
+    env.but("_squash2 a-branch-1 -m 'squashed a branch'")
         .assert()
         .success()
         .stdout_eq(snapbox::str![["
@@ -232,7 +232,7 @@ fn squash_reword_with_editor() {
     let editor_path = env.projects_root().join(".git/editor.sh");
     let editor_command = format!("sh {}", editor_path.display());
 
-    env.but("squash2 a-branch-1")
+    env.but("_squash2 a-branch-1")
         .env("GIT_EDITOR", editor_command)
         .assert()
         .success()
@@ -270,7 +270,7 @@ fn squash_combine_messages_with_editor() {
     let editor_path = env.projects_root().join(".git/editor.sh");
     let editor_command = format!("sh {}", editor_path.display());
 
-    env.but("squash2 a-branch-1")
+    env.but("_squash2 a-branch-1")
         .env("GIT_EDITOR", editor_command)
         .assert()
         .success()


### PR DESCRIPTION
We don't really want users to be playing around with the but-2 commands just yet, but unfoctunately they all show up in completions. By prepending the commands with `_`, which is an unusual character to type for a subcommand, we lessen the risk of users stumbling over them.