### PR TITLE
fix(cli): use `anyhow::Result<_>` for CLI `run` functions

### DIFF
--- a/crates/but/src/command/legacy/commit2.rs
+++ b/crates/but/src/command/legacy/commit2.rs
@@ -8,7 +8,6 @@ use but_core::{
     sync::{RepoExclusive, RepoExclusiveGuard},
 };
 use but_ctx::Context;
-use but_error::Code;
 use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
 use but_transaction::{DynamicOutcome, IntermediateCommitCreateResult, Transaction};
 use but_workspace::{
@@ -287,22 +286,9 @@ fn run(
                 branch_name,
             )))
         },
-    );
+    )?;
 
-    let DynamicOutcome::Commit(((new_commit, branch_name), _ws)) = match result {
-        Ok(outcome) => outcome,
-        Err(err) => {
-            return Err(
-                if let Some(Code::EditorExitedWithNonZeroStatus) =
-                    err.downcast_ref::<but_error::Code>()
-                {
-                    bad_input("Editor exited with non-zero status").into()
-                } else {
-                    err.into()
-                },
-            );
-        }
-    };
+    let DynamicOutcome::Commit(((new_commit, branch_name), _ws)) = result;
 
     Ok(CommitOutcome {
         new_commit,

--- a/crates/but/src/command/legacy/reword2.rs
+++ b/crates/but/src/command/legacy/reword2.rs
@@ -1,6 +1,7 @@
 use bstr::BString;
 use but_api::diff::ComputeLineStats;
 use but_core::{RefMetadata, diff::CommitDetails};
+use but_error::Code;
 use but_transaction::Transaction;
 use gix::prelude::ObjectIdExt as _;
 
@@ -42,15 +43,27 @@ impl RewordCommitOperation {
 
                 let current_message = commit_details.commit.inner.message.to_string();
 
-                get_commit_message_from_editor(
+                match get_commit_message_from_editor(
                     tx.repo(),
                     tx.context_lines(),
                     commit_details,
                     current_message,
                     "",
                     ShowDiffInEditor::Unspecified,
-                )?
-                .unwrap_or_default()
+                ) {
+                    Ok(message) => message.unwrap_or_default(),
+                    Err(err) => {
+                        return Err(
+                            if let Some(Code::EditorExitedWithNonZeroStatus) =
+                                err.downcast_ref::<but_error::Code>()
+                            {
+                                anyhow::anyhow!("Editor exited with non-zero status")
+                            } else {
+                                err
+                            },
+                        );
+                    }
+                }
             }
         };
 

--- a/crates/but/src/command/legacy/squash2.rs
+++ b/crates/but/src/command/legacy/squash2.rs
@@ -774,7 +774,7 @@ fn run(
     meta: &mut impl RefMetadata,
     perm: &mut RepoExclusive,
     squash_op: SquashOperation,
-) -> CliResult<SquashOutcome> {
+) -> anyhow::Result<SquashOutcome> {
     let executable_op = match squash_op {
         SquashOperation::Commits(SquashCommitsOperation {
             mut sources,
@@ -968,12 +968,10 @@ fn run(
                     perm,
                 )?;
 
-                if is_workspace_conflicted(&workspace) {
-                    return Err(anyhow::anyhow!(
-                        "Cannot uncommit commits that would result in merge conflicts"
-                    )
-                    .into());
-                }
+                anyhow::ensure!(
+                    !is_workspace_conflicted(&workspace),
+                    "Cannot uncommit commits that would result in merge conflicts"
+                );
             }
 
             let but_api::commit::types::UncommitResult {
@@ -1003,12 +1001,10 @@ fn run(
                         perm,
                     )?;
 
-                if is_workspace_conflicted(&workspace) {
-                    return Err(anyhow::anyhow!(
-                        "Cannot uncommit hunks that would result in merge conflicts"
-                    )
-                    .into());
-                }
+                anyhow::ensure!(
+                    !is_workspace_conflicted(&workspace),
+                    "Cannot uncommit hunks that would result in merge conflicts"
+                );
             }
 
             let but_api::commit::types::MoveChangesResult { workspace: _ } =


### PR DESCRIPTION
I think it makes sense that only `resolve` can return `CliResult` since thats
where we parse user input. `run` probably should only encounter internally
errors.

The one exception is quitting the editor with non-zero but its probably fine
for that to be an internal error.