### PR TITLE
Tweak Lite commit body

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -123,8 +123,7 @@
 }
 
 .commitMessageBody {
-	max-width: 700px;
-	background-color: var(--bg-2);
+	max-width: 70ch;
 	font-size: 13px;
 	white-space: pre-wrap;
 	user-select: text;

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -130,11 +130,6 @@
 	user-select: text;
 }
 
-.commitMessageBodyCollapsed {
-	max-height: 4.5lh;
-	overflow: auto;
-}
-
 .tabsRow {
 	display: flex;
 	column-gap: 12px;

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -1063,7 +1063,7 @@ export const Details: FC<
 		<div {...restProps} className={classes(restProps.className, styles.container)}>
 			<div className={styles.headerWrap}>
 				<div className={styles.titleRow}>
-					<div className={classes(detailsFullWindow && isMac && styles.titleRowMacSpacer)} />
+					{detailsFullWindow && isMac && <div className={styles.titleRowMacSpacer} />}
 					<Title
 						bodyCollapsed={commitBodyCollapsed}
 						bodyId={commitBodyId}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -718,16 +718,8 @@ const CommitDetailsContent: FC<{
 
 	return (
 		<>
-			{body !== undefined && (
-				<p
-					id={bodyId}
-					className={classes(
-						"text-monospace",
-						"text-body",
-						styles.commitMessageBody,
-						bodyCollapsed && styles.commitMessageBodyCollapsed,
-					)}
-				>
+			{body !== undefined && !bodyCollapsed && (
+				<p id={bodyId} className={classes("text-monospace", "text-body", styles.commitMessageBody)}>
 					{body}
 				</p>
 			)}


### PR DESCRIPTION
Closes GB-1660.

For now this takes the path of least resistance, which is removing the body preview entirely, leaving only the icon to indicate that there’s a body to see. This should be sufficient as GitHub has trained us all to expect this, and lots of other tooling offers no indication at all.

In the future we may move the body into a tab, mimicking the branch/PR tab, but that’s not necessary for this change.

We may also want to change the icon. This one as-is looks a little off with spacing, and there may be value in mimicking GitHub. Punting it.