### PR TITLE
fix(cli): fix committing to existing branch referenced via short code

### DIFF
--- a/crates/but/src/args/atoms/cli_id.rs
+++ b/crates/but/src/args/atoms/cli_id.rs
@@ -97,7 +97,7 @@ impl CliIdArg {
         };
         match id {
             CliId::Commit { commit_id, .. } => Ok(Some(commit_id)),
-            other => Err(self.wrong_kind_error(&other, "commit")),
+            _ => Ok(None),
         }
     }
 
@@ -144,11 +144,11 @@ impl CliIdArg {
         };
         match id {
             CliId::Branch { name, .. } => Ok(Some(BranchArg(name))),
-            other => Err(self.wrong_kind_error(&other, "branch")),
+            _ => Ok(None),
         }
     }
 
-    /// TODO
+    /// TODO: docs
     pub fn try_resolve_uncommitted(
         &self,
         repo: &gix::Repository,
@@ -184,7 +184,7 @@ impl CliIdArg {
                     })
                     .collect(),
             )),
-            other => Err(self.wrong_kind_error(&other, "uncommitted change")),
+            _ => Ok(None),
         }
     }
 
@@ -201,6 +201,7 @@ impl CliIdArg {
         }
     }
 
+    #[expect(dead_code)]
     fn wrong_kind_error(&self, id: &CliId, expected: &'static str) -> CliError {
         let kind = match id {
             CliId::Branch { .. } => "a branch",

--- a/crates/but/src/args/commit2.rs
+++ b/crates/but/src/args/commit2.rs
@@ -1,6 +1,8 @@
-#![deny(missing_docs)]
 //! Arguments for `commit2`.
-use crate::args::atoms::{BranchArg, CliIdArg};
+
+#![deny(missing_docs)]
+
+use crate::args::atoms::CliIdArg;
 
 /// Create a commit.
 ///
@@ -36,7 +38,7 @@ pub struct Platform {
     ///
     /// Attempting to place a commit on a branch that exists but is not applied is an error.
     #[clap(short, long, value_name = "BRANCH", group = "targeting")]
-    pub branch: Option<Option<BranchArg>>,
+    pub branch: Option<Option<CliIdArg>>,
     /// Place the commit above `BRANCH_OR_COMMIT`, which must be an applied branch or commit.
     ///
     /// If `BRANCH_OR_COMMIT` is a commit, the new commit is placed on the same branch as the

--- a/crates/but/src/command/legacy/commit2.rs
+++ b/crates/but/src/command/legacy/commit2.rs
@@ -313,7 +313,7 @@ fn run(
 /// Targeting modes for committing.
 enum CommitOperationTargetIsh {
     /// Target the branch if it exists, or create it at the newest base if it does not.
-    Branch(BranchArg),
+    Branch(CliIdArg),
     /// Target newest base with a new canned branch name.
     UnstackedCannedBranch,
     /// Targets above the [`CliIdArg`], which must denote either a commit or a branch.
@@ -343,8 +343,9 @@ fn route_commit_operation(
             let position = CommitRelativeToTargetPosition::Below;
             route_commit_above_or_below(repo, id_map, cli_id, position)
         }
-        CommitOperationTargetIsh::Branch(branch) => {
-            if let Some(segment) = branch.try_resolve_segment(head_info)? {
+        CommitOperationTargetIsh::Branch(cli_id) => {
+            if let Some(branch) = cli_id.try_resolve_branch(repo, id_map)? {
+                let segment = branch.resolve_segment(head_info)?;
                 let ref_info = segment.ref_info.with_context(|| {
                     format!("BUG: Segment resolved from branch name {branch} has no ref info")
                 })?;
@@ -355,6 +356,7 @@ fn route_commit_operation(
 
                 Ok(CommitOperation::CommitAt(CommitAtOperation { target }))
             } else {
+                let branch = BranchArg(cli_id.0);
                 let branch_name =
                     BranchArg(branch.resolve_for_creation(repo, head_info).with_hint(|| {
                         format!("Run `but apply {branch}` to apply the branch first")

--- a/crates/but/tests/but/command/commit2.rs
+++ b/crates/but/tests/but/command/commit2.rs
@@ -1263,7 +1263,7 @@ fn committing_something_that_isnt_a_cli_id() {
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Invalid uncommitted change. 'A' is a branch
+Error: Could not find uncommitted change: 'A'
 
 "#]]);
 }
@@ -1622,6 +1622,57 @@ fn gives_good_error_when_your_terminal_doesnt_support_input() {
         .failure()
         .stderr_eq(snapbox::str![[r#"
 Error: Terminal doesn't support interactivity
+
+"#]]);
+}
+
+#[test]
+fn commit_to_existing_branch_via_short_code() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    env.but("_commit2 -b g0 -m 'new commit'").assert().success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   2e0e1d8 new commit (no changes)
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn commit_to_new_branch_with_same_name_as_file() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.file("file", "");
+
+    env.but("_commit2 -b file -m 'add file'").assert().success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted changes] (no changes)
+┊
+┊╭┄fi [file]
+┊●   46b0823 add file
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
 
 "#]]);
 }

--- a/crates/but/tests/but/command/squash2.rs
+++ b/crates/but/tests/but/command/squash2.rs
@@ -513,7 +513,7 @@ fn cannot_squash_into_branches() {
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Invalid commit. 'a-branch-1' is a branch
+Error: Could not find commit: 'a-branch-1'
 
 Hint: --target must always target a commit
 

--- a/crates/but/tests/but/command/switch.rs
+++ b/crates/but/tests/but/command/switch.rs
@@ -210,9 +210,7 @@ fn rejects_non_branch_cli_id() -> anyhow::Result<()> {
         .assert()
         .failure()
         .stdout_eq(str![])
-        .stderr_eq(format!(
-            "Error: Invalid branch. '{commit_cli_id}' is a commit\n"
-        ));
+        .stderr_eq(format!("Error: Could not find branch: '{commit_cli_id}'\n"));
 
     Ok(())
 }


### PR DESCRIPTION
Fixes `but _commit2 -b g0` where `g0` is a short code that points to an
existing branch. It did make some error messages slightly worse but I think its
worth it.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #14392
- <kbd>&nbsp;1&nbsp;</kbd> #14391 👈 
<!-- GitButler Footer Boundary Bottom -->