### PR TITLE
Lite: change hotkey for inline reword/rename from "Enter" to "R"

### DIFF
--- a/apps/lite/ui/src/hotkeys.ts
+++ b/apps/lite/ui/src/hotkeys.ts
@@ -168,7 +168,7 @@ export const outlineHotkeys = {
 		meta: { group: "Commit", name: "Delete commit" },
 	},
 	composeCommitMessageFromChanges: {
-		hotkey: "Enter",
+		hotkey: "R",
 		meta: { group: "Changes", name: "Compose commit message" },
 	},
 	moveCommitDown: {
@@ -188,11 +188,11 @@ export const outlineHotkeys = {
 		meta: { group: "Stack", name: "Update stack (rebases)" },
 	},
 	renameBranch: {
-		hotkey: "Enter",
+		hotkey: "R",
 		meta: { group: "Branch", name: "Rename branch" },
 	},
 	rewordCommit: {
-		hotkey: "Enter",
+		hotkey: "R",
 		meta: { group: "Commit", name: "Reword commit" },
 	},
 	selectBranch: {


### PR DESCRIPTION
Towards GB-1664