### PR TITLE
Copy more things with shift+y in TUI

### DIFF
--- a/crates/but/src/command/legacy/status/tui/copy_selection_picker.rs
+++ b/crates/but/src/command/legacy/status/tui/copy_selection_picker.rs
@@ -1,0 +1,161 @@
+use std::borrow::Cow;
+
+use anyhow::Context as _;
+use bstr::ByteSlice as _;
+use but_api::diff::ComputeLineStats;
+use but_core::diff::CommitDetails;
+use but_ctx::Context;
+use gix::prelude::ObjectIdExt as _;
+use nonempty::NonEmpty;
+use ratatui::style::Style;
+
+use crate::{
+    command::legacy::status::tui::{
+        Col, FuzzyPicker, FuzzyPickerItem, Message, SearchableToken, ToastKind,
+    },
+    theme::Theme,
+};
+
+pub(super) fn commit_picker(
+    commit_id: gix::ObjectId,
+    theme: &'static Theme,
+) -> FuzzyPicker<CopySelectionItem> {
+    picker(
+        NonEmpty::from_slice(&[
+            CopySelectionItem::CommitSha(commit_id),
+            CopySelectionItem::ShortCommitSha(commit_id),
+            CopySelectionItem::CommitMessageTitle(commit_id),
+            CopySelectionItem::WholeCommitMessage(commit_id),
+            CopySelectionItem::CommitAuthor(commit_id),
+            CopySelectionItem::CommitDiff(commit_id),
+        ])
+        .unwrap(),
+        theme,
+    )
+}
+
+fn picker(
+    items: NonEmpty<CopySelectionItem>,
+    theme: &'static Theme,
+) -> FuzzyPicker<CopySelectionItem> {
+    FuzzyPicker::new(items, theme, |item, ctx, messages| {
+        arboard::Clipboard::new()
+            .context("failed to initialize clipboard")?
+            .set_text(item.what_to_copy(ctx)?)
+            .context("failed to copy to system clipboard")?;
+
+        messages.push(Message::ShowToast {
+            kind: ToastKind::Info,
+            text: format!("Copied {}", lowercase_first_letter(item.as_str())),
+        });
+
+        Ok(())
+    })
+}
+
+#[derive(Debug, Clone)]
+pub(super) enum CopySelectionItem {
+    CommitSha(gix::ObjectId),
+    ShortCommitSha(gix::ObjectId),
+    CommitMessageTitle(gix::ObjectId),
+    WholeCommitMessage(gix::ObjectId),
+    CommitAuthor(gix::ObjectId),
+    CommitDiff(gix::ObjectId),
+}
+
+impl CopySelectionItem {
+    fn as_str(&self) -> &'static str {
+        match self {
+            CopySelectionItem::CommitSha(_) => "Commit ID",
+            CopySelectionItem::ShortCommitSha(_) => "Short commit ID",
+            CopySelectionItem::CommitMessageTitle(_) => "Message title",
+            CopySelectionItem::WholeCommitMessage(_) => "Whole message",
+            CopySelectionItem::CommitAuthor(_) => "Author",
+            CopySelectionItem::CommitDiff(_) => "Diff",
+        }
+    }
+
+    fn what_to_copy(&self, ctx: &Context) -> anyhow::Result<String> {
+        let repo = ctx.repo.get()?;
+        match self {
+            CopySelectionItem::CommitSha(commit_id) => Ok(commit_id.to_string()),
+            CopySelectionItem::ShortCommitSha(commit_id) => {
+                Ok(commit_id.to_hex_with_len(7).to_string())
+            }
+            CopySelectionItem::CommitMessageTitle(commit_id) => {
+                let commit = commit(&repo, *commit_id)?;
+                let commit_message = commit.message.to_str_lossy();
+                Ok(commit_message
+                    .lines()
+                    .next()
+                    .unwrap_or_default()
+                    .to_string())
+            }
+            CopySelectionItem::WholeCommitMessage(commit_id) => {
+                let commit = commit(&repo, *commit_id)?;
+                let commit_message = commit.message.to_str_lossy();
+                Ok(commit_message.to_string())
+            }
+            CopySelectionItem::CommitAuthor(commit_id) => {
+                let commit = commit(&repo, *commit_id)?;
+                let author = &commit.author;
+                Ok(format!(
+                    "{} <{}>",
+                    author.name.to_str_lossy(),
+                    author.email.to_str_lossy()
+                ))
+            }
+            CopySelectionItem::CommitDiff(commit_id) => {
+                let commit_details = commit_details(&repo, *commit_id)?;
+                commit_details
+                    .diff_with_first_parent
+                    .iter()
+                    .map(|change| change.unified_diff(&repo, ctx.settings.context_lines))
+                    .filter_map(|diff| diff.transpose())
+                    .try_fold(String::new(), |mut diff, line| -> anyhow::Result<_> {
+                        diff.push_str(&line?.to_str_lossy());
+                        Ok(diff)
+                    })
+            }
+        }
+    }
+}
+
+impl FuzzyPickerItem for CopySelectionItem {
+    fn columns(&self, searchable: SearchableToken) -> impl IntoIterator<Item = Col<'_>> {
+        [Col {
+            text: self.as_str().into(),
+            searchable: Some(searchable),
+        }]
+    }
+
+    fn style(&self, theme: &'static Theme) -> Style {
+        theme.default
+    }
+}
+
+fn lowercase_first_letter(s: &str) -> Cow<'_, str> {
+    let Some(first) = s.chars().next() else {
+        return Cow::Borrowed(s);
+    };
+
+    let lowercase_first = first.to_lowercase().to_string();
+    if lowercase_first == first.to_string() {
+        return Cow::Borrowed(s);
+    }
+
+    let mut lowercased = lowercase_first;
+    lowercased.push_str(&s[first.len_utf8()..]);
+    Cow::Owned(lowercased)
+}
+
+fn commit(repo: &gix::Repository, commit_id: gix::ObjectId) -> anyhow::Result<CommitOwned> {
+    Ok(but_core::Commit::from_id(commit_id.attach(repo))?.detach())
+}
+
+fn commit_details(
+    repo: &gix::Repository,
+    commit_id: gix::ObjectId,
+) -> anyhow::Result<CommitDetails> {
+    CommitDetails::from_commit_id(commit_id.attach(repo), false)
+}

--- a/crates/but/src/command/legacy/status/tui/copy_selection_picker.rs
+++ b/crates/but/src/command/legacy/status/tui/copy_selection_picker.rs
@@ -2,10 +2,9 @@ use std::borrow::Cow;
 
 use anyhow::Context as _;
 use bstr::ByteSlice as _;
-use but_api::diff::ComputeLineStats;
-use but_core::diff::CommitDetails;
+use but_core::{CommitOwned, TreeChange, diff::CommitDetails};
 use but_ctx::Context;
-use gix::prelude::ObjectIdExt as _;
+use gix::{prelude::ObjectIdExt as _, refs::FullName};
 use nonempty::NonEmpty;
 use ratatui::style::Style;
 
@@ -28,6 +27,21 @@ pub(super) fn commit_picker(
             CopySelectionItem::WholeCommitMessage(commit_id),
             CopySelectionItem::CommitAuthor(commit_id),
             CopySelectionItem::CommitDiff(commit_id),
+        ])
+        .unwrap(),
+        theme,
+    )
+}
+
+pub(super) fn branch_picker(
+    branch: FullName,
+    theme: &'static Theme,
+) -> FuzzyPicker<CopySelectionItem> {
+    picker(
+        NonEmpty::from_slice(&[
+            CopySelectionItem::BranchName(branch.clone()),
+            CopySelectionItem::PullRequestUrl(branch.clone()),
+            CopySelectionItem::BranchDiff(branch.clone()),
         ])
         .unwrap(),
         theme,
@@ -61,6 +75,9 @@ pub(super) enum CopySelectionItem {
     WholeCommitMessage(gix::ObjectId),
     CommitAuthor(gix::ObjectId),
     CommitDiff(gix::ObjectId),
+    BranchName(FullName),
+    BranchDiff(FullName),
+    PullRequestUrl(FullName),
 }
 
 impl CopySelectionItem {
@@ -71,7 +88,9 @@ impl CopySelectionItem {
             CopySelectionItem::CommitMessageTitle(_) => "Message title",
             CopySelectionItem::WholeCommitMessage(_) => "Whole message",
             CopySelectionItem::CommitAuthor(_) => "Author",
-            CopySelectionItem::CommitDiff(_) => "Diff",
+            CopySelectionItem::CommitDiff(_) | CopySelectionItem::BranchDiff(_) => "Diff",
+            CopySelectionItem::BranchName(_) => "Branch name",
+            CopySelectionItem::PullRequestUrl(_) => "Pull Request URL",
         }
     }
 
@@ -107,15 +126,36 @@ impl CopySelectionItem {
             }
             CopySelectionItem::CommitDiff(commit_id) => {
                 let commit_details = commit_details(&repo, *commit_id)?;
-                commit_details
-                    .diff_with_first_parent
-                    .iter()
-                    .map(|change| change.unified_diff(&repo, ctx.settings.context_lines))
-                    .filter_map(|diff| diff.transpose())
-                    .try_fold(String::new(), |mut diff, line| -> anyhow::Result<_> {
-                        diff.push_str(&line?.to_str_lossy());
-                        Ok(diff)
-                    })
+                tree_changes_to_diff(
+                    commit_details.diff_with_first_parent,
+                    &repo,
+                    ctx.settings.context_lines,
+                )
+            }
+            CopySelectionItem::BranchName(branch_name) => {
+                Ok(branch_name.shorten().to_str_lossy().to_string())
+            }
+            CopySelectionItem::BranchDiff(branch_name) => {
+                let name = branch_name.shorten().to_str_lossy().to_string();
+                let tree_changes = but_api::branch::branch_diff(ctx, name)?;
+                tree_changes_to_diff(
+                    tree_changes.changes.into_iter().map(Into::into).collect(),
+                    &repo,
+                    ctx.settings.context_lines,
+                )
+            }
+            CopySelectionItem::PullRequestUrl(branch_name) => {
+                let name = branch_name.shorten().to_str_lossy();
+                let review_map = crate::command::legacy::forge::review::get_review_map(
+                    ctx,
+                    Some(but_forge::CacheConfig::CacheOnly),
+                )?;
+                let url = review_map
+                    .get(&*name)
+                    .and_then(|reviews| reviews.first())
+                    .map(|review| review.html_url.clone())
+                    .context("No pull request URL found")?;
+                Ok(url)
             }
         }
     }
@@ -158,4 +198,19 @@ fn commit_details(
     commit_id: gix::ObjectId,
 ) -> anyhow::Result<CommitDetails> {
     CommitDetails::from_commit_id(commit_id.attach(repo), false)
+}
+
+fn tree_changes_to_diff(
+    tree_changes: Vec<TreeChange>,
+    repo: &gix::Repository,
+    context_lines: u32,
+) -> anyhow::Result<String> {
+    tree_changes
+        .into_iter()
+        .map(|change| change.unified_diff(repo, context_lines))
+        .filter_map(|diff| diff.transpose())
+        .try_fold(String::new(), |mut diff, line| -> anyhow::Result<_> {
+            diff.push_str(&line?.to_str_lossy());
+            Ok(diff)
+        })
 }

--- a/crates/but/src/command/legacy/status/tui/details/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/details/mod.rs
@@ -152,6 +152,7 @@ impl Details {
         match msg {
             Message::JustRender
             | Message::CopySelection
+            | Message::CopySelectionPicker
             | Message::Quit
             | Message::ConfirmAndQuit
             | Message::DetailsLayout(DetailsLayoutMessage::Focus { .. })

--- a/crates/but/src/command/legacy/status/tui/key_bind/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/key_bind/mod.rs
@@ -733,7 +733,17 @@ impl KeyBindsBuilder<'_> {
             Message::CopySelection,
         )
         .hide_from_hotbar()
-        .long_description("Copy selection to clipboard")
+        .long_description("Copy selection")
+    }
+
+    fn copy_picker(&mut self) -> KeyBindsInModesBuilder<'_> {
+        self.key_bind(
+            "copy more",
+            press().shift().code(KeyCode::Char('Y')),
+            Message::CopySelectionPicker,
+        )
+        .hide_from_hotbar()
+        .long_description("Copy selection picker")
     }
 
     fn back(&mut self) -> KeyBindsInModesBuilder<'_> {
@@ -1040,6 +1050,7 @@ fn register_normal_mode_key_binds(builder: &mut KeyBindsBuilder<'_>, without_mar
 
     if without_marks {
         builder.copy().register();
+        builder.copy_picker().register();
     }
 
     builder.reload().register();

--- a/crates/but/src/command/legacy/status/tui/key_bind/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/key_bind/mod.rs
@@ -729,7 +729,7 @@ impl KeyBindsBuilder<'_> {
     fn copy(&mut self) -> KeyBindsInModesBuilder<'_> {
         self.key_bind(
             "copy",
-            press().shift().code(KeyCode::Char('C')),
+            press().code(KeyCode::Char('y')),
             Message::CopySelection,
         )
         .hide_from_hotbar()

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -42,6 +42,7 @@ use crate::{
             tui::{
                 backstack::{Backstack, BackstackEntry, RememberToUpdateBackstack},
                 confirm::{Confirm, ConfirmMessage},
+                copy_selection_picker::CopySelectionItem,
                 cursor::{Cursor, is_selectable_in_mode},
                 details::{Details, DetailsMessage, RenderNextChunkResult},
                 event_polling::{CrosstermEventPolling, EventPolling, NoopEventPolling},
@@ -86,6 +87,7 @@ use render::{details_viewport, ensure_cursor_visible, render_app, status_viewpor
 
 mod backstack;
 mod confirm;
+mod copy_selection_picker;
 mod cursor;
 mod details;
 mod event_polling;
@@ -297,7 +299,11 @@ where
     // poll terminal events
     for event in event_polling.poll(event_poll_timeout)? {
         let picker_shown = match &app.modal {
-            Some(Modal::GotoBranchPicker { .. } | Modal::ApplyStackPicker { .. }) => true,
+            Some(
+                Modal::GotoBranchPicker { .. }
+                | Modal::ApplyStackPicker { .. }
+                | Modal::CopySelectionPicker { .. },
+            ) => true,
             Some(Modal::Confirm { .. } | Modal::Help { .. }) | None => false,
         };
         event_to_messages(
@@ -469,6 +475,10 @@ enum Modal {
         confirm: Confirm,
         key_binds: KeyBinds,
     },
+    CopySelectionPicker {
+        picker: Box<FuzzyPicker<CopySelectionItem>>,
+        key_binds: KeyBinds,
+    },
     GotoBranchPicker {
         picker: Box<FuzzyPicker<GotoBranchItem>>,
         key_binds: KeyBinds,
@@ -558,6 +568,7 @@ impl App {
             Some(Modal::Confirm { key_binds, .. })
             | Some(Modal::GotoBranchPicker { key_binds, .. })
             | Some(Modal::ApplyStackPicker { key_binds, .. })
+            | Some(Modal::CopySelectionPicker { key_binds, .. })
             | Some(Modal::Help { key_binds, .. }) => key_binds,
             None => {
                 if let Mode::Normal(NormalMode { marks }) = &*self.mode
@@ -808,6 +819,9 @@ impl App {
             Message::CopySelection => {
                 self.handle_copy_selection()?;
             }
+            Message::CopySelectionPicker => {
+                self.handle_copy_selection_picker()?;
+            }
             Message::ShowToast { kind, text } => {
                 self.toasts.insert(kind, text);
             }
@@ -834,6 +848,14 @@ impl App {
                             self.modal = picker
                                 .handle_message(fuzzy_picker_message, ctx, messages)?
                                 .map(|picker| Modal::ApplyStackPicker {
+                                    picker: Box::new(picker),
+                                    key_binds,
+                                });
+                        }
+                        Modal::CopySelectionPicker { picker, key_binds } => {
+                            self.modal = picker
+                                .handle_message(fuzzy_picker_message, ctx, messages)?
+                                .map(|picker| Modal::CopySelectionPicker {
                                     picker: Box::new(picker),
                                     key_binds,
                                 });
@@ -2839,6 +2861,37 @@ impl App {
         Ok(())
     }
 
+    fn handle_copy_selection_picker(&mut self) -> anyhow::Result<()> {
+        let Some(selection) = self
+            .cursor
+            .selected_line(&self.status_lines)
+            .and_then(|selection| selection.data.cli_id())
+        else {
+            return Ok(());
+        };
+
+        let picker = match &**selection {
+            CliId::Commit { commit_id, .. } => {
+                let commit_id = *commit_id;
+                copy_selection_picker::commit_picker(commit_id, self.theme)
+            }
+            CliId::Branch { .. } => {
+                todo!()
+            }
+            CliId::UncommittedHunkOrFile(..)
+            | CliId::PathPrefix { .. }
+            | CliId::CommittedFile { .. }
+            | CliId::Uncommitted { .. }
+            | CliId::Stack { .. } => return Ok(()),
+        };
+        self.modal = Some(Modal::CopySelectionPicker {
+            picker: Box::new(picker),
+            key_binds: fuzzy_picker_key_binds(),
+        });
+
+        Ok(())
+    }
+
     /// Handles opening the full-screen commit reword editor for the selected commit.
     fn handle_reword_with_editor<T>(
         &mut self,
@@ -4172,6 +4225,7 @@ enum Message {
 
     // Utilities
     CopySelection,
+    CopySelectionPicker,
     #[expect(clippy::enum_variant_names)]
     RegisterOutOfBandMessage(Rc<Receiver<Message>>),
     WithOneFrameDelay(Box<Message>),

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -2875,8 +2875,9 @@ impl App {
                 let commit_id = *commit_id;
                 copy_selection_picker::commit_picker(commit_id, self.theme)
             }
-            CliId::Branch { .. } => {
-                todo!()
+            CliId::Branch { name, .. } => {
+                let branch = Category::LocalBranch.to_full_name(&**name)?;
+                copy_selection_picker::branch_picker(branch, self.theme)
             }
             CliId::UncommittedHunkOrFile(..)
             | CliId::PathPrefix { .. }

--- a/crates/but/src/command/legacy/status/tui/render.rs
+++ b/crates/but/src/command/legacy/status/tui/render.rs
@@ -145,6 +145,9 @@ pub(super) fn render_app(app: &App, frame: &mut Frame) {
         Some(Modal::ApplyStackPicker { picker, .. }) => {
             picker.render(app.has_focus, frame.area(), frame);
         }
+        Some(Modal::CopySelectionPicker { picker, .. }) => {
+            picker.render(app.has_focus, frame.area(), frame);
+        }
         Some(Modal::Help { help, .. }) => help.render(frame.area(), frame),
         None => {}
     }

--- a/crates/but/src/command/legacy/status/tui/toast.rs
+++ b/crates/but/src/command/legacy/status/tui/toast.rs
@@ -12,7 +12,6 @@ use crate::theme::Theme;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum ToastKind {
     Error,
-    #[expect(dead_code)]
     Info,
     Debug,
 }


### PR DESCRIPTION
Shift+y now shows a picker where you can copy more things than just the selection. For example commit message, diff, pr url, and more.