### PR TITLE
Use new commit command from TUI

### DIFF
--- a/crates/but/src/command/legacy/commit2.rs
+++ b/crates/but/src/command/legacy/commit2.rs
@@ -20,21 +20,21 @@ use nonempty::NonEmpty;
 use serde::Serialize;
 
 use crate::{
+    command::legacy::reword2::RewordCommitOperation,
+    id::UncommittedHunkOrFile,
+    theme::{self, Theme},
+    utils::{CliOutput, CliOutputHuman, WriteWithUtils, diff_specs::DiffSpecBuilder},
+};
+
+use crate::{
     CliId, CliResult, CliResultExt, IdMap,
     args::{
         atoms::{BranchArg, BranchOrCommit, CliIdArg, Purpose},
         commit2::Platform,
     },
     bad_input,
-    command::legacy::{
-        reword2::RewordCommitOperation,
-        status::{TuiOutcome, TuiRunOptions, tui_with_options},
-    },
-    id::UncommittedHunkOrFile,
-    theme::{self, Theme},
-    utils::{
-        CliOutput, CliOutputHuman, IntermediateChannel, WriteWithUtils, diff_specs::DiffSpecBuilder,
-    },
+    command::legacy::status::{TuiOutcome, TuiRunOptions, tui_with_options},
+    utils::IntermediateChannel,
 };
 
 #[must_use]
@@ -112,6 +112,7 @@ impl CliOutput for CommitOutcome {
     }
 }
 
+#[cfg_attr(not(feature = "but-2"), expect(dead_code))]
 pub fn commit(
     ctx: &mut Context,
     mut out: IntermediateChannel<'_>,

--- a/crates/but/src/command/legacy/commit2.rs
+++ b/crates/but/src/command/legacy/commit2.rs
@@ -39,13 +39,13 @@ use crate::{
 
 #[must_use]
 pub struct CommitOutcome {
-    new_commit: gix::ObjectId,
-    branch_name: Option<BranchNameTarget>,
+    pub new_commit: gix::ObjectId,
+    pub branch_name: Option<BranchNameTarget>,
 }
 
 /// `--format json` should only include newly created things. So if the branch already existed it
 /// wont be included in the JSON output.
-enum BranchNameTarget {
+pub enum BranchNameTarget {
     Existing(FullName),
     New(FullName),
 }
@@ -125,14 +125,14 @@ pub fn commit(
         let head_info = but_api::legacy::workspace::head_info(ctx)?;
         resolve(guard, ctx, args, &mut out, &head_info, &id_map)?
     };
-    run(
+    Ok(run(
         ctx,
         &mut meta,
         guard.write_permission(),
         commit_op,
         commit_selection,
         reword_op,
-    )
+    )?)
 }
 
 fn resolve(
@@ -229,14 +229,14 @@ fn resolve(
     Ok((guard, commit_op, commit_selection, reword_op))
 }
 
-fn run(
+pub fn run(
     ctx: &mut Context,
     meta: &mut impl RefMetadata,
     perm: &mut RepoExclusive,
     commit_op: CommitOperation,
     commit_selection: CommitSelection,
     reword_op: RewordCommitOperation,
-) -> CliResult<CommitOutcome> {
+) -> anyhow::Result<CommitOutcome> {
     let changes = {
         let context_lines = ctx.settings.context_lines;
         let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(perm.read_permission())?;
@@ -457,13 +457,13 @@ fn route_commit_above_or_below(
     Ok(CommitOperation::CommitAt(CommitAtOperation { target }))
 }
 
-enum CommitSelection {
+pub enum CommitSelection {
     AllChanges,
     Changes(Box<NonEmpty<UncommittedHunkOrFile>>),
     Nothing,
 }
 
-enum CommitOperation {
+pub enum CommitOperation {
     CommitToNewBranch(CommitToNewBranchOperation),
     CommitAt(CommitAtOperation),
 }
@@ -481,8 +481,8 @@ impl CommitOperation {
     }
 }
 
-struct CommitToNewBranchOperation {
-    branch_name: Option<FullName>,
+pub struct CommitToNewBranchOperation {
+    pub branch_name: Option<FullName>,
 }
 
 impl CommitToNewBranchOperation {
@@ -515,8 +515,8 @@ impl CommitToNewBranchOperation {
     }
 }
 
-struct CommitAtOperation {
-    target: CommitRelativeToTarget,
+pub struct CommitAtOperation {
+    pub target: CommitRelativeToTarget,
 }
 
 impl CommitAtOperation {
@@ -562,7 +562,7 @@ impl CommitAtOperation {
 
 /// Place a commit relative to something in the workspace.
 #[derive(Clone)]
-enum CommitRelativeToTarget {
+pub enum CommitRelativeToTarget {
     /// Place the commit relative to this commit, within the same branch.
     Commit {
         commit_id: gix::ObjectId,
@@ -581,7 +581,7 @@ enum CommitRelativeToTarget {
 }
 
 #[derive(Clone)]
-enum CommitRelativeToTargetPosition {
+pub enum CommitRelativeToTargetPosition {
     Above,
     Below,
 }
@@ -601,6 +601,15 @@ impl From<CommitRelativeToTargetPosition> for InsertSide {
         match value {
             CommitRelativeToTargetPosition::Above => Self::Above,
             CommitRelativeToTargetPosition::Below => Self::Below,
+        }
+    }
+}
+
+impl From<InsertSide> for CommitRelativeToTargetPosition {
+    fn from(value: InsertSide) -> Self {
+        match value {
+            InsertSide::Above => CommitRelativeToTargetPosition::Above,
+            InsertSide::Below => CommitRelativeToTargetPosition::Below,
         }
     }
 }

--- a/crates/but/src/command/legacy/mod.rs
+++ b/crates/but/src/command/legacy/mod.rs
@@ -10,7 +10,6 @@ pub mod ai;
 pub mod branch;
 pub mod clean;
 pub mod commit;
-#[cfg(all(feature = "legacy", feature = "but-2"))]
 pub mod commit2;
 pub mod commit_message_prep;
 pub mod diff;
@@ -25,7 +24,6 @@ pub mod push;
 pub mod refresh;
 pub mod resolve;
 pub mod reword;
-#[cfg(all(feature = "legacy", feature = "but-2"))]
 pub mod reword2;
 pub mod rub;
 pub mod setup;

--- a/crates/but/src/command/legacy/reword2.rs
+++ b/crates/but/src/command/legacy/reword2.rs
@@ -15,6 +15,16 @@ pub enum RewordCommitOperation {
 }
 
 impl RewordCommitOperation {
+    /// Check if this operation will open an editor.
+    ///
+    /// Used by the TUI to suspend itself.
+    pub fn will_open_editor(&self) -> bool {
+        match self {
+            RewordCommitOperation::UseEditor => true,
+            RewordCommitOperation::NoMessage | RewordCommitOperation::Message(_) => false,
+        }
+    }
+
     pub fn resolve(no_message: bool, message: Option<Vec<String>>) -> Self {
         match (no_message, message) {
             (true, None) => Self::NoMessage,

--- a/crates/but/src/command/legacy/squash2.rs
+++ b/crates/but/src/command/legacy/squash2.rs
@@ -220,7 +220,7 @@ fn resolve(
             ClassifiedSquashables::UncommittedHunks(source_hunks) => {
                 let (target, reword) = match target {
                     SquashTarget::Commit { commit, reword } => {
-                        (commit, reword.try_into_no_source()?)
+                        (commit, reword.try_into_uncommitting()?)
                     }
                     SquashTarget::Uncommitted => {
                         return Err(cannot_uncommit_uncommitted_changes_error());
@@ -235,7 +235,7 @@ fn resolve(
             ClassifiedSquashables::Uncommitted => {
                 let (target, reword) = match target {
                     SquashTarget::Commit { commit, reword } => {
-                        (commit, reword.try_into_no_source()?)
+                        (commit, reword.try_into_uncommitting()?)
                     }
                     SquashTarget::Uncommitted => {
                         return Err(cannot_uncommit_uncommitted_changes_error());
@@ -413,7 +413,7 @@ enum SquashTarget {
 enum MoveCommittedChangesTarget {
     Commit {
         commit: ObjectId,
-        reword: HowToRewordMovedChanges,
+        reword: HowToRewordTargetNoSource,
     },
     Uncommitted,
 }
@@ -423,7 +423,7 @@ impl MoveCommittedChangesTarget {
         match target {
             SquashTarget::Commit { commit, reword } => Ok(Self::Commit {
                 commit,
-                reword: HowToRewordMovedChanges::from_target_reword(reword)?,
+                reword: reword.try_into_moving_changes()?,
             }),
             SquashTarget::Uncommitted => Ok(Self::Uncommitted),
         }
@@ -588,6 +588,13 @@ enum HowToRewordTarget {
 }
 
 impl HowToRewordTarget {
+    fn will_open_editor(&self) -> bool {
+        match self {
+            Self::UseTargetMessage | Self::UseSourceMessage => false,
+            Self::Reword(op) => op.will_open_editor(),
+        }
+    }
+
     fn how_to_combine_messages(&self) -> MessageCombinationStrategy {
         match self {
             Self::UseTargetMessage => MessageCombinationStrategy::KeepTarget,
@@ -607,10 +614,21 @@ impl HowToRewordTarget {
         }
     }
 
-    fn try_into_no_source(self) -> CliResult<HowToRewordTargetNoSource> {
+    fn try_into_uncommitting(self) -> CliResult<HowToRewordTargetNoSource> {
         match self {
             HowToRewordTarget::UseSourceMessage => Err(bad_input(
                 "--use-source-message cannot be used when squashing uncommitted changes",
+            )
+            .into()),
+            HowToRewordTarget::UseTargetMessage => Ok(HowToRewordTargetNoSource::UseTargetMessage),
+            HowToRewordTarget::Reword(op) => Ok(HowToRewordTargetNoSource::Reword(op)),
+        }
+    }
+
+    fn try_into_moving_changes(self) -> CliResult<HowToRewordTargetNoSource> {
+        match self {
+            HowToRewordTarget::UseSourceMessage => Err(bad_input(
+                "--use-source-message cannot be used when moving committed changes",
             )
             .into()),
             HowToRewordTarget::UseTargetMessage => Ok(HowToRewordTargetNoSource::UseTargetMessage),
@@ -629,37 +647,10 @@ enum HowToRewordTargetNoSource {
 }
 
 impl HowToRewordTargetNoSource {
-    fn execute(
-        self,
-        commit: ObjectId,
-        tx: &mut Transaction<'_, '_, impl RefMetadata>,
-    ) -> anyhow::Result<gix::ObjectId> {
+    fn will_open_editor(&self) -> bool {
         match self {
-            Self::UseTargetMessage => Ok(commit),
-            Self::Reword(reword_commit_operation) => reword_commit_operation.execute(commit, tx),
-        }
-    }
-}
-
-/// How to reword a commit after moving a subset of changes from another commit.
-///
-/// `--use-source-message` is intentionally not representable here because the
-/// source is a set of committed changes, not a whole commit being squashed.
-#[derive(Debug, Clone)]
-enum HowToRewordMovedChanges {
-    UseTargetMessage,
-    Reword(RewordCommitOperation),
-}
-
-impl HowToRewordMovedChanges {
-    fn from_target_reword(reword: HowToRewordTarget) -> CliResult<Self> {
-        match reword {
-            HowToRewordTarget::UseSourceMessage => Err(bad_input(
-                "--use-source-message cannot be used when moving committed changes",
-            )
-            .into()),
-            HowToRewordTarget::UseTargetMessage => Ok(Self::UseTargetMessage),
-            HowToRewordTarget::Reword(op) => Ok(Self::Reword(op)),
+            Self::UseTargetMessage => false,
+            Self::Reword(op) => op.will_open_editor(),
         }
     }
 
@@ -1035,10 +1026,24 @@ enum SquashOperation {
         target: ObjectId,
         source: ObjectId,
         source_paths: Vec<BString>,
-        reword: HowToRewordMovedChanges,
+        reword: HowToRewordTargetNoSource,
     },
     Uncommit(UncommitOperation),
     UncommitCommittedFiles(UncommitCommittedFilesOperation),
+}
+
+impl SquashOperation {
+    #[expect(dead_code)]
+    pub fn will_open_editor(&self) -> bool {
+        match self {
+            SquashOperation::Commits(op) => op.reword.will_open_editor(),
+            SquashOperation::Branch(op) => op.reword.will_open_editor(),
+            SquashOperation::UncommittedHunks(op) => op.reword.will_open_editor(),
+            SquashOperation::Uncommitted { reword, .. } => reword.will_open_editor(),
+            SquashOperation::MoveCommittedFiles { reword, .. } => reword.will_open_editor(),
+            SquashOperation::Uncommit(..) | SquashOperation::UncommitCommittedFiles(..) => false,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -1151,7 +1156,7 @@ struct MoveCommittedFilesOperation {
     target: ObjectId,
     source: ObjectId,
     changes: Vec<but_core::DiffSpec>,
-    reword: HowToRewordMovedChanges,
+    reword: HowToRewordTargetNoSource,
 }
 
 impl MoveCommittedFilesOperation {

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -127,7 +127,6 @@ pub struct TuiLaunchOptions {
 pub enum TuiRunOptions {
     #[default]
     Normal,
-    #[cfg_attr(all(not(feature = "but-2"), not(test)), expect(dead_code))]
     PickChanges,
 }
 
@@ -141,7 +140,6 @@ pub enum TuiRunOptions {
 #[must_use]
 pub enum TuiOutcome {
     None,
-    #[cfg_attr(all(not(feature = "but-2"), not(test)), expect(dead_code))]
     CliIds(Vec<CliId>),
 }
 
@@ -294,7 +292,6 @@ pub(crate) async fn worktree(
     Ok(())
 }
 
-#[cfg_attr(not(feature = "but-2"), expect(dead_code))]
 pub(crate) fn tui_with_options(
     ctx: &mut Context,
     mut guard: RepoExclusiveGuard,

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -13,20 +13,15 @@ use anyhow::Context as _;
 use bstr::{BString, ByteSlice};
 use but_api::{diff::ComputeLineStats, legacy::oplog::RestoreKind};
 use but_core::{DryRun, ref_metadata::StackId};
-use but_core::{diff::CommitDetails, tree::create_tree::RejectionReason};
 use but_ctx::Context;
 use but_rebase::graph_rebase::mutate::InsertSide;
 use but_settings::AppSettingsWithDiskSync;
-use but_transaction::DynamicOutcome;
 use but_workspace::commit::squash_commits::MessageCombinationStrategy;
 use crossterm::event::{self, Event, KeyCode, KeyEvent};
 use gitbutler_branch_actions::BranchListingFilter;
 use gitbutler_operating_modes::OperatingMode;
 use gitbutler_oplog::entry::{OperationKind, SnapshotDetails};
-use gix::{
-    prelude::ObjectIdExt as _,
-    refs::{Category, FullName},
-};
+use gix::refs::{Category, FullName};
 use nonempty::NonEmpty;
 use ratatui::prelude::*;
 use ratatui_textarea::{CursorMove, TextArea};
@@ -35,8 +30,9 @@ use tracing::Level;
 use crate::{
     CliId, IdMap,
     command::legacy::{
-        self, ShowDiffInEditor,
+        commit2,
         reword::get_branch_name_from_editor,
+        reword2,
         status::{
             StatusFlags, StatusOutputLine, TuiLaunchOptions, TuiOutcome, TuiRunOptions,
             tui::{
@@ -781,7 +777,7 @@ impl App {
                     self.handle_commit_toggle_message_composer(composer);
                 }
                 CommitMessage::CommitToNewBranch => {
-                    self.handle_commit_to_new_branch(messages);
+                    self.handle_commit_to_new_branch(ctx, terminal_guard, messages)?;
                 }
                 CommitMessage::ToggleInsertSide => {
                     self.handle_commit_toggle_insert_side();
@@ -2255,249 +2251,107 @@ impl App {
         T: TerminalGuard,
         anyhow::Error: From<<T::Backend as Backend>::Error>,
     {
-        let Mode::Commit(CommitMode {
-            source,
-            insert_side,
-            scope_to_stack,
-            message_composer,
-        }) = &*self.mode
+        let Mode::Commit(
+            mode @ CommitMode {
+                source,
+                insert_side,
+                scope_to_stack: _,
+                message_composer: _,
+            },
+        ) = &*self.mode
         else {
             return Ok(());
         };
 
-        let Some(selection) = self.cursor.selected_line(&self.status_lines) else {
+        let Some(data) = self
+            .cursor
+            .selected_line(&self.status_lines)
+            .and_then(|s| s.data.cli_id())
+        else {
             return Ok(());
         };
 
-        if selection
-            .data
-            .cli_id()
-            .is_some_and(|target| source.contains(target))
-        {
+        if source.contains(data) {
             messages.push(Message::EnterNormalModeAfterConfirmingOperation);
             return Ok(());
         }
 
-        let target = match &selection.data {
-            StatusOutputLineData::Branch { cli_id }
-            | StatusOutputLineData::Commit { cli_id, .. } => cli_id,
-            StatusOutputLineData::UpdateNotice
-            | StatusOutputLineData::Connector
-            | StatusOutputLineData::BetweenStacks
-            | StatusOutputLineData::StagedChanges { .. }
-            | StatusOutputLineData::StagedFile { .. }
-            | StatusOutputLineData::UncommittedChanges { .. }
-            | StatusOutputLineData::UncommittedFile { .. }
-            | StatusOutputLineData::CommitMessage
-            | StatusOutputLineData::EmptyCommitMessage
-            | StatusOutputLineData::File { .. }
-            | StatusOutputLineData::MergeBase
-            | StatusOutputLineData::UpstreamChanges
-            | StatusOutputLineData::Warning
-            | StatusOutputLineData::Hint
-            | StatusOutputLineData::NoAssignmentsUnstaged => {
-                return Ok(());
-            }
-        };
-
-        let Some((insert_commit_relative_to, insert_side)) =
-            operations::where_to_place_commit(ctx, target, *insert_side)?
-        else {
-            return Ok(());
-        };
-
-        let changes_to_commit = {
-            let context_lines = ctx.settings.context_lines;
-            let guard = ctx.shared_worktree_access();
-            let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(guard.read_permission())?;
-            let mut builder = DiffSpecBuilder::new(&mut db, &repo, &ws, context_lines)
-                .with_scope_to_stack(*scope_to_stack);
-            match &**source {
-                CommitSource::Marks(marks) => {
-                    for mark in marks {
-                        let Markable::Uncommitted(uncommitted) = mark else {
-                            unreachable!(
-                                "commit marks were validated to contain only uncommitted files"
-                            );
-                        };
-                        builder.push_changes_from_uncommitted(uncommitted)?;
-                    }
-                }
-                CommitSource::UncommittedArea(UncommittedAreaCommitSource { id: _ }) => {
-                    builder.push_changes_from_uncommitted_area()?;
-                }
-                CommitSource::Uncommitted(uncommitted) => {
-                    builder.push_changes_from_uncommitted(uncommitted)?;
-                }
-                CommitSource::Stack(StackCommitSource { stack_id }) => {
-                    builder.push_changes_from_stack(*stack_id)?;
-                }
-            }
-            builder.into_diff_specs()
-        };
-
-        let mut meta = ctx.meta()?;
-        let snapshot_details = SnapshotDetails::new(OperationKind::CreateCommit);
-        let commit_create_result = but_transaction::with_transaction(
-            ctx,
-            &mut meta,
-            snapshot_details,
-            DryRun::No,
-            |mut tx| {
-                let commit_create_result = tx.create_commit(
-                    insert_commit_relative_to,
-                    insert_side,
-                    changes_to_commit,
-                    String::new(),
-                )?;
-
-                if commit_create_result.rejected_specs.is_empty() {
-                    if let Some(new_commit) = commit_create_result.new_commit {
-                        match message_composer {
-                            CommitMessageComposer::Editor => {
-                                let repo = tx.repo();
-                                let commit_details = CommitDetails::from_commit_id(
-                                    new_commit.attach(repo),
-                                    ComputeLineStats::No.into(),
-                                )?;
-                                let current_message =
-                                    commit_details.commit.inner.message.to_string();
-
-                                let _suspend_guard = terminal_guard.suspend()?;
-
-                                let message = legacy::reword::get_commit_message_from_editor(
-                                    tx.repo(),
-                                    tx.context_lines(),
-                                    commit_details,
-                                    String::new(),
-                                    &current_message,
-                                    ShowDiffInEditor::Unspecified,
-                                )?
-                                .unwrap_or_default();
-
-                                let reworded_commit =
-                                    tx.reword_commit(new_commit, BString::from(message).as_ref())?;
-
-                                Ok(DynamicOutcome::Commit((Some(reworded_commit), None)))
-                            }
-                            CommitMessageComposer::Inline => {
-                                Ok(DynamicOutcome::Commit((
-                                    commit_create_result.new_commit,
-                                    // TODO(david): rewording separately isn't great because it
-                                    // results in two oplog entries. One for creating the commit
-                                    // and one for rewording it.
-                                    //
-                                    // Fixing that is a little tricky because we'd have to show a
-                                    // "temp" commit in the status while composing the message and
-                                    // then only commit when the user confirms.
-                                    Some(Message::Reword(RewordMessage::InlineStart)),
-                                )))
-                            }
-                            CommitMessageComposer::Empty => Ok(DynamicOutcome::Commit((
-                                commit_create_result.new_commit,
-                                None,
-                            ))),
-                        }
-                    } else {
-                        Ok(DynamicOutcome::Commit((
-                            commit_create_result.new_commit,
-                            None,
-                        )))
-                    }
-                } else {
-                    Ok(DynamicOutcome::Rollback(
-                        commit_create_result.rejected_specs,
-                    ))
-                }
+        let target = match &**data {
+            CliId::Branch { name, .. } => commit2::CommitRelativeToTarget::BranchTip {
+                name: Category::LocalBranch.to_full_name(&**name)?,
             },
-        )?;
+            CliId::Commit { commit_id, .. } => commit2::CommitRelativeToTarget::Commit {
+                commit_id: *commit_id,
+                position: commit2::CommitRelativeToTargetPosition::from(*insert_side),
+            },
+            CliId::UncommittedHunkOrFile(..)
+            | CliId::PathPrefix { .. }
+            | CliId::CommittedFile { .. }
+            | CliId::Uncommitted { .. }
+            | CliId::Stack { .. } => return Ok(()),
+        };
+        let commit_op = commit2::CommitOperation::CommitAt(commit2::CommitAtOperation { target });
 
-        match commit_create_result {
-            DynamicOutcome::Commit(((new_commit, reword_msg), _workspace)) => {
-                messages.extend(
-                    [
-                        Message::EnterNormalModeAfterConfirmingOperation,
-                        Message::Reload(
-                            new_commit.map(SelectAfterReload::Commit),
-                            ReloadCause::Mutation,
-                        ),
-                    ]
-                    .into_iter()
-                    .chain(reword_msg),
-                );
-            }
-            DynamicOutcome::Rollback(rejected_specs) => {
-                let mut full_error_msg =
-                    "Some selected changes could not be committed:\n".to_owned();
-                let mut errors_per_diff_spec = rejected_specs
-                .iter()
-                .map(|(rejection_reason, diff_spec)| {
-                    let human_reason = match rejection_reason {
-                        RejectionReason::NoEffectiveChanges => "Changes were a no-op",
-                        RejectionReason::CherryPickMergeConflict
-                        | RejectionReason::WorkspaceMergeConflict
-                        | RejectionReason::WorkspaceMergeConflictOfUnrelatedFile => {
-                            "Failed with a conflict. Try committing to a different stack"
-                        }
-                        RejectionReason::WorktreeFileMissingForObjectConversion => "File was deleted",
-                        RejectionReason::FileToLargeOrBinary => "File is too large or binary",
-                        RejectionReason::PathNotFoundInBaseTree => {
-                            "A change with multiple hunks to be applied wasn't present in the base-tree"
-                        }
-                        RejectionReason::UnsupportedDirectoryEntry => "Path is not a file",
-                        RejectionReason::UnsupportedTreeEntry => "Undiffable entry type",
-                        RejectionReason::MissingDiffSpecAssociation => "Missing association between diff and file",
-                    };
-                    (human_reason, diff_spec)
-                }).map(|(human_reason, diff_spec)| {
-                    let mut out = format!("- {}: {human_reason}", diff_spec.path);
-                    if let Some(previous_path) = &diff_spec.previous_path {
-                        out.push_str(&format!(" (previously {previous_path})"));
-                    }
-                    out
-                })
-                .peekable();
-                while let Some(line) = errors_per_diff_spec.next() {
-                    full_error_msg.push_str(&line);
-                    if errors_per_diff_spec.peek().is_some() {
-                        full_error_msg.push('\n');
-                    }
-                }
-
-                messages.push(Message::ShowToast {
-                    kind: ToastKind::Error,
-                    text: full_error_msg.into(),
-                });
-            }
-        }
+        commit_with(ctx, terminal_guard, messages, mode, commit_op)?;
 
         Ok(())
     }
 
-    fn handle_commit_to_new_branch(&mut self, messages: &mut Vec<Message>) {
-        let Some(selection) = self.cursor.selected_line(&self.status_lines) else {
-            return;
+    #[allow(warnings)]
+    fn handle_commit_to_new_branch<T>(
+        &mut self,
+        ctx: &mut Context,
+        terminal_guard: &mut T,
+        messages: &mut Vec<Message>,
+    ) -> anyhow::Result<()>
+    where
+        T: TerminalGuard,
+        anyhow::Error: From<<T::Backend as Backend>::Error>,
+    {
+        let Mode::Commit(
+            mode @ CommitMode {
+                source,
+                insert_side,
+                scope_to_stack,
+                message_composer,
+            },
+        ) = &*self.mode
+        else {
+            return Ok(());
         };
-        match &selection.data {
-            StatusOutputLineData::UncommittedFile { .. }
-            | StatusOutputLineData::Branch { .. }
-            | StatusOutputLineData::UncommittedChanges { .. } => {}
-            StatusOutputLineData::UpdateNotice
-            | StatusOutputLineData::Connector
-            | StatusOutputLineData::BetweenStacks
-            | StatusOutputLineData::StagedChanges { .. }
-            | StatusOutputLineData::StagedFile { .. }
-            | StatusOutputLineData::Commit { .. }
-            | StatusOutputLineData::CommitMessage
-            | StatusOutputLineData::EmptyCommitMessage
-            | StatusOutputLineData::File { .. }
-            | StatusOutputLineData::MergeBase
-            | StatusOutputLineData::UpstreamChanges
-            | StatusOutputLineData::Warning
-            | StatusOutputLineData::Hint
-            | StatusOutputLineData::NoAssignmentsUnstaged => return,
-        }
-        messages.push(Message::NewBranch.and_then(Message::Commit(CommitMessage::Confirm)));
+
+        let Some(data) = self
+            .cursor
+            .selected_line(&self.status_lines)
+            .and_then(|s| s.data.cli_id())
+        else {
+            return Ok(());
+        };
+
+        let commit_op = match &**data {
+            CliId::UncommittedHunkOrFile(..) | CliId::Uncommitted { .. } => {
+                commit2::CommitOperation::CommitToNewBranch(commit2::CommitToNewBranchOperation {
+                    branch_name: None,
+                })
+            }
+            CliId::Branch { name, .. } => {
+                commit2::CommitOperation::CommitAt(commit2::CommitAtOperation {
+                    target: commit2::CommitRelativeToTarget::BranchBucket {
+                        name: Category::LocalBranch.to_full_name(&**name)?,
+                        position: commit2::CommitRelativeToTargetPosition::Above,
+                    },
+                })
+            }
+
+            CliId::PathPrefix { .. }
+            | CliId::CommittedFile { .. }
+            | CliId::Commit { .. }
+            | CliId::Stack { .. } => return Ok(()),
+        };
+
+        commit_with(ctx, terminal_guard, messages, mode, commit_op)?;
+
+        Ok(())
     }
 
     fn handle_commit_toggle_insert_side(&mut self) {
@@ -4265,6 +4119,7 @@ impl Message {
     }
 
     /// Send another message only if handling the first succeeds.
+    #[expect(dead_code)]
     pub(super) fn and_then(self, other: Self) -> Self {
         Self::AndThen {
             lhs: Box::new(self),
@@ -4548,4 +4403,100 @@ impl FuzzyPickerItem for ApplyBranchItem {
             theme.remote_branch
         }
     }
+}
+
+fn commit_with<T>(
+    ctx: &mut Context,
+    terminal_guard: &mut T,
+    messages: &mut Vec<Message>,
+    mode: &CommitMode,
+    commit_op: commit2::CommitOperation,
+) -> anyhow::Result<()>
+where
+    T: TerminalGuard,
+    anyhow::Error: From<<T::Backend as Backend>::Error>,
+{
+    let CommitMode {
+        source,
+        message_composer,
+        insert_side: _,
+        scope_to_stack,
+    } = mode;
+
+    anyhow::ensure!(
+        scope_to_stack.is_none(),
+        "committing stack assignments is not supported. Use `but commit`"
+    );
+
+    let commit_selection = match &**source {
+        CommitSource::Marks(marks) => {
+            let mut hunks = Vec::new();
+            for mark in marks {
+                match mark {
+                    Markable::Uncommitted(hunk) => {
+                        hunks.push(hunk.clone());
+                    }
+                    Markable::Commit { .. } => {
+                        anyhow::bail!("Error: Cannot commit a commit");
+                    }
+                }
+            }
+            let Some(hunks) = NonEmpty::from_vec(hunks) else {
+                return Ok(());
+            };
+            commit2::CommitSelection::Changes(Box::new(hunks))
+        }
+        CommitSource::UncommittedArea(..) => commit2::CommitSelection::AllChanges,
+        CommitSource::Uncommitted(hunk) => {
+            commit2::CommitSelection::Changes(Box::new(NonEmpty::new(hunk.clone())))
+        }
+        CommitSource::Stack(..) => {
+            anyhow::bail!("committing stack assignments is not supported. Use `but commit`")
+        }
+    };
+
+    let mut guard = ctx.exclusive_worktree_access();
+    let mut meta = ctx.meta()?;
+
+    let (reword_op, reword_msg) = match message_composer {
+        CommitMessageComposer::Editor => (reword2::RewordCommitOperation::UseEditor, None),
+        CommitMessageComposer::Inline => (
+            reword2::RewordCommitOperation::NoMessage,
+            Some(Message::Reword(RewordMessage::InlineStart)),
+        ),
+        CommitMessageComposer::Empty => (reword2::RewordCommitOperation::NoMessage, None),
+    };
+
+    let _suspend_guard = reword_op
+        .will_open_editor()
+        .then(|| terminal_guard.suspend())
+        .transpose()?;
+
+    let commit2::CommitOutcome {
+        new_commit,
+        branch_name: _,
+    } = commit2::run(
+        ctx,
+        &mut meta,
+        guard.write_permission(),
+        commit_op,
+        commit_selection,
+        reword_op,
+    )?;
+
+    drop(_suspend_guard);
+
+    messages.extend(
+        [
+            Message::EnterNormalModeAfterConfirmingOperation,
+            Message::Reload(
+                Some(SelectAfterReload::Commit(new_commit)),
+                ReloadCause::Mutation,
+            ),
+        ]
+        .into_iter()
+        .chain(reword_msg),
+    );
+
+    Ok(())
 }

--- a/crates/but/src/command/legacy/status/tui/mode.rs
+++ b/crates/but/src/command/legacy/status/tui/mode.rs
@@ -208,6 +208,7 @@ pub(super) struct CommitMode {
     /// If set, then the commit must be made on this stack
     ///
     /// Used when committing changes staged to a specific stack
+    // TODO: remove this when we no dont support assignments
     pub(super) scope_to_stack: Option<StackId>,
     /// How to compose the commit message.
     pub(super) message_composer: CommitMessageComposer,

--- a/crates/but/src/command/legacy/status/tui/operations.rs
+++ b/crates/but/src/command/legacy/status/tui/operations.rs
@@ -18,7 +18,6 @@ use gitbutler_operating_modes::OperatingMode;
 use gitbutler_oplog::entry::Snapshot;
 
 use crate::{
-    CliId,
     args::OutputFormat,
     command::legacy::{
         self, ShowDiffInEditor,
@@ -96,29 +95,6 @@ pub(super) fn create_empty_commit_relative_to_commit(
         InsertSide::Above,
         DryRun::No,
     )
-}
-
-pub(super) fn where_to_place_commit(
-    ctx: &Context,
-    target: &CliId,
-    insert_side: InsertSide,
-) -> anyhow::Result<Option<(RelativeTo, InsertSide)>> {
-    match target {
-        CliId::Branch { name, .. } => {
-            let repo = ctx.repo.get()?;
-            let reference = repo.find_reference(name)?;
-            Ok(Some((
-                RelativeTo::Reference(reference.name().to_owned()),
-                InsertSide::Below,
-            )))
-        }
-        CliId::Commit { commit_id, .. } => Ok(Some((RelativeTo::Commit(*commit_id), insert_side))),
-        CliId::UncommittedHunkOrFile(_)
-        | CliId::PathPrefix { .. }
-        | CliId::CommittedFile { .. }
-        | CliId::Uncommitted { .. }
-        | CliId::Stack { .. } => Ok(None),
-    }
 }
 
 pub(super) fn rub(

--- a/crates/but/src/error.rs
+++ b/crates/but/src/error.rs
@@ -183,7 +183,6 @@ pub enum CliError {
 
 pub type CliResult<T> = Result<T, CliError>;
 
-#[cfg_attr(not(feature = "but-2"), expect(dead_code))]
 pub trait CliResultExt<T> {
     /// Add a hint if the result is a [`CliError::BadInput`].
     fn hint<S: AsRef<str>>(self, hint: S) -> Self;

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -46,9 +46,7 @@ use crate::{
 };
 
 mod error;
-#[cfg(feature = "but-2")]
-pub(crate) use error::CliResultExt;
-pub(crate) use error::{CliError, CliResult, bad_input};
+pub(crate) use error::{CliError, CliResult, CliResultExt, bad_input};
 
 mod id;
 pub use id::{CliId, IdMap};

--- a/crates/but/src/utils/diff_specs.rs
+++ b/crates/but/src/utils/diff_specs.rs
@@ -40,6 +40,7 @@ impl<'a> DiffSpecBuilder<'a> {
         }
     }
 
+    #[expect(dead_code)] // TODO: remove this when we're removing assignments
     pub fn with_scope_to_stack(mut self, scope_to_stack: Option<StackId>) -> Self {
         self.scope_to_stack = scope_to_stack;
         self

--- a/crates/but/src/utils/diff_specs.rs
+++ b/crates/but/src/utils/diff_specs.rs
@@ -204,7 +204,6 @@ impl<'a> DiffSpecBuilder<'a> {
     /// WARNING: Does not support overlapping hunks - results may get very strange if such hunks are
     /// in the specs. The implementation naively assumes that hunk equality checks are sufficient
     /// for reconciling changes, whereas with overlapping hunks that is not the case.
-    #[cfg(feature = "but-2")]
     pub fn reconcile_worktree_diff_specs(&mut self) -> anyhow::Result<()> {
         use bstr::ByteSlice;
         use std::collections::HashMap;

--- a/crates/but/src/utils/mod.rs
+++ b/crates/but/src/utils/mod.rs
@@ -2,7 +2,6 @@ use std::io::Write;
 
 mod output_channel;
 pub(crate) use output_channel::PromptLine;
-#[cfg_attr(not(feature = "but-2"), expect(unused_imports))]
 pub use output_channel::experimental::*;
 pub use output_channel::{
     Confirm, ConfirmDefault, ConfirmOrEmpty, InputOutputChannel, OutputChannel, WriteWithUtils,

--- a/crates/but/src/utils/output_channel/experimental.rs
+++ b/crates/but/src/utils/output_channel/experimental.rs
@@ -34,7 +34,6 @@ impl<'out> IntermediateChannel<'out> {
         Self { out }
     }
 
-    #[cfg_attr(not(feature = "but-2"), expect(dead_code))]
     pub fn prepare_for_terminal_input(&mut self) -> Option<InputOutputChannel<'_>> {
         self.out.prepare_for_terminal_input()
     }


### PR DESCRIPTION
Changes the TUI to use the same function for committing that `but _commit2` uses.