### PR TITLE
Use the review data to determine integration

### DIFF
--- a/apps/desktop/src/lib/bootstrap/deps.ts
+++ b/apps/desktop/src/lib/bootstrap/deps.ts
@@ -243,6 +243,7 @@ export function initDependencies(args: {
 	const upstreamIntegrationService = new UpstreamIntegrationService(
 		clientState.backendApi,
 		stackService,
+		prService,
 	);
 
 	// ============================================================================

--- a/apps/desktop/src/lib/forge/prService.svelte.ts
+++ b/apps/desktop/src/lib/forge/prService.svelte.ts
@@ -17,6 +17,23 @@ import type { StartQueryActionCreatorOptions } from "@reduxjs/toolkit/query";
 
 export const PR_SERVICE = new InjectionToken<PrService>("PrService");
 
+const pendingReviewFetches = new Map<string, Set<Promise<unknown>>>();
+
+function trackReviewFetch(projectId: string, pending: Promise<unknown>) {
+	let pendingForProject = pendingReviewFetches.get(projectId);
+	if (!pendingForProject) {
+		pendingForProject = new Set();
+		pendingReviewFetches.set(projectId, pendingForProject);
+	}
+	pendingForProject.add(pending);
+	pending.finally(() => {
+		pendingForProject.delete(pending);
+		if (pendingForProject.size === 0) {
+			pendingReviewFetches.delete(projectId);
+		}
+	});
+}
+
 export class PrService {
 	loading = writable(false);
 	private backendApi: ReturnType<typeof injectBackendEndpoints>;
@@ -81,6 +98,14 @@ export class PrService {
 			options,
 		);
 		return review ? mapForgeReviewToPullRequest(review) : undefined;
+	}
+
+	async waitForRefreshes(projectId: string): Promise<void> {
+		let pending = pendingReviewFetches.get(projectId);
+		while (pending && pending.size > 0) {
+			await Promise.allSettled([...pending]);
+			pending = pendingReviewFetches.get(projectId);
+		}
 	}
 
 	get(projectId: string, number: number, options?: StartQueryActionCreatorOptions) {
@@ -199,6 +224,10 @@ function injectBackendEndpoints(api: BackendApi) {
 				extraOptions: { command: "get_review" },
 				query: (args) => args,
 				providesTags: (_result, _error, args) => providesItem(ReduxTag.PullRequests, args.reviewId),
+				onQueryStarted: (args, { queryFulfilled }) => {
+					const pending = queryFulfilled.catch(() => undefined);
+					trackReviewFetch(args.projectId, pending);
+				},
 			}),
 			getMergeStatus: build.query<ReviewMergeStatus, { projectId: string; reviewId: number }>({
 				extraOptions: { command: "get_review_merge_status" },

--- a/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
+++ b/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
@@ -4,6 +4,7 @@ import {
 	type UpstreamIntegrationStatuses,
 } from "$lib/upstream/types";
 import { InjectionToken } from "@gitbutler/core/context";
+import type { PrService } from "$lib/forge/prService.svelte";
 import type { StackService } from "$lib/stacks/stackService.svelte";
 import type { BackendApi } from "$lib/state/backendApi";
 
@@ -15,9 +16,12 @@ export class UpstreamIntegrationService {
 	constructor(
 		private backendApi: BackendApi,
 		private stackService: StackService,
+		private prService: PrService,
 	) {}
 
 	async upstreamStatuses(projectId: string): Promise<UpstreamIntegrationStatuses> {
+		await this.prService.waitForRefreshes(projectId);
+
 		const stacks = await this.stackService.fetchStacks(projectId);
 		const updates = buildUpstreamIntegrationUpdates(stacks);
 

--- a/apps/desktop/src/lib/upstream/upstreamIntegrationService.test.ts
+++ b/apps/desktop/src/lib/upstream/upstreamIntegrationService.test.ts
@@ -68,6 +68,9 @@ describe("UpstreamIntegrationService", () => {
 			{
 				fetchStacks: vi.fn().mockResolvedValue(stacks),
 			} as any,
+			{
+				waitForRefreshes: vi.fn().mockResolvedValue(undefined),
+			} as any,
 		);
 
 		const statuses = await service.upstreamStatuses("project-1");
@@ -110,6 +113,9 @@ describe("UpstreamIntegrationService", () => {
 			{
 				fetchStacks: vi.fn().mockResolvedValue(stacks),
 			} as any,
+			{
+				waitForRefreshes: vi.fn().mockResolvedValue(undefined),
+			} as any,
 		);
 
 		const statuses = await service.upstreamStatuses("project-1");
@@ -145,5 +151,57 @@ describe("UpstreamIntegrationService", () => {
 				},
 			],
 		});
+	});
+
+	test("waits for pending direct review refresh before previewing integration", async () => {
+		const calls: string[] = [];
+		// eslint-disable-next-line func-style
+		let finishRefresh: () => void = () => {};
+		const refresh = new Promise<void>((resolve) => {
+			finishRefresh = resolve;
+		});
+		const mutate = vi.fn().mockImplementation(async () => {
+			calls.push("preview");
+			return await Promise.resolve({
+				workspaceState: {
+					headInfo: refInfo([]),
+					changes: [],
+					replacedCommits: {},
+				},
+				worktreeConflicts: [],
+			});
+		});
+		const service = new UpstreamIntegrationService(
+			{
+				endpoints: {
+					workspaceIntegrateUpstream: {
+						mutate,
+					},
+				},
+			} as any,
+			{
+				fetchStacks: vi.fn().mockImplementation(async () => {
+					calls.push("stacks");
+					return await Promise.resolve([stack([segment("feature")])]);
+				}),
+			} as any,
+			{
+				waitForRefreshes: vi.fn().mockImplementation(async () => {
+					calls.push("wait");
+					await refresh;
+					calls.push("refreshed");
+				}),
+			} as any,
+		);
+
+		const statuses = service.upstreamStatuses("project-1");
+		await Promise.resolve();
+
+		expect(calls).toEqual(["wait"]);
+
+		finishRefresh();
+		await statuses;
+
+		expect(calls).toEqual(["wait", "refreshed", "stacks", "preview"]);
 	});
 });

--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -1,11 +1,17 @@
 //! Functions that operate on the workspace.
 
+use std::{borrow::Cow, collections::HashSet};
+
 use crate::WorkspaceState;
 use but_api_macros::but_api;
-use but_core::{DryRun, RefMetadata, is_workspace_ref_name, sync::RepoExclusive};
+use but_core::{
+    DryRun, RefMetadata, extract_remote_name_and_short_name, is_workspace_ref_name,
+    sync::RepoExclusive,
+};
+use but_forge::ForgeReview;
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
 use but_serde::BStringForFrontend;
-use but_workspace::IntegrateUpstreamOutcome;
+use but_workspace::{IntegrateUpstreamOutcome, ReviewIntegrationHint};
 use tracing::instrument;
 
 /// Result of integrating upstream changes into the current workspace.
@@ -94,6 +100,83 @@ pub mod json {
             })
         }
     }
+}
+
+fn target_branch_name(
+    symbolic_remote_names: &[String],
+    project_meta: &but_core::ref_metadata::ProjectMeta,
+) -> Option<String> {
+    let target_ref = project_meta.target_ref.as_ref()?;
+    let mut symbolic_remote_names = symbolic_remote_names.iter().collect::<Vec<_>>();
+    symbolic_remote_names.sort_by_key(|name| name.len());
+    let remote_names = symbolic_remote_names
+        .iter()
+        .map(|name| Cow::Borrowed(name.as_str().into()))
+        .collect();
+    Some(
+        extract_remote_name_and_short_name(target_ref.as_ref(), &remote_names)
+            .map(|(_, short_name)| short_name.to_string())
+            .unwrap_or_else(|| target_ref.shorten().to_string()),
+    )
+}
+
+fn review_integration_hints_from_reviews(
+    target_branch_name: &str,
+    incoming_commit_ids: &HashSet<String>,
+    reviews: impl IntoIterator<Item = ForgeReview>,
+) -> Vec<ReviewIntegrationHint> {
+    let mut seen = HashSet::new();
+
+    reviews
+        .into_iter()
+        .filter(|review| {
+            review.is_merged()
+                && review.target_branch == target_branch_name
+                && review
+                    .integration_commit_shas
+                    .iter()
+                    .any(|sha| incoming_commit_ids.contains(sha))
+        })
+        .filter_map(|review| gix::ObjectId::from_hex(review.sha.as_bytes()).ok())
+        .filter(|head_commit_at_merge| seen.insert(*head_commit_at_merge))
+        .map(|head_commit_at_merge| ReviewIntegrationHint {
+            head_commit_at_merge,
+        })
+        .collect()
+}
+
+fn forge_review_integration_hints(
+    workspace: &but_graph::Workspace,
+    project_meta: &but_core::ref_metadata::ProjectMeta,
+    db: &but_db::DbHandle,
+) -> anyhow::Result<Vec<ReviewIntegrationHint>> {
+    let Some(target_branch_name) =
+        target_branch_name(&workspace.graph.symbolic_remote_names, project_meta)
+    else {
+        return Ok(vec![]);
+    };
+
+    let incoming_commit_ids = workspace
+        .incoming_target_commit_ids()?
+        .into_iter()
+        .map(|id| id.to_hex().to_string())
+        .collect::<HashSet<_>>();
+    if incoming_commit_ids.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let associated_reviews = db
+        .forge_reviews()
+        .list_all()?
+        .into_iter()
+        .map(but_forge::ForgeReview::try_from)
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    Ok(review_integration_hints_from_reviews(
+        &target_branch_name,
+        &incoming_commit_ids,
+        associated_reviews,
+    ))
 }
 
 /// Integrate upstream changes into the current workspace without recording an
@@ -190,13 +273,21 @@ pub fn workspace_integrate_upstream_only_with_perm(
 ) -> anyhow::Result<WorkspaceIntegrateUpstreamOutcome> {
     let mut meta = ctx.meta()?;
     let (workspace_state, worktree_conflicts) = {
-        let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
+        let (repo, mut ws, db) = ctx.workspace_mut_and_db_with_perm(perm)?;
         let project_meta = ctx.project_meta()?;
+        let review_hints = forge_review_integration_hints(&ws, &project_meta, &db)?;
         let IntegrateUpstreamOutcome {
             rebase,
             ws_meta,
             project_meta,
-        } = but_workspace::integrate_upstream(&mut ws, &mut meta, project_meta, &repo, updates)?;
+        } = but_workspace::integrate_upstream_with_hints(
+            &mut ws,
+            &mut meta,
+            project_meta,
+            &repo,
+            updates,
+            &review_hints,
+        )?;
         let worktree_conflicts = but_workspace::worktree_conflicts_for_rebase(&rebase)?;
 
         if dry_run.into() {
@@ -234,4 +325,150 @@ pub fn workspace_integrate_upstream_only_with_perm(
         workspace_state,
         worktree_conflicts,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{review_integration_hints_from_reviews, target_branch_name};
+    use std::collections::HashSet;
+
+    fn review(
+        sha: &str,
+        integration_commit_shas: &[&str],
+        target_branch: &str,
+        merged_at: Option<&str>,
+    ) -> but_forge::ForgeReview {
+        but_forge::ForgeReview {
+            html_url: "https://example.test/review/1".into(),
+            number: 1,
+            title: "review".into(),
+            body: None,
+            author: None,
+            labels: vec![],
+            draft: false,
+            source_branch: "feature".into(),
+            target_branch: target_branch.into(),
+            sha: sha.into(),
+            integration_commit_shas: integration_commit_shas
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+            created_at: None,
+            modified_at: None,
+            merged_at: merged_at.map(str::to_owned),
+            closed_at: merged_at.map(str::to_owned),
+            repository_ssh_url: None,
+            repository_https_url: None,
+            repo_owner: None,
+            head_repo_is_fork: false,
+            reviewers: vec![],
+            unit_symbol: "#".into(),
+            last_sync_at: Default::default(),
+        }
+    }
+
+    #[test]
+    fn target_branch_name_prefers_longest_matching_remote_name() {
+        let project_meta = but_core::ref_metadata::ProjectMeta {
+            target_ref: Some(
+                "refs/remotes/foo/bar/main"
+                    .try_into()
+                    .expect("target ref is a valid full ref name"),
+            ),
+            ..Default::default()
+        };
+        let remote_names = vec!["foo".to_string(), "foo/bar".to_string()];
+
+        assert_eq!(
+            target_branch_name(&remote_names, &project_meta).as_deref(),
+            Some("main"),
+            "the longest matching remote name should be stripped from the target ref"
+        );
+    }
+
+    #[test]
+    fn review_hints_keep_only_merged_reviews_on_the_target_branch() {
+        let hints = review_integration_hints_from_reviews(
+            "main",
+            &HashSet::from(["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string()]),
+            vec![
+                review(
+                    "1234567890abcdef1234567890abcdef12345678",
+                    &["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"],
+                    "main",
+                    Some("2026-06-24T12:00:00Z"),
+                ),
+                review(
+                    "abcdef1234567890abcdef1234567890abcdef12",
+                    &["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"],
+                    "release",
+                    Some("2026-06-24T12:00:00Z"),
+                ),
+                review(
+                    "fedcba9876543210fedcba9876543210fedcba98",
+                    &["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"],
+                    "main",
+                    None,
+                ),
+            ],
+        );
+
+        assert_eq!(
+            hints.len(),
+            1,
+            "only merged reviews targeting the current branch produce hints"
+        );
+        assert_eq!(
+            hints[0].head_commit_at_merge.to_hex().to_string(),
+            "1234567890abcdef1234567890abcdef12345678",
+            "the hint should use the review head SHA reported by the forge"
+        );
+    }
+
+    #[test]
+    fn review_hints_dedupe_duplicate_review_heads() {
+        let hints = review_integration_hints_from_reviews(
+            "main",
+            &HashSet::from(["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string()]),
+            vec![
+                review(
+                    "1234567890abcdef1234567890abcdef12345678",
+                    &["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"],
+                    "main",
+                    Some("2026-06-24T12:00:00Z"),
+                ),
+                review(
+                    "1234567890abcdef1234567890abcdef12345678",
+                    &["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"],
+                    "main",
+                    Some("2026-06-24T12:00:00Z"),
+                ),
+            ],
+        );
+
+        assert_eq!(
+            hints.len(),
+            1,
+            "multiple incoming commits may map to the same merged review head"
+        );
+    }
+
+    #[test]
+    fn review_hints_ignore_reviews_without_matching_incoming_commit() {
+        let hints = review_integration_hints_from_reviews(
+            "main",
+            &HashSet::from(["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string()]),
+            vec![review(
+                "1234567890abcdef1234567890abcdef12345678",
+                &["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"],
+                "main",
+                Some("2026-06-24T12:00:00Z"),
+            )],
+        );
+
+        assert!(
+            hints.is_empty(),
+            "cached review hints should only match reviews whose landing commit is among incoming upstream commits"
+        );
+    }
 }

--- a/crates/but-db/src/table/forge_reviews.rs
+++ b/crates/but-db/src/table/forge_reviews.rs
@@ -160,38 +160,7 @@ impl ForgeReviewsHandleMut<'_> {
         self.sp.execute("DELETE FROM forge_reviews", [])?;
 
         for review in reviews {
-            self.sp.execute(
-                "INSERT INTO forge_reviews (html_url, number, title, body, author, labels, draft, \
-                 source_branch, target_branch, sha, integration_commit_shas, created_at, modified_at, merged_at, closed_at, \
-                 repository_ssh_url, repository_https_url, repo_owner, head_repo_is_fork, reviewers, \
-                 unit_symbol, last_sync_at, struct_version) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23)",
-                rusqlite::params![
-                    review.html_url,
-                    review.number,
-                    review.title,
-                    review.body,
-                    review.author,
-                    review.labels,
-                    review.draft,
-                    review.source_branch,
-                    review.target_branch,
-                    review.sha,
-                    review.integration_commit_shas,
-                    review.created_at,
-                    review.modified_at,
-                    review.merged_at,
-                    review.closed_at,
-                    review.repository_ssh_url,
-                    review.repository_https_url,
-                    review.repo_owner,
-                    review.head_repo_is_fork,
-                    review.reviewers,
-                    review.unit_symbol,
-                    review.last_sync_at,
-                    review.struct_version,
-                ],
-            )?;
+            self.upsert_without_commit(review)?;
         }
 
         self.sp.commit()?;
@@ -200,6 +169,61 @@ impl ForgeReviewsHandleMut<'_> {
 
     /// Inserts or updates a single forge review by review number.
     pub fn upsert(self, review: ForgeReview) -> rusqlite::Result<()> {
+        self.upsert_without_commit(review)?;
+
+        self.sp.commit()?;
+        Ok(())
+    }
+
+    /// Reconciles a fresh forge-list response with retained review rows.
+    ///
+    /// Listed reviews are inserted or updated, cached open reviews that no
+    /// longer appear in the latest list are deleted, and merged reviews at or
+    /// before `merged_cutoff` are pruned. Closed or recently merged reviews
+    /// that are absent from the list are retained so direct review lookups can
+    /// continue to serve integration hints.
+    pub fn reconcile_listed(
+        self,
+        reviews: Vec<ForgeReview>,
+        merged_cutoff: chrono::NaiveDateTime,
+    ) -> rusqlite::Result<()> {
+        let listed_numbers = reviews
+            .iter()
+            .map(|review| review.number)
+            .collect::<Vec<_>>();
+        for review in reviews {
+            self.upsert_without_commit(review)?;
+        }
+
+        if listed_numbers.is_empty() {
+            self.sp.execute(
+                "DELETE FROM forge_reviews WHERE merged_at IS NULL AND closed_at IS NULL",
+                [],
+            )?;
+        } else {
+            let placeholders = std::iter::repeat_n("?", listed_numbers.len())
+                .collect::<Vec<_>>()
+                .join(", ");
+            self.sp.execute(
+                &format!(
+                    "DELETE FROM forge_reviews \
+                     WHERE merged_at IS NULL AND closed_at IS NULL \
+                     AND number NOT IN ({placeholders})"
+                ),
+                rusqlite::params_from_iter(listed_numbers),
+            )?;
+        }
+
+        self.sp.execute(
+            "DELETE FROM forge_reviews WHERE merged_at IS NOT NULL AND merged_at <= ?1",
+            [merged_cutoff],
+        )?;
+
+        self.sp.commit()?;
+        Ok(())
+    }
+
+    fn upsert_without_commit(&self, review: ForgeReview) -> rusqlite::Result<()> {
         self.sp.execute(
             "INSERT INTO forge_reviews (html_url, number, title, body, author, labels, draft, \
              source_branch, target_branch, sha, integration_commit_shas, created_at, modified_at, merged_at, closed_at, \
@@ -254,6 +278,15 @@ impl ForgeReviewsHandleMut<'_> {
                 review.last_sync_at,
                 review.struct_version,
             ],
+        )?;
+        Ok(())
+    }
+
+    /// Deletes reviews with a merge timestamp at or before `cutoff`.
+    pub fn delete_merged_before(self, cutoff: chrono::NaiveDateTime) -> rusqlite::Result<()> {
+        self.sp.execute(
+            "DELETE FROM forge_reviews WHERE merged_at IS NOT NULL AND merged_at <= ?1",
+            [cutoff],
         )?;
 
         self.sp.commit()?;

--- a/crates/but-db/tests/db/table/forge_review.rs
+++ b/crates/but-db/tests/db/table/forge_review.rs
@@ -190,6 +190,83 @@ fn upsert_updates_existing_review() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[test]
+fn delete_merged_before_prunes_only_stale_merged_reviews() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+
+    let cutoff = chrono::DateTime::from_timestamp(2_000_000, 0)
+        .unwrap()
+        .naive_utc();
+    let mut stale_merged = forge_review(1, "Stale merged PR", "stale-merged");
+    stale_merged.merged_at = Some(cutoff);
+    let mut recent_merged = forge_review(2, "Recent merged PR", "recent-merged");
+    recent_merged.merged_at = Some(cutoff + chrono::Duration::seconds(1));
+    let open = forge_review(3, "Open PR", "open");
+
+    db.forge_reviews_mut()?
+        .set_all(vec![stale_merged, recent_merged.clone(), open.clone()])?;
+    db.forge_reviews_mut()?.delete_merged_before(cutoff)?;
+
+    let reviews = db.forge_reviews().list_all()?;
+    assert_eq!(
+        reviews,
+        [recent_merged, open],
+        "only merged reviews at or before the cutoff should be pruned"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn reconcile_listed_prunes_stale_rows() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+
+    let cutoff = chrono::DateTime::from_timestamp(2_000_000, 0)
+        .unwrap()
+        .naive_utc();
+    let stale_open = forge_review(1, "Stale open PR", "stale-open");
+    let mut listed_open = forge_review(2, "Cached open PR", "listed-open");
+    let mut closed = forge_review(3, "Closed PR", "closed");
+    closed.closed_at = Some(cutoff);
+    let mut recent_merged = forge_review(4, "Recent merged PR", "recent-merged");
+    recent_merged.merged_at = Some(cutoff + chrono::Duration::seconds(1));
+    let mut old_merged = forge_review(5, "Old merged PR", "old-merged");
+    old_merged.merged_at = Some(cutoff);
+
+    db.forge_reviews_mut()?.set_all(vec![
+        stale_open,
+        listed_open.clone(),
+        closed.clone(),
+        recent_merged.clone(),
+        old_merged,
+    ])?;
+
+    listed_open.title = "Fresh listed open PR".to_string();
+    db.forge_reviews_mut()?
+        .reconcile_listed(vec![listed_open.clone()], cutoff)?;
+
+    let reviews = db.forge_reviews().list_all()?;
+    assert_eq!(
+        reviews.len(),
+        3,
+        "stale open and old merged reviews should be pruned"
+    );
+    assert!(
+        reviews.contains(&listed_open),
+        "listed open review should be updated"
+    );
+    assert!(
+        reviews.contains(&closed),
+        "closed review should be retained when absent from open list"
+    );
+    assert!(
+        reviews.contains(&recent_merged),
+        "recent merged review should be retained for integration hints"
+    );
+
+    Ok(())
+}
+
 fn forge_review(number: i64, title: &str, source_branch: &str) -> ForgeReview {
     ForgeReview {
         html_url: format!("https://github.com/owner/repo/pull/{number}"),

--- a/crates/but-forge/src/db.rs
+++ b/crates/but-forge/src/db.rs
@@ -1,5 +1,7 @@
 use super::ForgeReview;
 
+const MERGED_REVIEW_RETENTION_DAYS: i64 = 15;
+
 impl TryFrom<ForgeReview> for but_db::ForgeReview {
     type Error = anyhow::Error;
     fn try_from(value: ForgeReview) -> anyhow::Result<Self, Self::Error> {
@@ -96,18 +98,27 @@ pub(crate) fn reviews_from_cache(db: &but_db::DbHandle) -> anyhow::Result<Vec<Fo
     Ok(reviews)
 }
 
+/// Refreshes the cached review rows returned by a forge listing.
+///
+/// Listed reviews are upserted instead of replacing the whole table so directly
+/// fetched reviews, such as recently merged PRs used by upstream integration,
+/// are not deleted by an open-review list response. Cached open reviews that no
+/// longer appear in the listed response are deleted, while retained merged
+/// reviews are pruned after 15 days.
 pub(crate) fn cache_reviews(
     db: &mut but_db::DbHandle,
     reviews: &[ForgeReview],
 ) -> anyhow::Result<()> {
-    let db_reviews: Vec<but_db::ForgeReview> = reviews
+    let cutoff =
+        chrono::Local::now().naive_local() - chrono::Duration::days(MERGED_REVIEW_RETENTION_DAYS);
+    let db_reviews = reviews
         .iter()
-        .map(|r| r.clone().try_into())
-        .collect::<anyhow::Result<Vec<but_db::ForgeReview>>>(
-    )?;
+        .map(|review| review.clone().try_into())
+        .collect::<anyhow::Result<Vec<_>>>()?;
     db.forge_reviews_mut()?
-        .set_all(db_reviews)
-        .map_err(Into::into)
+        .reconcile_listed(db_reviews, cutoff)
+        .map_err(anyhow::Error::from)?;
+    Ok(())
 }
 
 pub(crate) fn upsert_review(db: &mut but_db::DbHandle, review: &ForgeReview) -> anyhow::Result<()> {

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -63,7 +63,8 @@ use but_graph::{SegmentIndex, workspace::TargetCommit};
 
 mod upstream_integration;
 pub use upstream_integration::{
-    BottomUpdate, BottomUpdateKind, IntegrateUpstreamOutcome, integrate_upstream,
+    BottomUpdate, BottomUpdateKind, IntegrateUpstreamOutcome, ReviewIntegrationHint,
+    integrate_upstream, integrate_upstream_with_hints,
 };
 mod worktree;
 pub use worktree::worktree_conflicts_for_rebase;

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -36,6 +36,17 @@ pub struct BottomUpdate {
     pub selector: RelativeTo,
 }
 
+/// A merged-review-derived integration anchor.
+///
+/// The commit points to the review head that was merged upstream. When that
+/// commit is still present in a local stack, everything reachable beneath it is
+/// considered integrated for workspace upstream integration purposes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReviewIntegrationHint {
+    /// The merged review head commit that should act as an integration anchor.
+    pub head_commit_at_merge: gix::ObjectId,
+}
+
 /// The outcome of integrating upstream
 pub struct IntegrateUpstreamOutcome<'ws, 'meta, M: RefMetadata> {
     /// The updated workspace metadata.
@@ -51,6 +62,7 @@ struct AnnotatedNode {
     to_rebase: bool,
     historically_integrated: bool,
     content_integrated: bool,
+    review_integrated: bool,
     /// Only set to Some on references. Set to Some(<reference getting
     /// integrated>) if all the nodes exclusive to the current reference are
     /// marked as content or historically integrated or if the reference itself
@@ -67,8 +79,13 @@ impl AnnotatedNode {
             to_rebase: false,
             historically_integrated: false,
             content_integrated: false,
+            review_integrated: false,
             reference_integrated: None,
         }
+    }
+
+    fn is_integrated(&self) -> bool {
+        self.historically_integrated || self.content_integrated || self.review_integrated
     }
 }
 
@@ -137,6 +154,19 @@ pub fn integrate_upstream<'ws, 'meta, M: RefMetadata>(
     repo: &gix::Repository,
     updates: Vec<BottomUpdate>,
 ) -> Result<IntegrateUpstreamOutcome<'ws, 'meta, M>> {
+    integrate_upstream_with_hints(workspace, meta, project_meta, repo, updates, &[])
+}
+
+/// Like [`integrate_upstream()`], but accepts merged-review-derived integration
+/// anchors to classify additional integrated history.
+pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
+    workspace: &'ws mut but_graph::Workspace,
+    meta: &'meta mut M,
+    project_meta: ProjectMeta,
+    repo: &gix::Repository,
+    updates: Vec<BottomUpdate>,
+    review_hints: &[ReviewIntegrationHint],
+) -> Result<IntegrateUpstreamOutcome<'ws, 'meta, M>> {
     let mut ws_meta = workspace.metadata.clone();
     let target_sha = project_meta
         .target_commit_id
@@ -185,6 +215,7 @@ pub fn integrate_upstream<'ws, 'meta, M: RefMetadata>(
         &editor,
         from_target_sha,
         from_target_ref,
+        review_hints,
     )?;
 
     // Validate described updates and find commits to rebase
@@ -243,11 +274,10 @@ pub fn integrate_upstream<'ws, 'meta, M: RefMetadata>(
     let mut direct_checkout_replacement_ref: Option<(Selector, gix::refs::FullName)> = None;
     for stack in &stacks {
         let is_selected = stack.nodes.values().any(|attrs| attrs.to_rebase) || stack.to_merge;
-        let is_fully_integrated = stack.nodes.values().all(|attrs| {
-            attrs.historically_integrated
-                || attrs.content_integrated
-                || attrs.reference_integrated.is_some()
-        });
+        let is_fully_integrated = stack
+            .nodes
+            .values()
+            .all(|attrs| attrs.is_integrated() || attrs.reference_integrated.is_some());
         if !is_selected {
             continue;
         }
@@ -286,7 +316,7 @@ pub fn integrate_upstream<'ws, 'meta, M: RefMetadata>(
         // TODO: allow to keep some references.
         for (selector, attrs) in &stack.nodes {
             if let Some(ref_name) = attrs.reference_integrated.as_ref()
-                && ref_name.category() == Some(gix::refs::Category::LocalBranch)
+                && should_delete_integrated_local_branch(ref_name.as_ref())
             {
                 if direct_checkout_replacement_ref
                     .as_ref()
@@ -376,7 +406,7 @@ pub fn integrate_upstream<'ws, 'meta, M: RefMetadata>(
                 if attrs.historically_integrated {
                     continue;
                 };
-                if attrs.content_integrated {
+                if attrs.content_integrated || attrs.review_integrated {
                     editor.replace(*node, Step::None)?;
                 }
 
@@ -386,7 +416,10 @@ pub fn integrate_upstream<'ws, 'meta, M: RefMetadata>(
                         continue;
                     };
 
-                    if p_attrs.historically_integrated {
+                    if p_attrs.historically_integrated
+                        || p_attrs.content_integrated
+                        || p_attrs.review_integrated
+                    {
                         edges_to_replace.insert((*node, parent));
                     }
                 }
@@ -419,6 +452,7 @@ fn collect_stacks<'ws, 'meta, M: RefMetadata>(
     editor: &Editor<'ws, 'meta, M>,
     from_target_sha: HashSet<Selector>,
     from_target_ref: HashSet<Selector>,
+    review_hints: &[ReviewIntegrationHint],
 ) -> Result<Vec<Stack>> {
     let mut stacks = if head_is_workspace_commit {
         editor
@@ -514,6 +548,8 @@ fn collect_stacks<'ws, 'meta, M: RefMetadata>(
             }
         }
 
+        apply_review_integration_hints(editor, stack, review_hints)?;
+
         let reference_nodes = stack
             .nodes
             .keys()
@@ -559,10 +595,7 @@ fn collect_stacks<'ws, 'meta, M: RefMetadata>(
                         };
 
                     if seen.insert(parent) {
-                        if !(parent_is_non_local_reference
-                            || attrs.content_integrated
-                            || attrs.historically_integrated)
-                        {
+                        if !(parent_is_non_local_reference || attrs.is_integrated()) {
                             all_integrated = false;
                             break 'traversal;
                         }
@@ -577,12 +610,126 @@ fn collect_stacks<'ws, 'meta, M: RefMetadata>(
             if traversed_commits {
                 node.reference_integrated = all_integrated.then_some(r_name.clone());
             } else {
-                node.reference_integrated = node.historically_integrated.then_some(r_name.clone());
+                node.reference_integrated = node.is_integrated().then_some(r_name.clone());
             }
         }
     }
 
     Ok(output_stacks)
+}
+
+/// Whether an integrated local branch ref should be deleted during integration.
+///
+/// Only local branches are eligible for deletion here. As a conservative
+/// heuristic, never delete local `main` or `master`, even if the graph marks
+/// them as integrated. Those names often represent a user's primary local
+/// branch, so keeping them is safer than treating them like disposable topic
+/// branches.
+fn should_delete_integrated_local_branch(ref_name: &gix::refs::FullNameRef) -> bool {
+    let Some((gix::refs::Category::LocalBranch, short_name)) = ref_name.category_and_short_name()
+    else {
+        return false;
+    };
+
+    short_name != "main" && short_name != "master"
+}
+
+/// Mark stack commits as integrated when they are covered by merged-review hints.
+///
+/// Hints are review heads recorded at the time a forge review was merged. If a
+/// hinted review head is still present in the local stack, the review confirms
+/// that commit and all stack-local ancestors below it have landed upstream.
+/// Commits above the hinted head are intentionally left local, which lets a
+/// branch keep extra post-merge commits while dropping the already-merged prefix.
+fn apply_review_integration_hints<M: RefMetadata>(
+    editor: &Editor<'_, '_, M>,
+    stack: &mut Stack,
+    review_hints: &[ReviewIntegrationHint],
+) -> Result<()> {
+    let mut selectors_by_commit_id = HashMap::<gix::ObjectId, Selector>::new();
+    for selector in stack.nodes.keys().copied() {
+        if let Step::Pick(Pick { id, .. }) = editor.lookup_step(selector)? {
+            selectors_by_commit_id.insert(id, selector);
+        }
+    }
+
+    let matching_heads = review_hints
+        .iter()
+        .filter_map(|hint| {
+            selectors_by_commit_id
+                .get(&hint.head_commit_at_merge)
+                .copied()
+        })
+        .collect::<Vec<_>>();
+    if matching_heads.is_empty() {
+        return Ok(());
+    }
+
+    let highest_heads = highest_review_heads(editor, stack, &matching_heads)?;
+    for head in highest_heads {
+        let mut tips = vec![head];
+        let mut seen = HashSet::new();
+
+        while let Some(tip) = tips.pop() {
+            if !seen.insert(tip) {
+                continue;
+            }
+            if let Some(attrs) = stack.nodes.get_mut(&tip) {
+                attrs.review_integrated = true;
+            }
+            for (parent, _) in editor.direct_parents(tip)? {
+                if stack.nodes.contains_key(&parent) {
+                    tips.push(parent);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Return only the highest matching review heads within the stack graph.
+///
+/// Multiple review hints can match commits in the same ancestry chain. Marking
+/// from the highest matched head is enough because the traversal from that head
+/// already covers lower matched ancestors. Keeping only the highest heads avoids
+/// repeated ancestor walks while preserving independent matched branches in a
+/// multi-head stack.
+fn highest_review_heads<M: RefMetadata>(
+    editor: &Editor<'_, '_, M>,
+    stack: &Stack,
+    matching_heads: &[Selector],
+) -> Result<Vec<Selector>> {
+    let candidates = matching_heads.iter().copied().collect::<HashSet<_>>();
+    let mut discard = HashSet::new();
+
+    for head in matching_heads {
+        let mut tips = vec![*head];
+        let mut seen = HashSet::from([*head]);
+
+        while let Some(tip) = tips.pop() {
+            for (parent, _) in editor.direct_parents(tip)? {
+                if !stack.nodes.contains_key(&parent) {
+                    continue;
+                }
+                if candidates.contains(&parent) {
+                    discard.insert(parent);
+                }
+                if seen.insert(parent) {
+                    tips.push(parent);
+                }
+            }
+        }
+    }
+
+    let mut out = Vec::new();
+    let mut added = HashSet::new();
+    for head in matching_heads {
+        if !discard.contains(head) && added.insert(*head) {
+            out.push(*head);
+        }
+    }
+    Ok(out)
 }
 
 /// Convert a list of selectors into their current commit ids.

--- a/crates/but-workspace/tests/fixtures/scenario/review-hint-squash-integrated-direct-checkout.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/review-hint-squash-integrated-direct-checkout.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# Single-branch mode with HEAD checked out directly on branch A. A has two
+# local commits and neither commit is historically integrated into the target.
+# origin/main advances with a single squash commit that reproduces A's final
+# tree without using A's commits as ancestors. Review integration hints can
+# still identify A's head as merged, so upstream integration should replace the
+# direct checkout branch with the advanced target.
+git init
+commit M1
+setup_target_to_match_main
+
+git checkout -b A
+commit-file A1.txt A1
+commit-file A2.txt A2
+
+git checkout -b upstream-main main
+echo A1 >A1.txt
+echo A2 >A2.txt
+git add A1.txt A2.txt
+git commit -m "squash A"
+git update-ref refs/remotes/origin/main upstream-main
+
+git checkout A
+git branch -D upstream-main

--- a/crates/but-workspace/tests/fixtures/scenario/review-hint-squash-integrated-prefix-with-extra-commit-direct-checkout.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/review-hint-squash-integrated-prefix-with-extra-commit-direct-checkout.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# Single-branch mode with HEAD checked out directly on branch A. A has three
+# local commits and none of them are historically integrated into the target.
+# origin/main advances with a single squash commit that reproduces only A1 and
+# A2, while A3 remains local work above the squashed review head. Review
+# integration hints point at A2, so upstream integration should drop the
+# integrated prefix and keep A3 rebased onto the squashed target tip.
+git init
+commit M1
+setup_target_to_match_main
+
+git checkout -b A
+commit-file A1.txt A1
+commit-file A2.txt A2
+commit-file A3.txt A3
+
+git checkout -b upstream-main main
+echo A1 >A1.txt
+echo A2 >A2.txt
+git add A1.txt A2.txt
+git commit -m "squash A1 and A2"
+git update-ref refs/remotes/origin/main upstream-main
+
+git checkout A
+git branch -D upstream-main

--- a/crates/but-workspace/tests/fixtures/scenario/review-hint-squash-integrated-prefix-with-extra-commit-workspace.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/review-hint-squash-integrated-prefix-with-extra-commit-workspace.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A managed workspace contains one stack branch A with three local commits. None
+# of the local commits are historically integrated into the target. origin/main
+# advances with a single squash commit that reproduces only A1 and A2, while A3
+# remains local work above the squashed review head. Review integration hints
+# point at A2, so upstream integration should drop the integrated prefix and
+# keep A3 rebased onto the squashed target tip.
+git init
+commit M1
+setup_target_to_match_main
+
+git checkout -b A
+commit-file A1.txt A1
+commit-file A2.txt A2
+commit-file A3.txt A3
+
+create_workspace_commit_once A
+
+git checkout -b upstream-main main
+echo A1 >A1.txt
+echo A2 >A2.txt
+git add A1.txt A2.txt
+git commit -m "squash A1 and A2"
+git update-ref refs/remotes/origin/main upstream-main
+
+git checkout gitbutler/workspace
+git branch -D upstream-main

--- a/crates/but-workspace/tests/fixtures/scenario/review-hint-squash-integrated-two-commit-stack-with-sibling.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/review-hint-squash-integrated-two-commit-stack-with-sibling.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A managed workspace contains two independent single-branch stacks. Stack A
+# has two local commits and stack B has one local commit. None of the stack
+# commits are historically integrated into the target: origin/main advances with
+# a single squash commit that reproduces stack A's final tree without using A's
+# commits as ancestors. Review integration hints can still identify A's head as
+# merged, so upstream integration should remove stack A while keeping stack B.
+git init
+commit M1
+setup_target_to_match_main
+
+git checkout -b A
+commit-file A1.txt A1
+commit-file A2.txt A2
+
+git checkout main
+git checkout -b B
+commit-file B.txt B1
+
+create_workspace_commit_once A B
+
+git checkout -b upstream-main main
+echo A1 >A1.txt
+echo A2 >A2.txt
+git add A1.txt A2.txt
+git commit -m "squash A"
+git update-ref refs/remotes/origin/main upstream-main
+
+git checkout gitbutler/workspace
+git branch -D upstream-main

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -1,11 +1,13 @@
 use anyhow::{Context, Result};
+use bstr::ByteSlice;
 use but_core::{Commit, RefMetadata};
-use but_graph::init::Options;
+use but_graph::init::{Options, Tip};
 use but_meta::virtual_branches_legacy_types::Target;
 use but_rebase::graph_rebase::mutate::RelativeTo;
 use but_testsupport::{CommandExt, git, graph_workspace, visualize_commit_graph_all};
 use but_workspace::{
-    BottomUpdate, BottomUpdateKind, integrate_upstream, worktree_conflicts_for_rebase,
+    BottomUpdate, BottomUpdateKind, ReviewIntegrationHint, integrate_upstream,
+    integrate_upstream_with_hints, worktree_conflicts_for_rebase,
 };
 use gix::prelude::ObjectIdExt;
 use gix::refs::transaction::PreviousValue;
@@ -359,8 +361,15 @@ fn integrated_bottom_branch_no_workspace_rebase() -> Result<()> {
         sha: target_sha,
         push_remote_name: None,
     });
-    let graph = but_graph::Graph::from_head(
+    let graph = but_graph::Graph::from_commit_traversal_tips(
         &repo,
+        [
+            Tip::entrypoint(repo.head_id()?.detach(), Some("refs/heads/A".try_into()?)),
+            Tip::integrated(
+                repo.rev_parse_single("origin/main")?.detach(),
+                Some("refs/remotes/origin/main".try_into()?),
+            ),
+        ],
         &meta,
         project_meta(&meta)?,
         Options {
@@ -379,12 +388,12 @@ fn integrated_bottom_branch_no_workspace_rebase() -> Result<()> {
 
     let mut workspace = graph.into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&workspace), @"
-    ⌂:0:A[🌳] <> ✓refs/remotes/origin/main⇣2 on 3183e43
-    └── ≡:0:A[🌳] on 3183e43 {1}
-        ├── :0:A[🌳]
+    ⌂:1:A[🌳] <> ✓refs/remotes/origin/main⇣2 on 3183e43
+    └── ≡:1:A[🌳] on 3183e43 {1}
+        ├── :1:A[🌳]
         │   └── ·e792f40
         └── :3:B
-            └── ·b38b04b
+            └── ·b38b04b (✓)
     ");
     let project_meta = workspace.graph.project_meta.clone();
     let but_workspace::IntegrateUpstreamOutcome { rebase, .. } = integrate_upstream(
@@ -421,6 +430,71 @@ fn integrated_bottom_branch_no_workspace_rebase() -> Result<()> {
 }
 
 #[test]
+fn integrated_bottom_branch_does_not_delete_local_main_or_master() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("integrated-bottom-branch-no-workspace")?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+    let integrated_bottom_commit = repo.rev_parse_single("B")?.detach();
+
+    git(&repo).args(["branch", "-f", "main", "B"]).run();
+    git(&repo).args(["branch", "master", "B"]).run();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    let graph = but_graph::Graph::from_commit_traversal_tips(
+        &repo,
+        [
+            Tip::entrypoint(repo.head_id()?.detach(), Some("refs/heads/A".try_into()?)),
+            Tip::integrated(
+                repo.rev_parse_single("origin/main")?.detach(),
+                Some("refs/remotes/origin/main".try_into()?),
+            ),
+        ],
+        &meta,
+        project_meta(&meta)?,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+    let mut workspace = graph.into_workspace()?;
+    let project_meta = workspace.graph.project_meta.clone();
+
+    let but_workspace::IntegrateUpstreamOutcome { rebase, .. } = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        project_meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(integrated_bottom_commit),
+        }],
+    )?;
+    rebase.materialize()?;
+
+    assert!(
+        repo.try_find_reference("B")?.is_none(),
+        "ordinary integrated local branches should still be removed",
+    );
+    assert_eq!(
+        repo.rev_parse_single("main")?.detach(),
+        integrated_bottom_commit,
+        "local main should be protected from integrated-branch deletion",
+    );
+    assert_eq!(
+        repo.rev_parse_single("master")?.detach(),
+        integrated_bottom_commit,
+        "local master should be protected from integrated-branch deletion",
+    );
+
+    Ok(())
+}
+
+#[test]
 fn integrated_bottom_branch_no_workspace_merge() -> Result<()> {
     let (_tmp, repo, mut meta, _description) =
         named_writable_scenario_with_description("integrated-bottom-branch-no-workspace")?;
@@ -434,8 +508,15 @@ fn integrated_bottom_branch_no_workspace_merge() -> Result<()> {
         sha: target_sha,
         push_remote_name: None,
     });
-    let graph = but_graph::Graph::from_head(
+    let graph = but_graph::Graph::from_commit_traversal_tips(
         &repo,
+        [
+            Tip::entrypoint(repo.head_id()?.detach(), Some("refs/heads/A".try_into()?)),
+            Tip::integrated(
+                repo.rev_parse_single("origin/main")?.detach(),
+                Some("refs/remotes/origin/main".try_into()?),
+            ),
+        ],
         &meta,
         project_meta(&meta)?,
         Options {
@@ -454,12 +535,12 @@ fn integrated_bottom_branch_no_workspace_merge() -> Result<()> {
 
     let mut workspace = graph.into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&workspace), @"
-    ⌂:0:A[🌳] <> ✓refs/remotes/origin/main⇣2 on 3183e43
-    └── ≡:0:A[🌳] on 3183e43 {1}
-        ├── :0:A[🌳]
+    ⌂:1:A[🌳] <> ✓refs/remotes/origin/main⇣2 on 3183e43
+    └── ≡:1:A[🌳] on 3183e43 {1}
+        ├── :1:A[🌳]
         │   └── ·e792f40
         └── :3:B
-            └── ·b38b04b
+            └── ·b38b04b (✓)
     ");
     let project_meta = workspace.graph.project_meta.clone();
     let but_workspace::IntegrateUpstreamOutcome { rebase, .. } = integrate_upstream(
@@ -1844,6 +1925,510 @@ fn orphan_reparent_two_stacks_through_merge_target() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn review_hint_fully_integrates_direct_checkout_branch() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("integrated-bottom-branch-no-workspace")?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+    let review_head = repo.rev_parse_single("A")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    let graph = but_graph::Graph::from_commit_traversal_tips(
+        &repo,
+        [
+            Tip::entrypoint(repo.head_id()?.detach(), Some("refs/heads/A".try_into()?)),
+            Tip::integrated(
+                repo.rev_parse_single("origin/main")?.detach(),
+                Some("refs/remotes/origin/main".try_into()?),
+            ),
+        ],
+        &meta,
+        project_meta(&meta)?,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+    let mut workspace = graph.into_workspace()?;
+    let project_meta = workspace.graph.project_meta.clone();
+
+    let out = integrate_upstream_with_hints(
+        &mut workspace,
+        &mut meta,
+        project_meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("B")?.detach()),
+        }],
+        &[ReviewIntegrationHint {
+            head_commit_at_merge: review_head,
+        }],
+    )?;
+    out.rebase.materialize()?;
+
+    assert!(
+        repo.try_find_reference("A")?.is_none(),
+        "fully review-integrated direct checkout branch should be replaced",
+    );
+    assert_eq!(
+        repo.head_id()?.detach(),
+        repo.rev_parse_single("origin/main")?.detach(),
+        "replacement checkout should land at the advanced target tip",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn review_hint_integrates_squashed_two_commit_stack_in_managed_workspace() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) = named_writable_scenario_with_description(
+        "review-hint-squash-integrated-two-commit-stack-with-sibling",
+    )?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+    let review_head = repo.rev_parse_single("A")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    add_stack(&mut meta, 1, "A", StackState::InWorkspace);
+    add_stack(&mut meta, 2, "B", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta(&meta)?,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   b96a78e (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * ad1d22b (A) add A2
+    | * fe98e29 add A1
+    * | b38b04b (B) add B1
+    |/  
+    | * 56057f2 (origin/main) squash A
+    |/  
+    * 3183e43 (main) M1
+    ");
+
+    let mut workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+    ├── ≡📙:3:A on 3183e43 {1}
+    │   └── 📙:3:A
+    │       ├── ·ad1d22b (🏘️)
+    │       └── ·fe98e29 (🏘️)
+    └── ≡📙:4:B on 3183e43 {2}
+        └── 📙:4:B
+            └── ·b38b04b (🏘️)
+    ");
+
+    let project_meta = workspace.graph.project_meta.clone();
+
+    let out = integrate_upstream_with_hints(
+        &mut workspace,
+        &mut meta,
+        project_meta.clone(),
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A^")?.detach()),
+        }],
+        &[ReviewIntegrationHint {
+            head_commit_at_merge: review_head,
+        }],
+    )?;
+    out.rebase.materialize()?;
+
+    let graph = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?;
+    let workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+    └── ≡📙:3:B on 3183e43 {2}
+        └── 📙:3:B
+            └── ·b38b04b (🏘️)
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * e4abb28 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * b38b04b (B) add B1
+    | * 56057f2 (origin/main) squash A
+    |/  
+    * 3183e43 (main) M1
+    ");
+
+    assert!(
+        repo.try_find_reference("A")?.is_none(),
+        "squash-integrated stack should leave the workspace when its review head is hinted",
+    );
+    assert!(
+        repo.try_find_reference("B")?.is_some(),
+        "sibling stack should remain because it was not covered by the review hint",
+    );
+    assert_eq!(
+        workspace_parent_ids(&repo)?,
+        vec![repo.rev_parse_single("B")?.detach()],
+        "workspace commit should stay parented only to the remaining sibling stack",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn review_hint_integrates_squashed_two_commit_direct_checkout_branch() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("review-hint-squash-integrated-direct-checkout")?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+    let review_head = repo.rev_parse_single("A")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    let graph = but_graph::Graph::from_commit_traversal_tips(
+        &repo,
+        [
+            Tip::entrypoint(repo.head_id()?.detach(), Some("refs/heads/A".try_into()?)),
+            Tip::integrated(
+                repo.rev_parse_single("origin/main")?.detach(),
+                Some("refs/remotes/origin/main".try_into()?),
+            ),
+        ],
+        &meta,
+        project_meta(&meta)?,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * ad1d22b (HEAD -> A) add A2
+    * fe98e29 add A1
+    | * 56057f2 (origin/main) squash A
+    |/  
+    * 3183e43 (main) M1
+    ");
+
+    let mut workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    ⌂:1:A[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+    └── ≡:1:A[🌳] on 3183e43 {1}
+        └── :1:A[🌳]
+            ├── ·ad1d22b
+            └── ·fe98e29
+    ");
+
+    let project_meta = workspace.graph.project_meta.clone();
+
+    let out = integrate_upstream_with_hints(
+        &mut workspace,
+        &mut meta,
+        project_meta.clone(),
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A^")?.detach()),
+        }],
+        &[ReviewIntegrationHint {
+            head_commit_at_merge: review_head,
+        }],
+    )?;
+    out.rebase.materialize()?;
+    let graph = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?;
+    let workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    ⌂:0:amo-branch-1[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+    └── ≡:0:amo-branch-1[🌳] on 3183e43 {1}
+        └── :0:amo-branch-1[🌳]
+            └── ·56057f2
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * 56057f2 (HEAD -> amo-branch-1, origin/main) squash A
+    * 3183e43 (main) M1
+    ");
+
+    assert!(
+        repo.try_find_reference("A")?.is_none(),
+        "squash-integrated direct checkout branch should be replaced",
+    );
+    assert_eq!(
+        repo.head_id()?.detach(),
+        repo.rev_parse_single("origin/main")?.detach(),
+        "replacement checkout should land at the squashed target tip",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn review_hint_integrates_squashed_prefix_and_keeps_extra_commit_in_managed_workspace() -> Result<()>
+{
+    let (_tmp, repo, mut meta, _description) = named_writable_scenario_with_description(
+        "review-hint-squash-integrated-prefix-with-extra-commit-workspace",
+    )?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+    let review_head = repo.rev_parse_single("A^")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    add_stack(&mut meta, 1, "A", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta(&meta)?,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 9cf59eb (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * f015e95 (A) add A3
+    * ad1d22b add A2
+    * fe98e29 add A1
+    | * e2f5892 (origin/main) squash A1 and A2
+    |/  
+    * 3183e43 (main) M1
+    ");
+
+    let mut workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+    └── ≡📙:3:A on 3183e43 {1}
+        └── 📙:3:A
+            ├── ·f015e95 (🏘️)
+            ├── ·ad1d22b (🏘️)
+            └── ·fe98e29 (🏘️)
+    ");
+
+    integrate_with_hints_and_materialize(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A^^")?.detach()),
+        }],
+        &[ReviewIntegrationHint {
+            head_commit_at_merge: review_head,
+        }],
+    )?;
+
+    let graph =
+        but_graph::Graph::from_head(&repo, &meta, project_meta(&meta)?, Options::limited())?;
+    let workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e2f5892
+    └── ≡📙:3:A on e2f5892 {1}
+        └── 📙:3:A
+            └── ·92f1780 (🏘️)
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * a7a874f (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 92f1780 (A) add A3
+    * e2f5892 (origin/main) squash A1 and A2
+    * 3183e43 (main) M1
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn review_hint_integrates_squashed_prefix_and_keeps_extra_commit_in_direct_checkout() -> Result<()>
+{
+    let (_tmp, repo, mut meta, _description) = named_writable_scenario_with_description(
+        "review-hint-squash-integrated-prefix-with-extra-commit-direct-checkout",
+    )?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+    let review_head = repo.rev_parse_single("A^")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    let graph = but_graph::Graph::from_commit_traversal_tips(
+        &repo,
+        [
+            Tip::entrypoint(repo.head_id()?.detach(), Some("refs/heads/A".try_into()?)),
+            Tip::integrated(
+                repo.rev_parse_single("origin/main")?.detach(),
+                Some("refs/remotes/origin/main".try_into()?),
+            ),
+        ],
+        &meta,
+        project_meta(&meta)?,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * f015e95 (HEAD -> A) add A3
+    * ad1d22b add A2
+    * fe98e29 add A1
+    | * e2f5892 (origin/main) squash A1 and A2
+    |/  
+    * 3183e43 (main) M1
+    ");
+
+    let mut workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    ⌂:1:A[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+    └── ≡:1:A[🌳] on 3183e43 {1}
+        └── :1:A[🌳]
+            ├── ·f015e95
+            ├── ·ad1d22b
+            └── ·fe98e29
+    ");
+
+    let current_project_meta = workspace.graph.project_meta.clone();
+    let but_workspace::IntegrateUpstreamOutcome {
+        rebase,
+        project_meta: updated_project_meta,
+        ..
+    } = integrate_upstream_with_hints(
+        &mut workspace,
+        &mut meta,
+        current_project_meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A^^")?.detach()),
+        }],
+        &[ReviewIntegrationHint {
+            head_commit_at_merge: review_head,
+        }],
+    )?;
+    rebase.materialize()?;
+
+    let graph = but_graph::Graph::from_commit_traversal_tips(
+        &repo,
+        [
+            Tip::entrypoint(repo.head_id()?.detach(), repo.head_name()?),
+            Tip::integrated(
+                repo.rev_parse_single("origin/main")?.detach(),
+                Some("refs/remotes/origin/main".try_into()?),
+            ),
+        ],
+        &meta,
+        updated_project_meta,
+        Options::limited(),
+    )?;
+    let workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    ⌂:1:A[🌳] <> ✓refs/remotes/origin/main on e2f5892
+    └── ≡:1:A[🌳] on e2f5892 {1}
+        └── :1:A[🌳]
+            └── ·92f1780
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * 92f1780 (HEAD -> A) add A3
+    * e2f5892 (origin/main) squash A1 and A2
+    * 3183e43 (main) M1
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn review_hint_integrates_prefix_but_keeps_extra_local_commit() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("integrated-bottom-branch-no-workspace")?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+    let review_head = repo.rev_parse_single("A")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    std::fs::write(
+        repo.workdir()
+            .context("fixture repos should be writable")?
+            .join("file.txt"),
+        "post-review local change\n",
+    )?;
+    git(&repo).args(["add", "file.txt"]).run();
+    git(&repo)
+        .args(["commit", "-m", "post-review local commit"])
+        .run();
+
+    let graph = but_graph::Graph::from_commit_traversal_tips(
+        &repo,
+        [
+            Tip::entrypoint(repo.head_id()?.detach(), Some("refs/heads/A".try_into()?)),
+            Tip::integrated(
+                repo.rev_parse_single("origin/main")?.detach(),
+                Some("refs/remotes/origin/main".try_into()?),
+            ),
+        ],
+        &meta,
+        project_meta(&meta)?,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+    let mut workspace = graph.into_workspace()?;
+    let project_meta = workspace.graph.project_meta.clone();
+
+    let out = integrate_upstream_with_hints(
+        &mut workspace,
+        &mut meta,
+        project_meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("B")?.detach()),
+        }],
+        &[ReviewIntegrationHint {
+            head_commit_at_merge: review_head,
+        }],
+    )?;
+    out.rebase.materialize()?;
+
+    assert!(
+        repo.try_find_reference("A")?.is_some(),
+        "branch should remain because a local commit still sits above the merged review head",
+    );
+    assert_eq!(
+        repo.rev_parse_single("A^")?.detach(),
+        repo.rev_parse_single("origin/main")?.detach(),
+        "remaining local tip should be rebased onto the advanced target",
+    );
+    assert_eq!(
+        repo.find_commit(repo.rev_parse_single("A")?.detach())?
+            .message_raw()?
+            .to_str()?
+            .trim_end(),
+        "post-review local commit",
+    );
+
+    Ok(())
+}
+
 fn integrate_and_materialize<M: RefMetadata>(
     workspace: &mut but_graph::Workspace,
     meta: &mut M,
@@ -1855,6 +2440,39 @@ fn integrate_and_materialize<M: RefMetadata>(
         ws_meta,
         project_meta,
     } = integrate_upstream(workspace, meta, project_meta(&*meta)?, repo, updates)?;
+    let materialized = rebase.materialize()?;
+    if let Some(ref_name) = materialized.workspace.ref_name()
+        && let Some(ws_meta) = ws_meta
+    {
+        let mut md = materialized.meta.workspace(ref_name)?;
+        *md = ws_meta;
+        md.set_project_meta(project_meta);
+        materialized.meta.set_workspace(&md)?;
+    }
+    drop(materialized);
+
+    Ok(())
+}
+
+fn integrate_with_hints_and_materialize<M: RefMetadata>(
+    workspace: &mut but_graph::Workspace,
+    meta: &mut M,
+    repo: &gix::Repository,
+    updates: Vec<BottomUpdate>,
+    review_hints: &[ReviewIntegrationHint],
+) -> Result<()> {
+    let but_workspace::IntegrateUpstreamOutcome {
+        rebase,
+        ws_meta,
+        project_meta,
+    } = integrate_upstream_with_hints(
+        workspace,
+        meta,
+        project_meta(&*meta)?,
+        repo,
+        updates,
+        review_hints,
+    )?;
     let materialized = rebase.materialize()?;
     if let Some(ref_name) = materialized.workspace.ref_name()
         && let Some(ws_meta) = ws_meta


### PR DESCRIPTION
Read the cached review information and use that to determine integration status when performing the upstream integration.

--- 

Also: This adds a heuristic to avoid deleting the `main` or `master` branches when integrated.