### PR TITLE
Don't reject PR-number metadata writes when HEAD is off the workspace ref

### DIFF
--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -128,7 +128,8 @@ pub fn update_branch_pr_number(
     pr_number: Option<usize>,
 ) -> Result<()> {
     let mut guard = ctx.exclusive_worktree_access();
-    ctx.verify(guard.write_permission())?;
+    // Pure metadata write — skip verify so background syncs aren't
+    // blocked when HEAD is off the workspace ref (e.g. edit mode).
     let _ = ctx.create_snapshot(
         SnapshotDetails::new(OperationKind::UpdateDependentBranchPrNumber),
         guard.write_permission(),


### PR DESCRIPTION
## Summary

\`API error: (update_branch_pr_number) — <verification-failed>\` is one of the biggest toast clusters on 0.20.3 (62 events / 26 users).

[\`update_branch_pr_number\`](https://github.com/gitbutlerapp/gitbutler/blob/master/crates/gitbutler-branch-actions/src/stack.rs) is a pure metadata write — \`set_pr_number\` sets a field on the stack head and persists via the project doc-store. No git refs change, so HEAD position is irrelevant to correctness.

Calling \`ctx.verify()\` here means the write is rejected whenever HEAD isn't on \`gitbutler/workspace\` — edit mode, external \`git checkout\`, snapshot-restore transitions, etc. Meanwhile \`PrNumberSync.svelte\` keeps polling the forge listing and triggering this call in the background, so a just-created PR can fail to be recorded against its branch.

This drops the \`ctx.verify()\` line in \`update_branch_pr_number\` only. The snapshot and \`ensure_open_workspace_mode\` checks stay — they're not the failure source.

## Test plan

- [x] \`cargo check -p gitbutler-branch-actions\` clean
- [ ] Manual: open a PR while in edit mode, confirm the PR number is recorded against the branch
- [ ] Manual: confirm the \`<verification-failed>\` cluster for \`update_branch_pr_number\` drops in PostHog after rollout