### PR TITLE
Fix oplog restore leaving spurious uncommitted changes

### DIFF
--- a/crates/but/tests/but/command/undo.rs
+++ b/crates/but/tests/but/command/undo.rs
@@ -149,7 +149,6 @@ fn can_undo_but_discard_rename() {
 }
 
 #[test]
-#[ignore = "Test harness runs with cv3 feature flag, and but_core::worktree::safe_checkout_from_head does not restore the worktree file A for some reason. https://linear.app/gitbutler/issue/GB-1403/run-test-both-with-and-without-cv3-feature-flag"]
 fn can_undo_unapply() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.setup_metadata(&["A"]);
@@ -164,7 +163,6 @@ fn can_undo_unapply() {
 }
 
 #[test]
-#[ignore = "Test harness runs with cv3 feature flag, and but_core::worktree::safe_checkout_from_head does not remove the worktree file A for some reason. https://linear.app/gitbutler/issue/GB-1403/run-test-both-with-and-without-cv3-feature-flag"]
 fn can_undo_clean_apply() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.setup_metadata(&["A"]);
@@ -177,6 +175,61 @@ fn can_undo_clean_apply() {
             .stdout_eq("Applied branch 'A' to workspace\n")
             .stderr_eq("");
     });
+}
+
+// Restoring a snapshot must revert the worktree even when a later operation moved the workspace
+// commit: commit a new file, restore an earlier snapshot, and the file must be gone again.
+#[test]
+fn can_restore_snapshot_after_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    let status_before = env
+        .but("status")
+        .args(["--verbose", "--files"])
+        .output()
+        .unwrap();
+
+    // `but oplog snapshot --format human` prints a `  Snapshot ID: <hex>` line we restore from.
+    let snapshot = env
+        .but("oplog snapshot -m baseline --format human")
+        .output()
+        .unwrap();
+    let snapshot_output = String::from_utf8_lossy(&snapshot.stdout);
+    let snapshot_id = snapshot_output
+        .split("Snapshot ID:")
+        .nth(1)
+        .and_then(|rest| rest.split_whitespace().next())
+        .expect("snapshot output contains a `Snapshot ID:` line");
+    assert!(
+        !snapshot_id.is_empty() && snapshot_id.chars().all(|c| c.is_ascii_hexdigit()),
+        "parsed snapshot id should be a bare hex string, got {snapshot_id:?}"
+    );
+
+    env.file("brand-new-file.txt", "content");
+    env.but("commit A -m 'add brand new file'")
+        .assert()
+        .success();
+
+    // The commit must actually change workspace state, otherwise the round-trip below would match
+    // `status_before` without the restore having reverted anything.
+    let status_after_commit = env
+        .but("status")
+        .args(["--verbose", "--files"])
+        .output()
+        .unwrap();
+    assert_ne!(status_before.stdout, status_after_commit.stdout);
+
+    env.but(format!("oplog restore {snapshot_id}"))
+        .assert()
+        .success();
+
+    env.but("status")
+        .args(["--verbose", "--files"])
+        .assert()
+        .success()
+        .stdout_eq(status_before.stdout)
+        .stderr_eq(status_before.stderr);
 }
 
 #[test]

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -698,6 +698,9 @@ fn restore_snapshot(
     let before_restore_snapshot_result = prepare_snapshot(ctx, exclusive_access.read_permission());
     let snapshot_commit = repo.find_commit(snapshot_commit_id)?;
 
+    // The worktree checkout below diffs from this tree, so capture it before any refs move.
+    let pre_restore_head_tree_id = repo.head_tree_id_or_empty()?.detach();
+
     let snapshot_tree = snapshot_commit.tree()?;
     let vb_toml_entry = snapshot_tree
         .lookup_entry_by_path("virtual_branches.toml")?
@@ -722,6 +725,8 @@ fn restore_snapshot(
 
     // walk through all the entries (branches by id)
     let workspace_ref: &gix::refs::FullNameRef = WORKSPACE_REF_NAME.try_into()?;
+    // The workspace commit to repoint `gitbutler/workspace` at, applied *after* the checkout below.
+    let mut restored_workspace_commit: Option<gix::ObjectId> = None;
     for branch_entry in vb_tree.iter() {
         let branch_entry = branch_entry?;
         let branch_tree = repo
@@ -754,21 +759,9 @@ fn restore_snapshot(
                 }
             }
 
-            // if branch_name is 'workspace', we need to create or update the gitbutler/workspace branch
             // TODO: in the next iteration, this of course can't be hardcoded.
             if branch_name == "workspace" {
-                let head = repo.head()?;
-                let head_ref = head
-                    .referent_name()
-                    .context("We will not change a worktree in detached HEAD state")?;
-                if head_ref == workspace_ref {
-                    repo.reference(
-                        workspace_ref,
-                        commit_oid,
-                        gix::refs::transaction::PreviousValue::Any,
-                        "restore snapshot workspace ref",
-                    )?;
-                }
+                restored_workspace_commit = Some(commit_oid);
             }
         }
     }
@@ -784,15 +777,28 @@ fn restore_snapshot(
     let gix_repo = ctx.clone_repo_for_merging()?;
     let workdir_tree_id = get_workdir_tree(None, snapshot_commit_id, &gix_repo, ctx)?;
 
-    // Define the checkout builder
+    // Check out the snapshot's worktree while HEAD still points at the pre-restore commit: both
+    // backends diff from the head tree, so the workspace ref is repointed only afterwards (below).
+    // The git2 backend reads HEAD for its baseline; cv3 gets `pre_restore_head_tree_id` directly.
     if ctx.settings.feature_flags.cv3 {
-        but_core::worktree::safe_checkout_from_head(
+        but_core::worktree::safe_checkout(
+            pre_restore_head_tree_id,
             workdir_tree_id,
             &gix_repo,
             but_core::worktree::checkout::Options::default(),
         )?;
     } else {
         checkout_workdir_tree(ctx, workdir_tree_id)?;
+    }
+
+    // Worktree now matches the snapshot; repoint gitbutler/workspace at the restored commit.
+    if let Some(commit_oid) = restored_workspace_commit {
+        repo.reference(
+            workspace_ref,
+            commit_oid,
+            gix::refs::transaction::PreviousValue::Any,
+            "restore snapshot workspace ref",
+        )?;
     }
 
     // Update virtual_branches.toml with the state from the snapshot


### PR DESCRIPTION
## Problem

Updating the workspace — or any operation that moves the workspace commit — and then restoring or undoing it through the oplog left that operation's file changes behind in the worktree as spurious uncommitted changes. They were safe to discard, but shouldn't show up in the first place.

## Cause

`restore_snapshot` repointed `gitbutler/workspace` at the snapshot commit *before* checking out the snapshot's worktree. Both checkout backends — cv3 `safe_checkout` and the legacy git2 `checkout_workdir_tree` — diff from the current `HEAD` tree, so once the ref had been moved the from/to trees were identical, the diff was empty, and the worktree was never reverted.

## Fix

Capture the worktree's baseline tree before any refs move, and defer the workspace-ref update until after the checkout. The checkout then diffs from the pre-restore commit and reverts the worktree correctly. The cv3 path is given the captured baseline explicitly; the legacy path benefits because `HEAD` still points at the pre-restore commit during the checkout.

Note: the cv3 backend is covered by the regression tests here; the legacy backend isn't reproducible in the test harness (git2's index reconciliation masks it on small scenarios) and was verified by hand against a real repository.