### PR TITLE
feat(cli): initial move2 implementation

### DIFF
--- a/crates/but/src/args/metrics.rs
+++ b/crates/but/src/args/metrics.rs
@@ -17,6 +17,7 @@ pub enum CommandName {
     Squash,
     Squash2,
     Move,
+    Move2,
     Diff,
     Edit,
     Show,

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -266,6 +266,11 @@ pub enum Subcommands {
     #[clap(hide = true, name = "_squash2")]
     _Squash2(squash2::Platform),
 
+    #[cfg(all(feature = "legacy", feature = "but-2"))]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
+    #[clap(hide = true, name = "_move2")]
+    _Move2(move2::Platform),
+
     /// Stages a file or hunk to a specific branch.
     ///
     /// Without arguments, opens an interactive TUI for selecting files and hunks to stage.
@@ -1375,6 +1380,8 @@ pub mod commit;
 #[cfg(feature = "legacy")]
 pub mod commit2;
 pub mod config;
+#[cfg(feature = "legacy")]
+pub mod move2;
 pub mod skill;
 #[cfg(feature = "legacy")]
 pub mod squash2;

--- a/crates/but/src/args/move2.rs
+++ b/crates/but/src/args/move2.rs
@@ -1,0 +1,40 @@
+use crate::args::atoms::CliIdArg;
+
+#[derive(Debug, clap::Parser)]
+#[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
+pub struct Platform {
+    /// Place the commit above `BRANCH_OR_COMMIT`, which must be an applied branch or commit.
+    ///
+    /// If `BRANCH_OR_COMMIT` is a commit, the source commit is placed on the same branch as the
+    /// targeted commit.
+    ///
+    /// If `BRANCH_OR_COMMIT` is a branch, the source commit is placed on a new branch above the
+    /// targeted branch.
+    #[clap(
+        short = 'A',
+        long,
+        value_name = "BRANCH_OR_COMMIT",
+        group = "targeting"
+    )]
+    pub above: Option<CliIdArg>,
+    /// Place the commit below `BRANCH_OR_COMMIT`, which must be an applied branch or commit.
+    ///
+    /// If `BRANCH_OR_COMMIT` is a commit, the source commit is placed on the same branch as the
+    /// targeted commit.
+    ///
+    /// If `BRANCH_OR_COMMIT` is a branch, the source commit is placed on a new branch below the
+    /// targeted branch. Branches are treated as buckets, meaning that "below a branch" is treated
+    /// as below the oldest ancestor on that branch.
+    #[clap(
+        short = 'B',
+        long,
+        value_name = "BRANCH_OR_COMMIT",
+        group = "targeting"
+    )]
+    pub below: Option<CliIdArg>,
+    /// One or more sources to move.
+    ///
+    /// Providing any of the sources as an argument for `--above` or `--below` is an error.
+    #[clap(required = true)]
+    pub sources: Vec<CliIdArg>,
+}

--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -130,6 +130,8 @@ fn print_grouped_with_truncation(
                 #[cfg(all(feature = "legacy", feature = "but-2"))]
                 SubcommandDiscriminant::_Squash2 => Group::EditingCommits,
                 SubcommandDiscriminant::Move => Group::EditingCommits,
+                #[cfg(all(feature = "legacy", feature = "but-2"))]
+                SubcommandDiscriminant::_Move2 => Group::EditingCommits,
 
                 #[cfg(feature = "legacy")]
                 SubcommandDiscriminant::Oplog => Group::OperationHistory,

--- a/crates/but/src/command/legacy/commit2.rs
+++ b/crates/but/src/command/legacy/commit2.rs
@@ -1,5 +1,3 @@
-use std::fmt::Display;
-
 use anyhow::Context as _;
 use but_api::json::HexHash;
 use but_core::{
@@ -10,21 +8,11 @@ use but_core::{
 use but_ctx::Context;
 use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
 use but_transaction::{IntermediateCommitCreateResult, Transaction};
-use but_workspace::{
-    RefInfo,
-    branch::create_reference::{Anchor, Position},
-};
+use but_workspace::{RefInfo, branch::create_reference::Anchor};
 use gitbutler_oplog::entry::{OperationKind, SnapshotDetails};
 use gix::refs::FullName;
 use nonempty::NonEmpty;
 use serde::Serialize;
-
-use crate::{
-    command::legacy::reword2::RewordCommitOperation,
-    id::UncommittedHunkOrFile,
-    theme::{self, Theme},
-    utils::{CliOutput, CliOutputHuman, WriteWithUtils, diff_specs::DiffSpecBuilder},
-};
 
 use crate::{
     CliId, CliResult, CliResultExt, IdMap,
@@ -33,8 +21,16 @@ use crate::{
         commit2::Platform,
     },
     bad_input,
-    command::legacy::status::{TuiOutcome, TuiRunOptions, tui_with_options},
-    utils::IntermediateChannel,
+    command::legacy::{
+        reword2::RewordCommitOperation,
+        status::{TuiOutcome, TuiRunOptions, tui_with_options},
+    },
+    id::UncommittedHunkOrFile,
+    theme::{self, Theme},
+    utils::{
+        CliOutput, CliOutputHuman, IntermediateChannel, WriteWithUtils,
+        diff_specs::DiffSpecBuilder, targeting::Side,
+    },
 };
 
 #[must_use]
@@ -318,12 +314,12 @@ fn route_commit_operation(
 ) -> CliResult<CommitOperation> {
     match target {
         CommitOperationTargetIsh::Above(cli_id) => {
-            let position = CommitRelativeToTargetPosition::Above;
-            route_commit_above_or_below(repo, id_map, cli_id, position)
+            let side = Side::Above;
+            route_commit_above_or_below(repo, id_map, cli_id, side)
         }
         CommitOperationTargetIsh::Below(cli_id) => {
-            let position = CommitRelativeToTargetPosition::Below;
-            route_commit_above_or_below(repo, id_map, cli_id, position)
+            let side = Side::Below;
+            route_commit_above_or_below(repo, id_map, cli_id, side)
         }
         CommitOperationTargetIsh::Branch(cli_id) => {
             if let Some(branch) = cli_id.try_resolve_branch(repo, id_map)? {
@@ -431,7 +427,7 @@ fn route_commit_above_or_below(
     repo: &gix::Repository,
     id_map: &IdMap,
     cli_id: CliIdArg,
-    position: CommitRelativeToTargetPosition,
+    side: Side,
 ) -> CliResult<CommitOperation> {
     let target = match cli_id
         .resolve_in_workspace(repo, id_map, Purpose::Target, None)
@@ -441,13 +437,10 @@ fn route_commit_above_or_below(
         .into_branch_or_commit()
         .hint("Run `but status` to show applicable targets")?
     {
-        BranchOrCommit::Commit(commit_id) => CommitRelativeToTarget::Commit {
-            commit_id,
-            position,
-        },
+        BranchOrCommit::Commit(commit_id) => CommitRelativeToTarget::Commit { commit_id, side },
         BranchOrCommit::Branch(arg) => CommitRelativeToTarget::BranchBucket {
             name: arg.resolve_local_branch_name()?,
-            position,
+            side,
         },
     };
     Ok(CommitOperation::CommitAt(CommitAtOperation { target }))
@@ -522,13 +515,12 @@ impl CommitAtOperation {
         changes: Vec<DiffSpec>,
     ) -> anyhow::Result<(IntermediateCommitCreateResult, Option<BranchNameTarget>)> {
         let (relative_to, side, branch_name_target) = match self.target {
-            CommitRelativeToTarget::Commit {
-                commit_id,
-                position,
-            } => (RelativeTo::Commit(commit_id), position.into(), None),
-            CommitRelativeToTarget::BranchBucket { name, position } => {
+            CommitRelativeToTarget::Commit { commit_id, side } => {
+                (RelativeTo::Commit(commit_id), side.into(), None)
+            }
+            CommitRelativeToTarget::BranchBucket { name, side } => {
                 let new_branch_name = but_core::branch::unique_canned_refname(tx.repo())?;
-                let anchor = Anchor::at_segment(name.as_ref(), position.into());
+                let anchor = Anchor::at_segment(name.as_ref(), side.into());
                 tx.create_reference(
                     new_branch_name.as_ref(),
                     Some(anchor),
@@ -562,7 +554,7 @@ pub enum CommitRelativeToTarget {
     /// Place the commit relative to this commit, within the same branch.
     Commit {
         commit_id: gix::ObjectId,
-        position: CommitRelativeToTargetPosition,
+        side: Side,
     },
     /// Place the commit at the tip of the branch denoted by this reference, moving the reference to
     /// the new commit. This is effectively the same as committing to a branch.
@@ -570,51 +562,5 @@ pub enum CommitRelativeToTarget {
     /// Place the commit relative to this branch, treating the branch as a bucket.
     ///
     /// The commit is always inserted on a new branch with a canned name.
-    BranchBucket {
-        name: FullName,
-        position: CommitRelativeToTargetPosition,
-    },
-}
-
-#[derive(Clone)]
-pub enum CommitRelativeToTargetPosition {
-    Above,
-    Below,
-}
-
-impl Display for CommitRelativeToTargetPosition {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let pretty = match self {
-            Self::Above => "above",
-            Self::Below => "below",
-        };
-        write!(f, "{pretty}")
-    }
-}
-
-impl From<CommitRelativeToTargetPosition> for InsertSide {
-    fn from(value: CommitRelativeToTargetPosition) -> Self {
-        match value {
-            CommitRelativeToTargetPosition::Above => Self::Above,
-            CommitRelativeToTargetPosition::Below => Self::Below,
-        }
-    }
-}
-
-impl From<InsertSide> for CommitRelativeToTargetPosition {
-    fn from(value: InsertSide) -> Self {
-        match value {
-            InsertSide::Above => CommitRelativeToTargetPosition::Above,
-            InsertSide::Below => CommitRelativeToTargetPosition::Below,
-        }
-    }
-}
-
-impl From<CommitRelativeToTargetPosition> for Position {
-    fn from(value: CommitRelativeToTargetPosition) -> Self {
-        match value {
-            CommitRelativeToTargetPosition::Above => Self::Above,
-            CommitRelativeToTargetPosition::Below => Self::Below,
-        }
-    }
+    BranchBucket { name: FullName, side: Side },
 }

--- a/crates/but/src/command/legacy/mod.rs
+++ b/crates/but/src/command/legacy/mod.rs
@@ -17,6 +17,8 @@ pub mod discard;
 pub mod forge;
 pub mod land;
 pub mod mcp;
+#[cfg(all(feature = "legacy", feature = "but-2"))]
+pub mod move2;
 pub mod oplog;
 pub mod pick;
 pub mod pull;

--- a/crates/but/src/command/legacy/move2.rs
+++ b/crates/but/src/command/legacy/move2.rs
@@ -1,0 +1,177 @@
+use std::fmt::Display;
+
+use but_core::{DryRun, RefMetadata, sync::RepoExclusive};
+use but_ctx::Context;
+use but_rebase::graph_rebase::mutate::RelativeTo;
+use but_transaction::Transaction;
+use gitbutler_oplog::entry::{OperationKind, SnapshotDetails};
+use itertools::Itertools;
+use nonempty::NonEmpty;
+
+use crate::{
+    CliResult, IdMap,
+    args::move2::Platform,
+    bad_input,
+    theme::{self, Theme},
+    utils::{CliOutputHuman, IntermediateChannel, WriteWithUtils, targeting::Side},
+};
+
+pub enum MoveOutcome {
+    Commits {
+        sources: NonEmpty<gix::ObjectId>,
+        target: MoveTarget,
+    },
+}
+
+impl CliOutputHuman for MoveOutcome {
+    fn on_human(self, out: &mut dyn WriteWithUtils, _theme: &Theme) -> anyhow::Result<()> {
+        match self {
+            Self::Commits { sources, target } => {
+                let sources = sources.into_iter().map(theme::Commit).join(", ");
+
+                writeln!(out, "Moved {sources} {target}")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+pub fn r#move(
+    ctx: &mut Context,
+    _out: IntermediateChannel<'_>,
+    args: Platform,
+) -> CliResult<MoveOutcome> {
+    let mut guard = ctx.exclusive_worktree_access();
+    let mut meta = ctx.meta()?;
+    let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
+
+    let move_op = resolve(ctx, guard.write_permission(), args, &id_map)?;
+
+    run(ctx, &mut meta, guard.write_permission(), move_op)
+}
+
+#[derive(Clone)]
+enum MoveOperation {
+    Commit(MoveCommitsOperation),
+}
+
+#[derive(Clone)]
+struct MoveCommitsOperation {
+    sources: NonEmpty<gix::ObjectId>,
+    target: MoveTarget,
+}
+
+impl MoveCommitsOperation {
+    fn execute(self, tx: &mut Transaction<'_, '_, impl RefMetadata>) -> anyhow::Result<()> {
+        let (relative_to, side) = match self.target {
+            MoveTarget::Commit { commit_id, side } => (RelativeTo::Commit(commit_id), side.into()),
+        };
+
+        tx.move_commits(self.sources, relative_to, side)?;
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub enum MoveTarget {
+    /// Place the commit relative to this commit, within the same branch.
+    Commit {
+        commit_id: gix::ObjectId,
+        side: Side,
+    },
+}
+
+impl Display for MoveTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Commit { commit_id, side } => {
+                write!(f, "{} {}", side, theme::Commit(*commit_id))
+            }
+        }
+    }
+}
+
+fn resolve(
+    ctx: &mut Context,
+    perm: &mut RepoExclusive,
+    args: Platform,
+    id_map: &IdMap,
+) -> CliResult<MoveOperation> {
+    let Platform {
+        above,
+        below,
+        sources,
+    } = args;
+
+    let (repo, _ws, _db) = ctx.workspace_and_db_with_perm(perm.read_permission())?;
+
+    let (unresolved_target, side) = match (above, below) {
+        (Some(above), None) => (above, Side::Above),
+        (None, Some(below)) => (below, Side::Below),
+        _ => unimplemented!(),
+    };
+
+    let target = {
+        let commit_id = unresolved_target.resolve_commit_in_workspace(&repo, id_map)?;
+        MoveTarget::Commit { commit_id, side }
+    };
+
+    let sources = sources
+        .into_iter()
+        .map(|source| {
+            let resolved_source = source.resolve_commit_in_workspace(&repo, id_map)?;
+
+            match &target {
+                MoveTarget::Commit { commit_id, .. } if commit_id == &resolved_source => {
+                    return Err(bad_input("Source cannot also be target")
+                        .arg_value(source.to_string())
+                        .arg_name(format!("--{side}"))
+                        .hint(format!("Trying to move items {side} '{source}'? Remove '{source}' from '<SOURCES>' and try again!"))
+                        .into());
+                }
+                _ => (),
+            }
+
+            Ok(resolved_source)
+        })
+        .collect::<CliResult<Vec<_>>>()?;
+    let sources = NonEmpty::from_vec(sources)
+        .expect("BUG: Empty sources should not be possible as it's a required argument");
+
+    Ok(MoveOperation::Commit(MoveCommitsOperation {
+        sources,
+        target,
+    }))
+}
+
+fn run(
+    ctx: &mut Context,
+    meta: &mut impl RefMetadata,
+    perm: &mut RepoExclusive,
+    move_op: MoveOperation,
+) -> CliResult<MoveOutcome> {
+    let snapshot_details = SnapshotDetails::new(OperationKind::MoveCommit);
+    let ((), _ws) = but_transaction::with_transaction_with_perm(
+        ctx,
+        meta,
+        perm,
+        snapshot_details,
+        DryRun::No,
+        |mut tx| {
+            match move_op.clone() {
+                MoveOperation::Commit(op) => op.execute(&mut tx)?,
+            };
+
+            Ok(but_transaction::Commit(()))
+        },
+    )?;
+
+    let outcome = match move_op {
+        MoveOperation::Commit(MoveCommitsOperation { sources, target }) => {
+            MoveOutcome::Commits { sources, target }
+        }
+    };
+
+    Ok(outcome)
+}

--- a/crates/but/src/command/legacy/status/tui/app/commit_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/commit_mode.rs
@@ -21,6 +21,7 @@ use crate::{
     },
     id::{ShortId, UNCOMMITTED, UncommittedHunkOrFile},
     tui::TerminalGuard,
+    utils::targeting,
 };
 
 #[derive(Debug, Clone)]
@@ -358,7 +359,7 @@ impl App {
             },
             CliId::Commit { commit_id, .. } => commit2::CommitRelativeToTarget::Commit {
                 commit_id: *commit_id,
-                position: commit2::CommitRelativeToTargetPosition::from(*insert_side),
+                side: targeting::Side::from(*insert_side),
             },
             CliId::UncommittedHunkOrFile(..)
             | CliId::PathPrefix { .. }
@@ -405,7 +406,7 @@ impl App {
                 commit2::CommitOperation::CommitAt(commit2::CommitAtOperation {
                     target: commit2::CommitRelativeToTarget::BranchBucket {
                         name: Category::LocalBranch.to_full_name(&**name)?,
-                        position: commit2::CommitRelativeToTargetPosition::Above,
+                        side: targeting::Side::Above,
                     },
                 })
             }

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -1090,6 +1090,27 @@ async fn match_subcommand(
             out.print_cli_output(outcome)?;
             Ok(())
         }
+        #[cfg(all(feature = "legacy", feature = "but-2"))]
+        Subcommands::_Move2(move_args) => {
+            use crate::utils::{IntermediateChannel, OutputChannelExt};
+
+            let status_after = args.status_after;
+            let mut ctx = setup::init_ctx(
+                &args,
+                InitCtxOptions {
+                    background_sync: BackgroundSync::Enabled { silent: false },
+                    ..Default::default()
+                },
+                out,
+            )?;
+            out.begin_status_after(status_after);
+
+            let outcome =
+                command::legacy::move2::r#move(&mut ctx, IntermediateChannel::new(out), move_args)
+                    .emit_metrics(metrics_ctx)?;
+            out.print_cli_output_human(outcome)?;
+            Ok(())
+        }
         #[cfg(feature = "legacy")]
         Subcommands::Push(push_args) => {
             let mut ctx = setup::init_ctx(&args, InitCtxOptions::default(), out)?;

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -208,6 +208,8 @@ impl Subcommands {
             Subcommands::Squash { .. } => Squash,
             #[cfg(all(feature = "legacy", feature = "but-2"))]
             Subcommands::_Squash2(..) => Squash2,
+            #[cfg(all(feature = "legacy", feature = "but-2"))]
+            Subcommands::_Move2(..) => Move2,
             #[cfg(feature = "legacy")]
             Subcommands::Land { .. } => Land,
             Subcommands::Move { .. } => Move,

--- a/crates/but/src/utils/mod.rs
+++ b/crates/but/src/utils/mod.rs
@@ -25,6 +25,7 @@ pub mod time;
 
 pub(crate) mod binary_path;
 pub(crate) mod diff_specs;
+pub(crate) mod targeting;
 
 pub trait ResultErrorExt {
     fn show_root_cause_error_then_exit_without_destructors(self, out: OutputChannel) -> !;

--- a/crates/but/src/utils/targeting.rs
+++ b/crates/but/src/utils/targeting.rs
@@ -5,7 +5,7 @@ use std::fmt::Display;
 use but_rebase::graph_rebase::mutate::InsertSide;
 use but_workspace::branch::create_reference::Position;
 
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub(crate) enum Side {
     Above,
     Below,

--- a/crates/but/src/utils/targeting.rs
+++ b/crates/but/src/utils/targeting.rs
@@ -1,0 +1,49 @@
+//! Utility functions for targeting operations.
+
+use std::fmt::Display;
+
+use but_rebase::graph_rebase::mutate::InsertSide;
+use but_workspace::branch::create_reference::Position;
+
+#[derive(Clone)]
+pub(crate) enum Side {
+    Above,
+    Below,
+}
+
+impl Display for Side {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let pretty = match self {
+            Self::Above => "above",
+            Self::Below => "below",
+        };
+        write!(f, "{pretty}")
+    }
+}
+
+impl From<Side> for InsertSide {
+    fn from(value: Side) -> Self {
+        match value {
+            Side::Above => Self::Above,
+            Side::Below => Self::Below,
+        }
+    }
+}
+
+impl From<InsertSide> for Side {
+    fn from(value: InsertSide) -> Self {
+        match value {
+            InsertSide::Above => Self::Above,
+            InsertSide::Below => Self::Below,
+        }
+    }
+}
+
+impl From<Side> for Position {
+    fn from(value: Side) -> Self {
+        match value {
+            Side::Above => Self::Above,
+            Side::Below => Self::Below,
+        }
+    }
+}

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -30,6 +30,8 @@ mod help;
 mod land;
 #[cfg(feature = "legacy")]
 mod r#move;
+#[cfg(all(feature = "legacy", feature = "but-2"))]
+mod move2;
 mod onboarding;
 #[cfg(feature = "legacy")]
 mod pick;

--- a/crates/but/tests/but/command/move2.rs
+++ b/crates/but/tests/but/command/move2.rs
@@ -1,0 +1,319 @@
+use crate::utils::Sandbox;
+
+#[test]
+fn move_commit_above_other_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊●   fe12bcd add first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 fe --above 9a")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved fe12bcd above 9ac4652
+
+"#]]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   c6224e6 add first
+┊●   ce8b324 add second
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn move_commit_below_other_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊●   fe12bcd add first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 9a --below fe")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved 9ac4652 below fe12bcd
+
+"#]]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   c6224e6 add first
+┊●   ce8b324 add second
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn move_multiple_consecutive_commits_relative_to_other_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("commits-with-same-prefix");
+    env.setup_metadata(&["A"]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   5c88a8e add A13
+┊●   a18ea48 add A12
+┊●   0c0fcbf add A11
+┊●   c472887 add A10
+┊●   8188106 add A9
+┊●   769f4a8 add A8
+┊●   2a98cfc add A7
+┊●   d60e311 add A6
+┊●   c67c49e add A5
+┊●   23c280d add A4
+┊●   5c7c6d7 add A3
+┊●   1299ac9 add A2
+┊●   0748e42 add A1
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    for (operator, target_commit) in [("--above", "c4"), ("--below", "0c")] {
+        env.but("_move2 2a 76")
+            .arg(operator)
+            .arg(target_commit)
+            .assert()
+            .success()
+            .stdout_eq(snapbox::str![["
+Moved 2a98cfc, 769f4a8 [..]
+
+"]]);
+
+        env.but("status")
+            .assert()
+            .success()
+            .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   86218a9 add A13
+┊●   4ba5683 add A12
+┊●   33c2cee add A11
+┊●   894e57b add A8
+┊●   1c425d1 add A7
+┊●   73d652c add A10
+┊●   a6a6cd1 add A9
+┊●   d60e311 add A6
+┊●   c67c49e add A5
+┊●   23c280d add A4
+┊●   5c7c6d7 add A3
+┊●   1299ac9 add A2
+┊●   0748e42 add A1
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+        env.but("undo").assert().success();
+    }
+}
+
+#[test]
+fn move_multiple_non_consecutive_commits_in_arbitrary_order_relative_to_other_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("commits-with-same-prefix");
+    env.setup_metadata(&["A"]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   5c88a8e add A13
+┊●   a18ea48 add A12
+┊●   0c0fcbf add A11
+┊●   c472887 add A10
+┊●   8188106 add A9
+┊●   769f4a8 add A8
+┊●   2a98cfc add A7
+┊●   d60e311 add A6
+┊●   c67c49e add A5
+┊●   23c280d add A4
+┊●   5c7c6d7 add A3
+┊●   1299ac9 add A2
+┊●   0748e42 add A1
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    for (operator, target_commit) in [("--above", "76"), ("--below", "81")] {
+        // We pick the source commits in an "incorrect" order, but they should later be sorted correctly
+        // via topological sort.
+        //
+        // Order as picked is: A7 A1 A5 --above A8, but we expect the commits to be applied from oldest
+        // to newest, i.e. (A8) <- A1 <- A5 <- A7
+        env.but("_move2 2a 07 c6")
+            .arg(operator)
+            .arg(target_commit)
+            .assert()
+            .success()
+            .stdout_eq(snapbox::str![["
+Moved 2a98cfc, 0748e42, c67c49e [..]
+
+"]]);
+
+        env.but("status")
+            .assert()
+            .success()
+            .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   6f23074 add A13
+┊●   ae30331 add A12
+┊●   ad601eb add A11
+┊●   bfcf0d6 add A10
+┊●   a5511fb add A9
+┊●   79d9420 add A7
+┊●   651dbaf add A5
+┊●   33e2190 add A1
+┊●   ddfd694 add A8
+┊●   88fbf4b add A6
+┊●   4868a7b add A4
+┊●   c05b7a8 add A3
+┊●   b7e9e54 add A2
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+        env.but("undo").assert().success();
+    }
+}
+
+#[test]
+fn cannot_combine_above_and_below() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊●   fe12bcd add first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 9a --below fe --above fe")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+error: the argument '--below <BRANCH_OR_COMMIT>' cannot be used with '--above <BRANCH_OR_COMMIT>'
+
+Usage: but _move2 --below <BRANCH_OR_COMMIT> <SOURCES>...
+
+For more information, try '--help'.
+
+"#]]);
+}
+
+#[test]
+fn source_cannot_be_target() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
+
+    env.but("_move2 9a --above 9a")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: Bad input '9a' for '--above'
+
+Source cannot also be target
+
+Hint: Trying to move items above '9a'? Remove '9a' from '<SOURCES>' and try again!
+
+"#]]);
+
+    env.but("_move2 9a --below 9a")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: Bad input '9a' for '--below'
+
+Source cannot also be target
+
+Hint: Trying to move items below '9a'? Remove '9a' from '<SOURCES>' and try again!
+
+"#]]);
+}


### PR DESCRIPTION
Adds an initial implementation of `_move2` that only allows moving commits relative to other commits.

Some known missing features:

* Output formats (e.g. `--format json`) are not implemented, we don't really know what to output right now.
* Only commits addressable as sources/target.