### PR TITLE
Store ad-hoc branch order metadata

### DIFF
--- a/crates/but-core/src/lib.rs
+++ b/crates/but-core/src/lib.rs
@@ -231,6 +231,50 @@ pub trait RefMetadata {
     /// Set branch metadata to match `value`.
     fn set_branch(&mut self, value: &Self::Handle<ref_metadata::Branch>) -> anyhow::Result<()>;
 
+    /// Return the ordered local branch refs in the same stack as `ref_name`, from tip to base.
+    ///
+    /// Implementations that don't persist branch stack order can return `Ok(None)`.
+    fn branch_stack_order(
+        &self,
+        _ref_name: &gix::refs::FullNameRef,
+    ) -> anyhow::Result<Option<Vec<gix::refs::FullName>>> {
+        Ok(None)
+    }
+
+    /// Persist the ordered local branch refs for an ad-hoc/single-branch stack, from tip to base.
+    ///
+    /// Implementations that don't persist branch stack order should return an error.
+    fn set_branch_stack_order(&mut self, _branches: &[gix::refs::FullName]) -> anyhow::Result<()> {
+        anyhow::bail!("This metadata backend doesn't support branch stack order")
+    }
+
+    /// Return `true` if this backend can persist ad-hoc/single-branch stack order.
+    fn can_persist_branch_stack_order(&self) -> bool {
+        false
+    }
+
+    /// Rename a local branch ref in persisted ad-hoc/single-branch stack order metadata.
+    ///
+    /// Implementations that don't persist branch stack order can ignore this.
+    fn rename_branch_stack_order_reference(
+        &mut self,
+        _old_ref_name: &gix::refs::FullNameRef,
+        _new_ref_name: &gix::refs::FullNameRef,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    /// Remove persisted ad-hoc/single-branch stack order entries for refs that no longer exist.
+    ///
+    /// `existing_ref_names` must contain the complete set of existing local branch refs.
+    /// Implementations that don't persist branch stack order can ignore this.
+    fn remove_missing_branch_stack_order_references(
+        &mut self,
+        _existing_ref_names: &[gix::refs::FullName],
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     /// Delete the metadata associated with the given `ref_name` and return `true` if it existed, or `false` otherwise.
     ///
     /// It is OK to delete something that doesn't exist.

--- a/crates/but-db/src/handle.rs
+++ b/crates/but-db/src/handle.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use but_utils::OnDemand;
+use rusqlite::OpenFlags;
 use tracing::instrument;
 
 use crate::{CacheHandle, DbHandle, migration, migration::improve_concurrency};
@@ -23,6 +24,34 @@ impl DbHandle {
             std::fs::create_dir_all(parent_dir_to_create)?;
         }
         Self::new_at_path(db_file_path)
+    }
+
+    /// Open the project database for read-only access if it already exists.
+    ///
+    /// Unlike [`Self::new_in_directory()`], this never creates parent directories,
+    /// creates the database file, or runs migrations.
+    pub fn open_existing_read_only_in_directory(
+        db_dir: impl AsRef<Path>,
+    ) -> anyhow::Result<Option<Self>> {
+        let db_file_path = Self::db_file_path(db_dir);
+        if !db_file_path.exists() {
+            return Ok(None);
+        }
+        Self::open_existing_read_only_at_path(db_file_path).map(Some)
+    }
+
+    /// Open an existing project database for read-only access.
+    #[instrument(
+        name = "DbHandle::open_existing_read_only_at_path",
+        level = "trace",
+        skip(path),
+        err(Debug)
+    )]
+    pub fn open_existing_read_only_at_path(path: impl Into<PathBuf>) -> anyhow::Result<Self> {
+        let path = path.into();
+        let conn = rusqlite::Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        let cache = cache_for_db_path(&path);
+        Ok(DbHandle { conn, path, cache })
     }
 
     /// A new instance connecting to the project database at the given `path`.

--- a/crates/but-db/src/lib.rs
+++ b/crates/but-db/src/lib.rs
@@ -71,6 +71,7 @@ pub mod migration;
 #[rustfmt::skip]
 pub use table::{
     hunk_assignments::{HunkAssignmentsHandleMut, HunkAssignmentsHandle, HunkAssignment},
+    branch_order::{BranchOrderHandle, BranchOrderHandleMut},
     butler_actions::ButlerAction,
     workflows::Workflow,
     claude::{ClaudeMessage, ClaudePermissionRequest, ClaudeSession},
@@ -128,6 +129,7 @@ pub fn map_err(err: rusqlite::Error) -> ::backoff::Error<rusqlite::Error> {
 pub const MIGRATIONS: &[&[M<'static>]] = &[
     table::M_FULLY_REMOVED,
     table::hunk_assignments::M,
+    table::branch_order::M,
     table::butler_actions::M,
     table::workflows::M,
     table::claude::M,

--- a/crates/but-db/src/table/branch_order.rs
+++ b/crates/but-db/src/table/branch_order.rs
@@ -1,0 +1,278 @@
+#![allow(missing_docs)]
+
+use std::collections::BTreeSet;
+
+use rusqlite::OptionalExtension;
+
+use crate::{DbHandle, M, SchemaVersion, Transaction};
+
+pub(crate) const M: &[M<'static>] = &[M::up(
+    20260626120100,
+    SchemaVersion::Zero,
+    "CREATE TABLE `branch_order`(
+    `branch_ref_name` TEXT NOT NULL PRIMARY KEY,
+    `parent_ref_name` TEXT UNIQUE,
+    CHECK (`parent_ref_name` IS NULL OR `branch_ref_name` != `parent_ref_name`)
+);
+
+CREATE INDEX `idx_branch_order_parent_ref_name` ON `branch_order`(`parent_ref_name`);",
+)];
+
+/// Read-only accessor for ad-hoc branch ordering metadata.
+pub struct BranchOrderHandle<'conn> {
+    conn: &'conn rusqlite::Connection,
+}
+
+/// Mutating accessor for ad-hoc branch ordering metadata.
+pub struct BranchOrderHandleMut<'conn> {
+    sp: rusqlite::Savepoint<'conn>,
+}
+
+impl DbHandle {
+    /// Return a read-only handle for ad-hoc branch ordering metadata.
+    pub fn branch_order(&self) -> BranchOrderHandle<'_> {
+        BranchOrderHandle { conn: &self.conn }
+    }
+
+    /// Return a mutating handle for ad-hoc branch ordering metadata.
+    pub fn branch_order_mut(&mut self) -> rusqlite::Result<BranchOrderHandleMut<'_>> {
+        Ok(BranchOrderHandleMut {
+            sp: self.conn.savepoint()?,
+        })
+    }
+}
+
+impl<'conn> Transaction<'conn> {
+    /// Return a read-only handle for ad-hoc branch ordering metadata.
+    pub fn branch_order(&self) -> BranchOrderHandle<'_> {
+        BranchOrderHandle { conn: self.inner() }
+    }
+
+    /// Return a mutating handle for ad-hoc branch ordering metadata.
+    pub fn branch_order_mut(&mut self) -> rusqlite::Result<BranchOrderHandleMut<'_>> {
+        Ok(BranchOrderHandleMut {
+            sp: self.inner_mut().savepoint()?,
+        })
+    }
+}
+
+impl BranchOrderHandle<'_> {
+    /// Return the ordered chain containing `ref_name`, from tip to base.
+    pub fn order_for_reference(&self, ref_name: &str) -> rusqlite::Result<Option<Vec<String>>> {
+        let has_row = match self.has_reference(ref_name) {
+            Ok(has_row) => has_row,
+            Err(err) if is_missing_branch_order_table(&err) => return Ok(None),
+            Err(err) => return Err(err),
+        };
+        let has_child = self.child_of(ref_name)?.is_some();
+        if !has_row && !has_child {
+            return Ok(None);
+        }
+
+        let mut seen = BTreeSet::from([ref_name.to_owned()]);
+        let mut above = Vec::new();
+        let mut cursor = ref_name.to_owned();
+        while let Some(child) = self.child_of(&cursor)? {
+            if !seen.insert(child.clone()) {
+                return Ok(None);
+            }
+            above.push(child.clone());
+            cursor = child;
+        }
+
+        let mut below = vec![ref_name.to_owned()];
+        let mut cursor = ref_name.to_owned();
+        while let Some(parent) = self.parent_of(&cursor)? {
+            if !seen.insert(parent.clone()) {
+                return Ok(None);
+            }
+            below.push(parent.clone());
+            cursor = parent;
+        }
+
+        above.reverse();
+        above.extend(below);
+        Ok(Some(above))
+    }
+
+    fn has_reference(&self, ref_name: &str) -> rusqlite::Result<bool> {
+        self.conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM branch_order WHERE branch_ref_name = ?1)",
+            [ref_name],
+            |row| row.get(0),
+        )
+    }
+
+    fn parent_of(&self, ref_name: &str) -> rusqlite::Result<Option<String>> {
+        self.conn
+            .query_row(
+                "SELECT parent_ref_name FROM branch_order WHERE branch_ref_name = ?1",
+                [ref_name],
+                |row| row.get(0),
+            )
+            .optional()
+            .map(Option::flatten)
+    }
+
+    fn child_of(&self, ref_name: &str) -> rusqlite::Result<Option<String>> {
+        self.conn
+            .query_row(
+                "SELECT branch_ref_name FROM branch_order WHERE parent_ref_name = ?1",
+                [ref_name],
+                |row| row.get(0),
+            )
+            .optional()
+    }
+
+    fn all_references(&self) -> rusqlite::Result<Vec<String>> {
+        self.conn
+            .prepare("SELECT branch_ref_name FROM branch_order")?
+            .query_map([], |row| row.get(0))?
+            .collect()
+    }
+}
+
+fn is_missing_branch_order_table(err: &rusqlite::Error) -> bool {
+    matches!(
+        err,
+        rusqlite::Error::SqliteFailure(_, Some(message))
+            if message.contains("no such table: branch_order")
+    )
+}
+
+impl BranchOrderHandleMut<'_> {
+    /// Convert this mutating handle into a read-only view on the same savepoint.
+    pub fn to_ref(&self) -> BranchOrderHandle<'_> {
+        BranchOrderHandle { conn: &self.sp }
+    }
+
+    /// Replace the persisted chain containing `branches` with `branches` in tip-to-base order.
+    pub fn set_order(self, branches: &[String]) -> rusqlite::Result<()> {
+        let sp = self.sp;
+        if branches.is_empty() {
+            sp.commit()?;
+            return Ok(());
+        }
+
+        let mut seen = BTreeSet::new();
+        for branch in branches {
+            if !seen.insert(branch.as_str()) {
+                return Err(rusqlite::Error::InvalidQuery);
+            }
+        }
+
+        let order = BranchOrderHandle { conn: &sp };
+        let mut refs_to_replace = BTreeSet::new();
+        for branch in branches {
+            refs_to_replace.insert(branch.as_str().to_owned());
+            if let Some(order) = order.order_for_reference(branch)? {
+                refs_to_replace.extend(order);
+            }
+        }
+
+        for branch in refs_to_replace {
+            sp.execute(
+                "DELETE FROM branch_order WHERE branch_ref_name = ?1",
+                [branch],
+            )?;
+        }
+
+        let mut insert = sp.prepare(
+            "INSERT INTO branch_order (branch_ref_name, parent_ref_name) VALUES (?1, ?2)",
+        )?;
+        for (idx, branch) in branches.iter().enumerate() {
+            let parent = branches.get(idx + 1);
+            insert.execute(rusqlite::params![branch, parent])?;
+        }
+        drop(insert);
+
+        sp.commit()
+    }
+
+    /// Remove `ref_name` from its chain, connecting its child directly to its parent if needed.
+    pub fn remove_reference(self, ref_name: &str) -> rusqlite::Result<()> {
+        let sp = self.sp;
+        remove_reference_in_savepoint(&sp, ref_name)?;
+        sp.commit()
+    }
+
+    /// Rename `old_ref_name` to `new_ref_name` everywhere it appears in branch-order metadata.
+    pub fn rename_reference(self, old_ref_name: &str, new_ref_name: &str) -> rusqlite::Result<()> {
+        let sp = self.sp;
+        if old_ref_name == new_ref_name {
+            sp.commit()?;
+            return Ok(());
+        }
+
+        let order = BranchOrderHandle { conn: &sp };
+        let has_old = order.has_reference(old_ref_name)? || order.child_of(old_ref_name)?.is_some();
+        if !has_old {
+            sp.commit()?;
+            return Ok(());
+        }
+        if order.has_reference(new_ref_name)? || order.child_of(new_ref_name)?.is_some() {
+            return Err(rusqlite::Error::InvalidQuery);
+        }
+
+        sp.execute(
+            "UPDATE branch_order SET parent_ref_name = ?1 WHERE parent_ref_name = ?2",
+            [new_ref_name, old_ref_name],
+        )?;
+        sp.execute(
+            "UPDATE branch_order SET branch_ref_name = ?1 WHERE branch_ref_name = ?2",
+            [new_ref_name, old_ref_name],
+        )?;
+
+        sp.commit()
+    }
+
+    /// Remove branch-order rows for references not present in `existing_ref_names`.
+    pub fn remove_missing_references(self, existing_ref_names: &[String]) -> rusqlite::Result<()> {
+        let sp = self.sp;
+        let existing = existing_ref_names
+            .iter()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>();
+        let refs = BranchOrderHandle { conn: &sp }.all_references()?;
+        for ref_name in refs {
+            if !existing.contains(ref_name.as_str()) {
+                remove_reference_in_savepoint(&sp, &ref_name)?;
+            }
+        }
+        sp.commit()
+    }
+}
+
+fn remove_reference_in_savepoint(
+    sp: &rusqlite::Savepoint<'_>,
+    ref_name: &str,
+) -> rusqlite::Result<()> {
+    let parent = BranchOrderHandle { conn: sp }.parent_of(ref_name)?;
+    let child = BranchOrderHandle { conn: sp }.child_of(ref_name)?;
+
+    sp.execute(
+        "DELETE FROM branch_order WHERE branch_ref_name = ?1",
+        [ref_name],
+    )?;
+    if let Some(child) = child.as_ref() {
+        sp.execute(
+            "UPDATE branch_order SET parent_ref_name = ?1 WHERE branch_ref_name = ?2",
+            rusqlite::params![parent, child],
+        )?;
+    }
+    let singleton = match (parent.as_deref(), child.as_deref()) {
+        (Some(parent), None) => Some(parent),
+        (None, Some(child)) => Some(child),
+        _ => None,
+    };
+    if let Some(singleton) = singleton {
+        let order = BranchOrderHandle { conn: sp };
+        if order.parent_of(singleton)?.is_none() && order.child_of(singleton)?.is_none() {
+            sp.execute(
+                "DELETE FROM branch_order WHERE branch_ref_name = ?1",
+                [singleton],
+            )?;
+        }
+    }
+    Ok(())
+}

--- a/crates/but-db/src/table/mod.rs
+++ b/crates/but-db/src/table/mod.rs
@@ -1,5 +1,6 @@
 use crate::{M, SchemaVersion};
 
+pub(crate) mod branch_order;
 pub(crate) mod butler_actions;
 pub(crate) mod ci_checks;
 pub(crate) mod claude;

--- a/crates/but-db/tests/db/handle.rs
+++ b/crates/but-db/tests/db/handle.rs
@@ -29,6 +29,43 @@ fn in_nonexisting_dir() -> anyhow::Result<()> {
 }
 
 #[test]
+fn read_only_does_not_create_missing_database() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir()?;
+
+    let db = DbHandle::open_existing_read_only_in_directory(tmp.path())?;
+
+    assert!(
+        db.is_none(),
+        "missing databases should not be created by read-only opens"
+    );
+    assert!(
+        !tmp.path().join("but.sqlite").exists(),
+        "read-only opens should leave the filesystem untouched"
+    );
+    Ok(())
+}
+
+#[test]
+fn read_only_observes_existing_database() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir()?;
+    {
+        let mut db = DbHandle::new_in_directory(tmp.path())?;
+        db.branch_order_mut()?
+            .set_order(&["refs/heads/A".to_owned(), "refs/heads/B".to_owned()])?;
+    }
+
+    let db = DbHandle::open_existing_read_only_in_directory(tmp.path())?
+        .expect("database was created before read-only open");
+
+    assert_eq!(
+        db.branch_order().order_for_reference("refs/heads/B")?,
+        Some(vec!["refs/heads/A".to_owned(), "refs/heads/B".to_owned()]),
+        "read-only handles should see existing branch order"
+    );
+    Ok(())
+}
+
+#[test]
 fn in_parallel_with_threads() -> anyhow::Result<()> {
     let tmp = tempfile::tempdir()?;
     let num_threads = 2;

--- a/crates/but-db/tests/db/migration.rs
+++ b/crates/but-db/tests/db/migration.rs
@@ -363,6 +363,13 @@ CREATE TABLE __diesel_schema_migrations (
        run_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
+-- table branch_order
+CREATE TABLE `branch_order`(
+    `branch_ref_name` TEXT NOT NULL PRIMARY KEY,
+    `parent_ref_name` TEXT UNIQUE,
+    CHECK (`parent_ref_name` IS NULL OR `branch_ref_name` != `parent_ref_name`)
+);
+
 -- table butler_actions
 CREATE TABLE `butler_actions`(
 	`id` TEXT NOT NULL PRIMARY KEY,
@@ -541,6 +548,9 @@ CREATE TABLE `workflows`(
 	`summary` TEXT
 );
 
+-- index idx_branch_order_parent_ref_name
+CREATE INDEX `idx_branch_order_parent_ref_name` ON `branch_order`(`parent_ref_name`);
+
 -- index idx_butler_actions_created_at
 CREATE INDEX `idx_butler_actions_created_at` ON `butler_actions`(`created_at`);
 
@@ -605,6 +615,7 @@ Text("20260407120000")
 Text("20260618093000")
 Text("20260624170000")
 Text("20260626120000")
+Text("20260626120100")
 
 Table: hunk_assignments
 hunk_header | path | path_bytes | stack_id | id | branch_ref
@@ -647,6 +658,9 @@ stack_id | position | name | head_sha | pr_number | archived | review_id
 
 Table: vb_branch_targets
 stack_id | remote_name | branch_name | remote_url | sha | push_remote_name
+
+Table: branch_order
+branch_ref_name | parent_ref_name
 
 
 "#]]

--- a/crates/but-db/tests/db/table/branch_order.rs
+++ b/crates/but-db/tests/db/table/branch_order.rs
@@ -1,0 +1,381 @@
+use crate::table::in_memory_db;
+
+#[test]
+fn adding_branch_above_another_updates_order() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+    db.branch_order_mut()?
+        .set_order(&refs(["refs/heads/B", "refs/heads/C"]))?;
+
+    db.branch_order_mut()?
+        .set_order(&refs(["refs/heads/A", "refs/heads/B", "refs/heads/C"]))?;
+
+    assert_eq!(
+        db.branch_order().order_for_reference("refs/heads/B")?,
+        Some(refs(["refs/heads/A", "refs/heads/B", "refs/heads/C"])),
+        "inserting a branch above B should make it the new tip"
+    );
+    assert_eq!(
+        db.branch_order().order_for_reference("refs/heads/A")?,
+        Some(refs(["refs/heads/A", "refs/heads/B", "refs/heads/C"])),
+        "the new top branch should resolve to the full chain"
+    );
+    Ok(())
+}
+
+#[test]
+fn adding_branch_below_another_updates_order() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+    db.branch_order_mut()?
+        .set_order(&refs(["refs/heads/A", "refs/heads/B"]))?;
+
+    db.branch_order_mut()?
+        .set_order(&refs(["refs/heads/A", "refs/heads/B", "refs/heads/C"]))?;
+
+    assert_eq!(
+        db.branch_order().order_for_reference("refs/heads/B")?,
+        Some(refs(["refs/heads/A", "refs/heads/B", "refs/heads/C"])),
+        "inserting a branch below B should make it B's parent"
+    );
+    assert_eq!(
+        db.branch_order().order_for_reference("refs/heads/C")?,
+        Some(refs(["refs/heads/A", "refs/heads/B", "refs/heads/C"])),
+        "the new bottom branch should resolve to the full chain"
+    );
+    Ok(())
+}
+
+#[test]
+fn adding_branch_between_two_branches_updates_order() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+    db.branch_order_mut()?
+        .set_order(&refs(["refs/heads/A", "refs/heads/C"]))?;
+
+    db.branch_order_mut()?
+        .set_order(&refs(["refs/heads/A", "refs/heads/B", "refs/heads/C"]))?;
+
+    assert_eq!(
+        db.branch_order().order_for_reference("refs/heads/B")?,
+        Some(refs(["refs/heads/A", "refs/heads/B", "refs/heads/C"])),
+        "inserting a branch between A and C should splice it into the chain"
+    );
+    Ok(())
+}
+
+#[test]
+fn replacing_chain_with_shorter_order_drops_disconnected_tail() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+    db.branch_order_mut()?.set_order(&refs([
+        "refs/heads/A",
+        "refs/heads/B",
+        "refs/heads/C",
+        "refs/heads/D",
+    ]))?;
+
+    db.branch_order_mut()?
+        .set_order(&refs(["refs/heads/B", "refs/heads/C"]))?;
+
+    assert_eq!(
+        db.branch_order().order_for_reference("refs/heads/B")?,
+        Some(refs(["refs/heads/B", "refs/heads/C"])),
+        "replacement order should be the complete remaining chain"
+    );
+    assert!(
+        db.branch_order()
+            .order_for_reference("refs/heads/A")?
+            .is_none(),
+        "the old chain head should not keep stale order metadata"
+    );
+    assert!(
+        db.branch_order()
+            .order_for_reference("refs/heads/D")?
+            .is_none(),
+        "the old chain tail should not keep stale singleton metadata"
+    );
+    Ok(())
+}
+
+#[test]
+fn removing_reference_splices_chain() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+    db.branch_order_mut()?
+        .set_order(&refs(["refs/heads/A", "refs/heads/B", "refs/heads/C"]))?;
+
+    db.branch_order_mut()?.remove_reference("refs/heads/B")?;
+
+    assert_eq!(
+        db.branch_order().order_for_reference("refs/heads/A")?,
+        Some(refs(["refs/heads/A", "refs/heads/C"])),
+        "removing the middle branch should connect A directly to C"
+    );
+    assert!(
+        db.branch_order()
+            .order_for_reference("refs/heads/B")?
+            .is_none(),
+        "the removed branch should no longer have order metadata"
+    );
+    Ok(())
+}
+
+#[test]
+fn removing_top_from_two_branch_chain_removes_singleton_order() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+    db.branch_order_mut()?
+        .set_order(&refs(["refs/heads/A", "refs/heads/B"]))?;
+
+    db.branch_order_mut()?.remove_reference("refs/heads/A")?;
+
+    assert!(
+        db.branch_order()
+            .order_for_reference("refs/heads/B")?
+            .is_none(),
+        "a single remaining branch does not need durable order metadata"
+    );
+    Ok(())
+}
+
+#[test]
+fn removing_bottom_from_two_branch_chain_removes_singleton_order() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+    db.branch_order_mut()?
+        .set_order(&refs(["refs/heads/A", "refs/heads/B"]))?;
+
+    db.branch_order_mut()?.remove_reference("refs/heads/B")?;
+
+    assert!(
+        db.branch_order()
+            .order_for_reference("refs/heads/A")?
+            .is_none(),
+        "a single remaining branch does not need durable order metadata"
+    );
+    Ok(())
+}
+
+#[test]
+fn renaming_top_reference_preserves_order() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+    db.branch_order_mut()?
+        .set_order(&refs(["refs/heads/A", "refs/heads/B", "refs/heads/C"]))?;
+
+    db.branch_order_mut()?
+        .rename_reference("refs/heads/A", "refs/heads/renamed")?;
+
+    assert_eq!(
+        db.branch_order()
+            .order_for_reference("refs/heads/renamed")?,
+        Some(refs(["refs/heads/renamed", "refs/heads/B", "refs/heads/C"])),
+        "renaming the top branch should preserve its child relationship"
+    );
+    assert!(
+        db.branch_order()
+            .order_for_reference("refs/heads/A")?
+            .is_none(),
+        "old top branch metadata should be gone"
+    );
+    Ok(())
+}
+
+#[test]
+fn renaming_middle_reference_preserves_order() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+    db.branch_order_mut()?
+        .set_order(&refs(["refs/heads/A", "refs/heads/B", "refs/heads/C"]))?;
+
+    db.branch_order_mut()?
+        .rename_reference("refs/heads/B", "refs/heads/renamed")?;
+
+    assert_eq!(
+        db.branch_order()
+            .order_for_reference("refs/heads/renamed")?,
+        Some(refs(["refs/heads/A", "refs/heads/renamed", "refs/heads/C"])),
+        "renaming the middle branch should update both incoming and outgoing edges"
+    );
+    Ok(())
+}
+
+#[test]
+fn renaming_bottom_reference_preserves_order() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+    db.branch_order_mut()?
+        .set_order(&refs(["refs/heads/A", "refs/heads/B", "refs/heads/C"]))?;
+
+    db.branch_order_mut()?
+        .rename_reference("refs/heads/C", "refs/heads/renamed")?;
+
+    assert_eq!(
+        db.branch_order()
+            .order_for_reference("refs/heads/renamed")?,
+        Some(refs(["refs/heads/A", "refs/heads/B", "refs/heads/renamed"])),
+        "renaming the bottom branch should preserve its parent relationship"
+    );
+    Ok(())
+}
+
+#[test]
+fn renaming_unordered_reference_is_noop() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+    db.branch_order_mut()?
+        .set_order(&refs(["refs/heads/A", "refs/heads/B"]))?;
+
+    db.branch_order_mut()?
+        .rename_reference("refs/heads/unordered", "refs/heads/renamed")?;
+
+    assert_eq!(
+        db.branch_order().order_for_reference("refs/heads/A")?,
+        Some(refs(["refs/heads/A", "refs/heads/B"])),
+        "renaming an unordered ref should not change existing order metadata"
+    );
+    Ok(())
+}
+
+#[test]
+fn renaming_to_ordered_reference_fails_without_partial_changes() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+    db.branch_order_mut()?
+        .set_order(&refs(["refs/heads/A", "refs/heads/B", "refs/heads/C"]))?;
+
+    assert!(
+        db.branch_order_mut()?
+            .rename_reference("refs/heads/A", "refs/heads/C")
+            .is_err(),
+        "renaming onto another ordered ref should fail"
+    );
+    assert_eq!(
+        db.branch_order().order_for_reference("refs/heads/B")?,
+        Some(refs(["refs/heads/A", "refs/heads/B", "refs/heads/C"])),
+        "failed rename should leave order metadata unchanged"
+    );
+    Ok(())
+}
+
+#[test]
+fn removing_missing_top_reference_splices_chain() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+    db.branch_order_mut()?
+        .set_order(&refs(["refs/heads/A", "refs/heads/B", "refs/heads/C"]))?;
+
+    db.branch_order_mut()?
+        .remove_missing_references(&refs(["refs/heads/B", "refs/heads/C"]))?;
+
+    assert_eq!(
+        db.branch_order().order_for_reference("refs/heads/B")?,
+        Some(refs(["refs/heads/B", "refs/heads/C"])),
+        "missing top branch should be pruned from the chain"
+    );
+    Ok(())
+}
+
+#[test]
+fn removing_missing_middle_reference_splices_chain() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+    db.branch_order_mut()?
+        .set_order(&refs(["refs/heads/A", "refs/heads/B", "refs/heads/C"]))?;
+
+    db.branch_order_mut()?
+        .remove_missing_references(&refs(["refs/heads/A", "refs/heads/C"]))?;
+
+    assert_eq!(
+        db.branch_order().order_for_reference("refs/heads/A")?,
+        Some(refs(["refs/heads/A", "refs/heads/C"])),
+        "missing middle branch should connect the surviving neighbors"
+    );
+    Ok(())
+}
+
+#[test]
+fn removing_missing_bottom_reference_splices_chain() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+    db.branch_order_mut()?
+        .set_order(&refs(["refs/heads/A", "refs/heads/B", "refs/heads/C"]))?;
+
+    db.branch_order_mut()?
+        .remove_missing_references(&refs(["refs/heads/A", "refs/heads/B"]))?;
+
+    assert_eq!(
+        db.branch_order().order_for_reference("refs/heads/A")?,
+        Some(refs(["refs/heads/A", "refs/heads/B"])),
+        "missing bottom branch should be pruned from the chain"
+    );
+    Ok(())
+}
+
+#[test]
+fn removing_missing_references_drops_singleton_order() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+    db.branch_order_mut()?
+        .set_order(&refs(["refs/heads/A", "refs/heads/B"]))?;
+
+    db.branch_order_mut()?
+        .remove_missing_references(&refs(["refs/heads/A"]))?;
+
+    assert!(
+        db.branch_order()
+            .order_for_reference("refs/heads/A")?
+            .is_none(),
+        "a single surviving branch should not keep durable order metadata"
+    );
+    Ok(())
+}
+
+#[test]
+fn cycle_in_order_chain_is_ignored() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let db_path = tmp.path().join("but.sqlite");
+    let db = but_db::DbHandle::new_at_path(&db_path)?;
+    drop(db);
+
+    let conn = rusqlite::Connection::open(&db_path)?;
+    conn.execute(
+        "INSERT INTO branch_order (branch_ref_name, parent_ref_name) VALUES (?1, ?2)",
+        ("refs/heads/A", "refs/heads/B"),
+    )?;
+    conn.execute(
+        "INSERT INTO branch_order (branch_ref_name, parent_ref_name) VALUES (?1, ?2)",
+        ("refs/heads/B", "refs/heads/A"),
+    )?;
+    drop(conn);
+
+    let db = but_db::DbHandle::new_at_path(&db_path)?;
+    assert!(
+        db.branch_order()
+            .order_for_reference("refs/heads/A")?
+            .is_none(),
+        "cyclic branch-order metadata should be ignored instead of failing reads"
+    );
+    Ok(())
+}
+
+#[test]
+fn chain_attached_to_cycle_is_ignored() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let db_path = tmp.path().join("but.sqlite");
+    let db = but_db::DbHandle::new_at_path(&db_path)?;
+    drop(db);
+
+    let conn = rusqlite::Connection::open(&db_path)?;
+    conn.execute(
+        "INSERT INTO branch_order (branch_ref_name, parent_ref_name) VALUES (?1, ?2)",
+        ("refs/heads/A", "refs/heads/B"),
+    )?;
+    conn.execute(
+        "INSERT INTO branch_order (branch_ref_name, parent_ref_name) VALUES (?1, ?2)",
+        ("refs/heads/B", "refs/heads/C"),
+    )?;
+    conn.execute(
+        "INSERT INTO branch_order (branch_ref_name, parent_ref_name) VALUES (?1, ?2)",
+        ("refs/heads/C", "refs/heads/A"),
+    )?;
+    drop(conn);
+
+    let db = but_db::DbHandle::new_at_path(&db_path)?;
+    assert!(
+        db.branch_order()
+            .order_for_reference("refs/heads/B")?
+            .is_none(),
+        "a branch attached to cyclic branch-order metadata should degrade to unordered"
+    );
+    Ok(())
+}
+
+fn refs<const N: usize>(refs: [&str; N]) -> Vec<String> {
+    refs.into_iter().map(ToOwned::to_owned).collect()
+}

--- a/crates/but-db/tests/db/table/mod.rs
+++ b/crates/but-db/tests/db/table/mod.rs
@@ -1,5 +1,6 @@
 use but_db::DbHandle;
 
+mod branch_order;
 mod butler_actions;
 mod ci_check;
 mod claude;

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -430,6 +430,7 @@ pub struct Overlay {
     /// would list the particular reference as a dropped reference.
     dropped_references: Vec<gix::refs::FullName>,
     meta_branches: Vec<(gix::refs::FullName, ref_metadata::Branch)>,
+    branch_stack_orders: Vec<Vec<gix::refs::FullName>>,
     workspace: Option<(gix::refs::FullName, ref_metadata::Workspace)>,
 }
 

--- a/crates/but-graph/src/init/overlay.rs
+++ b/crates/but-graph/src/init/overlay.rs
@@ -91,6 +91,16 @@ impl Overlay {
         self.workspace = metadata;
         self
     }
+
+    /// Serve the given ad-hoc branch stack order from memory.
+    pub fn with_branch_stack_order_override(
+        mut self,
+        branches: impl IntoIterator<Item = gix::refs::FullName>,
+    ) -> Self {
+        self.branch_stack_orders
+            .push(branches.into_iter().collect());
+        self
+    }
 }
 
 impl Overlay {
@@ -107,6 +117,7 @@ impl Overlay {
             overriding_references,
             dropped_references,
             meta_branches,
+            branch_stack_orders,
             workspace,
             entrypoint,
         } = self;
@@ -134,6 +145,7 @@ impl Overlay {
             OverlayMetadata {
                 inner: meta,
                 meta_branches,
+                branch_stack_orders,
                 workspace,
             },
             entrypoint,
@@ -443,6 +455,7 @@ impl<'repo> OverlayRepo<'repo> {
 pub(crate) struct OverlayMetadata<'meta, T> {
     inner: &'meta T,
     meta_branches: Vec<(gix::refs::FullName, ref_metadata::Branch)>,
+    branch_stack_orders: Vec<Vec<gix::refs::FullName>>,
     workspace: Option<(gix::refs::FullName, ref_metadata::Workspace)>,
 }
 
@@ -502,5 +515,19 @@ where
         }
         let opt = self.inner.branch_opt(ref_name)?;
         Ok(opt.map(|data| data.clone()))
+    }
+
+    pub fn branch_stack_order(
+        &self,
+        ref_name: &gix::refs::FullNameRef,
+    ) -> anyhow::Result<Option<Vec<gix::refs::FullName>>> {
+        if let Some(branches) = self
+            .branch_stack_orders
+            .iter()
+            .find(|branches| branches.iter().any(|branch| branch.as_ref() == ref_name))
+        {
+            return Ok(Some(branches.clone()));
+        }
+        self.inner.branch_stack_order(ref_name)
     }
 }

--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -80,6 +80,7 @@ impl Graph {
         // traversal should have nothing to do with workspace details. It's just about laying
         // the foundation for figuring out our workspaces more easily.
         self.workspace_upgrades(meta, repo, &refs_by_id, &worktree_by_branch)?;
+        self.ad_hoc_branch_stack_upgrades(repo, meta, &worktree_by_branch)?;
 
         // Point entrypoint to the right spot after all the virtual branches were added.
         self.set_entrypoint_to_ref_name(meta)?;
@@ -1463,6 +1464,306 @@ impl Graph {
         self.edges_directed(below_sidx, Direction::Incoming)
             .any(|e| e.source() == above_sidx)
     }
+
+    /// In ad-hoc/single-branch mode, use persisted GitButler-created branch
+    /// ordering to split multiple same-tip refs into empty stack segments.
+    fn ad_hoc_branch_stack_upgrades<T: RefMetadata>(
+        &mut self,
+        repo: &OverlayRepo<'_>,
+        meta: &OverlayMetadata<'_, T>,
+        worktree_by_branch: &WorktreeByBranch,
+    ) -> anyhow::Result<()> {
+        let Some(entrypoint_ref) = self.entrypoint_ref.clone() else {
+            return Ok(());
+        };
+        if entrypoint_ref.category() != Some(Category::LocalBranch) {
+            return Ok(());
+        }
+        let Some((_entrypoint_sidx, _entrypoint)) = self.entrypoint else {
+            return Ok(());
+        };
+        let Some(branch_order) = meta.branch_stack_order(entrypoint_ref.as_ref())? else {
+            return Ok(());
+        };
+        let mut existing_ordered_refs = Vec::new();
+        for branch in branch_order {
+            if branch.category() != Some(Category::LocalBranch) {
+                continue;
+            }
+            if repo
+                .try_find_reference(branch.as_ref())
+                .with_context(|| {
+                    format!(
+                        "failed to find ordered ad-hoc branch '{}'",
+                        branch.shorten()
+                    )
+                })?
+                .is_some()
+            {
+                existing_ordered_refs.push(branch);
+            }
+        }
+        if existing_ordered_refs.len() < 2 {
+            return Ok(());
+        }
+
+        let Some((bottom_ref, _)) = existing_ordered_refs.split_last() else {
+            return Ok(());
+        };
+        let Some(mut bottom_reference) = repo
+            .try_find_reference(bottom_ref.as_ref())
+            .with_context(|| {
+                format!(
+                    "failed to find bottom ordered ad-hoc branch '{}'",
+                    bottom_ref.shorten()
+                )
+            })?
+        else {
+            return Ok(());
+        };
+        let bottom_commit_id = bottom_reference
+            .peel_to_id()
+            .with_context(|| {
+                format!(
+                    "failed to peel bottom ordered ad-hoc branch '{}'",
+                    bottom_ref.shorten()
+                )
+            })?
+            .detach();
+
+        let mut matching_refs = Vec::new();
+        for branch in &existing_ordered_refs {
+            let Some(mut reference) =
+                repo.try_find_reference(branch.as_ref()).with_context(|| {
+                    format!(
+                        "failed to find ordered ad-hoc branch '{}'",
+                        branch.shorten()
+                    )
+                })?
+            else {
+                continue;
+            };
+            if reference
+                .peel_to_id()
+                .with_context(|| {
+                    format!(
+                        "failed to peel ordered ad-hoc branch '{}'",
+                        branch.shorten()
+                    )
+                })?
+                .detach()
+                == bottom_commit_id
+            {
+                matching_refs.push(branch.clone());
+            }
+        }
+        if matching_refs.len() < 2 {
+            return Ok(());
+        }
+        self.ad_hoc_branch_stack_orders.push(matching_refs.clone());
+
+        let bottom_segment_id =
+            ad_hoc_order_bottom_segment_id(self, bottom_ref.as_ref(), bottom_commit_id);
+        let Some(bottom_segment_id) = bottom_segment_id else {
+            return Ok(());
+        };
+
+        rebuild_same_tip_segment_chain_by_branch_order(
+            self,
+            bottom_segment_id,
+            matching_refs,
+            entrypoint_ref.as_ref(),
+            meta,
+            worktree_by_branch,
+        )?;
+        Ok(())
+    }
+}
+
+fn ad_hoc_order_bottom_segment_id(
+    graph: &Graph,
+    bottom_ref: &gix::refs::FullNameRef,
+    bottom_commit_id: gix::ObjectId,
+) -> Option<SegmentIndex> {
+    graph
+        .node_weights()
+        .find(|segment| {
+            segment
+                .ref_name()
+                .is_some_and(|ref_name| ref_name == bottom_ref)
+        })
+        .or_else(|| {
+            graph
+                .node_weights()
+                .find(|segment| segment.tip() == Some(bottom_commit_id))
+        })
+        .map(|segment| segment.id)
+}
+
+/// Rebuild a same-tip ref bundle into the persisted ad-hoc branch order.
+///
+/// The refs all point at the same commit, so only the bottom ordered branch
+/// owns that commit. Branches above it become explicit empty segments, allowing
+/// single-branch mode to represent "top is empty above bottom" without managed
+/// workspace metadata.
+fn rebuild_same_tip_segment_chain_by_branch_order<T: RefMetadata>(
+    graph: &mut Graph,
+    bottom_segment_id: SegmentIndex,
+    matching_refs: Vec<gix::refs::FullName>,
+    entrypoint_ref: &gix::refs::FullNameRef,
+    meta: &OverlayMetadata<'_, T>,
+    worktree_by_branch: &WorktreeByBranch,
+) -> anyhow::Result<()> {
+    let Some((bottom_ref, empty_refs)) = matching_refs.split_last() else {
+        return Ok(());
+    };
+    if empty_refs.is_empty() {
+        return Ok(());
+    }
+
+    let mut empty_segment_by_ref = BTreeMap::new();
+    for segment in graph.node_weights() {
+        if segment.commits.is_empty()
+            && let Some(ref_name) = segment.ref_name()
+            && empty_refs
+                .iter()
+                .any(|empty_ref| empty_ref.as_ref() == ref_name)
+        {
+            empty_segment_by_ref.insert(ref_name.to_owned(), segment.id);
+        }
+    }
+
+    let bottom_commit_id = graph[bottom_segment_id]
+        .commits
+        .first()
+        .map(|commit| commit.id);
+    let mut bottom_segment = branch_segment_from_name_and_meta(
+        Some((bottom_ref.clone(), None)),
+        meta,
+        None,
+        worktree_by_branch,
+    )?;
+    if let Some(ref_info) = bottom_segment.ref_info.as_mut() {
+        ref_info.commit_id = bottom_commit_id;
+    }
+    graph[bottom_segment_id].ref_info = bottom_segment.ref_info;
+    graph[bottom_segment_id].metadata = bottom_segment.metadata;
+    if let Some(commit) = graph[bottom_segment_id].commits.first_mut() {
+        commit.refs.retain(|ri| {
+            !matching_refs
+                .iter()
+                .any(|ref_name| ref_name == &ri.ref_name)
+        });
+    }
+
+    let mut ordered_segment_ids = Vec::new();
+    let mut entrypoint_segment_id = None;
+    for ref_name in empty_refs {
+        let segment_id = if let Some(segment_id) = empty_segment_by_ref.get(ref_name.as_ref()) {
+            *segment_id
+        } else {
+            let new_segment = branch_segment_from_name_and_meta(
+                Some((ref_name.clone(), None)),
+                meta,
+                None,
+                worktree_by_branch,
+            )?;
+            graph.insert_segment(new_segment)
+        };
+        if ref_name.as_ref() == entrypoint_ref {
+            entrypoint_segment_id = Some(segment_id);
+        }
+        ordered_segment_ids.push(segment_id);
+    }
+    ordered_segment_ids.push(bottom_segment_id);
+    if bottom_ref.as_ref() == entrypoint_ref {
+        entrypoint_segment_id = Some(bottom_segment_id);
+    }
+
+    let involved_segments = ordered_segment_ids.iter().copied().collect::<BTreeSet<_>>();
+    let incoming_edges = involved_segments
+        .iter()
+        .flat_map(|segment_id| {
+            graph
+                .inner
+                .edges_directed(*segment_id, Direction::Incoming)
+                .map(EdgeOwned::from)
+                .collect::<Vec<_>>()
+        })
+        .filter(|edge| !involved_segments.contains(&edge.source))
+        .collect::<Vec<_>>();
+    let incoming_edge_ids_to_remove = involved_segments
+        .iter()
+        .flat_map(|segment_id| {
+            graph
+                .inner
+                .edges_directed(*segment_id, Direction::Incoming)
+                .map(|edge| edge.id())
+                .collect::<Vec<_>>()
+        })
+        .collect::<BTreeSet<_>>();
+    let outgoing_edge_ids_to_remove = involved_segments
+        .iter()
+        .flat_map(|segment_id| {
+            graph
+                .inner
+                .edges_directed(*segment_id, Direction::Outgoing)
+                .filter(|edge| {
+                    *segment_id != bottom_segment_id || involved_segments.contains(&edge.target())
+                })
+                .map(|edge| edge.id())
+                .collect::<Vec<_>>()
+        })
+        .collect::<BTreeSet<_>>();
+    let edge_ids_to_remove = incoming_edge_ids_to_remove
+        .into_iter()
+        .chain(outgoing_edge_ids_to_remove)
+        .collect::<BTreeSet<_>>();
+    for edge_id in edge_ids_to_remove {
+        graph.inner.remove_edge(edge_id);
+    }
+
+    for pair in ordered_segment_ids.windows(2) {
+        let [above, below] = pair else {
+            continue;
+        };
+        let below_commit_index = (*below == bottom_segment_id).then_some(0);
+        graph.connect_segments(*above, None, *below, below_commit_index);
+    }
+
+    let top_segment_id = ordered_segment_ids
+        .first()
+        .copied()
+        .context("BUG: empty refs should create a top segment")?;
+    for edge in incoming_edges.into_iter().rev() {
+        graph.inner.add_edge(
+            edge.source,
+            top_segment_id,
+            Edge {
+                src: edge.weight.src,
+                src_id: edge.weight.src_id,
+                dst: None,
+                dst_id: None,
+                parent_order: edge.weight.parent_order,
+            },
+        );
+    }
+
+    if graph
+        .entrypoint
+        .as_ref()
+        .is_some_and(|(entrypoint_segment_id, _)| involved_segments.contains(entrypoint_segment_id))
+    {
+        let entrypoint_commit = bottom_commit_id
+            .map(EntryPointCommit::AtCommit)
+            .unwrap_or(EntryPointCommit::Unborn);
+        graph.entrypoint = Some((
+            entrypoint_segment_id
+                .context("BUG: split branch order should retain the entrypoint ref")?,
+            entrypoint_commit,
+        ));
+    }
+    Ok(())
 }
 
 /// Search `ws_data` for all matching names in `commit_refs` and return them, once per stack.
@@ -1849,4 +2150,54 @@ fn collect_edges_at_commit_in_traversal_order(
         })
         .map(Into::into)
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Commit, RefInfo, Segment};
+
+    fn oid(hex: &str) -> gix::ObjectId {
+        gix::ObjectId::from_hex(hex.as_bytes()).expect("valid test object id")
+    }
+
+    fn ref_name(name: &str) -> gix::refs::FullName {
+        name.try_into().expect("valid full ref name")
+    }
+
+    fn segment(name: &str, commit_id: gix::ObjectId) -> Segment {
+        Segment {
+            ref_info: Some(RefInfo {
+                ref_name: ref_name(name),
+                commit_id: Some(commit_id),
+                worktree: None,
+            }),
+            commits: vec![Commit {
+                id: commit_id,
+                parent_ids: Vec::new(),
+                flags: CommitFlags::default(),
+                refs: Vec::new(),
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn ad_hoc_bottom_segment_selection_prefers_segment_named_by_bottom_ref() {
+        let commit_id = oid("1111111111111111111111111111111111111111");
+        let bottom_ref = ref_name("refs/heads/bottom");
+        let mut graph = Graph::default();
+        let unrelated = graph.insert_segment(segment("refs/heads/unrelated", commit_id));
+        let bottom = graph.insert_segment(segment("refs/heads/bottom", commit_id));
+
+        assert_eq!(
+            ad_hoc_order_bottom_segment_id(&graph, bottom_ref.as_ref(), commit_id),
+            Some(bottom),
+            "same-tip ordered branch rewrite should not pick an unrelated segment first"
+        );
+        assert_ne!(
+            unrelated, bottom,
+            "test setup must create two distinct same-tip segments"
+        );
+    }
 }

--- a/crates/but-graph/src/lib.rs
+++ b/crates/but-graph/src/lib.rs
@@ -258,6 +258,12 @@ pub struct Graph {
     /// reconnect segments, so consumers re-resolve each tip by commit id against
     /// the final graph shape and filter for the roles they need.
     traversal_tips: Vec<init::Tip>,
+    /// Ad-hoc/single-branch local branch orders read from metadata while post-processing.
+    ///
+    /// These are kept on the graph so projection can tell the difference between
+    /// an ordinary ad-hoc lower-bound branch and the bottom branch of a
+    /// GitButler-created dependent branch chain.
+    ad_hoc_branch_stack_orders: Vec<Vec<gix::refs::FullName>>,
     /// It's `true` only if we have stopped the traversal due to a hard limit.
     hard_limit_hit: bool,
     /// The options used to create the graph, which allows it to regenerate itself after something

--- a/crates/but-graph/src/projection/workspace/init.rs
+++ b/crates/but-graph/src/projection/workspace/init.rs
@@ -199,7 +199,6 @@ impl Graph {
                 ),
             }
         };
-
         let configured_target_ref = self
             .project_meta
             .target_ref
@@ -432,6 +431,9 @@ impl Graph {
                         // Cut the stack off at the lower base if we have one. This is only
                         // the case if we have a remote.
                         if Some(s.id) == lowest_base_sidx {
+                            if self.is_ordered_ad_hoc_lower_bound(start, s) {
+                                return stop;
+                            }
                             has_seen_base.replace(true);
                             return stop;
                         }
@@ -460,6 +462,35 @@ impl Graph {
             }
         }
         Ok(stacks)
+    }
+
+    /// Return whether `candidate` is below `start` in a persisted ad-hoc branch order.
+    ///
+    /// In ad-hoc/single-branch mode, ordinary local branches below the entrypoint can become
+    /// workspace lower bounds. GitButler-created empty dependent branches are different: their
+    /// lower branch is still part of the same user-visible stack. This lets projection keep
+    /// walking through ordered branch segments instead of truncating the stack at the next local
+    /// branch boundary.
+    fn is_ordered_ad_hoc_lower_bound(&self, start: &Segment, candidate: &Segment) -> bool {
+        let Some(start_ref) = start.ref_name() else {
+            return false;
+        };
+        let Some(candidate_ref) = candidate.ref_name() else {
+            return false;
+        };
+        if candidate_ref.category() != Some(Category::LocalBranch) {
+            return false;
+        }
+
+        self.ad_hoc_branch_stack_orders.iter().any(|order| {
+            let start_idx = order.iter().position(|branch| branch.as_ref() == start_ref);
+            let candidate_idx = order
+                .iter()
+                .position(|branch| branch.as_ref() == candidate_ref);
+            start_idx
+                .zip(candidate_idx)
+                .is_some_and(|(start_idx, candidate_idx)| start_idx < candidate_idx)
+        })
     }
 
     /// Compute the lowest base (i.e. the highest generation) for the
@@ -1123,7 +1154,26 @@ impl WorkspaceState {
         };
 
         let metadata = self.metadata.as_ref();
-        let keep_empty_segment_id = matches!(self.kind, WorkspaceKind::AdHoc).then_some(self.id);
+        let keep_empty_segment_ids = if matches!(self.kind, WorkspaceKind::AdHoc) {
+            let ordered_refs = graph
+                .ad_hoc_branch_stack_orders
+                .iter()
+                .flatten()
+                .map(|ref_name| ref_name.as_ref())
+                .collect::<BTreeSet<_>>();
+            graph
+                .node_weights()
+                .filter_map(|segment| {
+                    (segment.id == self.id
+                        || segment
+                            .ref_name()
+                            .is_some_and(|ref_name| ordered_refs.contains(ref_name)))
+                    .then_some(segment.id)
+                })
+                .collect::<HashSet<_>>()
+        } else {
+            HashSet::new()
+        };
         let keep_if_fully_integrated =
             upstream_advanced_past_target && !matches!(self.kind, WorkspaceKind::AdHoc);
         for stack in &mut self.stacks {
@@ -1131,7 +1181,7 @@ impl WorkspaceState {
             // tip in managed workspaces so it survives for `integrate_upstream`. Single-branch
             // mode keeps the branch shell, but prunes integrated target/base commits from it.
             prune_integrated_stack_segments(stack, &prune_segments, keep_if_fully_integrated);
-            remove_empty_branches(stack, metadata, keep_empty_segment_id);
+            remove_empty_branches(stack, metadata, &keep_empty_segment_ids);
             if upstream_advanced_past_target {
                 // Pruning moved the stack's bottom; refresh its base to the new fork point.
                 stack.recompute_last_segment_base(&graph.inner);
@@ -1414,14 +1464,14 @@ fn commits_are_integrated(commits: &[StackCommit]) -> bool {
 fn remove_empty_branches(
     stack: &mut Stack,
     metadata: Option<&but_core::ref_metadata::Workspace>,
-    keep_empty_segment_id: Option<SegmentIndex>,
+    keep_empty_segment_ids: &HashSet<SegmentIndex>,
 ) {
     let own_metadata_stack = stack.id.and_then(|stack_id| {
         metadata.and_then(|meta| meta.stacks(Applied).find(|ms| ms.id == stack_id))
     });
     stack.segments.retain(|seg| {
         !seg.commits.is_empty()
-            || Some(seg.id) == keep_empty_segment_id
+            || keep_empty_segment_ids.contains(&seg.id)
             || own_metadata_stack.is_some_and(|ms| {
                 seg.ref_info
                     .as_ref()

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -1,8 +1,12 @@
-use but_graph::{CommitFlags, Graph, StopCondition, init::Tip};
+use but_graph::{
+    CommitFlags, Graph, StopCondition,
+    init::{Overlay, Tip},
+};
 use but_testsupport::{
     gix_testtools::{self, Creation, rust_fixture_writable},
     graph_tree, graph_workspace, visualize_commit_graph_all,
 };
+use gix::prelude::ObjectIdExt;
 
 #[test]
 fn unborn() -> anyhow::Result<()> {
@@ -48,6 +52,7 @@ fn unborn() -> anyhow::Result<()> {
         ),
         entrypoint_ref: None,
         traversal_tips: [],
+        ad_hoc_branch_stack_orders: [],
         hard_limit_hit: false,
         options: Options {
             collect_tags: false,
@@ -174,6 +179,7 @@ fn detached() -> anyhow::Result<()> {
                 is_detached: false,
             },
         ],
+        ad_hoc_branch_stack_orders: [],
         hard_limit_hit: false,
         options: Options {
             collect_tags: true,
@@ -1564,7 +1570,7 @@ fn commit_with_two_parents() -> anyhow::Result<()> {
     * 86719d5 base
     ");
 
-    let meta = in_memory_meta(tmp.path())?;
+    let meta = in_memory_meta(tmp.as_ref())?;
     let graph = Graph::from_head(
         &repo,
         &*meta,
@@ -1584,6 +1590,216 @@ fn commit_with_two_parents() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[test]
+fn ad_hoc_same_tip_order_creates_empty_branch_segments() -> anyhow::Result<()> {
+    let (tmp, repo) = empty_repo()?;
+    let tip = commit(&repo, "same tip")?;
+    create_branches(&repo, tip, ["refs/heads/top", "refs/heads/bottom"])?;
+    let meta = in_memory_meta(tmp.as_ref())?;
+
+    let graph = graph_with_branch_order(
+        &repo,
+        &*meta,
+        "refs/heads/top",
+        ["refs/heads/top", "refs/heads/bottom"],
+    )?
+    .validated()?;
+
+    insta::assert_snapshot!(graph_tree(&graph), @"
+
+    └── 👉►:1[0]:top
+        └── ►:0[1]:bottom
+            └── 🏁·960152d (⌂|1) ►main[🌳]
+    ");
+    assert_eq!(
+        graph.entrypoint()?.commit().map(|commit| commit.id),
+        Some(tip),
+        "a checked-out empty ordered branch still points at the bottom commit"
+    );
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
+    ⌂:1:top <> ✓!
+    └── ≡:1:top {1}
+        ├── :1:top
+        └── :0:bottom
+            └── ·960152d ►main[🌳]
+    ");
+    Ok(())
+}
+
+#[test]
+fn ad_hoc_order_projects_from_entrypoint_when_top_is_above_it() -> anyhow::Result<()> {
+    let (tmp, repo) = empty_repo()?;
+    let tip = commit(&repo, "same tip")?;
+    create_branches(&repo, tip, ["refs/heads/top", "refs/heads/bottom"])?;
+    let meta = in_memory_meta(tmp.as_ref())?;
+
+    let graph = graph_with_branch_order(
+        &repo,
+        &*meta,
+        "refs/heads/bottom",
+        ["refs/heads/top", "refs/heads/bottom"],
+    )?
+    .validated()?;
+
+    insta::assert_snapshot!(graph_tree(&graph), @"
+
+    └── ►:1[0]:top
+        └── 👉►:0[1]:bottom
+            └── 🏁·960152d (⌂|1) ►main[🌳]
+    ");
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
+    ⌂:0:bottom <> ✓!
+    └── ≡:0:bottom {1}
+        └── :0:bottom
+            └── ·960152d ►main[🌳]
+    ");
+    Ok(())
+}
+
+#[test]
+fn ad_hoc_three_branch_order_preserves_middle_empty_segment() -> anyhow::Result<()> {
+    let (tmp, repo) = empty_repo()?;
+    let tip = commit(&repo, "same tip")?;
+    create_branches(
+        &repo,
+        tip,
+        ["refs/heads/top", "refs/heads/middle", "refs/heads/bottom"],
+    )?;
+    let meta = in_memory_meta(tmp.as_ref())?;
+
+    let graph = graph_with_branch_order(
+        &repo,
+        &*meta,
+        "refs/heads/top",
+        ["refs/heads/top", "refs/heads/middle", "refs/heads/bottom"],
+    )?
+    .validated()?;
+
+    insta::assert_snapshot!(graph_tree(&graph), @"
+
+    └── 👉►:1[0]:top
+        └── ►:2[1]:middle
+            └── ►:0[2]:bottom
+                └── 🏁·960152d (⌂|1) ►main[🌳]
+    ");
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
+    ⌂:1:top <> ✓!
+    └── ≡:1:top {1}
+        ├── :1:top
+        ├── :2:middle
+        └── :0:bottom
+            └── ·960152d ►main[🌳]
+    ");
+    Ok(())
+}
+
+#[test]
+fn ad_hoc_order_ignores_missing_metadata_refs_without_phantoms() -> anyhow::Result<()> {
+    let (tmp, repo) = empty_repo()?;
+    let tip = commit(&repo, "same tip")?;
+    create_branches(&repo, tip, ["refs/heads/top", "refs/heads/bottom"])?;
+    let meta = in_memory_meta(tmp.as_ref())?;
+
+    let graph = graph_with_branch_order(
+        &repo,
+        &*meta,
+        "refs/heads/top",
+        ["refs/heads/top", "refs/heads/missing", "refs/heads/bottom"],
+    )?
+    .validated()?;
+
+    insta::assert_snapshot!(graph_tree(&graph), @"
+
+    └── 👉►:1[0]:top
+        └── ►:0[1]:bottom
+            └── 🏁·960152d (⌂|1) ►main[🌳]
+    ");
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
+    ⌂:1:top <> ✓!
+    └── ≡:1:top {1}
+        ├── :1:top
+        └── :0:bottom
+            └── ·960152d ►main[🌳]
+    ");
+    Ok(())
+}
+
+#[test]
+fn ad_hoc_order_does_not_force_diverged_refs_into_empty_stack() -> anyhow::Result<()> {
+    let (tmp, repo) = empty_repo()?;
+    let bottom_tip = commit(&repo, "bottom")?;
+    let top_tip = commit_with_parent(&repo, "top", bottom_tip)?;
+    create_branches(&repo, bottom_tip, ["refs/heads/bottom", "refs/heads/main"])?;
+    create_branches(&repo, top_tip, ["refs/heads/top"])?;
+    let meta = in_memory_meta(tmp.as_ref())?;
+
+    let graph = graph_with_branch_order(
+        &repo,
+        &*meta,
+        "refs/heads/top",
+        ["refs/heads/top", "refs/heads/bottom"],
+    )?
+    .validated()?;
+
+    insta::assert_snapshot!(graph_tree(&graph), @"
+
+    └── 👉►:0[0]:top
+        ├── ·5cd63e5 (⌂|1)
+        └── 🏁·fa91c94 (⌂|1) ►bottom, ►main[🌳]
+    ");
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
+    ⌂:0:top <> ✓!
+    └── ≡:0:top {1}
+        └── :0:top
+            ├── ·5cd63e5
+            └── ·fa91c94 ►bottom, ►main[🌳]
+    ");
+    Ok(())
+}
+
+#[test]
+fn ad_hoc_order_scopes_empty_segments_to_active_chain() -> anyhow::Result<()> {
+    let (tmp, repo) = empty_repo()?;
+    let tip = commit(&repo, "same tip")?;
+    create_branches(
+        &repo,
+        tip,
+        [
+            "refs/heads/top",
+            "refs/heads/bottom",
+            "refs/heads/other-top",
+            "refs/heads/other-bottom",
+        ],
+    )?;
+    let meta = in_memory_meta(tmp.as_ref())?;
+
+    let graph = graph_with_branch_orders(
+        &repo,
+        &*meta,
+        "refs/heads/top",
+        &[
+            &["refs/heads/top", "refs/heads/bottom"],
+            &["refs/heads/other-top", "refs/heads/other-bottom"],
+        ],
+    )?
+    .validated()?;
+
+    insta::assert_snapshot!(graph_tree(&graph), @"
+
+    └── 👉►:1[0]:top
+        └── ►:0[1]:bottom
+            └── 🏁·960152d (⌂|1) ►main[🌳], ►other-bottom, ►other-top
+    ");
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
+    ⌂:1:top <> ✓!
+    └── ≡:1:top {1}
+        ├── :1:top
+        └── :0:bottom
+            └── ·960152d ►main[🌳], ►other-bottom, ►other-top
+    ");
+    Ok(())
+}
+
 mod overlay;
 mod with_workspace;
 
@@ -1598,4 +1814,97 @@ use crate::init::utils::{in_memory_meta, standard_options_with_extra_target};
 
 fn ref_name(name: &str) -> gix::refs::FullName {
     name.try_into().expect("valid full ref name")
+}
+
+fn empty_repo() -> anyhow::Result<(impl AsRef<std::path::Path>, gix::Repository)> {
+    rust_fixture_writable("empty", 1, Creation::Execute, |fixture| {
+        let open_opts = but_testsupport::open_repo_config()?;
+        Ok(match fixture {
+            FixtureState::Uninitialized(path) => gix::ThreadSafeRepository::init_opts(
+                path,
+                gix::create::Kind::WithWorktree,
+                gix::create::Options::default(),
+                open_opts,
+            )?
+            .to_thread_local(),
+            FixtureState::Fresh(path) => gix::open_opts(path, open_opts)?,
+        })
+    })
+    .map_err(anyhow::Error::from_boxed)
+}
+
+fn commit(repo: &gix::Repository, message: &str) -> anyhow::Result<gix::ObjectId> {
+    Ok(repo
+        .commit(
+            "HEAD",
+            message,
+            repo.object_hash().empty_tree(),
+            None::<gix::ObjectId>,
+        )?
+        .detach())
+}
+
+fn commit_with_parent(
+    repo: &gix::Repository,
+    message: &str,
+    parent: gix::ObjectId,
+) -> anyhow::Result<gix::ObjectId> {
+    Ok(repo
+        .commit(
+            "HEAD",
+            message,
+            repo.object_hash().empty_tree(),
+            Some(parent),
+        )?
+        .detach())
+}
+
+fn create_branches<const N: usize>(
+    repo: &gix::Repository,
+    target: gix::ObjectId,
+    branches: [&str; N],
+) -> anyhow::Result<()> {
+    for branch in branches {
+        repo.reference(
+            ref_name(branch),
+            target,
+            gix::refs::transaction::PreviousValue::Any,
+            "test branch order",
+        )?;
+    }
+    Ok(())
+}
+
+fn graph_with_branch_order<const N: usize>(
+    repo: &gix::Repository,
+    meta: &impl but_core::RefMetadata,
+    entrypoint_ref: &str,
+    order: [&str; N],
+) -> anyhow::Result<Graph> {
+    graph_with_branch_orders(repo, meta, entrypoint_ref, &[&order])
+}
+
+fn graph_with_branch_orders(
+    repo: &gix::Repository,
+    meta: &impl but_core::RefMetadata,
+    entrypoint_ref: &str,
+    orders: &[&[&str]],
+) -> anyhow::Result<Graph> {
+    let entrypoint_ref = ref_name(entrypoint_ref);
+    let tip = repo
+        .find_reference(entrypoint_ref.as_ref())?
+        .peel_to_id()?
+        .detach();
+    let mut overlay = Overlay::default();
+    for order in orders {
+        overlay = overlay.with_branch_stack_order_override(order.iter().copied().map(ref_name));
+    }
+    Graph::from_commit_traversal(
+        tip.attach(repo),
+        Some(entrypoint_ref),
+        meta,
+        but_core::ref_metadata::ProjectMeta::default(),
+        standard_options(),
+    )?
+    .redo_traversal_with_overlay(repo, meta, overlay)
 }

--- a/crates/but-meta/src/legacy/mod.rs
+++ b/crates/but-meta/src/legacy/mod.rs
@@ -971,6 +971,155 @@ impl RefMetadata for VirtualBranchesTomlMetadata {
     }
 }
 
+/// Ref metadata backed by legacy TOML for historical workspace metadata and by
+/// the project database for ad-hoc branch order metadata.
+pub struct BranchOrderMetadata {
+    legacy: VirtualBranchesTomlMetadata,
+    db: Option<but_db::DbHandle>,
+    read_only: bool,
+}
+
+impl BranchOrderMetadata {
+    /// Open metadata from a legacy TOML path and a project database directory.
+    pub fn from_paths(
+        toml_path: impl AsRef<Path>,
+        db_dir: impl AsRef<Path>,
+    ) -> anyhow::Result<Self> {
+        Ok(Self {
+            legacy: VirtualBranchesTomlMetadata::from_path(toml_path.as_ref().to_owned())?,
+            db: Some(but_db::DbHandle::new_in_directory(db_dir)?),
+            read_only: false,
+        })
+    }
+
+    /// Open metadata for read-only projections.
+    ///
+    /// This observes existing branch-order data when the project database already
+    /// exists, but it never creates the database or runs migrations.
+    pub fn from_paths_read_only(
+        toml_path: impl AsRef<Path>,
+        db_dir: impl AsRef<Path>,
+    ) -> anyhow::Result<Self> {
+        Ok(Self {
+            legacy: VirtualBranchesTomlMetadata::from_path_read_only(
+                toml_path.as_ref().to_owned(),
+            )?,
+            db: but_db::DbHandle::open_existing_read_only_in_directory(db_dir)?,
+            read_only: true,
+        })
+    }
+}
+
+impl RefMetadata for BranchOrderMetadata {
+    type Handle<T> = VBTomlMetadataHandle<T>;
+
+    fn iter(&self) -> impl Iterator<Item = anyhow::Result<(gix::refs::FullName, Box<dyn Any>)>> {
+        self.legacy.iter()
+    }
+
+    fn workspace(&self, ref_name: &FullNameRef) -> anyhow::Result<Self::Handle<Workspace>> {
+        self.legacy.workspace(ref_name)
+    }
+
+    fn branch(&self, ref_name: &FullNameRef) -> anyhow::Result<Self::Handle<Branch>> {
+        self.legacy.branch(ref_name)
+    }
+
+    fn set_workspace(&mut self, value: &Self::Handle<Workspace>) -> anyhow::Result<()> {
+        self.legacy.set_workspace(value)
+    }
+
+    fn set_branch(&mut self, value: &Self::Handle<Branch>) -> anyhow::Result<()> {
+        self.legacy.set_branch(value)
+    }
+
+    fn branch_stack_order(&self, ref_name: &FullNameRef) -> anyhow::Result<Option<Vec<FullName>>> {
+        let Some(db) = self.db.as_ref() else {
+            return Ok(None);
+        };
+        let refs = db
+            .branch_order()
+            .order_for_reference(ref_name.as_bstr().to_str()?)?;
+        match refs {
+            Some(refs) => refs
+                .into_iter()
+                .map(|ref_name| FullName::try_from(ref_name.as_str()).map_err(Into::into))
+                .collect::<anyhow::Result<Vec<_>>>()
+                .map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn set_branch_stack_order(&mut self, branches: &[FullName]) -> anyhow::Result<()> {
+        if self.read_only {
+            bail!("Read-only metadata can't persist branch stack order");
+        }
+        let db = self
+            .db
+            .as_mut()
+            .context("BUG: writable branch-order metadata should have a database handle")?;
+        let branches = branches
+            .iter()
+            .map(|branch| branch.as_bstr().to_str().map(ToOwned::to_owned))
+            .collect::<Result<Vec<_>, _>>()?;
+        db.branch_order_mut()?.set_order(&branches)?;
+        Ok(())
+    }
+
+    fn can_persist_branch_stack_order(&self) -> bool {
+        self.db.is_some() && !self.read_only
+    }
+
+    fn rename_branch_stack_order_reference(
+        &mut self,
+        old_ref_name: &FullNameRef,
+        new_ref_name: &FullNameRef,
+    ) -> anyhow::Result<()> {
+        if self.read_only {
+            bail!("Read-only metadata can't rename branch stack order references");
+        }
+        let Some(db) = self.db.as_mut() else {
+            return Ok(());
+        };
+        db.branch_order_mut()?.rename_reference(
+            old_ref_name.as_bstr().to_str()?,
+            new_ref_name.as_bstr().to_str()?,
+        )?;
+        Ok(())
+    }
+
+    fn remove_missing_branch_stack_order_references(
+        &mut self,
+        existing_ref_names: &[FullName],
+    ) -> anyhow::Result<()> {
+        if self.read_only {
+            bail!("Read-only metadata can't prune branch stack order references");
+        }
+        let Some(db) = self.db.as_mut() else {
+            return Ok(());
+        };
+        let existing_ref_names = existing_ref_names
+            .iter()
+            .map(|ref_name| ref_name.as_bstr().to_str().map(ToOwned::to_owned))
+            .collect::<Result<Vec<_>, _>>()?;
+        db.branch_order_mut()?
+            .remove_missing_references(&existing_ref_names)?;
+        Ok(())
+    }
+
+    fn remove(&mut self, ref_name: &FullNameRef) -> anyhow::Result<bool> {
+        let removed_branch_order =
+            !self.read_only && self.db.is_some() && self.branch_stack_order(ref_name)?.is_some();
+        if !self.read_only
+            && let Some(db) = self.db.as_mut()
+        {
+            db.branch_order_mut()?
+                .remove_reference(ref_name.as_bstr().to_str()?)?;
+        }
+        Ok(self.legacy.remove(ref_name)? || removed_branch_order)
+    }
+}
+
 fn branch_from_ref_name(ref_name: &FullNameRef) -> anyhow::Result<RemoteRefname> {
     let (category, short_name) = ref_name
         .category_and_short_name()

--- a/crates/but-meta/src/lib.rs
+++ b/crates/but-meta/src/lib.rs
@@ -5,7 +5,7 @@
 #[cfg(feature = "legacy")]
 mod legacy;
 #[cfg(feature = "legacy")]
-pub use legacy::{VirtualBranchesTomlMetadata, storage as legacy_storage};
+pub use legacy::{BranchOrderMetadata, VirtualBranchesTomlMetadata, storage as legacy_storage};
 
 #[cfg(feature = "legacy")]
 pub mod virtual_branches_legacy_types;


### PR DESCRIPTION
Store the branch ordering metadata for single branch mode, and use that to inform the ordering in the but-graph and projection.

### Changes
- This creates a new DB table with branch orderings. 
- The orderings are read and used in order to determine the order of branches that point to the same commit in ad-hoc workspaces (single branch mode)


<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #14376 
- <kbd>&nbsp;1&nbsp;</kbd> #14513 👈 
<!-- GitButler Footer Boundary Bottom -->

