### PR TITLE
docs(but): expose `but completions` in help output

### DIFF
--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -1300,8 +1300,20 @@ pub enum Subcommands {
         props: String,
     },
 
-    /// UTILITY: Generate shell completion scripts for the specified or inferred shell.
-    #[clap(hide = true)]
+    /// Generate `but` shell completions.
+    ///
+    /// ## Examples
+    ///
+    /// ```bash
+    /// # bash, put in .bashrc or .bash_profile depending on system setup
+    /// eval "$(but completions bash)"
+    ///
+    /// # zsh, put in .zshrc
+    /// eval "$(but completions zsh)"
+    ///
+    /// # fish, put in config.fish
+    /// but completions fish | source
+    /// ```
     #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Completions {
         /// The shell to generate completions for, or the one extracted from the `SHELL` environment variable.

--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -152,6 +152,7 @@ fn print_grouped_with_truncation(
                 SubcommandDiscriminant::Skill => Group::OtherCommands,
                 SubcommandDiscriminant::Agent => Group::OtherCommands,
                 SubcommandDiscriminant::Help => Group::OtherCommands,
+                SubcommandDiscriminant::Completions => Group::OtherCommands,
 
                 #[cfg(feature = "legacy")]
                 SubcommandDiscriminant::Setup => Group::OtherCommands,
@@ -162,7 +163,6 @@ fn print_grouped_with_truncation(
 
                 SubcommandDiscriminant::Edit => continue,
                 SubcommandDiscriminant::Metrics => continue,
-                SubcommandDiscriminant::Completions => continue,
                 SubcommandDiscriminant::Onboarding => continue,
                 SubcommandDiscriminant::EvalHook => continue,
                 SubcommandDiscriminant::External => continue,
@@ -366,6 +366,7 @@ Other Commands:
   config       View and manage GitButler configuration
   skill        Manage AI agent skills for GitButler
   agent        Set up GitButler for AI coding agents
+  completions  Generate but shell completions
 
 To add command completion, add this to your shell rc: (for example ~/.zshrc)
   eval "$(but completions zsh)"
@@ -438,6 +439,7 @@ Other Commands:
   config       View and manage GitButler configuration
   skill        Manage AI agent skills for GitButler
   agent        Set up GitButler for AI coding agents
+  completions  Generate but shell completions
 
 To add command completion, add this to your shell rc: (for example ~/.zshrc)
   eval "$(but completions zsh)"


### PR DESCRIPTION
Exposes the `but completions` command in help output. There's no good reason to hide this, and it's useful to know it's there if you just grab the `but` binary without running an installer that sets up completions for you.