### PR TITLE
Add `but agent setup` wizard

### DIFF
--- a/crates/but/src/args/agent.rs
+++ b/crates/but/src/args/agent.rs
@@ -1,0 +1,35 @@
+/// Arguments for AI agent setup commands.
+#[derive(Debug, clap::Parser)]
+pub struct Platform {
+    #[clap(subcommand)]
+    pub cmd: Subcommands,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum Subcommands {
+    /// Configure GitButler skills and workflow instructions for coding agents.
+    ///
+    /// Starts an interactive wizard that generates GitButler workflow steering,
+    /// installs selected agent skills, and optionally writes the generated
+    /// steering into agent instruction files.
+    ///
+    /// ## Examples
+    ///
+    /// Start the setup wizard:
+    ///
+    /// ```text
+    /// but agent setup
+    /// ```
+    ///
+    /// Print the default steering text without modifying files:
+    ///
+    /// ```text
+    /// but agent setup --print
+    /// ```
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
+    Setup {
+        /// Print the default generated steering text without prompting or modifying files.
+        #[clap(long)]
+        print: bool,
+    },
+}

--- a/crates/but/src/args/metrics.rs
+++ b/crates/but/src/args/metrics.rs
@@ -69,6 +69,7 @@ pub enum CommandName {
     Merge,
     SkillInstall,
     SkillCheck,
+    AgentSetup,
     Pick,
     Clean,
     External,

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -1190,6 +1190,28 @@ pub enum Subcommands {
     #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Skill(skill::Platform),
 
+    /// Set up GitButler for AI coding agents.
+    ///
+    /// Runs a guided setup wizard for installing GitButler agent skills and
+    /// writing workflow steering instructions into supported agent instruction
+    /// files.
+    ///
+    /// ## Examples
+    ///
+    /// Start the interactive setup wizard:
+    ///
+    /// ```text
+    /// but agent setup
+    /// ```
+    ///
+    /// Print the default generated steering text:
+    ///
+    /// ```text
+    /// but agent setup --print
+    /// ```
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
+    Agent(agent::Platform),
+
     /// Open a file in the built-in text editor.
     ///
     /// A simple terminal-based text editor for quick edits. This is the same
@@ -1348,6 +1370,7 @@ pub enum Subcommands {
     External(Vec<OsString>),
 }
 
+pub mod agent;
 pub mod alias;
 #[cfg(feature = "legacy")]
 pub mod commit;

--- a/crates/but/src/args/tests.rs
+++ b/crates/but/src/args/tests.rs
@@ -132,6 +132,41 @@ mod config_ai {
     }
 }
 
+mod agent_setup {
+    use clap::Parser;
+
+    use crate::args::{
+        Args, Subcommands,
+        agent::{Platform as AgentPlatform, Subcommands as AgentCmd},
+    };
+
+    #[test]
+    fn parses_agent_setup() {
+        let args = Args::try_parse_from(["but", "agent", "setup"]).expect("parse args");
+        let cmd = args.cmd.expect("subcommand");
+
+        match cmd {
+            Subcommands::Agent(AgentPlatform {
+                cmd: AgentCmd::Setup { print },
+            }) => assert!(!print),
+            _ => panic!("unexpected command shape"),
+        }
+    }
+
+    #[test]
+    fn parses_agent_setup_print() {
+        let args = Args::try_parse_from(["but", "agent", "setup", "--print"]).expect("parse args");
+        let cmd = args.cmd.expect("subcommand");
+
+        match cmd {
+            Subcommands::Agent(AgentPlatform {
+                cmd: AgentCmd::Setup { print },
+            }) => assert!(print),
+            _ => panic!("unexpected command shape"),
+        }
+    }
+}
+
 mod branch_update {
     use clap::Parser;
 

--- a/crates/but/src/command/agent/files.rs
+++ b/crates/but/src/command/agent/files.rs
@@ -1,0 +1,154 @@
+use std::path::Path;
+
+use anyhow::{Context as _, Result};
+
+use super::{MANAGED_BLOCK_END, MANAGED_BLOCK_START};
+
+pub(super) fn upsert_managed_block_file(path: &Path, block: &str) -> Result<()> {
+    let original = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(err) => return Err(err).with_context(|| format!("Failed to read {}", path.display())),
+    };
+    let updated = upsert_managed_block(&original, block)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create {}", parent.display()))?;
+    }
+    std::fs::write(path, updated).with_context(|| format!("Failed to write {}", path.display()))?;
+    Ok(())
+}
+
+/// Find the byte offset of the next occurrence of `needle` in `haystack` at or
+/// after `from` that sits on its own line (i.e. at the start of the file or
+/// right after a newline, and immediately followed by a newline or EOF).
+///
+/// This keeps a marker quoted inside prose or inline code (where surrounding
+/// text or backticks keep it off its own line), or shown as an example inside a
+/// fenced code block, from being mistaken for a real block delimiter — which
+/// would otherwise splice away the surrounding text.
+pub(super) fn find_line_anchored(haystack: &str, needle: &str, from: usize) -> Option<usize> {
+    let bytes = haystack.as_bytes();
+    let mut search = from;
+    while let Some(rel) = haystack[search..].find(needle) {
+        let idx = search + rel;
+        let at_line_start = idx == 0 || bytes[idx - 1] == b'\n';
+        let after = idx + needle.len();
+        let at_line_end = after == haystack.len() || matches!(bytes[after], b'\n' | b'\r');
+        if at_line_start && at_line_end && !inside_fenced_block(haystack, idx) {
+            return Some(idx);
+        }
+        search = idx + needle.len();
+    }
+    None
+}
+
+/// Whether the line starting at byte `idx` falls inside a fenced code block
+/// (```` ``` ```` or `~~~`). An odd number of fence delimiters before it means a
+/// fence is open, so a managed-block marker shown there as a documented example
+/// is left alone rather than treated as a real delimiter.
+fn inside_fenced_block(haystack: &str, idx: usize) -> bool {
+    let mut open = false;
+    for line in haystack[..idx].lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+            open = !open;
+        }
+    }
+    open
+}
+
+/// Rewrite `block` to use CRLF line endings when `existing` already does, so a
+/// replaced or appended block does not introduce mixed line endings.
+fn match_line_endings(existing: &str, block: &str) -> String {
+    if existing.contains("\r\n") {
+        block.replace("\r\n", "\n").replace('\n', "\r\n")
+    } else {
+        block.to_string()
+    }
+}
+
+pub(super) fn upsert_managed_block(existing: &str, block: &str) -> Result<String> {
+    let start = find_line_anchored(existing, MANAGED_BLOCK_START, 0);
+    let end = find_line_anchored(existing, MANAGED_BLOCK_END, 0);
+
+    match (start, end) {
+        // No managed block yet: append a fresh one.
+        (None, None) => return Ok(append_managed_block(existing, block)),
+        (Some(_), None) => anyhow::bail!(
+            "Found only the GitButler managed block start marker. Refusing to edit a partial managed block."
+        ),
+        (None, Some(_)) => anyhow::bail!(
+            "Found only the GitButler managed block end marker. Refusing to edit a partial managed block."
+        ),
+        (Some(start), Some(end)) if end < start => anyhow::bail!(
+            "Found GitButler managed block markers in the wrong order (end before start). Refusing to edit a malformed managed block."
+        ),
+        // Well-formed: a start marker with an end after it. Fall through to replace.
+        (Some(_), Some(_)) => {}
+    }
+
+    // Pair each start marker with the first end marker after it. Replace the
+    // first block with the fresh one and drop any extra blocks (e.g. left over
+    // from an earlier buggy run), so the file converges to exactly one block.
+    let mut spans = Vec::new();
+    let mut pos = 0;
+    while let Some(start) = find_line_anchored(existing, MANAGED_BLOCK_START, pos) {
+        let Some(end) = find_line_anchored(
+            existing,
+            MANAGED_BLOCK_END,
+            start + MANAGED_BLOCK_START.len(),
+        ) else {
+            anyhow::bail!(
+                "Found a GitButler managed block start marker without a matching end marker. Refusing to edit a partial managed block."
+            );
+        };
+        let mut block_end = end + MANAGED_BLOCK_END.len();
+        if existing[block_end..].starts_with("\r\n") {
+            block_end += 2;
+        } else if existing[block_end..].starts_with('\n') {
+            block_end += 1;
+        }
+        spans.push((start, block_end));
+        pos = block_end;
+    }
+
+    let block = match_line_endings(existing, block);
+    let mut updated = String::with_capacity(existing.len() + block.len());
+    let mut copied = 0;
+    for (index, (start, block_end)) in spans.iter().enumerate() {
+        updated.push_str(&existing[copied..*start]);
+        if index == 0 {
+            updated.push_str(&block);
+        }
+        copied = *block_end;
+    }
+    updated.push_str(&existing[copied..]);
+    Ok(updated)
+}
+
+fn append_managed_block(existing: &str, block: &str) -> String {
+    if existing.is_empty() {
+        return block.to_string();
+    }
+
+    let block = match_line_endings(existing, block);
+    let crlf = existing.contains("\r\n");
+    let mut updated = String::with_capacity(existing.len() + block.len() + 2);
+    updated.push_str(existing);
+    if existing.ends_with("\r\n\r\n") || existing.ends_with("\n\n") {
+        // Already separated by a blank line.
+    } else if crlf {
+        updated.push_str(if existing.ends_with("\r\n") {
+            "\r\n"
+        } else {
+            "\r\n\r\n"
+        });
+    } else if existing.ends_with('\n') {
+        updated.push('\n');
+    } else {
+        updated.push_str("\n\n");
+    }
+    updated.push_str(&block);
+    updated
+}

--- a/crates/but/src/command/agent/mod.rs
+++ b/crates/but/src/command/agent/mod.rs
@@ -1,0 +1,717 @@
+use std::{
+    fmt::{self, Write as _},
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context as _, Result};
+use nonempty::NonEmpty;
+
+use crate::{
+    args::agent,
+    command::skill,
+    theme::{self, Paint},
+    utils::{InputOutputChannel, OutputChannel, PromptLine, detect_agent},
+};
+
+mod files;
+mod plan;
+mod policy;
+#[cfg(test)]
+mod tests;
+
+use files::upsert_managed_block_file;
+use plan::{AgentTarget, Plan};
+use policy::{WizardAnswers, WorkflowOption, render_managed_policy_block};
+
+const MANAGED_BLOCK_START: &str = "<!-- gitbutler-agent-setup:start -->";
+const MANAGED_BLOCK_END: &str = "<!-- gitbutler-agent-setup:end -->";
+
+/// Error type for user-initiated cancellation.
+#[derive(Debug, Clone, Copy)]
+struct UserCancelled;
+
+impl fmt::Display for UserCancelled {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Agent setup cancelled")
+    }
+}
+
+impl std::error::Error for UserCancelled {}
+
+pub fn handle(current_dir: &Path, out: &mut OutputChannel, cmd: agent::Subcommands) -> Result<()> {
+    match cmd {
+        agent::Subcommands::Setup { print } => setup(current_dir, out, print),
+    }
+}
+
+fn setup(current_dir: &Path, out: &mut OutputChannel, print_only: bool) -> Result<()> {
+    if print_only {
+        let default_policy = render_managed_policy_block(&WizardAnswers::default());
+        print_policy(out, &default_policy)?;
+        return Ok(());
+    }
+
+    let repo = discover_repo(current_dir);
+
+    if !out.can_prompt() {
+        anyhow::bail!(
+            "Interactive setup requires a terminal. Use `but agent setup --print` to print the default instructions without modifying files."
+        );
+    }
+
+    let mut input = out
+        .prepare_for_terminal_input()
+        .context("Interactive setup requires a terminal.")?;
+
+    let plan = collect_plan(&mut input, repo)?;
+    drop(input);
+
+    match plan {
+        Some(plan) => apply_plan(out, current_dir, &plan),
+        None => print_cancelled(out),
+    }
+}
+
+/// Run the interactive wizard. Returns the confirmed plan, or `None` if the user
+/// cancelled at any point — an `Esc`/`Ctrl-C` on any screen, or the final
+/// "Cancel". Cancelling never writes anything.
+fn collect_plan(
+    input: &mut InputOutputChannel<'_>,
+    repo: Option<RepoInfo>,
+) -> Result<Option<Plan>> {
+    match collect_plan_inner(input, repo) {
+        Ok(plan) => Ok(Some(plan)),
+        Err(err) if err.downcast_ref::<UserCancelled>().is_some() => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
+fn collect_plan_inner(input: &mut InputOutputChannel<'_>, repo: Option<RepoInfo>) -> Result<Plan> {
+    write_intro(input, repo.as_ref())?;
+
+    // The scope question only appears inside a repository; outside one,
+    // everything is personal (global), so there is nothing to choose.
+    let mut steps = Steps::new(if repo.is_some() { 4 } else { 3 });
+
+    let agents = prompt_agents(&mut steps, input, repo.as_ref())?;
+    let scope = match repo.as_ref() {
+        Some(repo) => prompt_scope(&mut steps, input, repo)?,
+        None => Scope::Global,
+    };
+    let workflow = prompt_workflow_options(&mut steps, input)?;
+    let answers = prompt_follow_up_answers(input, workflow)?;
+    let policy = render_managed_policy_block(&answers);
+
+    let plan = Plan::new(repo.as_ref(), scope, agents, policy)?;
+
+    if prompt_review(&mut steps, input, &plan)? {
+        Ok(plan)
+    } else {
+        Err(UserCancelled.into())
+    }
+}
+
+fn print_cancelled(out: &mut OutputChannel) -> Result<()> {
+    if let Some(writer) = out.for_human() {
+        writeln!(writer)?;
+        writeln!(
+            writer,
+            "Cancelled. No skill was installed and no agent files were modified."
+        )?;
+    }
+    Ok(())
+}
+
+fn print_policy(out: &mut OutputChannel, policy: &str) -> Result<()> {
+    if let Some(json_out) = out.for_json() {
+        json_out.write_value(serde_json::json!({ "policy": policy }))?;
+        return Ok(());
+    }
+    let writer = out
+        .for_human_or_shell()
+        .context("Text output is required for `but agent setup --print`.")?;
+    writeln!(writer, "{policy}")?;
+    Ok(())
+}
+
+/// Width used for the banner rule and right-aligned step counter. Clamped so the
+/// header stays tidy on both narrow and very wide terminals.
+fn banner_width() -> usize {
+    crossterm::terminal::size()
+        .map(|(cols, _)| cols as usize)
+        .unwrap_or(72)
+        .clamp(40, 72)
+}
+
+/// Tracks the wizard's position so each screen can show "Step N of M".
+struct Steps {
+    current: usize,
+    total: usize,
+}
+
+impl Steps {
+    fn new(total: usize) -> Self {
+        Self { current: 0, total }
+    }
+
+    /// Advance to the next step and print its banner: the step's short title on
+    /// the left and the `Step N of M` counter on the right. The product name is
+    /// only shown once, in the intro, so it does not repeat on every screen.
+    fn banner(&mut self, writer: &mut impl fmt::Write, title: &str) -> fmt::Result {
+        self.current += 1;
+        let t = theme::get();
+        let width = banner_width();
+        let right = format!("Step {} of {}", self.current, self.total);
+        let gap = width
+            .saturating_sub(title.chars().count() + right.chars().count())
+            .max(1);
+        writeln!(writer)?;
+        writeln!(
+            writer,
+            "{}{}{}",
+            t.important.paint(title),
+            " ".repeat(gap),
+            t.hint.paint(right)
+        )?;
+        writeln!(writer, "{}", t.border.paint("─".repeat(width)))
+    }
+}
+
+fn write_intro(writer: &mut impl fmt::Write, repo: Option<&RepoInfo>) -> fmt::Result {
+    let t = theme::get();
+    let width = banner_width();
+
+    writeln!(writer)?;
+    writeln!(writer, "{}", t.important.paint("GitButler · agent setup"))?;
+    writeln!(writer, "{}", t.border.paint("─".repeat(width)))?;
+    writeln!(
+        writer,
+        "Set up your coding agent to work well with GitButler."
+    )?;
+    writeln!(writer)?;
+    writeln!(writer, "Here's what this does:")?;
+    writeln!(
+        writer,
+        "  {} Install the GitButler skill so your agent can drive {}",
+        t.info.paint("•"),
+        t.command_suggestion.paint("but")
+    )?;
+    writeln!(
+        writer,
+        "  {} Save a few preferences for how it commits, branches, and opens PRs",
+        t.info.paint("•")
+    )?;
+    writeln!(writer)?;
+    writeln!(
+        writer,
+        "{}",
+        t.hint.paint(
+            "Nothing is written until you review and confirm — you'll see exactly what changes first."
+        )
+    )?;
+    if repo.is_none() {
+        writeln!(
+            writer,
+            "{}",
+            t.hint
+                .paint("No repository here, so this applies to all your projects.")
+        )?;
+    }
+    writeln!(
+        writer,
+        "{}",
+        t.hint
+            .paint("↑/↓ move · space select · enter continue · esc cancel")
+    )
+}
+
+#[derive(Debug, Clone)]
+struct RepoInfo {
+    root: PathBuf,
+    needs_setup: bool,
+}
+
+fn discover_repo(current_dir: &Path) -> Option<RepoInfo> {
+    let repo = gix::discover(current_dir).ok()?;
+    let root = repo.workdir()?.to_path_buf();
+    let needs_setup = repo_needs_setup(&root);
+    Some(RepoInfo { root, needs_setup })
+}
+
+#[cfg(feature = "legacy")]
+fn repo_needs_setup(workdir: &Path) -> bool {
+    let Ok(project) = but_ctx::LegacyProject::find_by_worktree_dir(workdir) else {
+        return true;
+    };
+    let Ok(ctx) = but_ctx::Context::new_from_legacy_project(project) else {
+        return true;
+    };
+    let guard = ctx.shared_worktree_access();
+    crate::command::legacy::setup::check_project_setup(&ctx, guard.read_permission()).is_err()
+}
+
+#[cfg(not(feature = "legacy"))]
+fn repo_needs_setup(_workdir: &Path) -> bool {
+    false
+}
+
+/// Where the user wants this setup to apply. A single choice that drives both
+/// where skills install and where workflow preferences are written, so the user
+/// is not asked the same repository-vs-global question several times.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Scope {
+    Repository,
+    Global,
+    Both,
+}
+
+impl Scope {
+    fn summary(self) -> &'static str {
+        match self {
+            Self::Repository => "this project",
+            Self::Global => "all your projects",
+            Self::Both => "this project and your global setup",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PickerLabel {
+    label: String,
+    help: &'static str,
+}
+
+impl PickerLabel {
+    fn new(label: impl Into<String>, help: &'static str) -> Self {
+        Self {
+            label: label.into(),
+            help,
+        }
+    }
+}
+
+impl fmt::Display for PickerLabel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.label)
+    }
+}
+
+fn prompt_agents(
+    steps: &mut Steps,
+    input: &mut InputOutputChannel<'_>,
+    repo: Option<&RepoInfo>,
+) -> Result<Vec<AgentTarget>> {
+    steps.banner(input, "Agents")?;
+
+    // Pre-select every agent the user appears to use: the one currently invoking
+    // the CLI (if any), plus any whose config we can find on this machine or in
+    // this repository.
+    let running = detect_agent::detect().and_then(AgentTarget::from_detected);
+    let home = dirs::home_dir();
+    let preselect =
+        |agent: AgentTarget| Some(agent) == running || agent.in_use(home.as_deref(), repo);
+
+    let flags = AgentTarget::ALL
+        .into_iter()
+        .map(preselect)
+        .collect::<Vec<_>>();
+    let options = AgentTarget::ALL
+        .into_iter()
+        .zip(flags.iter().copied())
+        .map(|(agent, detected)| {
+            let label = if detected {
+                format!("{} (detected)", agent.name())
+            } else {
+                agent.name().to_string()
+            };
+            (PickerLabel::new(label, agent.help()), agent)
+        })
+        .collect::<Vec<_>>();
+
+    let mut defaults = flags
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, &detected)| detected.then_some(idx))
+        .collect::<Vec<_>>();
+
+    let options = NonEmpty::from_vec(options).context("agent options cannot be empty")?;
+    loop {
+        let selected = input
+            .prompt_multi_select_with_help(
+                "Which agents do you use?",
+                &options,
+                defaults.clone(),
+                |label| Some(label.help),
+            )?
+            .ok_or(UserCancelled)?;
+        if selected.is_empty() {
+            // The user cleared every agent on purpose; re-prompt from a clean
+            // slate so they don't have to deselect the detected defaults again.
+            defaults.clear();
+            let t = theme::get();
+            writeln!(
+                input,
+                "{}",
+                t.attention.paint("Pick at least one agent to continue.")
+            )?;
+            continue;
+        }
+        return Ok(selected.into_iter().copied().collect());
+    }
+}
+
+fn prompt_scope(
+    steps: &mut Steps,
+    input: &mut InputOutputChannel<'_>,
+    repo: &RepoInfo,
+) -> Result<Scope> {
+    steps.banner(input, "Where it applies")?;
+
+    let options = scope_options(repo);
+    input
+        .prompt_select_with_help("Where should this apply?", &options, Some(0), |label| {
+            Some(label.help)
+        })?
+        .copied()
+        .ok_or_else(|| UserCancelled.into())
+}
+
+fn scope_options(repo: &RepoInfo) -> NonEmpty<(PickerLabel, Scope)> {
+    // Lead with the global option: it is the better default, since the skill is
+    // useful in every repository and personal preferences travel with the user.
+    // The repository option is for deliberate, team-shared setups.
+    NonEmpty::from_vec(vec![
+        (
+            PickerLabel::new(
+                "All my projects (global)",
+                "Install the skill and save preferences in your personal config, for every repository.",
+            ),
+            Scope::Global,
+        ),
+        (
+            PickerLabel::new(
+                format!("Just this project ({})", repo_display_name(repo)),
+                "Install the skill and save preferences in this repository only.",
+            ),
+            Scope::Repository,
+        ),
+        (
+            PickerLabel::new("Both", "Set up this project and your personal config."),
+            Scope::Both,
+        ),
+    ])
+    .expect("scope options are non-empty")
+}
+
+fn repo_display_name(repo: &RepoInfo) -> String {
+    display_name_from_path(&repo.root)
+        .or_else(|| {
+            repo.root
+                .canonicalize()
+                .ok()
+                .and_then(|path| display_name_from_path(&path))
+        })
+        .unwrap_or_else(|| repo.root.display().to_string())
+}
+
+fn display_name_from_path(path: &Path) -> Option<String> {
+    let name = path.file_name()?.to_string_lossy();
+    (!name.is_empty() && name != "." && name != "..").then(|| name.into_owned())
+}
+
+fn prompt_workflow_options(
+    steps: &mut Steps,
+    input: &mut InputOutputChannel<'_>,
+) -> Result<Vec<WorkflowOption>> {
+    steps.banner(input, "Preferences")?;
+
+    let t = theme::get();
+    writeln!(input, "These shape how your agent works with GitButler.")?;
+    writeln!(
+        input,
+        "{}",
+        t.hint
+            .paint("Safe defaults are always on. These are extras you can override in any prompt.")
+    )?;
+    writeln!(
+        input,
+        "{}",
+        t.hint
+            .paint("Learn more: https://docs.gitbutler.com/ai-agents/tuning-agent-behavior")
+    )?;
+    writeln!(input)?;
+
+    let options = WorkflowOption::ALL
+        .into_iter()
+        .map(|option| (PickerLabel::new(option.label(), option.help()), option))
+        .collect::<Vec<_>>();
+    let defaults = options
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, (_, option))| option.default_selected().then_some(idx))
+        .collect();
+    let options = NonEmpty::from_vec(options).context("workflow options cannot be empty")?;
+    let selected = input
+        .prompt_multi_select_with_help(
+            "Pick any that fit how you like to work:",
+            &options,
+            defaults,
+            |label| Some(label.help),
+        )?
+        .ok_or(UserCancelled)?;
+    Ok(selected.into_iter().copied().collect())
+}
+
+fn prompt_follow_up_answers(
+    input: &mut InputOutputChannel<'_>,
+    selected: Vec<WorkflowOption>,
+) -> Result<WizardAnswers> {
+    let mut answers = WizardAnswers {
+        selected,
+        ..WizardAnswers::default()
+    };
+
+    // The follow-ups below are sub-questions of the Preferences step, so caption
+    // them once instead of giving each its own numbered banner.
+    if answers.has(WorkflowOption::PublishPhrase)
+        || answers.has(WorkflowOption::BranchPattern)
+        || answers.has(WorkflowOption::CommitConvention)
+    {
+        writeln!(input)?;
+        writeln!(
+            input,
+            "{}",
+            theme::get().hint.paint("A few details for your picks:")
+        )?;
+    }
+
+    if answers.has(WorkflowOption::PublishPhrase) {
+        answers.publish_phrase = prompt_optional_text(input, "Publish shortcut phrase", "ship it")?;
+    }
+
+    if answers.has(WorkflowOption::BranchPattern) {
+        answers.branch_pattern = Some(prompt_optional_text(
+            input,
+            "Branch naming pattern",
+            "<name>/<short-description>",
+        )?);
+    }
+
+    if answers.has(WorkflowOption::CommitConvention) {
+        answers.commit_convention = Some(prompt_optional_text(
+            input,
+            "Commit message convention",
+            "type(scope): summary",
+        )?);
+    }
+
+    Ok(answers)
+}
+
+/// Ask for an optional value, defaulting to `default` on an empty line. The
+/// prompt spells out that pressing Enter accepts the default.
+fn prompt_optional_text(
+    input: &mut InputOutputChannel<'_>,
+    label: &str,
+    default: &str,
+) -> Result<String> {
+    let prompt = format!("{label} (press Enter for '{default}'):");
+    match input.prompt_single_line_input(&prompt)? {
+        // `readline` already trims and routes empty input to PromptLine::Empty.
+        // Strip backticks, since the value is rendered inside inline code
+        // (`` `..` ``) in the generated steering and a stray backtick would break
+        // it. If nothing usable is left (e.g. only backticks), fall back to the
+        // default rather than emit an empty inline-code value.
+        PromptLine::Text(value) => {
+            let cleaned = value.replace('`', "");
+            let cleaned = cleaned.trim();
+            Ok(if cleaned.is_empty() {
+                default.to_string()
+            } else {
+                cleaned.to_string()
+            })
+        }
+        PromptLine::Empty => Ok(default.to_string()),
+        PromptLine::Cancelled => Err(UserCancelled.into()),
+    }
+}
+
+/// Show the concrete plan, then ask for a single confirmation. Returns `true` to
+/// apply and `false` to cancel; an `Esc`/`Ctrl-C` also cancels (propagated as
+/// `UserCancelled`).
+fn prompt_review(
+    steps: &mut Steps,
+    input: &mut InputOutputChannel<'_>,
+    plan: &Plan,
+) -> Result<bool> {
+    steps.banner(input, "Review")?;
+    write_review(input, plan)?;
+
+    let options = NonEmpty::from_vec(vec![
+        (
+            PickerLabel::new("Apply", "Install the skill and write the files now."),
+            true,
+        ),
+        (
+            PickerLabel::new("Cancel", "Change nothing and exit."),
+            false,
+        ),
+    ])
+    .expect("review options are non-empty");
+    input
+        .prompt_select_with_help("Apply these changes?", &options, Some(0), |label| {
+            Some(label.help)
+        })?
+        .copied()
+        .ok_or_else(|| UserCancelled.into())
+}
+
+fn write_review(writer: &mut impl fmt::Write, plan: &Plan) -> fmt::Result {
+    let t = theme::get();
+    let check = &t.sym().success;
+
+    writeln!(
+        writer,
+        "Here's what GitButler will set up for {}.",
+        t.important.paint(plan.scope.summary())
+    )?;
+
+    if !plan.skill_installs.is_empty() {
+        writeln!(writer)?;
+        writeln!(writer, "{}", t.important.paint("Install the skill"))?;
+        for install in &plan.skill_installs {
+            writeln!(
+                writer,
+                "  {check} {} {} {}",
+                install.agent.name(),
+                t.sym().arrow,
+                t.config_value.paint(display_path(&install.path))
+            )?;
+        }
+    }
+
+    if !plan.instruction_writes.is_empty() {
+        writeln!(writer)?;
+        writeln!(writer, "{}", t.important.paint("Save preferences to"))?;
+        for write in &plan.instruction_writes {
+            let agents = write
+                .agents
+                .iter()
+                .map(|agent| agent.name())
+                .collect::<Vec<_>>()
+                .join(", ");
+            writeln!(
+                writer,
+                "  {check} {} {}",
+                t.config_value.paint(display_path(&write.path)),
+                t.hint.paint(format!("({agents})"))
+            )?;
+        }
+    }
+
+    if !plan.print_only_notes.is_empty() {
+        writeln!(writer)?;
+        writeln!(writer, "{}", t.important.paint("Heads up"))?;
+        for note in &plan.print_only_notes {
+            writeln!(writer, "  {} {note}", t.sym().warning)?;
+        }
+    }
+
+    if plan.setup_needed {
+        writeln!(writer)?;
+        writeln!(writer, "{}", t.important.paint("Prepare this repository"))?;
+        writeln!(
+            writer,
+            "  {check} Run {}",
+            t.command_suggestion.paint("but setup")
+        )?;
+    }
+
+    writeln!(writer)?;
+    writeln!(writer, "{}", t.important.paint("The exact text"))?;
+    write_policy_preview(writer, &plan.policy)?;
+    writeln!(writer)
+}
+
+/// Shorten a path for display: collapse the home directory to `~` and drop a
+/// leading `.` component so review paths read cleanly (`AGENTS.md`,
+/// `~/.codex/...`).
+fn display_path(path: &Path) -> String {
+    if let Some(home) = dirs::home_dir()
+        && let Ok(rest) = path.strip_prefix(&home)
+    {
+        return if rest.as_os_str().is_empty() {
+            "~".to_string()
+        } else {
+            format!("~{}{}", std::path::MAIN_SEPARATOR, rest.display())
+        };
+    }
+    // Strip a leading `.` component (`./AGENTS.md` -> `AGENTS.md`); component-aware
+    // so it also handles Windows' `.\AGENTS.md`.
+    path.strip_prefix(".")
+        .map(|rest| rest.display().to_string())
+        .unwrap_or_else(|_| path.display().to_string())
+}
+
+/// Render the generated rules indented, with the managed-block markers dimmed so
+/// the human-facing content reads clearly while still being honest about what
+/// lands in the file.
+fn write_policy_preview(writer: &mut impl fmt::Write, policy: &str) -> fmt::Result {
+    let t = theme::get();
+    for line in policy.lines() {
+        if line == MANAGED_BLOCK_START || line == MANAGED_BLOCK_END {
+            writeln!(writer, "  {}", t.hint.paint(line))?;
+        } else if line.is_empty() {
+            writeln!(writer)?;
+        } else {
+            writeln!(writer, "  {line}")?;
+        }
+    }
+    Ok(())
+}
+
+fn apply_plan(out: &mut OutputChannel, current_dir: &Path, plan: &Plan) -> Result<()> {
+    // Run `but setup` first: it is the step most likely to fail (it needs a
+    // discoverable repo + project registration) and aborts before any file is
+    // written, keeping the intro's "nothing is written until you confirm"
+    // promise on the realistic abort path. The remaining skill→instruction
+    // writes are idempotent upserts, so a partial run is re-runnable.
+    if plan.setup_needed {
+        run_but_setup(current_dir, out)?;
+    }
+
+    for install in &plan.skill_installs {
+        skill::write_skill_files(&install.path)
+            .with_context(|| format!("Failed to install skill at {}", install.path.display()))?;
+    }
+
+    for write in &plan.instruction_writes {
+        upsert_managed_block_file(&write.path, &plan.policy)
+            .with_context(|| format!("Failed to update {}", write.path.display()))?;
+    }
+
+    if let Some(writer) = out.for_human() {
+        let t = theme::get();
+        writeln!(writer)?;
+        writeln!(
+            writer,
+            "{} GitButler agent setup complete.",
+            t.sym().success
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(feature = "legacy")]
+fn run_but_setup(current_dir: &Path, out: &mut OutputChannel) -> Result<()> {
+    let repo = gix::discover(current_dir).context("No git repository found for `but setup`.")?;
+    let mut ctx = but_ctx::Context::from_repo(repo)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    crate::command::legacy::setup::repo(&mut ctx, current_dir, out, guard.write_permission())
+        .context("Failed to set up GitButler project.")
+}
+
+#[cfg(not(feature = "legacy"))]
+fn run_but_setup(_current_dir: &Path, _out: &mut OutputChannel) -> Result<()> {
+    Ok(())
+}

--- a/crates/but/src/command/agent/plan.rs
+++ b/crates/but/src/command/agent/plan.rs
@@ -1,0 +1,321 @@
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context as _, Result};
+
+use crate::utils::detect_agent;
+
+use super::{RepoInfo, Scope};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) enum AgentTarget {
+    Codex,
+    ClaudeCode,
+    Cursor,
+    GitHubCopilot,
+    Windsurf,
+    OpenCode,
+    AgentSkills,
+}
+
+impl AgentTarget {
+    pub(super) const ALL: [Self; 7] = [
+        Self::Codex,
+        Self::ClaudeCode,
+        Self::Cursor,
+        Self::GitHubCopilot,
+        Self::Windsurf,
+        Self::OpenCode,
+        Self::AgentSkills,
+    ];
+
+    pub(super) fn name(self) -> &'static str {
+        match self {
+            Self::Codex => "Codex",
+            Self::ClaudeCode => "Claude Code",
+            Self::Cursor => "Cursor",
+            Self::GitHubCopilot => "GitHub Copilot",
+            Self::Windsurf => "Windsurf / Devin",
+            Self::OpenCode => "OpenCode",
+            Self::AgentSkills => "Agent Skills",
+        }
+    }
+
+    pub(super) fn help(self) -> &'static str {
+        match self {
+            Self::Codex => "Install the Codex skill and write Codex AGENTS.md steering.",
+            Self::ClaudeCode => "Install the Claude Code skill and write Claude instruction files.",
+            Self::Cursor => "Install the Cursor skill and write supported Cursor project steering.",
+            Self::GitHubCopilot => {
+                "Install the Copilot skill and write supported Copilot instructions."
+            }
+            Self::Windsurf => {
+                "Install the Windsurf skill and write Cascade-compatible AGENTS.md steering."
+            }
+            Self::OpenCode => "Install the OpenCode skill and write OpenCode AGENTS.md steering.",
+            Self::AgentSkills => {
+                "Install the shared .agents skill format and write generic AGENTS.md steering."
+            }
+        }
+    }
+
+    pub(super) fn from_detected(agent: detect_agent::Agent) -> Option<Self> {
+        match agent {
+            detect_agent::Agent::Codex => Some(Self::Codex),
+            detect_agent::Agent::ClaudeCode | detect_agent::Agent::ClaudeCodeCowork => {
+                Some(Self::ClaudeCode)
+            }
+            detect_agent::Agent::Cursor | detect_agent::Agent::CursorCli => Some(Self::Cursor),
+            detect_agent::Agent::GitHubCopilot => Some(Self::GitHubCopilot),
+            detect_agent::Agent::OpenCode => Some(Self::OpenCode),
+            detect_agent::Agent::Devin => Some(Self::Windsurf),
+            detect_agent::Agent::GeminiCli
+            | detect_agent::Agent::Augment
+            | detect_agent::Agent::Antigravity
+            | detect_agent::Agent::Replit
+            | detect_agent::Agent::V0 => None,
+        }
+    }
+
+    /// Whether this agent looks like it is already in use on this machine, so the
+    /// picker can pre-select it. Looks for the agent's config directory under
+    /// `$HOME`, then for an unambiguous per-repository marker.
+    pub(super) fn in_use(self, home: Option<&Path>, repo: Option<&RepoInfo>) -> bool {
+        // In use if the agent has config under $HOME, an unambiguous repo marker,
+        // or a GitButler skill already installed for it — the last makes a re-run
+        // of the wizard re-select agents it (or `but skill`) previously set up.
+        if let Some(home) = home
+            && (marker_exists(home, self.home_config_marker())
+                || marker_exists(home, self.skill_path_components(Scope::Global)))
+        {
+            return true;
+        }
+        if let Some(repo) = repo
+            && (marker_exists(&repo.root, self.repo_config_marker())
+                || marker_exists(&repo.root, self.skill_path_components(Scope::Repository)))
+        {
+            return true;
+        }
+        false
+    }
+
+    /// The agent's config directory under `$HOME`; its presence means the agent
+    /// is set up for this user.
+    fn home_config_marker(self) -> Option<&'static [&'static str]> {
+        Some(match self {
+            Self::Codex => &[".codex"],
+            Self::ClaudeCode => &[".claude"],
+            Self::Cursor => &[".cursor"],
+            Self::GitHubCopilot => &[".copilot"],
+            Self::OpenCode => &[".config", "opencode"],
+            Self::Windsurf => &[".codeium"],
+            // The shared `.agents` format has no agent-specific config to detect.
+            Self::AgentSkills => return None,
+        })
+    }
+
+    /// An unambiguous per-repository marker for this agent. `AGENTS.md` is shared
+    /// by several agents, so it is intentionally not treated as a marker.
+    fn repo_config_marker(self) -> Option<&'static [&'static str]> {
+        Some(match self {
+            Self::ClaudeCode => &["CLAUDE.md"],
+            Self::GitHubCopilot => &[".github", "copilot-instructions.md"],
+            Self::Cursor => &[".cursor"],
+            Self::Codex | Self::OpenCode | Self::Windsurf | Self::AgentSkills => return None,
+        })
+    }
+
+    /// Where this agent's skill installs, relative to a base directory. Derived
+    /// from `SKILL_FORMATS` in `crate::command::skill` so the wizard installs to
+    /// the exact paths `but skill` discovers. Only the single-location scopes
+    /// carry a path; `Both` is expanded into Global + Repository before this is
+    /// called.
+    pub(super) fn skill_path_components(self, scope: Scope) -> Option<&'static [&'static str]> {
+        crate::command::skill::path_components_for(
+            self.skill_format_name(),
+            matches!(scope, Scope::Global),
+        )
+    }
+
+    /// This agent's `SKILL_FORMATS` display name. The install paths themselves
+    /// are the single source of truth in `crate::command::skill`.
+    fn skill_format_name(self) -> &'static str {
+        match self {
+            Self::Codex => "Codex",
+            Self::ClaudeCode => "Claude Code",
+            Self::Cursor => "Cursor",
+            Self::GitHubCopilot => "GitHub Copilot",
+            Self::Windsurf => "Windsurf",
+            Self::OpenCode => "OpenCode",
+            Self::AgentSkills => "Agent Skills",
+        }
+    }
+
+    pub(super) fn shared_instruction_components(self) -> &'static [&'static str] {
+        match self {
+            // Cursor reads AGENTS.md without rule metadata, so prefer it over a
+            // `.cursor/rules/*.mdc` file, which would need YAML frontmatter
+            // (e.g. `alwaysApply: true`) to be loaded automatically.
+            Self::Codex | Self::OpenCode | Self::AgentSkills | Self::Cursor | Self::Windsurf => {
+                &["AGENTS.md"]
+            }
+            Self::ClaudeCode => &["CLAUDE.md"],
+            Self::GitHubCopilot => &[".github", "copilot-instructions.md"],
+        }
+    }
+
+    pub(super) fn global_instruction_components(self) -> Option<&'static [&'static str]> {
+        match self {
+            Self::Codex => Some(&[".codex", "AGENTS.md"]),
+            Self::ClaudeCode => Some(&[".claude", "rules", "gitbutler.md"]),
+            Self::GitHubCopilot => Some(&[".copilot", "copilot-instructions.md"]),
+            Self::OpenCode => Some(&[".config", "opencode", "AGENTS.md"]),
+            Self::Windsurf => Some(&[".codeium", "windsurf", "memories", "global_rules.md"]),
+            Self::Cursor | Self::AgentSkills => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct Plan {
+    pub(super) scope: Scope,
+    pub(super) policy: String,
+    pub(super) skill_installs: Vec<SkillInstallPlan>,
+    pub(super) instruction_writes: Vec<InstructionWritePlan>,
+    pub(super) print_only_notes: Vec<String>,
+    pub(super) setup_needed: bool,
+}
+
+impl Plan {
+    pub(super) fn new(
+        repo: Option<&RepoInfo>,
+        scope: Scope,
+        agents: Vec<AgentTarget>,
+        policy: String,
+    ) -> Result<Self> {
+        let skill_installs = collect_skill_installs(&agents, scope, repo)?;
+        let (instruction_writes, print_only_notes) =
+            collect_instruction_writes(&agents, scope, repo)?;
+        let setup_needed = repository_setup_needed(repo, scope);
+        Ok(Self {
+            scope,
+            policy,
+            skill_installs,
+            instruction_writes,
+            print_only_notes,
+            setup_needed,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct SkillInstallPlan {
+    pub(super) agent: AgentTarget,
+    pub(super) path: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct InstructionWritePlan {
+    pub(super) path: PathBuf,
+    pub(super) agents: Vec<AgentTarget>,
+}
+
+pub(super) fn collect_skill_installs(
+    agents: &[AgentTarget],
+    scope: Scope,
+    repo: Option<&RepoInfo>,
+) -> Result<Vec<SkillInstallPlan>> {
+    // Resolve each concrete install location (a single-location scope) to its
+    // base directory once, expanding `Both` into global + repository.
+    let mut locations: Vec<(Scope, PathBuf)> = Vec::new();
+    if matches!(scope, Scope::Global | Scope::Both) {
+        let home = dirs::home_dir()
+            .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
+        locations.push((Scope::Global, home));
+    }
+    if matches!(scope, Scope::Repository | Scope::Both) {
+        let root = repo
+            .map(|repo| repo.root.clone())
+            .context("Repository skill install requested outside a repository")?;
+        locations.push((Scope::Repository, root));
+    }
+
+    let mut installs = Vec::new();
+    for agent in agents {
+        for (location, base_dir) in &locations {
+            if let Some(components) = agent.skill_path_components(*location) {
+                installs.push(SkillInstallPlan {
+                    agent: *agent,
+                    path: join_components(base_dir, components),
+                });
+            }
+        }
+    }
+    Ok(installs)
+}
+
+pub(super) fn repository_setup_needed(repo: Option<&RepoInfo>, scope: Scope) -> bool {
+    repo.is_some_and(|repo| repo.needs_setup && matches!(scope, Scope::Repository | Scope::Both))
+}
+
+pub(super) fn collect_instruction_writes(
+    agents: &[AgentTarget],
+    scope: Scope,
+    repo: Option<&RepoInfo>,
+) -> Result<(Vec<InstructionWritePlan>, Vec<String>)> {
+    let mut by_path: BTreeMap<PathBuf, Vec<AgentTarget>> = BTreeMap::new();
+    let mut print_only_notes = Vec::new();
+    let home = if matches!(scope, Scope::Global | Scope::Both) {
+        Some(dirs::home_dir().context("Could not determine home directory")?)
+    } else {
+        None
+    };
+    for agent in agents {
+        if matches!(scope, Scope::Repository | Scope::Both) {
+            let repo = repo.context("Repository instructions requested outside a repository")?;
+            by_path
+                .entry(join_components(
+                    &repo.root,
+                    agent.shared_instruction_components(),
+                ))
+                .or_default()
+                .push(*agent);
+        }
+
+        if let Some(home) = &home {
+            if let Some(components) = agent.global_instruction_components() {
+                by_path
+                    .entry(join_components(home, components))
+                    .or_default()
+                    .push(*agent);
+            } else {
+                print_only_notes.push(format!(
+                    "{} has no supported global instructions file; copy the generated policy below into it manually.",
+                    agent.name()
+                ));
+            }
+        }
+    }
+
+    Ok((
+        by_path
+            .into_iter()
+            .map(|(path, agents)| InstructionWritePlan { path, agents })
+            .collect(),
+        print_only_notes,
+    ))
+}
+
+fn join_components(base: &Path, components: &[&str]) -> PathBuf {
+    components
+        .iter()
+        .fold(base.to_path_buf(), |path, component| path.join(component))
+}
+
+/// Whether `base` joined with `marker`'s components exists on disk. `None` marker
+/// (the agent has no such location) is never present.
+fn marker_exists(base: &Path, marker: Option<&'static [&'static str]>) -> bool {
+    marker.is_some_and(|components| join_components(base, components).exists())
+}

--- a/crates/but/src/command/agent/policy.rs
+++ b/crates/but/src/command/agent/policy.rs
@@ -1,0 +1,264 @@
+use std::fmt::Write as _;
+
+use super::{MANAGED_BLOCK_END, MANAGED_BLOCK_START};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum WorkflowOption {
+    FoldFixes,
+    SuggestSplits,
+    StackedBranches,
+    AutoUpdate,
+    DraftPrs,
+    PublishPhrase,
+    BranchPattern,
+    CommitConvention,
+    CommitAfterTurn,
+}
+
+impl WorkflowOption {
+    pub(super) const ALL: [Self; 9] = [
+        Self::FoldFixes,
+        Self::SuggestSplits,
+        Self::StackedBranches,
+        Self::AutoUpdate,
+        Self::DraftPrs,
+        Self::PublishPhrase,
+        Self::BranchPattern,
+        Self::CommitConvention,
+        Self::CommitAfterTurn,
+    ];
+
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            Self::FoldFixes => "Prefer folding small follow-up fixes into the matching commit",
+            Self::SuggestSplits => "Suggest splitting large or mixed commits into smaller commits",
+            Self::StackedBranches => "Favor stacked branches and PRs for dependent work",
+            Self::AutoUpdate => "Automatically update from the target branch (e.g. origin/main)",
+            Self::DraftPrs => "Open pull requests as drafts unless I say they are ready",
+            Self::PublishPhrase => "Use a shortcut phrase to publish everything",
+            Self::BranchPattern => "Set a preferred branch naming pattern",
+            Self::CommitConvention => "Set a preferred commit message convention",
+            Self::CommitAfterTurn => "Commit after each agent coding turn",
+        }
+    }
+
+    pub(super) fn help(self) -> &'static str {
+        match self {
+            Self::FoldFixes => {
+                "Small cleanup fixes go into the commit they belong to instead of becoming extra fixup commits."
+            }
+            Self::SuggestSplits => {
+                "For large or mixed work, the agent suggests a cleaner split before committing."
+            }
+            Self::StackedBranches => {
+                "For dependent work, prefer smaller stacked branches and PRs over one large branch."
+            }
+            Self::AutoUpdate => {
+                "Bring in latest target-branch changes when they apply cleanly; ask before conflicts or surprising context changes."
+            }
+            Self::DraftPrs => {
+                "New pull requests start as drafts unless you explicitly ask for a ready PR."
+            }
+            Self::PublishPhrase => {
+                "Default phrase: \"ship it\". You'll be asked next if you select this."
+            }
+            Self::BranchPattern => {
+                "You'll choose the pattern next, for example `<name>/<short-description>` or `feature/<ticket>-<slug>`."
+            }
+            Self::CommitConvention => {
+                "You'll choose the convention next, for example `type(scope): summary` or `summary only, no prefix`."
+            }
+            Self::CommitAfterTurn => {
+                "Your agent makes a local checkpoint commit after each coding turn, then tidies the history with GitButler when you tell it to."
+            }
+        }
+    }
+
+    pub(super) fn default_selected(self) -> bool {
+        matches!(self, Self::FoldFixes | Self::SuggestSplits)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct WizardAnswers {
+    pub(super) selected: Vec<WorkflowOption>,
+    pub(super) publish_phrase: String,
+    pub(super) branch_pattern: Option<String>,
+    pub(super) commit_convention: Option<String>,
+}
+
+impl Default for WizardAnswers {
+    fn default() -> Self {
+        Self {
+            selected: WorkflowOption::ALL
+                .into_iter()
+                .filter(|option| option.default_selected())
+                .collect(),
+            publish_phrase: "ship it".to_string(),
+            branch_pattern: None,
+            commit_convention: None,
+        }
+    }
+}
+
+impl WizardAnswers {
+    pub(super) fn has(&self, option: WorkflowOption) -> bool {
+        self.selected.contains(&option)
+    }
+}
+
+/// Render the GitButler steering as a managed block. Mirrors the published
+/// guidance: an always-on `## Version control` baseline (see the docs "Getting
+/// started" page) followed by one `###` section per selected preference (see
+/// the docs "Tuning agent behavior" page). The bullets are kept close to the
+/// docs text so the result matches hand-copying the relevant snippets, and they
+/// are phrased as direct instructions an agent can act on.
+pub(super) fn render_managed_policy_block(answers: &WizardAnswers) -> String {
+    let mut body = String::new();
+    body.push_str(MANAGED_BLOCK_START);
+    body.push('\n');
+    body.push_str("## Version control\n\n");
+    write_bullets(
+        &mut body,
+        &[
+            "Use GitButler (`but`) for version-control inspection and write operations, including status, diffs, branching, committing, pushing, and history edits.",
+            "Assume multiple agents may be working in this repository. Do not move, amend, squash, discard, commit, push, or otherwise modify another agent's work unless the user asks.",
+            "For commit order, branch layout, or conflict overview, start with compact `but status`. Use detailed status only when file IDs, hunk IDs, or per-commit file details are needed.",
+            "After a successful GitButler write command, use the workspace state it returns. Rerun status or diff only when that output lacks information you need or files changed since.",
+            "Use a dedicated GitButler branch for each agent session, unless the user asks for a different branch structure. Commit only changes that belong to that session.",
+            "Do not push or open pull requests unless the user asks.",
+            "Keep commit messages and pull request descriptions succinct: explain what changed, why it changed, and any important decision.",
+        ],
+    );
+
+    if answers.has(WorkflowOption::FoldFixes) {
+        write_section(
+            &mut body,
+            "Amend local fixes into the right commits",
+            &[
+                "For small cleanup or follow-up fixes, amend an unpublished local commit when the change clearly belongs with that commit's intent.",
+                "Do not create tiny fixup commits unless the user asks.",
+                "Use GitButler to move the relevant changes into the commit where they belong.",
+                "Ask before rewriting pushed, reviewed, shared, or ambiguous history.",
+            ],
+        );
+    }
+    if answers.has(WorkflowOption::SuggestSplits) {
+        write_section(
+            &mut body,
+            "Split unrelated changes into separate commits",
+            &[
+                "If one file contains unrelated changes, split them by hunk instead of committing the whole file.",
+                "Keep tests with the behavior they verify.",
+                "Split generated output, docs-only edits, or mechanical cleanup into separate commits when each commit remains coherent on its own.",
+                "If the split is ambiguous, summarize the options before committing.",
+            ],
+        );
+    }
+    if answers.has(WorkflowOption::StackedBranches) {
+        write_section(
+            &mut body,
+            "Create stacked pull requests",
+            &[
+                "If this session depends on another in-flight branch, stack its branch on top of that dependency instead of mixing the changes.",
+                "If this session is working in a stack, put commits on the branch where they belong.",
+                "Ask before moving commits onto lower, pushed, reviewed, or shared branches.",
+                "Use `but move` for branch stacking and restacking. Do not recreate branches to simulate stacking.",
+                "For stacked branches, create pull requests with `but pr`, not `gh`, so GitButler keeps the right PR base branches and stack metadata.",
+            ],
+        );
+    }
+    if answers.has(WorkflowOption::AutoUpdate) {
+        write_section(
+            &mut body,
+            "Update from the target branch automatically",
+            &[
+                "When GitButler status shows new changes on the target branch, run `but pull --check`.",
+                "If the check is clean and the update affects only this session's branches, update the workspace with `but pull`.",
+                "If the check reports conflicts or the update would affect another agent's branch, ask before updating.",
+                "If the user asks you to handle update conflicts, use GitButler's conflict tools. Ask before resolving semantic conflicts, dependency updates, generated files, or conflicts involving another person's work.",
+            ],
+        );
+    }
+    if answers.has(WorkflowOption::DraftPrs) {
+        write_section(
+            &mut body,
+            "Open draft pull requests by default",
+            &[
+                "When asked to open a pull request, create it as a draft with GitButler unless the user says it is ready for review.",
+                "Remember that creating a draft pull request still publishes the branch.",
+            ],
+        );
+    }
+    if answers.has(WorkflowOption::PublishPhrase) {
+        write_section_header(&mut body, "Publish on a shortcut phrase");
+        writeln!(
+            &mut body,
+            "- When the user says `{}`, commit this session's changes on its dedicated GitButler branch, creating one if needed.",
+            answers.publish_phrase
+        )
+        .expect("write to string");
+        write_bullets(
+            &mut body,
+            &[
+                "Push the branch and open or update its pull request with GitButler.",
+                "Reuse the existing branch or pull request for this session when one already exists.",
+                "Treat this phrase as approval to commit, push, and open or update a pull request without asking again, unless something risky or surprising changed.",
+            ],
+        );
+    }
+    if let Some(pattern) = &answers.branch_pattern {
+        write_section_header(&mut body, "Branch naming");
+        writeln!(
+            &mut body,
+            "- When creating a GitButler branch for an agent session, use `{pattern}`."
+        )
+        .expect("write to string");
+    }
+    if let Some(convention) = &answers.commit_convention {
+        write_section_header(&mut body, "Commit message convention");
+        writeln!(
+            &mut body,
+            "- Follow the `{convention}` commit-message convention when writing commit messages."
+        )
+        .expect("write to string");
+    }
+    if answers.has(WorkflowOption::CommitAfterTurn) {
+        write_section(
+            &mut body,
+            "Commit checkpoints after each turn",
+            &[
+                "Commit after a working checkpoint, when the requested change is complete and relevant checks have passed or been reported.",
+                "Treat checkpoint commits as local savepoints, not final review history.",
+                "When the user asks you to tidy the history, use GitButler to squash commits, reword commits, and move changes between commits where appropriate.",
+                "Only tidy unpublished local history unless the user explicitly authorizes changing pushed or shared history.",
+            ],
+        );
+    }
+
+    body.push_str(MANAGED_BLOCK_END);
+    body.push('\n');
+    body
+}
+
+/// Write a blank separator, a `### {title}` heading, and a blank line.
+fn write_section_header(body: &mut String, title: &str) {
+    body.push('\n');
+    body.push_str("### ");
+    body.push_str(title);
+    body.push_str("\n\n");
+}
+
+/// Write a `### {title}` section followed by its bullets.
+fn write_section(body: &mut String, title: &str, bullets: &[&str]) {
+    write_section_header(body, title);
+    write_bullets(body, bullets);
+}
+
+fn write_bullets(body: &mut String, bullets: &[&str]) {
+    for bullet in bullets {
+        body.push_str("- ");
+        body.push_str(bullet);
+        body.push('\n');
+    }
+}

--- a/crates/but/src/command/agent/tests.rs
+++ b/crates/but/src/command/agent/tests.rs
@@ -1,0 +1,579 @@
+use std::path::PathBuf;
+
+use super::{
+    files::{find_line_anchored, upsert_managed_block, upsert_managed_block_file},
+    plan::{collect_instruction_writes, collect_skill_installs, repository_setup_needed},
+    *,
+};
+
+#[test]
+fn generated_default_policy_includes_baseline_and_default_preferences() {
+    let policy = render_managed_policy_block(&WizardAnswers::default());
+
+    assert!(policy.contains("## Version control"));
+    assert!(
+        policy
+            .contains("Use GitButler (`but`) for version-control inspection and write operations")
+    );
+    assert!(policy.contains("otherwise modify another agent's work"));
+    assert!(policy.contains("amend an unpublished local commit"));
+    assert!(policy.contains("Use GitButler to move the relevant changes"));
+    assert!(policy.contains("If one file contains unrelated changes"));
+    assert!(!policy.contains("ship it"));
+}
+
+#[test]
+fn intro_explains_wizard_flow_before_first_prompt() {
+    let mut intro = String::new();
+
+    write_intro(&mut intro, None).expect("write intro");
+
+    assert!(intro.contains("GitButler · agent setup"));
+    assert!(intro.contains("Set up your coding agent to work well with GitButler"));
+    assert!(intro.contains("Install the GitButler skill"));
+    assert!(intro.contains("commits, branches, and opens PRs"));
+    assert!(intro.contains("Nothing is written until you review and confirm"));
+    assert!(intro.contains("see exactly what changes first"));
+    assert!(intro.contains("No repository here"));
+}
+
+#[test]
+fn scope_options_lead_with_global_and_name_repo() {
+    let repo = RepoInfo {
+        root: PathBuf::from("/tmp/gitbutler"),
+        needs_setup: false,
+    };
+
+    let options = scope_options(&repo);
+    let labels = options
+        .iter()
+        .map(|(label, scope)| (label.label.as_str(), *scope))
+        .collect::<Vec<_>>();
+
+    // Global leads so it is the highlighted default; the repo is still named.
+    assert_eq!(
+        labels,
+        vec![
+            ("All my projects (global)", Scope::Global),
+            ("Just this project (gitbutler)", Scope::Repository),
+            ("Both", Scope::Both),
+        ]
+    );
+}
+
+#[test]
+fn display_path_strips_leading_dot_component() {
+    use std::path::MAIN_SEPARATOR as SEP;
+    // A leading `.` component is dropped; the rest keeps native separators
+    // (`./` on POSIX, `.\` on Windows), so build paths and expectations from
+    // components rather than hard-coding `/`.
+    assert_eq!(
+        display_path(&PathBuf::from(".").join("AGENTS.md")),
+        "AGENTS.md"
+    );
+    let nested = PathBuf::from(".")
+        .join(".codex")
+        .join("skills")
+        .join("gitbutler");
+    assert_eq!(
+        display_path(&nested),
+        format!(".codex{SEP}skills{SEP}gitbutler")
+    );
+}
+
+#[test]
+fn display_path_collapses_home_to_tilde() {
+    use std::path::MAIN_SEPARATOR as SEP;
+    let home = dirs::home_dir().expect("home dir");
+    let inside = home.join(".codex").join("AGENTS.md");
+    assert_eq!(display_path(&inside), format!("~{SEP}.codex{SEP}AGENTS.md"));
+}
+
+#[test]
+fn agent_in_use_detects_home_config_dir() {
+    let home = tempfile::tempdir().expect("home");
+    std::fs::create_dir_all(home.path().join(".codex")).expect("create ~/.codex");
+
+    assert!(
+        AgentTarget::Codex.in_use(Some(home.path()), None),
+        "a ~/.codex directory should mark Codex as in use"
+    );
+    assert!(!AgentTarget::OpenCode.in_use(Some(home.path()), None));
+    assert!(!AgentTarget::Codex.in_use(None, None));
+}
+
+#[test]
+fn agent_in_use_detects_repo_marker_but_ignores_shared_agents_md() {
+    let dir = tempfile::tempdir().expect("repo");
+    std::fs::write(dir.path().join("CLAUDE.md"), "x").expect("write CLAUDE.md");
+    std::fs::write(dir.path().join("AGENTS.md"), "x").expect("write AGENTS.md");
+    let repo = RepoInfo {
+        root: dir.path().to_path_buf(),
+        needs_setup: false,
+    };
+
+    assert!(AgentTarget::ClaudeCode.in_use(None, Some(&repo)));
+    // AGENTS.md is shared by several agents, so it is not a marker.
+    assert!(!AgentTarget::Codex.in_use(None, Some(&repo)));
+}
+
+#[test]
+fn agent_in_use_detects_existing_skill_install() {
+    let home = tempfile::tempdir().expect("home");
+    // A skill a prior run installed for OpenCode (`~/.opencode/skills/gitbutler`)
+    // should mark it in use even without other config present.
+    std::fs::create_dir_all(
+        home.path()
+            .join(".opencode")
+            .join("skills")
+            .join("gitbutler"),
+    )
+    .expect("create skill dir");
+
+    assert!(AgentTarget::OpenCode.in_use(Some(home.path()), None));
+    assert!(!AgentTarget::Codex.in_use(Some(home.path()), None));
+}
+
+#[test]
+fn repo_display_name_resolves_dot_to_current_folder_name() {
+    let repo = RepoInfo {
+        root: PathBuf::from("."),
+        needs_setup: false,
+    };
+    let expected =
+        display_name_from_path(&std::env::current_dir().expect("current dir has a folder name"))
+            .expect("current dir has a folder name");
+
+    assert_eq!(repo_display_name(&repo), expected);
+}
+
+#[test]
+fn upsert_managed_block_appends_without_touching_existing_text() {
+    let existing = "# Existing\n\nKeep me.\n";
+    let block = format!("{MANAGED_BLOCK_START}\nnew\n{MANAGED_BLOCK_END}\n");
+
+    let updated = upsert_managed_block(existing, &block).expect("append managed block");
+
+    assert!(updated.starts_with(existing));
+    assert!(updated.contains(&block));
+}
+
+#[test]
+fn upsert_managed_block_replaces_existing_block_without_duplication() {
+    let existing = format!("before\n{MANAGED_BLOCK_START}\nold\n{MANAGED_BLOCK_END}\nafter\n");
+    let block = format!("{MANAGED_BLOCK_START}\nnew\n{MANAGED_BLOCK_END}\n");
+
+    let updated = upsert_managed_block(&existing, &block).expect("replace managed block");
+
+    assert_eq!(updated.matches(MANAGED_BLOCK_START).count(), 1);
+    assert!(updated.contains("before\n"));
+    assert!(updated.contains("new\n"));
+    assert!(updated.contains("after\n"));
+    assert!(!updated.contains("old\n"));
+}
+
+#[test]
+fn upsert_managed_block_rejects_partial_block() {
+    let existing = format!("before\n{MANAGED_BLOCK_START}\nold\n");
+    let block = format!("{MANAGED_BLOCK_START}\nnew\n{MANAGED_BLOCK_END}\n");
+
+    let err = upsert_managed_block(&existing, &block).expect_err("partial block fails");
+
+    assert!(err.to_string().contains("partial managed block"));
+}
+
+#[test]
+fn generated_policy_includes_selected_custom_values() {
+    let answers = WizardAnswers {
+        selected: vec![
+            WorkflowOption::PublishPhrase,
+            WorkflowOption::BranchPattern,
+            WorkflowOption::CommitConvention,
+        ],
+        publish_phrase: "release this".to_string(),
+        branch_pattern: Some("<name>/<ticket>-<short-description>".to_string()),
+        commit_convention: Some("type(scope): summary".to_string()),
+    };
+
+    let policy = render_managed_policy_block(&answers);
+
+    assert!(policy.contains("`release this`"));
+    assert!(policy.contains("`<name>/<ticket>-<short-description>`"));
+    assert!(policy.contains("`type(scope): summary`"));
+}
+
+#[test]
+fn generated_policy_expands_selected_tuning_recipes() {
+    let answers = WizardAnswers {
+        selected: WorkflowOption::ALL.to_vec(),
+        publish_phrase: "release this".to_string(),
+        branch_pattern: Some("<name>/<short-description>".to_string()),
+        commit_convention: Some("type(scope): summary".to_string()),
+    };
+
+    let policy = render_managed_policy_block(&answers);
+
+    assert!(policy.contains("Do not create tiny fixup commits"));
+    assert!(policy.contains("Keep tests with the behavior they verify"));
+    assert!(policy.contains("Use `but move` for branch stacking and restacking"));
+    assert!(policy.contains("create pull requests with `but pr`, not `gh`"));
+    assert!(policy.contains("run `but pull --check`"));
+    assert!(policy.contains("update the workspace with `but pull`"));
+    assert!(policy.contains("create it as a draft with GitButler"));
+    assert!(policy.contains("When the user says `release this`"));
+    assert!(policy.contains("Push the branch and open or update its pull request"));
+    assert!(policy.contains("When creating a GitButler branch for an agent session"));
+    assert!(policy.contains("commit-message convention"));
+    assert!(policy.contains("### Commit checkpoints after each turn"));
+    assert!(policy.contains("checkpoint commits as local savepoints"));
+    assert!(policy.contains("squash commits, reword commits, and move changes"));
+}
+
+#[test]
+fn instruction_writes_group_shared_agents_by_file() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = RepoInfo {
+        root: dir.path().to_path_buf(),
+        needs_setup: false,
+    };
+
+    let (writes, notes) = collect_instruction_writes(
+        &[
+            AgentTarget::Codex,
+            AgentTarget::OpenCode,
+            AgentTarget::AgentSkills,
+            AgentTarget::Windsurf,
+        ],
+        Scope::Repository,
+        Some(&repo),
+    )
+    .expect("collect instruction writes");
+
+    assert!(notes.is_empty());
+    assert_eq!(writes.len(), 1);
+    assert_eq!(writes[0].path, repo.root.join("AGENTS.md"));
+    assert_eq!(
+        writes[0].agents,
+        vec![
+            AgentTarget::Codex,
+            AgentTarget::OpenCode,
+            AgentTarget::AgentSkills,
+            AgentTarget::Windsurf
+        ]
+    );
+}
+
+#[test]
+fn skill_installs_expand_both_scopes() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = RepoInfo {
+        root: dir.path().to_path_buf(),
+        needs_setup: false,
+    };
+
+    let installs = collect_skill_installs(&[AgentTarget::Codex], Scope::Both, Some(&repo))
+        .expect("collect skill installs");
+
+    assert_eq!(installs.len(), 2);
+    let repo_path = repo.root.join(".codex").join("skills").join("gitbutler");
+    assert!(installs.iter().any(|install| install.path == repo_path));
+    assert!(installs.iter().any(|install| {
+        install.path != repo_path && install.path.ends_with(".codex/skills/gitbutler")
+    }));
+}
+
+/// Count the number of line-anchored block start markers.
+fn anchored_start_count(text: &str) -> usize {
+    let mut count = 0;
+    let mut pos = 0;
+    while let Some(idx) = find_line_anchored(text, MANAGED_BLOCK_START, pos) {
+        count += 1;
+        pos = idx + MANAGED_BLOCK_START.len();
+    }
+    count
+}
+
+#[test]
+fn upsert_managed_block_ignores_marker_quoted_in_prose() {
+    // A marker mentioned inside inline code (not on its own line) must not be
+    // treated as a block delimiter, or the splice would delete prose.
+    let existing = format!(
+        "# Notes\n\nWe use the `{MANAGED_BLOCK_START}` marker convention.\n\nKeep this paragraph.\n\n{MANAGED_BLOCK_START}\nold\n{MANAGED_BLOCK_END}\n\nTrailing prose.\n"
+    );
+    let block = format!("{MANAGED_BLOCK_START}\nnew\n{MANAGED_BLOCK_END}\n");
+
+    let updated = upsert_managed_block(&existing, &block).expect("replace real block only");
+
+    assert!(updated.starts_with("# Notes"));
+    assert!(updated.contains("We use the `"));
+    assert!(updated.contains("Keep this paragraph."));
+    assert!(updated.contains("Trailing prose."));
+    assert!(updated.contains("new\n"));
+    assert!(!updated.contains("\nold\n"));
+    assert_eq!(anchored_start_count(&updated), 1);
+}
+
+#[test]
+fn upsert_managed_block_ignores_marker_inside_fenced_code() {
+    // A file documenting the markers inside a fenced code block must be left
+    // intact, not spliced — the real block is appended after it.
+    let existing = format!(
+        "# Docs\n\nExample:\n\n```md\n{MANAGED_BLOCK_START}\n## example\n{MANAGED_BLOCK_END}\n```\n\nKeep me.\n"
+    );
+    let block = format!("{MANAGED_BLOCK_START}\nnew\n{MANAGED_BLOCK_END}\n");
+
+    let updated = upsert_managed_block(&existing, &block).expect("append, not splice");
+
+    assert!(updated.contains("## example"), "fenced example preserved");
+    assert!(updated.contains("Keep me."));
+    assert!(updated.contains("new\n"));
+    // The example markers (inside the fence) are ignored, so a fresh block is
+    // appended: the example pair plus the new pair.
+    assert_eq!(updated.matches(MANAGED_BLOCK_START).count(), 2);
+}
+
+#[test]
+fn upsert_managed_block_dedups_multiple_blocks() {
+    let existing = format!(
+        "head\n\n{MANAGED_BLOCK_START}\nA\n{MANAGED_BLOCK_END}\n\nmiddle\n\n{MANAGED_BLOCK_START}\nB\n{MANAGED_BLOCK_END}\n\ntail\n"
+    );
+    let block = format!("{MANAGED_BLOCK_START}\nnew\n{MANAGED_BLOCK_END}\n");
+
+    let updated = upsert_managed_block(&existing, &block).expect("collapse to one block");
+
+    assert_eq!(updated.matches(MANAGED_BLOCK_START).count(), 1);
+    assert_eq!(updated.matches(MANAGED_BLOCK_END).count(), 1);
+    assert!(updated.contains("new\n"));
+    assert!(!updated.contains("\nA\n"));
+    assert!(!updated.contains("\nB\n"));
+    assert!(updated.contains("head"));
+    assert!(updated.contains("middle"));
+    assert!(updated.contains("tail"));
+}
+
+#[test]
+fn upsert_managed_block_rejects_reversed_markers() {
+    let existing = format!("{MANAGED_BLOCK_END}\nstray\n{MANAGED_BLOCK_START}\n");
+    let block = format!("{MANAGED_BLOCK_START}\nnew\n{MANAGED_BLOCK_END}\n");
+
+    let err = upsert_managed_block(&existing, &block).expect_err("reversed markers fail");
+
+    assert!(err.to_string().contains("wrong order"));
+}
+
+#[test]
+fn upsert_managed_block_appends_with_crlf_separator() {
+    let existing = "# Title\r\n\r\nKeep me.\r\n";
+    let block = format!("{MANAGED_BLOCK_START}\nnew\n{MANAGED_BLOCK_END}\n");
+
+    let updated = upsert_managed_block(existing, &block).expect("crlf append");
+
+    assert!(updated.starts_with(existing));
+    assert!(updated.contains(&format!(
+        "{MANAGED_BLOCK_START}\r\nnew\r\n{MANAGED_BLOCK_END}"
+    )));
+    // No bare LF: every '\n' must be part of a "\r\n".
+    assert_eq!(
+        updated.matches('\n').count(),
+        updated.matches("\r\n").count()
+    );
+}
+
+#[test]
+fn upsert_managed_block_replaces_crlf_block_without_mixed_endings() {
+    let existing =
+        format!("before\r\n{MANAGED_BLOCK_START}\r\nold\r\n{MANAGED_BLOCK_END}\r\nafter\r\n");
+    let block = format!("{MANAGED_BLOCK_START}\nnew\n{MANAGED_BLOCK_END}\n");
+
+    let updated = upsert_managed_block(&existing, &block).expect("crlf replace");
+
+    assert_eq!(updated.matches(MANAGED_BLOCK_START).count(), 1);
+    assert!(updated.contains("after\r\n"));
+    assert!(!updated.contains("old"));
+    assert_eq!(
+        updated.matches('\n').count(),
+        updated.matches("\r\n").count()
+    );
+}
+
+#[test]
+fn upsert_managed_block_file_is_idempotent_and_creates_nested_dirs() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("nested").join("dir").join("AGENTS.md");
+    let block = render_managed_policy_block(&WizardAnswers::default());
+
+    upsert_managed_block_file(&path, &block).expect("first upsert");
+    assert!(path.exists(), "nested parent dirs must be created");
+    let first = std::fs::read_to_string(&path).expect("read first");
+
+    upsert_managed_block_file(&path, &block).expect("second upsert");
+    let second = std::fs::read_to_string(&path).expect("read second");
+    assert_eq!(first, second, "rerun must be byte-stable");
+    assert_eq!(second.matches(MANAGED_BLOCK_START).count(), 1);
+}
+
+#[test]
+fn upsert_managed_block_file_preserves_preexisting_content() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join(".github").join("copilot-instructions.md");
+    std::fs::create_dir_all(path.parent().expect("parent")).expect("create dir");
+    std::fs::write(&path, "# Team rules\n\nKeep me.\n").expect("seed file");
+    let block = render_managed_policy_block(&WizardAnswers::default());
+
+    upsert_managed_block_file(&path, &block).expect("first");
+    upsert_managed_block_file(&path, &block).expect("second");
+
+    let content = std::fs::read_to_string(&path).expect("read");
+    assert!(content.starts_with("# Team rules"));
+    assert!(content.contains("Keep me."));
+    assert_eq!(content.matches(MANAGED_BLOCK_START).count(), 1);
+}
+
+#[test]
+fn skill_installs_copilot_repo_and_global_diverge() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = RepoInfo {
+        root: dir.path().to_path_buf(),
+        needs_setup: false,
+    };
+
+    let installs = collect_skill_installs(&[AgentTarget::GitHubCopilot], Scope::Both, Some(&repo))
+        .expect("collect skill installs");
+
+    assert_eq!(installs.len(), 2);
+    assert!(installs.iter().any(|install| {
+        install.path == repo.root.join(".github").join("skills").join("gitbutler")
+    }));
+    assert!(
+        installs
+            .iter()
+            .any(|install| install.path.ends_with(".copilot/skills/gitbutler"))
+    );
+}
+
+#[test]
+fn skill_installs_global_only_uses_home_paths() {
+    let installs = collect_skill_installs(
+        &[
+            AgentTarget::Codex,
+            AgentTarget::GitHubCopilot,
+            AgentTarget::OpenCode,
+            AgentTarget::Windsurf,
+        ],
+        Scope::Global,
+        None,
+    )
+    .expect("collect skill installs");
+
+    assert_eq!(installs.len(), 4);
+    assert!(
+        installs
+            .iter()
+            .any(|i| i.path.ends_with(".codex/skills/gitbutler"))
+    );
+    assert!(
+        installs
+            .iter()
+            .any(|i| i.path.ends_with(".copilot/skills/gitbutler"))
+    );
+    // Paths match `but skill`'s SKILL_FORMATS so installs stay discoverable —
+    // OpenCode is `.opencode` (not `.config/opencode`) and Windsurf is
+    // `.windsurf` (not `.codeium/windsurf`).
+    assert!(
+        installs
+            .iter()
+            .any(|i| { i.path.ends_with(".opencode/skills/gitbutler") })
+    );
+    assert!(
+        installs
+            .iter()
+            .any(|i| { i.path.ends_with(".windsurf/skills/gitbutler") })
+    );
+}
+
+#[test]
+fn every_agent_resolves_to_a_skill_path_for_both_scopes() {
+    // Guards the AgentTarget -> SKILL_FORMATS name mapping: a typo would make an
+    // agent return no install path (and silently install nothing).
+    for agent in AgentTarget::ALL {
+        assert!(
+            agent.skill_path_components(Scope::Global).is_some(),
+            "{agent:?} has no global skill path"
+        );
+        assert!(
+            agent.skill_path_components(Scope::Repository).is_some(),
+            "{agent:?} has no repository skill path"
+        );
+    }
+}
+
+#[test]
+fn instruction_writes_global_emits_print_note_for_agents_without_global_target() {
+    let (writes, notes) = collect_instruction_writes(
+        &[
+            AgentTarget::ClaudeCode,
+            AgentTarget::Cursor,
+            AgentTarget::AgentSkills,
+        ],
+        Scope::Global,
+        None,
+    )
+    .expect("collect instruction writes");
+
+    // Claude Code has a trusted global target; Cursor and Agent Skills do not.
+    assert_eq!(writes.len(), 1);
+    assert!(writes[0].path.ends_with(".claude/rules/gitbutler.md"));
+    assert_eq!(writes[0].agents, vec![AgentTarget::ClaudeCode]);
+
+    assert_eq!(notes.len(), 2);
+    assert!(notes.iter().any(|n| n.contains("Cursor")));
+    assert!(notes.iter().any(|n| n.contains("Agent Skills")));
+    assert!(
+        notes
+            .iter()
+            .all(|n| n.contains("no supported global instructions file"))
+    );
+}
+
+#[test]
+fn repo_scoped_planning_requires_a_repository() {
+    assert!(collect_skill_installs(&[AgentTarget::Codex], Scope::Repository, None).is_err());
+    assert!(collect_instruction_writes(&[AgentTarget::Codex], Scope::Repository, None,).is_err());
+
+    // Global instructions need no repository.
+    let (writes, notes) = collect_instruction_writes(&[AgentTarget::Codex], Scope::Global, None)
+        .expect("global instructions need no repository");
+    assert_eq!(writes.len(), 1);
+    assert!(notes.is_empty());
+}
+
+#[test]
+fn global_only_plan_does_not_need_repository_setup() {
+    let repo = RepoInfo {
+        root: PathBuf::from("/tmp/repo"),
+        needs_setup: true,
+    };
+
+    assert!(!repository_setup_needed(Some(&repo), Scope::Global));
+}
+
+#[test]
+fn repository_targets_need_repository_setup_when_repo_is_not_setup() {
+    let repo = RepoInfo {
+        root: PathBuf::from("/tmp/repo"),
+        needs_setup: true,
+    };
+
+    assert!(repository_setup_needed(Some(&repo), Scope::Repository));
+    assert!(repository_setup_needed(Some(&repo), Scope::Both));
+}
+
+#[test]
+fn repository_targets_do_not_need_setup_when_repo_is_already_setup() {
+    let repo = RepoInfo {
+        root: PathBuf::from("/tmp/repo"),
+        needs_setup: false,
+    };
+
+    assert!(!repository_setup_needed(Some(&repo), Scope::Repository));
+}

--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -150,6 +150,7 @@ fn print_grouped_with_truncation(
                 SubcommandDiscriminant::Alias => Group::OtherCommands,
                 SubcommandDiscriminant::Config => Group::OtherCommands,
                 SubcommandDiscriminant::Skill => Group::OtherCommands,
+                SubcommandDiscriminant::Agent => Group::OtherCommands,
                 SubcommandDiscriminant::Help => Group::OtherCommands,
 
                 #[cfg(feature = "legacy")]
@@ -364,6 +365,7 @@ Other Commands:
   alias        Manage command aliases
   config       View and manage GitButler configuration
   skill        Manage AI agent skills for GitButler
+  agent        Set up GitButler for AI coding agents
 
 To add command completion, add this to your shell rc: (for example ~/.zshrc)
   eval "$(but completions zsh)"
@@ -435,6 +437,7 @@ Other Commands:
   alias        Manage command aliases
   config       View and manage GitButler configuration
   skill        Manage AI agent skills for GitButler
+  agent        Set up GitButler for AI coding agents
 
 To add command completion, add this to your shell rc: (for example ~/.zshrc)
   eval "$(but completions zsh)"

--- a/crates/but/src/command/mod.rs
+++ b/crates/but/src/command/mod.rs
@@ -2,6 +2,7 @@
 #[cfg(feature = "legacy")]
 pub mod legacy;
 
+pub mod agent;
 pub mod alias;
 pub mod branch;
 pub mod commit;

--- a/crates/but/src/command/skill.rs
+++ b/crates/but/src/command/skill.rs
@@ -122,6 +122,18 @@ impl SkillFormat {
     }
 }
 
+/// Install-path components (relative to a base directory) for a skill format,
+/// selected by its display name and whether the install is global. This keeps
+/// callers outside `but skill` — e.g. the `agent setup` wizard — installing to
+/// the same locations that `but skill check`/install/update discover, instead of
+/// duplicating (and drifting from) these paths.
+pub(crate) fn path_components_for(name: &str, global: bool) -> Option<&'static [&'static str]> {
+    SKILL_FORMATS
+        .iter()
+        .find(|format| format.name == name && format.is_available_for(global))
+        .map(|format| format.path_components)
+}
+
 /// Join a relative path from components using platform-native separators.
 fn join_relative_path(base_dir: &std::path::Path, components: &[&str]) -> PathBuf {
     components
@@ -1065,7 +1077,7 @@ fn prepare_skill_content(version: &str) -> Result<String> {
 /// Write the bundled skill files into `install_path`, creating the directory
 /// structure as needed and injecting the CLI version into SKILL.md. Returns the
 /// version that was written.
-fn write_skill_files(install_path: &std::path::Path) -> Result<&'static str> {
+pub(crate) fn write_skill_files(install_path: &std::path::Path) -> Result<&'static str> {
     if SKILL_FILES.iter().any(|f| f.content.is_empty()) {
         anyhow::bail!(
             "Skill files were not properly embedded at build time. Please report this as a bug."

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -31,7 +31,7 @@ use clap::Parser;
 
 pub mod args;
 use args::{
-    Args, OutputFormat, Subcommands, actions, alias as alias_args, branch, forge,
+    Args, OutputFormat, Subcommands, actions, agent, alias as alias_args, branch, forge,
     update as update_args, worktree,
 };
 use but_settings::AppSettings;
@@ -503,6 +503,11 @@ async fn match_subcommand(
             {
                 return Ok(());
             }
+
+            result.emit_metrics(metrics_ctx).map_err(CliError::from)
+        }
+        Subcommands::Agent(agent::Platform { cmd }) => {
+            let result = command::agent::handle(&args.current_dir, out, cmd);
 
             result.emit_metrics(metrics_ctx).map_err(CliError::from)
         }

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -80,7 +80,7 @@ impl Subcommands {
     pub(crate) fn to_metrics_command(&self) -> CommandName {
         use CommandName::*;
 
-        use crate::args::{alias as alias_args, branch, forge, skill, update, worktree};
+        use crate::args::{agent, alias as alias_args, branch, forge, skill, update, worktree};
         match self {
             #[cfg(feature = "legacy")]
             Subcommands::Status { .. } => Status,
@@ -219,6 +219,9 @@ impl Subcommands {
             Subcommands::Skill(skill::Platform { cmd }) => match cmd {
                 skill::Subcommands::Install { .. } => SkillInstall,
                 skill::Subcommands::Check { .. } => SkillCheck,
+            },
+            Subcommands::Agent(agent::Platform { cmd }) => match cmd {
+                agent::Subcommands::Setup { .. } => AgentSetup,
             },
             Subcommands::Edit { .. } => Edit,
             #[cfg(feature = "legacy")]
@@ -653,7 +656,7 @@ fn emit_metrics(command: CommandName, props: &Props) {
 mod tests {
     use super::*;
     use crate::{
-        args::{Subcommands, update},
+        args::{Subcommands, agent, update},
         bad_input,
     };
 
@@ -686,6 +689,12 @@ mod tests {
                 cmd: update::Subcommands::Suppress { days: 7 },
             }),
             "updateSuppress",
+        );
+        assert_command(
+            Subcommands::Agent(agent::Platform {
+                cmd: agent::Subcommands::Setup { print: false },
+            }),
+            "agentSetup",
         );
         assert_command(
             Subcommands::Move {

--- a/crates/but/src/utils/mod.rs
+++ b/crates/but/src/utils/mod.rs
@@ -1,6 +1,7 @@
 use std::io::Write;
 
 mod output_channel;
+pub(crate) use output_channel::PromptLine;
 #[cfg_attr(not(feature = "but-2"), expect(unused_imports))]
 pub use output_channel::experimental::*;
 pub use output_channel::{

--- a/crates/but/src/utils/output_channel.rs
+++ b/crates/but/src/utils/output_channel.rs
@@ -418,10 +418,21 @@ impl InputOutputChannel<'_> {
         &mut self,
         prompt: impl AsRef<str>,
     ) -> anyhow::Result<Option<String>> {
+        Ok(match self.prompt_single_line_input(prompt)? {
+            PromptLine::Text(line) => Some(line),
+            PromptLine::Empty | PromptLine::Cancelled => None,
+        })
+    }
+
+    pub(crate) fn prompt_single_line_input(
+        &mut self,
+        prompt: impl AsRef<str>,
+    ) -> anyhow::Result<PromptLine> {
         Ok(
             match self.readline(&format!("{} ", prompt.as_ref()), InputEcho::Visible)? {
-                ReadlineInput::Text(line) => Some(line),
-                ReadlineInput::Empty | ReadlineInput::EndOfInput => None,
+                ReadlineInput::Text(line) => PromptLine::Text(line),
+                ReadlineInput::Empty => PromptLine::Empty,
+                ReadlineInput::EndOfInput => PromptLine::Cancelled,
             },
         )
     }
@@ -560,6 +571,63 @@ impl InputOutputChannel<'_> {
             },
         )
     }
+
+    pub fn prompt_select_with_help<'a, Key, Value>(
+        &mut self,
+        prompt: impl AsRef<str>,
+        items: &'a NonEmpty<(Key, Value)>,
+        default_selected: Option<usize>,
+        help: impl Fn(&Key) -> Option<&str>,
+    ) -> anyhow::Result<Option<&'a Value>>
+    where
+        Key: std::fmt::Display,
+    {
+        let Some(picks) = tui::run_picker_with_help(
+            self,
+            prompt.as_ref(),
+            items,
+            PickerOptions {
+                allow_multiple: false,
+                default_selected: default_selected.into_iter().collect(),
+            },
+            help,
+        )?
+        else {
+            return Ok(None);
+        };
+
+        match &picks[..] {
+            [] => Ok(None),
+            [pick] => Ok(Some(pick)),
+            _ => {
+                anyhow::bail!(
+                    "the picker was configured to not allow multiple picks, yet multiple picks were returned"
+                )
+            }
+        }
+    }
+
+    pub fn prompt_multi_select_with_help<'a, Key, Value>(
+        &mut self,
+        prompt: impl AsRef<str>,
+        items: &'a NonEmpty<(Key, Value)>,
+        default_selected: Vec<usize>,
+        help: impl Fn(&Key) -> Option<&str>,
+    ) -> anyhow::Result<Option<Vec<&'a Value>>>
+    where
+        Key: std::fmt::Display,
+    {
+        tui::run_picker_with_help(
+            self,
+            prompt.as_ref(),
+            items,
+            PickerOptions {
+                allow_multiple: true,
+                default_selected,
+            },
+            help,
+        )
+    }
 }
 
 /// Normalized result of collecting one line of terminal input.
@@ -570,6 +638,12 @@ enum ReadlineInput {
     Empty,
     /// Input ended without a submission (for example Ctrl-C, Ctrl-D, or Esc).
     EndOfInput,
+}
+
+pub(crate) enum PromptLine {
+    Text(String),
+    Empty,
+    Cancelled,
 }
 
 /// How to play input back to the user during prompts.

--- a/crates/but/tests/but/command/agent.rs
+++ b/crates/but/tests/but/command/agent.rs
@@ -1,0 +1,92 @@
+use snapbox::str;
+
+use crate::utils::{CommandExt, Sandbox};
+
+fn assert_default_policy(policy: &str) {
+    assert!(
+        policy.contains("<!-- gitbutler-agent-setup:start -->"),
+        "policy should include the managed block start marker, got: {policy}"
+    );
+    assert!(
+        policy
+            .contains("Use GitButler (`but`) for version-control inspection and write operations"),
+        "policy should include baseline GitButler write guidance, got: {policy}"
+    );
+    assert!(
+        policy.contains("otherwise modify another agent's work"),
+        "policy should include multi-agent isolation guidance, got: {policy}"
+    );
+    assert!(
+        policy.contains("amend an unpublished local commit"),
+        "policy should include default fold-fixes preference, got: {policy}"
+    );
+    assert!(
+        policy.contains("Use GitButler to move the relevant changes"),
+        "policy should include default amend guidance, got: {policy}"
+    );
+    assert!(
+        policy.contains("If one file contains unrelated changes"),
+        "policy should include default split suggestion preference, got: {policy}"
+    );
+    assert!(
+        policy.contains("<!-- gitbutler-agent-setup:end -->"),
+        "policy should include the managed block end marker, got: {policy}"
+    );
+}
+
+#[test]
+fn agent_setup_print_outputs_default_managed_policy() -> anyhow::Result<()> {
+    let env = Sandbox::empty();
+
+    let output = env
+        .but("agent setup --print")
+        .assert()
+        .success()
+        .stderr_eq(str![[]])
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = std::str::from_utf8(&output)?;
+
+    assert_default_policy(stdout);
+
+    Ok(())
+}
+
+#[test]
+fn agent_setup_print_json_outputs_policy_field() -> anyhow::Result<()> {
+    let env = Sandbox::empty();
+
+    let output = env
+        .but("--format json agent setup --print")
+        .allow_json()
+        .assert()
+        .success()
+        .stderr_eq(str![[]])
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output)?;
+    let policy = json
+        .get("policy")
+        .and_then(|value| value.as_str())
+        .expect("JSON output should include a string policy field");
+
+    assert_default_policy(policy);
+
+    Ok(())
+}
+
+#[test]
+fn agent_setup_without_tty_points_to_print_mode() {
+    let env = Sandbox::empty();
+
+    env.but("agent setup")
+        .assert()
+        .failure()
+        .stdout_eq(str![[]])
+        .stderr_eq(str![[r#"
+Error: Interactive setup requires a terminal. Use `but agent setup --print` to print the default instructions without modifying files.
+
+"#]]);
+}

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -4,6 +4,7 @@
 //! **Only** test the *happy path* of a typical user journey, while keeping details in unit tests with private module access.
 #[cfg(feature = "legacy")]
 mod absorb;
+mod agent;
 mod alias;
 #[cfg(feature = "legacy")]
 mod amend;


### PR DESCRIPTION
## What

An interactive wizard — `but agent setup` — that sets up coding agents to use GitButler. It installs the GitButler skill for the agents you choose and writes version-control steering into their instruction files (`AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, …), faithfully mirroring the [tuning-agent-behavior docs](https://docs.gitbutler.com/ai-agents/tuning-agent-behavior).

## Flow

1. **Agents** — detects installed agents (config dirs + unambiguous repo markers, plus the env-detected running agent) and pre-checks them.
2. **Where it applies** (in a repo) — a single scope choice: _All my projects (global)_ / _Just this project_ / _Both_. That one answer drives both where the skill installs and where steering is written.
3. **Preferences** — pick from the tuning options (fold fixes, split commits, stacked PRs, draft PRs, publish phrase, branch/commit conventions, checkpoints, auto-update); the safe baseline steering is always included.
4. **Review** — shows every skill path and instruction file that will change, plus the exact steering text, before anything is written.
5. **Apply / Cancel** — a single confirmation. Cancelling (or Esc on any screen) writes nothing and says so.

## Notes

- The generated steering lives in an idempotent managed block (`<!-- gitbutler-agent-setup:start -->` … `:end -->`), so re-runs update in place instead of appending.
- Existing file content is preserved byte-for-byte; only the managed block is added or replaced.
- `but agent setup --print` prints the default steering non-interactively.
- Builds on the contextual-help picker from #14411 (already merged).
