### PR TITLE
Lite: don't fade details panel when selection is deferred

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -414,7 +414,6 @@ const WorkspacePage: FC = () => {
 				<Panel id={"details-panel" satisfies PanelId} className={styles.panel}>
 					<Details
 						key={deferredOutlineSelection ? operandIdentityKey(deferredOutlineSelection) : null}
-						style={{ opacity: deferredOutlineSelection !== outlineSelection ? 0.5 : 1 }}
 						outlineSelection={deferredOutlineSelection}
 						detailsFullWindow={detailsFullWindow}
 						onDetailsFullWindowChange={(fullWindow) =>


### PR DESCRIPTION
The deferred style is useful when selection moves quickly, but annoying when selection moves slowly:

- Moving selection slowly: tiny flicker of the deferred style, making it look like the details panel is fading in every time the selection changed
- Moving selection quickly: the deferred style appears for longer and is actually useful (to indicate why there's tearing lasting more than a split second)

References on `useDeferredValue`:
- https://www.joshwcomeau.com/react/use-deferred-value/
- https://react.dev/reference/react/useDeferredValue

# Moving selection slowly in a small repo

## Before

(Go frame by frame to see the flicker.)

https://github.com/user-attachments/assets/b1cfaad9-1ba3-4548-a360-ca0e0e6713a5

## After

https://github.com/user-attachments/assets/d8fbe8e5-4993-40bd-8507-15e459da3980

# Moving selection quickly in a large repo (deno)

## Before

https://github.com/user-attachments/assets/21466372-5b7b-438a-8ffb-ef5711bf54aa

## After

https://github.com/user-attachments/assets/7b349f57-24dd-4e32-b6df-5acaa3e1eec7

