### PR TITLE
Migrate but pull upstream integration

### DIFF
--- a/crates/but/src/command/legacy/pull/mod.rs
+++ b/crates/but/src/command/legacy/pull/mod.rs
@@ -2,13 +2,16 @@ mod json;
 
 use std::{collections::HashMap, fmt::Write};
 
-use but_core::{RepositoryExt, ref_metadata::StackId};
+use bstr::ByteSlice;
+use but_api::workspace::WorkspaceIntegrateUpstreamOutcome;
+use but_api::workspace::json::{BottomUpdate, BottomUpdateKind};
+use but_core::{DryRun, RepositoryExt};
 use but_ctx::Context;
-use gitbutler_branch_actions::upstream_integration::{
-    BranchStatus::{self, Conflicted, Empty, Integrated, SafelyUpdatable},
-    Resolution, ResolutionApproach,
-    StackStatuses::{UpToDate, UpdatesRequired},
-    UpstreamTreeStatus,
+use but_workspace::{
+    RefInfo,
+    branch::Stack,
+    ref_info::{LocalCommitRelation, Segment},
+    ui::PushStatus,
 };
 use json::{BaseBranchInfo, BranchStatusInfo, PullCheckOutput, UpstreamCommit, UpstreamInfo};
 use serde::{Deserialize, Serialize};
@@ -86,40 +89,24 @@ async fn handle_check(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<
     let base_branch =
         but_api::legacy::virtual_branches::fetch_from_remotes(ctx, Some("auto".to_string()))?;
 
-    writeln!(progress, "Checking integration statuses...")?;
-
-    let status =
-        but_api::legacy::virtual_branches::upstream_integration_statuses(ctx.to_sync(), None)?;
+    let should_check_integration = if base_branch.behind == 0 {
+        let current_head_info = but_api::legacy::workspace::head_info(ctx)?;
+        head_info_has_cleanup_candidate(&current_head_info)
+    } else {
+        true
+    };
+    let (has_worktree_conflicts, statuses) = if should_check_integration {
+        let (_current_head_info, _updates, preview, statuses) = dry_run_upstream_integration(ctx)?;
+        (!preview.worktree_conflicts.is_empty(), statuses)
+    } else {
+        (false, Vec::new())
+    };
+    let up_to_date = base_branch.behind == 0 && !statuses_need_update(&statuses);
+    if !up_to_date {
+        writeln!(progress, "Checking integration statuses...")?;
+    }
 
     if let Some(out) = out.for_json() {
-        let (up_to_date, has_worktree_conflicts, branch_statuses) = match &status {
-            UpToDate => (true, false, vec![]),
-            UpdatesRequired {
-                worktree_conflicts,
-                statuses,
-            } => {
-                let branch_statuses: Vec<BranchStatusInfo> = statuses
-                    .iter()
-                    .flat_map(|(_id, stack_status)| {
-                        stack_status.branch_statuses.iter().map(|bs| {
-                            let (status_str, rebasable) = match bs.status {
-                                SafelyUpdatable => ("updatable", None),
-                                Integrated => ("integrated", None),
-                                Conflicted { rebasable } => ("conflicted", Some(rebasable)),
-                                Empty => ("empty", None),
-                            };
-                            BranchStatusInfo {
-                                name: bs.name.clone(),
-                                status: status_str.to_string(),
-                                rebasable,
-                            }
-                        })
-                    })
-                    .collect();
-                (false, !worktree_conflicts.is_empty(), branch_statuses)
-            }
-        };
-
         let output = PullCheckOutput {
             base_branch: BaseBranchInfo {
                 name: base_branch.branch_name.clone(),
@@ -139,7 +126,7 @@ async fn handle_check(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<
                     })
                     .collect(),
             },
-            branch_statuses,
+            branch_statuses: check_branch_statuses(&statuses),
             up_to_date,
             has_worktree_conflicts,
         };
@@ -201,48 +188,37 @@ async fn handle_check(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<
             }
         }
 
-        match status {
-            UpToDate => {
-                writeln!(out, "\n{}", t.success.paint("Up to date"))?;
-            }
-            UpdatesRequired {
-                worktree_conflicts,
-                statuses,
-            } => {
-                if !worktree_conflicts.is_empty() {
-                    writeln!(
-                        out,
-                        "\n{}",
-                        t.attention
-                            .paint("Warning: uncommitted changes may conflict with updates.")
-                    )?;
-                }
-                if !statuses.is_empty() {
-                    writeln!(out, "\n{}", t.important.paint("Branch Status"))?;
-                    for (_id, status) in statuses {
-                        for bs in status.branch_statuses {
-                            let status_text = match bs.status {
-                                SafelyUpdatable => t.success.paint("[ok]"),
-                                Integrated => t.info.paint("[integrated]"),
-                                Conflicted { rebasable } => {
-                                    if rebasable {
-                                        t.attention.paint("[conflict - rebasable]")
-                                    } else {
-                                        t.error.paint("[conflict]")
-                                    }
-                                }
-                                Empty => t.hint.paint("[empty]"),
-                            };
-                            writeln!(out, "  {} {}", status_text, bs.name)?;
-                        }
-                    }
-                }
+        if up_to_date {
+            writeln!(out, "\n{}", t.success.paint("Up to date"))?;
+        } else {
+            if has_worktree_conflicts {
                 writeln!(
                     out,
                     "\n{}",
-                    t.hint.paint("Run `but pull` to update your branches")
+                    t.attention
+                        .paint("Warning: uncommitted changes may conflict with updates.")
                 )?;
             }
+            if !statuses.is_empty() {
+                writeln!(out, "\n{}", t.important.paint("Branch Status"))?;
+                for status in statuses {
+                    for bs in status.branch_statuses {
+                        let status_text = match bs.status {
+                            PullBranchStatus::Clear => t.success.paint("[ok]"),
+                            PullBranchStatus::Integrated => t.info.paint("[integrated]"),
+                            PullBranchStatus::Conflicted => {
+                                t.attention.paint("[conflict - rebasable]")
+                            }
+                        };
+                        writeln!(out, "  {} {}", status_text, bs.name)?;
+                    }
+                }
+            }
+            writeln!(
+                out,
+                "\n{}",
+                t.hint.paint("Run `but pull` to update your branches")
+            )?;
         }
     }
     Ok(())
@@ -336,236 +312,145 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
             )?;
         }
 
-        writeln!(progress, "   Checking integration statuses...")?;
+        if base_branch.behind > 0 {
+            writeln!(progress, "   Checking integration statuses...")?;
+        }
     }
 
-    // Step 2: Check integration status
-    let status =
-        but_api::legacy::virtual_branches::upstream_integration_statuses(ctx.to_sync(), None)?;
-
-    let resolutions = match status {
-        UpToDate => {
-            pull_result.status = "up_to_date".to_string();
-            if let Some(out) = out.for_human() {
-                writeln!(out, "\n{}", t.success.paint("Everything is up to date"))?;
-            }
-            if let Some(out) = out.for_json() {
-                out.write_value(&pull_result)?;
-            }
-            None
+    let should_check_integration = if base_branch.behind == 0 {
+        let current_head_info = but_api::legacy::workspace::head_info(ctx)?;
+        head_info_has_cleanup_candidate(&current_head_info)
+    } else {
+        true
+    };
+    if !should_check_integration {
+        pull_result.status = "up_to_date".to_string();
+        if let Some(out) = out.for_human() {
+            writeln!(out, "\n{}", t.success.paint("Everything is up to date"))?;
         }
-        UpdatesRequired {
-            worktree_conflicts,
-            statuses,
-        } => {
-            if !worktree_conflicts.is_empty() {
-                pull_result.status = "worktree_conflicts".to_string();
-                if let Some(out) = out.for_human() {
-                    writeln!(
-                        out,
-                        "\n{}",
-                        t.error.paint("There are uncommitted changes in the worktree that may conflict with the updates.")
-                    )?;
-                    writeln!(
-                        out,
-                        "   {}",
-                        t.attention
-                            .paint("Please commit or stash them and try again.")
-                    )?;
-                }
-                if let Some(out) = out.for_json() {
-                    out.write_value(&pull_result)?;
-                }
-                None
-            } else {
-                pull_result.status = "updating".to_string();
+        if let Some(out) = out.for_json() {
+            out.write_value(&pull_result)?;
+        }
+        return Ok(());
+    }
 
-                // Analyze branches to update
-                let mut branches_to_update = 0;
-                let mut integrated_branches = vec![];
-                let mut resolutions = vec![];
+    // Step 2: Dry-run integration and derive statuses from the preview, like the desktop app.
+    let (current_head_info, updates, preview, statuses) = dry_run_upstream_integration(ctx)?;
 
-                for (maybe_stack_id, status) in &statuses {
-                    let Some(stack_id) = maybe_stack_id else {
-                        if let Some(out) = out.for_human() {
-                            writeln!(
-                                out,
-                                "\n{}",
-                                t.attention
-                                    .paint("No stack ID, assuming we're on single-branch mode...")
-                            )?;
-                        }
-                        continue;
-                    };
+    if base_branch.behind == 0 && !statuses_need_update(&statuses) {
+        pull_result.status = "up_to_date".to_string();
+        if let Some(out) = out.for_human() {
+            writeln!(out, "\n{}", t.success.paint("Everything is up to date"))?;
+        }
+        if let Some(out) = out.for_json() {
+            out.write_value(&pull_result)?;
+        }
+        return Ok(());
+    }
 
-                    for branch_status in &status.branch_statuses {
-                        branches_to_update += 1;
+    let resolutions = if !preview.worktree_conflicts.is_empty() {
+        pull_result.status = "worktree_conflicts".to_string();
+        if let Some(out) = out.for_human() {
+            writeln!(
+                out,
+                "\n{}",
+                t.error.paint(
+                    "There are uncommitted changes in the worktree that conflict with the updates:"
+                )
+            )?;
+            for path in &preview.worktree_conflicts {
+                writeln!(out, "  {}", t.attention.paint(path.to_str_lossy()))?;
+            }
+            writeln!(
+                out,
+                "{}",
+                t.attention
+                    .paint("Please commit or stash them and try again.")
+            )?;
+        }
+        if let Some(out) = out.for_json() {
+            out.write_value(&pull_result)?;
+        }
+        None
+    } else {
+        pull_result.status = "updating".to_string();
 
-                        let branch_info = BranchUpdateInfo {
-                            name: branch_status.name.clone(),
-                            status: format_branch_status(&branch_status.status),
-                            commit_count: 0, // TODO: Get actual commit count
-                            conflicts: vec![],
-                        };
+        let mut branches_to_update = 0;
+        let mut integrated_branches = vec![];
+        for status in &statuses {
+            for branch_status in &status.branch_statuses {
+                branches_to_update += 1;
 
-                        match &branch_status.status {
-                            Integrated => {
-                                integrated_branches.push(branch_status.name.clone());
-                                pull_result.summary.branches_integrated += 1;
-                            }
-                            Conflicted { .. } => {
-                                pull_result.summary.branches_conflicted += 1;
-                            }
-                            SafelyUpdatable => {
-                                pull_result.summary.branches_updated += 1;
-                            }
-                            _ => {}
-                        }
+                let branch_info = BranchUpdateInfo {
+                    name: branch_status.name.clone(),
+                    status: branch_status.status.as_str().to_string(),
+                    commit_count: 0, // TODO: Get actual commit count
+                    conflicts: vec![],
+                };
 
-                        pull_result.branches_to_update.push(branch_info);
+                match branch_status.status {
+                    PullBranchStatus::Integrated => {
+                        integrated_branches.push(branch_status.name.clone());
+                        pull_result.summary.branches_integrated += 1;
                     }
-
-                    let approach = if status
-                        .branch_statuses
-                        .iter()
-                        .all(|s| s.status == Integrated)
-                        && status.tree_status != UpstreamTreeStatus::Conflicted
-                    {
-                        ResolutionApproach::Delete
-                    } else {
-                        ResolutionApproach::Rebase
-                    };
-
-                    let resolution = Resolution {
-                        stack_id: *stack_id,
-                        approach,
-                        delete_integrated_branches: true,
-                    };
-                    resolutions.push(resolution);
+                    PullBranchStatus::Conflicted => {
+                        pull_result.summary.branches_conflicted += 1;
+                    }
+                    PullBranchStatus::Clear => {
+                        pull_result.summary.branches_updated += 1;
+                    }
                 }
 
-                if let Some(out) = out.for_human()
-                    && branches_to_update > 0
-                {
-                    writeln!(
-                        out,
-                        "\n{} {} active branches...",
-                        t.progress.paint("Updating"),
-                        t.attention.paint(branches_to_update.to_string())
-                    )?;
-                }
-
-                pull_result.integrated_branches = integrated_branches.clone();
-
-                Some((resolutions, statuses))
+                pull_result.branches_to_update.push(branch_info);
             }
         }
+
+        if let Some(out) = out.for_human()
+            && branches_to_update > 0
+        {
+            writeln!(
+                out,
+                "\n{} {} active branches...",
+                t.progress.paint("Updating"),
+                t.attention.paint(branches_to_update.to_string())
+            )?;
+        }
+
+        pull_result.integrated_branches = integrated_branches.clone();
+
+        Some((updates, statuses))
     };
 
     // Step 3: Actually perform the integration
-    if let Some((resolutions, statuses)) = resolutions {
-        // Store branch information before integration, along with resolution approaches
-        let mut branch_info_map: HashMap<StackId, (String, String)> = HashMap::new();
-        let mut resolution_map: HashMap<StackId, ResolutionApproach> = HashMap::new();
-
-        for (maybe_stack_id, status) in &statuses {
-            if let Some(stack_id) = maybe_stack_id {
-                for branch_status in &status.branch_statuses {
-                    let status_str = format_branch_status(&branch_status.status);
-                    branch_info_map.insert(*stack_id, (branch_status.name.clone(), status_str));
-                }
-            }
-        }
-
-        // Store resolution approaches before moving resolutions
-        for resolution in &resolutions {
-            resolution_map.insert(resolution.stack_id, resolution.approach);
-        }
-
-        let integration_result =
-            but_api::legacy::virtual_branches::integrate_upstream(ctx.to_sync(), resolutions, None)
-                .await;
+    if let Some((updates, statuses)) = resolutions {
+        let integration_result = {
+            let mut ctx = ctx.to_sync().into_thread_local();
+            but_api::workspace::workspace_integrate_upstream(&mut ctx, updates, DryRun::No)
+        };
 
         match integration_result {
-            Ok(_outcome) => {
-                // Re-fetch status to check for any remaining conflicts
-                let post_status = but_api::legacy::virtual_branches::upstream_integration_statuses(
-                    ctx.to_sync(),
-                    None,
-                )?;
-
+            Ok(outcome) => {
+                let post_statuses = derive_upstream_integration_statuses(
+                    &current_head_info,
+                    &outcome.workspace_state,
+                );
                 // Report detailed results for each resolution
                 let mut successful_rebases: Vec<String> = Vec::new();
                 let mut conflicted_rebases: Vec<String> = Vec::new();
-
-                for (stack_id, approach) in &resolution_map {
-                    if let Some((branch_name, _original_status)) = branch_info_map.get(stack_id) {
-                        match approach {
-                            ResolutionApproach::Rebase => {
-                                // Check if this branch still has conflicts in post_status
-                                let still_conflicted = if let UpdatesRequired {
-                                    statuses: post_statuses,
-                                    ..
-                                } = &post_status
-                                {
-                                    post_statuses.iter().any(|(id, status)| {
-                                        id.as_ref() == Some(stack_id)
-                                            && status
-                                                .branch_statuses
-                                                .iter()
-                                                .any(|bs| matches!(bs.status, Conflicted { .. }))
-                                    })
-                                } else {
-                                    false
-                                };
-
-                                // Also check if any commits in the branch have conflicts
-                                let has_conflicted_commits =
-                                    crate::legacy::workspace::applied_stack_with_expensive_commit_info(
-                                        ctx,
-                                        Some(*stack_id),
-                                    )
-                                    .ok()
-                                    .map(|stack| {
-                                            stack.branches.iter().any(|branch| {
-                                                branch
-                                                    .commits
-                                                    .iter()
-                                                    .any(|commit| commit.has_conflicts)
-                                            })
-                                    })
-                                    .unwrap_or(false);
-
-                                if still_conflicted || has_conflicted_commits {
-                                    conflicted_rebases.push(branch_name.to_string());
-                                } else {
-                                    successful_rebases.push(branch_name.to_string());
-                                }
-                            }
-                            ResolutionApproach::Delete => {
-                                // Already handled in integrated_branches
-                            }
-                            _ => {}
-                        }
-                    }
-                }
+                collect_materialized_rebase_results(
+                    &statuses,
+                    &post_statuses,
+                    &mut successful_rebases,
+                    &mut conflicted_rebases,
+                );
 
                 // Check if there are any conflicted files
                 let has_conflicts = !conflicted_rebases.is_empty()
-                    || (if let UpdatesRequired {
-                        statuses: post_statuses,
-                        ..
-                    } = &post_status
-                    {
-                        post_statuses.iter().any(|(_, status)| {
-                            status.tree_status == UpstreamTreeStatus::Conflicted
-                                || status
-                                    .branch_statuses
-                                    .iter()
-                                    .any(|bs| matches!(bs.status, Conflicted { .. }))
-                        })
-                    } else {
-                        false
+                    || post_statuses.iter().any(|status| {
+                        status
+                            .branch_statuses
+                            .iter()
+                            .any(|bs| matches!(bs.status, PullBranchStatus::Conflicted))
                     });
 
                 // Update final status
@@ -596,26 +481,14 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
                 if let Some(out) = out.for_human() {
                     writeln!(out)?;
 
-                    // Show successful rebases
-                    for branch_name in &successful_rebases {
+                    if has_conflicts {
                         writeln!(
                             out,
-                            "{} of {} {}",
-                            t.important.paint("Rebase"),
-                            t.local_branch.paint(branch_name.as_str()),
-                            t.success.paint("successful")
+                            "{}",
+                            t.attention.paint("Rebase resulted in some conflicts")
                         )?;
-                    }
-
-                    // Show conflicted rebases
-                    for branch_name in &conflicted_rebases {
-                        writeln!(
-                            out,
-                            "{} of {} {}",
-                            t.important.paint("Rebase"),
-                            t.local_branch.paint(branch_name.as_str()),
-                            t.attention.paint("resulted in conflicts")
-                        )?;
+                    } else {
+                        writeln!(out, "{}", t.success.paint("Rebase successful"))?;
                     }
 
                     // Report on integrated branches
@@ -699,12 +572,8 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
             Err(e) => {
                 pull_result.status = "error".to_string();
                 if let Some(out) = out.for_human() {
-                    writeln!(
-                        out,
-                        "\n{} {}",
-                        t.error.paint("Error during integration:"),
-                        e
-                    )?;
+                    writeln!(out, "\n{}", t.error.paint("Failed to update branches"))?;
+                    writeln!(out, "   {e}")?;
                 }
                 if let Some(out) = out.for_json() {
                     out.write_value(&pull_result)?;
@@ -717,17 +586,288 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
     Ok(())
 }
 
-fn format_branch_status(status: &BranchStatus) -> String {
-    match status {
-        SafelyUpdatable => "updatable".to_string(),
-        Integrated => "integrated".to_string(),
-        Conflicted { rebasable } => {
-            if *rebasable {
-                "conflicted_rebasable".to_string()
-            } else {
-                "conflicted_not_rebasable".to_string()
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PullBranchStatus {
+    Clear,
+    Integrated,
+    Conflicted,
+}
+
+impl PullBranchStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            PullBranchStatus::Clear => "updatable",
+            PullBranchStatus::Integrated => "integrated",
+            PullBranchStatus::Conflicted => "conflicted_rebasable",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PullBranchStatusInfo {
+    name: String,
+    status: PullBranchStatus,
+}
+
+#[derive(Debug, Clone)]
+struct PullStackStatusInfo {
+    branch_statuses: Vec<PullBranchStatusInfo>,
+}
+
+/// Preview upstream integration through the workspace API without materializing it.
+///
+/// This keeps `but pull --check` and `but pull` on the same branch selectors and
+/// status derivation path as the desktop app.
+fn dry_run_upstream_integration(
+    ctx: &Context,
+) -> anyhow::Result<(
+    RefInfo,
+    Vec<BottomUpdate>,
+    WorkspaceIntegrateUpstreamOutcome,
+    Vec<PullStackStatusInfo>,
+)> {
+    let current_head_info = but_api::legacy::workspace::head_info(ctx)?;
+    let updates = build_upstream_integration_updates(&current_head_info)?;
+    let preview = {
+        let mut ctx = ctx.to_sync().into_thread_local();
+        but_api::workspace::workspace_integrate_upstream(&mut ctx, updates.clone(), DryRun::Yes)?
+    };
+    let statuses =
+        derive_upstream_integration_statuses(&current_head_info, &preview.workspace_state);
+    Ok((current_head_info, updates, preview, statuses))
+}
+
+fn check_branch_statuses(statuses: &[PullStackStatusInfo]) -> Vec<BranchStatusInfo> {
+    statuses
+        .iter()
+        .flat_map(|stack_status| {
+            stack_status.branch_statuses.iter().map(|branch_status| {
+                let (status, rebasable) = match branch_status.status {
+                    PullBranchStatus::Clear => ("updatable", None),
+                    PullBranchStatus::Integrated => ("integrated", None),
+                    PullBranchStatus::Conflicted => ("conflicted", Some(true)),
+                };
+                BranchStatusInfo {
+                    name: branch_status.name.clone(),
+                    status: status.to_string(),
+                    rebasable,
+                }
+            })
+        })
+        .collect()
+}
+
+fn collect_materialized_rebase_results(
+    pre_integration_statuses: &[PullStackStatusInfo],
+    post_integration_statuses: &[PullStackStatusInfo],
+    successful_rebases: &mut Vec<String>,
+    conflicted_rebases: &mut Vec<String>,
+) {
+    for stack_status in pre_integration_statuses {
+        for branch_status in &stack_status.branch_statuses {
+            if matches!(branch_status.status, PullBranchStatus::Integrated) {
+                continue;
+            }
+
+            match post_branch_status(post_integration_statuses, branch_status.name.as_str()) {
+                Some(PullBranchStatus::Conflicted) => {
+                    conflicted_rebases.push(branch_status.name.clone());
+                }
+                Some(PullBranchStatus::Clear | PullBranchStatus::Integrated) | None => {
+                    successful_rebases.push(branch_status.name.clone());
+                }
             }
         }
-        BranchStatus::Empty => "empty".to_string(),
     }
+}
+
+fn post_branch_status(
+    post_integration_statuses: &[PullStackStatusInfo],
+    branch_name: &str,
+) -> Option<PullBranchStatus> {
+    post_integration_statuses
+        .iter()
+        .flat_map(|stack_status| &stack_status.branch_statuses)
+        .find(|branch_status| branch_status.name == branch_name)
+        .map(|branch_status| branch_status.status)
+}
+
+fn statuses_need_update(statuses: &[PullStackStatusInfo]) -> bool {
+    statuses.iter().any(|stack_status| {
+        stack_status
+            .branch_statuses
+            .iter()
+            .any(|branch_status| branch_status.status != PullBranchStatus::Clear)
+    })
+}
+
+fn head_info_has_cleanup_candidate(head_info: &RefInfo) -> bool {
+    head_info
+        .stacks
+        .iter()
+        .flat_map(|stack| &stack.segments)
+        .any(|segment| {
+            matches!(segment.push_status, PushStatus::Integrated)
+                || segment
+                    .commits
+                    .iter()
+                    .any(|commit| matches!(commit.relation, LocalCommitRelation::Integrated(_)))
+                || (segment.commits.is_empty() && segment.remote_tracking_ref_name.is_some())
+        })
+}
+
+/// Build the stack-bottom update requests that the upstream integration API expects.
+///
+/// The desktop client derives the same list from the current workspace preview before
+/// calling `workspace_integrate_upstream`; keeping the CLI on the same selector shape
+/// makes the dry run and materialization paths classify the same branches.
+fn build_upstream_integration_updates(head_info: &RefInfo) -> anyhow::Result<Vec<BottomUpdate>> {
+    let mut updates = Vec::new();
+    for stack in &head_info.stacks {
+        if let Some(update) = bottom_update_for_stack(stack)? {
+            updates.push(update);
+        }
+    }
+    Ok(updates)
+}
+
+/// Select the bottom-most commit, or the empty bottom branch reference, for a stack.
+///
+/// Upstream integration rebases from the stack bottom. Empty branches have no commit to
+/// select, so they are represented by their branch reference instead.
+fn bottom_update_for_stack(stack: &Stack) -> anyhow::Result<Option<BottomUpdate>> {
+    let Some(segment) = stack.segments.last() else {
+        return Ok(None);
+    };
+    let selector = if let Some(commit) = segment.commits.last() {
+        but_api::commit::json::RelativeTo::Commit(commit.id)
+    } else {
+        let Some(ref_info) = segment.ref_info.as_ref() else {
+            return Ok(None);
+        };
+        but_api::commit::json::RelativeTo::ReferenceBytes(ref_info.ref_name.clone())
+    };
+
+    Ok(Some(BottomUpdate {
+        kind: BottomUpdateKind::Rebase,
+        selector,
+    }))
+}
+
+/// Whether each preview reference (keyed by its full ref name) survived the
+/// integration and, if so, whether any of its commits are conflicted.
+type PreviewReferenceConflicts = HashMap<Vec<u8>, bool>;
+
+/// Compare the current workspace to the dry-run or post-integration workspace.
+///
+/// Missing preview references are treated as integrated, while surviving references with
+/// conflicted commits are reported as conflicted. This mirrors the desktop status
+/// derivation without depending on the UI projection types.
+fn derive_upstream_integration_statuses(
+    current: &RefInfo,
+    preview: &but_api::WorkspaceState,
+) -> Vec<PullStackStatusInfo> {
+    let preview_conflicts = preview_reference_conflicts(preview);
+
+    current
+        .stacks
+        .iter()
+        .map(|stack| {
+            let branch_statuses = stack
+                .segments
+                .iter()
+                .map(|segment| derive_branch_status(segment, &preview_conflicts))
+                .collect::<Vec<_>>();
+
+            PullStackStatusInfo { branch_statuses }
+        })
+        .collect()
+}
+
+/// Index the preview references by their full ref name, recording whether each one still
+/// carries conflicted commits after the integration.
+///
+/// This reads the classic `RefInfo` projection returned when the `graph-workspace` feature
+/// is disabled.
+#[cfg(not(feature = "graph-workspace"))]
+fn preview_reference_conflicts(preview: &but_api::WorkspaceState) -> PreviewReferenceConflicts {
+    let mut conflicts = HashMap::new();
+    for stack in &preview.head_info.stacks {
+        for segment in &stack.segments {
+            if let Some(ref_info) = &segment.ref_info {
+                let has_conflicts = segment.commits.iter().any(|commit| commit.has_conflicts);
+                conflicts.insert(ref_info.ref_name.as_bstr().to_vec(), has_conflicts);
+            }
+        }
+    }
+    conflicts
+}
+
+/// Index the preview references by their full ref name, recording whether each one still
+/// carries conflicted commits after the integration.
+///
+/// This reads the detailed graph projection returned when the `graph-workspace` feature is
+/// enabled. Each reference segment owns the commit rows down to the next reference, mirroring
+/// the per-segment commits of the classic `RefInfo` projection.
+#[cfg(feature = "graph-workspace")]
+fn preview_reference_conflicts(preview: &but_api::WorkspaceState) -> PreviewReferenceConflicts {
+    use but_workspace::ui::workspace::DetailedGraphRowData;
+
+    let mut conflicts = HashMap::new();
+    for stack in &preview.graph_workspace.stacks {
+        for segment in &stack.reference_segments {
+            let Some(DetailedGraphRowData::Reference(reference)) =
+                stack.rows.get(segment.reference_idx).map(|row| &row.data)
+            else {
+                continue;
+            };
+            let has_conflicts = segment.row_idxs.iter().any(|&row_idx| {
+                matches!(
+                    stack.rows.get(row_idx).map(|row| &row.data),
+                    Some(DetailedGraphRowData::Commit(commit)) if commit.has_conflicts
+                )
+            });
+            conflicts.insert(reference.ref_name.full_name_bytes.to_vec(), has_conflicts);
+        }
+    }
+    conflicts
+}
+
+/// Derive the pull status for a single current segment from its preview counterpart.
+fn derive_branch_status(
+    segment: &Segment,
+    preview_conflicts: &PreviewReferenceConflicts,
+) -> PullBranchStatusInfo {
+    let name = branch_display_name(segment);
+    let Some(ref_info) = &segment.ref_info else {
+        return PullBranchStatusInfo {
+            name,
+            status: PullBranchStatus::Clear,
+        };
+    };
+
+    let Some(&has_conflicts) = preview_conflicts.get(ref_info.ref_name.as_bstr().as_bytes()) else {
+        return PullBranchStatusInfo {
+            name,
+            status: PullBranchStatus::Integrated,
+        };
+    };
+
+    PullBranchStatusInfo {
+        name,
+        status: if has_conflicts {
+            PullBranchStatus::Conflicted
+        } else {
+            PullBranchStatus::Clear
+        },
+    }
+}
+
+/// Return a human-readable branch name for CLI output.
+fn branch_display_name(segment: &Segment) -> String {
+    segment
+        .ref_info
+        .as_ref()
+        .map(|ref_info| ref_info.ref_name.shorten().to_string())
+        .unwrap_or_else(|| "Unnamed segment".to_string())
 }

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -38,6 +38,8 @@ mod onboarding;
 #[cfg(feature = "legacy")]
 mod pick;
 #[cfg(feature = "legacy")]
+mod pull;
+#[cfg(feature = "legacy")]
 mod push;
 #[cfg(feature = "legacy")]
 mod resolve;

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -1,0 +1,794 @@
+use std::ops::DerefMut;
+
+use but_core::{
+    RefMetadata, WORKSPACE_REF_NAME,
+    ref_metadata::{StackId, WorkspaceCommitRelation, WorkspaceStack, WorkspaceStackBranch},
+};
+use snapbox::str;
+
+use crate::utils::{CommandExt, Sandbox};
+
+#[test]
+fn pull_prunes_integrated_stack_and_keeps_remaining_stack_parent() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "pull-one-of-two-stacks-integrated",
+    );
+    env.setup_metadata_at_target(&["A", "B"], "origin/main");
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A] (no commits)
+├╯
+┊
+┊╭┄h0 [B]
+┊●   d3e2ba3 add B
+├╯
+┊
+┊● 26ecc90 (upstream) ⏫ 2 commits
+├╯ 26ecc90 (common base) 2000-01-02 add upstream
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("pull").assert().success();
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [B]
+┊◐   5542cc3 add B
+├╯
+┊
+┴ 26ecc90 (common base) 2000-01-02 add upstream
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    assert!(
+        !git_ref_exists(&env, "refs/heads/A")?,
+        "the branch already integrated into the target should be removed"
+    );
+    assert!(
+        git_ref_exists(&env, "refs/heads/B")?,
+        "the remaining stack should stay in the workspace"
+    );
+
+    let workspace_parents = rev_parse_all(&env, "gitbutler/workspace^@")?;
+    assert_eq!(
+        workspace_parents.len(),
+        1,
+        "the workspace should have exactly the remaining stack as parent"
+    );
+    assert_eq!(
+        workspace_parents[0],
+        rev_parse(&env, "B")?,
+        "the remaining stack should remain the workspace parent"
+    );
+    assert_ne!(
+        workspace_parents[0],
+        rev_parse(&env, "origin/main")?,
+        "the workspace should not be reparented directly to the target while a stack remains"
+    );
+    assert_eq!(
+        status_stack_count(&env)?,
+        1,
+        "exactly the remaining stack should stay applied"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pull_prunes_integrated_branch_from_partial_stack() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "pull-partially-integrated-multi-branch-stack",
+    );
+    setup_single_stack_metadata_at_target(&env, &["A", "C"], "refs/heads/base")?;
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   99cf923 add A
+┊│
+┊├┄h0 [C] (merged upstream)
+┊●   e5378e0 add C
+├╯
+┊
+┊● d4cb681 (upstream) ⏫ 2 commits
+├╯ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch
+
+"#]]);
+
+    env.but("pull").assert().success();
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊◐   3a110f4 add A
+├╯
+┊
+┴ d4cb681 (common base) 2000-01-02 add upstream
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    assert!(
+        git_ref_exists(&env, "refs/heads/A")?,
+        "the remaining top branch should stay in the workspace"
+    );
+    assert_eq!(
+        status_branch_names(&env)?,
+        vec!["A"],
+        "workspace status should contain only the rebased top branch after pruning the integrated lower branch"
+    );
+    assert_eq!(
+        status_stack_count(&env)?,
+        1,
+        "the partially integrated stack should remain applied through its top branch"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pull_keeps_empty_branch_above_merged_branch() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "upstream-merged-branch-below-empty-branch",
+    );
+    setup_single_stack_metadata_at_target(&env, &["top", "bottom"], "refs/heads/main")?;
+    env.invoke_git("remote set-url origin .");
+
+    env.but("pull").assert().success();
+
+    assert_eq!(
+        status_branch_names(&env)?,
+        vec!["top"],
+        "pull should prune only the genuinely merged lower branch and preserve the empty top branch"
+    );
+    assert!(
+        git_ref_exists(&env, "refs/heads/top")?,
+        "the empty top branch was not merged itself and must survive"
+    );
+    assert!(
+        !git_ref_exists(&env, "refs/heads/bottom")?,
+        "the lower branch landed upstream and should be removed"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pull_check_uses_workspace_dry_run_for_partial_stack() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "pull-partially-integrated-multi-branch-stack",
+    );
+    setup_single_stack_metadata_at_target(&env, &["A", "C"], "refs/heads/base")?;
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   99cf923 add A
+┊│
+┊├┄h0 [C] (merged upstream)
+┊●   e5378e0 add C
+├╯
+┊
+┊● d4cb681 (upstream) ⏫ 2 commits
+├╯ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch
+
+"#]]);
+
+    env.but("pull --check")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+
+Base branch:	origin/main
+Upstream:	2 new commits on origin/main
+
+  d4cb681 add upstream[..]
+  a4cc6be merge C[..]
+
+Branch Status
+  [ok] A
+  [integrated] C
+
+Run `but pull` to update your branches
+
+"#]]);
+
+    assert!(
+        git_ref_exists(&env, "refs/heads/C")?,
+        "dry-run check should not remove the integrated lower branch"
+    );
+    assert_eq!(
+        status_branch_names(&env)?,
+        vec!["A", "C"],
+        "dry-run check should leave both stack branches in workspace status"
+    );
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   99cf923 add A
+┊│
+┊├┄h0 [C] (merged upstream)
+┊●   e5378e0 add C
+├╯
+┊
+┊● d4cb681 (upstream) ⏫ 2 commits (checked [..])
+├╯ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn pull_check_reports_conflicted_branches_as_rebasable() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("upstream-conflicted");
+    env.setup_metadata_at_target(&["A"], "refs/heads/base");
+    env.invoke_git("remote set-url origin .");
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9283fc1 A-change
+├╯
+┊
+┊● bdfcf28 (upstream) ⏫ 1 commit
+├╯ efc9211 (common base) 2000-01-02 base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    let output = env
+        .but("--format json pull --check")
+        .allow_json()
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let output: serde_json::Value = serde_json::from_slice(&output)?;
+    let branch_status = output["branchStatuses"]
+        .as_array()
+        .and_then(|statuses| statuses.iter().find(|status| status["name"] == "A"))
+        .expect("pull check should report branch A status");
+
+    assert_eq!(
+        branch_status["status"], "conflicted",
+        "conflicted dry-run branch should be reported as conflicted"
+    );
+    assert_eq!(
+        branch_status["rebasable"], true,
+        "conflicted dry-run branch should remain rebasable"
+    );
+
+    env.but("pull").assert().success();
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊◐   6e0f28b A-change (no changes) {conflicted}
+├╯
+┊
+┴ bdfcf28 (common base) 2000-01-02 main-change
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn pull_reparents_workspace_to_target_after_all_stacks_integrate() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("pull-two-integrated-stacks");
+    env.setup_metadata_at_target(&["A", "B"], "origin/main");
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A] (no commits)
+├╯
+┊
+┊╭┄h0 [B] (no commits)
+├╯
+┊
+┊● 7e5d4e1 (upstream) ⏫ 3 commits
+├╯ 7e5d4e1 (common base) 2000-01-02 add upstream
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("pull").assert().success();
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┴ 7e5d4e1 (common base) 2000-01-02 add upstream
+
+Hint: run `but branch new` to create a new branch to work on
+
+"#]]);
+
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        rev_parse(&env, "origin/main")?,
+        "once all stacks are integrated, the workspace should be parented to the advanced target"
+    );
+    assert_eq!(
+        status_stack_count(&env)?,
+        0,
+        "no stacks should remain applied once both are integrated"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pull_reparents_empty_workspace_when_target_advances() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata_at_target(&[], "origin/main");
+    env.invoke_git("remote set-url origin .");
+
+    env.invoke_git("checkout main");
+    env.file("upstream.txt", "upstream\n");
+    env.invoke_git("add upstream.txt");
+    env.invoke_git("commit -m upstream-change");
+    env.invoke_git("checkout gitbutler/workspace");
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but branch new` to create a new branch to work on
+
+"#]]);
+
+    env.but("pull").assert().success();
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┴ 526bb83 (common base) 2000-01-02 upstream-change
+
+Hint: run `but branch new` to create a new branch to work on
+
+"#]]);
+
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        rev_parse(&env, "origin/main")?,
+        "an empty workspace should still move forward when the target advances"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pull_does_not_report_branch_rebase_conflicts_as_worktree_conflicts() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "pull-branch-and-dirty-worktree-conflict",
+    );
+    env.setup_metadata_at_target(&["A"], "main");
+
+    env.file("shared.txt", "local\nextra local work\n");
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [uncommitted]
+┊   ot M shared.txt
+┊
+┊╭┄g0 [A]
+┊●   ba99744 local change
+├╯
+┊
+┊● 7f73771 (upstream) ⏫ 1 commit
+├╯ 7f73771 (common base) 2000-01-02 upstream change
+
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
+
+"#]]);
+
+    let output = env.but("pull").output()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        stdout.contains("Rebase resulted in some conflicts"),
+        "pull should proceed to the branch conflict workflow instead of stopping at the worktree gate; stdout:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("uncommitted changes in the worktree"),
+        "branch rebase conflicts should not be reported as dirty worktree conflicts; stdout:\n{stdout}"
+    );
+    assert_eq!(
+        status_branch_names(&env)?,
+        vec!["A"],
+        "conflicted branch should remain in the workspace after pull"
+    );
+    assert!(
+        branch_has_conflicted_commit(&env, "A")?,
+        "pull should materialize the rebase conflict on a commit inside branch A"
+    );
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [uncommitted]
+┊   ot M shared.txt
+┊
+┊╭┄g0 [A]
+┊◐   705b03e local change (no changes) {conflicted}
+├╯
+┊
+┴ 7f73771 (common base) 2000-01-02 upstream change
+
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn pull_json_reports_branch_rebase_conflicts_as_successful_integration() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "pull-branch-and-dirty-worktree-conflict",
+    );
+    env.setup_metadata_at_target(&["A"], "main");
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   ba99744 local change
+├╯
+┊
+┊● 7f73771 (upstream) ⏫ 1 commit
+├╯ 7f73771 (common base) 2000-01-02 upstream change
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    let output = env
+        .but("--format json pull")
+        .allow_json()
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let output: serde_json::Value = serde_json::from_slice(&output)?;
+
+    assert_eq!(
+        output["status"], "completed_with_conflicts",
+        "branch rebase conflicts should complete pull with conflicts instead of blocking integration"
+    );
+    assert_eq!(
+        output["summary"]["branchesConflicted"], 1,
+        "pull summary should count the branch that now contains a conflicted commit"
+    );
+    assert_eq!(
+        output["conflicts"][0]["branch"], "A",
+        "pull JSON should identify the branch that needs conflict resolution"
+    );
+    assert!(
+        branch_has_conflicted_commit(&env, "A")?,
+        "pull should leave the conflicted commit visible in branch status"
+    );
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊◐   705b03e local change (no changes) {conflicted}
+├╯
+┊
+┴ 7f73771 (common base) 2000-01-02 upstream change
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn pull_reports_conflict_in_lower_branch_of_stack() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "pull-conflict-in-lower-branch-of-stack",
+    );
+    setup_single_stack_metadata_at_target(&env, &["A", "B"], "main")?;
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   [..] top change
+┊│
+┊├┄h0 [B]
+┊●   [..] bottom change
+├╯
+┊
+┊● 7f73771 (upstream) ⏫ 1 commit
+├╯ 7f73771 (common base) 2000-01-02 upstream change
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("pull").assert().success().stdout_eq(str![[r#"
+
+Found 1 upstream commits on origin/main
+   [..] upstream change
+
+Updating 2 active branches...
+
+Rebase resulted in some conflicts
+
+Summary
+────────
+  A - rebased
+  B - conflicted
+
+To resolve conflicts:
+  1. Run `but status` to see conflicted commits
+  2. Run `but resolve <commit>` to enter resolution mode on any conflicted commit
+  3. Edit files to resolve the conflicts
+  4. Run `but resolve finish` to finalize the resolution
+
+To undo this operation:
+  Run `but undo`
+
+"#]]);
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊◐   4a2dd6a top change
+┊│
+┊├┄h0 [B]
+┊◐   d5fa75c bottom change (no changes) {conflicted}
+├╯
+┊
+┴ 7f73771 (common base) 2000-01-02 upstream change
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn pull_reports_conflicts_in_multiple_branches_of_stack() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "pull-conflicts-in-both-branches-of-stack",
+    );
+    setup_single_stack_metadata_at_target(&env, &["A", "B"], "main")?;
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   [..] top change
+┊│
+┊├┄h0 [B]
+┊●   [..] bottom change
+├╯
+┊
+┊● [..] (upstream) ⏫ 1 commit
+├╯ [..] (common base) 2000-01-02 upstream change
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("pull").assert().success().stdout_eq(str![[r#"
+
+Found 1 upstream commits on origin/main
+   [..] upstream change
+
+Updating 2 active branches...
+
+Rebase resulted in some conflicts
+
+Summary
+────────
+  A - conflicted
+  B - conflicted
+
+To resolve conflicts:
+  1. Run `but status` to see conflicted commits
+  2. Run `but resolve <commit>` to enter resolution mode on any conflicted commit
+  3. Edit files to resolve the conflicts
+  4. Run `but resolve finish` to finalize the resolution
+
+To undo this operation:
+  Run `but undo`
+
+"#]]);
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊◐   09bcfd9 top change (no changes) {conflicted}
+┊│
+┊├┄h0 [B]
+┊◐   7ac1f5a bottom change (no changes) {conflicted}
+├╯
+┊
+┴ e4933d8 (common base) 2000-01-02 upstream change
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn pull_does_not_write_conflict_markers_into_uncommitted_files() -> anyhow::Result<()> {
+    // A dirty worktree edit on the same path a branch rebase conflicts on used to be at risk of
+    // silently receiving conflict markers. Modern integration materializes the conflict onto the
+    // commit instead, so the uncommitted file must be left untouched.
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "pull-branch-and-dirty-worktree-conflict",
+    );
+    env.setup_metadata_at_target(&["A"], "main");
+
+    env.file("shared.txt", "local\nextra local work\n");
+
+    env.but("pull").assert().success();
+
+    let shared = std::fs::read_to_string(env.projects_root().join("shared.txt"))?;
+    assert!(
+        !shared.contains("<<<<<<<"),
+        "pull must not write conflict markers into uncommitted files; got:\n{shared}"
+    );
+    assert!(
+        branch_has_conflicted_commit(&env, "A")?,
+        "the rebase conflict should be materialized on branch A's commit, not the worktree file"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pull_reports_worktree_conflict_paths() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "pull-dirty-worktree-conflicts-with-clean-rebase",
+    );
+    env.setup_metadata_at_target(&["A"], "main");
+
+    // The branch rebases cleanly, but this uncommitted edit conflicts with the upstream change
+    // to `shared.txt` on the resulting workspace head.
+    env.file("shared.txt", "dirty local\nmore local work\n");
+
+    env.but("pull").assert().success().stdout_eq(str![[r#"
+
+Found 1 upstream commits on origin/main
+   [..] upstream change
+
+There are uncommitted changes in the worktree that conflict with the updates:
+  shared.txt
+Please commit or stash them and try again.
+
+"#]]);
+
+    Ok(())
+}
+
+fn setup_single_stack_metadata_at_target(
+    env: &Sandbox,
+    branch_names: &[&str],
+    target_spec: &str,
+) -> anyhow::Result<()> {
+    let mut meta = env.meta();
+    let mut ws = meta.workspace(r(WORKSPACE_REF_NAME))?;
+    let repo = env.open_repo();
+    let ws_data = ws.deref_mut();
+    ws_data.stacks = vec![WorkspaceStack {
+        id: StackId::from_number_for_testing(0),
+        branches: branch_names
+            .iter()
+            .map(|branch_name| WorkspaceStackBranch {
+                ref_name: r(&format!("refs/heads/{branch_name}")).to_owned(),
+                archived: false,
+            })
+            .collect(),
+        workspacecommit_relation: WorkspaceCommitRelation::Merged,
+    }];
+    let mut project_meta = ws.project_meta();
+    project_meta.target_commit_id = Some(repo.rev_parse_single(target_spec)?.detach());
+    ws.set_project_meta(project_meta);
+    let project_meta = ws.project_meta();
+    meta.set_workspace(&ws)?;
+    project_meta.persist_to_local_config(&repo)?;
+    Ok(())
+}
+
+fn git_ref_exists(env: &Sandbox, ref_name: &str) -> anyhow::Result<bool> {
+    Ok(env.open_repo().try_find_reference(ref_name)?.is_some())
+}
+
+fn rev_parse(env: &Sandbox, spec: &str) -> anyhow::Result<String> {
+    let values = rev_parse_all(env, spec)?;
+    let [value] = values.as_slice() else {
+        anyhow::bail!("expected exactly one rev for {spec}, got {values:?}");
+    };
+    Ok(value.clone())
+}
+
+fn rev_parse_all(env: &Sandbox, spec: &str) -> anyhow::Result<Vec<String>> {
+    Ok(env
+        .invoke_git(&format!("rev-parse {spec}"))
+        .lines()
+        .map(str::to_owned)
+        .collect())
+}
+
+fn r(name: &str) -> &gix::refs::FullNameRef {
+    name.try_into().expect("statically known valid ref-name")
+}
+
+fn status_stack_count(env: &Sandbox) -> anyhow::Result<usize> {
+    let status = status_json(env)?;
+    Ok(status["stacks"].as_array().map_or(0, Vec::len))
+}
+
+fn status_branch_names(env: &Sandbox) -> anyhow::Result<Vec<String>> {
+    let status = status_json(env)?;
+    Ok(status["stacks"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .flat_map(|stack| stack["branches"].as_array().into_iter().flatten())
+        .filter_map(|branch| branch["name"].as_str().map(str::to_owned))
+        .collect())
+}
+
+fn branch_has_conflicted_commit(env: &Sandbox, branch_name: &str) -> anyhow::Result<bool> {
+    let status = status_json(env)?;
+    Ok(status["stacks"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .flat_map(|stack| stack["branches"].as_array().into_iter().flatten())
+        .filter(|branch| branch["name"].as_str() == Some(branch_name))
+        .flat_map(|branch| branch["commits"].as_array().into_iter().flatten())
+        .any(|commit| commit["conflicted"].as_bool() == Some(true)))
+}
+
+fn status_json(env: &Sandbox) -> anyhow::Result<serde_json::Value> {
+    let output = env
+        .but("status --format json")
+        .allow_json()
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    Ok(serde_json::from_slice(&output)?)
+}

--- a/crates/but/tests/fixtures/scenario/pull-branch-and-dirty-worktree-conflict.sh
+++ b/crates/but/tests/fixtures/scenario/pull-branch-and-dirty-worktree-conflict.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git-init-frozen
+
+echo base >shared.txt
+git add shared.txt
+git commit -m "base"
+setup_target_to_match_main
+git remote set-url origin .
+
+git checkout -b A
+echo local >shared.txt
+git add shared.txt
+git commit -m "local change"
+
+create_workspace_commit_once A
+
+git checkout main
+echo upstream >shared.txt
+git add shared.txt
+git commit -m "upstream change"
+git update-ref refs/remotes/origin/main main
+
+git checkout gitbutler/workspace

--- a/crates/but/tests/fixtures/scenario/pull-conflict-in-lower-branch-of-stack.sh
+++ b/crates/but/tests/fixtures/scenario/pull-conflict-in-lower-branch-of-stack.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git-init-frozen
+
+echo base >shared.txt
+git add shared.txt
+git commit -m "base"
+setup_target_to_match_main
+git remote set-url origin .
+
+git checkout -b B
+echo bottom >shared.txt
+git add shared.txt
+git commit -m "bottom change"
+
+git checkout -b A
+echo top >top.txt
+git add top.txt
+git commit -m "top change"
+
+create_workspace_commit_once A
+
+git checkout main
+echo upstream >shared.txt
+git add shared.txt
+git commit -m "upstream change"
+git update-ref refs/remotes/origin/main main
+
+git checkout gitbutler/workspace

--- a/crates/but/tests/fixtures/scenario/pull-conflicts-in-both-branches-of-stack.sh
+++ b/crates/but/tests/fixtures/scenario/pull-conflicts-in-both-branches-of-stack.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git-init-frozen
+
+echo base >bottom.txt
+echo base >top.txt
+git add bottom.txt top.txt
+git commit -m "base"
+setup_target_to_match_main
+git remote set-url origin .
+
+git checkout -b B
+echo bottom >bottom.txt
+git add bottom.txt
+git commit -m "bottom change"
+
+git checkout -b A
+echo top >top.txt
+git add top.txt
+git commit -m "top change"
+
+create_workspace_commit_once A
+
+git checkout main
+echo upstream >bottom.txt
+echo upstream >top.txt
+git add bottom.txt top.txt
+git commit -m "upstream change"
+git update-ref refs/remotes/origin/main main
+
+git checkout gitbutler/workspace

--- a/crates/but/tests/fixtures/scenario/pull-dirty-worktree-conflicts-with-clean-rebase.sh
+++ b/crates/but/tests/fixtures/scenario/pull-dirty-worktree-conflicts-with-clean-rebase.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+# A workspace branch rebases cleanly onto the updated target (it only adds a new
+# file), but a dirty worktree edit to shared.txt conflicts when applied onto the
+# new workspace head, which now carries the upstream change to shared.txt.
+
+git-init-frozen
+
+echo base >shared.txt
+git add shared.txt
+git commit -m "base"
+setup_target_to_match_main
+git remote set-url origin .
+
+git checkout -b A
+echo a >A.txt
+git add A.txt
+git commit -m "add A"
+
+create_workspace_commit_once A
+
+git checkout main
+echo upstream >shared.txt
+git add shared.txt
+git commit -m "upstream change"
+git update-ref refs/remotes/origin/main main
+
+git checkout gitbutler/workspace

--- a/crates/but/tests/fixtures/scenario/pull-one-of-two-stacks-integrated.sh
+++ b/crates/but/tests/fixtures/scenario/pull-one-of-two-stacks-integrated.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git-init-frozen
+
+commit-file M
+setup_target_to_match_main
+git remote set-url origin .
+
+git checkout -b A main
+commit-file A
+
+git checkout -b B main
+commit-file B
+
+create_workspace_commit_once A B
+
+git checkout main
+git merge --no-ff -m "merge A" A
+commit-file upstream
+git update-ref refs/remotes/origin/main main
+
+git checkout gitbutler/workspace

--- a/crates/but/tests/fixtures/scenario/pull-partially-integrated-multi-branch-stack.sh
+++ b/crates/but/tests/fixtures/scenario/pull-partially-integrated-multi-branch-stack.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git-init-frozen
+
+commit-file M
+setup_target_to_match_main
+git remote set-url origin .
+git update-ref refs/heads/base main
+
+git checkout -b C main
+commit-file C
+
+git checkout -b A
+commit-file A
+
+create_workspace_commit_once A
+
+git checkout main
+git merge --no-ff -m "merge C" C
+commit-file upstream
+git update-ref refs/remotes/origin/main main
+
+git checkout gitbutler/workspace

--- a/crates/but/tests/fixtures/scenario/pull-two-integrated-stacks.sh
+++ b/crates/but/tests/fixtures/scenario/pull-two-integrated-stacks.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git-init-frozen
+
+commit-file M
+setup_target_to_match_main
+git remote set-url origin .
+
+git checkout -b A main
+commit-file A
+
+git checkout -b B main
+commit-file B
+
+create_workspace_commit_once A B
+
+git checkout main
+git merge --no-ff -m "merge A" A
+git merge --no-ff -m "merge B" B
+commit-file upstream
+git update-ref refs/remotes/origin/main main
+
+git checkout gitbutler/workspace


### PR DESCRIPTION
## Summary
- migrate `but pull` to dry-run/apply through `workspace_integrate_upstream`
- derive pull statuses from preview workspace state and document helper behavior
- add CLI integration coverage for branch conflicts, integrated stacks, and empty workspace target advancement

## Validation
- `cargo test -p but command::pull::`
- `cargo clippy -p but --all-targets`