### PR TITLE
fix(lite): restrict openInWebBrowser to http(s)

### DIFF
--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -559,9 +559,22 @@ const registerIpcHandlers = (): void => {
 		(_e, { projectId, editorId, path, lineNr }: OpenInEditorParams) =>
 			openInEditor(projectId, editorId, path, lineNr),
 	);
-	senderValidatingHandle(liteIpcChannels.openInWebBrowser, (_e, url: string) =>
-		shell.openExternal(url),
-	);
+	senderValidatingHandle(liteIpcChannels.openInWebBrowser, (_e, url: string) => {
+		// shell.openExternal() is powerful and dangerous. For example, on macOS you can launch a
+		// program with shell.openExternal("file:///Applications/Numbers.app"). Similarly bad
+		// things are possible on Windows and Linux.
+		//
+		// We need to be able to open relatively arbitrary URLs so we can't lock this down too much,
+		// but we can at least make sure the URL is a reasonable protocol so we don't allow e.g.
+		// "file:///Applications/Numbers.app" to pass through.
+		//
+		// https://www.electronjs.org/docs/latest/tutorial/security#15-do-not-use-shellopenexternal-with-untrusted-content
+		const protocol = newUrlOrNull(url)?.protocol ?? "";
+		if (!["https:", "http:"].includes(protocol))
+			throw new Error(`URL ${url} with unsupported protocol ${protocol}`);
+
+		return shell.openExternal(url);
+	});
 	senderValidatingHandle(liteIpcChannels.pathJoin, (_e, ...paths: Array<string>) =>
 		path.join(...paths),
 	);


### PR DESCRIPTION
`shell.openExternal()` is a powerful and dangerous function that should not be exposed wholesale to the renderer. On macOS, it's very similar to the `open` command you have in the shell. So a straight passhtrough to it is dangerous. For example, right now you can do this on macOS from the renderer:

```javascript
window.lite.openInWebBrowser("file:///Applications/Numbers.app")
```

Rather surprisingly, that will actually launch the Numbers app. Some more interesting examples on other platforms are available in this blog post: https://benjamin-altpeter.de/shell-openexternal-dangers/

Electron's security guidelines recommend you never expose this to untrusted content (see https://www.electronjs.org/docs/latest/tutorial/security#15-do-not-use-shellopenexternal-with-untrusted-content). I don't think we have the luxury of being so restrictive as to never pass user controlled content to this function, but at the very least we should make sure that what we're opening is a HTTP(s) URL.