### PR TITLE
Desktop: land branches directly without a pull request

### DIFF
--- a/apps/desktop/src/components/branch/LandBranchModal.svelte
+++ b/apps/desktop/src/components/branch/LandBranchModal.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import { showError } from "$lib/error/showError";
+	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
+	import { inject } from "@gitbutler/core/context";
+	import { AsyncButton, Button, Modal, chipToasts } from "@gitbutler/ui";
+
+	type Props = {
+		projectId: string;
+		/** Remote-qualified name of the target branch (e.g. origin/master), shown for context. */
+		targetBranchName: string | undefined;
+	};
+
+	const { projectId, targetBranchName }: Props = $props();
+	const stackService = inject(STACK_SERVICE);
+
+	let modalEl = $state<ReturnType<typeof Modal>>();
+	let branchName = $state<string>();
+
+	const targetLabel = $derived(targetBranchName ?? "the target branch");
+
+	export function show(branch: string) {
+		branchName = branch;
+		modalEl?.show();
+	}
+
+	async function land(): Promise<boolean> {
+		if (!branchName) return false;
+		try {
+			const result = await stackService.landBranch({ projectId, branch: branchName, noFf: false });
+			if (result.landed.type === "alreadyIntegrated") {
+				chipToasts.success(`"${branchName}" is already integrated into ${targetLabel}`);
+			} else {
+				chipToasts.success(`Landed "${branchName}" into ${targetLabel}`);
+			}
+			if (result.reconcileSkipped) {
+				chipToasts.warning("Other branches were left un-reconciled. Run `but pull` to finish.");
+			}
+			return true;
+		} catch (error) {
+			showError("Failed to land branch", error);
+			return false;
+		}
+	}
+</script>
+
+<Modal bind:this={modalEl} width="small" title="Land branch">
+	<p>
+		This lands <strong>{branchName}</strong> directly onto {targetLabel}. It cannot be undone.
+	</p>
+	{#snippet controls(close)}
+		<Button kind="outline" type="reset" onclick={close}>Cancel</Button>
+		<AsyncButton
+			style="pop"
+			action={async () => {
+				if (await land()) close();
+			}}>Land</AsyncButton
+		>
+	{/snippet}
+</Modal>

--- a/apps/desktop/src/components/onboarding/ProjectSetupTarget.svelte
+++ b/apps/desktop/src/components/onboarding/ProjectSetupTarget.svelte
@@ -3,13 +3,24 @@
 	import ReduxResult from "$components/shared/ReduxResult.svelte";
 	import gerritLogoSvg from "$lib/assets/gerrit-logo.svg?raw";
 	import { getBestBranch, getBestRemote, getBranchRemoteFromRef } from "$lib/branches/branchUtils";
+	import { projectLandDirectly } from "$lib/config/config";
 	import { GIT_CONFIG_SERVICE } from "$lib/config/gitConfigService";
 	import { PROJECTS_SERVICE } from "$lib/project/projectsService";
 	import { combineResults } from "$lib/state/helpers";
 	import { OnboardingEvent, POSTHOG_WRAPPER } from "$lib/telemetry/posthog";
 	import { unique } from "$lib/utils/array";
 	import { inject } from "@gitbutler/core/context";
-	import { Button, CardGroup, Icon, Link, Select, SelectItem, TestId, Toggle } from "@gitbutler/ui";
+	import {
+		Button,
+		CardGroup,
+		Checkbox,
+		Icon,
+		Link,
+		Select,
+		SelectItem,
+		TestId,
+		Toggle,
+	} from "@gitbutler/ui";
 	import { slide } from "svelte/transition";
 	import type { RemoteBranchInfo } from "$lib/baseBranch/baseBranch";
 
@@ -27,6 +38,8 @@
 
 	const gbConfig = $derived(gitConfig.gbConfig(projectId));
 	const gerritMode = $derived(gbConfig.response?.gitbutlerGerritMode ?? false);
+
+	const landDirectly = $derived(projectLandDirectly(projectId));
 
 	let loading = $state<boolean>(false);
 	let showMoreInfo = $state<boolean>(false);
@@ -51,7 +64,9 @@
 
 	async function onSetTargetClick() {
 		if (!branch || !remote) return;
-		posthog.captureOnboarding(OnboardingEvent.ProjectSetupContinue);
+		posthog.captureOnboarding(OnboardingEvent.ProjectSetupContinue, undefined, {
+			landDirectly: $landDirectly,
+		});
 		onBranchSelected?.([branch.name, remote]);
 	}
 
@@ -160,6 +175,11 @@
 		</ReduxResult>
 	</div>
 
+	<label for="landDirectly" class="land-directly">
+		<Checkbox name="landDirectly" small bind:checked={$landDirectly} />
+		<span class="text-12 clr-text-2">Push to main / Skip pull requests mode</span>
+	</label>
+
 	<div
 		class="project-setup__info"
 		role="presentation"
@@ -248,6 +268,13 @@
 	.project-setup__field-caption {
 		width: 90%;
 		color: var(--text-2);
+	}
+
+	.land-directly {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		cursor: pointer;
 	}
 
 	.action-buttons {

--- a/apps/desktop/src/components/projectSettings/GitForm.svelte
+++ b/apps/desktop/src/components/projectSettings/GitForm.svelte
@@ -5,6 +5,7 @@
 	import ReduxResult from "$components/shared/ReduxResult.svelte";
 	import SettingsSection from "$components/shared/SettingsSection.svelte";
 	import { BACKEND } from "$lib/backend";
+	import { projectLandDirectly } from "$lib/config/config";
 	import { PROJECTS_SERVICE } from "$lib/project/projectsService";
 	import { inject } from "@gitbutler/core/context";
 	import { CardGroup, Spacer, Toggle } from "@gitbutler/ui";
@@ -14,6 +15,7 @@
 	const projectsService = inject(PROJECTS_SERVICE);
 	const projectQuery = $derived(projectsService.getProject(projectId));
 	const backend = inject(BACKEND);
+	const landDirectly = $derived(projectLandDirectly(projectId));
 
 	async function onForcePushProtectionClick(project: Project, value: boolean) {
 		await projectsService.updateProject({ ...project, force_push_protection: value });
@@ -21,6 +23,22 @@
 </script>
 
 <SettingsSection>
+	<CardGroup>
+		<CardGroup.Item labelFor="landDirectly">
+			{#snippet title()}
+				Land branches directly
+			{/snippet}
+			{#snippet caption()}
+				Replace the "Create PR" button with a "Land" button that integrates the branch straight into
+				the target branch, without opening a pull request. Shown on the bottom branch of a stack;
+				works without a forge integration.
+			{/snippet}
+			{#snippet actions()}
+				<Toggle id="landDirectly" bind:checked={$landDirectly} />
+			{/snippet}
+		</CardGroup.Item>
+	</CardGroup>
+
 	<GitHooksForm {projectId} />
 	<CommitSigningForm {projectId} />
 	{#if backend.platformName !== "windows"}

--- a/apps/desktop/src/components/shared/AnalyticsMonitor.svelte
+++ b/apps/desktop/src/components/shared/AnalyticsMonitor.svelte
@@ -4,6 +4,7 @@ This component keeps the analytics context up-to-date, i.e. the metadata
 attached to posthog events.
 -->
 <script lang="ts">
+	import { projectLandDirectly } from "$lib/config/config";
 	import { UI_STATE } from "$lib/state/uiState.svelte";
 	import { EVENT_CONTEXT } from "$lib/telemetry/eventContext";
 	import { inject } from "@gitbutler/core/context";
@@ -15,6 +16,7 @@ attached to posthog events.
 
 	const globalState = uiState.global;
 	const projectState = $derived(uiState.project(projectId));
+	const landDirectly = $derived(projectLandDirectly(projectId));
 
 	$effect(() => {
 		eventContext.update({
@@ -43,6 +45,12 @@ attached to posthog events.
 	$effect(() => {
 		eventContext.update({
 			v3: true,
+		});
+	});
+
+	$effect(() => {
+		eventContext.update({
+			landDirectly: $landDirectly,
 		});
 	});
 </script>

--- a/apps/desktop/src/components/views/BranchList.svelte
+++ b/apps/desktop/src/components/views/BranchList.svelte
@@ -6,6 +6,7 @@
 	import BranchDividerLine from "$components/branch/BranchDividerLine.svelte";
 	import BranchHeaderContextMenu from "$components/branch/BranchHeaderContextMenu.svelte";
 	import BranchReorderDropzone from "$components/branch/BranchReorderDropzone.svelte";
+	import LandBranchModal from "$components/branch/LandBranchModal.svelte";
 	import ChangedFilesPanel from "$components/files/ChangedFilesPanel.svelte";
 	import PushButton from "$components/forge/PushButton.svelte";
 	import {
@@ -17,6 +18,7 @@
 	import BranchCommitList from "$components/views/BranchCommitList.svelte";
 	import { URL_SERVICE } from "$lib/backend/url";
 	import { BASE_BRANCH_SERVICE } from "$lib/baseBranch/baseBranchService.svelte";
+	import { projectLandDirectly } from "$lib/config/config";
 	import { StartCommitDzHandler } from "$lib/dragging/dropHandlers/branchDropHandler";
 	import { REORDER_DROPZONE_FACTORY } from "$lib/dragging/stackingReorderDropzoneManager";
 	import { useForgeAuth } from "$lib/forge/forgeAuth.svelte";
@@ -55,6 +57,7 @@
 
 	let addDependentBranchModalContext = $state<AddDependentBranchModalProps>();
 	let addDependentBranchModal = $state<AddDependentBranchModal>();
+	let landBranchModal = $state<LandBranchModal>();
 
 	const selection = $derived(controller.selection);
 	const selectedCommitId = $derived(controller.commitId);
@@ -87,8 +90,10 @@
 	);
 
 	const canPublishPR = $derived(auth.authenticated.current);
-	const baseBranchNameResponse = $derived(baseBranchService.baseBranchShortName(projectId));
-	const baseBranchName = $derived(baseBranchNameResponse.response);
+	const landDirectly = $derived(projectLandDirectly(projectId));
+	const baseBranchResponse = $derived(baseBranchService.baseBranch(projectId));
+	const baseBranchName = $derived(baseBranchResponse.response?.shortName);
+	const landTargetName = $derived(baseBranchResponse.response?.branchName);
 
 	// Compute stack-wide derived values once per render so the per-iteration
 	// segmentContext() call below stays O(1) instead of O(n) per index.
@@ -212,7 +217,26 @@
 				/>
 			{/if}
 
-			{#if canPublishPR && !isNewBranch && branchName}
+			{#if $landDirectly}
+				{#if lastBranch && !isNewBranch && branchName}
+					<Button
+						size="tag"
+						kind="outline"
+						shrinkable
+						onclick={(e) => {
+							e.stopPropagation();
+							landBranchModal?.show(branchName);
+						}}
+						disabled={!!controller.exclusiveAction || isConflicted}
+						tooltip={isConflicted
+							? "Resolve conflicts before landing"
+							: "Land directly into the target branch"}
+						icon="branch-merge"
+					>
+						Land
+					</Button>
+				{/if}
+			{:else if canPublishPR && !isNewBranch && branchName}
 				{#if !prNumber}
 					<Button
 						size="tag"
@@ -343,6 +367,8 @@
 		{...addDependentBranchModalContext}
 	/>
 {/if}
+
+<LandBranchModal bind:this={landBranchModal} {projectId} targetBranchName={landTargetName} />
 
 <style lang="postcss">
 	.branches-wrapper {

--- a/apps/desktop/src/lib/config/config.ts
+++ b/apps/desktop/src/lib/config/config.ts
@@ -41,6 +41,16 @@ export function projectRunCommitHooks(projectId: string): Persisted<boolean> {
 	return persisted(false, key + projectId);
 }
 
+/**
+ * When enabled, the branch's "Create PR" button is replaced with a "Land"
+ * button that integrates the branch straight into the target branch. This is a
+ * frontend-only preference and does not require a forge integration.
+ */
+export function projectLandDirectly(projectId: string): Persisted<boolean> {
+	const key = "projectLandDirectly_";
+	return persisted(false, key + projectId);
+}
+
 export function persistedChatModelName<T extends string>(
 	projectId: string,
 	defaultValue: T,

--- a/apps/desktop/src/lib/stacks/stackEndpoints.test.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.test.ts
@@ -1,5 +1,5 @@
 import { buildStackEndpoints } from "$lib/stacks/stackEndpoints";
-import { invalidatesItem, invalidatesList, ReduxTag } from "$lib/state/tags";
+import { invalidatesItem, invalidatesList, invalidatesType, ReduxTag } from "$lib/state/tags";
 import { describe, expect, test } from "vitest";
 import type { BackendEndpointBuilder } from "$lib/state/backendApi";
 
@@ -270,7 +270,42 @@ describe("buildStackEndpoints", () => {
 			invalidatesList(ReduxTag.StackDetails),
 			invalidatesList(ReduxTag.BranchChanges),
 			invalidatesList(ReduxTag.BranchListing),
-			invalidatesList(ReduxTag.BaseBranchData),
+			invalidatesType(ReduxTag.BaseBranchData),
+			invalidatesList(ReduxTag.UpstreamIntegrationStatus),
+		]);
+	});
+
+	test("uses branch_land and invalidates target and stack state", () => {
+		const endpoints = buildStackEndpoints(createEndpointBuilder());
+		const query = endpoints.landBranch.query;
+
+		expect(endpoints.landBranch.extraOptions).toEqual({
+			command: "branch_land",
+			actionName: "Land Branch",
+		});
+		expect(query).toBeDefined();
+		expect(
+			query?.({
+				projectId: "project-1",
+				branch: "feature",
+				noFf: false,
+			}),
+		).toEqual({
+			projectId: "project-1",
+			branch: "feature",
+			noFf: false,
+		});
+
+		// The base-branch query provides a type-level tag, so it must be invalidated
+		// with invalidatesType rather than invalidatesList.
+		expect(endpoints.landBranch.invalidatesTags).toEqual([
+			invalidatesList(ReduxTag.HeadSha),
+			invalidatesList(ReduxTag.WorktreeChanges),
+			invalidatesList(ReduxTag.Stacks),
+			invalidatesList(ReduxTag.StackDetails),
+			invalidatesList(ReduxTag.BranchChanges),
+			invalidatesList(ReduxTag.BranchListing),
+			invalidatesType(ReduxTag.BaseBranchData),
 			invalidatesList(ReduxTag.UpstreamIntegrationStatus),
 		]);
 	});

--- a/apps/desktop/src/lib/stacks/stackEndpoints.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.ts
@@ -9,6 +9,7 @@ import { createSelectByIds, createSelectNth } from "$lib/state/customSelectors";
 import {
 	invalidatesItem,
 	invalidatesList,
+	invalidatesType,
 	providesItem,
 	providesItems,
 	providesList,
@@ -24,6 +25,7 @@ import type {
 import type { BackendEndpointBuilder } from "$lib/state/backendApi";
 import type {
 	AbsorptionTarget,
+	BranchLandResult,
 	CommitAbsorption,
 	BranchDetails,
 	BranchReference,
@@ -240,7 +242,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 					invalidatesList(ReduxTag.StackDetails),
 					invalidatesList(ReduxTag.BranchChanges),
 					invalidatesList(ReduxTag.BranchListing),
-					invalidatesList(ReduxTag.BaseBranchData),
+					invalidatesType(ReduxTag.BaseBranchData),
 					invalidatesList(ReduxTag.UpstreamIntegrationStatus),
 				];
 			},
@@ -800,6 +802,26 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 				invalidatesList(ReduxTag.WorktreeChanges),
 				invalidatesItem(ReduxTag.StackDetails, args.stackId),
 				invalidatesItem(ReduxTag.BranchChanges, args.seriesName),
+			],
+		}),
+		landBranch: build.mutation<
+			BranchLandResult,
+			{ projectId: string; branch: string; noFf: boolean }
+		>({
+			extraOptions: {
+				command: "branch_land",
+				actionName: "Land Branch",
+			},
+			query: (args) => args,
+			invalidatesTags: [
+				invalidatesList(ReduxTag.HeadSha),
+				invalidatesList(ReduxTag.WorktreeChanges),
+				invalidatesList(ReduxTag.Stacks),
+				invalidatesList(ReduxTag.StackDetails),
+				invalidatesList(ReduxTag.BranchChanges),
+				invalidatesList(ReduxTag.BranchListing),
+				invalidatesType(ReduxTag.BaseBranchData),
+				invalidatesList(ReduxTag.UpstreamIntegrationStatus),
 			],
 		}),
 		getInitialBranchIntegration: build.query<

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -573,6 +573,10 @@ export class StackService {
 		return this.backendApi.endpoints.unapply.mutate;
 	}
 
+	get landBranch() {
+		return this.backendApi.endpoints.landBranch.mutate;
+	}
+
 	get discardChanges() {
 		return this.backendApi.endpoints.discardChanges.mutate;
 	}

--- a/apps/desktop/src/lib/telemetry/posthog.ts
+++ b/apps/desktop/src/lib/telemetry/posthog.ts
@@ -29,11 +29,12 @@ export class PostHogWrapper {
 		});
 	}
 
-	captureOnboarding(event: OnboardingEvent, error?: unknown) {
+	captureOnboarding(event: OnboardingEvent, error?: unknown, extraProperties?: Properties) {
 		const context = this.eventContext.getAll();
 		const parsedError = parseQueryError(error);
 		const properties = {
 			...context,
+			...extraProperties,
 			error_title: parsedError.name,
 			error_message: parsedError.message,
 			error_code: parsedError.code,


### PR DESCRIPTION
Adds a project-scoped, frontend-only setting ("Land branches directly") that replaces a branch's "Create PR" button with a "Land" button calling the existing `branch_land` API.

- Toggle lives in the project Git settings, grouped with the hook/signing toggles, and there is a subtle, off-by-default checkbox on the project onboarding screen.
- The Land button shows only on the bottom branch of a stack, works without a forge integration, and confirms before landing since the push is not undoable.
- The confirmation modal and toasts reference the remote-qualified target (e.g. `origin/master`); the mutation invalidates the same caches as upstream integration so per-branch diffs refresh after landing.

<img width="636" height="557" alt="Screenshot 2026-06-30 at 00 52 13" src="https://github.com/user-attachments/assets/ade6ee27-987d-4268-a56a-1bb3cc56a75e" />
<img width="843" height="368" alt="Screenshot 2026-06-30 at 00 56 45" src="https://github.com/user-attachments/assets/6bfe9a76-cf7a-418d-9294-d810042f1c1b" />
<img width="363" height="191" alt="Screenshot 2026-06-30 at 00 53 45" src="https://github.com/user-attachments/assets/04ab73cf-1d2c-4d60-955f-00257431947c" />
