### PR TITLE
Disable upstream-integrate while HEAD is detached

### DIFF
--- a/apps/desktop/src/components/views/AppHeader.svelte
+++ b/apps/desktop/src/components/views/AppHeader.svelte
@@ -54,6 +54,9 @@
 	const isNotInWorkspace = $derived(
 		currentMode?.type !== "OpenWorkspace" && currentMode?.type !== "Edit",
 	);
+	const isDetached = $derived(
+		currentMode?.type === "OutsideWorkspace" && currentMode.subject.branchName === null,
+	);
 	const [switchBackToWorkspace, workspaceSwitch] = baseBranchService.switchBackToWorkspace;
 
 	async function switchToWorkspace() {
@@ -117,14 +120,16 @@
 			<SyncButton {projectId} disabled={actionsDisabled} />
 
 			{#if isHasUpstreamCommits}
-				<Button
-					testId={TestId.IntegrateUpstreamCommitsButton}
-					style="pop"
-					onclick={openModal}
-					disabled={!projectId || actionsDisabled}
-				>
-					{upstreamCommits} upstream {upstreamCommits === 1 ? "commit" : "commits"}
-				</Button>
+				<Tooltip text={isDetached ? "HEAD is detached" : undefined} disabled={!isDetached}>
+					<Button
+						testId={TestId.IntegrateUpstreamCommitsButton}
+						style="pop"
+						onclick={openModal}
+						disabled={!projectId || actionsDisabled || isDetached}
+					>
+						{upstreamCommits} upstream {upstreamCommits === 1 ? "commit" : "commits"}
+					</Button>
+				</Tooltip>
 			{:else}
 				<div class="chrome-you-are-up-to-date">
 					<Icon name="tick" />

--- a/crates/but-api/src/watcher.rs
+++ b/crates/but-api/src/watcher.rs
@@ -39,8 +39,8 @@ but_schemars::register_sdk_type!(WatcherGitFetchPayload);
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct WatcherGitHeadPayload {
-    /// The SHA of the repository's HEAD.
-    pub head: String,
+    /// The symbolic ref HEAD points at, or `null` when HEAD is detached.
+    pub head: Option<String>,
     /// The GitButler operating mode (edit mode, oper workspace, ...).
     pub operating_mode: OperatingMode,
 }

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -167,6 +167,12 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
     updates: Vec<BottomUpdate>,
     review_hints: &[ReviewIntegrationHint],
 ) -> Result<IntegrateUpstreamOutcome<'ws, 'meta, M>> {
+    if matches!(workspace.kind, but_graph::workspace::WorkspaceKind::AdHoc)
+        && workspace.ref_name().is_none()
+    {
+        bail!("Operation not possible while HEAD is detached");
+    }
+
     let mut ws_meta = workspace.metadata.clone();
     let target_sha = project_meta
         .target_commit_id

--- a/crates/gitbutler-watcher/src/events.rs
+++ b/crates/gitbutler-watcher/src/events.rs
@@ -8,7 +8,8 @@ pub enum Change {
     GitFetch(ProjectHandleOrLegacyProjectId),
     GitHead {
         project_id: ProjectHandleOrLegacyProjectId,
-        head: String,
+        /// The symbolic ref HEAD points at, or `None` when HEAD is detached.
+        head: Option<String>,
         operating_mode: OperatingMode,
     },
     GitActivity {

--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -216,13 +216,14 @@ impl Handler {
                 HEAD => {
                     let repo = ctx.repo.get()?;
                     let head_ref = repo.head().context("failed to get head")?;
-                    if let Some(head) = head_ref.referent_name() {
-                        self.emit_app_event(Change::GitHead {
-                            project_id: project_id.clone(),
-                            head: head.as_bstr().to_str_lossy().into_owned(),
-                            operating_mode: operating_mode(ctx, perm.read_permission())?,
-                        })?;
-                    }
+                    let head = head_ref
+                        .referent_name()
+                        .map(|name| name.as_bstr().to_str_lossy().into_owned());
+                    self.emit_app_event(Change::GitHead {
+                        project_id: project_id.clone(),
+                        head,
+                        operating_mode: operating_mode(ctx, perm.read_permission())?,
+                    })?;
                 }
                 _ => { /* Ignore other files */ }
             }

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -2547,8 +2547,8 @@ export type WatcherGitFetchPayload = null;
 
 /** Git head (and operating mode) change event */
 export type WatcherGitHeadPayload = {
-  /** The SHA of the repository's HEAD. */
-  head: string;
+  /** The symbolic ref HEAD points at, or `null` when HEAD is detached. */
+  head: string | null;
   /** The GitButler operating mode (edit mode, oper workspace, ...). */
   operatingMode: OperatingMode;
 };


### PR DESCRIPTION
## Summary

`BUG: Tried to construct rebase engine graph overlay with no entrypoints` (5 events / 2 users on 0.20.3) — the toast users see when they trigger "integrate upstream" on a detached HEAD. There's no current branch to rebase, so the operation has no useful semantics.

## Fix

Three guards, same condition (`OutsideWorkspace` + `branchName === null`):

- **AppHeader** — disable the "X upstream commits" button, tooltip explains why.
- **Modal** — warning `InfoMessage`, skip the dry-run, disable the Update button. Also closes if the operating mode changes while open, otherwise the next dry-run errors with `Failed to find reference … in rebase editor` against stale frontend-cached stacks.
- **Backend (`integrate_upstream_with_hints`)** — early `bail!` so non-desktop callers (CLI, tests) get the same message instead of the BUG bail.

Plus a watcher fix: `Change::GitHead` was skipping its emit when HEAD became detached (`referent_name()` returns `None`), so the frontend mode stayed stale after a live `git checkout <sha>`. Widened the payload to `Option<String>` and emit unconditionally.

## Doesn't affect

Managed workspaces like `gitbutler/workspace`  or ad-hoc workspaces on a named branch like `main`, `feature-x`,  etc.

## Test plan

- [x] `cargo check -p but-workspace`
- [x] `pnpm exec svelte-check`
- [x] Manual: `git checkout <sha>`, confirm the upstream button is disabled with tooltip
- [ ] Manual: open the modal on a feature branch, then "Back to workspace" — modal closes cleanly, no toast