### PR TITLE
Make bare `but agent` run the setup wizard

### DIFF
--- a/crates/but/src/args/agent.rs
+++ b/crates/but/src/args/agent.rs
@@ -1,8 +1,9 @@
 /// Arguments for AI agent setup commands.
 #[derive(Debug, clap::Parser)]
 pub struct Platform {
+    /// Running `but agent` with no subcommand runs the setup wizard.
     #[clap(subcommand)]
-    pub cmd: Subcommands,
+    pub cmd: Option<Subcommands>,
 }
 
 #[derive(Debug, clap::Subcommand)]

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -1198,10 +1198,10 @@ pub enum Subcommands {
     ///
     /// ## Examples
     ///
-    /// Start the interactive setup wizard:
+    /// Start the interactive setup wizard (`but agent setup` is equivalent):
     ///
     /// ```text
-    /// but agent setup
+    /// but agent
     /// ```
     ///
     /// Print the default generated steering text:

--- a/crates/but/src/args/tests.rs
+++ b/crates/but/src/args/tests.rs
@@ -147,7 +147,7 @@ mod agent_setup {
 
         match cmd {
             Subcommands::Agent(AgentPlatform {
-                cmd: AgentCmd::Setup { print },
+                cmd: Some(AgentCmd::Setup { print }),
             }) => assert!(!print),
             _ => panic!("unexpected command shape"),
         }
@@ -160,8 +160,21 @@ mod agent_setup {
 
         match cmd {
             Subcommands::Agent(AgentPlatform {
-                cmd: AgentCmd::Setup { print },
+                cmd: Some(AgentCmd::Setup { print }),
             }) => assert!(print),
+            _ => panic!("unexpected command shape"),
+        }
+    }
+
+    #[test]
+    fn parses_bare_agent_as_no_subcommand() {
+        // Bare `but agent` parses with no subcommand; the handler treats this as
+        // running the setup wizard.
+        let args = Args::try_parse_from(["but", "agent"]).expect("parse args");
+        let cmd = args.cmd.expect("subcommand");
+
+        match cmd {
+            Subcommands::Agent(AgentPlatform { cmd: None }) => {}
             _ => panic!("unexpected command shape"),
         }
     }

--- a/crates/but/src/command/agent/mod.rs
+++ b/crates/but/src/command/agent/mod.rs
@@ -38,9 +38,15 @@ impl fmt::Display for UserCancelled {
 
 impl std::error::Error for UserCancelled {}
 
-pub fn handle(current_dir: &Path, out: &mut OutputChannel, cmd: agent::Subcommands) -> Result<()> {
+pub fn handle(
+    current_dir: &Path,
+    out: &mut OutputChannel,
+    cmd: Option<agent::Subcommands>,
+) -> Result<()> {
     match cmd {
-        agent::Subcommands::Setup { print } => setup(current_dir, out, print),
+        // Bare `but agent` runs the setup wizard, same as `but agent setup`.
+        None => setup(current_dir, out, false),
+        Some(agent::Subcommands::Setup { print }) => setup(current_dir, out, print),
     }
 }
 

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -220,8 +220,9 @@ impl Subcommands {
                 skill::Subcommands::Install { .. } => SkillInstall,
                 skill::Subcommands::Check { .. } => SkillCheck,
             },
+            // Bare `but agent` (None) runs the setup wizard, same as `agent setup`.
             Subcommands::Agent(agent::Platform { cmd }) => match cmd {
-                agent::Subcommands::Setup { .. } => AgentSetup,
+                None | Some(agent::Subcommands::Setup { .. }) => AgentSetup,
             },
             Subcommands::Edit { .. } => Edit,
             #[cfg(feature = "legacy")]
@@ -692,8 +693,13 @@ mod tests {
         );
         assert_command(
             Subcommands::Agent(agent::Platform {
-                cmd: agent::Subcommands::Setup { print: false },
+                cmd: Some(agent::Subcommands::Setup { print: false }),
             }),
+            "agentSetup",
+        );
+        // Bare `but agent` (no subcommand) maps to the same metric.
+        assert_command(
+            Subcommands::Agent(agent::Platform { cmd: None }),
             "agentSetup",
         );
         assert_command(


### PR DESCRIPTION
Running `but agent` with no subcommand now runs the same setup wizard as `but agent setup`, so the common case needs less typing while leaving room for future `but agent <subcommand>`s.

The subcommand is made optional, matching the existing `Option<Subcommands>` + `None => default` convention already used by `oplog`, `pr`, and others. The metrics mapping and help/doc example are updated accordingly, and parsing/metrics tests cover the bare form.