### PR TITLE
feat(but): allow any prefix of the full hunk ID

### DIFF
--- a/crates/but/src/args/atoms/cli_id.rs
+++ b/crates/but/src/args/atoms/cli_id.rs
@@ -332,6 +332,7 @@ fn try_resolve_cli_id(
     Err(bad_input(format!(
         "Ambiguous {purpose} '{arg}', matches multiple items"
     ))
+    .hint("Use a longer ID to disambiguate")
     .into())
 }
 

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -469,8 +469,9 @@ impl IdMap {
                 reverse_hex,
                 UncommittedFile {
                     short_id: ShortId::default(),
-                    short_id_hunk_assignments: hunk_assignments
-                        .map(|hunk_assignment| (ShortId::default(), hunk_assignment)),
+                    short_id_hunk_assignments: hunk_assignments.map(|hunk_assignment| {
+                        (ShortId::default(), String::default(), hunk_assignment)
+                    }),
                 },
             );
             // Skip an ID for stability of other IDs below with respect to older
@@ -493,12 +494,12 @@ impl IdMap {
         let mut uncommitted_hunks = HashMap::new();
         for uncommitted_file in uncommitted_files.values_mut() {
             {
-                Self::assign_content_based_hunk_short_ids(
+                Self::assign_content_based_hunk_ids(
                     uncommitted_file.short_id_hunk_assignments.iter_mut(),
                 )?;
             }
 
-            for (short_id, hunk_assignment) in &uncommitted_file.short_id_hunk_assignments {
+            for (short_id, _, hunk_assignment) in &uncommitted_file.short_id_hunk_assignments {
                 uncommitted_hunks.insert(
                     format!("{}:{}", uncommitted_file.short_id, short_id),
                     UncommittedHunk {
@@ -561,11 +562,12 @@ impl IdMap {
     /// IDs that previously pointed to other colliding hunks.
     ///
     /// Note that hunks that lack a diff follow the same rules, only that `<prefix>="q"` always.
-    fn assign_content_based_hunk_short_ids<'a>(
-        short_ids_and_hunks: impl Iterator<Item = &'a mut (ShortId, HunkAssignment)>,
+    fn assign_content_based_hunk_ids<'a>(
+        short_ids_and_hunks: impl Iterator<Item = &'a mut (ShortId, String, HunkAssignment)>,
     ) -> anyhow::Result<()> {
-        let mut content_hash_to_short_ids: BTreeMap<ShortId, Vec<&'a mut String>> = BTreeMap::new();
-        for (short_id, hunk_assignment) in short_ids_and_hunks {
+        let mut content_hash_to_short_ids: BTreeMap<String, Vec<(&'a mut String, &'a mut String)>> =
+            BTreeMap::new();
+        for (short_id, full_id, hunk_assignment) in short_ids_and_hunks {
             let content_hash = match hunk_assignment.diff.as_ref() {
                 Some(diff) => {
                     let mut content_hasher = hasher(gix::hash::Kind::Sha1);
@@ -583,14 +585,14 @@ impl IdMap {
             content_hash_to_short_ids
                 .entry(content_hash)
                 .or_default()
-                .push(short_id);
+                .push((short_id, full_id));
         }
 
         let mut all_hashes = content_hash_to_short_ids.into_iter();
 
         let mut current = all_hashes.next();
         let mut len_in_common_with_last: usize = 0;
-        while let Some((content_hash, mut short_ids)) = current {
+        while let Some((content_hash, mut ids)) = current {
             let next = all_hashes.next();
 
             let len_in_common_with_next = common_prefix_len(
@@ -603,12 +605,14 @@ impl IdMap {
                 .max(len_in_common_with_next + 1)
                 .max(len_in_common_with_last + 1)];
 
-            let num_colliding_ids = short_ids.len();
-            for (i, short_id) in short_ids.iter_mut().enumerate() {
+            let num_colliding_ids = ids.len();
+            for (i, (short_id, full_id)) in ids.iter_mut().enumerate() {
                 short_id.push_str(shortest_distinct_prefix);
+                full_id.push_str(&content_hash);
 
                 if num_colliding_ids > 1 {
                     write!(short_id, "#{i}-{num_colliding_ids}")?;
+                    write!(full_id, "#{i}-{num_colliding_ids}")?;
                 }
             }
 
@@ -1212,7 +1216,7 @@ pub struct UncommittedFile {
     pub short_id: ShortId,
     /// Every element has the same [HunkAssignment::stack_id] and [HunkAssignment::path_bytes],
     /// so the first assignment can be used to obtain both.
-    pub short_id_hunk_assignments: NonEmpty<(ShortId, HunkAssignment)>,
+    pub short_id_hunk_assignments: NonEmpty<(ShortId, String, HunkAssignment)>,
 }
 
 impl UncommittedFile {
@@ -1238,7 +1242,7 @@ impl UncommittedFile {
     pub fn hunk_assignments(&self) -> NonEmpty<&HunkAssignment> {
         self.short_id_hunk_assignments
             .as_ref()
-            .map(|(_, hunk_assignment)| hunk_assignment)
+            .map(|(_, _, hunk_assignment)| hunk_assignment)
     }
 }
 
@@ -1251,7 +1255,8 @@ impl<'a> Node<'a> for &'a UncommittedFile {
     ) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>> {
         match element.strip_prefix('#') {
             Some(maybe_index) if let Ok(index) = usize::from_str(maybe_index) => {
-                if let Some((short_id, hunk_assignment)) = self.short_id_hunk_assignments.get(index)
+                if let Some((short_id, _, hunk_assignment)) =
+                    self.short_id_hunk_assignments.get(index)
                 {
                     let cli_id = CliId::UncommittedHunkOrFile(UncommittedHunkOrFile {
                         id: format!("{}:{}", self.short_id, short_id),
@@ -1267,8 +1272,13 @@ impl<'a> Node<'a> for &'a UncommittedFile {
                 let matches = self
                     .short_id_hunk_assignments
                     .iter()
-                    .filter(|(short_id, _)| short_id == element)
-                    .map(|(short_id, hunk_assignment)| {
+                    .filter(|(_, full_id, _)| match element.split_once("#") {
+                        Some((id_prefix, collision_index)) => {
+                            full_id.starts_with(id_prefix) && full_id.ends_with(collision_index)
+                        }
+                        None => full_id.starts_with(element),
+                    })
+                    .map(|(short_id, _, hunk_assignment)| {
                         let cli_id = CliId::UncommittedHunkOrFile(UncommittedHunkOrFile {
                             id: format!("{}:{}", self.short_id, short_id),
                             hunk_assignments: NonEmpty::new(hunk_assignment.to_owned()),

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -7,7 +7,6 @@
 #![forbid(missing_docs)]
 
 use std::collections::{BTreeMap, HashMap};
-use std::fmt::Write;
 use std::str::FromStr as _;
 
 use bstr::{BStr, BString, ByteSlice};
@@ -38,6 +37,69 @@ mod tests;
 pub(crate) type ShortId = String;
 
 pub(crate) const UNCOMMITTED: &str = "zz";
+
+const INDEX_SEPARATOR: &str = "#";
+
+/// The ID of a hunk, without its namespace (file).
+#[derive(Debug, Clone, Default)]
+pub struct UnqualifiedHunkId {
+    /// The ID of the hunk.
+    id: String,
+    /// The smallest amount of prefix characters necessary to form a distinct ID.
+    min_short_id_chars: usize,
+    /// The collision index if there are other hunks with the exact same ID. Otherwise this is
+    /// empty.
+    collision_index: Option<String>,
+}
+
+impl UnqualifiedHunkId {
+    fn short_id(&self) -> String {
+        let prefix = &self.id[..self.min_short_id_chars];
+
+        match &self.collision_index {
+            Some(collision_index) => format!("{prefix}{INDEX_SEPARATOR}{collision_index}"),
+            None => prefix.to_string(),
+        }
+    }
+
+    /// Check if `prefix` matches this ID by non-strict prefix match.
+    ///
+    /// Note that collision indices are matched separately and must match exactly if provided. For
+    /// example, given the full ID `f1#0-2`, all of `f`, `f1`, `f#0-2` and `f1#0-2` are valid
+    /// prefixes, but e.g. `f#0` is not as the collision index is only a partial match.
+    ///
+    /// Similarly, if the full id is `f1` then the prefix `f#0-2` does not match due to the
+    /// collision index mismatch.
+    ///
+    /// It's also not allowed to specify _only_ a collision index (e.g. `#0-2`), that matches
+    /// nothing simply because it doesn't seem useful at all, and also clashes a bit semantically
+    /// with the file wide hunk indexing.
+    ///
+    /// These prefixing rules aren't here because they're particularly useful to know about and
+    /// utilize. The purpose is to not cause a shortening of an ID to invalidate a longer form of
+    /// that ID. As a practical example of where that would be inconvenient, consider the case where
+    /// two hunks have short IDs `f1` and `f2`, the second character necessary to disambiguate from
+    /// the other hunk. If one were to run a `but status` to show these IDs and then commit hunk
+    /// `f1`, the ID for the other hunk would be shortened `f2 -> f`. If you then try to reference
+    /// it with ID `f2`, we still want that to work so you don't have to run repeated `but status`
+    /// commands.
+    ///
+    /// The reverse problem still exists, where the addition of new hunks can cause existing short
+    /// IDs to become ambiguous. That's not a solvable problem, we'll simply get more hits on the
+    /// same prefix.
+    fn matches_prefix(&self, prefix: &str) -> bool {
+        let (prefix_id, prefix_collision_index) = match prefix.split_once(INDEX_SEPARATOR) {
+            Some((prefix_id, prefix_collision_index)) => (prefix_id, Some(prefix_collision_index)),
+            None => (prefix, None),
+        };
+
+        // We only care about matching against the collision index if the user provided it
+        let collision_index_mismatch = prefix_collision_index.is_some()
+            && self.collision_index.as_deref() != prefix_collision_index;
+
+        !prefix_id.is_empty() && self.id.starts_with(prefix_id) && !collision_index_mismatch
+    }
+}
 
 /// Create a CLI ID for the given staged file (if `stack_id` is `Some`) or the
 /// given unstaged file or committed file (if `stack_id` is `None`).
@@ -469,9 +531,8 @@ impl IdMap {
                 reverse_hex,
                 UncommittedFile {
                     short_id: ShortId::default(),
-                    short_id_hunk_assignments: hunk_assignments.map(|hunk_assignment| {
-                        (ShortId::default(), String::default(), hunk_assignment)
-                    }),
+                    short_id_hunk_assignments: hunk_assignments
+                        .map(|hunk_assignment| (UnqualifiedHunkId::default(), hunk_assignment)),
                 },
             );
             // Skip an ID for stability of other IDs below with respect to older
@@ -499,9 +560,9 @@ impl IdMap {
                 )?;
             }
 
-            for (short_id, _, hunk_assignment) in &uncommitted_file.short_id_hunk_assignments {
+            for (hunk_id, hunk_assignment) in &uncommitted_file.short_id_hunk_assignments {
                 uncommitted_hunks.insert(
-                    format!("{}:{}", uncommitted_file.short_id, short_id),
+                    format!("{}:{}", uncommitted_file.short_id, hunk_id.short_id()),
                     UncommittedHunk {
                         hunk_assignment: hunk_assignment.clone(),
                     },
@@ -536,17 +597,13 @@ impl IdMap {
 
     const HUNK_EMPTY_CONTENT_PREFIX: &str = "q";
 
-    /// Assign unique hunk short IDs based on content hash into the input iterator's first element.
-    ///
-    /// The hunk IDs are computed as the shortest possible distinct prefix of the hash of the hunk's
-    /// content, where distinctness is computed only relative to the other hunks in the input. This
-    /// should typically be on a file-by-file basis.
+    /// Assign unique hunk IDs based on content hash into the input iterator's first element.
     ///
     /// On hash collisions, the IDs are disambiguated based on the amount of collisions for that
     /// particular hash.
     ///
-    /// Hunks that lack a diff are prefixed with "q" and then rely on the disambiguation mechanism
-    /// if there are multiple such hunks.
+    /// Hunks that lack a diff get a content hash of "q" and then rely on the disambiguation
+    /// mechanism if there are multiple such hunks.
     ///
     /// In summary, the formats are:
     ///
@@ -563,11 +620,11 @@ impl IdMap {
     ///
     /// Note that hunks that lack a diff follow the same rules, only that `<prefix>="q"` always.
     fn assign_content_based_hunk_ids<'a>(
-        short_ids_and_hunks: impl Iterator<Item = &'a mut (ShortId, String, HunkAssignment)>,
+        short_ids_and_hunks: impl Iterator<Item = &'a mut (UnqualifiedHunkId, HunkAssignment)>,
     ) -> anyhow::Result<()> {
-        let mut content_hash_to_short_ids: BTreeMap<String, Vec<(&'a mut String, &'a mut String)>> =
+        let mut content_hash_to_short_ids: BTreeMap<String, Vec<&'a mut UnqualifiedHunkId>> =
             BTreeMap::new();
-        for (short_id, full_id, hunk_assignment) in short_ids_and_hunks {
+        for (hunk_id, hunk_assignment) in short_ids_and_hunks {
             let content_hash = match hunk_assignment.diff.as_ref() {
                 Some(diff) => {
                     let mut content_hasher = hasher(gix::hash::Kind::Sha1);
@@ -585,7 +642,7 @@ impl IdMap {
             content_hash_to_short_ids
                 .entry(content_hash)
                 .or_default()
-                .push((short_id, full_id));
+                .push(hunk_id);
         }
 
         let mut all_hashes = content_hash_to_short_ids.into_iter();
@@ -601,18 +658,17 @@ impl IdMap {
                     .map(|(content_hash, _)| content_hash.as_bytes())
                     .unwrap_or_default(),
             );
-            let shortest_distinct_prefix = &content_hash[0..1
+            let min_short_id_chars = 1
                 .max(len_in_common_with_next + 1)
-                .max(len_in_common_with_last + 1)];
+                .max(len_in_common_with_last + 1);
 
             let num_colliding_ids = ids.len();
-            for (i, (short_id, full_id)) in ids.iter_mut().enumerate() {
-                short_id.push_str(shortest_distinct_prefix);
-                full_id.push_str(&content_hash);
+            for (i, hunk_id) in ids.iter_mut().enumerate() {
+                hunk_id.id.push_str(&content_hash);
+                hunk_id.min_short_id_chars = min_short_id_chars;
 
                 if num_colliding_ids > 1 {
-                    write!(short_id, "#{i}-{num_colliding_ids}")?;
-                    write!(full_id, "#{i}-{num_colliding_ids}")?;
+                    hunk_id.collision_index = Some(format!("{i}-{num_colliding_ids}"))
                 }
             }
 
@@ -1216,7 +1272,7 @@ pub struct UncommittedFile {
     pub short_id: ShortId,
     /// Every element has the same [HunkAssignment::stack_id] and [HunkAssignment::path_bytes],
     /// so the first assignment can be used to obtain both.
-    pub short_id_hunk_assignments: NonEmpty<(ShortId, String, HunkAssignment)>,
+    pub short_id_hunk_assignments: NonEmpty<(UnqualifiedHunkId, HunkAssignment)>,
 }
 
 impl UncommittedFile {
@@ -1242,7 +1298,7 @@ impl UncommittedFile {
     pub fn hunk_assignments(&self) -> NonEmpty<&HunkAssignment> {
         self.short_id_hunk_assignments
             .as_ref()
-            .map(|(_, _, hunk_assignment)| hunk_assignment)
+            .map(|(_, hunk_assignment)| hunk_assignment)
     }
 }
 
@@ -1253,13 +1309,12 @@ impl<'a> Node<'a> for &'a UncommittedFile {
         _id_map: &'a IdMap,
         _changes_in_commit_fn: &mut ChangesInCommitFn<'a>,
     ) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>> {
-        match element.strip_prefix('#') {
+        match element.strip_prefix(INDEX_SEPARATOR) {
             Some(maybe_index) if let Ok(index) = usize::from_str(maybe_index) => {
-                if let Some((short_id, _, hunk_assignment)) =
-                    self.short_id_hunk_assignments.get(index)
+                if let Some((hunk_id, hunk_assignment)) = self.short_id_hunk_assignments.get(index)
                 {
                     let cli_id = CliId::UncommittedHunkOrFile(UncommittedHunkOrFile {
-                        id: format!("{}:{}", self.short_id, short_id),
+                        id: format!("{}:{}", self.short_id, hunk_id.short_id()),
                         hunk_assignments: NonEmpty::new(hunk_assignment.to_owned()),
                         is_entire_file: false,
                     });
@@ -1272,15 +1327,10 @@ impl<'a> Node<'a> for &'a UncommittedFile {
                 let matches = self
                     .short_id_hunk_assignments
                     .iter()
-                    .filter(|(_, full_id, _)| match element.split_once("#") {
-                        Some((id_prefix, collision_index)) => {
-                            full_id.starts_with(id_prefix) && full_id.ends_with(collision_index)
-                        }
-                        None => full_id.starts_with(element),
-                    })
-                    .map(|(short_id, _, hunk_assignment)| {
+                    .filter(|(hunk_id, _)| hunk_id.matches_prefix(element))
+                    .map(|(hunk_id, hunk_assignment)| {
                         let cli_id = CliId::UncommittedHunkOrFile(UncommittedHunkOrFile {
-                            id: format!("{}:{}", self.short_id, short_id),
+                            id: format!("{}:{}", self.short_id, hunk_id.short_id()),
                             hunk_assignments: NonEmpty::new(hunk_assignment.to_owned()),
                             is_entire_file: false,
                         });

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -42,7 +42,7 @@ const INDEX_SEPARATOR: &str = "#";
 
 /// The ID of a hunk, without its namespace (file).
 #[derive(Debug, Clone, Default)]
-pub struct UnqualifiedHunkId {
+struct UnqualifiedHunkId {
     /// The ID of the hunk.
     id: String,
     /// The smallest amount of prefix characters necessary to form a distinct ID.
@@ -1272,7 +1272,7 @@ pub struct UncommittedFile {
     pub short_id: ShortId,
     /// Every element has the same [HunkAssignment::stack_id] and [HunkAssignment::path_bytes],
     /// so the first assignment can be used to obtain both.
-    pub short_id_hunk_assignments: NonEmpty<(UnqualifiedHunkId, HunkAssignment)>,
+    short_id_hunk_assignments: NonEmpty<(UnqualifiedHunkId, HunkAssignment)>,
 }
 
 impl UncommittedFile {

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -1618,9 +1618,10 @@ fn uncommitted_hunks_by_id_increase_id_length_as_necessary() -> anyhow::Result<(
 ///
 /// Because of this property, it's important that we can match the hunk by _any prefix_ of its full
 /// ID. That way, if a short hunk ID is shortened, the longer version still works as a reference.
-/// It's just as unique as any prefix of it, so there's no reason it wouldn't work.
+/// It's just as unique (sometimes more so) as any prefix of it, so there's no reason it wouldn't
+/// work.
 #[test]
-fn uncommitted_hunks_can_be_referenced_by_longer_prefix_than_short_id() -> anyhow::Result<()> {
+fn uncommitted_hunks_overspecifying_id_prefix() -> anyhow::Result<()> {
     let stacks = vec![Stack {
         id: Some(StackId::from_number_for_testing(1)),
         ..stack([segment("foo", [id(2)], Some(id(1)), [])])
@@ -1677,8 +1678,8 @@ fn uncommitted_hunks_can_be_referenced_by_longer_prefix_than_short_id() -> anyho
 /// Same reasoning as [`uncommitted_hunks_can_be_referenced_by_longer_prefix_than_short_id`], but
 /// including collision disambiguation.
 #[test]
-fn uncommitted_hunks_can_be_referenced_by_longer_prefix_than_short_id_with_collision_disambiguation()
--> anyhow::Result<()> {
+fn uncommitted_hunks_overspecifying_id_prefix_with_collision_disambiguation() -> anyhow::Result<()>
+{
     let stacks = vec![Stack {
         id: Some(StackId::from_number_for_testing(1)),
         ..stack([segment("foo", [id(2)], Some(id(1)), [])])
@@ -1740,6 +1741,167 @@ fn uncommitted_hunks_can_be_referenced_by_longer_prefix_than_short_id_with_colli
         ),
     ]
     "#);
+
+    Ok(())
+}
+
+#[test]
+fn underspecifying_hunk_ids() -> anyhow::Result<()> {
+    let stacks = vec![Stack {
+        id: Some(StackId::from_number_for_testing(1)),
+        ..stack([segment("foo", [id(2)], Some(id(1)), [])])
+    }];
+    let hunk_assignments = vec![
+        HunkAssignment {
+            hunk_header: Some(hunk_header("-1,6", "+1,7")),
+            diff: Some(BString::new(
+                "@@ -1,6 +1,7 @@\n 1\n 2\n 3\n+hellooooo\n 4\n 5\n 6\n"
+                    .as_bytes()
+                    .to_vec(),
+            )),
+            ..hunk_assignment("uncommitted1.txt", None)
+        },
+        HunkAssignment {
+            hunk_header: Some(hunk_header("-23,6", "+24,7")),
+            diff: Some(BString::new(
+                "@@ -23,6 +24,7 @@\n 1\n 2\n 3\n+hellooo\n 4\n 5\n 6\n"
+                    .as_bytes()
+                    .to_vec(),
+            )),
+            ..hunk_assignment("uncommitted1.txt", None)
+        },
+        HunkAssignment {
+            hunk_header: Some(hunk_header("-33,6", "+35,7")),
+            diff: Some(BString::new(
+                "@@ -33,6 +35,7 @@\n 1\n 2\n 3\n+hellooooo\n 4\n 5\n 6\n"
+                    .as_bytes()
+                    .to_vec(),
+            )),
+            ..hunk_assignment("uncommitted1.txt", None)
+        },
+    ];
+
+    let id_map = IdMap::new(stacks, hunk_assignments)?;
+    let changed_paths_fn = |commit_id: gix::ObjectId,
+                            parent_id: Option<gix::ObjectId>|
+     -> anyhow::Result<Vec<but_core::TreeChange>> {
+        bail!("unexpected IDs {commit_id} {parent_id:?}");
+    };
+
+    // Underspecifying with just first character finds all hunks
+    insta::assert_debug_snapshot!(id_map.parse("ro:7", Box::new(changed_paths_fn))?, @r#"
+    [
+        UncommittedHunkOrFile(
+            UncommittedHunkOrFile {
+                id: "ro:78#0-2",
+                hunk_assignments: NonEmpty {
+                    head: HunkAssignment {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-1,6", "+1,7"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        stack_id: None,
+                        branch_ref_bytes: None,
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: Some(
+                            "@@ -1,6 +1,7 @@\n 1\n 2\n 3\n+hellooooo\n 4\n 5\n 6\n",
+                        ),
+                    },
+                    tail: [],
+                },
+                is_entire_file: false,
+            },
+        ),
+        UncommittedHunkOrFile(
+            UncommittedHunkOrFile {
+                id: "ro:79",
+                hunk_assignments: NonEmpty {
+                    head: HunkAssignment {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-23,6", "+24,7"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        stack_id: None,
+                        branch_ref_bytes: None,
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: Some(
+                            "@@ -23,6 +24,7 @@\n 1\n 2\n 3\n+hellooo\n 4\n 5\n 6\n",
+                        ),
+                    },
+                    tail: [],
+                },
+                is_entire_file: false,
+            },
+        ),
+        UncommittedHunkOrFile(
+            UncommittedHunkOrFile {
+                id: "ro:78#1-2",
+                hunk_assignments: NonEmpty {
+                    head: HunkAssignment {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-33,6", "+35,7"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        stack_id: None,
+                        branch_ref_bytes: None,
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: Some(
+                            "@@ -33,6 +35,7 @@\n 1\n 2\n 3\n+hellooooo\n 4\n 5\n 6\n",
+                        ),
+                    },
+                    tail: [],
+                },
+                is_entire_file: false,
+            },
+        ),
+    ]
+    "#);
+
+    // Underspecifying with collision index only finds hunk with precisely matching collision index.
+    insta::assert_debug_snapshot!(id_map.parse("ro:7#0-2", Box::new(changed_paths_fn))?, @r#"
+    [
+        UncommittedHunkOrFile(
+            UncommittedHunkOrFile {
+                id: "ro:78#0-2",
+                hunk_assignments: NonEmpty {
+                    head: HunkAssignment {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-1,6", "+1,7"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        stack_id: None,
+                        branch_ref_bytes: None,
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: Some(
+                            "@@ -1,6 +1,7 @@\n 1\n 2\n 3\n+hellooooo\n 4\n 5\n 6\n",
+                        ),
+                    },
+                    tail: [],
+                },
+                is_entire_file: false,
+            },
+        ),
+    ]
+    "#);
+
+    // An entirely empty prefix matches nothing
+    insta::assert_debug_snapshot!(id_map.parse("ro:", Box::new(changed_paths_fn))?, @"[]");
+
+    // Omitting only specifying collision index matches nothing - we don't allow omitting the prefix
+    // unless you are explicitly indexing into the file's hunks
+    insta::assert_debug_snapshot!(id_map.parse("ro:#0-2", Box::new(changed_paths_fn))?, @"[]");
 
     Ok(())
 }

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -1611,6 +1611,139 @@ fn uncommitted_hunks_by_id_increase_id_length_as_necessary() -> anyhow::Result<(
     Ok(())
 }
 
+/// If there are two hunks with IDs that have common leading characters, the short ID is lengthened
+/// to disambiguate. If one of the hunks is subsequently committed, discarded or changed s.t. it no
+/// longer clashes with the prefix of the other hunk, that other hunk's short ID is shortened to the
+/// minimum necessary for uniqueness.
+///
+/// Because of this property, it's important that we can match the hunk by _any prefix_ of its full
+/// ID. That way, if a short hunk ID is shortened, the longer version still works as a reference.
+/// It's just as unique as any prefix of it, so there's no reason it wouldn't work.
+#[test]
+fn uncommitted_hunks_can_be_referenced_by_longer_prefix_than_short_id() -> anyhow::Result<()> {
+    let stacks = vec![Stack {
+        id: Some(StackId::from_number_for_testing(1)),
+        ..stack([segment("foo", [id(2)], Some(id(1)), [])])
+    }];
+    let hunk_assignments = vec![HunkAssignment {
+        hunk_header: Some(hunk_header("-1,6", "+1,7")),
+        diff: Some(BString::new(
+            "@@ -1,6 +1,7 @@\n 1\n 2\n 3\n+hellooooo\n 4\n 5\n 6\n"
+                .as_bytes()
+                .to_vec(),
+        )),
+        ..hunk_assignment("uncommitted1.txt", None)
+    }];
+
+    let id_map = IdMap::new(stacks, hunk_assignments)?;
+    let changed_paths_fn = |commit_id: gix::ObjectId,
+                            parent_id: Option<gix::ObjectId>|
+     -> anyhow::Result<Vec<but_core::TreeChange>> {
+        bail!("unexpected IDs {commit_id} {parent_id:?}");
+    };
+
+    insta::assert_debug_snapshot!(id_map.parse("ro:78", Box::new(changed_paths_fn))?, @r#"
+    [
+        UncommittedHunkOrFile(
+            UncommittedHunkOrFile {
+                id: "ro:7",
+                hunk_assignments: NonEmpty {
+                    head: HunkAssignment {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-1,6", "+1,7"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        stack_id: None,
+                        branch_ref_bytes: None,
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: Some(
+                            "@@ -1,6 +1,7 @@\n 1\n 2\n 3\n+hellooooo\n 4\n 5\n 6\n",
+                        ),
+                    },
+                    tail: [],
+                },
+                is_entire_file: false,
+            },
+        ),
+    ]
+    "#);
+
+    Ok(())
+}
+
+/// Same reasoning as [`uncommitted_hunks_can_be_referenced_by_longer_prefix_than_short_id`], but
+/// including collision disambiguation.
+#[test]
+fn uncommitted_hunks_can_be_referenced_by_longer_prefix_than_short_id_with_collision_disambiguation()
+-> anyhow::Result<()> {
+    let stacks = vec![Stack {
+        id: Some(StackId::from_number_for_testing(1)),
+        ..stack([segment("foo", [id(2)], Some(id(1)), [])])
+    }];
+    let hunk_assignments = vec![
+        HunkAssignment {
+            hunk_header: Some(hunk_header("-1,6", "+1,7")),
+            diff: Some(BString::new(
+                "@@ -1,6 +1,7 @@\n 1\n 2\n 3\n+hello\n 4\n 5\n 6\n"
+                    .as_bytes()
+                    .to_vec(),
+            )),
+            ..hunk_assignment("uncommitted1.txt", None)
+        },
+        // Same context lines as first hunk, but different diff
+        HunkAssignment {
+            hunk_header: Some(hunk_header("-23,6", "+24,7")),
+            diff: Some(BString::new(
+                "@@ -23,6 +24,7 @@\n 1\n 2\n 3\n+hello\n 4\n 5\n 6\n"
+                    .as_bytes()
+                    .to_vec(),
+            )),
+            ..hunk_assignment("uncommitted1.txt", None)
+        },
+    ];
+
+    let id_map = IdMap::new(stacks, hunk_assignments)?;
+    let changed_paths_fn = |commit_id: gix::ObjectId,
+                            parent_id: Option<gix::ObjectId>|
+     -> anyhow::Result<Vec<but_core::TreeChange>> {
+        bail!("unexpected IDs {commit_id} {parent_id:?}");
+    };
+
+    insta::assert_debug_snapshot!(id_map.parse("ro:3eeb#0-2", Box::new(changed_paths_fn))?, @r#"
+    [
+        UncommittedHunkOrFile(
+            UncommittedHunkOrFile {
+                id: "ro:3#0-2",
+                hunk_assignments: NonEmpty {
+                    head: HunkAssignment {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-1,6", "+1,7"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        stack_id: None,
+                        branch_ref_bytes: None,
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: Some(
+                            "@@ -1,6 +1,7 @@\n 1\n 2\n 3\n+hello\n 4\n 5\n 6\n",
+                        ),
+                    },
+                    tail: [],
+                },
+                is_entire_file: false,
+            },
+        ),
+    ]
+    "#);
+
+    Ok(())
+}
+
 #[test]
 fn uncommitted_hunks_by_id_collision_handling() -> anyhow::Result<()> {
     let stacks = vec![Stack {

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -1363,6 +1363,130 @@ fn commit_single_hunk_leaves_other_hunks_uncommitted() -> anyhow::Result<()> {
 }
 
 #[test]
+fn can_overspecify_hunk_id() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.file("file", "hello");
+
+    env.but("diff")
+        .assert()
+        .success()
+        // Full ID is qs:3c81ccd4449094b2becf2b846fc69cfdfcaa613c
+        .stdout_eq(str![[r#"
+─────────╮
+qs:3 file│
+─────────╯
+     1│+hello
+
+"#]]);
+
+    env.but("commit -m 'Add file' --changes qs:3c81")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Created new independent branch 'a-branch-1'
+✓ Created commit d215849 on branch a-branch-1
+
+"#]]);
+
+    env.but("status -f").assert().success().stdout_eq(str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄br [a-branch-1]
+┊●   d215849 Add file
+┊│     d2:qs A file
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn error_on_ambiguous_hunk_id() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.file(
+        "file",
+        "
+1
+2
+3
+4
+5
+6
+
+1
+2
+3
+4
+5
+6
+",
+    );
+
+    env.but("commit -m 'Add file'").assert().success();
+
+    env.file(
+        "file",
+        "
+1
+2
+3
+hellooo
+4
+5
+6
+
+1
+2
+3
+hellooooo
+4
+5
+6
+",
+    );
+
+    env.but("diff").assert().success().stdout_eq(str![[r#"
+──────────╮
+qs:79 file│
+──────────╯
+   2 2│ 1
+   3 3│ 2
+   4 4│ 3
+     5│+hellooo
+   5 6│ 4
+   6 7│ 5
+   7 8│ 6
+──────────╮
+qs:78 file│
+──────────╯
+    9 10│ 1
+   10 11│ 2
+   11 12│ 3
+      13│+hellooooo
+   12 14│ 4
+   13 15│ 5
+   14 16│ 6
+
+"#]]);
+
+    env.but("commit --no-hooks -m 'Modify file' --changes qs:7")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: Invalid file ID(s):
+  'qs:7' is ambiguous - matches 2 entities. Use more characters to disambiguate.
+
+"#]]);
+}
+
+#[test]
 fn committing_to_existing_branch_with_same_name_as_file() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.setup_metadata(&["A"]);

--- a/crates/but/tests/but/command/commit2.rs
+++ b/crates/but/tests/but/command/commit2.rs
@@ -1686,3 +1686,127 @@ Hint: run `but help` for all commands
 
 "#]]);
 }
+
+#[test]
+fn can_overspecify_hunk_id() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.file("file", "hello");
+
+    env.but("diff")
+        .assert()
+        .success()
+        // Full ID is qs:3c81ccd4449094b2becf2b846fc69cfdfcaa613c
+        .stdout_eq(snapbox::str![[r#"
+─────────╮
+qs:3 file│
+─────────╯
+     1│+hello
+
+"#]]);
+
+    env.but("_commit2 -m 'Add file' qs:3c81").assert().success();
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄br [a-branch-1]
+┊●   d215849 Add file
+┊│     d2:qs A file
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn error_on_ambiguous_hunk_id() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.file(
+        "file",
+        "
+1
+2
+3
+4
+5
+6
+
+1
+2
+3
+4
+5
+6
+",
+    );
+
+    env.but("_commit2 -m 'Add file'").assert().success();
+
+    env.file(
+        "file",
+        "
+1
+2
+3
+hellooo
+4
+5
+6
+
+1
+2
+3
+hellooooo
+4
+5
+6
+",
+    );
+
+    env.but("diff")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+──────────╮
+qs:79 file│
+──────────╯
+   2 2│ 1
+   3 3│ 2
+   4 4│ 3
+     5│+hellooo
+   5 6│ 4
+   6 7│ 5
+   7 8│ 6
+──────────╮
+qs:78 file│
+──────────╯
+    9 10│ 1
+   10 11│ 2
+   11 12│ 3
+      13│+hellooooo
+   12 14│ 4
+   13 15│ 5
+   14 16│ 6
+
+"#]]);
+
+    env.but("_commit2 --no-message qs:7")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: Ambiguous uncommitted change 'qs:7', matches multiple items
+
+Hint: Use a longer ID to disambiguate
+
+"#]]);
+}


### PR DESCRIPTION
In the prior iteration of this, you had to specify the precise short ID of the hunk to reference it. This causes an issue where a mutation that causes a short ID to be shortened further invalidating the use of the longer, more specific short ID that was there a moment ago.

There's no good reason for this: if the full ID is e.g. `f12...`, then any prefix of that should work to reference it, regardless of what the short ID ends up being.

This also extends to collision indexes. If you have e.g. `f12...#0-2` as a full ID to a hunk, then all of `f#0-2`, `f1#0-2`, `f12#0-2` ... should be valid references to that hunk.

Note that this leniency of course means that we now can get multiple matches for a hunk reference, which previously wasn't the case. But that's handled by the generic "ambiguous reference" handling as parsing CLI IDs can always result in matches.