### PR TITLE
Report dependency rejections in `but` commit and amend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,6 +807,7 @@ dependencies = [
  "but-gitlab",
  "but-graph",
  "but-hunk-assignment",
+ "but-hunk-dependency",
  "but-installer",
  "but-llm",
  "but-path",

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -64,6 +64,7 @@ but-forge-storage.workspace = true
 but-workspace = { workspace = true }
 but-api = { workspace = true, features = ["path-bytes"] }
 but-graph.workspace = true
+but-hunk-dependency.workspace = true
 but-llm.workspace = true
 but-agentlog.workspace = true
 but-transaction.workspace = true

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -18,7 +18,7 @@ use crate::{
     legacy::workspace::{HeadInfoBranch, HeadInfoStack},
     theme::{self, Paint},
     tui,
-    utils::{InputOutputChannel, OutputChannel, diff_specs},
+    utils::{InputOutputChannel, OutputChannel, diff_specs, rejection},
 };
 
 type TargetStack = (StackId, HeadInfoStack);
@@ -634,19 +634,20 @@ pub(crate) fn commit(
         guard.write_permission(),
     )?;
 
-    if !outcome.rejected_specs.is_empty() {
+    let rejected = if outcome.rejected_specs.is_empty() {
+        Vec::new()
+    } else {
         tracing::warn!(
             ?outcome.rejected_specs,
             "Failed to commit at least one selected change"
         );
-        if let Some(out) = out.for_human() {
-            writeln!(
-                out,
-                "{} Some selected changes could not be committed.",
-                t.attention.paint("Warning:"),
-            )?;
-        }
-    }
+        // Explain against the pre-commit workspace: the rejected hunks are still
+        // in the worktree, and the just-created commit must not be in the
+        // projection (or a rejected hunk could resolve to it). This relies on
+        // `commit_create` not invalidating the cached workspace.
+        let (repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
+        rejection::explain_rejections(&repo, &ws, &outcome.rejected_specs)
+    };
 
     if let Some(out) = out.for_human() {
         let commit_short = match outcome.new_commit {
@@ -660,6 +661,7 @@ pub(crate) fn commit(
             t.commit_id.paint(commit_short),
             t.local_branch.paint(&target_branch.name),
         )?;
+        rejection::write_rejection_report(out, &rejected, Some(target_branch.name.as_str()))?;
     } else if let Some(json_out) = out.for_json() {
         let commit_id = outcome.new_commit.map(|id| id.to_string());
         let mut commit_data = serde_json::json!({
@@ -669,6 +671,7 @@ pub(crate) fn commit(
         if !is_positioned_commit {
             commit_data["branch_tip"] = commit_data["commit_id"].clone();
         }
+        commit_data["rejected"] = serde_json::to_value(&rejected).unwrap_or_default();
         json_out.write_value(commit_data)?;
     }
 

--- a/crates/but/src/command/legacy/rub/amend.rs
+++ b/crates/but/src/command/legacy/rub/amend.rs
@@ -8,7 +8,9 @@ use nonempty::NonEmpty;
 
 use crate::{
     theme::{self, Paint},
-    utils::{OutputChannel, diff_specs::DiffSpecBuilder, shorten_object_id, split_short_id},
+    utils::{
+        OutputChannel, diff_specs::DiffSpecBuilder, rejection, shorten_object_id, split_short_id,
+    },
 };
 
 pub(crate) fn uncommitted_to_commit_with_perm(
@@ -19,15 +21,18 @@ pub(crate) fn uncommitted_to_commit_with_perm(
     out: &mut OutputChannel,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<()> {
-    let diff_specs = {
+    // Resolve the target commit's branch before amending, while `oid` is still
+    // valid, so a dependency rejection can suggest stacking onto it.
+    let (diff_specs, target_branch) = {
         let context_lines = ctx.settings.context_lines;
         let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(perm.read_permission())?;
+        let target_branch = rejection::branch_of_commit(&ws, oid, None);
         let mut builder = DiffSpecBuilder::new(&mut db, &repo, &ws, context_lines);
         builder.push_hunk_assignments(hunk_assignments.into_iter().map(ToOwned::to_owned))?;
-        builder.into_diff_specs()
+        (builder.into_diff_specs(), target_branch)
     };
 
-    let new_commit = amend_diff_specs(ctx, diff_specs, oid, perm)?;
+    let (new_commit, rejected) = amend_diff_specs(ctx, diff_specs, oid, perm)?;
     update_workspace_commit(ctx, false)?;
     if let Some(out) = out.for_human() {
         let repo = ctx.repo.get()?;
@@ -40,10 +45,12 @@ pub(crate) fn uncommitted_to_commit_with_perm(
             })
             .unwrap_or_default();
         writeln!(out, "Amended {description} → {new_commit}")?;
+        rejection::write_rejection_report(out, &rejected, target_branch.as_deref())?;
     } else if let Some(out) = out.for_json() {
         out.write_value(serde_json::json!({
             "ok": true,
             "new_commit_id": new_commit.map(|c| c.to_string()),
+            "rejected": serde_json::to_value(&rejected).unwrap_or_default(),
         }))?;
     }
     Ok(())
@@ -54,7 +61,7 @@ fn amend_diff_specs(
     diff_specs: Vec<DiffSpec>,
     oid: ObjectId,
     perm: &mut RepoExclusive,
-) -> anyhow::Result<Option<ObjectId>> {
+) -> anyhow::Result<(Option<ObjectId>, Vec<rejection::RejectedChange>)> {
     let mut meta = ctx.meta()?;
     let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
@@ -64,16 +71,19 @@ fn amend_diff_specs(
         but_workspace::flatten_diff_specs(diff_specs),
         ctx.settings.context_lines,
     )?;
-    if !outcome.rejected_specs.is_empty() {
-        tracing::warn!(
-            ?outcome.rejected_specs,
-            "Failed to commit at least one hunk"
-        );
+
+    let rejected_specs = outcome.rejected_specs;
+    if !rejected_specs.is_empty() {
+        tracing::warn!(?rejected_specs, "Failed to commit at least one hunk");
     }
     let new_commit = outcome
         .commit_selector
         .map(|selector| outcome.rebase.lookup_pick(selector))
         .transpose()?;
     outcome.rebase.materialize()?;
-    Ok(new_commit)
+
+    // `materialize()` released the workspace borrow, so we can now look up why
+    // the rejected changes were locked and to which branch each one depends on.
+    let rejected = rejection::explain_rejections(&repo, &ws, &rejected_specs);
+    Ok((new_commit, rejected))
 }

--- a/crates/but/src/utils/mod.rs
+++ b/crates/but/src/utils/mod.rs
@@ -10,6 +10,8 @@ pub use output_channel::{
 mod object_id;
 pub use object_id::{shorten_hex_object_id, shorten_object_id, split_short_id};
 
+pub mod rejection;
+
 mod pager;
 
 mod debug_as_type;

--- a/crates/but/src/utils/rejection.rs
+++ b/crates/but/src/utils/rejection.rs
@@ -1,0 +1,364 @@
+//! Explain why some changes could not be committed or amended.
+//!
+//! A commit or amend can partially succeed: GitButler allows several independent
+//! branches to be checked out at once, and a change that depends on a commit in
+//! another branch cannot be committed on its own. The commit/amend outcome lists
+//! the rejected changes and a coarse [`RejectionReason`], but it does not say
+//! which commit or branch a change depends on.
+//!
+//! This module joins the rejected changes with the workspace hunk dependencies
+//! (the same data the desktop app uses to render its "commit failed" modal) so
+//! the CLI can tell the user precisely which hunk depends on which branch, and
+//! suggest stacking the branches to resolve it.
+
+use bstr::{BString, ByteSlice};
+use but_core::{DiffSpec, HunkHeader, ref_metadata::StackId, tree::create_tree::RejectionReason};
+use but_graph::Workspace;
+use but_hunk_dependency::ui::{
+    HunkDependencies, HunkLockTarget, hunk_dependencies_for_workspace_changes_by_worktree_dir,
+};
+
+use crate::theme::{self, Paint};
+
+/// A single change that could not be committed, enriched with the workspace
+/// dependencies that explain why.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RejectedChange {
+    /// The worktree-relative path of the rejected change.
+    #[serde(serialize_with = "but_serde::bstring_lossy::serialize")]
+    pub path: BString,
+    /// The coarse reason the change was rejected.
+    pub reason: RejectionReason,
+    /// The hunks of this change that depend on a commit in the workspace,
+    /// together with the commit/branch they depend on.
+    ///
+    /// Empty when the rejection was not caused by a dependency, or when the
+    /// dependency could not be pinpointed to a specific hunk.
+    pub dependencies: Vec<HunkDependency>,
+}
+
+/// A hunk that depends on one or more commits in the workspace.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HunkDependency {
+    /// The dependent hunk, in worktree coordinates.
+    pub hunk: HunkHeader,
+    /// The commits (and their branches, when known) this hunk depends on.
+    pub commits: Vec<DependencyCommit>,
+}
+
+/// A commit a hunk depends on, resolved to a human-friendly branch name.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DependencyCommit {
+    /// The commit the hunk depends on.
+    #[serde(serialize_with = "but_serde::object_id::serialize")]
+    pub commit_id: gix::ObjectId,
+    /// The short name of the branch owning [`Self::commit_id`], if it could be
+    /// resolved from the workspace.
+    pub branch: Option<String>,
+}
+
+/// Explain `rejected_specs` by attaching the workspace dependency information
+/// (which commit/branch each rejected hunk depends on) for dependency-related
+/// rejections.
+///
+/// The hunk dependencies are computed lazily: only when at least one rejection
+/// looks like a dependency conflict, to avoid the cost on unrelated failures.
+/// Failure to compute dependencies is not fatal — the change is still reported,
+/// just without the dependency detail — because the commit/amend itself already
+/// happened and explaining it must never break the command.
+pub fn explain_rejections(
+    repo: &gix::Repository,
+    ws: &Workspace,
+    rejected_specs: &[(RejectionReason, DiffSpec)],
+) -> Vec<RejectedChange> {
+    let needs_dependencies = rejected_specs
+        .iter()
+        .any(|(reason, _)| is_dependency_reason(*reason));
+
+    let dependencies = if needs_dependencies {
+        match hunk_dependencies_for_workspace_changes_by_worktree_dir(repo, ws, None) {
+            Ok(dependencies) => Some(dependencies),
+            Err(err) => {
+                tracing::warn!(
+                    ?err,
+                    "Failed to compute hunk dependencies for rejected changes"
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    rejected_specs
+        .iter()
+        .map(|(reason, spec)| {
+            let dependencies = match &dependencies {
+                Some(deps) if is_dependency_reason(*reason) => {
+                    dependencies_for_spec(ws, deps, spec)
+                }
+                _ => Vec::new(),
+            };
+            RejectedChange {
+                path: spec.path.clone(),
+                reason: *reason,
+                dependencies,
+            }
+        })
+        .collect()
+}
+
+/// Write a human-readable explanation of `rejected` to `out`.
+///
+/// When every dependency points at a single branch and `target_branch` (the
+/// branch being committed/amended to) differs from it, suggests stacking the two
+/// with an exact `but move` command. Does nothing when there is nothing to
+/// report.
+pub fn write_rejection_report<W: std::fmt::Write + ?Sized>(
+    out: &mut W,
+    rejected: &[RejectedChange],
+    target_branch: Option<&str>,
+) -> std::fmt::Result {
+    if rejected.is_empty() {
+        return Ok(());
+    }
+    let t = theme::get();
+    let noun = if rejected.len() == 1 {
+        "change"
+    } else {
+        "changes"
+    };
+    writeln!(
+        out,
+        "{} {} {} could not be applied:",
+        t.attention.paint("Note:"),
+        rejected.len(),
+        noun,
+    )?;
+    for change in rejected {
+        writeln!(out, "  {}", change.path.to_str_lossy())?;
+        if change.dependencies.is_empty() {
+            writeln!(out, "    {}", reason_summary(change.reason))?;
+            continue;
+        }
+        for dependency in &change.dependencies {
+            let range = hunk_range_label(&dependency.hunk);
+            for commit in &dependency.commits {
+                let id = theme::Commit(commit.commit_id);
+                match &commit.branch {
+                    Some(branch) => writeln!(
+                        out,
+                        "    {range} depends on {} ({id})",
+                        t.local_branch.paint(branch),
+                    )?,
+                    None => writeln!(out, "    {range} depends on commit {id}")?,
+                }
+            }
+        }
+    }
+
+    // If everything depends on a single other branch, mention stacking onto it
+    // as an option — it's situational, so frame it as a hint, not a directive.
+    if let (Some(target), Some(dependency)) = (target_branch, sole_dependency_branch(rejected))
+        && target != dependency
+    {
+        writeln!(out)?;
+        writeln!(
+            out,
+            "{} you can stack {} on top of {} to apply these changes:",
+            t.hint.paint("Hint:"),
+            t.local_branch.paint(target),
+            t.local_branch.paint(dependency),
+        )?;
+        writeln!(
+            out,
+            "  {}",
+            t.command_suggestion.paint(format!(
+                "but move {} {}",
+                shell_quote(target),
+                shell_quote(dependency)
+            )),
+        )?;
+    }
+    Ok(())
+}
+
+/// Quote `name` for the suggested shell command if it contains anything a shell
+/// would treat specially. Git permits characters like `;` and `&` in ref names,
+/// so an unquoted name could otherwise break the copy-pasteable command.
+fn shell_quote(name: &str) -> std::borrow::Cow<'_, str> {
+    let safe = !name.is_empty()
+        && name.bytes().all(|b| {
+            b.is_ascii_alphanumeric()
+                || matches!(
+                    b,
+                    b'-' | b'_' | b'/' | b'.' | b'@' | b'+' | b'=' | b':' | b','
+                )
+        });
+    if safe {
+        std::borrow::Cow::Borrowed(name)
+    } else {
+        std::borrow::Cow::Owned(format!("'{}'", name.replace('\'', r"'\''")))
+    }
+}
+
+/// The two rejection reasons that indicate a change depends on another branch in
+/// the workspace, and are therefore worth resolving to a commit/branch.
+fn is_dependency_reason(reason: RejectionReason) -> bool {
+    matches!(
+        reason,
+        RejectionReason::CherryPickMergeConflict | RejectionReason::WorkspaceMergeConflict
+    )
+}
+
+/// The single branch every dependency points at, or `None` if it wouldn't be a
+/// complete fix: some rejected change isn't dependency-related (stacking can't
+/// resolve it), a dependency couldn't be resolved to a branch, or dependencies
+/// span more than one branch.
+fn sole_dependency_branch(rejected: &[RejectedChange]) -> Option<&str> {
+    let mut branch = None;
+    for change in rejected {
+        // Every rejected change must be dependency-locked; otherwise a single
+        // stack command wouldn't apply all of them.
+        if change.dependencies.is_empty() {
+            return None;
+        }
+        for dependency in &change.dependencies {
+            for commit in &dependency.commits {
+                let name = commit.branch.as_deref()?;
+                match branch {
+                    None => branch = Some(name),
+                    Some(existing) if existing != name => return None,
+                    _ => {}
+                }
+            }
+        }
+    }
+    branch
+}
+
+/// Find the hunks of `dependencies` that belong to `spec`.
+///
+/// Matching is by path, then by hunk overlap: a rejected spec covering specific
+/// hunks only reports the dependent hunks that overlap them, while a whole-file
+/// spec (no hunks) reports every dependent hunk for the path. Overlap is used
+/// rather than exact equality because the dependency hunks are computed without
+/// context lines, so their boundaries rarely match the spec's hunks exactly.
+fn dependencies_for_spec(
+    ws: &Workspace,
+    dependencies: &HunkDependencies,
+    spec: &DiffSpec,
+) -> Vec<HunkDependency> {
+    let spec_path = spec.path.as_bstr();
+    let mut result = Vec::new();
+    for (dep_path, dep_hunk, locks) in &dependencies.diffs {
+        // `dep_path` is a lossy-UTF8 key, so a path with invalid UTF8 simply
+        // won't match and falls back to the reason-only summary.
+        if dep_path.as_bytes().as_bstr() != spec_path {
+            continue;
+        }
+        if locks.is_empty() {
+            continue;
+        }
+        let hunk = HunkHeader::from(dep_hunk);
+        let overlaps = spec.hunk_headers.is_empty()
+            || spec
+                .hunk_headers
+                .iter()
+                .any(|spec_hunk| hunks_overlap(spec_hunk, &hunk));
+        if !overlaps {
+            continue;
+        }
+        let commits = locks
+            .iter()
+            .map(|lock| DependencyCommit {
+                commit_id: lock.commit_id,
+                branch: branch_of_commit(ws, lock.commit_id, stack_of(lock.target)),
+            })
+            .collect();
+        result.push(HunkDependency { hunk, commits });
+    }
+    result
+}
+
+/// The stack a lock points at, if it is identifiable.
+fn stack_of(target: HunkLockTarget) -> Option<StackId> {
+    match target {
+        HunkLockTarget::Stack(id) => Some(id),
+        HunkLockTarget::Unidentified => None,
+    }
+}
+
+/// Resolve the short branch name owning `commit_id`, searching `prefer` first
+/// (the stack a lock points at) and then the remaining workspace stacks.
+pub fn branch_of_commit(
+    ws: &Workspace,
+    commit_id: gix::ObjectId,
+    prefer: Option<StackId>,
+) -> Option<String> {
+    let ordered = ws
+        .stacks
+        .iter()
+        .filter(|stack| prefer.is_none() || stack.id == prefer)
+        .chain(
+            ws.stacks
+                .iter()
+                .filter(|stack| prefer.is_some() && stack.id != prefer),
+        );
+    for stack in ordered {
+        for segment in &stack.segments {
+            if segment.commits.iter().any(|commit| commit.id == commit_id)
+                && let Some(ref_name) = segment.ref_name()
+            {
+                return Some(ref_name.shorten().to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Whether two hunks touch the same lines on the new (worktree) side, which is
+/// the coordinate space both the spec hunk and the dependency hunk share.
+///
+/// Zero-length ranges (pure deletions) are treated as covering a single line so
+/// that they still match an overlapping hunk.
+fn hunks_overlap(a: &HunkHeader, b: &HunkHeader) -> bool {
+    let end_a = a.new_start.saturating_add(a.new_lines.max(1));
+    let end_b = b.new_start.saturating_add(b.new_lines.max(1));
+    a.new_start < end_b && b.new_start < end_a
+}
+
+/// A short, new-side line-range label for a hunk, e.g. `line 5` or `lines 5–9`.
+fn hunk_range_label(hunk: &HunkHeader) -> String {
+    match hunk.new_lines {
+        0 => format!("around line {}", hunk.new_start),
+        1 => format!("line {}", hunk.new_start),
+        lines => format!("lines {}–{}", hunk.new_start, hunk.new_start + lines - 1),
+    }
+}
+
+/// A plain-language summary for rejections that are not dependency-related.
+fn reason_summary(reason: RejectionReason) -> &'static str {
+    match reason {
+        RejectionReason::NoEffectiveChanges => "no effective change to commit",
+        RejectionReason::CherryPickMergeConflict | RejectionReason::WorkspaceMergeConflict => {
+            "depends on changes in another branch"
+        }
+        RejectionReason::WorkspaceMergeConflictOfUnrelatedFile => {
+            "conflicts with another change in the workspace"
+        }
+        RejectionReason::WorktreeFileMissingForObjectConversion => {
+            "the file went missing while committing"
+        }
+        RejectionReason::FileToLargeOrBinary => "the file is too large or binary",
+        RejectionReason::PathNotFoundInBaseTree => "the change was not found in the base tree",
+        RejectionReason::UnsupportedDirectoryEntry => "unsupported directory entry",
+        RejectionReason::UnsupportedTreeEntry => "unsupported file type",
+        RejectionReason::MissingDiffSpecAssociation => {
+            "the selected hunks no longer match the worktree"
+        }
+    }
+}

--- a/crates/but/tests/but/command/amend.rs
+++ b/crates/but/tests/but/command/amend.rs
@@ -30,6 +30,40 @@ fn branch_commits_contain_file(
 }
 
 #[test]
+fn amend_reports_dependency_changes() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    // Commit `first` to branch foo and an unrelated file to branch bar.
+    env.file("first", "Some text");
+    env.but("commit -m 'add first' -c foo").assert().success();
+    env.file("second", "Other text");
+    env.but("commit -m 'add second' -c bar").assert().success();
+
+    // Change `first` (which depends on foo) and try to amend it into bar's
+    // commit. It cannot land there, so amend should name the branch/commit it
+    // depends on and suggest stacking bar onto foo.
+    env.file("first", "changes");
+    let status = status_json(&env)?;
+    let bar_commit = branch_commit_ids(&status, "bar")[0].clone();
+    env.but(format!("amend {bar_commit} --changes first"))
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Amended the only hunk in first in the uncommitted area → [..]
+Note: 1 change could not be applied:
+  first
+    line 1 depends on foo ([..])
+
+Hint: you can stack bar on top of foo to apply these changes:
+  but move bar foo
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
 fn amend_accepts_comma_separated_uncommitted_changes() {
     assert_multiple_amend(|target_commit| {
         format!("amend {target_commit} --changes one.txt,two.txt")

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -66,6 +66,69 @@ fn commit_with_message_from_file() {
 }
 
 #[test]
+fn commit_reports_dependency_changes() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    // Commit a file to branch `foo`.
+    env.file("first", "Some text");
+    env.but("commit -m 'add first' -c foo").assert().success();
+
+    // Change the same file, then try to commit it onto a new, independent
+    // branch. The change depends on `foo`'s commit, so it cannot land here; the
+    // CLI should name the branch/commit it depends on and suggest stacking.
+    env.file("first", "changes");
+    env.but("commit -m 'change first elsewhere' -c bar")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Created new independent branch 'bar'
+✓ Created commit [..] on branch bar
+Note: 1 change could not be applied:
+  first
+    line 1 depends on foo ([..])
+
+Hint: you can stack bar on top of foo to apply these changes:
+  but move bar foo
+
+"#]]);
+}
+
+#[test]
+fn commit_reports_dependency_changes_json() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.file("first", "Some text");
+    env.but("commit -m 'add first' -c foo").assert().success();
+
+    // The change to `first` depends on foo, so committing it onto bar is
+    // rejected; assert the `--json` shape of the reported dependency.
+    env.file("first", "changes");
+    let output = env
+        .but("commit -m 'change first elsewhere' -c bar --format json")
+        .assert()
+        .success();
+    let stdout = std::str::from_utf8(&output.get_output().stdout)?;
+    let json: serde_json::Value = serde_json::from_str(stdout)?;
+
+    let rejected = json["rejected"].as_array().expect("rejected array");
+    assert_eq!(rejected.len(), 1, "exactly one change should be rejected");
+    let change = &rejected[0];
+    assert_eq!(change["path"], "first");
+    assert!(change["reason"].is_string(), "reason should be a string");
+    let commit = &change["dependencies"][0]["commits"][0];
+    assert_eq!(commit["branch"], "foo");
+    assert!(
+        commit["commitId"].as_str().is_some_and(|id| id.len() == 40),
+        "commitId should serialize as a full hex object id, got {:?}",
+        commit["commitId"]
+    );
+
+    Ok(())
+}
+
+#[test]
 fn commit_with_message_file_not_found() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
 


### PR DESCRIPTION
Committing or amending in GitButler can partially fail when some hunks depend on commits in another branch. Previously the CLI only logged a warning or printed a terse "Couldn't commit all changes" with no detail about why.

Now both `but commit` and `but amend` report, per hunk, which branch and commit each rejected change depends on — and, when everything depends on a single branch, offer an exact `but move` command to stack them:

    Note: 1 change could not be applied:
      first
        line 1 depends on foo (5a6fc56)

    Hint: you can stack bar on top of foo to apply these changes:
      but move bar foo

The dependency data comes from the same hunk-dependency computation the desktop app uses for its commit-failed modal, computed lazily only when a rejection is dependency-related. `--json` output gains a structured `rejected` array.