### PR TITLE
feat(but): add `--branch` argument to `_move2`

### DIFF
--- a/crates/but/src/args/atoms/branch_arg.rs
+++ b/crates/but/src/args/atoms/branch_arg.rs
@@ -105,6 +105,41 @@ impl BranchArg {
         Ok(self.0.clone())
     }
 
+    /// TODO replace head_info version with this
+    pub fn resolve_for_creation_ws(
+        &self,
+        repo: &gix::Repository,
+        ws: &but_graph::Workspace,
+    ) -> CliResult<FullName> {
+        let branch_name = self.0.as_str();
+        let normalized = but_core::branch::normalize_short_name(branch_name).map_err(|err| {
+            CliError::from(bad_input(format!("Invalid branch name: {err}")).arg_value(branch_name))
+        })?;
+
+        if normalized != <&BStr>::from(branch_name) {
+            return Err(bad_input("Invalid branch name")
+                .arg_value(branch_name)
+                .hint(format!("Try '{normalized}' instead"))
+                .into());
+        }
+
+        let local_name = self.resolve_local_branch_name()?;
+        if ws.is_reachable_from_entrypoint(local_name.as_ref()) {
+            return Err(
+                bad_input(format!("A branch named '{branch_name}' is already applied")).into(),
+            );
+        }
+
+        if repo.try_find_reference(&local_name)?.is_some() {
+            return Err(bad_input(format!(
+                "A branch named '{branch_name}' exists but is not applied"
+            ))
+            .into());
+        }
+
+        Ok(local_name)
+    }
+
     /// Resolve the argument to a branch that exists in the repository.
     pub fn resolve_branch(&self, repo: &gix::Repository) -> CliResult<ResolvedBranchRef> {
         for category in [Category::LocalBranch, Category::RemoteBranch] {

--- a/crates/but/src/args/atoms/branch_arg.rs
+++ b/crates/but/src/args/atoms/branch_arg.rs
@@ -64,49 +64,7 @@ impl BranchArg {
     ///
     /// Unlike the GUI, we don't normalize branch names for users in the CLI, as this could lead to
     /// unexpected behavior in scripts. This function rejects names that are possible to normalize.
-    // TODO(david): might wanna return FullName here
     pub fn resolve_for_creation(
-        &self,
-        repo: &gix::Repository,
-        head_info: &but_workspace::RefInfo,
-    ) -> CliResult<String> {
-        let branch_name = self.0.as_str();
-        let normalized = but_core::branch::normalize_short_name(branch_name).map_err(|err| {
-            CliError::from(bad_input(format!("Invalid branch name: {err}")).arg_value(branch_name))
-        })?;
-
-        if normalized != <&BStr>::from(branch_name) {
-            return Err(bad_input("Invalid branch name")
-                .arg_value(branch_name)
-                .hint(format!("Try '{normalized}' instead"))
-                .into());
-        }
-
-        let local_name = self.resolve_local_branch_name()?;
-        if head_info
-            .stacks
-            .iter()
-            .flat_map(|stack| &stack.segments)
-            .flat_map(|segment| &segment.ref_info)
-            .any(|ref_info| ref_info.ref_name == local_name)
-        {
-            return Err(
-                bad_input(format!("A branch named '{branch_name}' is already applied")).into(),
-            );
-        }
-
-        if repo.try_find_reference(&local_name)?.is_some() {
-            return Err(bad_input(format!(
-                "A branch named '{branch_name}' exists but is not applied"
-            ))
-            .into());
-        }
-
-        Ok(self.0.clone())
-    }
-
-    /// TODO replace head_info version with this
-    pub fn resolve_for_creation_ws(
         &self,
         repo: &gix::Repository,
         ws: &but_graph::Workspace,

--- a/crates/but/src/args/move2.rs
+++ b/crates/but/src/args/move2.rs
@@ -4,10 +4,19 @@ use crate::args::atoms::CliIdArg;
 #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
 #[clap(group(
     clap::ArgGroup::new("targeting")
-        .args(["above", "below"])
+        .args(["above", "below", "branch"])
         .required(true)
 ))]
 pub struct Platform {
+    /// Place the commits on the branch `BRANCH`.
+    ///
+    /// If `BRANCH` does not exist, it is created as an unstacked branch.
+    ///
+    /// If `BRANCH` is omitted, an unstacked branch with a generated name is created.
+    ///
+    /// Attempting to place commits on a branch that exists but is not applied is an error.
+    #[clap(short, long, value_name = "BRANCH")]
+    pub branch: Option<Option<CliIdArg>>,
     /// Place the commit above `BRANCH_OR_COMMIT`, which must be an applied branch or commit.
     ///
     /// If `BRANCH_OR_COMMIT` is a commit, the source commit is placed on the same branch as the

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -60,15 +60,18 @@ pub fn new(
     anchor_arg: Option<CliIdArg>,
 ) -> CliResult<()> {
     let t = theme::get();
-    let head_info = but_api::legacy::workspace::head_info(ctx)?;
+    let mut guard = ctx.exclusive_worktree_access();
 
     let branch_name = if let Some(branch_name_arg) = branch_name_arg {
-        branch_name_arg.resolve_for_creation(&*ctx.repo.get()?, &head_info)?
+        let (repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
+        branch_name_arg
+            .resolve_for_creation(&repo, &ws)?
+            .shorten()
+            .to_string()
     } else {
         but_api::legacy::workspace::canned_branch_name(ctx)?
     };
 
-    let mut guard = ctx.exclusive_worktree_access();
     let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
 
     let resolved_anchor = {

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -3,7 +3,12 @@ use std::{collections::BTreeMap, fmt::Write as _};
 use anyhow::{Context, Result, bail};
 use bstr::{BString, ByteSlice};
 use but_api::{commit::create::commit_create, diff, legacy::repo};
-use but_core::{DryRun, ref_metadata::StackId, sync::RepoExclusive, ui::TreeChange};
+use but_core::{
+    DryRun,
+    ref_metadata::StackId,
+    sync::{RepoExclusive, RepoShared},
+    ui::TreeChange,
+};
 use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
 use gitbutler_oplog::entry::{OperationKind, SnapshotDetails};
 use gitbutler_repo::hooks;
@@ -316,6 +321,7 @@ fn branch_hint_from_arg(
     ctx: &mut but_ctx::Context,
     id_map: &IdMap,
     branch_arg: Option<CliIdArg>,
+    perm: &RepoShared,
 ) -> CliResult<Option<String>> {
     if let Some(branch_arg) = branch_arg {
         let repo = ctx.repo.get()?;
@@ -331,10 +337,12 @@ fn branch_hint_from_arg(
         {
             Ok(Some(branch))
         } else {
-            let repo = ctx.repo.get()?;
-            let head_info = but_api::legacy::workspace::head_info(ctx)?;
+            let (repo, ws, _db) = ctx.workspace_and_db_with_perm(perm)?;
             Ok(Some(
-                BranchArg(branch_arg.0).resolve_for_creation(&repo, &head_info)?,
+                BranchArg(branch_arg.0)
+                    .resolve_for_creation(&repo, &ws)?
+                    .shorten()
+                    .to_string(),
             ))
         }
     } else {
@@ -480,7 +488,7 @@ pub(crate) fn commit(
     }
 
     let is_positioned_commit = before.is_some() || after.is_some();
-    let branch_hint = branch_hint_from_arg(ctx, &id_map, branch_arg)?;
+    let branch_hint = branch_hint_from_arg(ctx, &id_map, branch_arg, guard.read_permission())?;
 
     let t = theme::get();
 

--- a/crates/but/src/command/legacy/commit2.rs
+++ b/crates/but/src/command/legacy/commit2.rs
@@ -219,7 +219,10 @@ fn resolve(
         (guard, CommitSelection::AllChanges)
     };
 
-    let commit_op = route_commit_operation(&*ctx.repo.get()?, head_info, out, id_map, target_ish)?;
+    let commit_op = {
+        let (repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
+        route_commit_operation(&repo, &ws, head_info, out, id_map, target_ish)?
+    };
 
     let reword_op = RewordCommitOperation::resolve(no_message, message);
 
@@ -307,6 +310,7 @@ enum CommitOperationTargetIsh {
 
 fn route_commit_operation(
     repo: &gix::Repository,
+    ws: &but_graph::Workspace,
     head_info: &RefInfo,
     out: &mut IntermediateChannel<'_>,
     id_map: &IdMap,
@@ -335,11 +339,9 @@ fn route_commit_operation(
                 Ok(CommitOperation::CommitAt(CommitAtOperation { target }))
             } else {
                 let branch = BranchArg(cli_id.0);
-                let branch_name =
-                    BranchArg(branch.resolve_for_creation(repo, head_info).with_hint(|| {
-                        format!("Run `but apply {branch}` to apply the branch first")
-                    })?)
-                    .resolve_local_branch_name()?;
+                let branch_name = branch
+                    .resolve_for_creation(repo, ws)
+                    .with_hint(|| format!("Run `but apply {branch}` to apply the branch first"))?;
                 Ok(CommitOperation::CommitToNewBranch(
                     CommitToNewBranchOperation {
                         branch_name: Some(branch_name),

--- a/crates/but/src/command/legacy/move2.rs
+++ b/crates/but/src/command/legacy/move2.rs
@@ -13,7 +13,7 @@ use nonempty::NonEmpty;
 use crate::{
     CliResult, IdMap,
     args::{
-        atoms::{BranchOrCommit, CliIdArg, Purpose},
+        atoms::{BranchArg, BranchOrCommit, CliIdArg, Purpose},
         move2::Platform,
     },
     bad_input,
@@ -115,11 +115,16 @@ impl MoveCommitsRelativeToOperation {
 #[derive(Clone)]
 struct MoveCommitsToNewBranchOperation {
     sources: NonEmpty<gix::ObjectId>,
+    branch_name: Option<FullName>,
 }
 
 impl MoveCommitsToNewBranchOperation {
     fn execute(self, tx: &mut Transaction<'_, '_, impl RefMetadata>) -> anyhow::Result<FullName> {
-        let new_branch_name = but_core::branch::unique_canned_refname(tx.repo())?;
+        let new_branch_name = if let Some(branch_name) = self.branch_name {
+            branch_name
+        } else {
+            but_core::branch::unique_canned_refname(tx.repo())?
+        };
         tx.create_reference(
             new_branch_name.as_ref(),
             None,
@@ -180,7 +185,7 @@ fn resolve(
         branch,
     } = args;
 
-    let (repo, _ws, _db) = ctx.workspace_and_db_with_perm(perm.read_permission())?;
+    let (repo, ws, _db) = ctx.workspace_and_db_with_perm(perm.read_permission())?;
 
     match (branch, above, below) {
         (Some(Some(branch)), None, None) => {
@@ -198,7 +203,16 @@ fn resolve(
                         name: branch.resolve_local_branch_name()?,
                     },
                 })),
-                None => todo!(),
+                None => {
+                    let branch_name =
+                        BranchArg(branch.to_string()).resolve_for_creation_ws(&repo, &ws)?;
+                    Ok(MoveOperation::ToNewBranch(
+                        MoveCommitsToNewBranchOperation {
+                            sources,
+                            branch_name: Some(branch_name),
+                        },
+                    ))
+                }
             }
         }
         (Some(None), None, None) => {
@@ -209,7 +223,10 @@ fn resolve(
             let sources = NonEmpty::from_vec(resolved_sources)
                 .expect("BUG: Empty sources should not be possible as it's a required argument");
             Ok(MoveOperation::ToNewBranch(
-                MoveCommitsToNewBranchOperation { sources },
+                MoveCommitsToNewBranchOperation {
+                    sources,
+                    branch_name: None,
+                },
             ))
         }
         (None, Some(above), None) => {
@@ -301,7 +318,10 @@ fn run(
                 new_branch_name,
             }
         }
-        MoveOperation::ToNewBranch(MoveCommitsToNewBranchOperation { sources }) => MoveOutcome {
+        MoveOperation::ToNewBranch(MoveCommitsToNewBranchOperation {
+            sources,
+            branch_name: _,
+        }) => MoveOutcome {
             sources,
             target: None,
             new_branch_name,

--- a/crates/but/src/command/legacy/move2.rs
+++ b/crates/but/src/command/legacy/move2.rs
@@ -205,7 +205,7 @@ fn resolve(
                 })),
                 None => {
                     let branch_name =
-                        BranchArg(branch.to_string()).resolve_for_creation_ws(&repo, &ws)?;
+                        BranchArg(branch.to_string()).resolve_for_creation(&repo, &ws)?;
                     Ok(MoveOperation::ToNewBranch(
                         MoveCommitsToNewBranchOperation {
                             sources,

--- a/crates/but/src/command/legacy/move2.rs
+++ b/crates/but/src/command/legacy/move2.rs
@@ -13,7 +13,7 @@ use nonempty::NonEmpty;
 use crate::{
     CliResult, IdMap,
     args::{
-        atoms::{BranchOrCommit, Purpose},
+        atoms::{BranchOrCommit, CliIdArg, Purpose},
         move2::Platform,
     },
     bad_input,
@@ -23,7 +23,7 @@ use crate::{
 
 pub struct MoveOutcome {
     pub sources: NonEmpty<gix::ObjectId>,
-    pub target: MoveTarget,
+    pub target: Option<MoveTarget>,
     pub new_branch_name: Option<FullName>,
 }
 
@@ -36,15 +36,17 @@ impl CliOutputHuman for MoveOutcome {
         } = self;
         let sources = sources.into_iter().map(theme::Commit).join(", ");
 
+        write!(out, "Moved {sources}")?;
+
         if let Some(new_branch_name) = new_branch_name {
-            writeln!(
-                out,
-                "Moved {sources} to new branch {} {target}",
-                theme::Branch(new_branch_name)
-            )?;
-        } else {
-            writeln!(out, "Moved {sources} {target}")?;
+            write!(out, " to new branch {}", theme::Branch(new_branch_name))?;
         }
+
+        if let Some(target) = target {
+            write!(out, " {target}")?;
+        }
+
+        writeln!(out)?;
 
         Ok(())
     }
@@ -66,16 +68,17 @@ pub fn r#move(
 
 #[derive(Clone)]
 enum MoveOperation {
-    Commit(MoveCommitsOperation),
+    RelativeTo(MoveCommitsRelativeToOperation),
+    ToNewBranch(MoveCommitsToNewBranchOperation),
 }
 
 #[derive(Clone)]
-struct MoveCommitsOperation {
+struct MoveCommitsRelativeToOperation {
     sources: NonEmpty<gix::ObjectId>,
     target: MoveTarget,
 }
 
-impl MoveCommitsOperation {
+impl MoveCommitsRelativeToOperation {
     fn execute(
         self,
         tx: &mut Transaction<'_, '_, impl RefMetadata>,
@@ -99,9 +102,35 @@ impl MoveCommitsOperation {
                     Some(new_branch_name),
                 )
             }
+            MoveTarget::BranchTip { name } => {
+                (RelativeTo::Reference(name), Side::Below.into(), None)
+            }
         };
 
         tx.move_commits(self.sources, relative_to, side)?;
+        Ok(new_branch_name)
+    }
+}
+
+#[derive(Clone)]
+struct MoveCommitsToNewBranchOperation {
+    sources: NonEmpty<gix::ObjectId>,
+}
+
+impl MoveCommitsToNewBranchOperation {
+    fn execute(self, tx: &mut Transaction<'_, '_, impl RefMetadata>) -> anyhow::Result<FullName> {
+        let new_branch_name = but_core::branch::unique_canned_refname(tx.repo())?;
+        tx.create_reference(
+            new_branch_name.as_ref(),
+            None,
+            |_| StackId::generate(),
+            Some(0),
+        )?;
+        tx.move_commits(
+            self.sources,
+            RelativeTo::Reference(new_branch_name.clone()),
+            Side::Below.into(),
+        )?;
         Ok(new_branch_name)
     }
 }
@@ -112,6 +141,9 @@ pub enum MoveTarget {
     Commit {
         commit_id: gix::ObjectId,
         side: Side,
+    },
+    BranchTip {
+        name: FullName,
     },
     BranchBucket {
         name: FullName,
@@ -124,6 +156,9 @@ impl Display for MoveTarget {
         match self {
             Self::Commit { commit_id, side } => {
                 write!(f, "{} commit {}", side, theme::Commit(*commit_id))
+            }
+            Self::BranchTip { name } => {
+                write!(f, "to the tip of branch {}", theme::Branch(name))
             }
             Self::BranchBucket { name, side } => {
                 write!(f, "{} branch {}", side, theme::Branch(name))
@@ -142,24 +177,66 @@ fn resolve(
         above,
         below,
         sources,
+        branch,
     } = args;
 
     let (repo, _ws, _db) = ctx.workspace_and_db_with_perm(perm.read_permission())?;
 
-    let (unresolved_target, side) = match (above, below) {
-        (Some(above), None) => (above, Side::Above),
-        (None, Some(below)) => (below, Side::Below),
-        _ => unimplemented!(),
-    };
+    match (branch, above, below) {
+        (Some(Some(branch)), None, None) => {
+            let resolved_sources = sources
+                .into_iter()
+                .map(|source| source.resolve_commit_in_workspace(&repo, id_map))
+                .collect::<CliResult<Vec<_>>>()?;
+            let sources = NonEmpty::from_vec(resolved_sources)
+                .expect("BUG: Empty sources should not be possible as it's a required argument");
 
+            match branch.try_resolve_branch(&repo, id_map)? {
+                Some(branch) => Ok(MoveOperation::RelativeTo(MoveCommitsRelativeToOperation {
+                    sources,
+                    target: MoveTarget::BranchTip {
+                        name: branch.resolve_local_branch_name()?,
+                    },
+                })),
+                None => todo!(),
+            }
+        }
+        (Some(None), None, None) => {
+            let resolved_sources = sources
+                .into_iter()
+                .map(|source| source.resolve_commit_in_workspace(&repo, id_map))
+                .collect::<CliResult<Vec<_>>>()?;
+            let sources = NonEmpty::from_vec(resolved_sources)
+                .expect("BUG: Empty sources should not be possible as it's a required argument");
+            Ok(MoveOperation::ToNewBranch(
+                MoveCommitsToNewBranchOperation { sources },
+            ))
+        }
+        (None, Some(above), None) => {
+            create_move_above_or_below_op(&repo, id_map, sources, above, Side::Above)
+        }
+        (None, None, Some(below)) => {
+            create_move_above_or_below_op(&repo, id_map, sources, below, Side::Below)
+        }
+        _ => unreachable!("BUG: Targeting group is required"),
+    }
+}
+
+fn create_move_above_or_below_op(
+    repo: &gix::Repository,
+    id_map: &IdMap,
+    sources: impl IntoIterator<Item = CliIdArg>,
+    unresolved_target: CliIdArg,
+    side: Side,
+) -> CliResult<MoveOperation> {
     let target = {
         match unresolved_target
-            .resolve_in_workspace(&repo, id_map, Purpose::Anchor, None)?
+            .resolve_in_workspace(repo, id_map, Purpose::Anchor, None)?
             .into_branch_or_commit()?
         {
             BranchOrCommit::Commit(commit_id) => MoveTarget::Commit { commit_id, side },
             BranchOrCommit::Branch(branch_arg) => MoveTarget::BranchBucket {
-                name: branch_arg.resolve_existing_local_branch(&repo)?,
+                name: branch_arg.resolve_existing_local_branch(repo)?,
                 side,
             },
         }
@@ -168,7 +245,7 @@ fn resolve(
     let sources = sources
         .into_iter()
         .map(|source| {
-            let resolved_source = source.resolve_commit_in_workspace(&repo, id_map)?;
+            let resolved_source = source.resolve_commit_in_workspace(repo, id_map)?;
 
             match &target {
                 MoveTarget::Commit { commit_id, .. } if commit_id == &resolved_source => {
@@ -187,7 +264,7 @@ fn resolve(
     let sources = NonEmpty::from_vec(sources)
         .expect("BUG: Empty sources should not be possible as it's a required argument");
 
-    Ok(MoveOperation::Commit(MoveCommitsOperation {
+    Ok(MoveOperation::RelativeTo(MoveCommitsRelativeToOperation {
         sources,
         target,
     }))
@@ -208,7 +285,8 @@ fn run(
         DryRun::No,
         |mut tx| {
             let new_branch_name = match move_op.clone() {
-                MoveOperation::Commit(op) => op.execute(&mut tx)?,
+                MoveOperation::RelativeTo(op) => op.execute(&mut tx)?,
+                MoveOperation::ToNewBranch(op) => Some(op.execute(&mut tx)?),
             };
 
             Ok(but_transaction::Commit(new_branch_name))
@@ -216,9 +294,16 @@ fn run(
     )?;
 
     let outcome = match move_op {
-        MoveOperation::Commit(MoveCommitsOperation { sources, target }) => MoveOutcome {
+        MoveOperation::RelativeTo(MoveCommitsRelativeToOperation { sources, target }) => {
+            MoveOutcome {
+                sources,
+                target: Some(target),
+                new_branch_name,
+            }
+        }
+        MoveOperation::ToNewBranch(MoveCommitsToNewBranchOperation { sources }) => MoveOutcome {
             sources,
-            target,
+            target: None,
             new_branch_name,
         },
     };

--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -100,9 +100,11 @@ fn edit_branch_name(
             };
 
             let new_branch_name = {
-                let repo = ctx.repo.get()?;
-                let head_info = but_api::legacy::workspace::head_info(ctx)?;
-                BranchArg(non_validated_new_name).resolve_for_creation(&repo, &head_info)?
+                let (repo, ws, _db) = ctx.workspace_and_db_with_perm(perm.read_permission())?;
+                BranchArg(non_validated_new_name)
+                    .resolve_for_creation(&repo, &ws)?
+                    .shorten()
+                    .to_string()
             };
             but_api::legacy::stack::update_branch_name_with_perm(
                 ctx,

--- a/crates/but/tests/but/command/move2.rs
+++ b/crates/but/tests/but/command/move2.rs
@@ -695,6 +695,7 @@ Error: Could not find anchor: 'B'
 Hint: Run `but status` for applicable targets.
 
 "#]]);
+
     env.but("_move2 94 --below B")
         .assert()
         .failure()
@@ -714,6 +715,7 @@ Error: Could not find anchor: 'no-such-branch'
 Hint: Run `but status` for applicable targets.
 
 "#]]);
+
     env.but("_move2 94 --below no-such-branch")
         .assert()
         .failure()
@@ -726,7 +728,113 @@ Hint: Run `but status` for applicable targets.
 }
 
 #[test]
-fn cannot_combine_above_and_below() {
+fn move_to_tip_of_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┊╭┄h0 [B]
+┊●   d3e2ba3 add B
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 94 -b B")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved 9477ae7 to the tip of branch 'B'
+
+"#]]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A] (no commits)
+├╯
+┊
+┊╭┄h0 [B]
+┊●   22c3ce2 add A
+┊●   d3e2ba3 add B
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn move_to_tip_of_empty_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks-one-empty");
+    env.setup_metadata(&["A", "B"]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┊╭┄h0 [B] (no commits)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 94 -b B")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved 9477ae7 to the tip of branch 'B'
+
+"#]]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A] (no commits)
+├╯
+┊
+┊╭┄h0 [B]
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn cannot_combine_targets() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
     env.setup_metadata(&["A"]);
 
@@ -753,7 +861,7 @@ Hint: run `but help` for all commands
         .stderr_eq(snapbox::str![[r#"
 error: the argument '--below <BRANCH_OR_COMMIT>' cannot be used with '--above <BRANCH_OR_COMMIT>'
 
-Usage: but _move2 <--above <BRANCH_OR_COMMIT>|--below <BRANCH_OR_COMMIT>> <SOURCES>...
+Usage: but _move2 <--above <BRANCH_OR_COMMIT>|--below <BRANCH_OR_COMMIT>|--branch [<BRANCH>]> <SOURCES>...
 
 For more information, try '--help'.
 
@@ -770,9 +878,9 @@ fn must_specify_target() {
         .failure()
         .stderr_eq(snapbox::str![[r#"
 error: the following required arguments were not provided:
-  <--above <BRANCH_OR_COMMIT>|--below <BRANCH_OR_COMMIT>>
+  <--above <BRANCH_OR_COMMIT>|--below <BRANCH_OR_COMMIT>|--branch [<BRANCH>]>
 
-Usage: but _move2 <--above <BRANCH_OR_COMMIT>|--below <BRANCH_OR_COMMIT>> <SOURCES>...
+Usage: but _move2 <--above <BRANCH_OR_COMMIT>|--below <BRANCH_OR_COMMIT>|--branch [<BRANCH>]> <SOURCES>...
 
 For more information, try '--help'.
 

--- a/crates/but/tests/but/command/move2.rs
+++ b/crates/but/tests/but/command/move2.rs
@@ -834,6 +834,142 @@ Hint: run `but help` for all commands
 }
 
 #[test]
+fn move_to_tip_of_new_unstacked_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊●   fe12bcd add first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 9a --branch new-branch")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved 9ac4652 to new branch 'new-branch'
+
+"#]]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   fe12bcd add first
+├╯
+┊
+┊╭┄ne [new-branch]
+┊●   ce8b324 add second
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn move_to_tip_of_new_unstacked_branch_with_canned_name() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊●   fe12bcd add first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 9a --branch")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved 9ac4652 to new branch 'a-branch-1'
+
+"#]]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   fe12bcd add first
+├╯
+┊
+┊╭┄br [a-branch-1]
+┊●   ce8b324 add second
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn targeting_unapplied_branch_errors() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks-one-empty");
+    env.setup_metadata(&["A", "B"]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┊╭┄h0 [B] (no commits)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+    env.but("unapply B").assert().success();
+
+    env.but("_move2 94 --branch B")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: A branch named 'B' exists but is not applied
+
+"#]]);
+}
+
+#[test]
 fn cannot_combine_targets() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
     env.setup_metadata(&["A"]);


### PR DESCRIPTION
## 🧢 Changes
Adds branch tip targeting to `_move2`, working precisely the same way as it does in `_commit2`.