### PR TITLE
Explain rewritten status marker for agents

### DIFF
--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -195,6 +195,7 @@ struct StatusContext<'a> {
     ci_map: BTreeMap<String, Vec<but_forge::CiCheck>>,
     branch_merge_statuses: BTreeMap<String, UpstreamBranchStatus>,
     has_branches: bool,
+    is_agent_invocation: bool,
     is_paged: bool,
     should_truncate_for_terminal: bool,
     id_map: IdMap,
@@ -535,6 +536,8 @@ fn build_status_context<'a>(
         branch_merge_statuses,
         flags,
         has_branches,
+        is_agent_invocation: matches!(format, OutputFormat::Agent)
+            || crate::utils::detect_agent::detect().is_some(),
         is_paged,
         should_truncate_for_terminal,
         id_map,
@@ -630,6 +633,13 @@ fn print_hint(
     // Determine what hint to show based on workspace state
     let has_uncommitted_files = !status_ctx.worktree_changes.is_empty();
 
+    if should_explain_rewritten_commit_marker(status_ctx) {
+        output.hint(Vec::from([Span::styled(
+            "Hint: ◐ means rewritten locally vs upstream.",
+            crate::theme::get().hint,
+        )]))?;
+    }
+
     let hint_text = if not_on_workspace {
         "Hint: run `but setup` to switch back to GitButler managed mode."
     } else if has_merged_upstream_branch {
@@ -648,6 +658,21 @@ fn print_hint(
     )]))?;
 
     Ok(())
+}
+
+fn should_explain_rewritten_commit_marker(status_ctx: &StatusContext<'_>) -> bool {
+    status_ctx.is_agent_invocation
+        && status_ctx
+            .local_commits_by_id
+            .values()
+            .any(is_rewritten_local_commit)
+}
+
+fn is_rewritten_local_commit(commit: &LocalCommit) -> bool {
+    matches!(
+        commit.relation,
+        LocalCommitRelation::LocalAndRemote(remote_id) if remote_id != commit.inner.id
+    )
 }
 
 fn branch_merge_status<'a>(
@@ -1295,13 +1320,10 @@ fn print_group(
                     .context("BUG: head_info does not contain local commit that graph has")?;
                 let classification = match inner.relation {
                     LocalCommitRelation::LocalOnly => CommitClassification::LocalOnly,
-                    LocalCommitRelation::LocalAndRemote(object_id) => {
-                        if object_id == commit.commit_id() {
-                            CommitClassification::Pushed
-                        } else {
-                            CommitClassification::Modified
-                        }
+                    LocalCommitRelation::LocalAndRemote(_) if is_rewritten_local_commit(inner) => {
+                        CommitClassification::Modified
                     }
+                    LocalCommitRelation::LocalAndRemote(_) => CommitClassification::Pushed,
                     LocalCommitRelation::Integrated(_) => CommitClassification::Integrated,
                 };
 

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -1070,6 +1070,80 @@ fn status_shows_rewritten_branch_with_remote_and_local_commits() {
 }
 
 #[test]
+fn agent_status_explains_rewritten_commit_marker() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.file("one.txt", "one\n");
+    env.but("commit -m 'add one' -c A")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![]);
+    env.invoke_git("update-ref refs/remotes/origin/A refs/heads/A");
+
+    env.file("one.txt", "one amended\n");
+    let target_commit = env.invoke_git("rev-parse --short refs/heads/A");
+    env.but(format!("amend {target_commit} --changes one.txt"))
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊◐   [..] add one
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("status")
+        .env("AI_AGENT", "codex")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊◐   [..] add one
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: ◐ means rewritten locally vs upstream.
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("--format agent status")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊◐   [..] add one
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: ◐ means rewritten locally vs upstream.
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
 fn status_in_edit_mode_delegates_to_resolve_status() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     enter_edit_mode_with_conflicted_commit(&env)?;


### PR DESCRIPTION
Adds an agent-only status hint for the ◐ commit marker when status contains a locally rewritten commit relative to upstream. This keeps normal human status output unchanged while giving agent runs the marker semantics directly in the output they inspect.

Tests:
- cargo fmt --check -p but
- cargo test -p but agent_status_explains_rewritten_commit_marker
- cargo test -p but status_shows_rewritten_branch_with_remote_and_local_commits