### PR TITLE
update git2 and git2-hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3864,27 +3864,25 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe 0.1.6",
  "openssl-sys",
- "url",
 ]
 
 [[package]]
 name = "git2-hooks"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "587d0dd757ea38f8a7b4761026162f6b9ab39e2cc7eba386852371841f5fe69b"
+checksum = "9e21a2c5eee3085f2b622805d4f4c878d9519bf70fa76bed0923b82a25f24199"
 dependencies = [
  "git2",
- "gix-path 0.10.22",
+ "gix-path 0.11.3",
  "log",
  "shellexpand",
  "thiserror 2.0.18",
@@ -4386,7 +4384,7 @@ dependencies = [
  "gix-traverse",
  "gix-url",
  "gix-utils",
- "gix-validate 0.11.2",
+ "gix-validate 0.11.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e)",
  "gix-worktree",
  "gix-worktree-state",
  "gix-worktree-stream",
@@ -4698,7 +4696,7 @@ version = "0.2.2"
 source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e#66f70f3063724b4145b21c6691c4f57892c7a74e"
 dependencies = [
  "bstr",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -4718,7 +4716,7 @@ dependencies = [
  "gix-object",
  "gix-traverse",
  "gix-utils",
- "gix-validate 0.11.2",
+ "gix-validate 0.11.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e)",
  "hashbrown 0.17.1",
  "itoa",
  "libc",
@@ -4801,7 +4799,7 @@ dependencies = [
  "gix-hash",
  "gix-hashtable",
  "gix-utils",
- "gix-validate 0.11.2",
+ "gix-validate 0.11.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e)",
  "itoa",
  "serde",
  "smallvec",
@@ -4864,13 +4862,13 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.10.22"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb06c3e4f8eed6e24fd915fa93145e28a511f4ea0e768bae16673e05ed3f366"
+checksum = "c8fd1fe596dc393b538e1d5492c5585971a9311475b3255f7b889023df208476"
 dependencies = [
  "bstr",
  "gix-trace 0.1.19",
- "gix-validate 0.10.1",
+ "gix-validate 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 2.0.18",
 ]
 
@@ -4881,7 +4879,7 @@ source = "git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21
 dependencies = [
  "bstr",
  "gix-trace 0.1.20",
- "gix-validate 0.11.2",
+ "gix-validate 0.11.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e)",
  "thiserror 2.0.18",
 ]
 
@@ -4961,7 +4959,7 @@ dependencies = [
  "gix-path 0.12.1",
  "gix-tempfile",
  "gix-utils",
- "gix-validate 0.11.2",
+ "gix-validate 0.11.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e)",
  "memmap2",
  "serde",
  "thiserror 2.0.18",
@@ -4977,7 +4975,7 @@ dependencies = [
  "gix-glob",
  "gix-hash",
  "gix-revision",
- "gix-validate 0.11.2",
+ "gix-validate 0.11.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e)",
  "smallvec",
  "thiserror 2.0.18",
 ]
@@ -5186,12 +5184,11 @@ dependencies = [
 
 [[package]]
 name = "gix-validate"
-version = "0.10.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1e63a5b516e970a594f870ed4571a8fdcb8a344e7bd407a20db8bd61dbfde4"
+checksum = "7bc6fc771c4063ba7cd2f47b91fb6076251c6a823b64b7fe7b8874b0fe4afae3"
 dependencies = [
  "bstr",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5216,7 +5213,7 @@ dependencies = [
  "gix-index",
  "gix-object",
  "gix-path 0.12.1",
- "gix-validate 0.11.2",
+ "gix-validate 0.11.2 (git+https://github.com/GitoxideLabs/gitoxide?rev=66f70f3063724b4145b21c6691c4f57892c7a74e)",
  "serde",
 ]
 
@@ -6366,13 +6363,12 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.5+1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
@@ -6415,20 +6411,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,7 +221,7 @@ gix-testtools = { version = "0.19.0", git = "https://github.com/GitoxideLabs/git
 
 
 insta = { version = "1.47.2", features = ["json"] }
-git2 = { version = "0.20.4", features = [
+git2 = { version = "0.21.0", features = [
     "vendored-openssl",
     "vendored-libgit2",
 ] }
@@ -246,7 +246,7 @@ tracing-subscriber = "0.3.23"
 tempfile = "3.24"
 rand = "0.9.3"
 notify-rust = "4.16.0"
-git2-hooks = { version = "0.5.0" }
+git2-hooks = { version = "0.7.0" }
 itertools = "0.14.0"
 dirs = "6.0.0"
 rmcp = { version = "0.16.0", default-features = false, features = [

--- a/crates/gitbutler-repo/src/hooks.rs
+++ b/crates/gitbutler-repo/src/hooks.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use bstr::ByteSlice;
 use but_ctx::Context;
 use but_oxidize::ObjectIdExt;
-use git2_hooks::{self, HookResult as H};
+use git2_hooks::{self, HookResult as H, HookRunResponse};
 use serde::Serialize;
 
 use crate::{managed_hooks::get_hooks_dir, staging};
@@ -61,19 +61,22 @@ pub fn commit_msg(ctx: &Context, mut message: String) -> Result<MessageHookResul
         husky_search_paths(ctx),
         &mut message,
     )? {
-        H::Ok { hook: _ } => match message == original_message {
-            true => Ok(MessageHookResult::Success),
-            false => Ok(MessageHookResult::Message(MessageData { message })),
-        },
         H::NoHookFound => Ok(MessageHookResult::NotConfigured),
-        H::RunNotSuccessful {
+        H::Run(HookRunResponse {
             stdout,
             stderr,
             code,
             ..
-        } => {
-            let error = join_output(stdout, stderr, code);
-            Ok(MessageHookResult::Failure(ErrorData { error }))
+        }) => {
+            if code == 0 {
+                match message == original_message {
+                    true => Ok(MessageHookResult::Success),
+                    false => Ok(MessageHookResult::Message(MessageData { message })),
+                }
+            } else {
+                let error = join_output(stdout, stderr, Some(code));
+                Ok(MessageHookResult::Failure(ErrorData { error }))
+            }
         }
     }
 }
@@ -97,21 +100,24 @@ pub fn pre_commit_with_tree(ctx: &Context, tree_id: gix::ObjectId) -> Result<Hoo
 
     Ok(
         match git2_hooks::hooks_pre_commit(repo, husky_search_paths(ctx))? {
-            H::Ok { hook: _ } => HookResult::Success,
             H::NoHookFound => HookResult::NotConfigured,
-            H::RunNotSuccessful {
+            H::Run(HookRunResponse {
                 stdout,
                 stderr,
                 code,
                 ..
-            } => {
-                // If the output contains GITBUTLER_ERROR, it's our managed hook blocking
-                // commits on gitbutler/workspace - this is expected behavior, not a failure
-                if stdout.contains("GITBUTLER_ERROR") || stderr.contains("GITBUTLER_ERROR") {
+            }) => {
+                if code == 0 {
                     HookResult::Success
                 } else {
-                    let error = join_output(stdout, stderr, code);
-                    HookResult::Failure(ErrorData { error })
+                    // If the output contains GITBUTLER_ERROR, it's our managed hook blocking
+                    // commits on gitbutler/workspace - this is expected behavior, not a failure
+                    if stdout.contains("GITBUTLER_ERROR") || stderr.contains("GITBUTLER_ERROR") {
+                        HookResult::Success
+                    } else {
+                        let error = join_output(stdout, stderr, Some(code));
+                        HookResult::Failure(ErrorData { error })
+                    }
                 }
             }
         },
@@ -121,16 +127,19 @@ pub fn pre_commit_with_tree(ctx: &Context, tree_id: gix::ObjectId) -> Result<Hoo
 pub fn post_commit(ctx: &Context) -> Result<HookResult> {
     #[expect(deprecated, reason = "libgit2 hook adapter boundary")]
     match git2_hooks::hooks_post_commit(&*ctx.git2_repo.get()?, husky_search_paths(ctx))? {
-        H::Ok { hook: _ } => Ok(HookResult::Success),
         H::NoHookFound => Ok(HookResult::NotConfigured),
-        H::RunNotSuccessful {
+        H::Run(HookRunResponse {
             stdout,
             stderr,
             code,
             ..
-        } => {
-            let error = join_output(stdout, stderr, code);
-            Ok(HookResult::Failure(ErrorData { error }))
+        }) => {
+            if code == 0 {
+                Ok(HookResult::Success)
+            } else {
+                let error = join_output(stdout, stderr, Some(code));
+                Ok(HookResult::Failure(ErrorData { error }))
+            }
         }
     }
 }


### PR DESCRIPTION
Also updated some call sites to match the new API.

This was mainly motivated by needing to debug what libgit2 does when creating another PR. It's useful to have the latest versions so that if we suspect a bug, we can immediately rule out the possibility that it's a bug that only exists in an old version of a dependency.
