### PR TITLE
Document but PR workflow in skill

### DIFF
--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -64,6 +64,8 @@ but <mutation> ...
 - Tear off a branch: `but move <branch-name-or-id> zz` (`zz` = unassigned; branch name or branch CLI ID)
 - Push: `but push <branch-name>` — always specify the branch; bare `but push` pushes ALL branches when run non-interactively
 - Pull: `but pull --check` then `but pull`
+- Create PR: `but pr new <branch-id> [-m "Title..."] [-F pr_message.txt] [-t] [--draft]` — auto-pushes before creating the PR; do not run `but push` first
+- Manage PRs: `but pr auto-merge <selector>`, `but pr set-draft <selector>`, `but pr set-ready <selector>`
 
 ## Task Recipes
 
@@ -151,6 +153,22 @@ but move feature/logging zz
 
 **Note:** branch stack/tear-off operations use branch **names** (like `feature/frontend`) or branch CLI IDs, while commit reordering uses commit **IDs** (like `c3`). Do NOT use `but undo` to unstack — it may revert more than intended and lose commits.
 
+### Create or manage pull requests
+
+`but pr new <branch-id>` pushes the branch and creates a pull request in one step. Do not run `but push` first. Agents must provide `-F pr_message.txt`, `-t`, or `-m` with real newline characters (zsh/bash: `-m $'Title\n\nBody'`) so the command does not open an editor. If forge auth is missing, run `but config forge auth`.
+
+For independent, unstacked branches, another forge tool may be okay if the user asked for it or `but pr` is unavailable. Still prefer `but pr new` when you are already working from GitButler branch IDs.
+
+For stacked branches, `but pr` is mandatory. Create and manage stacked PRs with GitButler so PR bases match the stack and GitButler can maintain the stack metadata in PR description footers. Do not create stacked PRs with `gh pr create` or other forge tools.
+
+To publish a whole stack, create the PR from the top branch you want published:
+
+```bash
+but pr new <top-branch-id> -t
+```
+
+That creates or updates reviews for that branch and its dependencies in stack order. Use `but pr auto-merge <selector>`, `but pr set-draft <selector>`, and `but pr set-ready <selector>` for follow-up PR management; selectors can be branch names, branch IDs, stack IDs, or numeric review IDs.
+
 ### Stacked dependency / commit-lock recovery
 
 A **dependency lock** occurs when a file was originally committed on branch A, but you're trying to commit changes to it on branch B. Symptoms:
@@ -192,6 +210,7 @@ If `but move` causes conflicts (conflicted commits in status):
 | `git rebase -i` | `but move`, `but squash`, `but reword` |
 | `git rebase --onto` | `but move <branch> <new-base>` |
 | `git cherry-pick` | `but pick` |
+| `gh pr create` | `but pr new <branch-id>` (pushes the branch, then creates the PR; no separate `but push`) |
 
 ## Notes
 

--- a/crates/but/skill/references/examples.md
+++ b/crates/but/skill/references/examples.md
@@ -64,12 +64,11 @@ but branch new user-profile -a bu
 but status -fv
 but commit bv -m "Add user profile page" --changes <file-ids>
 
-# 6. Push both branches explicitly (maintains stack relationship)
-but push add-authentication
-but push user-profile
+# 6. Create stacked pull requests through GitButler (auto-pushes the stack)
+but pr new bv -t
 ```
 
-**Result:** Two PRs where user-profile PR depends on authentication PR. GitHub/GitLab shows the dependency.
+**Result:** Two PRs where user-profile targets add-authentication, with GitButler stack information in the PR descriptions.
 
 ## Example 3: Using Absorb Instead of New Commits
 

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -418,9 +418,9 @@ Use `--no-hooks` to bypass pre-push hooks when needed.
 
 Selectors for `auto-merge`, `set-draft`, and `set-ready` can be branch names, branch IDs, stack IDs, or numeric review IDs, comma-separated.
 
-In non-interactive environments, use `--message (-m)`, `--file (-F)`, or `--default (-t)` to avoid editor prompts. The `-t` flag uses the commit message as title/description for single-commit branches; for multi-commit branches it falls back to the branch name as the title.
+Agents must use `--message (-m)`, `--file (-F)`, or `--default (-t)` to avoid editor prompts. The `-t` flag uses the commit message as title/description for single-commit branches; for multi-commit branches it falls back to the branch name as the title.
 
-**Note:** For stacked branches, the custom message (`-m` or `-F`) only applies to the selected branch. Dependent branches in the stack will use default messages (commit title/description).
+**Stacked branches:** Use `but pr` for stacked PRs. It creates reviews against the right bases and updates GitButler stack footers in PR descriptions. Creating stacked PRs with `gh pr create` or another forge tool loses that stack-aware behavior. To publish a whole stack, run `but pr new <top-branch-id> -t`; custom messages (`-m` or `-F`) only apply to the selected branch, while dependent branches use default messages (commit title/description).
 
 Requires forge integration to be configured via `but config forge auth`.
 


### PR DESCRIPTION
## Summary
- document `but pr new` as the direct PR creation path for agents
- make stacked PRs mandatory through `but pr` for correct bases and stack footers
- update the stacked workflow example to use `but pr new` instead of push-only steps

## Validation
- `git diff --check`
- `cargo test -p but skill_files_are_valid`