### PR TITLE
Prevent apply from silently succeeding on stale workspaces

### DIFF
--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -122,7 +122,7 @@ pub fn set_default_target_with_perm(
 
 /// JSON transport types for branch APIs.
 pub mod json {
-    use but_workspace::ui::ref_info::BranchReference;
+    use but_workspace::{branch::apply::OutcomeStatus, ui::ref_info::BranchReference};
     use serde::{Deserialize, Serialize};
 
     use crate::branch::{
@@ -137,14 +137,16 @@ pub mod json {
     #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
     #[serde(rename_all = "camelCase")]
     pub struct ApplyOutcome {
+        /// What kind of apply operation completed.
+        pub status: OutcomeStatus,
         /// Whether `apply()` produced a new workspace graph.
         ///
         /// This can be true even when merge conflicts prevented the result from being persisted.
-        /// Use `applied_branches` to determine whether anything was persisted.
+        /// Use `status` to determine whether anything was persisted.
         pub workspace_changed: bool,
-        /// The branches that were actually persisted into the workspace.
+        /// Branches activated or recorded by the operation.
         ///
-        /// This is empty when the branch was already present or when conflicts aborted the apply.
+        /// This is empty for `alreadyApplied` and `conflictAborted`, and populated for `applied`.
         pub applied_branches: Vec<crate::json::FullRefName>,
         /// Whether the workspace reference had to be created.
         pub workspace_ref_created: bool,
@@ -172,6 +174,7 @@ pub mod json {
             let workspace_changed = value.workspace_changed();
             let but_workspace::branch::apply::Outcome {
                 workspace: _,
+                status,
                 applied_branches,
                 workspace_ref_created,
                 workspace_merge: _,
@@ -179,6 +182,7 @@ pub mod json {
             } = value;
 
             ApplyOutcome {
+                status,
                 workspace_changed,
                 applied_branches: applied_branches.into_iter().map(Into::into).collect(),
                 workspace_ref_created,
@@ -625,9 +629,9 @@ pub fn apply_only(
 /// exclusive repository access.
 ///
 /// It applies the branch with the default workspace-apply options, updates the
-/// in-memory workspace stored in `ctx` to the returned workspace state, and
-/// returns the apply outcome. This variant does not create an oplog
-/// entry. For lower-level implementation details, see
+/// in-memory workspace stored in `ctx` to the returned workspace state when the
+/// state was persisted, and returns the apply outcome. This variant does not
+/// create an oplog entry. For lower-level implementation details, see
 /// [`but_workspace::branch::apply()`].
 pub fn apply_only_with_perm(
     ctx: &mut but_ctx::Context,
@@ -654,7 +658,9 @@ pub fn apply_only_with_perm(
     )?
     .into_owned();
 
-    *ws = out.workspace.clone().into_owned();
+    if out.status.persisted_mutation() {
+        *ws = out.workspace.clone().into_owned();
+    }
     Ok(out)
 }
 
@@ -696,7 +702,9 @@ pub fn apply_with_perm(
 
     let res = apply_only_with_perm(ctx, existing_branch, perm);
     if let Some(snapshot) = maybe_oplog_entry
-        && res.is_ok()
+        && res
+            .as_ref()
+            .is_ok_and(|out| out.status.persisted_mutation())
     {
         snapshot.commit(ctx, perm).ok();
     }

--- a/crates/but-workspace/src/branch/apply.rs
+++ b/crates/but-workspace/src/branch/apply.rs
@@ -1,7 +1,9 @@
 use std::borrow::Cow;
 
 use but_core::{
-    WORKSPACE_REF_NAME, ref_metadata::StackId, worktree::checkout::UncommitedWorktreeChanges,
+    WORKSPACE_REF_NAME,
+    ref_metadata::{StackId, StackKind},
+    worktree::checkout::UncommitedWorktreeChanges,
 };
 
 use crate::branch::{OnWorkspaceMergeConflict, try_find_validated_ref};
@@ -25,6 +27,37 @@ impl std::fmt::Debug for ConflictingStack {
     }
 }
 
+/// What kind of apply operation completed.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Serialize)]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub enum OutcomeStatus {
+    /// The branch was already active in the current workspace, so nothing changed.
+    AlreadyApplied,
+    /// The branch was applied or recorded in the workspace.
+    Applied,
+    /// A workspace merge was attempted and conflicts prevented persistence.
+    ConflictAborted,
+}
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(OutcomeStatus);
+
+impl OutcomeStatus {
+    /// The stable lower-camel-case name used by machine-readable CLI output.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            OutcomeStatus::AlreadyApplied => "alreadyApplied",
+            OutcomeStatus::Applied => "applied",
+            OutcomeStatus::ConflictAborted => "conflictAborted",
+        }
+    }
+
+    /// Whether this status represents a persisted repository/workspace mutation.
+    pub fn persisted_mutation(self) -> bool {
+        matches!(self, OutcomeStatus::Applied)
+    }
+}
+
 /// Returned by [apply()].
 pub struct Outcome<'workspace> {
     /// The newly created workspace, if owned, or the one that was passed in if borrowed, to show how the workspace looks like now.
@@ -34,12 +67,15 @@ pub struct Outcome<'workspace> {
     ///
     /// If owned, the returned workspace can also be a proposed state that was not persisted because
     /// [Options::on_workspace_conflict] aborted the operation. Check [Outcome::conflicting_stacks]
-    /// and [Outcome::applied_branches] to tell whether anything was actually applied.
+    /// and [Outcome::status] to tell whether anything was actually persisted.
     pub workspace: Cow<'workspace, but_graph::Workspace>,
-    /// The name of the branch(es) that were actually applied.
+    /// The precise kind of apply operation that completed.
+    pub status: OutcomeStatus,
+    /// The branch(es) that were activated or recorded by the operation.
     ///
     /// This is empty when `apply()` did not persist any branch, including when the branch was already
-    /// present in the workspace or when workspace merge conflicts aborted the operation. In that case, take a look at [Outcome::conflicting_stacks].
+    /// present in the workspace or when workspace merge conflicts aborted the operation. Use [Outcome::status]
+    /// to distinguish applied, no-op, and conflict-aborted outcomes.
     ///
     /// If a remote tracking branch is given to apply, it will actually apply its local tracking branch, which is created on demand as well.
     /// Further, if there is no target or if the current branch isn't the target branch, then the current branch and the given one
@@ -58,10 +94,10 @@ pub struct Outcome<'workspace> {
 }
 
 impl Outcome<'_> {
-    /// Return `true` if a new graph traversal was performed, which always is a sign for an operation which changed the workspace.
-    /// This is `false` if the to be applied branch was already contained in the current workspace.
+    /// Return `true` if apply performed work that should be visible to callers, including metadata-only repairs.
+    /// This is `false` only for a true already-applied no-op.
     pub fn workspace_changed(&self) -> bool {
-        matches!(self.workspace, Cow::Owned(_))
+        !matches!(self.status, OutcomeStatus::AlreadyApplied)
     }
 }
 
@@ -70,6 +106,7 @@ impl<'a> Outcome<'a> {
     pub fn into_owned(self) -> Outcome<'static> {
         let Outcome {
             workspace,
+            status,
             applied_branches,
             workspace_ref_created,
             workspace_merge,
@@ -78,6 +115,7 @@ impl<'a> Outcome<'a> {
 
         Outcome {
             workspace: Cow::Owned(workspace.into_owned()),
+            status,
             applied_branches,
             workspace_ref_created,
             workspace_merge,
@@ -90,6 +128,7 @@ impl std::fmt::Debug for Outcome<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let Outcome {
             workspace: _,
+            status: _,
             workspace_ref_created,
             workspace_merge: _,
             conflicting_stacks,
@@ -165,7 +204,7 @@ use anyhow::{Context as _, bail};
 use but_core::{
     ObjectStorageExt, RefMetadata, RepositoryExt, extract_remote_name_and_short_name, ref_metadata,
     ref_metadata::{
-        StackKind, Workspace,
+        Workspace,
         WorkspaceCommitRelation::{Merged, Outside},
     },
 };
@@ -249,11 +288,12 @@ pub fn apply<'ws>(
         branch = upstream_branch_name;
         branch_ref = try_find_validated_ref(repo, branch.as_ref(), "apply")?;
     }
-    if ws.is_reachable_from_entrypoint(branch.as_ref()) {
+    if branch_is_already_applied(branch.as_ref(), ws, meta)? {
         let workspace_ref_created = false;
         // When exiting early, don't try to adjust the ws commit.
         return Ok(Outcome {
             workspace: Cow::Borrowed(workspace),
+            status: OutcomeStatus::AlreadyApplied,
             workspace_ref_created,
             workspace_merge: None,
             conflicting_stacks: Vec::new(),
@@ -278,6 +318,15 @@ pub fn apply<'ws>(
                 ..Default::default()
             },
         )?;
+        let applied_branches = vec![branch.to_owned()];
+        if !branch_has_applied_workspace_metadata(branch.as_ref(), ws, meta)? {
+            let ws_ref_name = ws
+                .ref_name()
+                .context("Workspace metadata must be available to repair stale applied state")?;
+            let mut ws_md = meta.workspace(ws_ref_name)?;
+            add_branch_as_stack_forcefully(&mut ws_md, branch.as_ref(), order, new_stack_id);
+            persist_metadata_and_gitconfig(meta, &applied_branches, &ws_md, None)?;
+        }
         let ws = ws
             .graph
             .redo_traversal_with_overlay(
@@ -291,10 +340,11 @@ pub fn apply<'ws>(
         // When exiting early, don't try to adjust the ws commit.
         return Ok(Outcome {
             workspace: Cow::Owned(ws),
+            status: OutcomeStatus::Applied,
             workspace_ref_created: false,
             workspace_merge: None,
             conflicting_stacks: Vec::new(),
-            applied_branches: vec![branch.to_owned()],
+            applied_branches,
         });
     };
 
@@ -483,6 +533,7 @@ pub fn apply<'ws>(
         )?;
         return Ok(Outcome {
             workspace: Cow::Owned(graph.into_workspace()?),
+            status: OutcomeStatus::Applied,
             workspace_ref_created: needs_ws_ref_creation,
             workspace_merge: None,
             conflicting_stacks: Vec::new(),
@@ -525,7 +576,8 @@ pub fn apply<'ws>(
             correlate_conflicting_stacks(&ws_md, &merge_result.conflicting_stacks);
         return Ok(Outcome {
             workspace: Cow::Owned(ws),
-            workspace_ref_created: needs_ws_ref_creation,
+            status: OutcomeStatus::ConflictAborted,
+            workspace_ref_created: false,
             workspace_merge: Some(merge_result),
             conflicting_stacks,
             applied_branches: Vec::new(),
@@ -644,7 +696,8 @@ pub fn apply<'ws>(
                 correlate_conflicting_stacks(&ws_md, &merge_result.conflicting_stacks);
             return Ok(Outcome {
                 workspace: Cow::Owned(ws),
-                workspace_ref_created: needs_ws_ref_creation,
+                status: OutcomeStatus::ConflictAborted,
+                workspace_ref_created: false,
                 workspace_merge: Some(merge_result),
                 conflicting_stacks,
                 applied_branches: Vec::new(),
@@ -710,6 +763,7 @@ pub fn apply<'ws>(
     )?;
     Ok(Outcome {
         workspace: Cow::Owned(ws),
+        status: OutcomeStatus::Applied,
         workspace_ref_created: needs_ws_ref_creation,
         workspace_merge: Some(merge_result),
         conflicting_stacks,
@@ -766,6 +820,33 @@ fn remove_conflicting_stacks_from_workspace(
         // TODO: this might as well be 'Unmerged' to keep them in the workspace, but not let them be merged.
         stack.workspacecommit_relation = Outside;
     }
+}
+
+fn branch_is_already_applied(
+    branch: &FullNameRef,
+    ws: &but_graph::Workspace,
+    meta: &impl RefMetadata,
+) -> anyhow::Result<bool> {
+    if !ws.is_reachable_from_entrypoint(branch) {
+        return Ok(false);
+    }
+
+    branch_has_applied_workspace_metadata(branch, ws, meta)
+}
+
+fn branch_has_applied_workspace_metadata(
+    branch: &FullNameRef,
+    ws: &but_graph::Workspace,
+    meta: &impl RefMetadata,
+) -> anyhow::Result<bool> {
+    let Some(ws_ref_name) = ws.ref_name() else {
+        return Ok(true);
+    };
+    let Some(ws_md) = meta.workspace_opt(ws_ref_name)? else {
+        return Ok(true);
+    };
+    Ok(ws_md.find_branch(branch, StackKind::Applied).is_some()
+        || (ws.is_entrypoint() && ws_ref_name == branch))
 }
 
 fn filter_superseded_metadata_stacks<'a>(

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
@@ -7,8 +7,8 @@ use crate::{
 };
 use bstr::ByteSlice;
 use but_core::{
-    RefMetadata, ref_metadata,
-    ref_metadata::{StackId, WorkspaceCommitRelation::Outside},
+    RefMetadata, WORKSPACE_REF_NAME, ref_metadata,
+    ref_metadata::{StackId, StackKind, WorkspaceCommitRelation::Outside},
     worktree::checkout::UncommitedWorktreeChanges,
 };
 use but_graph::{
@@ -22,7 +22,7 @@ use but_testsupport::{
 };
 use but_workspace::branch::{
     OnWorkspaceMergeConflict,
-    apply::{WorkspaceMerge, WorkspaceReferenceNaming},
+    apply::{OutcomeStatus, WorkspaceMerge, WorkspaceReferenceNaming},
     create_reference::{Anchor, Position::Above},
     unapply::WorkspaceDisposition,
 };
@@ -2131,6 +2131,44 @@ fn unapply_dirty_worktree_abort_keeps_refs_and_metadata() -> anyhow::Result<()> 
 }
 
 #[test]
+fn apply_repairs_stale_outside_metadata_for_reachable_branch() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph("ws-ref-ws-commit-one-stack", |meta| {
+            add_stack_with_segments(meta, 1, "B", StackState::InWorkspace, &["A"]);
+        })?;
+    let ws = graph.into_workspace()?;
+    assert!(
+        ws.is_reachable_from_entrypoint(r("refs/heads/B")),
+        "fixture must start with B visible in the cached workspace graph"
+    );
+
+    let mut ws_md = meta.workspace(r(WORKSPACE_REF_NAME))?;
+    for stack in &mut ws_md.stacks {
+        stack.workspacecommit_relation = Outside;
+    }
+    meta.set_workspace(&ws_md)?;
+
+    let out =
+        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, apply_options())?;
+    assert_eq!(
+        out.status,
+        OutcomeStatus::Applied,
+        "reachable-but-unapplied metadata must be repaired instead of reported as a no-op"
+    );
+    assert_eq!(out.applied_branches, [r("refs/heads/B").to_owned()]);
+
+    let ws_md = meta.workspace(r(WORKSPACE_REF_NAME))?;
+    assert!(
+        ws_md
+            .find_branch(r("refs/heads/B"), StackKind::Applied)
+            .is_some(),
+        "apply should put the reachable branch back into the applied metadata set"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result<()> {
     let (_tmp, graph, repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph(
@@ -3629,6 +3667,11 @@ fn conflicting_apply_reports_no_applied_branches_and_names_conflicting_stacks() 
         &mut meta,
         apply_options(),
     )?;
+    assert_eq!(
+        out.status,
+        OutcomeStatus::ConflictAborted,
+        "conflicted apply should be classified as an aborted apply"
+    );
     // The workspace is changed, notably, as it always passes the most recent projection.
     insta::assert_snapshot!(sanitize_uuids_and_timestamps(format!("{out:#?}")), "a conflict-aborted apply must not report branches as applied", @r#"
     Outcome {
@@ -3811,9 +3854,22 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
     }
     "#);
 
-    // To apply A, we just checkout the surrounding workspace, as it's contained there.
+    // Simulate stale metadata: the cached graph still contains A, but metadata says it is outside.
+    let mut ws_md = meta.workspace(r(WORKSPACE_REF_NAME))?;
+    let (stack_idx, _) = ws_md
+        .find_owner_indexes_by_name(r("refs/heads/A"), StackKind::AppliedAndUnapplied)
+        .expect("A is in metadata");
+    ws_md.stacks[stack_idx].workspacecommit_relation = Outside;
+    meta.set_workspace(&ws_md)?;
+
+    // To apply A, we checkout the surrounding workspace and repair the stale metadata.
     let out =
         but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
+    assert_eq!(
+        out.status,
+        OutcomeStatus::Applied,
+        "enclosed branches should report a successful apply"
+    );
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -3821,6 +3877,13 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
         applied_branches: "[refs/heads/A]",
     }
     "#);
+    let ws_md = meta.workspace(r(WORKSPACE_REF_NAME))?;
+    assert!(
+        ws_md
+            .find_branch(r("refs/heads/A"), StackKind::Applied)
+            .is_some(),
+        "apply should repair stale enclosing-branch metadata"
+    );
 
     // Now the workspace ref itself is checked out.
     let ws = out.workspace.into_owned();
@@ -3880,6 +3943,11 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
     // Apply the first branch, it must be independent.
     let out =
         but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
+    assert_eq!(
+        out.status,
+        OutcomeStatus::Applied,
+        "already-visible branches should report a successful apply"
+    );
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -4054,6 +4122,11 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
     // To apply, we just checkout the surrounding workspace.
     let out =
         but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
+    assert_eq!(
+        out.status,
+        OutcomeStatus::Applied,
+        "enclosed branches with commits should report a successful apply"
+    );
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -97,7 +97,7 @@ Activate a branch in the workspace.
 but apply feature-branch  # Activate branch in workspace
 ```
 
-Applied branches are merged into `gitbutler/workspace` and visible in working directory.
+Default human output reports whether the branch was applied, was already active, or conflicted. Conflicts are reported as non-zero CLI errors.
 
 ### `but unapply <id>`
 

--- a/crates/but/src/command/branch/apply.rs
+++ b/crates/but/src/command/branch/apply.rs
@@ -1,4 +1,5 @@
 use but_ctx::Context;
+use but_workspace::branch::apply::OutcomeStatus;
 use gix::reference::Category;
 
 use crate::utils::OutputChannel;
@@ -10,48 +11,114 @@ pub fn apply(mut ctx: Context, branch_name: &str, out: &mut OutputChannel) -> an
         let repo = ctx.repo.get()?;
         repo.find_reference(branch_name)?.detach()
     };
-    let mut outcome = but_api::branch::apply_with_perm(
+    let outcome = but_api::branch::apply_with_perm(
         &mut ctx,
         reference.name.as_ref(),
         guard.write_permission(),
     )?;
 
+    let error_message = apply_error_message(reference.name.as_ref(), &outcome);
+
+    if let Some(out) = out.for_human() {
+        if let Some(message) = error_message.as_deref() {
+            anyhow::bail!("{message}");
+        }
+        write_human_apply_outcome(out, reference.name.as_ref(), &outcome)?;
+    } else if let Some(out) = out.for_shell() {
+        write_shell_apply_outcome(out, reference.name.as_ref(), &outcome)?;
+    }
+
+    if let Some(out) = out.for_json() {
+        out.write_value(but_api::branch::json::ApplyOutcome::from(outcome))?;
+    }
+    if let Some(message) = error_message.as_deref() {
+        anyhow::bail!("{message}");
+    }
+    Ok(())
+}
+
+fn apply_error_message(
+    requested_branch: &gix::refs::FullNameRef,
+    outcome: &but_workspace::branch::apply::Outcome<'_>,
+) -> Option<String> {
     if !outcome.conflicting_stacks.is_empty() {
-        let short_name = reference.name.shorten();
+        let short_name = requested_branch.shorten();
         let conflicting_stack_names = outcome
             .conflicting_stacks
             .iter()
             .map(|stack| stack.ref_name.shorten().to_string())
             .collect::<Vec<_>>()
             .join(", ");
-        anyhow::bail!(
+        Some(format!(
             "'{short_name}' conflicts with existing stack in the workspace: {conflicting_stack_names}"
-        );
+        ))
+    } else if matches!(outcome.status, OutcomeStatus::ConflictAborted) {
+        let short_name = requested_branch.shorten();
+        Some(format!(
+            "'{short_name}' could not be applied because conflicts prevented persistence"
+        ))
+    } else {
+        None
     }
+}
 
-    if let Some(out) = out.for_human() {
-        // Since `applied_branches` is the actual applied branches, turning remotes into local branches,
-        // hack it into submission while the legacy version exists that it has to match.
-        let special_case_remove_me_once_there_is_no_legacy_apply =
-            outcome.applied_branches.len() == 1;
-        if special_case_remove_me_once_there_is_no_legacy_apply {
-            outcome.applied_branches = vec![reference.name.clone()];
+fn write_shell_apply_outcome(
+    out: &mut dyn crate::utils::WriteWithUtils,
+    requested_branch: &gix::refs::FullNameRef,
+    outcome: &but_workspace::branch::apply::Outcome<'_>,
+) -> std::fmt::Result {
+    writeln!(out, "status={}", outcome.status.as_str())?;
+    writeln!(out, "requested_branch={requested_branch}")?;
+    writeln!(out, "workspace_changed={}", outcome.workspace_changed())?;
+    writeln!(
+        out,
+        "workspace_ref_created={}",
+        outcome.workspace_ref_created
+    )?;
+    for name in &outcome.applied_branches {
+        writeln!(out, "applied_branch={name}")?;
+    }
+    for stack in &outcome.conflicting_stacks {
+        writeln!(out, "conflicting_stack={}", stack.ref_name)?;
+    }
+    Ok(())
+}
+
+fn write_human_apply_outcome(
+    out: &mut dyn crate::utils::WriteWithUtils,
+    requested_branch: &gix::refs::FullNameRef,
+    outcome: &but_workspace::branch::apply::Outcome<'_>,
+) -> std::fmt::Result {
+    match outcome.status {
+        OutcomeStatus::AlreadyApplied => {
+            let short_name = requested_branch.shorten();
+            writeln!(
+                out,
+                "Branch '{short_name}' is already in the workspace; nothing changed"
+            )?;
         }
-        for name in outcome.applied_branches {
-            let short_name = name.shorten();
-            let is_remote_reference = name.category().is_some_and(|c| c == Category::RemoteBranch);
-            if is_remote_reference {
-                writeln!(out, "Applied remote branch '{short_name}' to workspace")
+        OutcomeStatus::Applied => {
+            let mut write_applied_branch = |name: &gix::refs::FullNameRef| {
+                let short_name = name.shorten();
+                let is_remote_reference =
+                    name.category().is_some_and(|c| c == Category::RemoteBranch);
+                if is_remote_reference {
+                    writeln!(out, "Applied remote branch '{short_name}' to workspace")
+                } else {
+                    writeln!(out, "Applied branch '{short_name}' to workspace")
+                }
+            };
+            if outcome.applied_branches.len() == 1 {
+                write_applied_branch(requested_branch)?;
             } else {
-                writeln!(out, "Applied branch '{short_name}' to workspace")
-            }?;
+                for name in &outcome.applied_branches {
+                    write_applied_branch(name.as_ref())?;
+                }
+            }
         }
-    } else if let Some(out) = out.for_shell() {
-        writeln!(out, "{reference}", reference = reference.name)?;
-    }
-
-    if let Some(out) = out.for_json() {
-        out.write_value(but_api::json::Reference::from(reference))?;
+        OutcomeStatus::ConflictAborted => {
+            unreachable!("conflict-aborted applies are rejected before formatting");
+        }
     }
     Ok(())
 }

--- a/crates/but/tests/but/command/branch/apply.rs
+++ b/crates/but/tests/but/command/branch/apply.rs
@@ -111,6 +111,16 @@ fn local_branch() {
 Applied branch 'feature-branch' to workspace
 
 "#]]);
+    env.but("apply")
+        .arg(branch_name)
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+Branch 'feature-branch' is already in the workspace; nothing changed
+
+"#]]);
+
     // It's idempotent and can produce a shell value.
     env.but("--format shell apply feature-branch")
         .allow_json()
@@ -118,7 +128,10 @@ Applied branch 'feature-branch' to workspace
         .success()
         .stderr_eq(str![])
         .stdout_eq(str![[r#"
-refs/heads/feature-branch
+status=alreadyApplied
+requested_branch=refs/heads/feature-branch
+workspace_changed=false
+workspace_ref_created=false
 
 "#]]);
 
@@ -153,38 +166,42 @@ fn local_branch_with_json_output() {
         .success()
         .stdout_eq(str![[r#"
 {
-  "name": {
-    "full": "refs/heads/feature-branch",
-    "full_bytes": [
-      114,
-      101,
-      102,
-      115,
-      47,
-      104,
-      101,
-      97,
-      100,
-      115,
-      47,
-      102,
-      101,
-      97,
-      116,
-      117,
-      114,
-      101,
-      45,
-      98,
-      114,
-      97,
-      110,
-      99,
-      104
-    ]
-  },
-  "target_id": "9f9d5a694afe171f5f9c72f8cf06db6210c3cf43",
-  "target_ref": null
+  "status": "applied",
+  "workspaceChanged": true,
+  "appliedBranches": [
+    {
+      "full": "refs/heads/feature-branch",
+      "full_bytes": [
+        114,
+        101,
+        102,
+        115,
+        47,
+        104,
+        101,
+        97,
+        100,
+        115,
+        47,
+        102,
+        101,
+        97,
+        116,
+        117,
+        114,
+        101,
+        45,
+        98,
+        114,
+        97,
+        110,
+        99,
+        104
+      ]
+    }
+  ],
+  "workspaceRefCreated": false,
+  "conflictingStacks": []
 }
 
 "#]])
@@ -198,6 +215,34 @@ fn local_branch_with_json_output() {
     |/  
     * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
     ");
+}
+
+#[test]
+fn local_branch_with_shell_output() {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
+    insta::assert_snapshot!(env.git_log(), @"
+    * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 9477ae7 (A) add A
+    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    ");
+
+    env.setup_metadata(&["A"]);
+
+    create_local_branch_with_commit(&env, "feature-branch");
+
+    env.but("--format shell apply feature-branch")
+        .allow_json()
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+status=applied
+requested_branch=refs/heads/feature-branch
+workspace_changed=true
+workspace_ref_created=false
+applied_branch=refs/heads/feature-branch
+
+"#]])
+        .stderr_eq(str![]);
 }
 
 #[test]
@@ -479,6 +524,23 @@ Failed to apply branch. 'conflicting-branch' conflicts with existing stack in th
 
 "#]])
         .stdout_eq(str![""]);
+
+    env.but("--format shell apply conflicting-branch")
+        .allow_json()
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Failed to apply branch. 'conflicting-branch' conflicts with existing stack in the workspace: A
+
+"#]])
+        .stdout_eq(str![[r#"
+status=conflictAborted
+requested_branch=refs/heads/conflicting-branch
+workspace_changed=true
+workspace_ref_created=false
+conflicting_stack=refs/heads/A
+
+"#]]);
 }
 
 mod utils {

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -606,17 +606,19 @@ export type AppSettings = {
 
 /** JSON sibling of [`but_workspace::branch::apply::Outcome`]. */
 export type ApplyOutcome = {
+  /** What kind of apply operation completed. */
+  status: OutcomeStatus;
   /**
    * Whether `apply()` produced a new workspace graph.
    *
    * This can be true even when merge conflicts prevented the result from being persisted.
-   * Use `applied_branches` to determine whether anything was persisted.
+   * Use `status` to determine whether anything was persisted.
    */
   workspaceChanged: boolean;
   /**
-   * The branches that were actually persisted into the workspace.
+   * Branches activated or recorded by the operation.
    *
-   * This is empty when the branch was already present or when conflicts aborted the apply.
+   * This is empty for `alreadyApplied` and `conflictAborted`, and populated for `applied`.
    */
   appliedBranches: Array<FullRefName>;
   /** Whether the workspace reference had to be created. */
@@ -1882,6 +1884,9 @@ export type OperatingMode = {
 };
 
 export type OperationKind = "CreateCommit" | "CreateBranch" | "StashIntoBranch" | "SetBaseBranch" | "MergeUpstream" | "UpdateWorkspaceBase" | "MoveHunk" | "UpdateBranchName" | "UpdateBranchNotes" | "ReorderBranches" | "UpdateBranchRemoteName" | "GenericBranchUpdate" | "DeleteBranch" | "ApplyBranch" | "DiscardLines" | "DiscardHunk" | "DiscardFile" | "DiscardChanges" | "Discard" | "AmendCommit" | "Absorb" | "AutoCommit" | "UndoCommit" | "DiscardCommit" | "UnapplyBranch" | "CherryPick" | "SquashCommit" | "UpdateCommitMessage" | "MoveCommit" | "MoveBranch" | "TearOffBranch" | "ReorderCommit" | "InsertBlankCommit" | "MoveCommitFile" | "FileChanges" | "EnterEditMode" | "SyncWorkspace" | "CreateDependentBranch" | "RemoveDependentBranch" | "UpdateDependentBranchName" | "UpdateDependentBranchDescription" | "UpdateDependentBranchPrNumber" | "AutoHandleChangesBefore" | "AutoHandleChangesAfter" | "SplitBranch" | "CleanWorkspace" | "OnDemandSnapshot" | "Unknown" | "RestoreFromSnapshotViaUndo" | "RestoreFromSnapshotViaRedo" | "RestoreFromSnapshot";
+
+/** What kind of apply operation completed. */
+export type OutcomeStatus = "alreadyApplied" | "applied" | "conflictAborted";
 
 export type OutsideWorkspaceMetadata = {
   /** The name of the currently checked out branch or None if in detached head state. */


### PR DESCRIPTION
## Summary

`but apply` could report success while leaving a degraded workspace unchanged when the cached workspace graph showed a branch as reachable but workspace metadata still marked it outside the applied set.

This PR makes apply distinguish a real no-op from stale metadata, repairs the stale applied state, and reports truthful outcomes across human, shell, JSON, and SDK surfaces.

## Why

The original failure mode was dangerous for agents and scripts: a command could look successful while the branch never actually became applied. That creates recovery traps after plain Git operations, squash merges, or other out-of-band workspace changes.

