### PR TITLE
Handle integrated empty branch segments

### DIFF
--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -17,6 +17,7 @@ use but_rebase::{
 
 use crate::changeset::compute_similarity_by_commit_ids;
 use crate::graph_manipulation::traverse_nodes;
+use crate::resolve_tracking_branch_ref_name;
 
 /// Whether a bottom most commit should be rebased, or a merge commit should be
 /// created at the top of the commit run.
@@ -221,6 +222,9 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
         &editor,
         from_target_sha,
         from_target_ref,
+        target_sha,
+        target_ref.ref_name.as_ref(),
+        target_ref_commit.detach(),
         review_hints,
     )?;
 
@@ -279,7 +283,11 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
     let mut fully_integrated_workspace_parents = HashSet::new();
     let mut direct_checkout_replacement_ref: Option<(Selector, gix::refs::FullName)> = None;
     for stack in &stacks {
-        let is_selected = stack.nodes.values().any(|attrs| attrs.to_rebase) || stack.to_merge;
+        let is_selected = stack.nodes.values().any(|attrs| attrs.to_rebase)
+            || stack.to_merge
+            || updates_with_selectors
+                .iter()
+                .any(|(selector, _)| stack.bottoms.contains(selector));
         let is_fully_integrated = stack
             .nodes
             .values()
@@ -321,18 +329,18 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
         // Remove integrated refs from the workspace and from git.
         // TODO: allow to keep some references.
         for (selector, attrs) in &stack.nodes {
-            if let Some(ref_name) = attrs.reference_integrated.as_ref()
-                && should_delete_integrated_local_branch(ref_name.as_ref())
-            {
-                if direct_checkout_replacement_ref
-                    .as_ref()
-                    .is_some_and(|(replacement_selector, _)| replacement_selector == selector)
-                {
-                    continue;
-                }
-                editor.replace(*selector, Step::None)?;
+            if let Some(ref_name) = attrs.reference_integrated.as_ref() {
                 if let Some(ws_meta) = ws_meta.as_mut() {
                     ws_meta.remove_segment(ref_name.as_ref());
+                }
+                if should_delete_integrated_local_branch(ref_name.as_ref()) {
+                    if direct_checkout_replacement_ref
+                        .as_ref()
+                        .is_some_and(|(replacement_selector, _)| replacement_selector == selector)
+                    {
+                        continue;
+                    }
+                    editor.replace(*selector, Step::None)?;
                 }
             }
         }
@@ -452,12 +460,16 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn collect_stacks<'ws, 'meta, M: RefMetadata>(
     head_commit: gix::Commit<'_>,
     head_is_workspace_commit: bool,
     editor: &Editor<'ws, 'meta, M>,
     from_target_sha: HashSet<Selector>,
     from_target_ref: HashSet<Selector>,
+    target_sha: gix::ObjectId,
+    target_ref_name: &gix::refs::FullNameRef,
+    target_ref_commit: gix::ObjectId,
     review_hints: &[ReviewIntegrationHint],
 ) -> Result<Vec<Stack>> {
     let mut stacks = if head_is_workspace_commit {
@@ -510,12 +522,16 @@ fn collect_stacks<'ws, 'meta, M: RefMetadata>(
         output_stacks.push(out);
     }
 
-    let upstream_commits = commit_ids(
-        editor,
-        from_target_ref
-            .iter()
-            .filter_map(|s| (!from_target_sha.contains(s)).then_some(*s)),
-    )?;
+    let upstream_selectors = from_target_ref
+        .iter()
+        .filter_map(|s| (!from_target_sha.contains(s)).then_some(*s))
+        .collect::<Vec<_>>();
+    let upstream_selectors = if upstream_selectors.is_empty() {
+        from_target_ref.iter().copied().collect()
+    } else {
+        upstream_selectors
+    };
+    let upstream_commits = commit_ids(editor, upstream_selectors)?;
     let mut workspace_selectors = HashSet::new();
     for stack in &output_stacks {
         workspace_selectors.extend(stack.nodes.keys());
@@ -612,16 +628,116 @@ fn collect_stacks<'ws, 'meta, M: RefMetadata>(
             let Some(node) = stack.nodes.get_mut(r_sel) else {
                 continue;
             };
-
+            let remote_tip_integrated = empty_local_reference_remote_tip_integrated(
+                editor,
+                *r_sel,
+                r_name.as_ref(),
+                &reference_nodes,
+                &from_target_ref,
+                target_sha,
+                target_ref_name,
+                target_ref_commit,
+            )?;
             if traversed_commits {
+                // The remote-tip check is only an empty-segment fallback. Once
+                // we have traversed local commits, those commits decide whether
+                // the segment is integrated so local work ahead of its tracking
+                // branch is not discarded.
                 node.reference_integrated = all_integrated.then_some(r_name.clone());
             } else {
-                node.reference_integrated = node.is_integrated().then_some(r_name.clone());
+                node.reference_integrated =
+                    (node.is_integrated() || remote_tip_integrated).then_some(r_name.clone());
             }
         }
     }
 
     Ok(output_stacks)
+}
+
+/// Return `true` if an empty local branch can be treated as integrated because
+/// its tracking branch tip is already contained in the target branch.
+///
+/// Empty branch segments have no local commits to compare content-wise, so this
+/// looks at the branch's configured remote-tracking ref instead. The check is
+/// deliberately conservative: it only applies to local branches, ignores the
+/// target branch itself, rejects stale tracking refs that still point at the old
+/// target, and preserves an empty branch if it sits on top of another local
+/// branch that is not itself target-integrated.
+#[allow(clippy::too_many_arguments)]
+fn empty_local_reference_remote_tip_integrated<'ws, 'meta, M: RefMetadata>(
+    editor: &Editor<'ws, 'meta, M>,
+    selector: Selector,
+    ref_name: &gix::refs::FullNameRef,
+    reference_nodes: &HashMap<Selector, gix::refs::FullName>,
+    from_target_ref: &HashSet<Selector>,
+    target_sha: gix::ObjectId,
+    target_ref_name: &gix::refs::FullNameRef,
+    target_ref_commit: gix::ObjectId,
+) -> Result<bool> {
+    if ref_name.category() != Some(gix::refs::Category::LocalBranch) {
+        return Ok(false);
+    }
+    if editor.direct_parents(selector)?.iter().any(|(parent, _)| {
+        reference_nodes.get(parent).is_some_and(|parent_ref| {
+            parent_ref.category() == Some(gix::refs::Category::LocalBranch)
+                && !from_target_ref.contains(parent)
+                && !reference_points_to_target(
+                    editor.repo(),
+                    parent_ref.as_ref(),
+                    target_sha,
+                    target_ref_commit,
+                )
+        })
+    }) {
+        return Ok(false);
+    }
+
+    let Ok(remote_ref_name) = resolve_tracking_branch_ref_name(ref_name, editor.repo()) else {
+        return Ok(false);
+    };
+    if remote_ref_name.as_bstr() == target_ref_name.as_bstr() {
+        return Ok(false);
+    }
+
+    let Some(remote_tip_id) = editor
+        .repo()
+        .try_find_reference(remote_ref_name.as_ref())?
+        .and_then(|mut reference| reference.peel_to_id().ok())
+        .map(|id| id.detach())
+    else {
+        return Ok(false);
+    };
+    if remote_tip_id == target_sha && remote_tip_id != target_ref_commit {
+        return Ok(false);
+    }
+
+    Ok(editor
+        .repo()
+        .merge_base(remote_tip_id, target_ref_commit)
+        .is_ok_and(|merge_base| merge_base.detach() == remote_tip_id))
+}
+
+/// Return `true` if `ref_name` currently resolves to either the old target
+/// commit or the advanced target tip.
+///
+/// This is used when checking the parent refs of an empty branch. Parent refs
+/// that point at either target boundary are safe to treat as target-frame
+/// anchors, while other local parent refs keep the empty branch alive.
+fn reference_points_to_target(
+    repo: &gix::Repository,
+    ref_name: &gix::refs::FullNameRef,
+    target_sha: gix::ObjectId,
+    target_ref_commit: gix::ObjectId,
+) -> bool {
+    repo.try_find_reference(ref_name)
+        .ok()
+        .flatten()
+        .and_then(|mut reference| reference.peel_to_id().ok())
+        .map(|id| {
+            let id = id.detach();
+            id == target_sha || id == target_ref_commit
+        })
+        .unwrap_or(false)
 }
 
 /// Whether an integrated local branch ref should be deleted during integration.

--- a/crates/but-workspace/tests/fixtures/scenario/empty-branch-remote-tip-integrated.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/empty-branch-remote-tip-integrated.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git init
+
+commit-file base
+
+git checkout -b topic
+commit-file topic
+
+git checkout main
+git merge --no-ff -m "merge topic" topic
+
+setup_target_to_match_main
+turn_into_remote_branch topic topic
+git config branch.topic.remote origin
+git config branch.topic.merge refs/heads/topic
+git checkout -b topic origin/topic
+create_workspace_commit_once topic

--- a/crates/but-workspace/tests/fixtures/scenario/merged-branch-below-empty-branch.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/merged-branch-below-empty-branch.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git init
+
+commit-file base
+
+git checkout -b bottom
+commit-file bottom
+
+git checkout -b top
+
+mkdir -p .git/refs/remotes/origin
+cp .git/refs/heads/bottom .git/refs/remotes/origin/bottom
+cp .git/refs/heads/top .git/refs/remotes/origin/top
+git config branch.bottom.remote origin
+git config branch.bottom.merge refs/heads/bottom
+git config branch.top.remote origin
+git config branch.top.merge refs/heads/top
+
+git checkout main
+git merge --no-ff -m "merge bottom" bottom
+
+setup_target_to_match_main
+
+git checkout top
+create_workspace_commit_once top

--- a/crates/but-workspace/tests/fixtures/scenario/non-empty-branch-remote-tip-integrated.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/non-empty-branch-remote-tip-integrated.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git init
+
+commit-file base
+
+git checkout -b topic
+commit-file topic
+
+git checkout main
+git merge --no-ff -m "merge topic" topic
+
+setup_target_to_match_main
+turn_into_remote_branch topic topic
+git config branch.topic.remote origin
+git config branch.topic.merge refs/heads/topic
+git checkout -b topic origin/topic
+commit-file local
+create_workspace_commit_once topic

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -884,6 +884,69 @@ fn fully_integrated_single_branch_reparents_workspace_commit_to_advanced_target(
 }
 
 #[test]
+fn non_bottom_update_selector_does_not_prune_fully_integrated_stack() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("fully-integrated-single-branch-target-advanced")?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    add_stack(&mut meta, 1, "A", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta(&meta)?,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+
+    let mut workspace = graph.into_workspace()?;
+    let project_meta = project_meta(&meta)?;
+    let out = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        project_meta.clone(),
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A")?.detach()),
+        }],
+    )?;
+    let ws_meta = out
+        .ws_meta
+        .as_ref()
+        .context("workspace metadata should be returned")?;
+    assert_eq!(
+        ws_meta.stacks.len(),
+        1,
+        "non-bottom update selectors should not mark integrated stacks as selected for pruning"
+    );
+    out.rebase.materialize()?;
+
+    assert!(
+        repo.try_find_reference("A")?.is_some(),
+        "local branch should remain when update selector is not a stack bottom"
+    );
+    let graph = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?;
+    let workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 8d5739f
+    └── ≡📙:3:A on 8d5739f {1}
+        └── 📙:3:A
+            ├── ·ffde79e (🏘️|✓)
+            └── ·86b55e6 (🏘️|✓)
+    ");
+
+    Ok(())
+}
+
+#[test]
 fn fully_integrated_single_branch_reparents_workspace_commit_to_advanced_merge_target() -> Result<()>
 {
     let (_tmp, repo, mut meta, _description) = named_writable_scenario_with_description(
@@ -1822,6 +1885,270 @@ fn orphan_reparent_empty_stack_to_target_tip() -> Result<()> {
         repo.rev_parse_single("origin/main")?.detach(),
         "orphaned workspace commit should be reparented to the target tip after integrating an empty stack"
     );
+
+    Ok(())
+}
+
+#[test]
+fn empty_branch_with_integrated_remote_tip_is_removed() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("empty-branch-remote-tip-integrated")?;
+    let target_sha = repo.rev_parse_single("main^")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    add_stack(&mut meta, 1, "topic", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta(&meta)?,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+ * 6b2e0ef (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+ | *   364a08f (origin/main, main) merge topic
+ | |\  
+ | |/  
+ |/|   
+ * | 6ba217e (origin/topic, topic) add topic
+ |/  
+ * 563a7fc add base
+ ");
+
+    let mut workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 563a7fc
+    └── ≡📙:4:topic <> origin/topic →:5: on 563a7fc {1}
+        └── 📙:4:topic <> origin/topic →:5:
+            └── ❄️6ba217e (🏘️|✓)
+    ");
+
+    let topic_bottom_commit = repo.rev_parse_single("topic")?.object()?.id;
+
+    let project_meta = project_meta(&meta)?;
+    let out = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        project_meta.clone(),
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(topic_bottom_commit),
+        }],
+    )?;
+    let ws_meta = out
+        .ws_meta
+        .as_ref()
+        .context("workspace metadata should be returned")?;
+    assert!(
+        ws_meta.stacks.is_empty(),
+        "workspace metadata should no longer expose the integrated empty branch"
+    );
+    out.rebase.materialize()?;
+    let graph = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?;
+    let workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 563a7fc
+    └── ≡:2:main <> origin/main →:1: on 563a7fc
+        └── :2:main <> origin/main →:1:
+            └── ❄️364a08f (🏘️|✓)
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * cf134fb (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   364a08f (origin/main, main) merge topic
+    |\  
+    | * 6ba217e (origin/topic) add topic
+    |/  
+    * 563a7fc add base
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn non_empty_branch_with_integrated_remote_tip_keeps_local_work() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("non-empty-branch-remote-tip-integrated")?;
+    let target_sha = repo.rev_parse_single("main^")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    add_stack(&mut meta, 1, "topic", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta(&meta)?,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+  * bb8f85a (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+  * f1a3cba (topic) add local
+  | *   364a08f (origin/main, main) merge topic
+  | |\  
+  | |/  
+  |/|   
+  * | 6ba217e (origin/topic) add topic
+  |/  
+  * 563a7fc add base
+  ");
+
+    let mut workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 563a7fc
+    └── ≡📙:4:topic <> origin/topic →:5:⇡1 on 563a7fc {1}
+        └── 📙:4:topic <> origin/topic →:5:⇡1
+            ├── ·f1a3cba (🏘️)
+            └── ❄️6ba217e (🏘️|✓)
+    ");
+    let topic_base = repo.rev_parse_single("topic~")?.object()?.id;
+    let project_meta = project_meta(&meta)?;
+    integrate_and_materialize(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(topic_base),
+        }],
+    )?;
+
+    assert!(
+        repo.try_find_reference("topic")?.is_some(),
+        "branch should remain because it still has local work above its integrated tracking tip",
+    );
+    assert_eq!(
+        repo.find_commit(repo.rev_parse_single("topic")?.detach())?
+            .message_raw()?
+            .to_str()?
+            .trim_end(),
+        "add local",
+    );
+    let graph = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?;
+    let workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 563a7fc
+    └── ≡📙:4:topic <> origin/topic →:5:⇡1 on 563a7fc {1}
+        ├── 📙:4:topic <> origin/topic →:5:⇡1
+        │   └── ·f3ceb3d (🏘️)
+        └── :2:main <> origin/main →:1:
+            └── ❄️364a08f (🏘️|✓)
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * d0cd028 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * f3ceb3d (topic) add local
+    *   364a08f (origin/main, main) merge topic
+    |\  
+    | * 6ba217e (origin/topic) add topic
+    |/  
+    * 563a7fc add base
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn empty_branch_above_integrated_branch_is_preserved() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("merged-branch-below-empty-branch")?;
+    let target_sha = repo.rev_parse_single("main^")?.detach();
+
+    meta.data_mut().default_target = Some(Target {
+        branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+        remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+        sha: target_sha,
+        push_remote_name: None,
+    });
+    add_stack_with_segments(&mut meta, 1, "top", StackState::InWorkspace, &["bottom"]);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta(&meta)?,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+* 07e525c (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+| *   334227d (origin/main, main) merge bottom
+| |\  
+| |/  
+|/|   
+* | 141de4f (origin/top, origin/bottom, top, bottom) add bottom
+|/  
+* 563a7fc add base
+");
+
+    let mut workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 563a7fc
+    └── ≡📙:7:top <> origin/top →:6: on 563a7fc {1}
+        ├── 📙:7:top <> origin/top →:6:
+        └── 📙:8:bottom <> origin/bottom →:5:
+            └── ❄️141de4f (🏘️|✓)
+    ");
+
+    let bottom_bottom_commit = repo.rev_parse_single("bottom")?.object()?.id;
+    let project_meta = project_meta(&meta)?;
+    let out = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        project_meta.clone(),
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(bottom_bottom_commit),
+        }],
+    )?;
+
+    let ws_meta = out
+        .ws_meta
+        .as_ref()
+        .context("workspace metadata should be returned")?;
+    let branch_names = ws_meta
+        .stacks
+        .iter()
+        .flat_map(|stack| stack.branches.iter())
+        .map(|branch| branch.ref_name.as_ref())
+        .map(|ref_name| ref_name.shorten().to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        branch_names,
+        vec!["top"],
+        "workspace metadata should retain only the unmerged empty top branch"
+    );
+    out.rebase.materialize()?;
+    let graph = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?;
+    let workspace = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 563a7fc
+    └── ≡📙:2:top <> origin/top →:4: on 563a7fc {1}
+        └── 📙:2:top <> origin/top →:4:
+            └── ·334227d (🏘️|✓)
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * f381153 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   334227d (origin/main, top, main) merge bottom
+    |\  
+    | * 141de4f (origin/top, origin/bottom) add bottom
+    |/  
+    * 563a7fc add base
+    ");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- handle empty local branch references whose remote tip is already integrated into the target
- preserve empty branches when their lower branch has not been integrated
- add upstream integration fixtures and tests for both cases

## Test plan
- cargo test -p but-workspace upstream_integration
- cargo test -p but --test but command::pull::
- cargo test -p but --test but command::status::