### PR TITLE
fix(but): avoid paging for stage to not break prompting

### DIFF
--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -186,12 +186,7 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     #[cfg(feature = "legacy")]
     if matches!(
         &args.cmd,
-        Some(Subcommands::Status { .. })
-            | Some(Subcommands::Diff { tui: false, .. })
-            | Some(Subcommands::Stage {
-                file_or_hunk: Some(_),
-                ..
-            })
+        Some(Subcommands::Status { .. }) | Some(Subcommands::Diff { tui: false, .. })
     ) {
         out.request_pager();
     }


### PR DESCRIPTION
The pager makes prompting via crossterm impossible as crossterm can't determine the cursor position. You get output like this:

```
Waiting for data... (^X or interrupt to abort)
Error: Failed to stage.

Caused by:
    0: failed to setup picker tui
    1: The cursor position could not be read within a normal duration
```