### PR TITLE
Lite: change expand/collapse commit body button icon and variant

### DIFF
--- a/apps/lite/ui/src/components/Button.module.css
+++ b/apps/lite/ui/src/components/Button.module.css
@@ -53,7 +53,7 @@
 	padding-inline: 6px;
 	--icon-size: 14px;
 
-	&.iconOnly {
+	&:where(.iconOnly) {
 		width: 22px;
 		padding-inline: 3px;
 	}
@@ -65,7 +65,7 @@
 	padding-inline: 10px;
 	--icon-size: 16px;
 
-	&.iconOnly {
+	&:where(.iconOnly) {
 		width: 28px;
 		padding-inline: 8px;
 	}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -32,6 +32,11 @@
 	margin-inline-start: auto;
 }
 
+.compactButton {
+	width: 24px;
+	height: 14px;
+}
+
 .title {
 	display: flex;
 	column-gap: 8px;

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -129,7 +129,8 @@
 
 .commitMessageBody {
 	max-width: 70ch;
-	font-size: 13px;
+	font-size: 12px;
+	line-height: 160%;
 	white-space: pre-wrap;
 	user-select: text;
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -583,11 +583,14 @@ const Title: FC<{
 										aria-expanded={!bodyCollapsed}
 										aria-label={bodyCollapsed ? "Expand commit body" : "Collapse commit body"}
 										aria-pressed={!bodyCollapsed}
-										className={getButtonClassName({
-											variant: bodyCollapsed ? "outline" : "gray",
-											iconOnly: true,
-											size: "small",
-										})}
+										className={classes(
+											getButtonClassName({
+												variant: bodyCollapsed ? "outline" : "gray",
+												iconOnly: true,
+												size: "small",
+											}),
+											styles.compactButton,
+										)}
 										onClick={() => onBodyCollapsedChange(!bodyCollapsed)}
 									>
 										<Icon name="kebab" />

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -582,6 +582,7 @@ const Title: FC<{
 										aria-controls={bodyId}
 										aria-expanded={!bodyCollapsed}
 										aria-label={bodyCollapsed ? "Expand commit body" : "Collapse commit body"}
+										aria-pressed={!bodyCollapsed}
 										className={getButtonClassName({
 											variant: "ghost",
 											iconOnly: true,

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -584,12 +584,12 @@ const Title: FC<{
 										aria-label={bodyCollapsed ? "Expand commit body" : "Collapse commit body"}
 										aria-pressed={!bodyCollapsed}
 										className={getButtonClassName({
-											variant: "ghost",
+											variant: bodyCollapsed ? "outline" : "gray",
 											iconOnly: true,
 										})}
 										onClick={() => onBodyCollapsedChange(!bodyCollapsed)}
 									>
-										<Icon name={bodyCollapsed ? "uncollapse" : "collapse"} />
+										<Icon name="kebab" />
 									</Tooltip.Trigger>
 									<Tooltip.Portal>
 										<Tooltip.Positioner sideOffset={4}>

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -586,6 +586,7 @@ const Title: FC<{
 										className={getButtonClassName({
 											variant: bodyCollapsed ? "outline" : "gray",
 											iconOnly: true,
+											size: "small",
 										})}
 										onClick={() => onBodyCollapsedChange(!bodyCollapsed)}
 									>


### PR DESCRIPTION



Based on GitHub's implementation: https://linear.app/gitbutler/issue/GB-1660/completely-collapse-commit-bodies#comment-eba43c0f

I used `outline` rather than `ghost` to make the button more noticeable (again like GitHub), so it's clearer when there's a commit body.


https://github.com/user-attachments/assets/d0ed4bd0-b767-4e19-ab58-71ecc0051025

