### PR TITLE
Remove unused feature flags `undo` and `rules`

### DIFF
--- a/apps/desktop/src/components/shared/AnalyticsMonitor.svelte
+++ b/apps/desktop/src/components/shared/AnalyticsMonitor.svelte
@@ -4,7 +4,6 @@ This component keeps the analytics context up-to-date, i.e. the metadata
 attached to posthog events.
 -->
 <script lang="ts">
-	import { SETTINGS_SERVICE } from "$lib/settings/appSettings";
 	import { UI_STATE } from "$lib/state/uiState.svelte";
 	import { EVENT_CONTEXT } from "$lib/telemetry/eventContext";
 	import { inject } from "@gitbutler/core/context";
@@ -13,7 +12,6 @@ attached to posthog events.
 
 	const uiState = inject(UI_STATE);
 	const eventContext = inject(EVENT_CONTEXT);
-	const settingsService = inject(SETTINGS_SERVICE);
 
 	const globalState = uiState.global;
 	const projectState = $derived(uiState.project(projectId));
@@ -45,7 +43,6 @@ attached to posthog events.
 	$effect(() => {
 		eventContext.update({
 			v3: true,
-			rules: $settingsService?.featureFlags.rules,
 		});
 	});
 </script>

--- a/crates/but-settings/assets/defaults.jsonc
+++ b/crates/but-settings/assets/defaults.jsonc
@@ -23,10 +23,6 @@
 		"cv3": false,
 		/// Use the V3 unapply compatibility mode that keeps workspace commits unless deleting the workspace ref.
 		"unapplyV3Pgm": false,
-		/// Enable undo/redo support.
-		"undo": false,
-		/// Enable processing of workspace rules.
-		"rules": false,
 		/// Enable single branch mode.
 		"singleBranch": false,
 		/// Enable IRC integration.

--- a/crates/but-settings/src/api.rs
+++ b/crates/but-settings/src/api.rs
@@ -18,7 +18,6 @@ pub struct TelemetryUpdate {
 pub struct FeatureFlagsUpdate {
     pub cv3: Option<bool>,
     pub unapply_v3_pgm: Option<bool>,
-    pub rules: Option<bool>,
     pub single_branch: Option<bool>,
     pub irc: Option<bool>,
 }
@@ -118,7 +117,6 @@ impl AppSettingsWithDiskSync {
         FeatureFlagsUpdate {
             cv3,
             unapply_v3_pgm,
-            rules,
             single_branch,
             irc,
         }: FeatureFlagsUpdate,
@@ -129,9 +127,6 @@ impl AppSettingsWithDiskSync {
         }
         if let Some(unapply_v3_pgm) = unapply_v3_pgm {
             settings.feature_flags.unapply_v3_pgm = unapply_v3_pgm;
-        }
-        if let Some(rules) = rules {
-            settings.feature_flags.rules = rules;
         }
         if let Some(single_branch) = single_branch {
             settings.feature_flags.single_branch = single_branch;
@@ -373,7 +368,6 @@ mod tests {
             .update_feature_flags(FeatureFlagsUpdate {
                 cv3: None,
                 unapply_v3_pgm: Some(true),
-                rules: None,
                 single_branch: None,
                 irc: None,
             })

--- a/crates/but-settings/src/app_settings.rs
+++ b/crates/but-settings/src/app_settings.rs
@@ -40,23 +40,6 @@ pub struct FeatureFlags {
     pub cv3: bool,
     /// Use the V3 unapply compatibility mode that keeps workspace commits unless deleting the workspace ref.
     pub unapply_v3_pgm: bool,
-    /// Enable undo/redo support.
-    ///
-    /// ### Progression for implementation
-    ///
-    /// * use snapshot system in undo/redo queue
-    ///     - consider not referring to these objects by reference to `git gc` will catch them,
-    ///       or even purge them on shutdown. Alternatively, keep them in-memory with in-memory objects.
-    /// * add user-control to snapshot system to purge now, or purge after time X. That way data isn't stored forever.
-    /// * Finally, consider implementing undo/redo with invasive primitives that are undoable/redoable themselves for
-    ///   the most efficient solution, inherently in memory, i.e.
-    ///     - CRUD reference
-    ///     - CRUD metadata
-    ///     - CRUD workspace
-    ///     - CRUD files
-    pub undo: bool,
-    /// Enable processing of workspace rules.
-    pub rules: bool,
     /// Enable single branch mode.
     pub single_branch: bool,
     /// Enable IRC integration.

--- a/crates/but-settings/src/persistence.rs
+++ b/crates/but-settings/src/persistence.rs
@@ -23,11 +23,10 @@ fn remove_deprecated_settings(customizations: &mut serde_json::Value) -> bool {
         .get_mut("featureFlags")
         .and_then(serde_json::Value::as_object_mut)
     {
-        if feature_flags.remove("apply3").is_some() {
-            removed = true;
-        }
-        if feature_flags.remove("unapplyV3").is_some() {
-            removed = true;
+        for deprecated in ["apply3", "unapplyV3", "undo", "rules"] {
+            if feature_flags.remove(deprecated).is_some() {
+                removed = true;
+            }
         }
         if feature_flags.is_empty() {
             root.remove("featureFlags");
@@ -214,6 +213,8 @@ mod tests {
                 "featureFlags": {
                     "apply3": true,
                     "unapplyV3": false,
+                    "undo": true,
+                    "rules": true,
                     "cv3": true
                 }
             }"#,
@@ -229,6 +230,8 @@ mod tests {
         assert_eq!(saved["featureFlags"]["cv3"], json!(true));
         assert_eq!(saved["featureFlags"].get("apply3"), None);
         assert_eq!(saved["featureFlags"].get("unapplyV3"), None);
+        assert_eq!(saved["featureFlags"].get("undo"), None);
+        assert_eq!(saved["featureFlags"].get("rules"), None);
     }
 
     #[test]

--- a/crates/but-testsupport/src/sandbox.rs
+++ b/crates/but-testsupport/src/sandbox.rs
@@ -510,8 +510,6 @@ impl Sandbox {
             feature_flags: FeatureFlags {
                 cv3: true,
                 unapply_v3_pgm: false,
-                undo: true,
-                rules: true,
                 single_branch: true,
                 irc: false,
                 watch_mode: "auto".into(),

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -119,7 +119,6 @@ fn main() -> anyhow::Result<()> {
     std::fs::create_dir_all(&app_log_dir).context("failed to create app log dir")?;
 
     let tokio_debug = matches!(std::env::var("GITBUTLER_TOKIO_DEBUG").as_deref(), Ok("1"));
-    let app_settings_for_menu = app_settings.clone();
     runtime.block_on(async {
         tauri::async_runtime::set(tokio::runtime::Handle::current());
 
@@ -522,7 +521,7 @@ fn main() -> anyhow::Result<()> {
                 workspace::tauri_workspace_integrate_upstream::workspace_integrate_upstream,
                 platform::tauri_build_type::build_type,
             ])
-            .menu(move |handle| menu::build(handle, &app_settings_for_menu))
+            .menu(menu::build)
             .on_window_event(|window, event| match event {
                 #[cfg(target_os = "macos")]
                 tauri::WindowEvent::CloseRequested { .. } => {

--- a/crates/gitbutler-tauri/src/menu.rs
+++ b/crates/gitbutler-tauri/src/menu.rs
@@ -1,7 +1,6 @@
 use anyhow::Context as _;
 use but_api::json::Error;
 use but_error::Code;
-use but_settings::AppSettingsWithDiskSync;
 #[cfg(target_os = "macos")]
 use tauri::menu::AboutMetadata;
 use tauri::{
@@ -34,10 +33,7 @@ pub fn menu_item_set_enabled(handle: AppHandle, id: &str, enabled: bool) -> Resu
     Ok(())
 }
 
-pub fn build<R: Runtime>(
-    handle: &AppHandle<R>,
-    #[cfg_attr(target_os = "linux", allow(unused_variables))] settings: &AppSettingsWithDiskSync,
-) -> tauri::Result<Menu<R>> {
+pub fn build<R: Runtime>(handle: &AppHandle<R>) -> tauri::Result<Menu<R>> {
     #[cfg(not(feature = "disable-auto-updates"))]
     let check_for_updates =
         MenuItemBuilder::with_id("global/update", "Check for updates…").build(handle)?;
@@ -107,20 +103,6 @@ pub fn build<R: Runtime>(
 
     #[cfg(not(target_os = "linux"))]
     let edit_menu = &Submenu::new(handle, "Edit", true)?;
-
-    // For now, only on MacOS. Once mainstream, we'd have to set the accelerators correctly and test it more.
-    #[cfg(not(target_os = "linux"))]
-    if settings.get()?.feature_flags.undo && cfg!(target_os = "macos") {
-        edit_menu.append_items(&[
-            &MenuItemBuilder::with_id("edit/undo", "Undo")
-                .accelerator("CmdOrCtrl+Z")
-                .build(handle)?,
-            &MenuItemBuilder::with_id("edit/redo", "Redo")
-                .accelerator("CmdOrCtrl+Shift+Z")
-                .build(handle)?,
-            &PredefinedMenuItem::separator(handle)?,
-        ])?;
-    }
 
     #[cfg(not(target_os = "linux"))]
     {
@@ -254,14 +236,6 @@ pub fn build<R: Runtime>(
 }
 
 pub fn handle_event(webview: &WebviewWindow, event: &MenuEvent) {
-    if event.id() == "edit/undo" {
-        eprintln!("use app undo queue to undo.");
-        return;
-    }
-    if event.id() == "edit/redo" {
-        eprintln!("use app undo queue to redo.");
-        return;
-    }
     if event.id() == "file/add-local-repo" {
         emit(webview, "menu://shortcut", "add-local-repo");
         return;

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -1198,25 +1198,6 @@ export type FeatureFlags = {
   cv3: boolean;
   /** Use the V3 unapply compatibility mode that keeps workspace commits unless deleting the workspace ref. */
   unapplyV3Pgm: boolean;
-  /**
-   * Enable undo/redo support.
-   *
-   * ### Progression for implementation
-   *
-   * * use snapshot system in undo/redo queue
-   *     - consider not referring to these objects by reference to `git gc` will catch them,
-   *       or even purge them on shutdown. Alternatively, keep them in-memory with in-memory objects.
-   * * add user-control to snapshot system to purge now, or purge after time X. That way data isn't stored forever.
-   * * Finally, consider implementing undo/redo with invasive primitives that are undoable/redoable themselves for
-   *   the most efficient solution, inherently in memory, i.e.
-   *     - CRUD reference
-   *     - CRUD metadata
-   *     - CRUD workspace
-   *     - CRUD files
-   */
-  undo: boolean;
-  /** Enable processing of workspace rules. */
-  rules: boolean;
   /** Enable single branch mode. */
   singleBranch: boolean;
   /** Enable IRC integration. */


### PR DESCRIPTION
Removes two dead-weight flags found while auditing `FeatureFlags` in `but-settings`.

- **`rules`** — gated the workspace-rules feature, which was already fully removed (its `workspace_rules` DB table was dropped). The only remaining reference was a PostHog telemetry property.
- **`undo`** — only gated a macOS Undo/Redo menu whose event handler never performed any undo/redo (it just logged to stderr), and the flag wasn't even exposed through the settings update API.

This drops the struct fields, update-API plumbing, defaults, generated TS bindings, and the now-unused menu wiring, and prunes both keys from existing on-disk settings on load (same path that already strips `apply3`/`unapplyV3`).

The other seven flags are kept — they either gate live behavior (`cv3`, `unapply_v3_pgm`, `single_branch`, `irc`, `watch_mode`, `tui_file_browser`) or back in-progress work (`write_commit_evolution`).