### PR TITLE
Fix branch move when target is ahead of base

### DIFF
--- a/crates/but-workspace/src/branch/move_branch.rs
+++ b/crates/but-workspace/src/branch/move_branch.rs
@@ -108,13 +108,7 @@ pub(super) mod function {
             delimiter: subject_delimiter,
             children_to_disconnect,
             parents_to_disconnect,
-        } = get_disconnect_parameters(
-            &editor,
-            &workspace,
-            source_stack,
-            subject_segment,
-            workspace_head,
-        )?;
+        } = get_disconnect_parameters(&editor, source_stack, subject_segment, workspace_head)?;
 
         editor.disconnect_segment_from(
             subject_delimiter.clone(),
@@ -229,13 +223,7 @@ pub(super) mod function {
             delimiter: subject_delimiter,
             children_to_disconnect,
             parents_to_disconnect,
-        } = get_disconnect_parameters(
-            &editor,
-            &workspace,
-            &source_stack,
-            &subject_segment,
-            workspace_head,
-        )?;
+        } = get_disconnect_parameters(&editor, &source_stack, &subject_segment, workspace_head)?;
 
         let skip_reconnect_step = source_stack.segments.len() == 1;
         editor.disconnect_segment_from(

--- a/crates/but-workspace/src/graph_manipulation.rs
+++ b/crates/but-workspace/src/graph_manipulation.rs
@@ -25,7 +25,6 @@ pub struct DisconnectParameters {
 /// as well as the right segment delimiter to move.
 pub fn get_disconnect_parameters<'ws, 'meta, M: RefMetadata>(
     editor: &Editor<'ws, 'meta, M>,
-    workspace: &but_graph::Workspace,
     source_stack: &Stack,
     subject_segment: &StackSegment,
     workspace_head: gix::ObjectId,
@@ -60,36 +59,21 @@ pub fn get_disconnect_parameters<'ws, 'meta, M: RefMetadata>(
         parent: delimiter_parent,
     };
 
-    // The parent segment in the stack if any.
-    // This will be `None` if the branch we want to move is at the bottom of the stack.
-    let stack_base_segment = subject_segment.base_segment_id.and_then(|base_segment_id| {
-        source_stack
-            .segments
-            .iter()
-            .find(|segment| segment.id == base_segment_id)
-    });
-
-    // The parent segment in the graph.
-    // If the `stack_base_segment` is `None` but there's a `base_segment_id` defined, it means we'll find it in the
-    // graph data, and it's probably the target branch, which is not included in the workspace.
-    let graph_base_segment = subject_segment
-        .base_segment_id
-        .map(|segment_idx| &workspace.graph[segment_idx]);
-
-    let parents_to_disconnect = if let Some(stack_base_segment) = stack_base_segment {
-        // Base segment is part of the source stack.
-        select_segment(editor, stack_base_segment)?
-    } else if let Some(graph_base_segment) = graph_base_segment {
-        // Base segment is outside of workspace (probably target branch).
-        select_segment(editor, graph_base_segment)?
-    } else if subject_segment.base_segment_id.is_some() {
-        // Base segment could not be found, but there is an ID defined. Error out.
-        bail!(
-            "Failed to find the base segment of the subject we want to move, even if it seems to be defined"
-        );
-    } else {
-        // Nothing found. Remove all parents.
-        SelectorSet::All
+    // Disconnect the subject from the base directly below its parent-delimiter — the branch's last
+    // commit, or its reference when the branch is empty. The base is the first-parent edge (lowest
+    // edge order); if the bottom commit is a merge, its higher-order parents must travel with the
+    // subject rather than be cut. We read this from the rebase editor graph (which
+    // `disconnect_segment_from` validates against) rather than the workspace projection: when the
+    // target is ahead of the merge base the projection's base segment is anonymous and resolves to
+    // the base commit, while the editor graph keeps the target reference node between the branch and
+    // that commit, so only the editor-graph first parent matches the edge being checked.
+    let parents_to_disconnect = match editor
+        .direct_parents(delimiter.parent)?
+        .into_iter()
+        .min_by_key(|(_, order)| *order)
+    {
+        Some((base, _)) => SelectorSet::Some(SomeSelectors::new(vec![base])?),
+        None => SelectorSet::All,
     };
 
     if index_of_segment == 0 {
@@ -172,44 +156,6 @@ pub fn determine_parent_selector<'ws, 'meta, M: RefMetadata>(
     }
 }
 
-/// Select a segment by its ref name if available, otherwise fall back to its tip commit.
-fn select_segment<M: RefMetadata>(
-    editor: &Editor<'_, '_, M>,
-    segment: &impl SegmentLike,
-) -> anyhow::Result<SelectorSet> {
-    let selector = if let Some(ref_name) = segment.ref_name() {
-        editor.select_reference(ref_name)?
-    } else if let Some(tip) = segment.tip() {
-        editor.select_commit(tip)?
-    } else {
-        bail!("Base segment has neither a ref name nor any commits.");
-    };
-    let selectors = SomeSelectors::new(vec![selector])?;
-    Ok(SelectorSet::Some(selectors))
-}
-
-trait SegmentLike {
-    fn ref_name(&self) -> Option<&gix::refs::FullNameRef>;
-    fn tip(&self) -> Option<gix::ObjectId>;
-}
-
-impl SegmentLike for StackSegment {
-    fn ref_name(&self) -> Option<&gix::refs::FullNameRef> {
-        self.ref_name()
-    }
-    fn tip(&self) -> Option<gix::ObjectId> {
-        self.tip()
-    }
-}
-
-impl SegmentLike for but_graph::Segment {
-    fn ref_name(&self) -> Option<&gix::refs::FullNameRef> {
-        self.ref_name()
-    }
-    fn tip(&self) -> Option<gix::ObjectId> {
-        self.tip()
-    }
-}
 /// Which direct edge set to resolve from a selector.
 #[derive(Clone, Copy)]
 pub(crate) enum EdgeSelection {

--- a/crates/but-workspace/tests/fixtures/scenario/ws-with-empty-stack-target-advanced.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/ws-with-empty-stack-target-advanced.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A ws-ref points to a workspace commit, with two stacks inside, one empty and one with a commit.
+# Additionally, the target (origin/main) has advanced past the workspace base, while the
+# `gitbutler/target` anchor still points at the base. This makes the merge-base segment carry the
+# `gitbutler/target` reference node above the base commit in the editor graph. See
+# `ws-with-empty-stack.sh` for the variant where the target is caught up.
+git init
+commit M
+setup_target_to_match_main
+git branch gitbutler/target main
+
+git branch B
+git checkout -b A
+  commit A
+git checkout B
+create_workspace_commit_once A B
+
+# Advance the target past the workspace base while leaving `gitbutler/target` at the base.
+git checkout main
+commit-file X.txt X
+git update-ref refs/remotes/origin/main main
+git checkout gitbutler/workspace

--- a/crates/but-workspace/tests/workspace/branch/move_branch.rs
+++ b/crates/but-workspace/tests/workspace/branch/move_branch.rs
@@ -871,6 +871,137 @@ fn move_branch_when_base_segment_has_no_ref_name() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[test]
+fn move_empty_branch_onto_non_empty_branch_with_advanced_target() -> anyhow::Result<()> {
+    // Regression: when the target branch (local `main`/`origin/main`) is ahead of the workspace
+    // base, the merge-base segment is represented in the editor graph by the `gitbutler/target`
+    // reference node sitting above the base commit. Selecting the base by commit would point one
+    // hop too far and fail the direct-parent check. Moving the empty branch onto the non-empty one
+    // must still succeed.
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-with-empty-stack-target-advanced",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "B", StackState::InWorkspace, &[]);
+            },
+        )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   6d5c23e (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 09d8e52 (A) A
+    |/  
+    | * e1bbad3 (origin/main, main) add X
+    |/  
+    * 85efbe4 (gitbutler/target, B) M
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 85efbe4
+    ├── ≡📙:3:A on 85efbe4 {1}
+    │   └── 📙:3:A
+    │       └── ·09d8e52 (🏘️)
+    └── ≡📙:5:B on 85efbe4 {2}
+        └── 📙:5:B
+    ");
+
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+    // Put empty B on top of non-empty A.
+    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
+        but_workspace::branch::move_branch(
+            editor,
+            "refs/heads/B".try_into()?,
+            "refs/heads/A".try_into()?,
+        )?;
+
+    rebase.materialize()?;
+    set_workspace_metadata(&mut meta, &ws, ws_meta)?;
+    let project_meta = ws.graph.project_meta.clone();
+    ws.refresh_from_head(&repo, &meta, project_meta)?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 2c820f0 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 09d8e52 (B, A) A
+    | * e1bbad3 (origin/main, main) add X
+    |/  
+    * 85efbe4 (gitbutler/target) M
+    ");
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 85efbe4
+    └── ≡📙:5:B on 85efbe4 {1}
+        ├── 📙:5:B
+        └── 📙:6:A
+            └── ·09d8e52 (🏘️)
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn move_non_empty_branch_onto_empty_branch_with_advanced_target() -> anyhow::Result<()> {
+    // Same setup as the empty-onto-non-empty regression, but the subject is the non-empty branch
+    // and the target is the empty one. Both directions must succeed when the target is ahead.
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-with-empty-stack-target-advanced",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "B", StackState::InWorkspace, &[]);
+            },
+        )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   6d5c23e (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 09d8e52 (A) A
+    |/  
+    | * e1bbad3 (origin/main, main) add X
+    |/  
+    * 85efbe4 (gitbutler/target, B) M
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 85efbe4
+    ├── ≡📙:3:A on 85efbe4 {1}
+    │   └── 📙:3:A
+    │       └── ·09d8e52 (🏘️)
+    └── ≡📙:5:B on 85efbe4 {2}
+        └── 📙:5:B
+    ");
+
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+    // Put non-empty A on top of empty B.
+    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
+        but_workspace::branch::move_branch(
+            editor,
+            "refs/heads/A".try_into()?,
+            "refs/heads/B".try_into()?,
+        )?;
+
+    rebase.materialize()?;
+    set_workspace_metadata(&mut meta, &ws, ws_meta)?;
+    let project_meta = ws.graph.project_meta.clone();
+    ws.refresh_from_head(&repo, &meta, project_meta)?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 2c820f0 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 09d8e52 (A) A
+    | * e1bbad3 (origin/main, main) add X
+    |/  
+    * 85efbe4 (gitbutler/target, B) M
+    ");
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 85efbe4
+    └── ≡📙:3:A on 85efbe4 {2}
+        ├── 📙:3:A
+        │   └── ·09d8e52 (🏘️)
+        └── 📙:5:B
+    ");
+
+    Ok(())
+}
+
 fn stack_display_order(ws: &but_graph::Workspace) -> Vec<String> {
     ws.stacks
         .iter()


### PR DESCRIPTION
Moving a branch onto another to stack them failed with "Invalid parent delimitation: requested parent is not a direct parent of target.parent" whenever the workspace target had advanced past the merge base.

`get_disconnect_parameters` resolved the base to disconnect from the workspace projection, where the base segment is anonymous in that situation and resolves to the base commit. But the rebase editor graph that `disconnect_segment_from` actually validates and mutates keeps the target reference node between the branch and the base commit, so the selected parent was one hop too far and failed the direct-parent check.

Resolve the parent to disconnect from the editor graph instead, reusing the existing `determine_parent_selector` helper (already used by the move-commit and integrate-upstream paths). This also lets the projection-based `select_segment` helper, the `SegmentLike` trait, and the now-unused `workspace` parameter be removed.

Adds a fixture and regression tests for moving a branch in both directions while the target is ahead.