### PR TITLE
Make `but-debug repo dump` work with relative paths

### DIFF
--- a/crates/but-debug/src/command/dump/mod.rs
+++ b/crates/but-debug/src/command/dump/mod.rs
@@ -51,6 +51,8 @@ fn run_repo(
             current_dir.display()
         )
     })?;
+    // nothing really works unless we have a non-relative path, keep it simple.
+    let repo = gix::open_opts(repo.git_dir().canonicalize()?, repo.open_options().clone())?;
 
     let output_path = match &repo_args.archive.output {
         Some(path) => current_dir.join(path),


### PR DESCRIPTION
`cargo run --bin but-debug -- repo dump` now works with relative paths
