### PR TITLE
Replace change status icon with kebab menu on file row hover and selection

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.module.css
@@ -20,6 +20,13 @@
 	font-size: 11px;
 
 	font-family: var(--text-fontfamily-base);
+
+	.fileRow:hover &,
+	.fileRow:focus-within &,
+	.fileRow[aria-selected="true"] & {
+		display: none;
+	}
+
 	&[data-char="A"] {
 		color: var(--change-status-addition);
 	}


### PR DESCRIPTION
Swaps the 'change status' icon menu for kebab menu to prevent layout shifting on hover.

<img width="533" height="266" alt="image" src="https://github.com/user-attachments/assets/9cbd4c69-339c-43c5-9595-4ad0c7a1902a" />

Reference (Conductor app):

https://github.com/user-attachments/assets/39f0564c-ced4-4d68-bd70-5cf49ead0526

