### PR TITLE
Apply creates a new workspace when transitioning from regular branch

### DIFF
--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -169,8 +169,8 @@ pub mod json {
     #[cfg(feature = "export-schema")]
     but_schemars::register_sdk_type!(ApplyOutcome);
 
-    impl<'a> From<but_workspace::branch::apply::Outcome<'a>> for ApplyOutcome {
-        fn from(value: but_workspace::branch::apply::Outcome<'a>) -> Self {
+    impl From<but_workspace::branch::apply::Outcome> for ApplyOutcome {
+        fn from(value: but_workspace::branch::apply::Outcome) -> Self {
             let workspace_changed = value.workspace_changed();
             let but_workspace::branch::apply::Outcome {
                 workspace: _,
@@ -620,7 +620,7 @@ pub mod json {
 pub fn apply_only(
     ctx: &mut but_ctx::Context,
     existing_branch: &gix::refs::FullNameRef,
-) -> anyhow::Result<but_workspace::branch::apply::Outcome<'static>> {
+) -> anyhow::Result<but_workspace::branch::apply::Outcome> {
     let mut guard = ctx.exclusive_worktree_access();
     apply_only_with_perm(ctx, existing_branch, guard.write_permission())
 }
@@ -637,12 +637,12 @@ pub fn apply_only_with_perm(
     ctx: &mut but_ctx::Context,
     existing_branch: &gix::refs::FullNameRef,
     perm: &mut RepoExclusive,
-) -> anyhow::Result<but_workspace::branch::apply::Outcome<'static>> {
+) -> anyhow::Result<but_workspace::branch::apply::Outcome> {
     let mut meta = ctx.meta()?;
     let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let out = but_workspace::branch::apply(
         existing_branch,
-        &ws,
+        ws.clone(),
         &repo,
         &mut meta,
         // NOTE: Options can later be passed as parameter, or we have a separate function for that.
@@ -654,11 +654,10 @@ pub fn apply_only_with_perm(
             order: None,
             new_stack_id: None,
         },
-    )?
-    .into_owned();
+    )?;
 
     if out.status.persisted_mutation() {
-        *ws = out.workspace.clone().into_owned();
+        *ws = out.workspace.clone();
     }
     Ok(out)
 }
@@ -673,7 +672,7 @@ pub fn apply_only_with_perm(
 pub fn apply(
     ctx: &mut but_ctx::Context,
     existing_branch: &gix::refs::FullNameRef,
-) -> anyhow::Result<but_workspace::branch::apply::Outcome<'static>> {
+) -> anyhow::Result<but_workspace::branch::apply::Outcome> {
     let mut guard = ctx.exclusive_worktree_access();
     apply_with_perm(ctx, existing_branch, guard.write_permission())
 }
@@ -689,7 +688,7 @@ pub fn apply_with_perm(
     ctx: &mut but_ctx::Context,
     existing_branch: &gix::refs::FullNameRef,
     perm: &mut RepoExclusive,
-) -> anyhow::Result<but_workspace::branch::apply::Outcome<'static>> {
+) -> anyhow::Result<but_workspace::branch::apply::Outcome> {
     // NOTE: since this is optional by nature, the same would be true if snapshotting/undo would be disabled via `ctx` app settings, for instance.
     let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
         ctx,

--- a/crates/but-debug/src/command/workspace.rs
+++ b/crates/but-debug/src/command/workspace.rs
@@ -25,7 +25,7 @@ pub(crate) fn apply(
 
     let outcome = but_workspace::branch::apply(
         branch.as_ref(),
-        &ws,
+        ws.clone(),
         &repo,
         &mut meta,
         but_workspace::branch::apply::Options {
@@ -38,7 +38,7 @@ pub(crate) fn apply(
     )?;
 
     writeln!(out, "{outcome:#?}")?;
-    *ws = outcome.workspace.into_owned();
+    *ws = outcome.workspace;
     emit_after(&ws, &mutation_args.debug, err)
 }
 

--- a/crates/but-transaction/src/lib.rs
+++ b/crates/but-transaction/src/lib.rs
@@ -1040,12 +1040,12 @@ fn workspace_state_from_rebase<M: RefMetadata>(
         }
         let outcome = but_workspace::branch::apply(
             branch.as_ref(),
-            materialized.workspace,
+            materialized.workspace.clone(),
             repo,
             materialized.meta,
             Default::default(),
         )?;
-        *materialized.workspace = outcome.workspace.into_owned();
+        *materialized.workspace = outcome.workspace;
     }
     for update in pending_metadata_updates {
         match update {

--- a/crates/but-workspace/src/branch/apply.rs
+++ b/crates/but-workspace/src/branch/apply.rs
@@ -431,6 +431,25 @@ pub fn apply<'ws>(
     let ws_md_orig = ws_md.clone();
     {
         let ws_mut: &mut Workspace = &mut ws_md;
+        // After a `git switch` out of a managed workspace onto a foreign branch, the metadata is
+        // stale: old stacks are still marked in-workspace though they're gone from the projection.
+        // Demote those so only the applied branches survive. Skip when HEAD still points at the
+        // workspace ref (re-entering it) or the stack is still projected (a genuinely enclosed
+        // adhoc checkout).
+        let head_points_at_workspace_ref = repo
+            .head_name()?
+            .is_some_and(|name| name == workspace_ref_name_to_update);
+        if matches!(ws.kind, WorkspaceKind::AdHoc) && !head_points_at_workspace_ref {
+            for stack in &mut ws_mut.stacks {
+                let visible = stack.branches.iter().any(|b| {
+                    ws.find_segment_and_stack_by_refname(b.ref_name.as_ref())
+                        .is_some()
+                });
+                if !visible {
+                    stack.workspacecommit_relation = Outside;
+                }
+            }
+        }
         for rn in &branches_to_apply {
             add_branch_as_stack_forcefully(ws_mut, rn.as_ref(), order, new_stack_id);
         }

--- a/crates/but-workspace/src/branch/apply.rs
+++ b/crates/but-workspace/src/branch/apply.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use but_core::{
     WORKSPACE_REF_NAME,
     ref_metadata::{StackId, StackKind},
@@ -58,16 +56,13 @@ impl OutcomeStatus {
 }
 
 /// Returned by [apply()].
-pub struct Outcome<'workspace> {
-    /// The newly created workspace, if owned, or the one that was passed in if borrowed, to show how the workspace looks like now.
+pub struct Outcome {
+    /// The workspace as it looks like now.
     ///
-    /// If borrowed, the graph already contained the desired branch and nothing had to be applied. Note that metadata changes
-    /// might not be included in this case, as they aren't the source of truth.
-    ///
-    /// If owned, the returned workspace can also be a proposed state that was not persisted because
+    /// The returned workspace can also be a proposed state that was not persisted because
     /// [Options::on_workspace_conflict] aborted the operation. Check [Outcome::conflicting_stacks]
     /// and [Outcome::status] to tell whether anything was actually persisted.
-    pub workspace: Cow<'workspace, but_graph::Workspace>,
+    pub workspace: but_graph::Workspace,
     /// The precise kind of apply operation that completed.
     pub status: OutcomeStatus,
     /// The branch(es) that were activated or recorded by the operation.
@@ -92,7 +87,7 @@ pub struct Outcome<'workspace> {
     pub conflicting_stacks: Vec<ConflictingStack>,
 }
 
-impl Outcome<'_> {
+impl Outcome {
     /// Return `true` if apply performed work that should be visible to callers, including metadata-only repairs.
     /// This is `false` only for a true already-applied no-op.
     pub fn workspace_changed(&self) -> bool {
@@ -100,30 +95,7 @@ impl Outcome<'_> {
     }
 }
 
-impl<'a> Outcome<'a> {
-    /// Convert this instance into a fully-owned one.
-    pub fn into_owned(self) -> Outcome<'static> {
-        let Outcome {
-            workspace,
-            status,
-            applied_branches,
-            workspace_ref_created,
-            workspace_merge,
-            conflicting_stacks,
-        } = self;
-
-        Outcome {
-            workspace: Cow::Owned(workspace.into_owned()),
-            status,
-            applied_branches,
-            workspace_ref_created,
-            workspace_merge,
-            conflicting_stacks,
-        }
-    }
-}
-
-impl std::fmt::Debug for Outcome<'_> {
+impl std::fmt::Debug for Outcome {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let Outcome {
             workspace: _,
@@ -244,9 +216,9 @@ use crate::{
 /// Note that options have no effect if `branch` is already in the workspace, so `apply` is *not* a way
 /// to alter certain aspects of the workspace by applying the same branch again.
 #[instrument(skip(workspace, repo, meta), err(Debug))]
-pub fn apply<'ws>(
+pub fn apply(
     branch: &FullNameRef,
-    workspace: &'ws but_graph::Workspace,
+    workspace: but_graph::Workspace,
     repo: &gix::Repository,
     meta: &mut impl RefMetadata,
     Options {
@@ -256,7 +228,7 @@ pub fn apply<'ws>(
         order,
         new_stack_id,
     }: Options,
-) -> anyhow::Result<Outcome<'ws>> {
+) -> anyhow::Result<Outcome> {
     let ws = workspace;
     let new_stack_id = new_stack_id.unwrap_or(generate_new_stack_id);
     let branch_orig = branch;
@@ -283,11 +255,11 @@ pub fn apply<'ws>(
         branch = upstream_branch_name;
         branch_ref = try_find_validated_ref(repo, branch.as_ref(), "apply")?;
     }
-    if branch_is_already_applied(branch.as_ref(), ws, meta)? {
+    if branch_is_already_applied(branch.as_ref(), &ws, meta)? {
         let workspace_ref_created = false;
         // When exiting early, don't try to adjust the ws commit.
         return Ok(Outcome {
-            workspace: Cow::Borrowed(workspace),
+            workspace: ws,
             status: OutcomeStatus::AlreadyApplied,
             workspace_ref_created,
             workspace_merge: None,
@@ -313,7 +285,7 @@ pub fn apply<'ws>(
             },
         )?;
         let applied_branches = vec![branch.to_owned()];
-        if !branch_has_applied_workspace_metadata(branch.as_ref(), ws, meta)? {
+        if !branch_has_applied_workspace_metadata(branch.as_ref(), &ws, meta)? {
             let ws_ref_name = ws
                 .ref_name()
                 .context("Workspace metadata must be available to repair stale applied state")?;
@@ -321,19 +293,19 @@ pub fn apply<'ws>(
             add_branch_as_stack_forcefully(&mut ws_md, branch.as_ref(), order, new_stack_id);
             persist_metadata_and_gitconfig(meta, &applied_branches, &ws_md, None)?;
         }
+        let ws_ref_name = ws.ref_name().map(|rn| rn.to_owned());
         let ws = ws
             .graph
             .redo_traversal_with_overlay(
                 repo,
                 meta,
-                Overlay::default()
-                    .with_entrypoint(commit_to_checkout, ws.ref_name().map(|rn| rn.to_owned())),
+                Overlay::default().with_entrypoint(commit_to_checkout, ws_ref_name),
             )?
             .into_workspace()?;
 
         // When exiting early, don't try to adjust the ws commit.
         return Ok(Outcome {
-            workspace: Cow::Owned(ws),
+            workspace: ws,
             status: OutcomeStatus::Applied,
             workspace_ref_created: false,
             workspace_merge: None,
@@ -431,20 +403,21 @@ pub fn apply<'ws>(
     let ws_md_orig = ws_md.clone();
     {
         let ws_mut: &mut Workspace = &mut ws_md;
-        // After a `git switch` out of a managed workspace onto a foreign branch, the metadata is
-        // stale: old stacks are still marked in-workspace though they're gone from the projection.
-        // Demote those so only the applied branches survive. Skip when HEAD still points at the
-        // workspace ref (re-entering it) or the stack is still projected (a genuinely enclosed
-        // adhoc checkout).
-        let head_points_at_workspace_ref = repo
-            .head_name()?
-            .is_some_and(|name| name == workspace_ref_name_to_update);
-        if matches!(ws.kind, WorkspaceKind::AdHoc) && !head_points_at_workspace_ref {
+        // After switching out of a workspace the metadata can be stale: old stacks are still marked
+        // in-workspace though they're gone from the projection. Demote them, except stacks still
+        // visible in the projection (genuinely enclosed adhoc checkouts).
+        if matches!(ws.kind, WorkspaceKind::AdHoc) {
+            let visible_ref_names: std::collections::HashSet<&gix::bstr::BStr> = ws
+                .stacks
+                .iter()
+                .flat_map(|s| s.segments.iter())
+                .filter_map(|seg| seg.ref_name().map(|rn| rn.as_bstr()))
+                .collect();
             for stack in &mut ws_mut.stacks {
-                let visible = stack.branches.iter().any(|b| {
-                    ws.find_segment_and_stack_by_refname(b.ref_name.as_ref())
-                        .is_some()
-                });
+                let visible = stack
+                    .branches
+                    .iter()
+                    .any(|b| visible_ref_names.contains(b.ref_name.as_ref().as_bstr()));
                 if !visible {
                     stack.workspacecommit_relation = Outside;
                 }
@@ -545,7 +518,7 @@ pub fn apply<'ws>(
             (!ws_ref_exists).then_some(workspace_ref_name_to_update.as_ref()),
         )?;
         return Ok(Outcome {
-            workspace: Cow::Owned(graph.into_workspace()?),
+            workspace: graph.into_workspace()?,
             status: OutcomeStatus::Applied,
             workspace_ref_created: needs_ws_ref_creation,
             workspace_merge: None,
@@ -588,7 +561,7 @@ pub fn apply<'ws>(
         let conflicting_stacks =
             correlate_conflicting_stacks(&ws_md, &merge_result.conflicting_stacks);
         return Ok(Outcome {
-            workspace: Cow::Owned(ws),
+            workspace: ws,
             status: OutcomeStatus::ConflictAborted,
             workspace_ref_created: false,
             workspace_merge: Some(merge_result),
@@ -708,7 +681,7 @@ pub fn apply<'ws>(
             let conflicting_stacks =
                 correlate_conflicting_stacks(&ws_md, &merge_result.conflicting_stacks);
             return Ok(Outcome {
-                workspace: Cow::Owned(ws),
+                workspace: ws,
                 status: OutcomeStatus::ConflictAborted,
                 workspace_ref_created: false,
                 workspace_merge: Some(merge_result),
@@ -774,7 +747,7 @@ pub fn apply<'ws>(
         (!ws_ref_exists).then_some(workspace_ref_name_to_update.as_ref()),
     )?;
     Ok(Outcome {
-        workspace: Cow::Owned(ws),
+        workspace: ws,
         status: OutcomeStatus::Applied,
         workspace_ref_created: needs_ws_ref_creation,
         workspace_merge: Some(merge_result),

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
@@ -59,16 +59,17 @@ fn operation_denied_on_improper_workspace() -> anyhow::Result<()> {
     ");
 
     let branch_b = r("refs/heads/B");
-    let err =
-        but_workspace::branch::apply(branch_b, &ws, &repo, &mut meta, apply_options()).unwrap_err();
+    let err = but_workspace::branch::apply(branch_b, ws.clone(), &repo, &mut meta, apply_options())
+        .unwrap_err();
     assert_eq!(
         err.to_string(),
         "Refusing to work on workspace whose workspace commit isn't at the top",
         "cannot apply on a workspace that isn't proper"
     );
 
-    let err = but_workspace::branch::apply(r("HEAD"), &ws, &repo, &mut meta, apply_options())
-        .unwrap_err();
+    let err =
+        but_workspace::branch::apply(r("HEAD"), ws.clone(), &repo, &mut meta, apply_options())
+            .unwrap_err();
     assert_eq!(
         err.to_string(),
         "Refusing to apply symbolic ref 'HEAD' due to potential ambiguity"
@@ -242,7 +243,7 @@ fn ws_ref_no_ws_commit_two_virtual_stacks_on_same_commit_apply_dependent_first()
 
     // Put "B" into the workspace, even though it's the dependent branch of A.
     let out =
-        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, apply_options())?;
+        but_workspace::branch::apply(r("refs/heads/B"), ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -250,7 +251,7 @@ fn ws_ref_no_ws_commit_two_virtual_stacks_on_same_commit_apply_dependent_first()
         applied_branches: "[refs/heads/B]",
     }
     "#);
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     └── ≡📙:2:B on e5d0542 {1}
@@ -259,7 +260,7 @@ fn ws_ref_no_ws_commit_two_virtual_stacks_on_same_commit_apply_dependent_first()
 
     // Applying A is always a new stack then.
     let out =
-        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
+        but_workspace::branch::apply(r("refs/heads/A"), ws, &repo, &mut meta, apply_options())?;
     insta::assert_snapshot!(graph_workspace(&out.workspace), "the workspace ref still points to the base e5d0542", @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:2:B on e5d0542 {1}
@@ -271,7 +272,7 @@ fn ws_ref_no_ws_commit_two_virtual_stacks_on_same_commit_apply_dependent_first()
     // It's all virtual.
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
 
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     let out = but_workspace::branch::unapply(
         r("refs/heads/A"),
         &ws,
@@ -495,14 +496,9 @@ mod workspace_disposition {
             standard_traversal_options(),
         )?
         .into_workspace()?;
-        let out = but_workspace::branch::apply(
-            r("refs/heads/A"),
-            &ws,
-            &repo,
-            &mut meta,
-            apply_options(),
-        )?;
-        let ws = out.workspace.into_owned();
+        let out =
+            but_workspace::branch::apply(r("refs/heads/A"), ws, &repo, &mut meta, apply_options())?;
+        let ws = out.workspace;
         insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e5d0542
         └── ≡📙:3:A on e5d0542 {41}
@@ -549,14 +545,9 @@ mod workspace_disposition {
             standard_traversal_options(),
         )?
         .into_workspace()?;
-        let out = but_workspace::branch::apply(
-            r("refs/heads/A"),
-            &ws,
-            &repo,
-            &mut meta,
-            apply_options(),
-        )?;
-        let ws = out.workspace.into_owned();
+        let out =
+            but_workspace::branch::apply(r("refs/heads/A"), ws, &repo, &mut meta, apply_options())?;
+        let ws = out.workspace;
 
         let out = but_workspace::branch::unapply(
             r("refs/heads/A"),
@@ -600,14 +591,9 @@ mod workspace_disposition {
             standard_traversal_options(),
         )?
         .into_workspace()?;
-        let out = but_workspace::branch::apply(
-            r("refs/heads/A"),
-            &ws,
-            &repo,
-            &mut meta,
-            apply_options(),
-        )?;
-        let ws = out.workspace.into_owned();
+        let out =
+            but_workspace::branch::apply(r("refs/heads/A"), ws, &repo, &mut meta, apply_options())?;
+        let ws = out.workspace;
         insta::assert_snapshot!(graph_workspace(&ws), "the workspace ref is checked out", @"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e5d0542
         └── ≡📙:3:A on e5d0542 {41}
@@ -787,7 +773,7 @@ fn main_with_advanced_remote_tracking_branch() -> anyhow::Result<()> {
     // We cannot apply remote tracking branches directly, but it resolves automatically to local tracking branches.
     let out = but_workspace::branch::apply(
         r("refs/remotes/origin/main"),
-        &ws,
+        ws.clone(),
         &repo,
         &mut meta,
         apply_options(),
@@ -803,7 +789,7 @@ fn main_with_advanced_remote_tracking_branch() -> anyhow::Result<()> {
     // Set up an automatic tracking of origin/feature, as remote tracking branches can't be in the workspace.
     let out = but_workspace::branch::apply(
         r("refs/remotes/origin/feature"),
-        &ws,
+        ws,
         &repo,
         &mut meta,
         apply_options(),
@@ -815,7 +801,7 @@ fn main_with_advanced_remote_tracking_branch() -> anyhow::Result<()> {
         applied_branches: "[refs/heads/main, refs/heads/feature]",
     }
     "#);
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     // both branches, main and feature, are available in the newly created workspace ref.
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
@@ -874,8 +860,8 @@ fn unapply_remotely_tracked_tip_of_multi_segment_stack_can_delete_workspace_ref(
 
     let ws = graph.into_workspace()?;
     let out =
-        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, apply_options())?;
-    let ws = out.workspace.into_owned();
+        but_workspace::branch::apply(r("refs/heads/B"), ws, &repo, &mut meta, apply_options())?;
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     └── ≡📙:3:B <> origin/B →:5: on 85efbe4 {42}
@@ -951,7 +937,7 @@ fn workspace_with_out_of_ws_ref_and_anon_stack() -> anyhow::Result<()> {
 
     let out = but_workspace::branch::apply(
         r("refs/heads/feature"),
-        &ws,
+        ws,
         &repo,
         &mut meta,
         apply_options(),
@@ -993,7 +979,7 @@ fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
 
     // Put "A" into the workspace, yielding a single branch.
     let out =
-        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
+        but_workspace::branch::apply(r("refs/heads/A"), ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -1001,7 +987,7 @@ fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
         applied_branches: "[refs/heads/A]",
     }
     "#);
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     └── ≡📙:2:A on e5d0542 {41}
@@ -1011,7 +997,7 @@ fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
 
     let branch_b = r("refs/heads/B");
-    let out = but_workspace::branch::apply(branch_b, &ws, &repo, &mut meta, apply_options())?;
+    let out = but_workspace::branch::apply(branch_b, ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -1021,7 +1007,7 @@ fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
     "#);
     // Note how it will create a new stack (to keep it simple),
     // in theory we could also add B as dependent branch.
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:2:A on e5d0542 {41}
@@ -1239,7 +1225,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     // Put "A" into the workspace, creating the workspace ref, but never put a branch related to the target in as well,
     // which is currently checked out with `main`.
     let out =
-        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
+        but_workspace::branch::apply(r("refs/heads/A"), ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -1259,9 +1245,11 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     // No commit was created, as it's not enabled by default, but a ws-ref was created, and it's checked out.
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, origin/main, main, B, A) A");
 
+    // Thread the post-apply workspace into the next apply instead of reusing the stale projection.
+    let ws = out.workspace;
     let out = but_workspace::branch::apply(
         r("refs/heads/B"),
-        &ws,
+        ws,
         &repo,
         &mut meta,
         but_workspace::branch::apply::Options {
@@ -1274,10 +1262,10 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     Outcome {
         workspace_changed: true,
         workspace_ref_created: false,
-        applied_branches: "[refs/heads/main, refs/heads/B]",
+        applied_branches: "[refs/heads/B]",
     }
     "#);
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:2:main on e5d0542 {1a5}
@@ -1311,7 +1299,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
 
     let out = but_workspace::branch::apply(
         r("refs/heads/A"),
-        &ws,
+        ws,
         &repo,
         &mut meta,
         but_workspace::branch::apply::Options {
@@ -1325,7 +1313,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     * e5d0542 (origin/main, main, B, A) A
     ");
 
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
     └── ≡📙:2:A {41}
@@ -1335,7 +1323,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
 
     let out = but_workspace::branch::apply(
         r("refs/heads/B"),
-        &ws,
+        ws,
         &repo,
         &mut meta,
         but_workspace::branch::apply::Options {
@@ -1351,7 +1339,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     * e5d0542 (origin/main, main, B, A) A
     ");
 
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:2:B on e5d0542 {42}
@@ -1389,7 +1377,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target
     // Put "A" into the workspace, creating the workspace ref, but never put a branch related to the target in as well,
     // which is currently checked out with `main`.
     let out =
-        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
+        but_workspace::branch::apply(r("refs/heads/A"), ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -1398,7 +1386,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target
     }
     "#);
 
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e5d0542
     └── ≡📙:3:A on e5d0542 {41}
@@ -1409,7 +1397,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, origin/main, main, B, A) A");
 
     let out =
-        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, apply_options())?;
+        but_workspace::branch::apply(r("refs/heads/B"), ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -1417,7 +1405,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target
         applied_branches: "[refs/heads/B]",
     }
     "#);
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e5d0542
     ├── ≡📙:3:A on e5d0542 {41}
@@ -1431,8 +1419,9 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target
 
     // Cannot put local tracking branch of target into workspace that has it configured.
     for branch in ["refs/heads/main", "refs/remotes/origin/main"] {
-        let err = but_workspace::branch::apply(r(branch), &ws, &repo, &mut meta, apply_options())
-            .unwrap_err();
+        let err =
+            but_workspace::branch::apply(r(branch), ws.clone(), &repo, &mut meta, apply_options())
+                .unwrap_err();
         assert_eq!(
             err.to_string(),
             format!("Cannot add the target '{branch}' branch to its own workspace")
@@ -1504,7 +1493,7 @@ fn apply_after_switching_out_of_workspace_drops_stale_stacks() -> anyhow::Result
     // current branch plus the applied one, while the stale `outside` stack is demoted.
     let out = but_workspace::branch::apply(
         r("refs/heads/applied"),
-        &ws,
+        ws,
         &repo,
         &mut meta,
         apply_options(),
@@ -1568,7 +1557,7 @@ fn new_workspace_exists_elsewhere_and_to_be_applied_branch_exists_there() -> any
 
     // Put "A" into the workspace, hence we want "A" and "B" in it.
     let out =
-        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
+        but_workspace::branch::apply(r("refs/heads/A"), ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -1577,7 +1566,7 @@ fn new_workspace_exists_elsewhere_and_to_be_applied_branch_exists_there() -> any
     }
     "#);
 
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     // This apply brings both branches into the existing workspace, and it's where HEAD points to.
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
@@ -1663,12 +1652,12 @@ mod unapply_checked_out {
                 Category::LocalBranch
                     .to_full_name(branch_to_apply)?
                     .as_ref(),
-                &ws,
+                ws,
                 &repo,
                 &mut meta,
                 apply_options(),
             )?;
-            ws = out.workspace.into_owned();
+            ws = out.workspace;
         }
         insta::allow_duplicates! {
             insta::assert_snapshot!(graph_workspace(&ws), "C and B are real stacks in the managed workspace", @"
@@ -1943,7 +1932,7 @@ fn apply_multiple_without_target_or_metadata_or_base() -> anyhow::Result<()> {
     ");
 
     let out =
-        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
+        but_workspace::branch::apply(r("refs/heads/A"), ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -1952,7 +1941,7 @@ fn apply_multiple_without_target_or_metadata_or_base() -> anyhow::Result<()> {
     }
     "#);
 
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on e31e6ca
     ├── ≡📙:1:main on e31e6ca {1a5}
@@ -1975,7 +1964,7 @@ fn apply_multiple_without_target_or_metadata_or_base() -> anyhow::Result<()> {
     ");
 
     let branch_b_rt = r("refs/remotes/origin/B");
-    let out = but_workspace::branch::apply(branch_b_rt, &ws, &repo, &mut meta, apply_options())?;
+    let out = but_workspace::branch::apply(branch_b_rt, ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -1984,7 +1973,7 @@ fn apply_multiple_without_target_or_metadata_or_base() -> anyhow::Result<()> {
     }
     "#);
 
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on e31e6ca
     ├── ≡📙:1:main on e31e6ca {1a5}
@@ -2108,16 +2097,16 @@ fn unapply_dirty_worktree_abort_keeps_refs_and_metadata() -> anyhow::Result<()> 
             └── ·e31e6ca
     ");
     let out =
-        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
-    let ws = out.workspace.into_owned();
+        but_workspace::branch::apply(r("refs/heads/A"), ws, &repo, &mut meta, apply_options())?;
+    let ws = out.workspace;
     let out = but_workspace::branch::apply(
         r("refs/remotes/origin/B"),
-        &ws,
+        ws,
         &repo,
         &mut meta,
         apply_options(),
     )?;
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on e31e6ca
     ├── ≡📙:1:main on e31e6ca {1a5}
@@ -2207,7 +2196,7 @@ fn apply_repairs_stale_outside_metadata_for_reachable_branch() -> anyhow::Result
     meta.set_workspace(&ws_md)?;
 
     let out =
-        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, apply_options())?;
+        but_workspace::branch::apply(r("refs/heads/B"), ws, &repo, &mut meta, apply_options())?;
     assert_eq!(
         out.status,
         OutcomeStatus::Applied,
@@ -2256,7 +2245,7 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
     // Add another stack to be sure we correctly handle the removal of existing stacks later (i.e. don't get the index wrong)
     let out = but_workspace::branch::apply(
         r("refs/heads/unrelated"),
-        &ws,
+        ws,
         &repo,
         &mut meta,
         apply_options(),
@@ -2278,10 +2267,10 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
     * 3183e43 (origin/main, main) M1
     ");
 
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
 
     let out =
-        but_workspace::branch::apply(r("refs/heads/A1"), &ws, &repo, &mut meta, apply_options())?;
+        but_workspace::branch::apply(r("refs/heads/A1"), ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -2290,7 +2279,7 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
     }
     "#);
 
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
     ├── ≡📙:3:unrelated on 3183e43 {3c4}
@@ -2303,7 +2292,7 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
 
     let out = but_workspace::branch::apply(
         r("refs/heads/A2"),
-        &ws,
+        ws,
         &repo,
         &mut meta,
         but_workspace::branch::apply::Options {
@@ -2320,7 +2309,7 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
     }
     "#);
 
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
     ├── ≡📙:3:unrelated on 3183e43 {3c4}
@@ -2435,7 +2424,7 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
         checked_out: None,
     }
     ");
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43");
 
     insta::assert_snapshot!(
@@ -2562,7 +2551,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
     ");
 
     let out =
-        but_workspace::branch::apply(r("refs/heads/C"), &ws, &repo, &mut meta, apply_options())?;
+        but_workspace::branch::apply(r("refs/heads/C"), ws, &repo, &mut meta, apply_options())?;
 
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
@@ -2572,7 +2561,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
     }
     "#);
 
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), "the actual HEAD is ignored, and we only see C (instead of C + HEAD-ref)", @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     └── ≡📙:2:C on 3183e43 {43}
@@ -2591,7 +2580,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
     ");
 
     let out =
-        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, apply_options())?;
+        but_workspace::branch::apply(r("refs/heads/B"), ws, &repo, &mut meta, apply_options())?;
 
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
@@ -2612,7 +2601,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
     * 3183e43 (main) M1
     ");
 
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     ├── ≡📙:2:C on 3183e43 {43}
@@ -2625,7 +2614,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
 
     let out = but_workspace::branch::apply(
         r("refs/heads/A"),
-        &ws,
+        ws,
         &repo,
         &mut meta,
         but_workspace::branch::apply::Options {
@@ -2642,7 +2631,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
         applied_branches: "[refs/heads/A]",
     }
     "#);
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     ├── ≡📙:2:A on 3183e43 {41}
@@ -2753,17 +2742,17 @@ fn unapply_workspace_ref_without_target_checks_out_named_stack() -> anyhow::Resu
             Category::LocalBranch
                 .to_full_name(branch_to_apply)?
                 .as_ref(),
-            &ws,
+            ws,
             &repo,
             &mut meta,
             apply_options(),
         )?;
-        ws = out.workspace.into_owned();
+        ws = out.workspace;
     }
 
     let out = but_workspace::branch::apply(
         r("refs/heads/A"),
-        &ws,
+        ws,
         &repo,
         &mut meta,
         but_workspace::branch::apply::Options {
@@ -2771,7 +2760,7 @@ fn unapply_workspace_ref_without_target_checks_out_named_stack() -> anyhow::Resu
             ..apply_options()
         },
     )?;
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), "the workspace has named stacks but no target ref", @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     ├── ≡📙:2:A on 3183e43 {41}
@@ -2869,12 +2858,12 @@ fn unapply_workspace_ref_refuses_conflicted_named_stack_checkout() -> anyhow::Re
     .into_workspace()?;
     let out = but_workspace::branch::apply(
         r("refs/heads/tip-conflicted"),
-        &ws,
+        ws,
         &repo,
         &mut meta,
         apply_options(),
     )?;
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), "the target-less workspace can contain a conflicted named stack", @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
     └── ≡📙:1:tip-conflicted {595}
@@ -2929,7 +2918,7 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
 
     // Apply the dependent branch, to bring in only the dependent branch
     let out =
-        but_workspace::branch::apply(r("refs/heads/E"), &ws, &repo, &mut meta, apply_options())?;
+        but_workspace::branch::apply(r("refs/heads/E"), ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -2938,7 +2927,7 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
     }
     "#);
 
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     └── ≡📙:4:E on 85efbe4 {1}
@@ -2949,8 +2938,8 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
     // Apply the former tip of the stack, to create a new stack. Note how it won't double-list the
     // other stack.
     let out =
-        but_workspace::branch::apply(r("refs/heads/C"), &ws, &repo, &mut meta, apply_options())?;
-    let ws = out.workspace.into_owned();
+        but_workspace::branch::apply(r("refs/heads/C"), ws, &repo, &mut meta, apply_options())?;
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:5:E on 85efbe4 {1}
@@ -2975,8 +2964,8 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
     // Accepting this behaviour for now as it's quite rare to have such ambiguity, even though I'd love if one day
     // for this to just work as people might intuitively want, even if that means the same commit is used multiple times.
     let out =
-        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, apply_options())?;
-    let ws = out.workspace.into_owned();
+        but_workspace::branch::apply(r("refs/heads/B"), ws, &repo, &mut meta, apply_options())?;
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:5:E on 85efbe4 {1}
@@ -2991,9 +2980,9 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
     // This is what happens because we notice that C can't be applied as independent stack due to the graph algorithm,
     // and then it tries it a dependent stack, which should always work.
     let out =
-        but_workspace::branch::apply(r("refs/heads/C"), &ws, &repo, &mut meta, apply_options())
+        but_workspace::branch::apply(r("refs/heads/C"), ws, &repo, &mut meta, apply_options())
             .unwrap();
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:5:E on 85efbe4 {1}
@@ -3030,7 +3019,7 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
 
     // Apply `A` first.
     let out =
-        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
+        but_workspace::branch::apply(r("refs/heads/A"), ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -3038,7 +3027,7 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
         applied_branches: "[refs/heads/A]",
     }
     "#);
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     └── ≡📙:3:A on 85efbe4 {41}
@@ -3055,7 +3044,7 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
 
     // Apply `B` - the only sane way is to make it its own stack, but allow it to diverge.
     let out =
-        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, apply_options())
+        but_workspace::branch::apply(r("refs/heads/B"), ws, &repo, &mut meta, apply_options())
             .expect("apply actually works");
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
@@ -3065,7 +3054,7 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
     }
     "#);
 
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     └── ≡📙:4:B on 85efbe4 {41}
@@ -3083,7 +3072,7 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
 
     // What follows is a bit wonky, but for now is here to document what happens in a complex scenario.
     let out =
-        but_workspace::branch::apply(r("refs/heads/C"), &ws, &repo, &mut meta, apply_options())
+        but_workspace::branch::apply(r("refs/heads/C"), ws, &repo, &mut meta, apply_options())
             .expect("apply actually works");
     insta::assert_debug_snapshot!(out, "applying C succeeds and updates the workspace metadata", @r#"
     Outcome {
@@ -3093,7 +3082,7 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
     }
     "#);
 
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), "C is recorded as another segment at the same tip in the B/A stack", @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     └── ≡📙:4:B on 85efbe4 {41}
@@ -3111,7 +3100,7 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
     ");
 
     let out =
-        but_workspace::branch::apply(r("refs/heads/D"), &ws, &repo, &mut meta, apply_options())
+        but_workspace::branch::apply(r("refs/heads/D"), ws, &repo, &mut meta, apply_options())
             .expect("apply actually works");
     insta::assert_debug_snapshot!(out, "applying D succeeds and updates the workspace metadata", @r#"
     Outcome {
@@ -3121,7 +3110,7 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
     }
     "#);
 
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), "D becomes a lower segment in the same projected stack, leaving E as the remaining alternate ref at that commit", @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     └── ≡📙:5:B on 85efbe4 {41}
@@ -3140,7 +3129,7 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
     ");
 
     let out =
-        but_workspace::branch::apply(r("refs/heads/E"), &ws, &repo, &mut meta, apply_options())
+        but_workspace::branch::apply(r("refs/heads/E"), ws, &repo, &mut meta, apply_options())
             .expect("apply actually works");
     insta::assert_debug_snapshot!(out, "applying E forces the lower same-commit branch pair into its own stack", @r#"
     Outcome {
@@ -3150,7 +3139,7 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
     }
     "#);
 
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), "applying all ambiguous dependent branches ends with B/C/A and E/D split into two stacks", @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:5:B {41}
@@ -3410,13 +3399,13 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
             Category::LocalBranch
                 .to_full_name(branch_to_apply)?
                 .as_ref(),
-            &ws,
+            ws,
             &repo,
             &mut meta,
             apply_options(),
         )
         .unwrap_or_else(|err| panic!("{branch_to_apply}: {err}"));
-        ws = out.workspace.into_owned();
+        ws = out.workspace;
     }
 
     insta::assert_snapshot!(graph_workspace(&ws), @"
@@ -3463,7 +3452,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
 
     let out = but_workspace::branch::apply(
         r("refs/heads/conflict-hero"),
-        &ws,
+        ws,
         &repo,
         &mut meta,
         apply_options(),
@@ -3485,7 +3474,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
         ],
     }
     "#);
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     // By default, it fails and just reports the conflicting stacks, so it's the same as it was before.
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 85efbe4
@@ -3519,7 +3508,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
 
     let out = but_workspace::branch::apply(
         r("refs/heads/conflict-hero"),
-        &ws,
+        ws,
         &repo,
         &mut meta,
         but_workspace::branch::apply::Options {
@@ -3547,7 +3536,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
     "#);
 
     // Now the other stacks are unapplied.
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 85efbe4
     ├── ≡📙:6:main on 85efbe4 {1a5}
@@ -3698,8 +3687,8 @@ fn conflicting_apply_reports_no_applied_branches_and_names_conflicting_stacks() 
 
     let ws = graph.into_workspace()?;
     let out =
-        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
-    let ws = out.workspace.into_owned();
+        but_workspace::branch::apply(r("refs/heads/A"), ws, &repo, &mut meta, apply_options())?;
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), "A is applied before trying the conflicting sibling branch", @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e31e6ca
     └── ≡📙:3:A on e31e6ca {41}
@@ -3720,7 +3709,7 @@ fn conflicting_apply_reports_no_applied_branches_and_names_conflicting_stacks() 
 
     let out = but_workspace::branch::apply(
         r("refs/heads/add-A-too"),
-        &ws,
+        ws,
         &repo,
         &mut meta,
         apply_options(),
@@ -3796,7 +3785,7 @@ fn unapply_with_workspace_merge_conflicts_always_works_as_conflicts_do_not_repea
             Category::LocalBranch
                 .to_full_name(branch_to_apply)?
                 .as_ref(),
-            &ws,
+            ws,
             &repo,
             &mut meta,
             but_workspace::branch::apply::Options {
@@ -3805,7 +3794,7 @@ fn unapply_with_workspace_merge_conflicts_always_works_as_conflicts_do_not_repea
                 ..apply_options()
             },
         )?;
-        ws = out.workspace.into_owned();
+        ws = out.workspace;
     }
     insta::assert_snapshot!(graph_workspace(&ws), "all branches are applied", @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 85efbe4
@@ -3873,7 +3862,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
     // Apply the workspace ref itself, it's a no-op
     let out = but_workspace::branch::apply(
         r("refs/heads/gitbutler/workspace"),
-        &ws,
+        ws,
         &repo,
         &mut meta,
         apply_options(),
@@ -3903,7 +3892,13 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
         └── 👉📙:3:B
     ");
     // Already applied (the HEAD points to it).
-    let out = but_workspace::branch::apply(b_ref.as_ref(), &ws, &repo, &mut meta, apply_options())?;
+    let out = but_workspace::branch::apply(
+        b_ref.as_ref(),
+        ws.clone(),
+        &repo,
+        &mut meta,
+        apply_options(),
+    )?;
     insta::assert_debug_snapshot!(out, "no-ops aren't listing the already applied branches", @r#"
     Outcome {
         workspace_changed: false,
@@ -3922,7 +3917,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
 
     // To apply A, we checkout the surrounding workspace and repair the stale metadata.
     let out =
-        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
+        but_workspace::branch::apply(r("refs/heads/A"), ws, &repo, &mut meta, apply_options())?;
     assert_eq!(
         out.status,
         OutcomeStatus::Applied,
@@ -3944,7 +3939,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
     );
 
     // Now the workspace ref itself is checked out.
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:2:A on e5d0542 {1}
@@ -3977,7 +3972,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
     ");
 
     let out =
-        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
+        but_workspace::branch::apply(r("refs/heads/A"), ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, "Nothing changed, the desired branch was already applied", @r#"
     Outcome {
         workspace_changed: false,
@@ -4000,7 +3995,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
 
     // Apply the first branch, it must be independent.
     let out =
-        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
+        but_workspace::branch::apply(r("refs/heads/A"), ws, &repo, &mut meta, apply_options())?;
     assert_eq!(
         out.status,
         OutcomeStatus::Applied,
@@ -4013,7 +4008,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
         applied_branches: "[refs/heads/A]",
     }
     "#);
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     └── ≡📙:2:A on e5d0542 {41}
@@ -4022,7 +4017,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
 
     // Apply the first branch, it must be independent.
     let out =
-        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, apply_options())?;
+        but_workspace::branch::apply(r("refs/heads/B"), ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -4055,7 +4050,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
         └── 👉📙:3:B
     ");
 
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     let out = but_workspace::branch::unapply(
         r("refs/heads/A"),
         &ws,
@@ -4130,7 +4125,7 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
 
     // Apply the workspace ref itself, it's a no-op
     let ws_ref = r("refs/heads/gitbutler/workspace");
-    let out = but_workspace::branch::apply(ws_ref, &ws, &repo, &mut meta, apply_options())?;
+    let out = but_workspace::branch::apply(ws_ref, ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, "the workspace ref itself counts as no-op as well", @r#"
     Outcome {
         workspace_changed: false,
@@ -4159,7 +4154,13 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
     ");
 
     // Already applied (the HEAD points to it, it literally IS the workspace).
-    let out = but_workspace::branch::apply(b_ref.as_ref(), &ws, &repo, &mut meta, apply_options())?;
+    let out = but_workspace::branch::apply(
+        b_ref.as_ref(),
+        ws.clone(),
+        &repo,
+        &mut meta,
+        apply_options(),
+    )?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: false,
@@ -4168,8 +4169,8 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
     }
     "#);
 
-    let err =
-        but_workspace::branch::apply(ws_ref, &ws, &repo, &mut meta, apply_options()).unwrap_err();
+    let err = but_workspace::branch::apply(ws_ref, ws.clone(), &repo, &mut meta, apply_options())
+        .unwrap_err();
     assert_eq!(
         err.to_string(),
         "Refusing to apply a reference that already is a workspace: 'gitbutler/workspace'",
@@ -4179,7 +4180,7 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
 
     // To apply, we just checkout the surrounding workspace.
     let out =
-        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
+        but_workspace::branch::apply(r("refs/heads/A"), ws, &repo, &mut meta, apply_options())?;
     assert_eq!(
         out.status,
         OutcomeStatus::Applied,
@@ -4193,7 +4194,7 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
     }
     "#);
 
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:3:A on 85efbe4 {1}
@@ -4233,7 +4234,7 @@ fn apply_nonexisting_branch_failure() -> anyhow::Result<()> {
 
     let err = but_workspace::branch::apply(
         r("refs/heads/does-not-exist"),
-        &ws,
+        ws,
         &repo,
         &mut *meta,
         apply_options(),
@@ -4316,7 +4317,7 @@ fn unborn_apply_needs_base() -> anyhow::Result<()> {
     // Idempotency in ad-hoc workspace
     let out = but_workspace::branch::apply(
         r("refs/heads/main"),
-        &ws,
+        ws.clone(),
         &repo,
         &mut *meta,
         apply_options(),
@@ -4333,7 +4334,7 @@ fn unborn_apply_needs_base() -> anyhow::Result<()> {
     // but since remote is transformed into a local tracking branch, it's a noop.
     let out = but_workspace::branch::apply(
         r("refs/remotes/orphan/main"),
-        &ws,
+        ws,
         &repo,
         &mut *meta,
         apply_options(),
@@ -4346,7 +4347,7 @@ fn unborn_apply_needs_base() -> anyhow::Result<()> {
     }
     "#);
 
-    let ws = out.workspace.into_owned();
+    let ws = out.workspace;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
     └── ≡:0:main[🌳] {1}

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
@@ -1479,6 +1479,65 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target
 }
 
 #[test]
+fn apply_after_switching_out_of_workspace_drops_stale_stacks() -> anyhow::Result<()> {
+    // A managed workspace exists with `outside` marked in-workspace. The user then `git switch`es
+    // onto `feature`, a branch outside the workspace, leaving the metadata stale.
+    let (_tmp, _graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "advanced-stack-and-unnamed-stack-in-workspace",
+            |meta| {
+                add_stack_with_segments(meta, 1, "outside", StackState::InWorkspace, &[]);
+            },
+        )?;
+    git(&repo).args(["branch", "applied", "feature"]).run();
+    git(&repo).args(["checkout", "feature"]).run();
+
+    let ws = Graph::from_head(
+        &repo,
+        &meta,
+        but_core::ref_metadata::ProjectMeta::default(),
+        standard_traversal_options(),
+    )?
+    .into_workspace()?;
+
+    // Apply a different branch from the adhoc `feature` checkout. The new workspace should hold the
+    // current branch plus the applied one, while the stale `outside` stack is demoted.
+    let out = but_workspace::branch::apply(
+        r("refs/heads/applied"),
+        &ws,
+        &repo,
+        &mut meta,
+        apply_options(),
+    )?;
+    assert_eq!(out.status, OutcomeStatus::Applied);
+
+    let ws_md = meta.workspace(WORKSPACE_REF_NAME.try_into().unwrap())?;
+    let in_workspace = |name: &str| {
+        ws_md
+            .stacks
+            .iter()
+            .find(|s| s.name().is_some_and(|n| n.shorten() == name))
+            .map(|s| s.is_in_workspace())
+    };
+    assert_eq!(
+        in_workspace("outside"),
+        Some(false),
+        "the stale stack from the abandoned workspace is demoted to outside"
+    );
+    assert_eq!(
+        in_workspace("feature"),
+        Some(true),
+        "the foreign branch we switched to joins the new workspace"
+    );
+    assert_eq!(
+        in_workspace("applied"),
+        Some(true),
+        "the newly applied branch is in the new workspace"
+    );
+    Ok(())
+}
+
+#[test]
 fn new_workspace_exists_elsewhere_and_to_be_applied_branch_exists_there() -> anyhow::Result<()> {
     let (_tmp, ws_graph, repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph(

--- a/crates/but/src/command/branch/apply.rs
+++ b/crates/but/src/command/branch/apply.rs
@@ -39,7 +39,7 @@ pub fn apply(mut ctx: Context, branch_name: &str, out: &mut OutputChannel) -> an
 
 fn apply_error_message(
     requested_branch: &gix::refs::FullNameRef,
-    outcome: &but_workspace::branch::apply::Outcome<'_>,
+    outcome: &but_workspace::branch::apply::Outcome,
 ) -> Option<String> {
     if !outcome.conflicting_stacks.is_empty() {
         let short_name = requested_branch.shorten();
@@ -65,7 +65,7 @@ fn apply_error_message(
 fn write_shell_apply_outcome(
     out: &mut dyn crate::utils::WriteWithUtils,
     requested_branch: &gix::refs::FullNameRef,
-    outcome: &but_workspace::branch::apply::Outcome<'_>,
+    outcome: &but_workspace::branch::apply::Outcome,
 ) -> std::fmt::Result {
     writeln!(out, "status={}", outcome.status.as_str())?;
     writeln!(out, "requested_branch={requested_branch}")?;
@@ -87,7 +87,7 @@ fn write_shell_apply_outcome(
 fn write_human_apply_outcome(
     out: &mut dyn crate::utils::WriteWithUtils,
     requested_branch: &gix::refs::FullNameRef,
-    outcome: &but_workspace::branch::apply::Outcome<'_>,
+    outcome: &but_workspace::branch::apply::Outcome,
 ) -> std::fmt::Result {
     match outcome.status {
         OutcomeStatus::AlreadyApplied => {

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -109,7 +109,7 @@ impl BranchManager<'_> {
         let branch_to_apply = target_ref.as_str().try_into()?;
         let mut out = but_workspace::branch::apply(
             branch_to_apply,
-            &ws,
+            ws,
             &repo,
             &mut meta,
             but_workspace::branch::apply::Options {
@@ -121,7 +121,7 @@ impl BranchManager<'_> {
                 new_stack_id: None,
             },
         )?;
-        let ws = out.workspace.into_owned();
+        let ws = out.workspace;
         let applied_branch_ref = out
             .applied_branches
             .pop()


### PR DESCRIPTION
When you're on a plain branch (an AdHoc workspace) and apply a second branch, we want to spin up a fresh managed workspace containing just the branch you were on plus the one you're applying — not drag along whatever stale stacks the old workspace metadata still remembers.

### What's here

**1. Reset stale stacks when applying onto an AdHoc workspace**

- After a `git switch` out of a managed workspace, the `gitbutler/workspace` metadata is stale: its old stacks are still marked in-workspace.
- So before re-applying, we demote those stacks to `Outside`, then mark only the branches we actually apply as `Merged`.
- Stacks that are genuinely still part of the projection (an enclosed AdHoc checkout of one of the workspace's own stacks) are left alone.

**2. Make `apply()` consume the workspace**

While testing the above we hit a sharp edge: an old test reused a now-stale `Workspace` projection across two `apply()` calls, which silently produced wrong results. The first version papered over it with a runtime `HEAD` guard. This commit removes the footgun at the type level instead:

```rust
// before
pub fn apply(branch: &FullNameRef, workspace: &Workspace, ...) -> Outcome<'_>

// after — takes the workspace by value, returns an owned one
pub fn apply(branch: &FullNameRef, workspace: Workspace, ...) -> Outcome
```

- Callers now have to thread the returned workspace into the next call, so the borrow checker simply won't let you reuse a stale one.
- With reuse impossible, the `HEAD` guard is gone — a fresh `AdHoc` projection reliably means HEAD isn't on the workspace ref, so the per-stack visibility check is enough on its own.
- `Outcome` loses its lifetime and owns its `workspace`; callers drop their `.into_owned()` calls.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #14532 
- <kbd>&nbsp;1&nbsp;</kbd> #14517 👈 
<!-- GitButler Footer Boundary Bottom -->

