### PR TITLE
Don't treat unmerged stacked branches as merged upstream

### DIFF
--- a/crates/but-workspace/src/changeset.rs
+++ b/crates/but-workspace/src/changeset.rs
@@ -18,7 +18,11 @@ use gix::{
     prelude::ObjectIdExt,
 };
 
-use crate::{RefInfo, ref_info::LocalCommitRelation, ui::PushStatus};
+use crate::{
+    RefInfo,
+    ref_info::{LocalCommit, LocalCommitRelation},
+    ui::PushStatus,
+};
 
 /// The ID of a changeset, calculated as Git hash for convenience.
 type ChangesetID = gix::ObjectId;
@@ -153,15 +157,23 @@ impl RefInfo {
             let base_commit_id = stack.segments.last().and_then(|s| s.base);
             let mut segments = stack.segments.iter_mut();
             while let Some(segment) = segments.next() {
-                let Some(topmost_unintegrated_commit) = segment
-                    .commits
-                    .first()
-                    .filter(|c| !matches!(c.relation, LocalCommitRelation::Integrated(_)))
+                // Find the topmost commit that isn't already integrated and carries changes of its
+                // own; that is the integration boundary for the squash-merge trial. Commits above it
+                // are either already integrated or introduce no changes of their own, so the trial
+                // must not mark them: otherwise a no-change commit at the tip would be treated as
+                // merged - because it borrows the cumulative content of the commits below it - and
+                // its branch deleted.
+                let Some((boundary, boundary_tree_id)) =
+                    segment.commits.iter().enumerate().find_map(|(i, c)| {
+                        let carries_changes =
+                            !matches!(c.relation, LocalCommitRelation::Integrated(_))
+                                && commit_introduces_changes(repo, c);
+                        carries_changes.then_some((i, c.tree_id))
+                    })
                 else {
                     continue;
                 };
-                let Some(changeset_id) =
-                    id_for_tree_diff(repo, base_commit_id, topmost_unintegrated_commit.tree_id)?
+                let Some(changeset_id) = id_for_tree_diff(repo, base_commit_id, boundary_tree_id)?
                 else {
                     continue;
                 };
@@ -172,8 +184,11 @@ impl RefInfo {
                     continue;
                 };
 
-                for segment in Some(segment).into_iter().chain(segments) {
-                    for commit in &mut segment.commits {
+                // Mark the boundary commit and everything below it (down to the base, across the
+                // lower segments) as integrated; leave the commits above the boundary untouched.
+                for (i, segment) in Some(segment).into_iter().chain(segments).enumerate() {
+                    let skip = if i == 0 { boundary } else { 0 };
+                    for commit in segment.commits.iter_mut().skip(skip) {
                         commit.relation = LocalCommitRelation::Integrated(squashed_commit_id)
                     }
                 }
@@ -581,6 +596,19 @@ fn should_stop(start: std::time::Instant, commit_idx: usize) -> bool {
 /// Produce a changeset ID to represent the changes between `lhs` and `rhs`, where `lhs` is
 /// the previous version of the treeish, and `rhs` is the current version of that treeish.
 /// We use the [`CURRENT_VERSION`], which must be considered when handling persisted values.
+/// Whether `commit` introduces changes of its own, i.e. its tree differs from its first
+/// parent's tree. This only compares tree ids and skips the full diff that [`id_for_tree_diff`]
+/// computes, which matters when scanning many commits. On a lookup failure we assume the commit
+/// carries changes, so a genuinely merged branch is never spared from squash-merge detection.
+fn commit_introduces_changes(repo: &gix::Repository, commit: &LocalCommit) -> bool {
+    match commit.parent_ids.first() {
+        None => !commit.tree_id.is_empty_tree(),
+        Some(parent) => id_to_tree(repo, *parent)
+            .map(|parent_tree| parent_tree.id != commit.tree_id)
+            .unwrap_or(true),
+    }
+}
+
 fn id_for_tree_diff(
     repo: &gix::Repository,
     lhs: Option<gix::ObjectId>,

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -687,6 +687,7 @@ fn branch_is_merged_upstream(
     status_ctx: &StatusContext<'_>,
     segment: &SegmentWithId,
     repo: &gix::Repository,
+    eligible_for_empty_merge: bool,
 ) -> bool {
     if matches!(
         status_ctx
@@ -700,7 +701,8 @@ fn branch_is_merged_upstream(
         return true;
     }
 
-    if segment.workspace_commits.is_empty()
+    if eligible_for_empty_merge
+        && segment.workspace_commits.is_empty()
         && empty_branch_is_merged_upstream(repo, status_ctx, segment)
     {
         return true;
@@ -1143,8 +1145,20 @@ fn print_group(
         .for_commit_shortening();
     let mut has_merged_upstream_branch = false;
     if let Some(stack_with_id) = stack_with_id {
+        // The bottom-most branch resting on the target is the only one eligible to be
+        // reported as merged purely because it has no commits: branches above it merely
+        // inherit the remote tip of the branch below and were not themselves merged.
+        let bottom_non_target_segment = stack_with_id.segments.iter().rposition(|segment| {
+            segment
+                .inner
+                .remote_tracking_ref_name
+                .as_ref()
+                .is_none_or(|remote| {
+                    !remote_tracking_ref_is_target_branch(status_ctx, remote.as_ref())
+                })
+        });
         let mut first = true;
-        for segment in &stack_with_id.segments {
+        for (segment_index, segment) in stack_with_id.segments.iter().enumerate() {
             let notch = if first { "╭" } else { "├" };
             if !first {
                 output.connector(Vec::from([Span::raw("┊│")]))?;
@@ -1192,7 +1206,12 @@ fn print_group(
                 .unwrap_or_default();
 
             let branch_merge_status = branch_merge_status(status_ctx, segment);
-            let is_merged_upstream = branch_is_merged_upstream(status_ctx, segment, &repo);
+            let is_merged_upstream = branch_is_merged_upstream(
+                status_ctx,
+                segment,
+                &repo,
+                Some(segment_index) == bottom_non_target_segment,
+            );
             has_merged_upstream_branch |= is_merged_upstream;
             let branch_status = if is_merged_upstream {
                 Some(Span::styled(" (merged upstream)", t.remote_branch))

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -662,6 +662,150 @@ Applied remote branch 'origin/document-but-pr-skill' to workspace
     assert_pull_removes_merged_upstream_branch(&env);
 }
 
+/// An empty branch stacked on top of a branch that merged upstream must not be treated
+/// as merged itself: it contributed no commits of its own. Regression test for `but status`
+/// labelling it `(merged upstream)` and `but pull` deleting the whole stack (including the
+/// unmerged top branch) because every branch was wrongly classified as integrated.
+#[test]
+fn unmerged_empty_branch_above_merged_one_is_not_treated_as_merged() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "upstream-merged-branch-below-empty-branch",
+    );
+    env.setup_metadata(&["bottom"]);
+    // Stack `top` directly above `bottom` so they form a single two-branch stack.
+    {
+        use but_core::RefMetadata as _;
+        use std::ops::DerefMut as _;
+        let mut meta = env.meta();
+        let ws_ref: &gix::refs::FullNameRef = but_core::WORKSPACE_REF_NAME.try_into().unwrap();
+        let mut ws = meta.workspace(ws_ref).unwrap();
+        ws.deref_mut()
+            .insert_new_segment_above_anchor_if_not_present(
+                "refs/heads/top".try_into().unwrap(),
+                "refs/heads/bottom".try_into().unwrap(),
+            );
+        meta.set_workspace(&ws).unwrap();
+    }
+
+    // `bottom` merged upstream; `top` rests on it and must not be labelled merged.
+    env.but("status")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄op [top] (no commits)
+┊│
+┊├┄bo [bottom] (merged upstream) (no commits)
+├╯
+┊
+┊● 334227d (upstream) ⏫ 1 commit
+├╯ 334227d (common base) 2000-01-02 merge bottom
+
+Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch
+
+"#]]);
+
+    env.invoke_git("remote set-url origin .");
+    env.but("pull").env("NO_BG_TASKS", "1").assert().success();
+
+    let branches: Vec<String> = status_json(&env).unwrap()["stacks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .flat_map(|stack| stack["branches"].as_array().into_iter().flatten())
+        .map(|b| b["name"].as_str().unwrap_or_default().to_string())
+        .collect();
+    assert!(
+        branches.iter().any(|b| b == "top"),
+        "`but pull` must keep the unmerged `top` branch, got: {branches:?}"
+    );
+}
+
+/// A branch whose only commit introduces no changes of its own, stacked on top of a
+/// branch that was *squash-merged* upstream, must not be treated as merged itself: it
+/// contributed nothing that was merged. Regression test for the data-loss bug where the
+/// squash-merge trial let the no-change top commit "borrow" the cumulative content of the
+/// squash-merged `bottom` below it, so `but status` labelled `top` `(merged upstream)` and
+/// `but pull` deleted the whole stack — losing the unmerged `top` branch. The genuinely
+/// squash-merged `bottom` must still be detected and removed.
+#[test]
+fn no_change_commit_above_squash_merged_branch_is_not_treated_as_merged() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "upstream-squash-merged-below-no-change-branch",
+    );
+    env.setup_metadata(&["bottom"]);
+    // Stack `top` directly above `bottom` so they form a single two-branch stack.
+    {
+        use but_core::RefMetadata as _;
+        use std::ops::DerefMut as _;
+        let mut meta = env.meta();
+        let ws_ref: &gix::refs::FullNameRef = but_core::WORKSPACE_REF_NAME.try_into().unwrap();
+        let mut ws = meta.workspace(ws_ref).unwrap();
+        ws.deref_mut()
+            .insert_new_segment_above_anchor_if_not_present(
+                "refs/heads/top".try_into().unwrap(),
+                "refs/heads/bottom".try_into().unwrap(),
+            );
+        meta.set_workspace(&ws).unwrap();
+    }
+
+    // `bottom` was squash-merged upstream and must be labelled `(merged upstream)`.
+    // `top`'s sole commit introduces no changes, so it must NOT be labelled merged.
+    let status = env
+        .but("status --format json")
+        .allow_json()
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let status: serde_json::Value = serde_json::from_slice(&status).unwrap();
+    let branch_status_of = |name: &str| -> String {
+        status["stacks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .flat_map(|stack| stack["branches"].as_array().into_iter().flatten())
+            .find(|b| b["name"].as_str() == Some(name))
+            .and_then(|b| b["branchStatus"].as_str())
+            .unwrap_or_default()
+            .to_string()
+    };
+    assert_eq!(
+        branch_status_of("bottom"),
+        "integrated",
+        "`bottom` was squash-merged upstream and must be detected as integrated"
+    );
+    assert_ne!(
+        branch_status_of("top"),
+        "integrated",
+        "`top`'s no-change commit must NOT be treated as integrated"
+    );
+
+    env.invoke_git("remote set-url origin .");
+    env.but("pull").env("NO_BG_TASKS", "1").assert().success();
+
+    let branches: Vec<String> = status_json(&env).unwrap()["stacks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .flat_map(|stack| stack["branches"].as_array().into_iter().flatten())
+        .map(|b| b["name"].as_str().unwrap_or_default().to_string())
+        .collect();
+    assert!(
+        branches.iter().any(|b| b == "top"),
+        "`but pull` must keep the unmerged `top` branch, got: {branches:?}"
+    );
+    assert!(
+        !branches.iter().any(|b| b == "bottom"),
+        "`but pull` must remove the genuinely squash-merged `bottom` branch, got: {branches:?}"
+    );
+}
+
 fn assert_pull_removes_merged_upstream_branch(env: &Sandbox) {
     env.invoke_git("remote set-url origin .");
     env.but("pull").env("NO_BG_TASKS", "1").assert().success();

--- a/crates/but/tests/fixtures/scenario/upstream-merged-branch-below-empty-branch.sh
+++ b/crates/but/tests/fixtures/scenario/upstream-merged-branch-below-empty-branch.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### A stack of two branches where only the *lower* branch merged upstream.
+###
+### Stack layout (top to bottom): top -> bottom -> base
+### - bottom: has a real commit, pushed, and merged into the target (origin/main).
+### - top: empty branch stacked on bottom, pushed. Its remote ref points at bottom's
+###   (now-merged) commit, which is an ancestor of the new target.
+###
+### `top` contributed no commits of its own and was never merged, so it must survive
+### `but pull` even though `bottom` below it is removed.
+
+git-init-frozen
+
+commit-file base
+
+git checkout -b bottom
+commit-file bottom
+
+# top is stacked on bottom and has no commits of its own.
+git checkout -b top
+
+# Both branches were pushed; top is empty so it sits at bottom's tip.
+mkdir -p .git/refs/remotes/origin
+cp .git/refs/heads/bottom .git/refs/remotes/origin/bottom
+cp .git/refs/heads/top .git/refs/remotes/origin/top
+
+# bottom's PR merged upstream: main advances to include bottom via a merge commit.
+git checkout main
+git merge --no-ff -m "merge bottom" bottom
+
+setup_target_to_match_main
+
+git checkout top
+create_workspace_commit_once top

--- a/crates/but/tests/fixtures/scenario/upstream-squash-merged-below-no-change-branch.sh
+++ b/crates/but/tests/fixtures/scenario/upstream-squash-merged-below-no-change-branch.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### A stack of two branches where the *lower* branch was SQUASH-merged upstream,
+### and the *upper* branch carries only a no-change commit of its own.
+###
+### Stack layout (top to bottom): top -> bottom -> base
+### - bottom: a real commit that carries a gitbutler change-id, pushed, and then
+###   squash-merged into the target (origin/main) as a NEW commit with the SAME
+###   change-id but a DIFFERENT sha (same content/tree).
+### - top: a NON-empty branch stacked on bottom whose single commit introduces no
+###   changes of its own (an `--allow-empty` commit). It was never separately merged.
+###
+### `top` contributed nothing that was merged and is a distinct named branch the user
+### never merged, so it must survive `but pull` even though the genuinely squash-merged
+### `bottom` below it is removed.
+
+git-init-frozen
+
+commit-file base
+
+git checkout -b bottom
+commit-file bottom
+# Give bottom a real change-id so the upstream squash can be matched by change-id.
+new_bottom=$(add_change_id_to_given_commit 1 refs/heads/bottom)
+git update-ref refs/heads/bottom "$new_bottom"
+
+# top is a NON-empty branch stacked on bottom whose only commit introduces no changes.
+git checkout -b top
+git commit --allow-empty -m "feat: target branch tip (no changes)"
+
+# Both branches were pushed.
+mkdir -p .git/refs/remotes/origin
+cp .git/refs/heads/bottom .git/refs/remotes/origin/bottom
+cp .git/refs/heads/top .git/refs/remotes/origin/top
+
+# bottom's PR was SQUASH-merged upstream: main advances with a NEW commit that
+# reproduces bottom's tree, carrying the SAME change-id but a different sha.
+git checkout main
+bottom_tree=$(git rev-parse refs/heads/bottom^{tree})
+squashed=$(git commit-tree "$bottom_tree" -p main -m "squash bottom")
+git update-ref refs/heads/main "$squashed"
+# Re-stamp main's tip with bottom's change-id (same id, different sha than bottom).
+new_main=$(add_change_id_to_given_commit 1 refs/heads/main)
+git update-ref refs/heads/main "$new_main"
+
+setup_target_to_match_main
+
+git checkout top
+create_workspace_commit_once top

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -423,13 +423,30 @@ fn get_stack_status(
     };
 
     let branches = details.branch_details;
+    // Branches are iterated bottom-to-top.
+    let mut lower_branch_seen = false;
     for branch in branches.into_iter().rev() {
+        let is_target_branch = branch
+            .remote_tracking_branch
+            .as_ref()
+            .is_some_and(|remote| remote.as_bstr() == target_commits.ref_name.as_bstr());
+        // An empty branch only counts as merged upstream if it is the bottom-most branch
+        // resting on the target. An empty branch resting on another branch merely inherits
+        // that branch's remote tip and was not itself merged, so treating it as merged
+        // would wrongly delete unmerged stacked branches.
+        let is_bottom_branch = !is_target_branch && !lower_branch_seen;
+        if !is_target_branch {
+            lower_branch_seen = true;
+        }
+
         let local_commits = &branch.commits;
 
         let Some(branch_head) = local_commits.first() else {
             branch_statuses.push(NameAndStatus {
                 name: branch.name.to_string(),
-                status: if empty_branch_is_merged_upstream(gix_repo, &branch, target_commits) {
+                status: if is_bottom_branch
+                    && empty_branch_is_merged_upstream(gix_repo, &branch, target_commits)
+                {
                     BranchStatus::Integrated
                 } else {
                     BranchStatus::Empty


### PR DESCRIPTION
## The problem

`but pull` can silently delete a branch that was never merged. When a stack contains a branch that has landed upstream, GitButler can wrongly conclude that an *unmerged* branch sitting above it in the same stack has also landed — and remove it. The branch is often unpushed, so a routine pull just loses the work. `but status` shows the same false conclusion via its `(merged upstream)` label.

This is most damaging for agent workflows (the motivation behind #14289): the `(merged upstream)` signal exists to steer agents *away* from stale, already-merged branches — so mislabeling a live branch as merged actively points them away from work they should keep.

## How it arises

Both cases reduce to the same mistake: concluding a branch is merged because content it *inherits from the branch below it* is upstream, rather than because the branch's *own* work landed.

**1. An empty branch riding on a merged branch.** A branch with no commits of its own — a freshly created branch on top of a stack, or one whose commits already landed — points at the same commit as the branch beneath it, so its remote-tracking ref points at that lower branch's tip. Once the lower branch merges, that commit becomes part of the target's history, and the empty branch gets judged "merged" purely because its remote tip is now contained upstream — even though the branch itself never was. Since `but pull` removes a whole stack once every branch in it looks integrated, the unmerged branch is deleted alongside the merged one.

**2. A no-change commit on top of a squash-merged branch.** When a lower branch is squash-merged (the usual GitHub squash, where several commits collapse into one new upstream commit), GitButler detects it by matching the branch's *cumulative* content against upstream. If an upper branch carries a commit that introduces no changes of its own — e.g. a placeholder / "target branch tip" marker — its cumulative content measured from the stack base is identical to the squash-merged content below it. So it matches the upstream squash and is classified merged despite having contributed nothing, and `but pull` removes it.

## Scope

Case 1 is a regression introduced by #14394; case 2 is pre-existing. Genuine merged and squash-merged branches are still detected, labeled `(merged upstream)`, and removed by `but pull` exactly as before — only branches that inherit their "merged" appearance from a branch below are now left alone.

Relates to #14289.