### PR TITLE
Silence offline toast spam from list_reviews / get_pull_request

### DIFF
--- a/apps/desktop/src/lib/error/errorClassification.test.ts
+++ b/apps/desktop/src/lib/error/errorClassification.test.ts
@@ -38,6 +38,14 @@ describe("classify", () => {
 			);
 			expect(classify(error).severity).toBe("silent");
 		});
+
+		test("NetworkError is silent — offline forge polls shouldn't toast", () => {
+			const error = new IpcError(
+				{ message: "Unable to connect to GitHub.", code: "NetworkError" },
+				"list_reviews",
+			);
+			expect(classify(error).severity).toBe("silent");
+		});
 	});
 
 	describe("message-pattern classifications", () => {

--- a/apps/desktop/src/lib/error/errorClassification.ts
+++ b/apps/desktop/src/lib/error/errorClassification.ts
@@ -69,6 +69,14 @@ const CLASSIFICATIONS: Partial<Record<Code, Classification>> = {
 		severity: "warning",
 	},
 	/**
+	 * Transport-level failure reaching a forge (DNS, timeout, connection
+	 * refused). The user is effectively offline; surfacing a toast every
+	 * time a polled `list_reviews` round-trip fails is just noise.
+	 */
+	NetworkError: {
+		severity: "silent",
+	},
+	/**
 	 * Auto-fetch / fetch-from-remotes failure caused by missing
 	 * credentials. Soft style — the user can fix it from project settings.
 	 */

--- a/crates/but-github/src/client.rs
+++ b/crates/but-github/src/client.rs
@@ -19,6 +19,19 @@ pub struct HttpStatusError {
     pub status: reqwest::StatusCode,
 }
 
+/// Return `HttpStatusError` for non-success responses so callers can downcast
+/// to distinguish 401/403 from other failures. The textual prefix that callers
+/// used to build into `bail!` is left to outer `.context(...)`.
+fn ensure_success(response: &reqwest::Response) -> Result<()> {
+    if !response.status().is_success() {
+        return Err(HttpStatusError {
+            status: response.status(),
+        }
+        .into());
+    }
+    Ok(())
+}
+
 pub struct GitHubClient {
     client: reqwest::Client,
     base_url: String,
@@ -223,9 +236,7 @@ impl GitHubClient {
             .send()
             .await?;
 
-        if !response.status().is_success() {
-            bail!("Failed to list open pulls: {}", response.status());
-        }
+        ensure_success(&response)?;
 
         let pulls: Vec<GitHubPullRequest> = response.json().await?;
         Ok(pulls.into_iter().map(Into::into).collect())
@@ -253,9 +264,7 @@ impl GitHubClient {
             .send()
             .await?;
 
-        if !response.status().is_success() {
-            bail!("Failed to list pulls for base: {}", response.status());
-        }
+        ensure_success(&response)?;
 
         let pulls: Vec<GitHubPullRequest> = response.json().await?;
         Ok(pulls.into_iter().map(Into::into).collect())
@@ -281,9 +290,7 @@ impl GitHubClient {
             .send()
             .await?;
 
-        if !response.status().is_success() {
-            bail!("Failed to list pulls for commit: {}", response.status());
-        }
+        ensure_success(&response)?;
 
         let pulls: Vec<GitHubPullRequest> = response.json().await?;
         Ok(pulls.into_iter().map(Into::into).collect())
@@ -420,9 +427,7 @@ impl GitHubClient {
 
         let response = self.client.get(&url).send().await?;
 
-        if !response.status().is_success() {
-            bail!("Failed to get pull request: {}", response.status());
-        }
+        ensure_success(&response)?;
 
         let pr: GitHubPullRequest = response.json().await?;
         Ok(pr.into())

--- a/crates/but-github/src/lib.rs
+++ b/crates/but-github/src/lib.rs
@@ -313,7 +313,7 @@ pub async fn get_gh_user(
 /// Check if an error is a network connectivity error.
 ///
 /// This includes DNS resolution failures, connection timeouts, connection refused, etc.
-fn is_network_error(err: &reqwest::Error) -> bool {
+pub(crate) fn is_network_error(err: &reqwest::Error) -> bool {
     err.is_timeout() || err.is_connect() || err.is_request()
 }
 

--- a/crates/but-github/src/pr.rs
+++ b/crates/but-github/src/pr.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context as _, Result};
 
-use crate::client::GitHubClient;
+use crate::client::{GitHubClient, HttpStatusError};
 
 pub async fn list(
     preferred_account: Option<&crate::GithubAccountIdentifier>,
@@ -11,6 +11,7 @@ pub async fn list(
     if let Ok(gh) = GitHubClient::from_storage(storage, preferred_account) {
         gh.list_open_pulls(owner, repo)
             .await
+            .map_err(classify_forge_error)
             .context("Failed to list open pull requests")
     } else {
         Ok(vec![])
@@ -26,6 +27,7 @@ pub async fn list_all_for_branch(
     if let Ok(gh) = GitHubClient::from_storage(storage, preferred_account) {
         gh.list_pulls_for_base(owner, repo, branch)
             .await
+            .map_err(classify_forge_error)
             .context("Failed to list pull requests for branch")
     } else {
         Ok(vec![])
@@ -42,10 +44,34 @@ pub async fn list_for_commit(
     if let Ok(gh) = GitHubClient::from_storage(storage, preferred_account) {
         gh.list_pulls_for_commit(owner, repo, commit_sha)
             .await
+            .map_err(classify_forge_error)
             .context("Failed to list pull requests for commit")
     } else {
         Ok(vec![])
     }
+}
+
+/// Tag transport / auth failures with a `but_error::Code` so the desktop
+/// can present them appropriately (silent for offline, re-auth hint for 401).
+/// Only applied to read paths — mutations should still surface failures.
+fn classify_forge_error(err: anyhow::Error) -> anyhow::Error {
+    if let Some(reqwest_err) = err.downcast_ref::<reqwest::Error>()
+        && crate::is_network_error(reqwest_err)
+    {
+        return err.context(but_error::Context::new_static(
+            but_error::Code::NetworkError,
+            "Unable to connect to GitHub.",
+        ));
+    }
+    if let Some(http_err) = err.downcast_ref::<HttpStatusError>()
+        && http_err.status == reqwest::StatusCode::UNAUTHORIZED
+    {
+        return err.context(but_error::Context::new_static(
+            but_error::Code::GitHubTokenExpired,
+            "GitHub authentication failed.",
+        ));
+    }
+    err
 }
 
 pub async fn create(
@@ -71,6 +97,7 @@ pub async fn get(
     let pr = GitHubClient::from_storage(storage, preferred_account)?
         .get_pull_request(owner, repo, pr_number)
         .await
+        .map_err(classify_forge_error)
         .context("Failed to get pull request")?;
     Ok(pr)
 }


### PR DESCRIPTION
## Summary

`API error: (list_reviews) — Failed to list open pull requests` is the #1 toast on 0.20.3 (263 events / 63 users in 7 days). The underlying cause is being offline while the polled forge listing runs — there's nothing the user can do, but every poll surfaces a toast.

This change tags transport / auth failures on the read paths in `but-github` with a `but_error::Code`, and adds a frontend classification rule for `NetworkError` that silences the toast (and the PostHog / Sentry capture) entirely.

- `pr::list`, `pr::list_all_for_branch`, `pr::list_for_commit`, `pr::get` now run their error through `classify_forge_error`:
  - `reqwest::Error` (timeout / connect / request) → `Code::NetworkError`
  - HTTP 401 → `Code::GitHubTokenExpired`
- The mutating endpoints (`create` / `update` / `merge` / `set_draft_state` / `set_auto_merge`) are intentionally left alone — user-initiated writes should still fail loudly.
- Frontend `CLASSIFICATIONS` table gains `NetworkError: { severity: "silent" }`. `GitHubTokenExpired` already exists at the existing classification and keeps surfacing its "log out and back in" hint.

## Test plan

- [x] `cargo test -p but-github --lib` — passes (11/11)
- [x] `pnpm vitest run src/lib/error/` — passes (26/26)
- [x] Manual: disconnect network, observe no toast on the polled PR listing
- [ ] Manual: with an expired GitHub token, observe the existing "log out and back in" toast still fires