### PR TITLE
Lite: add head info index

### DIFF
--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -1,5 +1,5 @@
 import { encodeBytes } from "#ui/api/bytes.ts";
-import { findCommitStackId, renameBranchInHeadInfo } from "#ui/api/ref-info.ts";
+import { getHeadInfoIndex, renameBranchInHeadInfo } from "#ui/api/ref-info.ts";
 import {
 	changesInWorktreeQueryOptions,
 	getReviewMergeStatusQueryOptions,
@@ -464,8 +464,10 @@ export const useCommitInsertBlank = () => {
 		onSuccess: async (response, input, _context, mutation) => {
 			syncCoreCaches(mutation.client, dispatch, input.projectId, response);
 
-			const stackId = findCommitStackId(response.workspace.headInfo, response.newCommit);
-			if (stackId !== null)
+			const stackId = getHeadInfoIndex(response.workspace.headInfo).commitContextById(
+				response.newCommit,
+			)?.stack.id;
+			if (stackId != null)
 				dispatch(
 					projectActions.selectOutline({
 						projectId: input.projectId,

--- a/apps/lite/ui/src/api/ref-info.ts
+++ b/apps/lite/ui/src/api/ref-info.ts
@@ -1,32 +1,57 @@
 import { encodeBytes, bytesEqual } from "#ui/api/bytes.ts";
 import type { Commit, RefInfo, RelativeTo, Segment, Stack } from "@gitbutler/but-sdk";
 
+type StackIndex = {
+	stack: Stack;
+	stackIndex: number;
+};
+
+type SegmentIndex = {
+	segment: Segment;
+	segmentIndex: number;
+};
+
+type CommitIndex = {
+	commit: Commit;
+	commitIndex: number;
+};
+
 export type HeadInfoIndex = {
-	stackContextById: (stackId: string) => { stack: Stack } | undefined;
-	branchContextByRefBytes: (ref: Array<number>) => { stack: Stack; segment: Segment } | undefined;
-	commitContextById: (
-		commitId: string,
-	) => { stack: Stack; segment: Segment; commit: Commit } | undefined;
+	stackContextById: (stackId: string) => StackIndex | undefined;
+	branchContextByRefBytes: (ref: Array<number>) => (StackIndex & SegmentIndex) | undefined;
+	commitContextById: (commitId: string) => (StackIndex & SegmentIndex & CommitIndex) | undefined;
 };
 
 const headInfoIndexCache = new WeakMap<RefInfo, HeadInfoIndex>();
 
 const buildHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
-	const stackContextById = new Map<string, { stack: Stack }>();
-	const branchContextByRef = new Map<string, { stack: Stack; segment: Segment }>();
-	const commitContextById = new Map<string, { stack: Stack; segment: Segment; commit: Commit }>();
+	const stackContextById = new Map<string, StackIndex>();
+	const branchContextByRef = new Map<string, StackIndex & SegmentIndex>();
+	const commitContextById = new Map<string, StackIndex & SegmentIndex & CommitIndex>();
 
 	const branchRefKey = (ref: Array<number>): string => ref.join(",");
 
-	for (const stack of headInfo.stacks) {
-		if (stack.id !== null) stackContextById.set(stack.id, { stack });
+	for (const [stackIndex, stack] of headInfo.stacks.entries()) {
+		if (stack.id !== null) stackContextById.set(stack.id, { stack, stackIndex });
 
-		for (const segment of stack.segments) {
+		for (const [segmentIndex, segment] of stack.segments.entries()) {
 			if (segment.refName)
-				branchContextByRef.set(branchRefKey(segment.refName.fullNameBytes), { stack, segment });
+				branchContextByRef.set(branchRefKey(segment.refName.fullNameBytes), {
+					stack,
+					stackIndex,
+					segment,
+					segmentIndex,
+				});
 
-			for (const commit of segment.commits)
-				commitContextById.set(commit.id, { stack, segment, commit });
+			for (const [commitIndex, commit] of segment.commits.entries())
+				commitContextById.set(commit.id, {
+					stack,
+					stackIndex,
+					segment,
+					segmentIndex,
+					commit,
+					commitIndex,
+				});
 		}
 	}
 

--- a/apps/lite/ui/src/api/ref-info.ts
+++ b/apps/lite/ui/src/api/ref-info.ts
@@ -19,7 +19,9 @@ export type HeadInfoIndex = {
 	stackIdByCommitId: Map<string, string>;
 };
 
-export const getHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
+const headInfoIndexCache = new WeakMap<RefInfo, HeadInfoIndex>();
+
+const buildHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
 	const branchNameByCommitId = new Map<string, string | undefined>();
 	const branchOperandByRef = new Map<string, BranchOperand>();
 	const commitById = new Map<string, Commit>();
@@ -59,6 +61,15 @@ export const getHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
 		stackById,
 		stackIdByCommitId,
 	};
+};
+
+export const getHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
+	const cached = headInfoIndexCache.get(headInfo);
+	if (cached) return cached;
+
+	const index = buildHeadInfoIndex(headInfo);
+	headInfoIndexCache.set(headInfo, index);
+	return index;
 };
 
 export const findCommitStackId = (headInfo: RefInfo, commitId: string): string | null => {

--- a/apps/lite/ui/src/api/ref-info.ts
+++ b/apps/lite/ui/src/api/ref-info.ts
@@ -8,11 +8,9 @@ import {
 	type Stack,
 } from "@gitbutler/but-sdk";
 
-export const branchRefKey = (branchRef: Array<number>): string => branchRef.join(",");
-
 export type HeadInfoIndex = {
 	stackContextById: (stackId: string) => { stack: Stack } | undefined;
-	branchContextByRef: (ref: string) => { stack: Stack; segment: Segment } | undefined;
+	branchContextByRefBytes: (ref: Array<number>) => { stack: Stack; segment: Segment } | undefined;
 	commitContextById: (
 		commitId: string,
 	) => { stack: Stack; segment: Segment; commit: Commit } | undefined;
@@ -24,6 +22,8 @@ const buildHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
 	const stackContextById = new Map<string, { stack: Stack }>();
 	const branchContextByRef = new Map<string, { stack: Stack; segment: Segment }>();
 	const commitContextById = new Map<string, { stack: Stack; segment: Segment; commit: Commit }>();
+
+	const branchRefKey = (ref: Array<number>): string => ref.join(",");
 
 	for (const stack of headInfo.stacks) {
 		if (stack.id !== null) stackContextById.set(stack.id, { stack });
@@ -42,7 +42,7 @@ const buildHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
 
 	return {
 		stackContextById: (id: string) => stackContextById.get(id),
-		branchContextByRef: (ref: string) => branchContextByRef.get(ref),
+		branchContextByRefBytes: (ref: Array<number>) => branchContextByRef.get(branchRefKey(ref)),
 		commitContextById: (id: string) => commitContextById.get(id),
 	};
 };
@@ -133,13 +133,12 @@ export const resolveRelativeTo = ({
 			return relativeTo.subject;
 		case "referenceBytes":
 			return (
-				headInfoIndex.branchContextByRef(branchRefKey(relativeTo.subject))?.segment.commits[0]
-					?.id ?? null
+				headInfoIndex.branchContextByRefBytes(relativeTo.subject)?.segment.commits[0]?.id ?? null
 			);
 		case "reference":
 			return (
-				headInfoIndex.branchContextByRef(branchRefKey(encodeBytes(relativeTo.subject)))?.segment
-					.commits[0]?.id ?? null
+				headInfoIndex.branchContextByRefBytes(encodeBytes(relativeTo.subject))?.segment.commits[0]
+					?.id ?? null
 			);
 	}
 };

--- a/apps/lite/ui/src/api/ref-info.ts
+++ b/apps/lite/ui/src/api/ref-info.ts
@@ -1,11 +1,5 @@
 import { encodeBytes, bytesEqual } from "#ui/api/bytes.ts";
-import {
-	type Commit,
-	type RefInfo,
-	type RelativeTo,
-	type Segment,
-	type Stack,
-} from "@gitbutler/but-sdk";
+import type { Commit, RefInfo, RelativeTo, Segment, Stack } from "@gitbutler/but-sdk";
 
 export type HeadInfoIndex = {
 	stackContextById: (stackId: string) => { stack: Stack } | undefined;

--- a/apps/lite/ui/src/api/ref-info.ts
+++ b/apps/lite/ui/src/api/ref-info.ts
@@ -11,45 +11,37 @@ import {
 export const branchRefKey = (branchRef: Array<number>): string => branchRef.join(",");
 
 export type HeadInfoIndex = {
-	// files tree
-	branchNameByCommitId: Map<string, string | undefined>;
-	commitById: Map<string, Commit>;
-	// outline & label. label could probably get by w/o it
-	segmentByBranchRef: Map<string, Segment>;
-	// outline
-	stackById: Map<string, Stack>;
+	stackContextById: Map<string, { stack: Stack }>;
+	branchContextByRef: Map<string, { stack: Stack; segment: Segment }>;
+	commitContextById: Map<string, { stack: Stack; segment: Segment; commit: Commit }>;
 };
 
 const headInfoIndexCache = new WeakMap<RefInfo, HeadInfoIndex>();
 
 const buildHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
-	const branchNameByCommitId = new Map<string, string | undefined>();
-	const commitById = new Map<string, Commit>();
-	const segmentByBranchRef = new Map<string, Segment>();
-	const stackById = new Map<string, Stack>();
+	const stackContextById = new Map<string, { stack: Stack }>();
+	const branchContextByRef = new Map<string, { stack: Stack; segment: Segment }>();
+	const commitContextById = new Map<string, { stack: Stack; segment: Segment; commit: Commit }>();
 
 	for (const stack of headInfo.stacks) {
-		if (stack.id !== null) stackById.set(stack.id, stack);
+		if (stack.id !== null) stackContextById.set(stack.id, { stack });
 
 		for (const segment of stack.segments) {
 			if (segment.refName) {
 				const key = branchRefKey(segment.refName.fullNameBytes);
-				if (!segmentByBranchRef.has(key)) segmentByBranchRef.set(key, segment);
+				if (!branchContextByRef.has(key)) branchContextByRef.set(key, { stack, segment });
 			}
 
-			const branchName = segment.refName?.displayName;
-			for (const commit of segment.commits) {
-				branchNameByCommitId.set(commit.id, branchName);
-				if (!commitById.has(commit.id)) commitById.set(commit.id, commit);
-			}
+			for (const commit of segment.commits)
+				if (!commitContextById.has(commit.id))
+					commitContextById.set(commit.id, { stack, segment, commit });
 		}
 	}
 
 	return {
-		branchNameByCommitId,
-		commitById,
-		segmentByBranchRef,
-		stackById,
+		stackContextById,
+		branchContextByRef,
+		commitContextById,
 	};
 };
 
@@ -139,13 +131,13 @@ export const resolveRelativeTo = ({
 			return relativeTo.subject;
 		case "referenceBytes":
 			return (
-				headInfoIndex.segmentByBranchRef.get(branchRefKey(relativeTo.subject))?.commits[0]?.id ??
-				null
+				headInfoIndex.branchContextByRef.get(branchRefKey(relativeTo.subject))?.segment.commits[0]
+					?.id ?? null
 			);
 		case "reference":
 			return (
-				headInfoIndex.segmentByBranchRef.get(branchRefKey(encodeBytes(relativeTo.subject)))
-					?.commits[0]?.id ?? null
+				headInfoIndex.branchContextByRef.get(branchRefKey(encodeBytes(relativeTo.subject)))?.segment
+					.commits[0]?.id ?? null
 			);
 	}
 };

--- a/apps/lite/ui/src/api/ref-info.ts
+++ b/apps/lite/ui/src/api/ref-info.ts
@@ -1,45 +1,64 @@
 import { encodeBytes, bytesEqual } from "#ui/api/bytes.ts";
-import { BranchOperand } from "#ui/operands.ts";
-import { type Commit, type RefInfo, type RelativeTo, type Segment } from "@gitbutler/but-sdk";
+import { type BranchOperand } from "#ui/operands.ts";
+import {
+	type Commit,
+	type RefInfo,
+	type RelativeTo,
+	type Segment,
+	type Stack,
+} from "@gitbutler/but-sdk";
 
-export const getBranchNameByCommitId = (headInfo: RefInfo): Map<string, string | undefined> => {
-	const byCommitId = new Map<string, string | undefined>();
+export const branchRefKey = (branchRef: Array<number>): string => branchRef.join(",");
 
-	for (const stack of headInfo.stacks)
+export type HeadInfoIndex = {
+	branchNameByCommitId: Map<string, string | undefined>;
+	branchOperandByRef: Map<string, BranchOperand>;
+	commitById: Map<string, Commit>;
+	segmentByBranchRef: Map<string, Segment>;
+	stackById: Map<string, Stack>;
+	stackIdByCommitId: Map<string, string>;
+};
+
+export const getHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
+	const branchNameByCommitId = new Map<string, string | undefined>();
+	const branchOperandByRef = new Map<string, BranchOperand>();
+	const commitById = new Map<string, Commit>();
+	const segmentByBranchRef = new Map<string, Segment>();
+	const stackById = new Map<string, Stack>();
+	const stackIdByCommitId = new Map<string, string>();
+
+	for (const stack of headInfo.stacks) {
+		if (stack.id !== null) stackById.set(stack.id, stack);
+
 		for (const segment of stack.segments) {
+			if (segment.refName) {
+				const key = branchRefKey(segment.refName.fullNameBytes);
+				if (!segmentByBranchRef.has(key)) segmentByBranchRef.set(key, segment);
+				if (stack.id !== null && !branchOperandByRef.has(key))
+					branchOperandByRef.set(key, {
+						stackId: stack.id,
+						branchRef: segment.refName.fullNameBytes,
+					});
+			}
+
 			const branchName = segment.refName?.displayName;
-			for (const commit of segment.commits) byCommitId.set(commit.id, branchName);
+			for (const commit of segment.commits) {
+				branchNameByCommitId.set(commit.id, branchName);
+				if (!commitById.has(commit.id)) commitById.set(commit.id, commit);
+				if (stack.id !== null && !stackIdByCommitId.has(commit.id))
+					stackIdByCommitId.set(commit.id, stack.id);
+			}
 		}
+	}
 
-	return byCommitId;
-};
-
-export const getCommitById = (headInfo: RefInfo): Map<string, Commit> => {
-	const byCommitId = new Map<string, Commit>();
-
-	for (const stack of headInfo.stacks)
-		for (const segment of stack.segments)
-			for (const commit of segment.commits) byCommitId.set(commit.id, commit);
-
-	return byCommitId;
-};
-
-export const findCommit = ({
-	headInfo,
-	commitId,
-}: {
-	headInfo: RefInfo;
-	commitId: string;
-}): Commit | null => {
-	for (const stack of headInfo.stacks)
-		for (const segment of stack.segments) {
-			const commit = segment.commits.find((candidate) => candidate.id === commitId);
-			if (!commit) continue;
-
-			return commit;
-		}
-
-	return null;
+	return {
+		branchNameByCommitId,
+		branchOperandByRef,
+		commitById,
+		segmentByBranchRef,
+		stackById,
+		stackIdByCommitId,
+	};
 };
 
 export const findCommitStackId = (headInfo: RefInfo, commitId: string): string | null => {
@@ -49,20 +68,6 @@ export const findCommitStackId = (headInfo: RefInfo, commitId: string): string |
 		for (const segment of stack.segments)
 			if (segment.commits.some((commit) => commit.id === commitId)) return stack.id;
 	}
-
-	return null;
-};
-
-export const findSegmentByBranchRef = ({
-	headInfo,
-	branchRef,
-}: {
-	headInfo: RefInfo;
-	branchRef: Array<number>;
-}): Segment | null => {
-	for (const stack of headInfo.stacks)
-		for (const segment of stack.segments)
-			if (segment.refName && bytesEqual(segment.refName.fullNameBytes, branchRef)) return segment;
 
 	return null;
 };
@@ -122,10 +127,10 @@ export const renameBranchInHeadInfo = ({
 });
 
 export const resolveRelativeTo = ({
-	headInfo,
+	headInfoIndex,
 	relativeTo,
 }: {
-	headInfo: RefInfo;
+	headInfoIndex: HeadInfoIndex;
 	relativeTo: RelativeTo;
 }): string | null => {
 	switch (relativeTo.type) {
@@ -133,12 +138,13 @@ export const resolveRelativeTo = ({
 			return relativeTo.subject;
 		case "referenceBytes":
 			return (
-				findSegmentByBranchRef({ headInfo, branchRef: relativeTo.subject })?.commits[0]?.id ?? null
+				headInfoIndex.segmentByBranchRef.get(branchRefKey(relativeTo.subject))?.commits[0]?.id ??
+				null
 			);
 		case "reference":
 			return (
-				findSegmentByBranchRef({ headInfo, branchRef: encodeBytes(relativeTo.subject) })?.commits[0]
-					?.id ?? null
+				headInfoIndex.segmentByBranchRef.get(branchRefKey(encodeBytes(relativeTo.subject)))
+					?.commits[0]?.id ?? null
 			);
 	}
 };

--- a/apps/lite/ui/src/api/ref-info.ts
+++ b/apps/lite/ui/src/api/ref-info.ts
@@ -11,10 +11,12 @@ import {
 export const branchRefKey = (branchRef: Array<number>): string => branchRef.join(",");
 
 export type HeadInfoIndex = {
+	// files tree
 	branchNameByCommitId: Map<string, string | undefined>;
-	branchOperandByRef: Map<string, BranchOperand>;
 	commitById: Map<string, Commit>;
+	// outline & label. label could probably get by w/o it
 	segmentByBranchRef: Map<string, Segment>;
+	// outline
 	stackById: Map<string, Stack>;
 };
 
@@ -22,7 +24,6 @@ const headInfoIndexCache = new WeakMap<RefInfo, HeadInfoIndex>();
 
 const buildHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
 	const branchNameByCommitId = new Map<string, string | undefined>();
-	const branchOperandByRef = new Map<string, BranchOperand>();
 	const commitById = new Map<string, Commit>();
 	const segmentByBranchRef = new Map<string, Segment>();
 	const stackById = new Map<string, Stack>();
@@ -34,11 +35,6 @@ const buildHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
 			if (segment.refName) {
 				const key = branchRefKey(segment.refName.fullNameBytes);
 				if (!segmentByBranchRef.has(key)) segmentByBranchRef.set(key, segment);
-				if (stack.id !== null && !branchOperandByRef.has(key))
-					branchOperandByRef.set(key, {
-						stackId: stack.id,
-						branchRef: segment.refName.fullNameBytes,
-					});
 			}
 
 			const branchName = segment.refName?.displayName;
@@ -51,7 +47,6 @@ const buildHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
 
 	return {
 		branchNameByCommitId,
-		branchOperandByRef,
 		commitById,
 		segmentByBranchRef,
 		stackById,

--- a/apps/lite/ui/src/api/ref-info.ts
+++ b/apps/lite/ui/src/api/ref-info.ts
@@ -16,7 +16,6 @@ export type HeadInfoIndex = {
 	commitById: Map<string, Commit>;
 	segmentByBranchRef: Map<string, Segment>;
 	stackById: Map<string, Stack>;
-	stackIdByCommitId: Map<string, string>;
 };
 
 const headInfoIndexCache = new WeakMap<RefInfo, HeadInfoIndex>();
@@ -27,7 +26,6 @@ const buildHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
 	const commitById = new Map<string, Commit>();
 	const segmentByBranchRef = new Map<string, Segment>();
 	const stackById = new Map<string, Stack>();
-	const stackIdByCommitId = new Map<string, string>();
 
 	for (const stack of headInfo.stacks) {
 		if (stack.id !== null) stackById.set(stack.id, stack);
@@ -47,8 +45,6 @@ const buildHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
 			for (const commit of segment.commits) {
 				branchNameByCommitId.set(commit.id, branchName);
 				if (!commitById.has(commit.id)) commitById.set(commit.id, commit);
-				if (stack.id !== null && !stackIdByCommitId.has(commit.id))
-					stackIdByCommitId.set(commit.id, stack.id);
 			}
 		}
 	}
@@ -59,7 +55,6 @@ const buildHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
 		commitById,
 		segmentByBranchRef,
 		stackById,
-		stackIdByCommitId,
 	};
 };
 

--- a/apps/lite/ui/src/api/ref-info.ts
+++ b/apps/lite/ui/src/api/ref-info.ts
@@ -1,5 +1,4 @@
 import { encodeBytes, bytesEqual } from "#ui/api/bytes.ts";
-import { type BranchOperand } from "#ui/operands.ts";
 import {
 	type Commit,
 	type RefInfo,
@@ -51,35 +50,6 @@ export const getHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
 	const index = buildHeadInfoIndex(headInfo);
 	headInfoIndexCache.set(headInfo, index);
 	return index;
-};
-
-export const findCommitStackId = (headInfo: RefInfo, commitId: string): string | null => {
-	for (const stack of headInfo.stacks) {
-		if (stack.id === null) continue;
-
-		for (const segment of stack.segments)
-			if (segment.commits.some((commit) => commit.id === commitId)) return stack.id;
-	}
-
-	return null;
-};
-
-export const findBranchOperandByRef = ({
-	headInfo,
-	branchRef,
-}: {
-	headInfo: RefInfo;
-	branchRef: Array<number>;
-}): BranchOperand | null => {
-	for (const stack of headInfo.stacks) {
-		if (stack.id === null) continue;
-
-		for (const segment of stack.segments)
-			if (segment.refName && bytesEqual(segment.refName.fullNameBytes, branchRef))
-				return { stackId: stack.id, branchRef };
-	}
-
-	return null;
 };
 
 export const renameBranchInHeadInfo = ({

--- a/apps/lite/ui/src/api/ref-info.ts
+++ b/apps/lite/ui/src/api/ref-info.ts
@@ -14,6 +14,16 @@ export const getBranchNameByCommitId = (headInfo: RefInfo): Map<string, string |
 	return byCommitId;
 };
 
+export const getCommitById = (headInfo: RefInfo): Map<string, Commit> => {
+	const byCommitId = new Map<string, Commit>();
+
+	for (const stack of headInfo.stacks)
+		for (const segment of stack.segments)
+			for (const commit of segment.commits) byCommitId.set(commit.id, commit);
+
+	return byCommitId;
+};
+
 export const findCommit = ({
 	headInfo,
 	commitId,

--- a/apps/lite/ui/src/api/ref-info.ts
+++ b/apps/lite/ui/src/api/ref-info.ts
@@ -29,14 +29,11 @@ const buildHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
 		if (stack.id !== null) stackContextById.set(stack.id, { stack });
 
 		for (const segment of stack.segments) {
-			if (segment.refName) {
-				const key = branchRefKey(segment.refName.fullNameBytes);
-				if (!branchContextByRef.has(key)) branchContextByRef.set(key, { stack, segment });
-			}
+			if (segment.refName)
+				branchContextByRef.set(branchRefKey(segment.refName.fullNameBytes), { stack, segment });
 
 			for (const commit of segment.commits)
-				if (!commitContextById.has(commit.id))
-					commitContextById.set(commit.id, { stack, segment, commit });
+				commitContextById.set(commit.id, { stack, segment, commit });
 		}
 	}
 

--- a/apps/lite/ui/src/api/ref-info.ts
+++ b/apps/lite/ui/src/api/ref-info.ts
@@ -11,9 +11,11 @@ import {
 export const branchRefKey = (branchRef: Array<number>): string => branchRef.join(",");
 
 export type HeadInfoIndex = {
-	stackContextById: Map<string, { stack: Stack }>;
-	branchContextByRef: Map<string, { stack: Stack; segment: Segment }>;
-	commitContextById: Map<string, { stack: Stack; segment: Segment; commit: Commit }>;
+	stackContextById: (stackId: string) => { stack: Stack } | undefined;
+	branchContextByRef: (ref: string) => { stack: Stack; segment: Segment } | undefined;
+	commitContextById: (
+		commitId: string,
+	) => { stack: Stack; segment: Segment; commit: Commit } | undefined;
 };
 
 const headInfoIndexCache = new WeakMap<RefInfo, HeadInfoIndex>();
@@ -39,9 +41,9 @@ const buildHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
 	}
 
 	return {
-		stackContextById,
-		branchContextByRef,
-		commitContextById,
+		stackContextById: (id: string) => stackContextById.get(id),
+		branchContextByRef: (ref: string) => branchContextByRef.get(ref),
+		commitContextById: (id: string) => commitContextById.get(id),
 	};
 };
 
@@ -131,12 +133,12 @@ export const resolveRelativeTo = ({
 			return relativeTo.subject;
 		case "referenceBytes":
 			return (
-				headInfoIndex.branchContextByRef.get(branchRefKey(relativeTo.subject))?.segment.commits[0]
+				headInfoIndex.branchContextByRef(branchRefKey(relativeTo.subject))?.segment.commits[0]
 					?.id ?? null
 			);
 		case "reference":
 			return (
-				headInfoIndex.branchContextByRef.get(branchRefKey(encodeBytes(relativeTo.subject)))?.segment
+				headInfoIndex.branchContextByRef(branchRefKey(encodeBytes(relativeTo.subject)))?.segment
 					.commits[0]?.id ?? null
 			);
 	}

--- a/apps/lite/ui/src/projects/workspace/state.ts
+++ b/apps/lite/ui/src/projects/workspace/state.ts
@@ -24,7 +24,7 @@ import {
 	type OutlineMode,
 	type TransferOperationMode,
 } from "#ui/outline/mode.ts";
-import { findCommitStackId } from "#ui/api/ref-info.ts";
+import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
 import { mapKeys } from "effect/Record";
 
 export type SelectionState = {
@@ -214,8 +214,8 @@ const rewrittenCommitOperand = ({
 	const commitId = replacedCommits[commit.commitId];
 	if (commitId === undefined) return null;
 
-	const stackId = findCommitStackId(headInfo, commitId);
-	if (stackId === null) return null;
+	const stackId = getHeadInfoIndex(headInfo).commitContextById(commitId)?.stack.id;
+	if (stackId == null) return null;
 
 	return { stackId, commitId };
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/DependencyIndicator.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DependencyIndicator.tsx
@@ -1,10 +1,7 @@
-import { headInfoQueryOptions } from "#ui/api/queries.ts";
-import { getBranchNameByCommitId } from "#ui/api/ref-info.ts";
 import { projectActions } from "#ui/projects/state.ts";
 import { useAppDispatch } from "#ui/store.ts";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
 import { Tooltip } from "@base-ui/react";
-import { useQuery } from "@tanstack/react-query";
 import { Array, pipe } from "effect";
 import { ComponentProps, FC } from "react";
 
@@ -12,17 +9,13 @@ export const DependencyIndicator: FC<
 	{
 		projectId: string;
 		commitIds: Array.NonEmptyArray<string>;
+		branchNameByCommitId?: Map<string, string | undefined>;
 	} & ComponentProps<"button">
-> = ({ projectId, commitIds, ...restProps }) => {
+> = ({ projectId, commitIds, branchNameByCommitId, ...restProps }) => {
 	const dispatch = useAppDispatch();
-	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
-	// TODO: expensive
-	const branchNameByCommitId = headInfo
-		? getBranchNameByCommitId(headInfo)
-		: new Map<string, string>();
 	const branchNames = pipe(
 		commitIds,
-		Array.flatMapNullable((commitId) => branchNameByCommitId.get(commitId)),
+		Array.flatMapNullable((commitId) => branchNameByCommitId?.get(commitId)),
 		Array.dedupe,
 	);
 	const tooltip =

--- a/apps/lite/ui/src/routes/project/$id/workspace/DependencyIndicator.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DependencyIndicator.tsx
@@ -9,13 +9,13 @@ export const DependencyIndicator: FC<
 	{
 		projectId: string;
 		commitIds: Array.NonEmptyArray<string>;
-		branchNameByCommitId?: Map<string, string | undefined>;
+		branchNameByCommitId?: (commitId: string) => string | undefined;
 	} & ComponentProps<"button">
 > = ({ projectId, commitIds, branchNameByCommitId, ...restProps }) => {
 	const dispatch = useAppDispatch();
 	const branchNames = pipe(
 		commitIds,
-		Array.flatMapNullable((commitId) => branchNameByCommitId?.get(commitId)),
+		Array.flatMapNullable((commitId) => branchNameByCommitId?.(commitId)),
 		Array.dedupe,
 	);
 	const tooltip =

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
@@ -190,7 +190,9 @@ export const FilesTree: FC<
 													onFileSelection={onFileSelection}
 													projectId={projectId}
 													fileParent={fileParent}
-													branchNameByCommitId={headInfoIndex?.branchNameByCommitId}
+													branchNameByCommitId={(cid) =>
+														headInfoIndex?.commitContextById.get(cid)?.segment.refName?.displayName
+													}
 												/>
 											}
 										/>
@@ -261,7 +263,7 @@ const FileRow: FC<
 		item: FileTreeItem;
 		projectId: string;
 		fileParent: FileParent;
-		branchNameByCommitId?: Map<string, string | undefined>;
+		branchNameByCommitId?: (commitId: string) => string | undefined;
 	} & Omit<ComponentProps<typeof ItemRow>, "projectId">
 > = ({ item, projectId, fileParent, branchNameByCommitId, id, ...restProps }) => {
 	const relativePath = item._tag === "Change" ? item.change.path : item.path;

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
@@ -1,5 +1,6 @@
 import workspaceItemRowStyles from "./WorkspaceItemRow.module.css";
-import { changesInWorktreeQueryOptions } from "#ui/api/queries.ts";
+import { changesInWorktreeQueryOptions, headInfoQueryOptions } from "#ui/api/queries.ts";
+import { getBranchNameByCommitId } from "#ui/api/ref-info.ts";
 import { showNativeContextMenu, showNativeMenuFromTrigger } from "#ui/native-menu.ts";
 import { uncommittedChangesFileParent, fileOperand, FileParent } from "#ui/operands.ts";
 import {
@@ -131,6 +132,10 @@ export const FilesTree: FC<
 	...props
 }) => {
 	const selection = useFilesSelection(projectId, navigationIndex);
+	const { data: branchNameByCommitId } = useQuery({
+		...headInfoQueryOptions(projectId),
+		select: getBranchNameByCommitId,
+	});
 
 	const ref = useRef<HTMLDivElement>(null);
 
@@ -185,6 +190,7 @@ export const FilesTree: FC<
 													onFileSelection={onFileSelection}
 													projectId={projectId}
 													fileParent={fileParent}
+													branchNameByCommitId={branchNameByCommitId}
 												/>
 											}
 										/>
@@ -255,8 +261,9 @@ const FileRow: FC<
 		item: FileTreeItem;
 		projectId: string;
 		fileParent: FileParent;
+		branchNameByCommitId?: Map<string, string | undefined>;
 	} & Omit<ComponentProps<typeof ItemRow>, "projectId">
-> = ({ item, projectId, fileParent, id, ...restProps }) => {
+> = ({ item, projectId, fileParent, branchNameByCommitId, id, ...restProps }) => {
 	const relativePath = item._tag === "Change" ? item.change.path : item.path;
 
 	const outlineMode = useAppSelector((state) => selectProjectOutlineModeState(state, projectId));
@@ -339,6 +346,7 @@ const FileRow: FC<
 										<DependencyIndicator
 											projectId={projectId}
 											commitIds={item.dependencyCommitIds}
+											branchNameByCommitId={branchNameByCommitId}
 											className={getWorkspaceItemRowButtonClassName({ iconOnly: true })}
 										/>
 									}

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
@@ -191,7 +191,7 @@ export const FilesTree: FC<
 													projectId={projectId}
 													fileParent={fileParent}
 													branchNameByCommitId={(cid) =>
-														headInfoIndex?.commitContextById.get(cid)?.segment.refName?.displayName
+														headInfoIndex?.commitContextById(cid)?.segment.refName?.displayName
 													}
 												/>
 											}

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
@@ -1,6 +1,6 @@
 import workspaceItemRowStyles from "./WorkspaceItemRow.module.css";
 import { changesInWorktreeQueryOptions, headInfoQueryOptions } from "#ui/api/queries.ts";
-import { getBranchNameByCommitId } from "#ui/api/ref-info.ts";
+import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
 import { showNativeContextMenu, showNativeMenuFromTrigger } from "#ui/native-menu.ts";
 import { uncommittedChangesFileParent, fileOperand, FileParent } from "#ui/operands.ts";
 import {
@@ -132,9 +132,9 @@ export const FilesTree: FC<
 	...props
 }) => {
 	const selection = useFilesSelection(projectId, navigationIndex);
-	const { data: branchNameByCommitId } = useQuery({
+	const { data: headInfoIndex } = useQuery({
 		...headInfoQueryOptions(projectId),
-		select: getBranchNameByCommitId,
+		select: getHeadInfoIndex,
 	});
 
 	const ref = useRef<HTMLDivElement>(null);
@@ -190,7 +190,7 @@ export const FilesTree: FC<
 													onFileSelection={onFileSelection}
 													projectId={projectId}
 													fileParent={fileParent}
-													branchNameByCommitId={branchNameByCommitId}
+													branchNameByCommitId={headInfoIndex?.branchNameByCommitId}
 												/>
 											}
 										/>

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
@@ -1,5 +1,6 @@
 import { useAbsorb } from "#ui/api/mutations.ts";
 import { absorptionPlanQueryOptions, headInfoQueryOptions } from "#ui/api/queries.ts";
+import { getHeadInfoIndex, type HeadInfoIndex } from "#ui/api/ref-info.ts";
 import { assert } from "#ui/assert.ts";
 import { getButtonClassName } from "#ui/components/Button.tsx";
 import { classes } from "#ui/components/classes.ts";
@@ -26,7 +27,6 @@ import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { Button, Tooltip } from "@base-ui/react";
 import { Toggle } from "@base-ui/react/toggle";
 import { ToggleGroup } from "@base-ui/react/toggle-group";
-import { type RefInfo } from "@gitbutler/but-sdk";
 import { useHotkeys, type UseHotkeyDefinition } from "@tanstack/react-hotkeys";
 import { useQuery } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
@@ -162,10 +162,10 @@ const CheckedCommitOperationControls: FC<{ checkedCommitCount: number; projectId
 };
 
 const AbsorbOperationControls: FC<{
-	headInfo: RefInfo;
+	headInfoIndex: HeadInfoIndex;
 	projectId: string;
 	mode: AbsorbMode;
-}> = ({ headInfo, projectId, mode }) => {
+}> = ({ headInfoIndex, projectId, mode }) => {
 	const dispatch = useAppDispatch();
 	const absorptionPlan = useQuery(
 		absorptionPlanQueryOptions({ projectId, target: mode.sourceTarget }),
@@ -195,7 +195,7 @@ const AbsorbOperationControls: FC<{
 					<Label>Failed to load absorb plan</Label>
 				) : (
 					<Label>
-						Absorb {operandLabel({ headInfo, operand: mode.source })} into{" "}
+						Absorb {operandLabel({ headInfoIndex, operand: mode.source })} into{" "}
 						{absorptionPlan.data.length} commits
 					</Label>
 				)}
@@ -292,11 +292,11 @@ const TransferTypeToggleGroup: FC<{
 };
 
 const TransferKeyboardOperationControls: FC<{
-	headInfo: RefInfo;
+	headInfoIndex: HeadInfoIndex;
 	projectId: string;
 	mode: KeyboardTransferOperationMode;
 	target: Operand;
-}> = ({ headInfo, projectId, mode, target }) => {
+}> = ({ headInfoIndex, projectId, mode, target }) => {
 	const dispatch = useAppDispatch();
 	const { mutate: runOperation } = useRunOperation();
 	const operations = getOperations(mode.source, target);
@@ -326,8 +326,8 @@ const TransferKeyboardOperationControls: FC<{
 			<Separator />
 			<ControlsRow>
 				<Label>
-					<div>Source: {operandLabel({ headInfo, operand: mode.source })}</div>
-					<div>Target: {operandLabel({ headInfo, operand: target })}</div>
+					<div>Source: {operandLabel({ headInfoIndex, operand: mode.source })}</div>
+					<div>Target: {operandLabel({ headInfoIndex, operand: target })}</div>
 				</Label>
 				<Controls
 					onCancel={cancel}
@@ -352,7 +352,10 @@ export const OperationControls: FC = () => {
 	const navigationIndex = assert(use(NavigationIndexContext));
 	const selection = useOutlineSelection({ projectId, navigationIndex });
 	const outlineMode = useAppSelector((state) => selectProjectOutlineModeState(state, projectId));
-	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
+	const { data: headInfoIndex } = useQuery({
+		...headInfoQueryOptions(projectId),
+		select: getHeadInfoIndex,
+	});
 	const checkedCommitCount = useAppSelector((state) =>
 		selectProjectCheckedCommitCount(state, projectId),
 	);
@@ -367,17 +370,21 @@ export const OperationControls: FC = () => {
 					/>
 				),
 			Absorb: (mode) =>
-				headInfo && (
-					<AbsorbOperationControls headInfo={headInfo} projectId={projectId} mode={mode} />
+				headInfoIndex && (
+					<AbsorbOperationControls
+						headInfoIndex={headInfoIndex}
+						projectId={projectId}
+						mode={mode}
+					/>
 				),
 			Transfer: ({ value: mode }) =>
 				Match.value(mode).pipe(
 					Match.tags({
 						Keyboard: (mode) =>
 							selection &&
-							headInfo && (
+							headInfoIndex && (
 								<TransferKeyboardOperationControls
-									headInfo={headInfo}
+									headInfoIndex={headInfoIndex}
 									projectId={projectId}
 									mode={mode}
 									target={selection}

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationSourceC.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationSourceC.tsx
@@ -3,6 +3,7 @@ import { getOperationSource, pointerTransferOperationMode } from "#ui/outline/mo
 import styles from "./OperationSourceC.module.css";
 import { operandLabel } from "./operandLabel.ts";
 import { headInfoQueryOptions } from "#ui/api/queries.ts";
+import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
 import { classes } from "#ui/components/classes.ts";
 import { projectActions, selectProjectOutlineModeState } from "#ui/projects/state.ts";
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
@@ -29,7 +30,10 @@ export const OperationSourceC: FC<
 		source: Operand;
 	} & Omit<useRender.ComponentProps<"div">, "onDragStart">
 > = ({ onDragStart: onDragStartProp, projectId, source, render, ...props }) => {
-	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
+	const { data: headInfoIndex } = useQuery({
+		...headInfoQueryOptions(projectId),
+		select: getHeadInfoIndex,
+	});
 	const outlineMode = useAppSelector((state) => selectProjectOutlineModeState(state, projectId));
 
 	const dispatch = useAppDispatch();
@@ -40,9 +44,11 @@ export const OperationSourceC: FC<
 				nativeSetDragImage,
 				getOffset: centerUnderPointer,
 				render: ({ container }) => {
-					if (!headInfo) return;
+					if (!headInfoIndex) return;
 					const root = createRoot(container);
-					root.render(<DragPreview>{operandLabel({ operand: source, headInfo })}</DragPreview>);
+					root.render(
+						<DragPreview>{operandLabel({ operand: source, headInfoIndex })}</DragPreview>,
+					);
 					return () => {
 						root.unmount();
 					};

--- a/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
@@ -1,6 +1,6 @@
 import { useBranchCreate, useWorkspaceIntegrateUpstream } from "#ui/api/mutations.ts";
 import { headInfoQueryOptions } from "#ui/api/queries.ts";
-import { findBranchOperandByRef } from "#ui/api/ref-info.ts";
+import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
 import { stackBottomRelativeTo } from "#ui/api/stack.ts";
 import { getButtonClassName } from "#ui/components/Button.tsx";
 import { classes } from "#ui/components/classes.ts";
@@ -80,11 +80,12 @@ export const Outline: FC<
 			},
 			{
 				onSuccess: (response) => {
-					const newBranch = findBranchOperandByRef({
-						headInfo: response.workspace.headInfo,
-						branchRef: response.newRef.fullNameBytes,
-					});
-					if (newBranch) selectBranch(newBranch);
+					const newBranchStack = getHeadInfoIndex(
+						response.workspace.headInfo,
+					).branchContextByRefBytes(response.newRef.fullNameBytes)?.stack;
+
+					if (newBranchStack && newBranchStack.id !== null)
+						selectBranch({ stackId: newBranchStack.id, branchRef: response.newRef.fullNameBytes });
 				},
 			},
 		);

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
@@ -25,7 +25,6 @@ import {
 	treeChangeDiffsQueryOptions,
 } from "#ui/api/queries.ts";
 import {
-	branchRefKey,
 	findBranchOperandByRef,
 	getHeadInfoIndex,
 	resolveRelativeTo,
@@ -203,7 +202,7 @@ const useOutlineTreeHotkeys = ({
 			: undefined;
 	const selectedBranchSegment =
 		selection?._tag === "Branch"
-			? headInfoIndex?.branchContextByRef(branchRefKey(selection.branchRef))?.segment
+			? headInfoIndex?.branchContextByRefBytes(selection.branchRef)?.segment
 			: undefined;
 
 	const selectedBranchCommitsChecked = useAppSelector((state) =>

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
@@ -24,12 +24,7 @@ import {
 	listProjectsQueryOptions,
 	treeChangeDiffsQueryOptions,
 } from "#ui/api/queries.ts";
-import {
-	findBranchOperandByRef,
-	getHeadInfoIndex,
-	resolveRelativeTo,
-	type HeadInfoIndex,
-} from "#ui/api/ref-info.ts";
+import { getHeadInfoIndex, resolveRelativeTo, type HeadInfoIndex } from "#ui/api/ref-info.ts";
 import { decodeBytes, bytesEqual } from "#ui/api/bytes.ts";
 import { commitBody, commitForgeUrl, commitIsDiverged, commitTitle } from "#ui/commit.ts";
 import {
@@ -308,15 +303,18 @@ const useOutlineTreeHotkeys = ({
 			},
 			{
 				onSuccess: (response) => {
-					const newBranch = findBranchOperandByRef({
-						headInfo: response.workspace.headInfo,
-						branchRef: response.newRef.fullNameBytes,
-					});
-					if (newBranch)
+					const newBranchStack = getHeadInfoIndex(
+						response.workspace.headInfo,
+					).branchContextByRefBytes(response.newRef.fullNameBytes)?.stack;
+
+					if (newBranchStack && newBranchStack.id !== null)
 						dispatch(
 							projectActions.selectOutline({
 								projectId,
-								selection: branchOperand(newBranch),
+								selection: branchOperand({
+									stackId: newBranchStack.id,
+									branchRef: response.newRef.fullNameBytes,
+								}),
 							}),
 						);
 				},
@@ -1168,15 +1166,18 @@ const CommitRow: FC<
 			},
 			{
 				onSuccess: (response) => {
-					const newBranch = findBranchOperandByRef({
-						headInfo: response.workspace.headInfo,
-						branchRef: response.newRef.fullNameBytes,
-					});
-					if (newBranch)
+					const newBranchStack = getHeadInfoIndex(
+						response.workspace.headInfo,
+					).branchContextByRefBytes(response.newRef.fullNameBytes)?.stack;
+
+					if (newBranchStack && newBranchStack.id !== null)
 						dispatch(
 							projectActions.selectOutline({
 								projectId,
-								selection: branchOperand(newBranch),
+								selection: branchOperand({
+									stackId: newBranchStack.id,
+									branchRef: response.newRef.fullNameBytes,
+								}),
 							}),
 						);
 				},
@@ -2232,15 +2233,18 @@ const BranchRow: FC<
 			},
 			{
 				onSuccess: (response) => {
-					const newBranch = findBranchOperandByRef({
-						headInfo: response.workspace.headInfo,
-						branchRef: response.newRef.fullNameBytes,
-					});
-					if (newBranch)
+					const newBranchStack = getHeadInfoIndex(
+						response.workspace.headInfo,
+					).branchContextByRefBytes(response.newRef.fullNameBytes)?.stack;
+
+					if (newBranchStack && newBranchStack.id !== null)
 						dispatch(
 							projectActions.selectOutline({
 								projectId,
-								selection: branchOperand(newBranch),
+								selection: branchOperand({
+									stackId: newBranchStack.id,
+									branchRef: response.newRef.fullNameBytes,
+								}),
 							}),
 						);
 				},

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
@@ -408,32 +408,20 @@ const useOutlineTreeHotkeys = ({
 		);
 	};
 
-	const selectedPushContext = Match.value(selection).pipe(
-		Match.tags({
-			Branch: (selection) => {
-				if (!selectedStack || selectedStack.id === null) return null;
+	const selectedSegmentIndex =
+		selection?._tag === "Branch"
+			? headInfoIndex?.branchContextByRefBytes(selection.branchRef)?.segmentIndex
+			: selection?._tag === "Commit"
+				? headInfoIndex?.commitContextById(selection.commitId)?.segmentIndex
+				: undefined;
 
-				const segmentIndex = selectedStack.segments.findIndex(
-					(segment) =>
-						!!segment.refName && bytesEqual(segment.refName.fullNameBytes, selection.branchRef),
-				);
-				if (segmentIndex === -1) return null;
-
-				return pushContextForSegment({ segments: selectedStack.segments, segmentIndex });
-			},
-			Commit: (selection) => {
-				if (!selectedStack || selectedStack.id === null) return null;
-
-				const segmentIndex = selectedStack.segments.findIndex((segment) =>
-					segment.commits.some((commit) => commit.id === selection.commitId),
-				);
-				if (segmentIndex === -1) return null;
-
-				return pushContextForSegment({ segments: selectedStack.segments, segmentIndex });
-			},
-		}),
-		Match.orElse(() => null),
-	);
+	const selectedPushContext =
+		selectedStack && selectedSegmentIndex !== undefined
+			? pushContextForSegment({
+					segments: selectedStack.segments,
+					segmentIndex: selectedSegmentIndex,
+				})
+			: null;
 	const selectedStackRelativeTo = selectedStack ? stackBottomRelativeTo(selectedStack) : null;
 	const selectedStackRebaseUpdate: BottomUpdate | null = selectedStackRelativeTo
 		? { kind: "rebase", selector: selectedStackRelativeTo }

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
@@ -143,12 +143,7 @@ import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
 import { OperationControls } from "#ui/routes/project/$id/workspace/OperationControls.tsx";
 import { prForgeUrl } from "#ui/pr.ts";
 
-type DryRunWorkspace = {
-	workspace: WorkspaceState;
-	headInfoIndex: HeadInfoIndex;
-};
-
-const DryRunWorkspaceContext = createContext<DryRunWorkspace | null>(null);
+const DryRunWorkspaceContext = createContext<WorkspaceState | null>(null);
 
 const AbsorptionTargetKeysContext = createContext<ReadonlySet<string> | null>(null);
 
@@ -799,12 +794,7 @@ export const OutlineTree: FC<
 
 	// TODO: debounce?
 	const dryRunOperationQuery = useDryRunOperation({ projectId, operation: dryRunOperation });
-	const dryRunWorkspace = dryRunOperationQuery.data?.workspace
-		? ({
-				workspace: dryRunOperationQuery.data.workspace,
-				headInfoIndex: getHeadInfoIndex(dryRunOperationQuery.data.workspace.headInfo),
-			} satisfies DryRunWorkspace)
-		: null;
+	const dryRunWorkspace = dryRunOperationQuery.data?.workspace ?? null;
 
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
 	const headInfoIndex = headInfo ? getHeadInfoIndex(headInfo) : undefined;
@@ -2666,14 +2656,15 @@ const SegmentContent: FC<{
 	}
 
 	const dryRunWorkspace = use(DryRunWorkspaceContext);
+	const dryRunHeadInfoIndex = dryRunWorkspace ? getHeadInfoIndex(dryRunWorkspace.headInfo) : null;
 
 	return (
 		<div>
 			{segment.commits.map((commit) => {
-				const dryRunCommitId = dryRunWorkspace?.workspace.replacedCommits[commit.id];
+				const dryRunCommitId = dryRunWorkspace?.replacedCommits[commit.id];
 				const dryRunCommit =
-					dryRunWorkspace && dryRunCommitId !== undefined
-						? (dryRunWorkspace.headInfoIndex.commitById.get(dryRunCommitId) ?? null)
+					dryRunCommitId !== undefined
+						? (dryRunHeadInfoIndex?.commitById.get(dryRunCommitId) ?? null)
 						: null;
 				return (
 					<CommitC

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
@@ -24,7 +24,12 @@ import {
 	listProjectsQueryOptions,
 	treeChangeDiffsQueryOptions,
 } from "#ui/api/queries.ts";
-import { findBranchOperandByRef, findCommit, resolveRelativeTo } from "#ui/api/ref-info.ts";
+import {
+	findBranchOperandByRef,
+	findCommit,
+	getCommitById,
+	resolveRelativeTo,
+} from "#ui/api/ref-info.ts";
 import { decodeBytes, bytesEqual } from "#ui/api/bytes.ts";
 import { commitBody, commitForgeUrl, commitIsDiverged, commitTitle } from "#ui/commit.ts";
 import {
@@ -137,7 +142,12 @@ import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
 import { OperationControls } from "#ui/routes/project/$id/workspace/OperationControls.tsx";
 import { prForgeUrl } from "#ui/pr.ts";
 
-const DryRunWorkspaceContext = createContext<WorkspaceState | null>(null);
+type DryRunWorkspace = {
+	workspace: WorkspaceState;
+	commitById: ReadonlyMap<string, Commit>;
+};
+
+const DryRunWorkspaceContext = createContext<DryRunWorkspace | null>(null);
 
 const AbsorptionTargetKeysContext = createContext<ReadonlySet<string> | null>(null);
 
@@ -788,7 +798,12 @@ export const OutlineTree: FC<
 
 	// TODO: debounce?
 	const dryRunOperationQuery = useDryRunOperation({ projectId, operation: dryRunOperation });
-	const dryRunWorkspace = dryRunOperationQuery.data?.workspace ?? null;
+	const dryRunWorkspace = dryRunOperationQuery.data?.workspace
+		? ({
+				workspace: dryRunOperationQuery.data.workspace,
+				commitById: getCommitById(dryRunOperationQuery.data.workspace.headInfo),
+			} satisfies DryRunWorkspace)
+		: null;
 
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
 
@@ -2644,10 +2659,10 @@ const SegmentContent: FC<{
 	return (
 		<div>
 			{segment.commits.map((commit) => {
-				const dryRunCommitId = dryRunWorkspace?.replacedCommits[commit.id];
+				const dryRunCommitId = dryRunWorkspace?.workspace.replacedCommits[commit.id];
 				const dryRunCommit =
 					dryRunWorkspace && dryRunCommitId !== undefined
-						? findCommit({ headInfo: dryRunWorkspace.headInfo, commitId: dryRunCommitId })
+						? (dryRunWorkspace.commitById.get(dryRunCommitId) ?? null)
 						: null;
 				return (
 					<CommitC

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
@@ -25,10 +25,11 @@ import {
 	treeChangeDiffsQueryOptions,
 } from "#ui/api/queries.ts";
 import {
+	branchRefKey,
 	findBranchOperandByRef,
-	findCommit,
-	getCommitById,
+	getHeadInfoIndex,
 	resolveRelativeTo,
+	type HeadInfoIndex,
 } from "#ui/api/ref-info.ts";
 import { decodeBytes, bytesEqual } from "#ui/api/bytes.ts";
 import { commitBody, commitForgeUrl, commitIsDiverged, commitTitle } from "#ui/commit.ts";
@@ -144,7 +145,7 @@ import { prForgeUrl } from "#ui/pr.ts";
 
 type DryRunWorkspace = {
 	workspace: WorkspaceState;
-	commitById: ReadonlyMap<string, Commit>;
+	headInfoIndex: HeadInfoIndex;
 };
 
 const DryRunWorkspaceContext = createContext<DryRunWorkspace | null>(null);
@@ -191,7 +192,10 @@ const useOutlineTreeHotkeys = ({
 	projectId: string;
 	ref: React.RefObject<HTMLElement | null>;
 }) => {
-	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
+	const { data: headInfoIndex } = useQuery({
+		...headInfoQueryOptions(projectId),
+		select: getHeadInfoIndex,
+	});
 	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
 	const selection = useOutlineSelection({ projectId, navigationIndex });
 	const isDefaultMode = useAppSelector(
@@ -200,14 +204,11 @@ const useOutlineTreeHotkeys = ({
 
 	const selectedStack =
 		selection && "stackId" in selection
-			? headInfo?.stacks.find((stack) => stack.id === selection.stackId)
+			? headInfoIndex?.stackById.get(selection.stackId)
 			: undefined;
 	const selectedBranchSegment =
 		selection?._tag === "Branch"
-			? selectedStack?.segments.find(
-					(segment) =>
-						!!segment.refName && bytesEqual(segment.refName.fullNameBytes, selection.branchRef),
-				)
+			? headInfoIndex?.segmentByBranchRef.get(branchRefKey(selection.branchRef))
 			: undefined;
 
 	const selectedBranchCommitsChecked = useAppSelector((state) =>
@@ -223,8 +224,8 @@ const useOutlineTreeHotkeys = ({
 			: false,
 	);
 	const selectedCommit =
-		selection?._tag === "Commit" && headInfo
-			? findCommit({ headInfo, commitId: selection.commitId })
+		selection?._tag === "Commit"
+			? (headInfoIndex?.commitById.get(selection.commitId) ?? null)
 			: null;
 	const selectedCommitForgeUrl =
 		selectedCommit && forgeInfo ? commitForgeUrl(selectedCommit, forgeInfo) : null;
@@ -801,11 +802,12 @@ export const OutlineTree: FC<
 	const dryRunWorkspace = dryRunOperationQuery.data?.workspace
 		? ({
 				workspace: dryRunOperationQuery.data.workspace,
-				commitById: getCommitById(dryRunOperationQuery.data.workspace.headInfo),
+				headInfoIndex: getHeadInfoIndex(dryRunOperationQuery.data.workspace.headInfo),
 			} satisfies DryRunWorkspace)
 		: null;
 
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
+	const headInfoIndex = headInfo ? getHeadInfoIndex(headInfo) : undefined;
 
 	const ref = useRef<HTMLDivElement>(null);
 
@@ -816,7 +818,11 @@ export const OutlineTree: FC<
 	});
 
 	const commitTargetState = useAppSelector((state) => selectProjectCommitTarget(state, projectId));
-	const targetComboboxItems = buildCommitTargetComboboxItems({ headInfo, commitTargetState });
+	const targetComboboxItems = buildCommitTargetComboboxItems({
+		headInfo,
+		headInfoIndex,
+		commitTargetState,
+	});
 	const commitTarget = selectCommitTargetComboboxItem({
 		items: targetComboboxItems,
 		commitTargetState,
@@ -1655,14 +1661,16 @@ type CommitTargetComboboxItem = {
 
 const buildCommitTargetComboboxItems = ({
 	headInfo,
+	headInfoIndex,
 	commitTargetState,
 }: {
 	headInfo: RefInfo | undefined;
+	headInfoIndex: HeadInfoIndex | undefined;
 	commitTargetState: RelativeTo | null;
 }): Array<CommitTargetComboboxItem> => {
 	const commitTarget =
-		headInfo && commitTargetState?.type === "commit"
-			? findCommit({ headInfo, commitId: commitTargetState.subject })
+		commitTargetState?.type === "commit"
+			? headInfoIndex?.commitById.get(commitTargetState.subject)
 			: null;
 
 	return [
@@ -1774,7 +1782,10 @@ const Changes: FC<{
 		(state) => selectProjectOutlineModeState(state, projectId)._tag === "Default",
 	);
 
-	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
+	const { data: headInfoIndex } = useQuery({
+		...headInfoQueryOptions(projectId),
+		select: getHeadInfoIndex,
+	});
 	const isCommitOrAmendPending = commitCreateMutation.isPending || commitAmendMutation.isPending;
 	const canCommitOrAmendBase = isDefaultMode && commitTarget !== null && !isCommitOrAmendPending;
 	const canCommit = canCommitOrAmendBase;
@@ -1782,8 +1793,8 @@ const Changes: FC<{
 		canCommitOrAmendBase &&
 		worktreeChanges &&
 		worktreeChanges.changes.length > 0 &&
-		headInfo &&
-		resolveRelativeTo({ headInfo, relativeTo: commitTarget.relativeTo }) !== null;
+		headInfoIndex &&
+		resolveRelativeTo({ headInfoIndex, relativeTo: commitTarget.relativeTo }) !== null;
 
 	const [open, setOpen] = useState(false);
 
@@ -1818,10 +1829,10 @@ const Changes: FC<{
 	};
 
 	const amendCommit = () => {
-		if (!commitTarget || !headInfo) return;
+		if (!commitTarget || !headInfoIndex) return;
 
 		const commitId = resolveRelativeTo({
-			headInfo,
+			headInfoIndex,
 			relativeTo: commitTarget.relativeTo,
 		});
 		if (commitId === null) throw new Error("No commit to amend.");
@@ -2662,7 +2673,7 @@ const SegmentContent: FC<{
 				const dryRunCommitId = dryRunWorkspace?.workspace.replacedCommits[commit.id];
 				const dryRunCommit =
 					dryRunWorkspace && dryRunCommitId !== undefined
-						? (dryRunWorkspace.commitById.get(dryRunCommitId) ?? null)
+						? (dryRunWorkspace.headInfoIndex.commitById.get(dryRunCommitId) ?? null)
 						: null;
 				return (
 					<CommitC

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
@@ -199,11 +199,11 @@ const useOutlineTreeHotkeys = ({
 
 	const selectedStack =
 		selection && "stackId" in selection
-			? headInfoIndex?.stackById.get(selection.stackId)
+			? headInfoIndex?.stackContextById.get(selection.stackId)?.stack
 			: undefined;
 	const selectedBranchSegment =
 		selection?._tag === "Branch"
-			? headInfoIndex?.segmentByBranchRef.get(branchRefKey(selection.branchRef))
+			? headInfoIndex?.branchContextByRef.get(branchRefKey(selection.branchRef))?.segment
 			: undefined;
 
 	const selectedBranchCommitsChecked = useAppSelector((state) =>
@@ -220,7 +220,7 @@ const useOutlineTreeHotkeys = ({
 	);
 	const selectedCommit =
 		selection?._tag === "Commit"
-			? (headInfoIndex?.commitById.get(selection.commitId) ?? null)
+			? (headInfoIndex?.commitContextById.get(selection.commitId) ?? null)?.commit
 			: null;
 	const selectedCommitForgeUrl =
 		selectedCommit && forgeInfo ? commitForgeUrl(selectedCommit, forgeInfo) : null;
@@ -1660,7 +1660,7 @@ const buildCommitTargetComboboxItems = ({
 }): Array<CommitTargetComboboxItem> => {
 	const commitTarget =
 		commitTargetState?.type === "commit"
-			? headInfoIndex?.commitById.get(commitTargetState.subject)
+			? headInfoIndex?.commitContextById.get(commitTargetState.subject)?.commit
 			: null;
 
 	return [
@@ -2664,7 +2664,7 @@ const SegmentContent: FC<{
 				const dryRunCommitId = dryRunWorkspace?.replacedCommits[commit.id];
 				const dryRunCommit =
 					dryRunCommitId !== undefined
-						? (dryRunHeadInfoIndex?.commitById.get(dryRunCommitId) ?? null)
+						? (dryRunHeadInfoIndex?.commitContextById.get(dryRunCommitId)?.commit ?? null)
 						: null;
 				return (
 					<CommitC

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
@@ -25,7 +25,7 @@ import {
 	treeChangeDiffsQueryOptions,
 } from "#ui/api/queries.ts";
 import { getHeadInfoIndex, resolveRelativeTo, type HeadInfoIndex } from "#ui/api/ref-info.ts";
-import { decodeBytes, bytesEqual } from "#ui/api/bytes.ts";
+import { decodeBytes } from "#ui/api/bytes.ts";
 import { commitBody, commitForgeUrl, commitIsDiverged, commitTitle } from "#ui/commit.ts";
 import {
 	nativeMenuItem,

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree.tsx
@@ -199,11 +199,11 @@ const useOutlineTreeHotkeys = ({
 
 	const selectedStack =
 		selection && "stackId" in selection
-			? headInfoIndex?.stackContextById.get(selection.stackId)?.stack
+			? headInfoIndex?.stackContextById(selection.stackId)?.stack
 			: undefined;
 	const selectedBranchSegment =
 		selection?._tag === "Branch"
-			? headInfoIndex?.branchContextByRef.get(branchRefKey(selection.branchRef))?.segment
+			? headInfoIndex?.branchContextByRef(branchRefKey(selection.branchRef))?.segment
 			: undefined;
 
 	const selectedBranchCommitsChecked = useAppSelector((state) =>
@@ -220,7 +220,7 @@ const useOutlineTreeHotkeys = ({
 	);
 	const selectedCommit =
 		selection?._tag === "Commit"
-			? (headInfoIndex?.commitContextById.get(selection.commitId) ?? null)?.commit
+			? (headInfoIndex?.commitContextById(selection.commitId) ?? null)?.commit
 			: null;
 	const selectedCommitForgeUrl =
 		selectedCommit && forgeInfo ? commitForgeUrl(selectedCommit, forgeInfo) : null;
@@ -1660,7 +1660,7 @@ const buildCommitTargetComboboxItems = ({
 }): Array<CommitTargetComboboxItem> => {
 	const commitTarget =
 		commitTargetState?.type === "commit"
-			? headInfoIndex?.commitContextById.get(commitTargetState.subject)?.commit
+			? headInfoIndex?.commitContextById(commitTargetState.subject)?.commit
 			: null;
 
 	return [
@@ -2664,7 +2664,7 @@ const SegmentContent: FC<{
 				const dryRunCommitId = dryRunWorkspace?.replacedCommits[commit.id];
 				const dryRunCommit =
 					dryRunCommitId !== undefined
-						? (dryRunHeadInfoIndex?.commitContextById.get(dryRunCommitId)?.commit ?? null)
+						? (dryRunHeadInfoIndex?.commitContextById(dryRunCommitId)?.commit ?? null)
 						: null;
 				return (
 					<CommitC

--- a/apps/lite/ui/src/routes/project/$id/workspace/operandLabel.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/operandLabel.ts
@@ -1,21 +1,26 @@
-import { findCommit, findSegmentByBranchRef } from "#ui/api/ref-info.ts";
+import { branchRefKey, type HeadInfoIndex } from "#ui/api/ref-info.ts";
 import { commitTitle, shortCommitId } from "#ui/commit.ts";
 import { Match } from "effect";
-import { type RefInfo } from "@gitbutler/but-sdk";
 import { Operand } from "#ui/operands.ts";
 import { assert } from "#ui/assert.ts";
 
-export const operandLabel = ({ operand, headInfo }: { operand: Operand; headInfo: RefInfo }) =>
+export const operandLabel = ({
+	operand,
+	headInfoIndex,
+}: {
+	operand: Operand;
+	headInfoIndex: HeadInfoIndex;
+}) =>
 	Match.value(operand).pipe(
 		Match.tagsExhaustive({
 			Branch: ({ branchRef }) => {
-				const segment = findSegmentByBranchRef({ headInfo, branchRef });
+				const segment = headInfoIndex.segmentByBranchRef.get(branchRefKey(branchRef));
 				return assert(segment?.refName).displayName;
 			},
 			File: ({ path }) => path,
 			UncommittedChanges: () => "Uncommitted changes",
 			Commit: ({ commitId }) => {
-				const commit = findCommit({ headInfo, commitId });
+				const commit = headInfoIndex.commitById.get(commitId);
 				return commit
 					? `${commitTitle(commit.message) ?? "(no message)"}${commit.hasConflicts ? " ⚠️" : ""}`
 					: shortCommitId(commitId);

--- a/apps/lite/ui/src/routes/project/$id/workspace/operandLabel.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/operandLabel.ts
@@ -14,13 +14,13 @@ export const operandLabel = ({
 	Match.value(operand).pipe(
 		Match.tagsExhaustive({
 			Branch: ({ branchRef }) => {
-				const segment = headInfoIndex.branchContextByRef.get(branchRefKey(branchRef))?.segment;
+				const segment = headInfoIndex.branchContextByRef(branchRefKey(branchRef))?.segment;
 				return assert(segment?.refName).displayName;
 			},
 			File: ({ path }) => path,
 			UncommittedChanges: () => "Uncommitted changes",
 			Commit: ({ commitId }) => {
-				const commit = headInfoIndex.commitContextById.get(commitId)?.commit;
+				const commit = headInfoIndex.commitContextById(commitId)?.commit;
 				return commit
 					? `${commitTitle(commit.message) ?? "(no message)"}${commit.hasConflicts ? " ⚠️" : ""}`
 					: shortCommitId(commitId);

--- a/apps/lite/ui/src/routes/project/$id/workspace/operandLabel.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/operandLabel.ts
@@ -1,4 +1,4 @@
-import { branchRefKey, type HeadInfoIndex } from "#ui/api/ref-info.ts";
+import type { HeadInfoIndex } from "#ui/api/ref-info.ts";
 import { commitTitle, shortCommitId } from "#ui/commit.ts";
 import { Match } from "effect";
 import { Operand } from "#ui/operands.ts";
@@ -14,7 +14,7 @@ export const operandLabel = ({
 	Match.value(operand).pipe(
 		Match.tagsExhaustive({
 			Branch: ({ branchRef }) => {
-				const segment = headInfoIndex.branchContextByRef(branchRefKey(branchRef))?.segment;
+				const segment = headInfoIndex.branchContextByRefBytes(branchRef)?.segment;
 				return assert(segment?.refName).displayName;
 			},
 			File: ({ path }) => path,

--- a/apps/lite/ui/src/routes/project/$id/workspace/operandLabel.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/operandLabel.ts
@@ -14,13 +14,13 @@ export const operandLabel = ({
 	Match.value(operand).pipe(
 		Match.tagsExhaustive({
 			Branch: ({ branchRef }) => {
-				const segment = headInfoIndex.segmentByBranchRef.get(branchRefKey(branchRef));
+				const segment = headInfoIndex.branchContextByRef.get(branchRefKey(branchRef))?.segment;
 				return assert(segment?.refName).displayName;
 			},
 			File: ({ path }) => path,
 			UncommittedChanges: () => "Uncommitted changes",
 			Commit: ({ commitId }) => {
-				const commit = headInfoIndex.commitById.get(commitId);
+				const commit = headInfoIndex.commitContextById.get(commitId)?.commit;
 				return commit
 					? `${commitTitle(commit.message) ?? "(no message)"}${commit.hasConflicts ? " ⚠️" : ""}`
 					: shortCommitId(commitId);


### PR DESCRIPTION
> In the future we should make `headInfo` contents cheaply available for lookups rather than iterating with each new selection with e.g. `findCommit`.

https://github.com/gitbutlerapp/gitbutler/pull/14479#pullrequestreview-4579851695

@samhh Keen for your review on this one, not sure if this is the direction we want to go?