### PR TITLE
Lite: use translucent outline for tooltips

### DIFF
--- a/apps/lite/ui/src/components/Tooltip.module.css
+++ b/apps/lite/ui/src/components/Tooltip.module.css
@@ -3,8 +3,8 @@
 	align-items: center;
 	padding: 6px 8px;
 	gap: 8px;
-	border: 1px solid var(--border-3);
 	border-radius: var(--radius-m);
+	outline: 1px solid hsla(0, 0%, 0%, 0.1);
 	background-color: var(--bg-1);
 	box-shadow: var(--shadow-s);
 	color: var(--text-1);

--- a/apps/lite/ui/src/components/Tooltip.module.css
+++ b/apps/lite/ui/src/components/Tooltip.module.css
@@ -4,7 +4,7 @@
 	padding: 6px 8px;
 	gap: 8px;
 	border-radius: var(--radius-m);
-	outline: 1px solid hsla(0, 0%, 0%, 0.1);
+	outline: 1px solid color-mix(var(--scale-gray-0) 10%, transparent);
 	background-color: var(--bg-1);
 	box-shadow: var(--shadow-s);
 	color: var(--text-1);


### PR DESCRIPTION
I think this looks nicer, WDYT?

# Before

<img width="228" height="99" alt="Screenshot 2026-06-23 at 11 45 06" src="https://github.com/user-attachments/assets/c2e7116f-4730-49e8-8997-82106368abb5" />


# After


<img width="228" height="99" alt="Screenshot 2026-06-23 at 11 44 46" src="https://github.com/user-attachments/assets/d6cabadd-c097-4fbf-bace-31a68e0366d3" />
