### PR TITLE
feat(but-transaction): support moving commits

### DIFF
--- a/crates/but-api/src/commit/move_commit.rs
+++ b/crates/but-api/src/commit/move_commit.rs
@@ -1,11 +1,7 @@
-use anyhow::bail;
 use but_api_macros::but_api;
 use but_core::{DryRun, sync::RepoExclusive};
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
-use but_rebase::graph_rebase::{
-    Editor, LookupStep as _,
-    mutate::{InsertSide, RelativeTo},
-};
+use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
 use tracing::instrument;
 
 use crate::WorkspaceState;
@@ -54,49 +50,11 @@ pub fn commit_move_only_with_perm(
     dry_run: DryRun,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitMoveResult> {
-    if subject_commit_ids.is_empty() {
-        bail!("No commits were provided to move")
-    }
-
     let mut meta = ctx.meta()?;
     let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
-    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
-
-    let ordered_selectors = editor.order_commit_selectors_by_parentage(subject_commit_ids)?;
-    let mut ordered_ids = ordered_selectors
-        .iter()
-        .map(|selector| editor.lookup_pick(*selector))
-        .collect::<anyhow::Result<Vec<_>>>()?;
-
-    let ordered_ids = if matches!(side, InsertSide::Above) {
-        ordered_ids.reverse();
-        ordered_ids
-    } else {
-        ordered_ids
-    };
-
-    let mut subjects = ordered_ids.into_iter();
-    let first_subject = subjects
-        .next()
-        .expect("non-empty commit list always has a first subject");
-
-    let mut editor = but_workspace::commit::move_commit_no_rebase(
-        editor,
-        first_subject,
-        relative_to.clone(),
-        side,
-    )?;
-
-    for subject_id in subjects {
-        editor = but_workspace::commit::move_commit_no_rebase(
-            editor,
-            subject_id,
-            relative_to.clone(),
-            side,
-        )?;
-    }
-
-    let rebase = editor.rebase()?;
+    let editor = but_rebase::graph_rebase::Editor::create(&mut ws, &mut meta, &repo)?;
+    let rebase =
+        but_workspace::commit::move_commits(editor, subject_commit_ids, relative_to, side)?;
 
     Ok(CommitMoveResult {
         workspace: WorkspaceState::from_successful_rebase(rebase, &repo, dry_run)?,

--- a/crates/but-transaction/src/lib.rs
+++ b/crates/but-transaction/src/lib.rs
@@ -534,6 +534,28 @@ where
         })
     }
 
+    pub fn move_commits(
+        &mut self,
+        subject_commit_ids: impl IntoIterator<Item = ObjectId>,
+        relative_to: RelativeTo,
+        side: InsertSide,
+    ) -> anyhow::Result<()> {
+        self.rebase(|editor, commit_mappings, _| {
+            let subject_commit_ids = subject_commit_ids
+                .into_iter()
+                .map(|commit| commit_mappings.map(commit));
+            let relative_to = match relative_to {
+                RelativeTo::Commit(object_id) => RelativeTo::Commit(commit_mappings.map(object_id)),
+                RelativeTo::Reference(full_name) => RelativeTo::Reference(full_name),
+            };
+
+            let rebase =
+                but_workspace::commit::move_commits(editor, subject_commit_ids, relative_to, side)?;
+
+            Ok(((), rebase))
+        })
+    }
+
     pub fn amend_commit(
         &mut self,
         target: ObjectId,

--- a/crates/but-transaction/src/tests.rs
+++ b/crates/but-transaction/src/tests.rs
@@ -361,6 +361,104 @@ fn create_reference_then_commit_below_anchor_keeps_commit_in_workspace() {
 }
 
 #[test]
+fn move_commits_then_commit_relative_to_moved_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    let [three, one] = find_commits(&env, ["1e25c58", "dbdbcea"]);
+
+    let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
+    let mut ctx = Context::from_repo(repo)
+        .map(Context::with_memory_app_cache)
+        .unwrap();
+
+    let mut meta = ctx.meta().unwrap();
+    let snapshot_details = SnapshotDetails::new(OperationKind::MoveCommit);
+
+    let outcome = with_transaction(
+        &mut ctx,
+        &mut meta,
+        snapshot_details,
+        DryRun::No,
+        |mut tx| {
+            tx.move_commits([one], RelativeTo::Commit(three), InsertSide::Above)?;
+            let new_commit = tx.insert_blank_commit(RelativeTo::Commit(one), InsertSide::Above)?;
+
+            Ok(DynamicOutcome::<_, ()>::Commit(new_commit))
+        },
+    )
+    .unwrap();
+
+    let DynamicOutcome::Commit((new_commit, _workspace)) = outcome else {
+        panic!("transaction should commit");
+    };
+
+    assert_eq!(
+        Some(new_commit),
+        ref_target(
+            &env,
+            FullName::try_from("refs/heads/branch").unwrap().as_ref()
+        ),
+        "blank commit inserted relative to the moved commit should become the branch tip"
+    );
+    snapbox::assert_data_eq!(
+        env.git_log(),
+        snapbox::str![[r#"
+* 4eb318d (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* a381780 (branch) 
+* b18afe3 add file-one
+* 5fdd02a add file-three
+* 0d4aae5 add file-two
+* 6674d4f (origin/main, origin/HEAD, main, gitbutler/target) add random-file
+
+"#]]
+    );
+    assert_num_snapshots(&ctx, 1);
+}
+
+#[test]
+fn move_commits_reorders_multiple_subjects() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    let [three, two, one] = find_commits(&env, ["1e25c58", "9b3b3d5", "dbdbcea"]);
+
+    let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
+    let mut ctx = Context::from_repo(repo)
+        .map(Context::with_memory_app_cache)
+        .unwrap();
+
+    let mut meta = ctx.meta().unwrap();
+    let snapshot_details = SnapshotDetails::new(OperationKind::MoveCommit);
+
+    let _workspace: WorkspaceState = with_transaction(
+        &mut ctx,
+        &mut meta,
+        snapshot_details,
+        DryRun::No,
+        |mut tx| {
+            tx.move_commits([one, two], RelativeTo::Commit(three), InsertSide::Above)?;
+
+            Ok(())
+        },
+    )
+    .unwrap();
+
+    snapbox::assert_data_eq!(
+        env.git_log(),
+        snapbox::str![[r#"
+* 7fc8bdd (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* aedbf87 (branch) add file-two
+* 18aee11 add file-one
+* 647709c add file-three
+* 6674d4f (origin/main, origin/HEAD, main, gitbutler/target) add random-file
+
+"#]]
+    );
+    assert_num_snapshots(&ctx, 1);
+}
+
+#[test]
 fn create_reference_then_commit_relative_to_it() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.setup_metadata(&["A"]);

--- a/crates/but-workspace/src/commit/mod.rs
+++ b/crates/but-workspace/src/commit/mod.rs
@@ -58,7 +58,7 @@ pub use move_changes::{MoveChangesOutcome, move_changes_between_commits};
 pub mod uncommit_changes;
 pub use uncommit_changes::{UncommitChangesOutcome, uncommit_changes};
 pub mod move_commit;
-pub use move_commit::{move_commit, move_commit_no_rebase};
+pub use move_commit::{move_commit, move_commit_no_rebase, move_commits};
 pub mod discard_commit;
 pub use discard_commit::discard_commits;
 pub mod squash_commits;

--- a/crates/but-workspace/src/commit/move_commit.rs
+++ b/crates/but-workspace/src/commit/move_commit.rs
@@ -1,9 +1,10 @@
 //! Move a commit within or across branches and stacks.
 
+use anyhow::bail;
 use but_core::RefMetadata;
 use but_rebase::graph_rebase::{
-    Editor, SuccessfulRebase, ToCommitSelector, ToSelector,
-    mutate::{InsertSide, SegmentDelimiter, SelectorSet},
+    Editor, LookupStep as _, SuccessfulRebase, ToCommitSelector, ToSelector,
+    mutate::{InsertSide, RelativeTo, SegmentDelimiter, SelectorSet},
 };
 
 use crate::graph_manipulation::determine_parent_selector;
@@ -27,6 +28,48 @@ pub fn move_commit<'ws, 'meta, M: RefMetadata>(
     side: InsertSide,
 ) -> anyhow::Result<SuccessfulRebase<'ws, 'meta, M>> {
     let editor = move_commit_no_rebase(editor, subject_commit, anchor, side)?;
+    editor.rebase()
+}
+
+/// Move multiple commits.
+///
+/// The commits are ordered by parentage before moving so callers do not need to
+/// provide them in graph order.
+pub fn move_commits<'ws, 'meta, M: RefMetadata>(
+    editor: Editor<'ws, 'meta, M>,
+    subject_commit_ids: impl IntoIterator<Item = gix::ObjectId>,
+    relative_to: RelativeTo,
+    side: InsertSide,
+) -> anyhow::Result<SuccessfulRebase<'ws, 'meta, M>> {
+    let subject_commit_ids = subject_commit_ids.into_iter().collect::<Vec<_>>();
+    if subject_commit_ids.is_empty() {
+        bail!("No commits were provided to move")
+    }
+
+    let ordered_selectors = editor.order_commit_selectors_by_parentage(subject_commit_ids)?;
+    let mut ordered_ids = ordered_selectors
+        .iter()
+        .map(|selector| editor.lookup_pick(*selector))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    let ordered_ids = if matches!(side, InsertSide::Above) {
+        ordered_ids.reverse();
+        ordered_ids
+    } else {
+        ordered_ids
+    };
+
+    let mut subjects = ordered_ids.into_iter();
+    let first_subject = subjects
+        .next()
+        .expect("non-empty commit list always has a first subject");
+
+    let mut editor = move_commit_no_rebase(editor, first_subject, relative_to.clone(), side)?;
+
+    for subject_id in subjects {
+        editor = move_commit_no_rebase(editor, subject_id, relative_to.clone(), side)?;
+    }
+
     editor.rebase()
 }
 


### PR DESCRIPTION
For the new `but move2` command that @slarse and I are working we need to be able to move commits with but-transaction. This wasn't previously implemented. This was because but-api's version of the function did a bunch of sorting that but-transaction would also need.

Here I extract that code into but-workspace and changes it slightly so the caller can pass in an `Editor`. Then but-api and but-transaction can call that.

Consider reviewing just the first commit if you only care about the but-api and but-workspace changes.