### PR TITLE
feat(but): implement branches as targets for `_move2`

### DIFF
--- a/crates/but/src/args/atoms/branch_arg.rs
+++ b/crates/but/src/args/atoms/branch_arg.rs
@@ -172,6 +172,24 @@ impl BranchArg {
         Ok(None)
     }
 
+    /// Try to resolve as a branch that's applied in the workspace.
+    ///
+    /// Errors if the branch does not exist.
+    ///
+    /// Returns `Ok(None)` if the branch exists but is not applied.
+    pub fn try_resolve_applied_branch(
+        &self,
+        repo: &gix::Repository,
+        ws: &Workspace,
+    ) -> CliResult<Option<FullName>> {
+        let branch = self.resolve_existing_local_branch(repo)?;
+        if ws.refname_is_segment(branch.as_ref()) {
+            Ok(Some(branch))
+        } else {
+            Ok(None)
+        }
+    }
+
     /// Try to resolve the branch to a stack that exists in the workspace.
     ///
     /// Returns `None` if the branch can't be found which might be caused it not being applied.

--- a/crates/but/src/args/atoms/branch_arg.rs
+++ b/crates/but/src/args/atoms/branch_arg.rs
@@ -172,24 +172,6 @@ impl BranchArg {
         Ok(None)
     }
 
-    /// Try to resolve as a branch that's applied in the workspace.
-    ///
-    /// Errors if the branch does not exist.
-    ///
-    /// Returns `Ok(None)` if the branch exists but is not applied.
-    pub fn try_resolve_applied_branch(
-        &self,
-        repo: &gix::Repository,
-        ws: &Workspace,
-    ) -> CliResult<Option<FullName>> {
-        let branch = self.resolve_existing_local_branch(repo)?;
-        if ws.refname_is_segment(branch.as_ref()) {
-            Ok(Some(branch))
-        } else {
-            Ok(None)
-        }
-    }
-
     /// Try to resolve the branch to a stack that exists in the workspace.
     ///
     /// Returns `None` if the branch can't be found which might be caused it not being applied.

--- a/crates/but/src/command/legacy/move2.rs
+++ b/crates/but/src/command/legacy/move2.rs
@@ -21,21 +21,29 @@ use crate::{
     utils::{CliOutputHuman, IntermediateChannel, WriteWithUtils, targeting::Side},
 };
 
-pub enum MoveOutcome {
-    Commits {
-        sources: NonEmpty<gix::ObjectId>,
-        target: MoveTarget,
-    },
+pub struct MoveOutcome {
+    pub sources: NonEmpty<gix::ObjectId>,
+    pub target: MoveTarget,
+    pub new_branch_name: Option<FullName>,
 }
 
 impl CliOutputHuman for MoveOutcome {
     fn on_human(self, out: &mut dyn WriteWithUtils, _theme: &Theme) -> anyhow::Result<()> {
-        match self {
-            Self::Commits { sources, target } => {
-                let sources = sources.into_iter().map(theme::Commit).join(", ");
+        let Self {
+            sources,
+            target,
+            new_branch_name,
+        } = self;
+        let sources = sources.into_iter().map(theme::Commit).join(", ");
 
-                writeln!(out, "Moved {sources} {target}")?;
-            }
+        if let Some(new_branch_name) = new_branch_name {
+            writeln!(
+                out,
+                "Moved {sources} to new branch {} {target}",
+                theme::Branch(new_branch_name)
+            )?;
+        } else {
+            writeln!(out, "Moved {sources} {target}")?;
         }
 
         Ok(())
@@ -68,9 +76,14 @@ struct MoveCommitsOperation {
 }
 
 impl MoveCommitsOperation {
-    fn execute(self, tx: &mut Transaction<'_, '_, impl RefMetadata>) -> anyhow::Result<()> {
-        let (relative_to, side) = match self.target {
-            MoveTarget::Commit { commit_id, side } => (RelativeTo::Commit(commit_id), side.into()),
+    fn execute(
+        self,
+        tx: &mut Transaction<'_, '_, impl RefMetadata>,
+    ) -> anyhow::Result<Option<FullName>> {
+        let (relative_to, side, new_branch_name) = match self.target {
+            MoveTarget::Commit { commit_id, side } => {
+                (RelativeTo::Commit(commit_id), side.into(), None)
+            }
             MoveTarget::BranchBucket { name, side } => {
                 let new_branch_name = but_core::branch::unique_canned_refname(tx.repo())?;
                 let anchor = Anchor::at_segment(name.as_ref(), side.into());
@@ -80,12 +93,16 @@ impl MoveCommitsOperation {
                     |_| StackId::generate(),
                     Some(0),
                 )?;
-                (RelativeTo::Reference(new_branch_name), Side::Below.into())
+                (
+                    RelativeTo::Reference(new_branch_name.clone()),
+                    Side::Below.into(),
+                    Some(new_branch_name),
+                )
             }
         };
 
         tx.move_commits(self.sources, relative_to, side)?;
-        Ok(())
+        Ok(new_branch_name)
     }
 }
 
@@ -183,25 +200,27 @@ fn run(
     move_op: MoveOperation,
 ) -> CliResult<MoveOutcome> {
     let snapshot_details = SnapshotDetails::new(OperationKind::MoveCommit);
-    let ((), _ws) = but_transaction::with_transaction_with_perm(
+    let (new_branch_name, _ws) = but_transaction::with_transaction_with_perm(
         ctx,
         meta,
         perm,
         snapshot_details,
         DryRun::No,
         |mut tx| {
-            match move_op.clone() {
+            let new_branch_name = match move_op.clone() {
                 MoveOperation::Commit(op) => op.execute(&mut tx)?,
             };
 
-            Ok(but_transaction::Commit(()))
+            Ok(but_transaction::Commit(new_branch_name))
         },
     )?;
 
     let outcome = match move_op {
-        MoveOperation::Commit(MoveCommitsOperation { sources, target }) => {
-            MoveOutcome::Commits { sources, target }
-        }
+        MoveOperation::Commit(MoveCommitsOperation { sources, target }) => MoveOutcome {
+            sources,
+            target,
+            new_branch_name,
+        },
     };
 
     Ok(outcome)

--- a/crates/but/src/command/legacy/move2.rs
+++ b/crates/but/src/command/legacy/move2.rs
@@ -1,16 +1,21 @@
 use std::fmt::Display;
 
-use but_core::{DryRun, RefMetadata, sync::RepoExclusive};
+use but_core::{DryRun, RefMetadata, ref_metadata::StackId, sync::RepoExclusive};
 use but_ctx::Context;
 use but_rebase::graph_rebase::mutate::RelativeTo;
 use but_transaction::Transaction;
+use but_workspace::branch::create_reference::Anchor;
 use gitbutler_oplog::entry::{OperationKind, SnapshotDetails};
+use gix::refs::FullName;
 use itertools::Itertools;
 use nonempty::NonEmpty;
 
 use crate::{
     CliResult, IdMap,
-    args::move2::Platform,
+    args::{
+        atoms::{BranchOrCommit, Purpose},
+        move2::Platform,
+    },
     bad_input,
     theme::{self, Theme},
     utils::{CliOutputHuman, IntermediateChannel, WriteWithUtils, targeting::Side},
@@ -66,6 +71,17 @@ impl MoveCommitsOperation {
     fn execute(self, tx: &mut Transaction<'_, '_, impl RefMetadata>) -> anyhow::Result<()> {
         let (relative_to, side) = match self.target {
             MoveTarget::Commit { commit_id, side } => (RelativeTo::Commit(commit_id), side.into()),
+            MoveTarget::BranchBucket { name, side } => {
+                let new_branch_name = but_core::branch::unique_canned_refname(tx.repo())?;
+                let anchor = Anchor::at_segment(name.as_ref(), side.into());
+                tx.create_reference(
+                    new_branch_name.as_ref(),
+                    anchor,
+                    |_| StackId::generate(),
+                    Some(0),
+                )?;
+                (RelativeTo::Reference(new_branch_name), Side::Below.into())
+            }
         };
 
         tx.move_commits(self.sources, relative_to, side)?;
@@ -80,13 +96,20 @@ pub enum MoveTarget {
         commit_id: gix::ObjectId,
         side: Side,
     },
+    BranchBucket {
+        name: FullName,
+        side: Side,
+    },
 }
 
 impl Display for MoveTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Commit { commit_id, side } => {
-                write!(f, "{} {}", side, theme::Commit(*commit_id))
+                write!(f, "{} commit {}", side, theme::Commit(*commit_id))
+            }
+            Self::BranchBucket { name, side } => {
+                write!(f, "{} branch {}", side, theme::Branch(name))
             }
         }
     }
@@ -104,7 +127,7 @@ fn resolve(
         sources,
     } = args;
 
-    let (repo, _ws, _db) = ctx.workspace_and_db_with_perm(perm.read_permission())?;
+    let (repo, ws, _db) = ctx.workspace_and_db_with_perm(perm.read_permission())?;
 
     let (unresolved_target, side) = match (above, below) {
         (Some(above), None) => (above, Side::Above),
@@ -113,8 +136,18 @@ fn resolve(
     };
 
     let target = {
-        let commit_id = unresolved_target.resolve_commit_in_workspace(&repo, id_map)?;
-        MoveTarget::Commit { commit_id, side }
+        match unresolved_target
+            .resolve_in_workspace(&repo, id_map, Purpose::Anchor, None)?
+            .into_branch_or_commit()?
+        {
+            BranchOrCommit::Commit(commit_id) => MoveTarget::Commit { commit_id, side },
+            BranchOrCommit::Branch(branch_arg) => {
+                let name = branch_arg
+                    .try_resolve_applied_branch(&repo, &ws)?
+                    .expect("TODO: What if branch is not applied?");
+                MoveTarget::BranchBucket { name, side }
+            }
+        }
     };
 
     let sources = sources

--- a/crates/but/src/command/legacy/move2.rs
+++ b/crates/but/src/command/legacy/move2.rs
@@ -127,7 +127,7 @@ fn resolve(
         sources,
     } = args;
 
-    let (repo, ws, _db) = ctx.workspace_and_db_with_perm(perm.read_permission())?;
+    let (repo, _ws, _db) = ctx.workspace_and_db_with_perm(perm.read_permission())?;
 
     let (unresolved_target, side) = match (above, below) {
         (Some(above), None) => (above, Side::Above),
@@ -141,12 +141,10 @@ fn resolve(
             .into_branch_or_commit()?
         {
             BranchOrCommit::Commit(commit_id) => MoveTarget::Commit { commit_id, side },
-            BranchOrCommit::Branch(branch_arg) => {
-                let name = branch_arg
-                    .try_resolve_applied_branch(&repo, &ws)?
-                    .expect("TODO: What if branch is not applied?");
-                MoveTarget::BranchBucket { name, side }
-            }
+            BranchOrCommit::Branch(branch_arg) => MoveTarget::BranchBucket {
+                name: branch_arg.resolve_existing_local_branch(&repo)?,
+                side,
+            },
         }
     };
 

--- a/crates/but/tests/but/command/move2.rs
+++ b/crates/but/tests/but/command/move2.rs
@@ -26,7 +26,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved fe12bcd above 9ac4652
+Moved fe12bcd above commit 9ac4652
 
 "#]]);
 
@@ -74,7 +74,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 9ac4652 below fe12bcd
+Moved 9ac4652 below commit fe12bcd
 
 "#]]);
 
@@ -251,6 +251,206 @@ Hint: run `but help` for all commands
 
         env.but("undo").assert().success();
     }
+}
+
+#[test]
+fn moving_commits_above_branch_creates_branch_above() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊●   fe12bcd add first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 fe --above g0")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved fe12bcd above branch 'A'
+
+"#]]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄br [a-branch-1]
+┊●   c6224e6 add first
+┊│
+┊├┄g0 [A]
+┊●   ce8b324 add second
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn moving_commits_above_branch_without_changing_relative_order_only_creates_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊●   fe12bcd add first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 9a --above g0")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved 9ac4652 above branch 'A'
+
+"#]]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄br [a-branch-1]
+┊●   9ac4652 add second
+┊│
+┊├┄g0 [A]
+┊●   fe12bcd add first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn moving_commits_below_branch_creates_branch_below() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊●   fe12bcd add first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 9a --below g0")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved 9ac4652 below branch 'A'
+
+"#]]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   c6224e6 add first
+┊│
+┊├┄br [a-branch-1]
+┊●   ce8b324 add second
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn moving_commits_below_branch_without_changing_relative_order_only_creates_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊●   fe12bcd add first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 fe --below g0")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved fe12bcd below branch 'A'
+
+"#]]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊│
+┊├┄br [a-branch-1]
+┊●   fe12bcd add first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
 }
 
 #[test]

--- a/crates/but/tests/but/command/move2.rs
+++ b/crates/but/tests/but/command/move2.rs
@@ -279,7 +279,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved fe12bcd above branch 'A'
+Moved fe12bcd to new branch 'a-branch-1' above branch 'A'
 
 "#]]);
 
@@ -329,7 +329,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 9ac4652 above branch 'A'
+Moved 9ac4652 to new branch 'a-branch-1' above branch 'A'
 
 "#]]);
 
@@ -379,7 +379,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 9ac4652 below branch 'A'
+Moved 9ac4652 to new branch 'a-branch-1' below branch 'A'
 
 "#]]);
 
@@ -429,7 +429,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved fe12bcd below branch 'A'
+Moved fe12bcd to new branch 'a-branch-1' below branch 'A'
 
 "#]]);
 
@@ -479,7 +479,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 9ac4652, fe12bcd above branch 'A'
+Moved 9ac4652, fe12bcd to new branch 'a-branch-1' above branch 'A'
 
 "#]]);
 
@@ -529,7 +529,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 9ac4652, fe12bcd below branch 'A'
+Moved 9ac4652, fe12bcd to new branch 'a-branch-1' below branch 'A'
 
 "#]]);
 
@@ -597,13 +597,19 @@ Hint: Run `but status` for applicable targets.
 
 "#]]);
 
-    env.but("_move2 94 --above no-such-branch").assert().failure().stderr_eq(snapbox::str![[r#"
+    env.but("_move2 94 --above no-such-branch")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
 Error: Could not find anchor: 'no-such-branch'
 
 Hint: Run `but status` for applicable targets.
 
 "#]]);
-    env.but("_move2 94 --below no-such-branch").assert().failure().stderr_eq(snapbox::str![[r#"
+    env.but("_move2 94 --below no-such-branch")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
 Error: Could not find anchor: 'no-such-branch'
 
 Hint: Run `but status` for applicable targets.

--- a/crates/but/tests/but/command/move2.rs
+++ b/crates/but/tests/but/command/move2.rs
@@ -454,6 +454,164 @@ Hint: run `but help` for all commands
 }
 
 #[test]
+fn moving_all_commits_above_branch_retains_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊●   fe12bcd add first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 9a fe --above g0")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved 9ac4652, fe12bcd above branch 'A'
+
+"#]]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄br [a-branch-1]
+┊●   9ac4652 add second
+┊●   fe12bcd add first
+┊│
+┊├┄g0 [A] (no commits)
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn moving_all_commits_below_branch_retains_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊●   fe12bcd add first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 9a fe --below g0")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved 9ac4652, fe12bcd below branch 'A'
+
+"#]]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A] (no commits)
+┊│
+┊├┄br [a-branch-1]
+┊●   9ac4652 add second
+┊●   fe12bcd add first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn above_or_below_unapplied_or_non_existing_branch_errors() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks-one-empty");
+    env.setup_metadata(&["A", "B"]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┊╭┄h0 [B] (no commits)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+    env.but("unapply B").assert().success();
+
+    env.but("_move2 94 --above B")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: Could not find anchor: 'B'
+
+Hint: Run `but status` for applicable targets.
+
+"#]]);
+    env.but("_move2 94 --below B")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: Could not find anchor: 'B'
+
+Hint: Run `but status` for applicable targets.
+
+"#]]);
+
+    env.but("_move2 94 --above no-such-branch").assert().failure().stderr_eq(snapbox::str![[r#"
+Error: Could not find anchor: 'no-such-branch'
+
+Hint: Run `but status` for applicable targets.
+
+"#]]);
+    env.but("_move2 94 --below no-such-branch").assert().failure().stderr_eq(snapbox::str![[r#"
+Error: Could not find anchor: 'no-such-branch'
+
+Hint: Run `but status` for applicable targets.
+
+"#]]);
+}
+
+#[test]
 fn cannot_combine_above_and_below() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
     env.setup_metadata(&["A"]);

--- a/crates/but/tests/but/command/move2.rs
+++ b/crates/but/tests/but/command/move2.rs
@@ -554,6 +554,114 @@ Hint: run `but help` for all commands
 }
 
 #[test]
+fn move_commit_above_empty_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks-one-empty");
+    env.setup_metadata(&["A", "B"]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┊╭┄h0 [B] (no commits)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 94 --above h0")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved 9477ae7 to new branch 'a-branch-1' above branch 'B'
+
+"#]]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A] (no commits)
+├╯
+┊
+┊╭┄br [a-branch-1]
+┊●   9477ae7 add A
+┊│
+┊├┄h0 [B] (no commits)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn move_commit_below_empty_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks-one-empty");
+    env.setup_metadata(&["A", "B"]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┊╭┄h0 [B] (no commits)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 94 --below h0")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved 9477ae7 to new branch 'a-branch-1' below branch 'B'
+
+"#]]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A] (no commits)
+├╯
+┊
+┊╭┄h0 [B] (no commits)
+┊│
+┊├┄br [a-branch-1]
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
 fn above_or_below_unapplied_or_non_existing_branch_errors() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks-one-empty");
     env.setup_metadata(&["A", "B"]);


### PR DESCRIPTION
Targeting a branch with `--above`/`--below` with commit sources creates a new branch at the target location and moves the commits there.