### PR TITLE
Remove the cv3 feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4052,7 +4052,6 @@ dependencies = [
  "but-serde",
  "but-testsupport",
  "but-utils",
- "git2",
  "gitbutler-branch",
  "gitbutler-cherry-pick",
  "gitbutler-repo",

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -21,7 +21,6 @@
 	import { GIT_CONFIG_SERVICE } from "$lib/config/gitConfigService";
 	import { fModeEnabled } from "$lib/config/uiFeatureFlags";
 	import { PROJECTS_SERVICE } from "$lib/project/projectsService";
-	import { SETTINGS_SERVICE } from "$lib/settings/appSettings";
 	import { TERMINAL_SERVICE } from "$lib/settings/terminalService";
 	import { createKeybind } from "$lib/shortcuts/hotkeys";
 	import { SHORTCUT_SERVICE } from "$lib/shortcuts/shortcutService";
@@ -114,10 +113,6 @@
 	// EXPERIMENTAL FEATURES
 	// =============================================================================
 
-	// App settings from backend
-	const settingsService = inject(SETTINGS_SERVICE);
-	const settingsStore = settingsService.appSettings;
-
 	// IRC connections are managed by the Rust backend (irc_lifecycle.rs).
 	// The backend handles auto-connect on startup and reacts to settings changes.
 	// Frontend queries IRC state via RTKQ endpoints (ircApi.ts).
@@ -145,10 +140,6 @@
 
 	// Debug keyboard shortcuts
 	const handleKeyBind = createKeybind({
-		// Toggle next-gen safe checkout.
-		"c o 3": () => {
-			settingsService.updateFeatureFlags({ cv3: !$settingsStore?.featureFlags.cv3 });
-		},
 		// Show commit graph visualization
 		"d o t": async () => {
 			const projectId = page.params.projectId;

--- a/crates/but-settings/assets/defaults.jsonc
+++ b/crates/but-settings/assets/defaults.jsonc
@@ -19,8 +19,6 @@
 		"oauthClientId": "cd51880daa675d9e6452"
 	},
 	"featureFlags": {
-		// Enables the v3 safe checkout.
-		"cv3": false,
 		/// Use the V3 unapply compatibility mode that keeps workspace commits unless deleting the workspace ref.
 		"unapplyV3Pgm": false,
 		/// Enable single branch mode.

--- a/crates/but-settings/src/api.rs
+++ b/crates/but-settings/src/api.rs
@@ -16,7 +16,6 @@ pub struct TelemetryUpdate {
 #[serde(rename_all = "camelCase")]
 /// Update request for [`crate::app_settings::FeatureFlags`].
 pub struct FeatureFlagsUpdate {
-    pub cv3: Option<bool>,
     pub unapply_v3_pgm: Option<bool>,
     pub single_branch: Option<bool>,
     pub irc: Option<bool>,
@@ -115,16 +114,12 @@ impl AppSettingsWithDiskSync {
     pub fn update_feature_flags(
         &self,
         FeatureFlagsUpdate {
-            cv3,
             unapply_v3_pgm,
             single_branch,
             irc,
         }: FeatureFlagsUpdate,
     ) -> Result<()> {
         let mut settings = self.get_mut_enforce_save()?;
-        if let Some(cv3) = cv3 {
-            settings.feature_flags.cv3 = cv3;
-        }
         if let Some(unapply_v3_pgm) = unapply_v3_pgm {
             settings.feature_flags.unapply_v3_pgm = unapply_v3_pgm;
         }
@@ -366,7 +361,6 @@ mod tests {
 
         settings
             .update_feature_flags(FeatureFlagsUpdate {
-                cv3: None,
                 unapply_v3_pgm: Some(true),
                 single_branch: None,
                 irc: None,

--- a/crates/but-settings/src/app_settings.rs
+++ b/crates/but-settings/src/app_settings.rs
@@ -36,8 +36,6 @@ but_schemars::register_sdk_type!(GitHubOAuthAppSettings);
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct FeatureFlags {
-    /// Turn on the set a v3 version of checkout
-    pub cv3: bool,
     /// Use the V3 unapply compatibility mode that keeps workspace commits unless deleting the workspace ref.
     pub unapply_v3_pgm: bool,
     /// Enable single branch mode.

--- a/crates/but-settings/src/persistence.rs
+++ b/crates/but-settings/src/persistence.rs
@@ -23,7 +23,7 @@ fn remove_deprecated_settings(customizations: &mut serde_json::Value) -> bool {
         .get_mut("featureFlags")
         .and_then(serde_json::Value::as_object_mut)
     {
-        for deprecated in ["apply3", "unapplyV3", "undo", "rules"] {
+        for deprecated in ["apply3", "unapplyV3", "undo", "rules", "cv3"] {
             if feature_flags.remove(deprecated).is_some() {
                 removed = true;
             }
@@ -215,7 +215,8 @@ mod tests {
                     "unapplyV3": false,
                     "undo": true,
                     "rules": true,
-                    "cv3": true
+                    "cv3": true,
+                    "singleBranch": true
                 }
             }"#,
         )
@@ -227,11 +228,12 @@ mod tests {
         let saved: serde_json::Value =
             serde_json_lenient::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
 
-        assert_eq!(saved["featureFlags"]["cv3"], json!(true));
+        assert_eq!(saved["featureFlags"]["singleBranch"], json!(true));
         assert_eq!(saved["featureFlags"].get("apply3"), None);
         assert_eq!(saved["featureFlags"].get("unapplyV3"), None);
         assert_eq!(saved["featureFlags"].get("undo"), None);
         assert_eq!(saved["featureFlags"].get("rules"), None);
+        assert_eq!(saved["featureFlags"].get("cv3"), None);
     }
 
     #[test]

--- a/crates/but-testsupport/src/sandbox.rs
+++ b/crates/but-testsupport/src/sandbox.rs
@@ -508,7 +508,6 @@ impl Sandbox {
                 oauth_client_id: "but journey tests won't use github".to_string(),
             },
             feature_flags: FeatureFlags {
-                cv3: true,
                 unapply_v3_pgm: false,
                 single_branch: true,
                 irc: false,

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -8,9 +8,8 @@ use but_core::{
     worktree::checkout::UncommitedWorktreeChanges,
 };
 use but_ctx::Context;
-use but_error::{Code, Marker};
+use but_error::Code;
 use but_graph::FirstParent;
-use but_oxidize::ObjectIdExt;
 use gitbutler_git::GitContextExt as _;
 use gitbutler_project::{FetchResult, Project};
 use gitbutler_reference::{Refname, RemoteRefname};
@@ -135,47 +134,22 @@ pub fn bootstrap_default_target_if_missing(ctx: &Context) -> Result<bool> {
 
 #[instrument(skip(ctx, perm), err(Debug))]
 fn go_back_to_integration(ctx: &Context, perm: &RepoShared) -> Result<BaseBranch> {
-    if ctx.settings.feature_flags.cv3 {
-        {
-            let repo = ctx.repo.get()?;
-            let workspace_commit_to_checkout =
-                but_workspace::legacy::remerged_workspace_commit_v2(ctx)?;
-            let tree_to_checkout_to_avoid_ref_update =
-                repo.find_commit(workspace_commit_to_checkout)?.tree_id()?;
-            but_core::worktree::safe_checkout(
-                repo.head_id()?.detach(),
-                tree_to_checkout_to_avoid_ref_update.detach(),
-                &repo,
-                but_core::worktree::checkout::Options {
-                    uncommitted_changes: UncommitedWorktreeChanges::KeepAndAbortOnConflict,
-                    skip_head_update: false,
-                    ..Default::default()
-                },
-            )?;
-        }
-    } else {
-        let final_tree_id = {
-            let repo = ctx.repo.get()?;
-            let (mut outcome, conflict_kind) =
-                but_workspace::legacy::merge_worktree_with_workspace(ctx, &repo)?;
-
-            if outcome.has_unresolved_conflicts(conflict_kind) {
-                return Err(anyhow!("Conflicts while going back to gitbutler/workspace"))
-                    .context(Marker::ProjectConflict);
-            }
-
-            outcome.tree.write()?.detach()
-        };
-
-        #[expect(deprecated, reason = "checkout/materialization boundary")]
-        let git2_repo = &*ctx.git2_repo.get()?;
-        let final_tree = git2_repo.find_tree(final_tree_id.to_git2())?;
-        git2_repo
-            .checkout_tree(
-                final_tree.as_object(),
-                Some(git2::build::CheckoutBuilder::new().force()),
-            )
-            .context("failed to checkout tree")?;
+    {
+        let repo = ctx.repo.get()?;
+        let workspace_commit_to_checkout =
+            but_workspace::legacy::remerged_workspace_commit_v2(ctx)?;
+        let tree_to_checkout_to_avoid_ref_update =
+            repo.find_commit(workspace_commit_to_checkout)?.tree_id()?;
+        but_core::worktree::safe_checkout(
+            repo.head_id()?.detach(),
+            tree_to_checkout_to_avoid_ref_update.detach(),
+            &repo,
+            but_core::worktree::checkout::Options {
+                uncommitted_changes: UncommitedWorktreeChanges::KeepAndAbortOnConflict,
+                skip_head_update: false,
+                ..Default::default()
+            },
+        )?;
     }
 
     update_workspace_commit(ctx, false)?;

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_removal.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_removal.rs
@@ -1,7 +1,6 @@
 use anyhow::{Context as _, Result};
-use but_core::{DiffSpec, RepositoryExt, ref_metadata::StackId};
+use but_core::{DiffSpec, ref_metadata::StackId};
 use but_ctx::access::RepoExclusive;
-use but_oxidize::ObjectIdExt;
 use but_rebase::graph_rebase::{
     Editor,
     mutate::{InsertSide, RelativeToRef},
@@ -20,7 +19,6 @@ impl BranchManager<'_> {
         perm: &mut RepoExclusive,
         delete_vb_state: bool,
         assigned_diffspec: Vec<DiffSpec>,
-        safe_checkout: bool,
     ) -> Result<String> {
         let mut vb_state = self.ctx.virtual_branches();
         let mut stack = vb_state.get_stack(stack_id)?;
@@ -34,9 +32,6 @@ impl BranchManager<'_> {
                 .full_name()?
                 .to_string());
         }
-
-        #[expect(deprecated, reason = "checkout/materialization boundary")]
-        let git2_repo = self.ctx.git2_repo.get()?;
 
         // Commit any assigned diffspecs if such exist so that it will be part of the unapplied branch.
         if !assigned_diffspec.is_empty()
@@ -71,65 +66,14 @@ impl BranchManager<'_> {
         vb_state.set_stack(stack.clone())?;
 
         let repo = self.ctx.clone_repo_for_merging()?;
-        if safe_checkout {
-            // This reads the just stored data and re-merges it all stacks, excluding the unapplied one.
-            let res = checkout_remerged_head(self.ctx, &repo);
-            // Undo the removal, stack is still there officially now.
-            if res.is_err() {
-                stack.in_workspace = true;
-                vb_state.set_stack(stack.clone())?;
-            }
-            res?
-        } else {
-            // We want to transition the worktree from its current state (all
-            // stacks merged + uncommitted edits) to the new state (remaining
-            // stacks only), while preserving any uncommitted worktree changes.
-            //
-            // The correct 3-way merge for this is:
-            //   base  = current workspace commit tree (all stacks merged)
-            //   ours  = cwdt (workspace + uncommitted changes)
-            //   theirs = remerged tree (target + remaining stacks only)
-            //
-            // For files with no uncommitted edits: base==ours, so theirs wins
-            // → cleanly transitions to the new workspace state.
-            // For files with uncommitted edits: base≠ours, and on conflict
-            // FileFavor::Ours preserves the user's uncommitted work.
-
-            let merge_options = repo
-                .tree_merge_options()?
-                .with_file_favor(Some(gix::merge::tree::FileFavor::Ours))
-                .with_tree_favor(Some(gix::merge::tree::TreeFavor::Ours));
-
-            #[expect(deprecated)]
-            let cwdt = repo.create_wd_tree(0)?;
-            let (remerged_tree_id, _, _) =
-                but_workspace::legacy::remerged_workspace_tree_v2(self.ctx, &repo)?;
-
-            // The current workspace commit tree represents the committed state
-            // with all stacks merged (before this unapply). Using it as the
-            // merge base means only uncommitted changes show up as "ours" diffs.
-            let current_workspace_tree = {
-                let mut head = repo.head()?;
-                head.peel_to_commit()?.tree_id()?.detach()
-            };
-
-            let mut merge = repo.merge_trees(
-                current_workspace_tree,
-                cwdt,
-                remerged_tree_id,
-                repo.default_merge_labels(),
-                merge_options,
-            )?;
-            let new_workspace_tree_with_worktree_changes =
-                git2_repo.find_tree(merge.tree.write()?.to_git2())?;
-
-            git2_repo
-                .checkout_tree(
-                    new_workspace_tree_with_worktree_changes.as_object(),
-                    Some(git2::build::CheckoutBuilder::new().force()),
-                )
-                .context("failed to checkout tree")?;
+        // This reads the just stored data and re-merges it all stacks, excluding the unapplied one.
+        let res = checkout_remerged_head(self.ctx, &repo);
+        // Undo the removal, stack is still there officially now.
+        if res.is_err() {
+            stack.in_workspace = true;
+            vb_state.set_stack(stack.clone())?;
         }
+        res?;
 
         if delete_vb_state {
             self.ctx.delete_branch_reference(&stack)?;

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -779,13 +779,8 @@ pub(crate) fn integrate_upstream(
                 continue;
             };
 
-            ctx.branch_manager().unapply(
-                *stack_id,
-                permission,
-                false,
-                Vec::new(),
-                ctx.settings.feature_flags.cv3,
-            )?;
+            ctx.branch_manager()
+                .unapply(*stack_id, permission, false, Vec::new())?;
         }
 
         let mut stacks = virtual_branches_state.list_stacks_in_workspace()?;

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/mod.rs
@@ -4,7 +4,7 @@ use std::{fs, path::PathBuf, str::FromStr};
 
 use but_core::{RepositoryExt as _, ref_metadata::StackId};
 use but_ctx::{Context, ProjectHandleOrLegacyProjectId, RepoOpenMode};
-use but_error::Marker;
+use but_error::{AnyhowContextExt as _, Code};
 use but_rebase::graph_rebase::LookupStep as _;
 use but_settings::AppSettings;
 use but_testsupport::{

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/set_base_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/set_base_branch.rs
@@ -192,16 +192,17 @@ mod go_back_to_workspace {
         std::fs::write(repo.path().join("file.txt"), "tree").unwrap();
 
         let mut guard = ctx.exclusive_worktree_access();
-        assert!(matches!(
-            gitbutler_branch_actions::set_base_branch(
-                ctx,
-                &"refs/remotes/origin/master".parse().unwrap(),
-                guard.write_permission(),
-            )
-            .unwrap_err()
-            .downcast_ref(),
-            Some(Marker::ProjectConflict)
-        ));
+        let err = gitbutler_branch_actions::set_base_branch(
+            ctx,
+            &"refs/remotes/origin/master".parse().unwrap(),
+            guard.write_permission(),
+        )
+        .unwrap_err();
+        // Going back to the workspace aborts up-front rather than leaving the project conflicted.
+        assert_eq!(
+            err.custom_context().map(|ctx| ctx.code),
+            Some(Code::PreconditionFailed)
+        );
     }
 
     #[test]
@@ -230,16 +231,17 @@ mod go_back_to_workspace {
         std::fs::write(repo.path().join("file.txt"), "tree").unwrap();
 
         let mut guard = ctx.exclusive_worktree_access();
-        assert!(matches!(
-            gitbutler_branch_actions::set_base_branch(
-                ctx,
-                &"refs/remotes/origin/master".parse().unwrap(),
-                guard.write_permission(),
-            )
-            .unwrap_err()
-            .downcast_ref(),
-            Some(Marker::ProjectConflict)
-        ));
+        let err = gitbutler_branch_actions::set_base_branch(
+            ctx,
+            &"refs/remotes/origin/master".parse().unwrap(),
+            guard.write_permission(),
+        )
+        .unwrap_err();
+        // Going back to the workspace aborts up-front rather than leaving the project conflicted.
+        assert_eq!(
+            err.custom_context().map(|ctx| ctx.code),
+            Some(Code::PreconditionFailed)
+        );
     }
 
     #[test]

--- a/crates/gitbutler-oplog/Cargo.toml
+++ b/crates/gitbutler-oplog/Cargo.toml
@@ -26,7 +26,6 @@ gitbutler-repo.workspace = true
 gitbutler-cherry-pick.workspace = true
 
 anyhow.workspace = true
-git2.workspace = true
 serde.workspace = true
 itertools.workspace = true
 strum = { version = "0.27", features = ["derive"] }

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -18,11 +18,7 @@ use gitbutler_repo::{
     signature_gix,
 };
 use gix::objs::Write as _;
-use gix::{
-    ObjectId,
-    bstr::{BString, ByteSlice, ByteVec},
-    object::tree::EntryKind,
-};
+use gix::{ObjectId, bstr::ByteSlice, object::tree::EntryKind};
 use tracing::instrument;
 
 use super::{
@@ -324,53 +320,6 @@ fn write_index_tree(ctx: &Context) -> Result<gix::ObjectId> {
     let git2_repo = ctx.git2_repo.get()?;
     let mut index = git2_repo.index()?;
     Ok(index.write_tree()?.to_gix())
-}
-
-fn checkout_workdir_tree(ctx: &Context, workdir_tree_id: gix::ObjectId) -> Result<()> {
-    #[expect(deprecated, reason = "checkout/materialization boundary")]
-    let git2_repo = ctx.git2_repo.get()?;
-    ignore_large_files_in_diffs(&git2_repo, AUTO_TRACK_LIMIT_BYTES)?;
-    let workdir_tree = git2_repo.find_tree(workdir_tree_id.to_git2())?;
-    let mut checkout_builder = git2::build::CheckoutBuilder::new();
-    checkout_builder.remove_untracked(true);
-    checkout_builder.force();
-    git2_repo.checkout_tree(workdir_tree.as_object(), Some(&mut checkout_builder))?;
-    Ok(())
-}
-
-fn ignore_large_files_in_diffs(repo: &git2::Repository, limit_in_bytes: u64) -> Result<()> {
-    if limit_in_bytes == 0 {
-        return Ok(());
-    }
-    let gix_repo = gix::open(repo.path())?;
-    let worktree_dir = gix_repo
-        .workdir()
-        .context("All repos are expected to have a worktree")?;
-    let files_to_exclude: Vec<_> = gix_repo
-        .dirwalk_iter(
-            gix_repo.index_or_empty()?,
-            None::<BString>,
-            Default::default(),
-            gix_repo
-                .dirwalk_options()?
-                .emit_ignored(None)
-                .emit_pruned(false)
-                .emit_untracked(gix::dir::walk::EmissionMode::Matching),
-        )?
-        .filter_map(Result::ok)
-        .filter_map(|item| {
-            let path = worktree_dir.join(gix::path::from_bstr(item.entry.rela_path.as_bstr()));
-            let file_is_too_large = path
-                .metadata()
-                .is_ok_and(|md| md.is_file() && md.len() > limit_in_bytes);
-            file_is_too_large
-                .then(|| Vec::from(item.entry.rela_path).into_string().ok())
-                .flatten()
-        })
-        .collect();
-    let ignore_list = files_to_exclude.join("\n");
-    repo.add_ignore_rule(&ignore_list)?;
-    Ok(())
 }
 
 fn reset_index_to_tree(ctx: &Context, tree_id: gix::ObjectId) -> Result<()> {
@@ -777,21 +726,18 @@ fn restore_snapshot(
     let gix_repo = ctx.clone_repo_for_merging()?;
     let workdir_tree_id = get_workdir_tree(None, snapshot_commit_id, &gix_repo, ctx)?;
 
-    // Check out the snapshot's worktree while HEAD still points at the pre-restore commit: both
-    // backends diff from the head tree, so the workspace ref is repointed only afterwards (below).
-    // The git2 backend reads HEAD for its baseline; cv3 gets `pre_restore_head_tree_id` directly.
-    if ctx.settings.feature_flags.cv3 {
-        but_core::worktree::safe_checkout(
-            pre_restore_head_tree_id,
-            workdir_tree_id,
-            &gix_repo,
-            but_core::worktree::checkout::Options::default(),
-        )?;
-    } else {
-        checkout_workdir_tree(ctx, workdir_tree_id)?;
-    }
+    // Check out the snapshot's worktree while HEAD still points at the pre-restore commit:
+    // safe_checkout diffs from `pre_restore_head_tree_id`, so the workspace ref is repointed
+    // only afterwards (below).
+    but_core::worktree::safe_checkout(
+        pre_restore_head_tree_id,
+        workdir_tree_id,
+        &gix_repo,
+        but_core::worktree::checkout::Options::default(),
+    )?;
 
-    // Worktree now matches the snapshot; repoint gitbutler/workspace at the restored commit.
+    // Tracked content now matches the snapshot (untracked files outside the restored diff are
+    // left in place); repoint gitbutler/workspace at the restored commit.
     if let Some(commit_oid) = restored_workspace_commit {
         repo.reference(
             workspace_ref,

--- a/crates/gitbutler-workspace/src/branch_trees.rs
+++ b/crates/gitbutler-workspace/src/branch_trees.rs
@@ -85,18 +85,11 @@ pub fn update_uncommitted_changes(
     new: WorkspaceState,
     perm: &mut RepoExclusive,
 ) -> Result<()> {
-    let repo = &*ctx.repo.get()?;
-    let uncommitted_changes = if ctx.settings.feature_flags.cv3 {
-        None
-    } else {
-        #[expect(deprecated)]
-        Some(repo.create_wd_tree(0)?)
-    };
-
-    update_uncommitted_changes_with_tree(ctx, old, new, uncommitted_changes, None, perm)
+    update_uncommitted_changes_with_tree(ctx, old, new, None, None, perm)
 }
 
-/// `old_uncommitted_changes` is `None` if the `safe_checkout` feature is toggled on in `ctx`
+/// Pass `None` for `old_uncommitted_changes` to transition the worktree via safe checkout;
+/// pass `Some(tree_id)` to move that materialized worktree tree between workspaces instead.
 pub fn update_uncommitted_changes_with_tree(
     ctx: &Context,
     old: WorkspaceState,

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -1194,8 +1194,6 @@ export type ExtraCsp = {
 };
 
 export type FeatureFlags = {
-  /** Turn on the set a v3 version of checkout */
-  cv3: boolean;
   /** Use the V3 unapply compatibility mode that keeps workspace commits unless deleting the workspace ref. */
   unapplyV3Pgm: boolean;
   /** Enable single branch mode. */


### PR DESCRIPTION
Removes the `cv3` feature flag and routes all checkout paths to the safe-checkout behavior that was gated behind it, deleting the now-dead legacy git2 paths (`go_back_to_integration`, `unapply`, oplog restore, `update_uncommitted_changes`).

The flag is added to the deprecated-settings prune list so it is stripped from existing users' settings files on save.

FYI @Caleb-T-Owens @jonathantanmy2  - removing this feature flag. 

It seems like there is one leftover path for the old checkout but that was never feature flag gated:
`save_and_return_to_workspace` -> `update_uncommitted_changes_with_tree` -> (`move_tree_between_workspaces` + `checkout_index`). 

I left that part as is.... but maybe worth looking into some spring cleaning there as well