### PR TITLE
auto-transition: improvements

### DIFF
--- a/apps/desktop/src/components/branchesPage/BranchesViewPR.svelte
+++ b/apps/desktop/src/components/branchesPage/BranchesViewPR.svelte
@@ -3,12 +3,13 @@
 	import PRListCard from "$components/branchesPage/PRListCard.svelte";
 	import ReduxResult from "$components/shared/ReduxResult.svelte";
 	import { BASE_BRANCH_SERVICE } from "$lib/baseBranch/baseBranchService.svelte";
+	import { newBranchApplyFeature } from "$lib/config/uiFeatureFlags";
 	import { FORGE_INFO_SERVICE } from "$lib/forge/forgeInfo.svelte";
 	import { PR_SERVICE } from "$lib/forge/prService.svelte";
 	import { REMOTES_SERVICE } from "$lib/git/remotesService";
 	import { showWarning } from "$lib/notifications/toasts";
 	import { workspacePath } from "$lib/routes/routes.svelte";
-	import { handleCreateBranchFromBranchOutcome } from "$lib/stacks/stack";
+	import { handleApplyOutcome, handleCreateBranchFromBranchOutcome } from "$lib/stacks/stack";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 
 	import { inject } from "@gitbutler/core/context";
@@ -81,8 +82,23 @@
 		}
 	}
 
-	export function applyPr() {
-		createRemoteModal?.show();
+	export async function applyPr() {
+		if (!$newBranchApplyFeature) {
+			createRemoteModal?.show();
+			return;
+		}
+
+		loading = true;
+		try {
+			const outcome = await stackService.reviewApply({
+				projectId,
+				reviewId: prNumber,
+			});
+			handleApplyOutcome(outcome);
+			goto(workspacePath(projectId));
+		} finally {
+			loading = false;
+		}
 	}
 </script>
 

--- a/apps/desktop/src/components/settings/ExperimentalSettings.svelte
+++ b/apps/desktop/src/components/settings/ExperimentalSettings.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import {
 		fModeEnabled,
+		newBranchApplyFeature,
 		newIntegrateUpstreamModalFeature,
 		newPushFeature,
 	} from "$lib/config/uiFeatureFlags";
@@ -71,6 +72,22 @@
 				id="new-push"
 				checked={$newPushFeature}
 				onclick={() => newPushFeature.set(!$newPushFeature)}
+			/>
+		{/snippet}
+	</CardGroup.Item>
+
+	<CardGroup.Item labelFor="new-branch-apply">
+		{#snippet title()}
+			New branch apply
+		{/snippet}
+		{#snippet caption()}
+			Use the newer branch apply implementation from the branches view.
+		{/snippet}
+		{#snippet actions()}
+			<Toggle
+				id="new-branch-apply"
+				checked={$newBranchApplyFeature}
+				onclick={() => newBranchApplyFeature.set(!$newBranchApplyFeature)}
 			/>
 		{/snippet}
 	</CardGroup.Item>

--- a/apps/desktop/src/components/views/BranchesView.svelte
+++ b/apps/desktop/src/components/views/BranchesView.svelte
@@ -23,7 +23,6 @@
 	import { useGitHubForgeUser } from "$lib/forge/github/hooks.svelte";
 	import { useGitLabForgeUser } from "$lib/forge/gitlab/hooks.svelte";
 	import { workspacePath } from "$lib/routes/routes.svelte";
-	import { handleCreateBranchFromBranchOutcome } from "$lib/stacks/stack";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { combineResults } from "$lib/state/helpers";
 	import { inject } from "@gitbutler/core/context";
@@ -98,22 +97,15 @@
 		defaultValue: 20,
 	};
 
-	async function checkoutBranch(args: {
-		branchName: string;
-		remote?: string;
-		prNumber?: number;
-		hasLocal: boolean;
-	}) {
-		const { remote, hasLocal, branchName, prNumber } = args;
+	async function checkoutBranch(args: { branchName: string; remote?: string; hasLocal: boolean }) {
+		const { remote, hasLocal, branchName } = args;
 		const remoteRef = remote ? `refs/remotes/${remote}/${branchName}` : undefined;
 		const branchRef = hasLocal ? `refs/heads/${branchName}` : remoteRef;
 		if (branchRef) {
-			const outcome = await stackService.createVirtualBranchFromBranch({
+			await stackService.branchApply({
 				projectId,
-				branch: branchRef,
-				prNumber,
+				existingBranch: branchRef,
 			});
-			handleCreateBranchFromBranchOutcome(outcome);
 			await baseBranchService.refreshBaseBranch(projectId);
 		}
 		goto(workspacePath(projectId));
@@ -317,7 +309,6 @@
 									result={combineResults(selectedBranch.result, listing.result)}
 								>
 									{#snippet children([branch, listing])}
-										{@const prNumber = branch.stack?.pullRequests[branchName]}
 										{@const inWorkspace = branch.stack?.inWorkspace}
 										{@const hasLocal = listing.hasLocal}
 										<!-- Apply branch -->
@@ -329,7 +320,7 @@
 													icon="workbench"
 													shrinkable
 													action={async () => {
-														await checkoutBranch({ remote, branchName, hasLocal, prNumber });
+														await checkoutBranch({ remote, branchName, hasLocal });
 													}}
 												>
 													Apply to workspace

--- a/apps/desktop/src/components/views/BranchesView.svelte
+++ b/apps/desktop/src/components/views/BranchesView.svelte
@@ -18,12 +18,13 @@
 	import TargetCommitList from "$components/views/TargetCommitList.svelte";
 	import { BASE_BRANCH_SERVICE } from "$lib/baseBranch/baseBranchService.svelte";
 	import { BRANCH_SERVICE } from "$lib/branches/branchService.svelte";
+	import { newBranchApplyFeature } from "$lib/config/uiFeatureFlags";
 	import { isNormalizedError } from "$lib/error/normalizedError";
 	import { FORGE_INFO_SERVICE } from "$lib/forge/forgeInfo.svelte";
 	import { useGitHubForgeUser } from "$lib/forge/github/hooks.svelte";
 	import { useGitLabForgeUser } from "$lib/forge/gitlab/hooks.svelte";
 	import { workspacePath } from "$lib/routes/routes.svelte";
-	import { handleApplyOutcome } from "$lib/stacks/stack";
+	import { handleApplyOutcome, handleCreateBranchFromBranchOutcome } from "$lib/stacks/stack";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { combineResults } from "$lib/state/helpers";
 	import { inject } from "@gitbutler/core/context";
@@ -101,17 +102,27 @@
 	async function applyBranchToWorkspace(args: {
 		branchName: string;
 		remote?: string;
+		prNumber?: number;
 		hasLocal: boolean;
 	}) {
-		const { remote, hasLocal, branchName } = args;
+		const { remote, hasLocal, branchName, prNumber } = args;
 		const remoteRef = remote ? `refs/remotes/${remote}/${branchName}` : undefined;
 		const branchRef = hasLocal ? `refs/heads/${branchName}` : remoteRef;
 		if (branchRef) {
-			const outcome = await stackService.branchApply({
-				projectId,
-				existingBranch: branchRef,
-			});
-			handleApplyOutcome(outcome);
+			if ($newBranchApplyFeature) {
+				const outcome = await stackService.branchApply({
+					projectId,
+					existingBranch: branchRef,
+				});
+				handleApplyOutcome(outcome);
+			} else {
+				const outcome = await stackService.createVirtualBranchFromBranch({
+					projectId,
+					branch: branchRef,
+					prNumber,
+				});
+				handleCreateBranchFromBranchOutcome(outcome);
+			}
 			await baseBranchService.refreshBaseBranch(projectId);
 		}
 		goto(workspacePath(projectId));
@@ -315,6 +326,7 @@
 									result={combineResults(selectedBranch.result, listing.result)}
 								>
 									{#snippet children([branch, listing])}
+										{@const prNumber = branch.stack?.pullRequests[branchName]}
 										{@const inWorkspace = branch.stack?.inWorkspace}
 										{@const hasLocal = listing.hasLocal}
 										<!-- Apply branch -->
@@ -326,7 +338,12 @@
 													icon="workbench"
 													shrinkable
 													action={async () => {
-														await applyBranchToWorkspace({ remote, branchName, hasLocal });
+														await applyBranchToWorkspace({
+															remote,
+															branchName,
+															hasLocal,
+															prNumber,
+														});
 													}}
 												>
 													Apply to workspace

--- a/apps/desktop/src/components/views/BranchesView.svelte
+++ b/apps/desktop/src/components/views/BranchesView.svelte
@@ -23,6 +23,7 @@
 	import { useGitHubForgeUser } from "$lib/forge/github/hooks.svelte";
 	import { useGitLabForgeUser } from "$lib/forge/gitlab/hooks.svelte";
 	import { workspacePath } from "$lib/routes/routes.svelte";
+	import { handleApplyOutcome } from "$lib/stacks/stack";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { combineResults } from "$lib/state/helpers";
 	import { inject } from "@gitbutler/core/context";
@@ -97,15 +98,20 @@
 		defaultValue: 20,
 	};
 
-	async function checkoutBranch(args: { branchName: string; remote?: string; hasLocal: boolean }) {
+	async function applyBranchToWorkspace(args: {
+		branchName: string;
+		remote?: string;
+		hasLocal: boolean;
+	}) {
 		const { remote, hasLocal, branchName } = args;
 		const remoteRef = remote ? `refs/remotes/${remote}/${branchName}` : undefined;
 		const branchRef = hasLocal ? `refs/heads/${branchName}` : remoteRef;
 		if (branchRef) {
-			await stackService.branchApply({
+			const outcome = await stackService.branchApply({
 				projectId,
 				existingBranch: branchRef,
 			});
+			handleApplyOutcome(outcome);
 			await baseBranchService.refreshBaseBranch(projectId);
 		}
 		goto(workspacePath(projectId));
@@ -320,7 +326,7 @@
 													icon="workbench"
 													shrinkable
 													action={async () => {
-														await checkoutBranch({ remote, branchName, hasLocal });
+														await applyBranchToWorkspace({ remote, branchName, hasLocal });
 													}}
 												>
 													Apply to workspace

--- a/apps/desktop/src/components/views/BranchesView.svelte
+++ b/apps/desktop/src/components/views/BranchesView.svelte
@@ -140,8 +140,8 @@
 
 	let prBranch = $state<BranchesViewPr>();
 
-	function applyFromFork() {
-		prBranch?.applyPr();
+	async function applyFromFork() {
+		await prBranch?.applyPr();
 	}
 
 	let deleteLocalBranchModal = $state<Modal>();
@@ -405,13 +405,13 @@
 							{:else if selection.type === "pr"}
 								{@const prNumber = selection.prNumber}
 								<div class="branch-actions">
-									<Button
+									<AsyncButton
 										testId={TestId.BranchesViewApplyFromForkButton}
 										icon="workbench"
-										onclick={applyFromFork}
+										action={applyFromFork}
 									>
 										Apply {reviewUnitAbbr} to workspace
-									</Button>
+									</AsyncButton>
 								</div>
 								<BranchesViewPr bind:this={prBranch} {projectId} {prNumber} {onerror} />
 							{/if}

--- a/apps/desktop/src/lib/config/uiFeatureFlags.ts
+++ b/apps/desktop/src/lib/config/uiFeatureFlags.ts
@@ -15,6 +15,7 @@ export const stagingBehaviorFeature = persisted<StagingBehavior>("all", "feature
 export const fModeEnabled = persisted(true, "f-mode");
 export const newlineOnEnter = persisted(false, "feature-newline-on-enter");
 export const newPushFeature = persisted(true, "feature-new-push");
+export const newBranchApplyFeature = persisted(true, "feature-new-branch-apply");
 export const newIntegrateUpstreamModalFeature = persisted(
 	true,
 	"feature-new-integrate-upstream-modal",

--- a/apps/desktop/src/lib/stacks/stack.ts
+++ b/apps/desktop/src/lib/stacks/stack.ts
@@ -1,8 +1,8 @@
-import { showToast } from "$lib/notifications/toasts";
+import { showToast, showWarning } from "$lib/notifications/toasts";
 import { TestId } from "@gitbutler/ui";
 import type { BranchIconName } from "$lib/branches/branchIcon";
 import type { DropResult } from "$lib/dragging/dropResult";
-import type { PushStatus, Segment, Stack as RefInfoStack } from "@gitbutler/but-sdk";
+import type { ApplyOutcome, PushStatus, Segment, Stack as RefInfoStack } from "@gitbutler/but-sdk";
 
 export type CreateBranchFromBranchOutcome = {
 	stackId: string;
@@ -47,6 +47,18 @@ export function handleCreateBranchFromBranchOutcome(outcome: CreateBranchFromBra
 You can always re-apply them later from the branches page.`,
 		});
 	}
+}
+
+export function handleApplyOutcome(outcome: ApplyOutcome) {
+	if (outcome.status !== "conflictAborted") return;
+	const names = outcome.conflictingStacks.map((stack) => stack.shortName);
+	const single = names.length === 1;
+	showWarning(
+		"Couldn't apply branch due to conflicts",
+		`It conflicts with ${prettyNamedListIfPossible(names.length, names) || "another applied stack"}. Unapply ${single ? "it" : "them"} first, then try applying again.`,
+		undefined,
+		TestId.BranchApplyConflictToast,
+	);
 }
 
 export type Stack = RefInfoStack;

--- a/apps/desktop/src/lib/stacks/stackEndpoints.test.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.test.ts
@@ -232,6 +232,35 @@ describe("buildStackEndpoints", () => {
 		]);
 	});
 
+	test("uses apply for branch application", () => {
+		const endpoints = buildStackEndpoints(createEndpointBuilder());
+		const query = endpoints.branchApply.query;
+
+		expect(endpoints.branchApply.extraOptions).toEqual({
+			command: "apply",
+			actionName: "Apply Branch",
+		});
+		expect(query).toBeDefined();
+		expect(
+			query?.({
+				projectId: "project-1",
+				existingBranch: "refs/heads/feature",
+			}),
+		).toEqual({
+			projectId: "project-1",
+			existingBranch: "refs/heads/feature",
+		});
+		expect(endpoints.branchApply.invalidatesTags).toEqual([
+			invalidatesList(ReduxTag.HeadMetadata),
+			invalidatesList(ReduxTag.HeadSha),
+			invalidatesList(ReduxTag.WorktreeChanges),
+			invalidatesList(ReduxTag.Stacks),
+			invalidatesList(ReduxTag.StackDetails),
+			invalidatesList(ReduxTag.BranchListing),
+			invalidatesList(ReduxTag.UpstreamIntegrationStatus),
+		]);
+	});
+
 	test("uses workspace_integrate_upstream for dry-run previews and execution", () => {
 		const endpoints = buildStackEndpoints(createEndpointBuilder());
 		const query = endpoints.workspaceIntegrateUpstream.query;

--- a/apps/desktop/src/lib/stacks/stackEndpoints.test.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.test.ts
@@ -261,6 +261,36 @@ describe("buildStackEndpoints", () => {
 		]);
 	});
 
+	test("uses review_apply for review application", () => {
+		const endpoints = buildStackEndpoints(createEndpointBuilder());
+		const query = endpoints.reviewApply.query;
+
+		expect(endpoints.reviewApply.extraOptions).toEqual({
+			command: "review_apply",
+			actionName: "Apply Review",
+		});
+		expect(query).toBeDefined();
+		expect(
+			query?.({
+				projectId: "project-1",
+				reviewId: 42,
+			}),
+		).toEqual({
+			projectId: "project-1",
+			reviewId: 42,
+		});
+		expect(endpoints.reviewApply.invalidatesTags).toEqual([
+			invalidatesList(ReduxTag.HeadMetadata),
+			invalidatesList(ReduxTag.HeadSha),
+			invalidatesList(ReduxTag.WorktreeChanges),
+			invalidatesList(ReduxTag.Stacks),
+			invalidatesList(ReduxTag.StackDetails),
+			invalidatesList(ReduxTag.BranchListing),
+			invalidatesList(ReduxTag.UpstreamIntegrationStatus),
+			invalidatesList(ReduxTag.PullRequests),
+		]);
+	});
+
 	test("uses workspace_integrate_upstream for dry-run previews and execution", () => {
 		const endpoints = buildStackEndpoints(createEndpointBuilder());
 		const query = endpoints.workspaceIntegrateUpstream.query;

--- a/apps/desktop/src/lib/stacks/stackEndpoints.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.ts
@@ -886,6 +886,23 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 				invalidatesList(ReduxTag.UpstreamIntegrationStatus),
 			],
 		}),
+		reviewApply: build.mutation<ApplyOutcome, { projectId: string; reviewId: number }>({
+			extraOptions: {
+				command: "review_apply",
+				actionName: "Apply Review",
+			},
+			query: (args) => args,
+			invalidatesTags: [
+				invalidatesList(ReduxTag.HeadMetadata),
+				invalidatesList(ReduxTag.HeadSha),
+				invalidatesList(ReduxTag.WorktreeChanges),
+				invalidatesList(ReduxTag.Stacks),
+				invalidatesList(ReduxTag.StackDetails),
+				invalidatesList(ReduxTag.BranchListing),
+				invalidatesList(ReduxTag.UpstreamIntegrationStatus),
+				invalidatesList(ReduxTag.PullRequests),
+			],
+		}),
 		createVirtualBranchFromBranch: build.mutation<
 			CreateBranchFromBranchOutcome,
 			{ projectId: string; branch: string; prNumber?: number }

--- a/apps/desktop/src/lib/stacks/stackEndpoints.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.ts
@@ -45,6 +45,7 @@ import type {
 	CommitRewordResult,
 	CommitSquashResult,
 	CommitInsertBlankResult,
+	ApplyOutcome,
 	MoveBranchResult,
 	RejectionReason,
 	UncommitResult,
@@ -868,6 +869,22 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 							invalidatesList(ReduxTag.UpstreamIntegrationStatus),
 							invalidatesItem(ReduxTag.IntegrationSteps, args.branchRef),
 						],
+		}),
+		branchApply: build.mutation<ApplyOutcome, { projectId: string; existingBranch: string }>({
+			extraOptions: {
+				command: "apply",
+				actionName: "Apply Branch",
+			},
+			query: (args) => args,
+			invalidatesTags: [
+				invalidatesList(ReduxTag.HeadMetadata),
+				invalidatesList(ReduxTag.HeadSha),
+				invalidatesList(ReduxTag.WorktreeChanges),
+				invalidatesList(ReduxTag.Stacks),
+				invalidatesList(ReduxTag.StackDetails),
+				invalidatesList(ReduxTag.BranchListing),
+				invalidatesList(ReduxTag.UpstreamIntegrationStatus),
+			],
 		}),
 		createVirtualBranchFromBranch: build.mutation<
 			CreateBranchFromBranchOutcome,

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -738,6 +738,10 @@ export class StackService {
 		return this.backendApi.endpoints.branchApply.mutate;
 	}
 
+	get reviewApply() {
+		return this.backendApi.endpoints.reviewApply.mutate;
+	}
+
 	get createVirtualBranchFromBranch() {
 		return this.backendApi.endpoints.createVirtualBranchFromBranch.mutate;
 	}

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -734,6 +734,10 @@ export class StackService {
 		});
 	}
 
+	get branchApply() {
+		return this.backendApi.endpoints.branchApply.mutate;
+	}
+
 	get createVirtualBranchFromBranch() {
 		return this.backendApi.endpoints.createVirtualBranchFromBranch.mutate;
 	}

--- a/apps/desktop/src/lib/testing/mockStackService.ts
+++ b/apps/desktop/src/lib/testing/mockStackService.ts
@@ -124,6 +124,7 @@ export function getStackServiceMock() {
 	StackServiceMock.prototype.applyBranchIntegration = vi.fn();
 	StackServiceMock.prototype.previewBranchIntegration = vi.fn();
 	StackServiceMock.prototype.fetchInitialBranchIntegration = vi.fn();
+	StackServiceMock.prototype.branchApply = vi.fn();
 	StackServiceMock.prototype.legacyUnapplyLines = vi.fn();
 	StackServiceMock.prototype.legacyUnapplyHunk = vi.fn();
 	StackServiceMock.prototype.legacyUnapplyFiles = vi.fn();

--- a/apps/desktop/src/lib/testing/mockStackService.ts
+++ b/apps/desktop/src/lib/testing/mockStackService.ts
@@ -125,6 +125,7 @@ export function getStackServiceMock() {
 	StackServiceMock.prototype.previewBranchIntegration = vi.fn();
 	StackServiceMock.prototype.fetchInitialBranchIntegration = vi.fn();
 	StackServiceMock.prototype.branchApply = vi.fn();
+	StackServiceMock.prototype.reviewApply = vi.fn();
 	StackServiceMock.prototype.legacyUnapplyLines = vi.fn();
 	StackServiceMock.prototype.legacyUnapplyHunk = vi.fn();
 	StackServiceMock.prototype.legacyUnapplyFiles = vi.fn();

--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -1,11 +1,17 @@
 //! In place of commands.rs
-use anyhow::{Context as _, Result};
+use anyhow::{Context as _, Result, bail};
+use bstr::ByteSlice;
 use but_api_macros::but_api;
-use but_core::{RepositoryExt, ref_metadata::ProjectMeta};
+use but_core::{
+    RefMetadata as _, RepositoryExt,
+    git_config::{edit_repo_config, ensure_config_value},
+    ref_metadata::ProjectMeta,
+};
 use but_ctx::{Context, ThreadSafeContext};
 use but_forge::{
     ForgeName, ReviewTemplateFunctions, available_review_templates, get_review_template_functions,
 };
+use gitbutler_git::GitContextExt;
 use gitbutler_repo::{FileInfo, RepoCommands};
 use tracing::instrument;
 
@@ -236,9 +242,191 @@ pub fn list_reviews(
     )
 }
 
+/// Applies a forge review by resolving it to its source branch.
+///
+/// This fetches the review's head repository through a configured or newly
+/// created remote, applies the fetched remote-tracking branch, and records the
+/// review number on the applied branch metadata.
+#[but_api(napi, crate::branch::json::ApplyOutcome)]
+#[instrument(err(Debug))]
+pub fn review_apply(
+    ctx: &mut but_ctx::Context,
+    review_id: usize,
+) -> Result<but_workspace::branch::apply::Outcome> {
+    let (forge_repo_info, preferred_forge_user, target_protocol) = {
+        let project_meta = ctx.project_meta()?;
+        let repo = ctx.repo.get()?;
+        let remote_url = project_meta.remote_url_with_fallback(&repo)?;
+        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url)
+            .context("No supported forge could be determined for this repository")?;
+        let target_protocol = forge_repo_info.protocol.clone();
+        (
+            forge_repo_info,
+            ctx.legacy_project.preferred_forge_user.clone(),
+            target_protocol,
+        )
+    };
+
+    if forge_repo_info.forge != but_forge::ForgeName::GitHub {
+        bail!("Applying reviews is currently only supported for GitHub pull requests");
+    }
+
+    let review = {
+        let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
+        let db = &mut *ctx.db.get_cache_mut()?;
+        but_forge::get_forge_review(
+            &preferred_forge_user,
+            &forge_repo_info,
+            review_id,
+            db,
+            &storage,
+        )?
+    };
+
+    let head_url = review_head_url(&review, &target_protocol)
+        .with_context(|| format!("Review #{review_id} does not include a source repository URL"))?;
+
+    let mut guard = ctx.exclusive_worktree_access();
+    let remote_name = ensure_review_remote(ctx, &head_url, &review, review_id)?;
+    ctx.fetch(&remote_name, Some("apply review".into()))
+        .with_context(|| format!("Failed to fetch review remote '{remote_name}'"))?;
+    ctx.reload_repo_and_invalidate_workspace(guard.write_permission())?;
+
+    let remote_ref: gix::refs::FullName =
+        format!("refs/remotes/{remote_name}/{}", review.source_branch)
+            .try_into()
+            .with_context(|| {
+                format!(
+                    "Review #{} source branch '{}' is not a valid remote-tracking reference",
+                    review_id, review.source_branch
+                )
+            })?;
+
+    let out = crate::branch::apply_with_perm(ctx, remote_ref.as_ref(), guard.write_permission())?;
+    if out.status.persisted_mutation()
+        && let Some(applied_branch_ref) = out.applied_branches.last()
+    {
+        let mut meta = ctx.meta()?;
+        let mut branch = meta.branch(applied_branch_ref.as_ref())?;
+        branch.review.pull_request = Some(review_id);
+        meta.set_branch(&branch)?;
+        ctx.invalidate_workspace_cache()?;
+    }
+    Ok(out)
+}
+
+fn review_head_url(review: &but_forge::ForgeReview, target_protocol: &str) -> Option<String> {
+    let prefers_ssh = target_protocol.eq_ignore_ascii_case("ssh")
+        || target_protocol.to_ascii_lowercase().contains("ssh");
+    if prefers_ssh {
+        review
+            .repository_ssh_url
+            .clone()
+            .or_else(|| review.repository_https_url.clone())
+    } else {
+        review
+            .repository_https_url
+            .clone()
+            .or_else(|| review.repository_ssh_url.clone())
+    }
+}
+
+fn ensure_review_remote(
+    ctx: &but_ctx::Context,
+    remote_url: &str,
+    review: &but_forge::ForgeReview,
+    review_id: usize,
+) -> Result<String> {
+    let repo = ctx.open_isolated_repo()?;
+    if let Some(existing) = find_remote_by_url(&repo, remote_url)? {
+        return Ok(existing);
+    }
+
+    let owner_hint = review
+        .repo_owner
+        .as_deref()
+        .or_else(|| review.author.as_ref().map(|author| author.login.as_str()));
+    let base_name = sanitize_remote_name(owner_hint.unwrap_or(""), review_id);
+    let remote_name = unique_remote_name(&repo, &base_name)?;
+    add_remote_to_config(&repo, &remote_name, remote_url)?;
+    Ok(remote_name)
+}
+
+fn find_remote_by_url(repo: &gix::Repository, remote_url: &str) -> Result<Option<String>> {
+    for name in repo.remote_names().iter() {
+        let remote = repo.find_remote(name.as_ref())?;
+        let Some(url) = remote.url(gix::remote::Direction::Fetch) else {
+            continue;
+        };
+        let configured = url.to_bstring().to_str_lossy().into_owned();
+        if remote_urls_match(&configured, remote_url) {
+            return Ok(Some(name.to_string()));
+        }
+    }
+    Ok(None)
+}
+
+fn remote_urls_match(configured: &str, candidate: &str) -> bool {
+    if configured == candidate {
+        return true;
+    }
+    let configured_info = but_forge::derive_forge_repo_info(configured);
+    let candidate_info = but_forge::derive_forge_repo_info(candidate);
+    configured_info.is_some() && configured_info == candidate_info
+}
+
+fn sanitize_remote_name(input: &str, review_id: usize) -> String {
+    let mut out = String::new();
+    let mut last_was_dash = false;
+    for ch in input.chars().flat_map(char::to_lowercase) {
+        let safe = ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-');
+        let next = if safe { ch } else { '-' };
+        if next == '-' {
+            if !last_was_dash {
+                out.push(next);
+            }
+            last_was_dash = true;
+        } else {
+            out.push(next);
+            last_was_dash = false;
+        }
+    }
+    let out = out.trim_matches(|ch| matches!(ch, '.' | '_' | '-'));
+    if out.is_empty() || out == "head" {
+        format!("pr-{review_id}")
+    } else {
+        out.to_owned()
+    }
+}
+
+fn unique_remote_name(repo: &gix::Repository, base: &str) -> Result<String> {
+    let mut candidate = base.to_owned();
+    let mut suffix = 2;
+    while repo.find_remote(candidate.as_str()).is_ok() {
+        candidate = format!("{base}-{suffix}");
+        suffix += 1;
+    }
+    Ok(candidate)
+}
+
+fn add_remote_to_config(repo: &gix::Repository, name: &str, remote_url: &str) -> Result<()> {
+    edit_repo_config(repo, gix::config::Source::Local, |config| {
+        let mut section = config.section_mut_or_create_new("remote", Some(name.into()))?;
+        section.push("url".try_into()?, Some(remote_url.into()));
+        ensure_config_value(
+            config,
+            &format!("remote.{name}.fetch"),
+            &format!("+refs/heads/*:refs/remotes/{name}/*"),
+        )?;
+        Ok(())
+    })?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use but_testsupport::{CommandExt, git_at_dir, open_repo};
 
     #[test]
     fn missing_review_template_returns_empty_content() {
@@ -257,6 +445,109 @@ mod tests {
             err.to_string(),
             "PR template exists but must be valid UTF-8 text or markdown"
         );
+    }
+
+    #[test]
+    fn review_remote_name_is_sanitized() {
+        assert_eq!(
+            sanitize_remote_name("Alice Cooper!", 42),
+            "alice-cooper",
+            "forge owner names become git remote-safe names"
+        );
+        assert_eq!(
+            sanitize_remote_name("...", 42),
+            "pr-42",
+            "empty sanitized names fall back to the review number"
+        );
+    }
+
+    #[test]
+    fn review_without_head_repository_url_has_no_applyable_source() {
+        let review = but_forge::ForgeReview {
+            html_url: "https://github.com/acme/widgets/pull/42".into(),
+            number: 42,
+            title: "Fork PR".into(),
+            body: None,
+            author: None,
+            labels: Vec::new(),
+            draft: false,
+            source_branch: "fork-feature".into(),
+            target_branch: "main".into(),
+            sha: "0000000000000000000000000000000000000000".into(),
+            integration_commit_shas: Vec::new(),
+            created_at: None,
+            modified_at: None,
+            merged_at: None,
+            closed_at: None,
+            repository_ssh_url: None,
+            repository_https_url: None,
+            repo_owner: Some("alice".into()),
+            head_repo_is_fork: true,
+            reviewers: Vec::new(),
+            unit_symbol: "#".into(),
+            last_sync_at: Default::default(),
+        };
+
+        assert!(
+            review_head_url(&review, "https").is_none(),
+            "reviews without a head repository URL cannot be fetched for apply"
+        );
+    }
+
+    #[test]
+    fn review_remote_name_collision_gets_suffix() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        git_at_dir(tmp.path()).args(["init"]).run();
+        git_at_dir(tmp.path())
+            .args([
+                "remote",
+                "add",
+                "alice",
+                "https://github.com/elsewhere/widgets.git",
+            ])
+            .run();
+        let repo = open_repo(tmp.path())?;
+
+        assert_eq!(
+            unique_remote_name(&repo, "alice")?,
+            "alice-2",
+            "new fork remotes should not overwrite an existing remote"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn review_remote_reuses_matching_remote_by_exact_url() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        git_at_dir(tmp.path()).args(["init"]).run();
+        git_at_dir(tmp.path())
+            .args(["remote", "add", "alice", "/tmp/alice/widgets.git"])
+            .run();
+        let repo = open_repo(tmp.path())?;
+
+        assert_eq!(
+            find_remote_by_url(&repo, "/tmp/alice/widgets.git")?,
+            Some("alice".to_string()),
+            "existing exact-url fork remotes should be reused"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn review_remote_reuses_matching_remote_by_forge_identity() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        git_at_dir(tmp.path()).args(["init"]).run();
+        git_at_dir(tmp.path())
+            .args(["remote", "add", "alice", "git@github.com:alice/widgets.git"])
+            .run();
+        let repo = open_repo(tmp.path())?;
+
+        assert_eq!(
+            find_remote_by_url(&repo, "https://github.com/alice/widgets.git")?,
+            Some("alice".to_string()),
+            "matching GitHub remotes should be reused across SSH/HTTPS URL forms"
+        );
+        Ok(())
     }
 }
 

--- a/crates/but-api/tests/api/branch_apply.rs
+++ b/crates/but-api/tests/api/branch_apply.rs
@@ -1,0 +1,35 @@
+#[test]
+fn apply_only_threads_returned_workspace_back_into_context_cache() -> anyhow::Result<()> {
+    let (repo, _tmp) = crate::support::writable_scenario("checkout-head-info");
+    crate::support::persist_default_target(&repo)?;
+
+    let mut ctx = but_ctx::Context::from_repo(repo)?.with_memory_app_cache();
+    let feature = gix::refs::FullName::try_from("refs/heads/feature")?;
+    let sibling = gix::refs::FullName::try_from("refs/heads/sibling")?;
+
+    let first = but_api::branch::apply_only(&mut ctx, feature.as_ref())?;
+    assert!(
+        first.applied_branches.contains(&feature),
+        "first apply should persist the requested feature branch: {:?}",
+        first.applied_branches
+    );
+
+    let second = but_api::branch::apply_only(&mut ctx, sibling.as_ref())?;
+    assert!(
+        second.applied_branches.contains(&sibling),
+        "second apply should use the cached workspace updated by the first apply: {:?}",
+        second.applied_branches
+    );
+
+    let workspace = crate::support::workspace_graph(&ctx)?;
+    assert!(
+        workspace.contains("feature"),
+        "cached workspace should still contain the first applied branch after the second apply:\n{workspace}"
+    );
+    assert!(
+        workspace.contains("sibling"),
+        "cached workspace should contain the second applied branch:\n{workspace}"
+    );
+
+    Ok(())
+}

--- a/crates/but-api/tests/api/main.rs
+++ b/crates/but-api/tests/api/main.rs
@@ -1,2 +1,3 @@
+mod branch_apply;
 mod branch_checkout;
 mod support;

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -545,6 +545,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
         )
         .route("/branch_diff", but_post(but_api::branch::branch_diff_cmd))
         .route("/move_branch", but_post(but_api::branch::move_branch_cmd))
+        .route("/apply", but_post(but_api::branch::apply_cmd))
         .route(
             "/get_initial_branch_integration",
             but_post(but_api::branch::get_initial_branch_integration_cmd),

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -546,6 +546,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
         .route("/branch_diff", but_post(but_api::branch::branch_diff_cmd))
         .route("/move_branch", but_post(but_api::branch::move_branch_cmd))
         .route("/apply", but_post(but_api::branch::apply_cmd))
+        .route("/review_apply", but_post(legacy::forge::review_apply_cmd))
         .route(
             "/get_initial_branch_integration",
             but_post(but_api::branch::get_initial_branch_integration_cmd),

--- a/crates/but-workspace/src/branch/apply.rs
+++ b/crates/but-workspace/src/branch/apply.rs
@@ -381,10 +381,12 @@ pub fn apply(
             )
         }
     };
-    let current_head_name = repo.head_name()?.map(|rn| rn.to_owned());
-    let switch_head_to_workspace_ref = current_head_name
+    // Whether HEAD already points at the workspace ref, or sits directly on a branch. When it's on a
+    // branch we move HEAD onto the workspace ref and rebuild the workspace around the branches we keep.
+    let head_ref_name = repo.head_name()?.map(|rn| rn.to_owned());
+    let head_on_workspace_ref = head_ref_name
         .as_ref()
-        .is_none_or(|head_name| head_name.as_bstr() != workspace_ref_name_to_update.as_bstr());
+        .is_some_and(|head| head.as_bstr() == workspace_ref_name_to_update.as_bstr());
 
     // First, see if the branches to apply would naturally emerge if they had metadata.
     let (ws_ref_id, ws_ref_exists) = match repo
@@ -405,23 +407,23 @@ pub fn apply(
 
     let mut ws_md = meta.workspace(workspace_ref_name_to_update.as_ref())?;
     let ws_md_orig = ws_md.clone();
-    let checked_out_applied_branch = current_head_name
-        .as_ref()
-        .filter(|head_name| head_name.as_bstr() != workspace_ref_name_to_update.as_bstr())
-        .filter(|head_name| {
-            ws_md
-                .find_branch(head_name.as_ref(), StackKind::Applied)
-                .is_some()
-        })
-        .cloned();
-    let recreate_workspace_around_selected_branches = checked_out_applied_branch.is_some();
+    // When HEAD is on a branch that's already in the workspace, applying another branch re-roots
+    // the workspace around just that branch plus the ones we apply.
+    let head_branch_in_workspace = head_ref_name.as_ref().is_some_and(|head| {
+        ws_md
+            .find_branch(head.as_ref(), StackKind::Applied)
+            .is_some()
+    });
     {
         let ws_mut: &mut Workspace = &mut ws_md;
-        // After switching out of a workspace the metadata can be stale: old stacks are still marked
-        // in-workspace though they're gone from the projection. Demote them, except stacks still
-        // visible in the projection. If HEAD is an already-applied branch rather than the workspace
-        // ref, rebuild the workspace around HEAD and the newly applied branches.
-        let visible_ref_names = matches!(ws.kind, WorkspaceKind::AdHoc).then(|| {
+        // Demote previously-applied stacks before re-applying, in two situations:
+        //  - stale AdHoc metadata left after switching out of the workspace: the stack no longer
+        //    appears in the projection, and
+        //  - re-rooting around a branch we have checked out that's already in the workspace: keep
+        //    only that branch and the branch being applied.
+        // Ref names the projection (`ws`) contains, in AdHoc mode only; `None` in a managed
+        // workspace, where the metadata is authoritative so projection absence doesn't demote.
+        let projected_refs = matches!(ws.kind, WorkspaceKind::AdHoc).then(|| {
             ws.stacks
                 .iter()
                 .flat_map(|s| s.segments.iter())
@@ -429,24 +431,21 @@ pub fn apply(
                 .collect::<std::collections::HashSet<_>>()
         });
         for stack in &mut ws_mut.stacks {
-            let is_stale_ad_hoc_stack =
-                visible_ref_names.as_ref().is_some_and(|visible_ref_names| {
-                    !stack
-                        .branches
-                        .iter()
-                        .any(|b| visible_ref_names.contains(b.ref_name.as_ref().as_bstr()))
-                });
-            let is_selected_branch = stack.branches.iter().any(|b| {
-                checked_out_applied_branch
-                    .as_ref()
-                    .is_some_and(|head_ref| b.ref_name.as_ref() == head_ref.as_ref())
-                    || branches_to_apply
-                        .iter()
-                        .any(|rn| b.ref_name.as_ref() == rn.as_ref())
+            let dropped_from_projection = projected_refs.as_ref().is_some_and(|projected| {
+                !stack
+                    .branches
+                    .iter()
+                    .any(|b| projected.contains(b.ref_name.as_ref().as_bstr()))
             });
-            if is_stale_ad_hoc_stack
-                || (recreate_workspace_around_selected_branches && !is_selected_branch)
-            {
+            let stack_is_kept = stack.branches.iter().any(|b| {
+                branches_to_apply
+                    .iter()
+                    .any(|rn| rn.as_ref() == b.ref_name.as_ref())
+                    || head_ref_name
+                        .as_ref()
+                        .is_some_and(|head| head.as_ref() == b.ref_name.as_ref())
+            });
+            if dropped_from_projection || (head_branch_in_workspace && !stack_is_kept) {
                 stack.workspacecommit_relation = Outside;
             }
         }
@@ -542,8 +541,9 @@ pub fn apply(
         set_head_to_reference(
             repo,
             new_head_id,
-            (switch_head_to_workspace_ref || !ws_ref_exists)
-                .then_some(workspace_ref_name_to_update.as_ref()),
+            // Point HEAD at the workspace ref whenever it isn't already there (covers creating the
+            // ref and switching off a directly-checked-out branch).
+            (!head_on_workspace_ref).then_some(workspace_ref_name_to_update.as_ref()),
         )?;
         return Ok(Outcome {
             workspace: graph.into_workspace()?,
@@ -770,8 +770,9 @@ pub fn apply(
     set_head_to_reference(
         repo,
         new_head_id,
-        (switch_head_to_workspace_ref || !ws_ref_exists)
-            .then_some(workspace_ref_name_to_update.as_ref()),
+        // Point HEAD at the workspace ref whenever it isn't already there (covers creating the ref
+        // and switching off a directly-checked-out branch).
+        (!head_on_workspace_ref).then_some(workspace_ref_name_to_update.as_ref()),
     )?;
     Ok(Outcome {
         workspace: ws,

--- a/crates/but-workspace/src/branch/apply.rs
+++ b/crates/but-workspace/src/branch/apply.rs
@@ -381,6 +381,10 @@ pub fn apply(
             )
         }
     };
+    let current_head_name = repo.head_name()?.map(|rn| rn.to_owned());
+    let switch_head_to_workspace_ref = current_head_name
+        .as_ref()
+        .is_none_or(|head_name| head_name.as_bstr() != workspace_ref_name_to_update.as_bstr());
 
     // First, see if the branches to apply would naturally emerge if they had metadata.
     let (ws_ref_id, ws_ref_exists) = match repo
@@ -401,26 +405,49 @@ pub fn apply(
 
     let mut ws_md = meta.workspace(workspace_ref_name_to_update.as_ref())?;
     let ws_md_orig = ws_md.clone();
+    let checked_out_applied_branch = current_head_name
+        .as_ref()
+        .filter(|head_name| head_name.as_bstr() != workspace_ref_name_to_update.as_bstr())
+        .filter(|head_name| {
+            ws_md
+                .find_branch(head_name.as_ref(), StackKind::Applied)
+                .is_some()
+        })
+        .cloned();
+    let recreate_workspace_around_selected_branches = checked_out_applied_branch.is_some();
     {
         let ws_mut: &mut Workspace = &mut ws_md;
         // After switching out of a workspace the metadata can be stale: old stacks are still marked
         // in-workspace though they're gone from the projection. Demote them, except stacks still
-        // visible in the projection (genuinely enclosed adhoc checkouts).
-        if matches!(ws.kind, WorkspaceKind::AdHoc) {
-            let visible_ref_names: std::collections::HashSet<&gix::bstr::BStr> = ws
-                .stacks
+        // visible in the projection. If HEAD is an already-applied branch rather than the workspace
+        // ref, rebuild the workspace around HEAD and the newly applied branches.
+        let visible_ref_names = matches!(ws.kind, WorkspaceKind::AdHoc).then(|| {
+            ws.stacks
                 .iter()
                 .flat_map(|s| s.segments.iter())
                 .filter_map(|seg| seg.ref_name().map(|rn| rn.as_bstr()))
-                .collect();
-            for stack in &mut ws_mut.stacks {
-                let visible = stack
-                    .branches
-                    .iter()
-                    .any(|b| visible_ref_names.contains(b.ref_name.as_ref().as_bstr()));
-                if !visible {
-                    stack.workspacecommit_relation = Outside;
-                }
+                .collect::<std::collections::HashSet<_>>()
+        });
+        for stack in &mut ws_mut.stacks {
+            let is_stale_ad_hoc_stack =
+                visible_ref_names.as_ref().is_some_and(|visible_ref_names| {
+                    !stack
+                        .branches
+                        .iter()
+                        .any(|b| visible_ref_names.contains(b.ref_name.as_ref().as_bstr()))
+                });
+            let is_selected_branch = stack.branches.iter().any(|b| {
+                checked_out_applied_branch
+                    .as_ref()
+                    .is_some_and(|head_ref| b.ref_name.as_ref() == head_ref.as_ref())
+                    || branches_to_apply
+                        .iter()
+                        .any(|rn| b.ref_name.as_ref() == rn.as_ref())
+            });
+            if is_stale_ad_hoc_stack
+                || (recreate_workspace_around_selected_branches && !is_selected_branch)
+            {
+                stack.workspacecommit_relation = Outside;
             }
         }
         for rn in &branches_to_apply {
@@ -515,7 +542,8 @@ pub fn apply(
         set_head_to_reference(
             repo,
             new_head_id,
-            (!ws_ref_exists).then_some(workspace_ref_name_to_update.as_ref()),
+            (switch_head_to_workspace_ref || !ws_ref_exists)
+                .then_some(workspace_ref_name_to_update.as_ref()),
         )?;
         return Ok(Outcome {
             workspace: graph.into_workspace()?,
@@ -570,12 +598,10 @@ pub fn apply(
         });
     }
 
-    let prev_head_id = ws
-        .graph
-        .entrypoint()?
-        .commit()
-        .context("BUG: unborn was skipped, why no entrypoint")?
-        .id;
+    let prev_head_id = repo
+        .head_id()
+        .context("BUG: we assume HEAD is born here")?
+        .detach();
     let mut new_head_id = merge_result.workspace_commit_id;
     let mut conflicting_stacks =
         correlate_conflicting_stacks(&ws_md, &merge_result.conflicting_stacks);
@@ -744,7 +770,8 @@ pub fn apply(
     set_head_to_reference(
         repo,
         new_head_id,
-        (!ws_ref_exists).then_some(workspace_ref_name_to_update.as_ref()),
+        (switch_head_to_workspace_ref || !ws_ref_exists)
+            .then_some(workspace_ref_name_to_update.as_ref()),
     )?;
     Ok(Outcome {
         workspace: ws,
@@ -1088,7 +1115,7 @@ fn set_head_to_reference(
                             force_create_reflog: false,
                             message: "created by GitButler during apply-branch".into(),
                         },
-                        expected: PreviousValue::MustNotExist,
+                        expected: PreviousValue::Any,
                         new: Target::Object(new_ref_target),
                     },
                     name: new_ref.to_owned(),

--- a/crates/but-workspace/tests/fixtures/scenario/ws-ref-ws-commit-two-file-stacks.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/ws-ref-ws-commit-two-file-stacks.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A ws-ref points to a workspace commit with two independent file-backed stacks.
+git init
+
+echo base >base
+git add base
+git commit -m M
+setup_target_to_match_main
+
+git branch B
+git checkout -b A
+  echo A >A
+  git add A
+  git commit -m A
+git checkout B
+  echo B >B
+  git add B
+  git commit -m B
+create_workspace_commit_once A B

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
@@ -13,6 +13,7 @@ use but_core::{
 use but_graph::{
     Graph,
     init::{Options, Overlay, Tip},
+    workspace::WorkspaceKind,
 };
 use but_testsupport::{
     CommandExt, InMemoryRefMetadata, git, graph_workspace, graph_workspace_determinisitcally,
@@ -35,6 +36,25 @@ fn project_meta(meta: &impl RefMetadata) -> ref_metadata::ProjectMeta {
     )
     .map(|workspace| workspace.project_meta())
     .unwrap_or_default()
+}
+
+fn assert_worktree_files(repo: &gix::Repository, present: &[&str], absent: &[&str]) {
+    for path in present {
+        let path = repo.workdir_path(path).expect("non-bare");
+        assert!(
+            path.exists(),
+            "{} should exist in the worktree",
+            path.display()
+        );
+    }
+    for path in absent {
+        let path = repo.workdir_path(path).expect("non-bare");
+        assert!(
+            !path.exists(),
+            "{} should not exist in the worktree",
+            path.display()
+        );
+    }
 }
 
 #[test]
@@ -1522,6 +1542,280 @@ fn apply_after_switching_out_of_workspace_drops_stale_stacks() -> anyhow::Result
         in_workspace("applied"),
         Some(true),
         "the newly applied branch is in the new workspace"
+    );
+    Ok(())
+}
+
+#[test]
+fn apply_from_enclosed_adhoc_workspace_rebuilds_around_current_and_applied() -> anyhow::Result<()> {
+    // A managed workspace has two live stacks, then HEAD is moved to one of its branches. Applying
+    // a third branch from that enclosed AdHoc checkout rebuilds the workspace around the checked-out
+    // branch and the newly applied branch.
+    let (_tmp, _graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-ws-commit-two-file-stacks",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "B", StackState::InWorkspace, &[]);
+            },
+        )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "initial workspace has A and B applied", @r"
+    *   4fce3a1 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * ccf539c (A) A
+    * | 53c254d (B) B
+    |/  
+    * 893d602 (origin/main, main) M
+    ");
+    assert_worktree_files(&repo, &["A", "B"], &["C"]);
+    insta::assert_snapshot!(
+        visualize_disk_tree_with_hashes_skip_dot_git(repo.workdir().expect("worktree dir"))?,
+        "workspace checkout contains A and B files",
+        @"
+    .
+    ├── .git:40755
+    ├── A:100644:f70f10e4db19068f79bc43844b49f3eece45c4e8
+    ├── B:100644:223b7836fb19fdf64ba2d3cd6173c6a283141f78
+    └── base:100644:df967b96a579e45a18b8251732d16804b2e56a55
+    "
+    );
+
+    git(&repo).args(["checkout", "-b", "C", "main"]).run();
+    std::fs::write(repo.workdir_path("C").expect("non-bare"), "C\n")?;
+    git(&repo).args(["add", "C"]).run();
+    git(&repo).args(["commit", "-m", "add C"]).run();
+    git(&repo).args(["checkout", "B"]).run();
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "direct checkout of B leaves C outside the workspace", @r"
+    * 863775d (C) add C
+    | *   4fce3a1 (gitbutler/workspace) GitButler Workspace Commit
+    | |\  
+    | | * ccf539c (A) A
+    | |/  
+    |/|   
+    | * 53c254d (HEAD -> B) B
+    |/  
+    * 893d602 (origin/main, main) M
+    ");
+    assert_worktree_files(&repo, &["B"], &["A", "C"]);
+    insta::assert_snapshot!(
+        visualize_disk_tree_with_hashes_skip_dot_git(repo.workdir().expect("worktree dir"))?,
+        "direct checkout of B contains only B's file",
+        @"
+    .
+    ├── .git:40755
+    ├── B:100644:223b7836fb19fdf64ba2d3cd6173c6a283141f78
+    └── base:100644:df967b96a579e45a18b8251732d16804b2e56a55
+    "
+    );
+
+    let ws = Graph::from_head(
+        &repo,
+        &meta,
+        project_meta(&meta),
+        standard_traversal_options(),
+    )?
+    .into_workspace()?;
+    assert!(
+        matches!(ws.kind, WorkspaceKind::Managed { .. }),
+        "direct checkout of B can still project as a managed workspace"
+    );
+    insta::assert_snapshot!(graph_workspace(&ws), "direct checkout of B is still enclosed by the existing workspace", @"
+    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on 893d602
+    ├── ≡📙:4:A on 893d602 {1}
+    │   └── 📙:4:A
+    │       └── ·ccf539c (🏘️)
+    └── ≡👉📙:0:B[🌳] on 893d602 {2}
+        └── 👉📙:0:B[🌳]
+            └── ·53c254d (🏘️)
+    ");
+
+    let out =
+        but_workspace::branch::apply(r("refs/heads/C"), ws, &repo, &mut meta, apply_options())?;
+    assert_eq!(out.status, OutcomeStatus::Applied);
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "applying C rebuilds the workspace around B and C", @r"
+    * ccf539c (A) A
+    | *   7ed2c6c (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    | |\  
+    | | * 863775d (C) add C
+    | |/  
+    |/|   
+    | * 53c254d (B) B
+    |/  
+    * 893d602 (origin/main, main) M
+    ");
+    assert_worktree_files(&repo, &["B", "C"], &["A"]);
+    insta::assert_snapshot!(
+        visualize_disk_tree_with_hashes_skip_dot_git(repo.workdir().expect("worktree dir"))?,
+        "workspace checkout contains B and C files after apply",
+        @"
+    .
+    ├── .git:40755
+    ├── B:100644:223b7836fb19fdf64ba2d3cd6173c6a283141f78
+    ├── C:100644:3cc58df83752123644fef39faab2393af643b1d2
+    └── base:100644:df967b96a579e45a18b8251732d16804b2e56a55
+    "
+    );
+    assert_eq!(
+        repo.head_name()?.as_ref().map(|rn| rn.as_bstr()),
+        Some(r("refs/heads/gitbutler/workspace").as_bstr()),
+        "applying from an ad-hoc checkout should switch back to the managed workspace"
+    );
+
+    let ws_md = meta.workspace(WORKSPACE_REF_NAME.try_into().unwrap())?;
+    let in_workspace = |name: &str| {
+        ws_md
+            .stacks
+            .iter()
+            .find(|s| s.name().is_some_and(|n| n.shorten() == name))
+            .map(|s| s.is_in_workspace())
+    };
+    assert_eq!(
+        in_workspace("A"),
+        Some(false),
+        "previously visible stack A should be left behind"
+    );
+    assert_eq!(
+        in_workspace("B"),
+        Some(true),
+        "checked-out enclosed stack B should stay in the workspace"
+    );
+    assert_eq!(
+        in_workspace("C"),
+        Some(true),
+        "the newly applied branch joins the workspace"
+    );
+    Ok(())
+}
+
+#[test]
+fn apply_from_adhoc_checkout_rebuilds_around_current_and_applied() -> anyhow::Result<()> {
+    // A managed workspace has two live stacks, then HEAD is moved to a third branch. Applying one
+    // of the previously applied branches rebuilds the workspace around the checked-out branch and
+    // the branch being applied.
+    let (_tmp, _graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-ws-commit-two-file-stacks",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "B", StackState::InWorkspace, &[]);
+            },
+        )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "initial workspace has A and B applied", @r"
+    *   4fce3a1 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * ccf539c (A) A
+    * | 53c254d (B) B
+    |/  
+    * 893d602 (origin/main, main) M
+    ");
+    assert_worktree_files(&repo, &["A", "B"], &["C"]);
+    insta::assert_snapshot!(
+        visualize_disk_tree_with_hashes_skip_dot_git(repo.workdir().expect("worktree dir"))?,
+        "workspace checkout contains A and B files",
+        @"
+    .
+    ├── .git:40755
+    ├── A:100644:f70f10e4db19068f79bc43844b49f3eece45c4e8
+    ├── B:100644:223b7836fb19fdf64ba2d3cd6173c6a283141f78
+    └── base:100644:df967b96a579e45a18b8251732d16804b2e56a55
+    "
+    );
+
+    git(&repo).args(["checkout", "-b", "C", "main"]).run();
+    std::fs::write(repo.workdir_path("C").expect("non-bare"), "C\n")?;
+    git(&repo).args(["add", "C"]).run();
+    git(&repo).args(["commit", "-m", "add C"]).run();
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "direct checkout of C leaves A and B in the old workspace", @r"
+    * 863775d (HEAD -> C) add C
+    | *   4fce3a1 (gitbutler/workspace) GitButler Workspace Commit
+    | |\  
+    | | * ccf539c (A) A
+    | |/  
+    |/|   
+    | * 53c254d (B) B
+    |/  
+    * 893d602 (origin/main, main) M
+    ");
+    assert_worktree_files(&repo, &["C"], &["A", "B"]);
+    insta::assert_snapshot!(
+        visualize_disk_tree_with_hashes_skip_dot_git(repo.workdir().expect("worktree dir"))?,
+        "direct checkout of C contains only C's file",
+        @"
+    .
+    ├── .git:40755
+    ├── C:100644:3cc58df83752123644fef39faab2393af643b1d2
+    └── base:100644:df967b96a579e45a18b8251732d16804b2e56a55
+    "
+    );
+
+    let ws = Graph::from_head(
+        &repo,
+        &meta,
+        project_meta(&meta),
+        standard_traversal_options(),
+    )?
+    .into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), "direct checkout of C is an ad-hoc workspace next to the existing managed workspace", @"
+    ⌂:0:C[🌳] <> ✓refs/remotes/origin/main on 893d602
+    └── ≡:0:C[🌳] on 893d602 {1}
+        └── :0:C[🌳]
+            └── ·863775d
+    ");
+
+    let out =
+        but_workspace::branch::apply(r("refs/heads/A"), ws, &repo, &mut meta, apply_options())?;
+    assert_eq!(out.status, OutcomeStatus::Applied);
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "applying A rebuilds the workspace around C and A", @r"
+    * 53c254d (B) B
+    | *   dbb9910 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    | |\  
+    | | * 863775d (C) add C
+    | |/  
+    |/|   
+    | * ccf539c (A) A
+    |/  
+    * 893d602 (origin/main, main) M
+    ");
+    assert_worktree_files(&repo, &["A", "C"], &["B"]);
+    insta::assert_snapshot!(
+        visualize_disk_tree_with_hashes_skip_dot_git(repo.workdir().expect("worktree dir"))?,
+        "workspace checkout contains C and A files after apply",
+        @"
+    .
+    ├── .git:40755
+    ├── A:100644:f70f10e4db19068f79bc43844b49f3eece45c4e8
+    ├── C:100644:3cc58df83752123644fef39faab2393af643b1d2
+    └── base:100644:df967b96a579e45a18b8251732d16804b2e56a55
+    "
+    );
+    assert_eq!(
+        repo.head_name()?.as_ref().map(|rn| rn.as_bstr()),
+        Some(r("refs/heads/gitbutler/workspace").as_bstr()),
+        "applying from an ad-hoc checkout should switch back to the managed workspace"
+    );
+
+    let ws_md = meta.workspace(WORKSPACE_REF_NAME.try_into().unwrap())?;
+    let in_workspace = |name: &str| {
+        ws_md
+            .stacks
+            .iter()
+            .find(|s| s.name().is_some_and(|n| n.shorten() == name))
+            .map(|s| s.is_in_workspace())
+    };
+    assert_eq!(
+        in_workspace("A"),
+        Some(true),
+        "the newly applied branch joins the workspace"
+    );
+    assert_eq!(
+        in_workspace("B"),
+        Some(false),
+        "previously visible stack B should be left behind"
+    );
+    assert_eq!(
+        in_workspace("C"),
+        Some(true),
+        "the checked-out branch joins the workspace"
     );
     Ok(())
 }

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -357,6 +357,7 @@ fn main() -> anyhow::Result<()> {
                 legacy::virtual_branches::tauri_upstream_integration_statuses::upstream_integration_statuses,
                 legacy::virtual_branches::tauri_integrate_upstream::integrate_upstream,
                 legacy::virtual_branches::tauri_resolve_upstream_integration::resolve_upstream_integration,
+                branch::tauri_apply::apply,
                 branch::tauri_get_initial_branch_integration::get_initial_branch_integration,
                 branch::tauri_apply_branch_integration::apply_branch_integration,
                 legacy::stack::tauri_create_reference::create_reference,

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -397,6 +397,7 @@ fn main() -> anyhow::Result<()> {
                 legacy::forge::tauri_forge_info::forge_info,
                 legacy::forge::tauri_forge_compare_branch_url::forge_compare_branch_url,
                 legacy::forge::tauri_list_reviews::list_reviews,
+                legacy::forge::tauri_review_apply::review_apply,
                 legacy::forge::tauri_get_review::get_review,
                 legacy::forge::tauri_get_review_merge_status::get_review_merge_status,
                 legacy::forge::tauri_get_review_base_repo_url::get_review_base_repo_url,

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -163,6 +163,7 @@ describe("Your Feature", () => {
 - **Playwright**: Test scripts are in `playwright/scripts/` - these are bash scripts that set up git repositories
 - **Blackbox**: Setup scripts in `blackbox/scripts/` prepare test repositories
 - **Fixtures**: Shared fixtures can be placed in `playwright/fixtures/`
+- **Review apply fixture**: See [review-apply-fixture.md](review-apply-fixture.md) for the fake GitHub setup used by PR apply tests.
 
 ### Best Practices
 

--- a/e2e/playwright/scripts/project-in-single-branch-apply-transition.sh
+++ b/e2e/playwright/scripts/project-in-single-branch-apply-transition.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "GIT CONFIG $GIT_CONFIG_GLOBAL"
+echo "DATA DIR $E2E_TEST_APP_DATA_DIR"
+echo "BUT $BUT"
+
+# Start with a remote-backed project because GitButler setup expects one in e2e.
+mkdir remote-project
+pushd remote-project
+git init -b master --object-format=sha1
+echo "base" > base.txt
+git add base.txt
+git commit -m "base: initial commit"
+
+git checkout -b stale-workspace-branch
+echo "stale workspace branch" > stale_workspace_branch.txt
+git add stale_workspace_branch.txt
+git commit -m "stale-workspace-branch: first commit"
+
+git checkout master
+git checkout -b single-branch-fixture
+echo "single branch" > single_branch_file.txt
+git add single_branch_file.txt
+git commit -m "single-branch: first commit"
+
+git checkout master
+git checkout -b branch-to-apply
+echo "branch to apply" > branch_to_apply.txt
+git add branch_to_apply.txt
+git commit -m "branch-to-apply: first commit"
+
+git checkout master
+popd
+
+git clone remote-project local-clone
+pushd local-clone
+git checkout master
+target_branch="$(git rev-parse --symbolic-full-name @{u})"
+target_branch="${target_branch#refs/remotes/}"
+"$BUT" setup
+"$BUT" config target "$target_branch"
+
+# Create a managed workspace whose metadata will become stale after the direct checkout below.
+"$BUT" apply stale-workspace-branch
+
+git checkout -b single-branch-fixture origin/single-branch-fixture
+popd

--- a/e2e/playwright/scripts/project-in-single-branch-enclosed-apply.sh
+++ b/e2e/playwright/scripts/project-in-single-branch-enclosed-apply.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "GIT CONFIG $GIT_CONFIG_GLOBAL"
+echo "DATA DIR $E2E_TEST_APP_DATA_DIR"
+echo "BUT $BUT"
+
+# Start with a remote-backed project because GitButler setup expects one in e2e.
+mkdir remote-project
+pushd remote-project
+git init -b master --object-format=sha1
+echo "base" > base.txt
+git add base.txt
+git commit -m "base: initial commit"
+
+git checkout -b A
+echo "A" > A.txt
+git add A.txt
+git commit -m "A: first commit"
+
+git checkout master
+git checkout -b B
+echo "B" > B.txt
+git add B.txt
+git commit -m "B: first commit"
+
+git checkout master
+git checkout -b C
+echo "C" > C.txt
+git add C.txt
+git commit -m "C: first commit"
+
+git checkout master
+popd
+
+git clone remote-project local-clone
+pushd local-clone
+git checkout master
+target_branch="$(git rev-parse --symbolic-full-name @{u})"
+target_branch="${target_branch#refs/remotes/}"
+"$BUT" setup
+"$BUT" config target "$target_branch"
+
+git branch --track A origin/A
+git branch --track B origin/B
+git branch --track C origin/C
+
+"$BUT" apply A
+"$BUT" apply B
+test "$(git branch --show-current)" = "gitbutler/workspace"
+
+# Enter single-branch/ad-hoc mode from a branch already enclosed by the workspace.
+git checkout B
+popd

--- a/e2e/playwright/scripts/project-with-github-fork-pr.sh
+++ b/e2e/playwright/scripts/project-with-github-fork-pr.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -euo pipefail
+
+FORGE_REMOTE_URL="${1:?forge remote URL is required}"
+
+echo "GIT CONFIG $GIT_CONFIG_GLOBAL"
+echo "DATA DIR $E2E_TEST_APP_DATA_DIR"
+echo "BUT $BUT"
+
+mkdir remote-project
+pushd remote-project
+git init -b master --object-format=sha1
+echo "base" > base.txt
+git add base.txt
+git commit -m "base commit"
+
+git checkout -b base-pr-feature
+echo "base pr content" > base-pr.txt
+git add base-pr.txt
+git commit -m "base-pr: add pr content"
+
+git checkout master
+git checkout -b single-branch-fixture
+echo "single branch content" > single-branch.txt
+git add single-branch.txt
+git commit -m "single-branch: add content"
+
+git checkout master
+popd
+
+git clone remote-project fork-project
+pushd fork-project
+git checkout -b fork-feature
+echo "fork pr content" > fork-pr.txt
+git add fork-pr.txt
+git commit -m "fork: add pr content"
+popd
+
+git clone --bare fork-project fork-project-bare
+
+git clone remote-project local-clone
+pushd local-clone
+git checkout master
+target_branch="$(git rev-parse --symbolic-full-name @{u})"
+target_branch="${target_branch#refs/remotes/}"
+"$BUT" setup
+"$BUT" config target "$target_branch"
+git remote set-url origin "$FORGE_REMOTE_URL"
+popd

--- a/e2e/playwright/src/branch.ts
+++ b/e2e/playwright/src/branch.ts
@@ -58,6 +58,15 @@ export async function assertBranch(branchName: string, pathToRepo: string): Prom
 		.toBe(branchName);
 }
 
+export async function assertSymbolicHead(refName: string, pathToRepo: string): Promise<void> {
+	await expect
+		.poll(() => git(pathToRepo, ["symbolic-ref", "--short", "HEAD"]), {
+			message: `Expected HEAD to point to "${refName}"`,
+			intervals: [100, 200, 500, 1000],
+		})
+		.toBe(refName);
+}
+
 export async function assertCommitSubjects(
 	expectedSubjects: string[],
 	pathToRepo: string,

--- a/e2e/playwright/src/fakeGithub.ts
+++ b/e2e/playwright/src/fakeGithub.ts
@@ -1,0 +1,179 @@
+import http, { type IncomingMessage, type ServerResponse } from "node:http";
+
+type FakeGitHubOptions = {
+	headRepoPath?: string;
+	forkRepoPath?: string;
+	sourceBranch?: string;
+	owner?: string;
+	repo?: string;
+	repoOwner?: string;
+	reviewNumber?: number;
+	title?: string;
+	isFork?: boolean;
+};
+
+type ResolvedFakeGitHubOptions = {
+	headRepoPath: string;
+	sourceBranch: string;
+	owner: string;
+	repo: string;
+	repoOwner: string;
+	reviewNumber: number;
+	title: string;
+	isFork: boolean;
+};
+
+export type FakeGitHubServer = {
+	apiBaseUrl: string;
+	repositoryUrl: string;
+	close: () => Promise<void>;
+};
+
+export async function startFakeGitHubServer({
+	headRepoPath,
+	forkRepoPath,
+	sourceBranch = "fork-feature",
+	owner = "acme",
+	repo = "widgets",
+	repoOwner = "Contributor User",
+	reviewNumber = 42,
+	title = "Fork PR",
+	isFork = true,
+}: FakeGitHubOptions): Promise<FakeGitHubServer> {
+	const reviewRepoPath = headRepoPath ?? forkRepoPath;
+	if (!reviewRepoPath) {
+		throw new Error("Fake GitHub review needs a headRepoPath or forkRepoPath");
+	}
+
+	const server = http.createServer((request, response) => {
+		handleRequest(request, response, {
+			headRepoPath: reviewRepoPath,
+			sourceBranch,
+			owner,
+			repo,
+			repoOwner,
+			reviewNumber,
+			title,
+			isFork,
+		});
+	});
+
+	await new Promise<void>((resolve) => {
+		server.listen(0, "127.0.0.1", resolve);
+	});
+
+	const address = server.address();
+	if (!address || typeof address === "string") {
+		throw new Error("Fake GitHub server did not bind to a TCP port");
+	}
+
+	const root = `http://127.0.0.1:${address.port}`;
+	return {
+		apiBaseUrl: `${root}/api/v3`,
+		repositoryUrl: `${root}/${owner}/${repo}.git`,
+		close: async () =>
+			await new Promise<void>((resolve, reject) => {
+				server.close((error) => (error ? reject(error) : resolve()));
+			}),
+	};
+}
+
+function handleRequest(
+	request: IncomingMessage,
+	response: ServerResponse,
+	options: ResolvedFakeGitHubOptions,
+) {
+	const url = new URL(request.url ?? "/", "http://127.0.0.1");
+	const pullPath = `/api/v3/repos/${options.owner}/${options.repo}/pulls`;
+	const review = pullRequestPayload(options);
+
+	if (request.method === "GET" && url.pathname === "/api/v3/user") {
+		return json(response, {
+			id: 1,
+			login: "e2e-user",
+			name: "E2E User",
+			email: null,
+			avatar_url: null,
+			type: "User",
+		});
+	}
+
+	if (request.method === "GET" && url.pathname === pullPath) {
+		return json(response, [review]);
+	}
+
+	if (request.method === "GET" && url.pathname === `${pullPath}/${options.reviewNumber}`) {
+		return json(response, review);
+	}
+
+	response.writeHead(404, { "Content-Type": "application/json" });
+	response.end(
+		JSON.stringify({ message: `No fake GitHub route for ${request.method} ${url.pathname}` }),
+	);
+}
+
+function pullRequestPayload({
+	headRepoPath,
+	sourceBranch,
+	owner,
+	repo,
+	repoOwner,
+	reviewNumber,
+	title,
+	isFork,
+}: ResolvedFakeGitHubOptions) {
+	return {
+		html_url: `http://127.0.0.1/${owner}/${repo}/pull/${reviewNumber}`,
+		number: reviewNumber,
+		title,
+		body: null,
+		user: null,
+		labels: [],
+		draft: false,
+		merge_commit_sha: null,
+		head: {
+			ref: sourceBranch,
+			sha: "0000000000000000000000000000000000000000",
+			repo: {
+				ssh_url: headRepoPath,
+				clone_url: headRepoPath,
+				owner: {
+					id: 2,
+					login: repoOwner,
+					name: repoOwner,
+					email: null,
+					avatar_url: null,
+					type: "User",
+				},
+				fork: isFork,
+			},
+		},
+		base: {
+			ref: "master",
+			sha: "0000000000000000000000000000000000000000",
+			repo: {
+				ssh_url: `git@example.com:${owner}/${repo}.git`,
+				clone_url: `https://example.com/${owner}/${repo}.git`,
+				owner: {
+					id: 3,
+					login: owner,
+					name: owner,
+					email: null,
+					avatar_url: null,
+					type: "Organization",
+				},
+				fork: false,
+			},
+		},
+		created_at: "2026-06-01T00:00:00Z",
+		updated_at: "2026-06-01T00:00:00Z",
+		merged_at: null,
+		closed_at: null,
+		requested_reviewers: [],
+	};
+}
+
+function json(response: ServerResponse, subject: unknown) {
+	response.writeHead(200, { "Content-Type": "application/json" });
+	response.end(JSON.stringify(subject));
+}

--- a/e2e/playwright/src/setup.ts
+++ b/e2e/playwright/src/setup.ts
@@ -4,7 +4,7 @@ import { serverLogSink } from "./serverLog.ts";
 import { waitForTestId } from "./util.ts";
 import { type BrowserContext, type Page } from "@playwright/test";
 import { ChildProcess, spawn } from "node:child_process";
-import { existsSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { Socket } from "node:net";
 import path from "node:path";
 
@@ -59,6 +59,7 @@ class GitButlerManager implements GitButler {
 	private scriptsDir: string;
 	private butServerProcess: ChildProcess;
 	private env: Record<string, string> | undefined;
+	private gitConfigGlobal: string;
 
 	constructor(
 		workdir: string,
@@ -82,11 +83,13 @@ class GitButlerManager implements GitButler {
 				setConfig(config, this.configDir);
 			}
 		}
+		this.gitConfigGlobal =
+			env?.GIT_CONFIG_GLOBAL ?? createIsolatedGitConfig(this.configDir, GIT_CONFIG_GLOBAL);
 
 		const serverEnv = {
 			E2E_TEST_APP_DATA_DIR: this.configDir,
 			BUTLER_PORT: getButlerPort(),
-			GIT_CONFIG_GLOBAL,
+			GIT_CONFIG_GLOBAL: this.gitConfigGlobal,
 			RUST_LOG: "info",
 			...this.env,
 		};
@@ -172,13 +175,27 @@ class GitButlerManager implements GitButler {
 
 		const envVars = {
 			E2E_TEST_APP_DATA_DIR: this.configDir,
-			GIT_CONFIG_GLOBAL,
+			GIT_CONFIG_GLOBAL: this.gitConfigGlobal,
 			...this.env,
 			...env,
 		};
 
 		await runCommand("bash", [scriptPath, ...scriptArgs], this.workdir, envVars);
 	}
+}
+
+function createIsolatedGitConfig(configDir: string, baseGitConfig: string): string {
+	const gitConfig = path.join(configDir, "gitconfig");
+	const credentialStore = path.join(configDir, "git-credentials");
+	const base = readFileSync(baseGitConfig, "utf8").trimEnd();
+	writeFileSync(
+		gitConfig,
+		`${base}
+[credential]
+	helper = store --file ${credentialStore}
+`,
+	);
+	return gitConfig;
 }
 
 function createButServerProcess(rootDir: string, serverEnv: Record<string, string>): ChildProcess {

--- a/e2e/playwright/tests/branches.spec.ts
+++ b/e2e/playwright/tests/branches.spec.ts
@@ -263,7 +263,7 @@ test("should handle gracefully applying two conflicting branches", async ({ page
 	await clickByTestId(page, "branches-view-apply-branch-button");
 	await waitForTestId(page, "workspace-view");
 
-	await waitForTestId(page, "stacks-unapplied-toast");
+	await waitForTestId(page, "branch-apply-conflict-toast");
 });
 
 test("should update the stale selection of an unexisting branch", async ({ page, gitbutler }) => {

--- a/e2e/playwright/tests/branches.spec.ts
+++ b/e2e/playwright/tests/branches.spec.ts
@@ -1,5 +1,6 @@
-import { createNewBranch, deleteBranch, unapplyStack } from "../src/branch.ts";
-import { applyUpstream, openWorkspace } from "../src/setup.ts";
+import { assertBranch, createNewBranch, deleteBranch, unapplyStack } from "../src/branch.ts";
+import { startFakeGitHubServer, type FakeGitHubServer } from "../src/fakeGithub.ts";
+import { applyUpstream, getButlerPort, openWorkspace, type GitButler } from "../src/setup.ts";
 import { test } from "../src/test.ts";
 import {
 	clickByTestId,
@@ -12,6 +13,7 @@ import {
 	waitForTestIdToNotExist,
 } from "../src/util.ts";
 import { expect, type Page } from "@playwright/test";
+import { execFileSync } from "child_process";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 
 /**
@@ -49,6 +51,58 @@ async function syncAndIntegrate(page: Page) {
 	await waitForTestIdToNotExist(page, "branch-integration-modal");
 }
 
+async function storeFakeGitHubEnterprisePat(page: Page, fakeGitHub: FakeGitHubServer) {
+	const response = await page.request.post(
+		`http://localhost:${getButlerPort()}/store_github_enterprise_pat`,
+		{
+			data: {
+				host: fakeGitHub.apiBaseUrl,
+				accessToken: "fake-token",
+			},
+		},
+	);
+	expect(response.ok()).toBe(true);
+	const body = await response.json();
+	expect(body.type).toBe("success");
+}
+
+function git(pathToRepo: string, args: string[]): string {
+	return execFileSync("git", args, {
+		cwd: pathToRepo,
+		encoding: "utf8",
+	}).trim();
+}
+
+async function openProjectWithFakeGitHub(
+	page: Page,
+	gitbutler: GitButler,
+	fakeGitHub: FakeGitHubServer,
+) {
+	await gitbutler.runScript("project-with-github-fork-pr.sh", [fakeGitHub.repositoryUrl]);
+	await openWorkspace(page);
+	await storeFakeGitHubEnterprisePat(page, fakeGitHub);
+	await page.reload();
+	await waitForTestId(page, "workspace-view");
+}
+
+async function applyReviewFromBranchesView(page: Page, title: string) {
+	await clickByTestId(page, "navigation-branches-button");
+	await expect(getByTestId(page, "pr-list-card").filter({ hasText: "#42" })).toBeVisible();
+	await getByTestId(page, "pr-list-card").filter({ hasText: title }).click();
+	await clickByTestId(page, "branches-view-apply-from-fork-button");
+	await waitForTestId(page, "workspace-view");
+}
+
+async function applyReviewBranchFromBranchesView(page: Page, branchName: string) {
+	await clickByTestId(page, "navigation-branches-button");
+	await waitForTestId(page, "branches-view");
+	await expect(getByTestId(page, "branch-list-card").filter({ hasText: "#42" })).toBeVisible();
+	await getByTestId(page, "branch-list-card").filter({ hasText: branchName }).click();
+	await waitForTestId(page, "branches-view-apply-branch-button");
+	await clickByTestId(page, "branches-view-apply-branch-button");
+	await waitForTestId(page, "workspace-view");
+}
+
 test("should be able to apply a remote branch", async ({ page, gitbutler }) => {
 	await gitbutler.runScript("project-with-remote-branches.sh");
 	await openWorkspace(page);
@@ -57,6 +111,179 @@ test("should be able to apply a remote branch", async ({ page, gitbutler }) => {
 
 	await expect(stack(page, "branch1")).toHaveCount(1);
 	await expect(commitRow(page)).toHaveCount(2);
+});
+
+test.describe("GitHub review apply", () => {
+	test.describe.configure({ mode: "serial" });
+
+	test("should apply a GitHub fork PR by creating the fork remote in the backend", async ({
+		page,
+		gitbutler,
+	}) => {
+		const localClone = gitbutler.pathInWorkdir("local-clone");
+		const forkRepoPath = gitbutler.pathInWorkdir("fork-project-bare");
+		const fakeGitHub = await startFakeGitHubServer({ forkRepoPath });
+		try {
+			await openProjectWithFakeGitHub(page, gitbutler, fakeGitHub);
+			await applyReviewFromBranchesView(page, "Fork PR");
+
+			expect(git(localClone, ["remote", "get-url", "contributor-user"])).toBe(forkRepoPath);
+			expect(
+				git(localClone, ["show-ref", "--verify", "refs/remotes/contributor-user/fork-feature"]),
+			).toContain("refs/remotes/contributor-user/fork-feature");
+			expect(readFileSync(gitbutler.pathInWorkdir("local-clone", "fork-pr.txt"), "utf-8")).toBe(
+				"fork pr content\n",
+			);
+			await expect(stack(page, "fork-feature")).toHaveCount(1);
+			await expect(getByTestId(page, "pr-review-badge")).toContainText("PR");
+			await expect(getByTestId(page, "pr-review-badge")).toContainText("#42");
+		} finally {
+			await fakeGitHub.close();
+		}
+	});
+
+	test("should apply a GitHub fork PR by reusing an existing fork remote", async ({
+		page,
+		gitbutler,
+	}) => {
+		const localClone = gitbutler.pathInWorkdir("local-clone");
+		const forkRepoPath = gitbutler.pathInWorkdir("fork-project-bare");
+		const fakeGitHub = await startFakeGitHubServer({ forkRepoPath });
+		try {
+			await gitbutler.runScript("project-with-github-fork-pr.sh", [fakeGitHub.repositoryUrl]);
+			git(localClone, ["remote", "add", "contributor-user", forkRepoPath]);
+			await openWorkspace(page);
+			await storeFakeGitHubEnterprisePat(page, fakeGitHub);
+			await page.reload();
+			await waitForTestId(page, "workspace-view");
+
+			await applyReviewBranchFromBranchesView(page, "fork-feature");
+
+			expect(git(localClone, ["remote", "get-url", "contributor-user"])).toBe(forkRepoPath);
+			expect(git(localClone, ["remote"]).split("\n")).not.toContain("contributor-user-2");
+			await expect(stack(page, "fork-feature")).toHaveCount(1);
+		} finally {
+			await fakeGitHub.close();
+		}
+	});
+
+	test("should apply a GitHub PR from the base repository to the managed workspace", async ({
+		page,
+		gitbutler,
+	}) => {
+		const localClone = gitbutler.pathInWorkdir("local-clone");
+		const baseRepoPath = gitbutler.pathInWorkdir("remote-project");
+		const fakeGitHub = await startFakeGitHubServer({
+			headRepoPath: baseRepoPath,
+			sourceBranch: "base-pr-feature",
+			repoOwner: "acme",
+			title: "Base PR",
+			isFork: false,
+		});
+		try {
+			await openProjectWithFakeGitHub(page, gitbutler, fakeGitHub);
+			await applyReviewBranchFromBranchesView(page, "base-pr-feature");
+
+			expect(readFileSync(gitbutler.pathInWorkdir("local-clone", "base-pr.txt"), "utf-8")).toBe(
+				"base pr content\n",
+			);
+			await assertBranch("gitbutler/workspace", localClone);
+			await expect(stack(page, "base-pr-feature")).toHaveCount(1);
+			await expect(getByTestId(page, "pr-review-badge")).toContainText("#42");
+		} finally {
+			await fakeGitHub.close();
+		}
+	});
+
+	test.describe("single-branch mode", () => {
+		test.use({
+			gitbutlerOptions: {
+				config: {
+					onboardingComplete: true,
+					featureFlags: { singleBranch: true },
+				},
+			},
+		});
+
+		test("should apply a GitHub PR from the base repository", async ({ page, gitbutler }) => {
+			const localClone = gitbutler.pathInWorkdir("local-clone");
+			const baseRepoPath = gitbutler.pathInWorkdir("remote-project");
+			const fakeGitHub = await startFakeGitHubServer({
+				headRepoPath: baseRepoPath,
+				sourceBranch: "base-pr-feature",
+				repoOwner: "acme",
+				title: "Base PR",
+				isFork: false,
+			});
+			try {
+				await gitbutler.runScript("project-with-github-fork-pr.sh", [fakeGitHub.repositoryUrl]);
+				git(localClone, [
+					"checkout",
+					"-b",
+					"single-branch-fixture",
+					"origin/single-branch-fixture",
+				]);
+				await openWorkspace(page);
+				await expect(getByTestId(page, "chrome-header-current-branch")).toContainText(
+					"single-branch-fixture",
+				);
+				await storeFakeGitHubEnterprisePat(page, fakeGitHub);
+				await page.reload();
+				await waitForTestId(page, "workspace-view");
+
+				await applyReviewBranchFromBranchesView(page, "base-pr-feature");
+
+				await assertBranch("gitbutler/workspace", localClone);
+				expect(
+					readFileSync(gitbutler.pathInWorkdir("local-clone", "single-branch.txt"), "utf-8"),
+				).toBe("single branch content\n");
+				expect(readFileSync(gitbutler.pathInWorkdir("local-clone", "base-pr.txt"), "utf-8")).toBe(
+					"base pr content\n",
+				);
+				await expect(stack(page, "single-branch-fixture")).toHaveCount(1);
+				await expect(stack(page, "base-pr-feature")).toHaveCount(1);
+			} finally {
+				await fakeGitHub.close();
+			}
+		});
+
+		test("should apply a GitHub fork PR", async ({ page, gitbutler }) => {
+			const localClone = gitbutler.pathInWorkdir("local-clone");
+			const forkRepoPath = gitbutler.pathInWorkdir("fork-project-bare");
+			const fakeGitHub = await startFakeGitHubServer({ forkRepoPath });
+			try {
+				await gitbutler.runScript("project-with-github-fork-pr.sh", [fakeGitHub.repositoryUrl]);
+				git(localClone, [
+					"checkout",
+					"-b",
+					"single-branch-fixture",
+					"origin/single-branch-fixture",
+				]);
+				await openWorkspace(page);
+				await expect(getByTestId(page, "chrome-header-current-branch")).toContainText(
+					"single-branch-fixture",
+				);
+				await storeFakeGitHubEnterprisePat(page, fakeGitHub);
+				await page.reload();
+				await waitForTestId(page, "workspace-view");
+
+				await applyReviewFromBranchesView(page, "Fork PR");
+
+				await assertBranch("gitbutler/workspace", localClone);
+				expect(git(localClone, ["remote", "get-url", "contributor-user"])).toBe(forkRepoPath);
+				expect(
+					readFileSync(gitbutler.pathInWorkdir("local-clone", "single-branch.txt"), "utf-8"),
+				).toBe("single branch content\n");
+				expect(readFileSync(gitbutler.pathInWorkdir("local-clone", "fork-pr.txt"), "utf-8")).toBe(
+					"fork pr content\n",
+				);
+				await expect(stack(page, "single-branch-fixture")).toHaveCount(1);
+				await expect(stack(page, "fork-feature")).toHaveCount(1);
+			} finally {
+				await fakeGitHub.close();
+			}
+		});
+	});
 });
 
 test("should be able to apply a remote branch and integrate the remote changes - simple", async ({

--- a/e2e/playwright/tests/singleBranch/commitActions.spec.ts
+++ b/e2e/playwright/tests/singleBranch/commitActions.spec.ts
@@ -1,9 +1,15 @@
-import { setupSingleBranchProject, SINGLE_BRANCH_NAME } from "./helpers.ts";
+import {
+	applyBranchFromBranchesView,
+	openSingleBranchWorkspace,
+	setupSingleBranchProject,
+	SINGLE_BRANCH_NAME,
+} from "./helpers.ts";
 import {
 	assertBranch,
 	assertCleanWorktree,
 	assertCommitSubjects,
 	assertDirtyWorktree,
+	assertSymbolicHead,
 } from "../../src/branch.ts";
 import {
 	openCommitDrawer,
@@ -15,7 +21,13 @@ import {
 } from "../../src/commit.ts";
 import { assertFileContent, unstageAllFiles, writeToFile } from "../../src/file.ts";
 import { test } from "../../src/test.ts";
-import { clickByTestId, commitRow, dragAndDropByLocator, getByTestId } from "../../src/util.ts";
+import {
+	clickByTestId,
+	commitRow,
+	dragAndDropByLocator,
+	getByTestId,
+	stack,
+} from "../../src/util.ts";
 import { expect } from "@playwright/test";
 
 test.use({
@@ -110,4 +122,61 @@ test("can amend file changes into an existing commit", async ({ page, gitbutler 
 		["single-branch: add file", "single-branch: second commit", "single-branch: first commit"],
 		localClone,
 	);
+});
+
+test("can apply another branch after leaving a managed workspace", async ({ page, gitbutler }) => {
+	await gitbutler.runScript("project-in-single-branch-apply-transition.sh");
+	const localClone = gitbutler.pathInWorkdir("local-clone");
+	await openSingleBranchWorkspace(page);
+
+	await assertBranch(SINGLE_BRANCH_NAME, localClone);
+	await applyBranchFromBranchesView(page, "branch-to-apply");
+
+	await assertBranch("gitbutler/workspace", localClone);
+	await expect(getByTestId(page, "chrome-header-current-branch")).toContainText(
+		"gitbutler/workspace",
+	);
+	await expect(getByTestId(page, "chrome-header-current-branch")).not.toContainText("read-only");
+	await expect(getByTestId(page, "chrome-header-switch-back-to-workspace-button")).toHaveCount(0);
+	await expect(getByTestId(page, "branch-card")).toHaveCount(2);
+	await expect(
+		getByTestId(page, "branch-card").filter({ hasText: SINGLE_BRANCH_NAME }),
+	).toBeVisible();
+	await expect(
+		getByTestId(page, "branch-card").filter({ hasText: "branch-to-apply" }),
+	).toBeVisible();
+	await expect(
+		getByTestId(page, "branch-card").filter({ hasText: "stale-workspace-branch" }),
+	).toHaveCount(0);
+	await assertCleanWorktree(localClone);
+});
+
+test("rebuilds an enclosed ad-hoc workspace around the current and applied branches", async ({
+	page,
+	gitbutler,
+}) => {
+	await gitbutler.runScript("project-in-single-branch-enclosed-apply.sh");
+	const localClone = gitbutler.pathInWorkdir("local-clone");
+	await openSingleBranchWorkspace(page);
+
+	await assertBranch("B", localClone);
+	await assertSymbolicHead("B", localClone);
+	await expect(getByTestId(page, "chrome-header-current-branch")).toContainText("B");
+	await expect(getByTestId(page, "chrome-header-current-branch")).toContainText("read-only");
+	await expect(getByTestId(page, "chrome-header-switch-back-to-workspace-button")).toBeVisible();
+
+	await applyBranchFromBranchesView(page, "C");
+
+	await assertBranch("gitbutler/workspace", localClone);
+	await assertSymbolicHead("gitbutler/workspace", localClone);
+	await expect(getByTestId(page, "chrome-header-current-branch")).toContainText(
+		"gitbutler/workspace",
+	);
+	await expect(getByTestId(page, "chrome-header-current-branch")).not.toContainText("read-only");
+	await expect(getByTestId(page, "chrome-header-switch-back-to-workspace-button")).toHaveCount(0);
+	await expect(getByTestId(page, "branch-card")).toHaveCount(2);
+	await expect(stack(page, "A")).toHaveCount(0);
+	await expect(stack(page, "B")).toBeVisible();
+	await expect(stack(page, "C")).toBeVisible();
+	await assertCleanWorktree(localClone);
 });

--- a/e2e/playwright/tests/singleBranch/helpers.ts
+++ b/e2e/playwright/tests/singleBranch/helpers.ts
@@ -1,4 +1,5 @@
 import { openWorkspace } from "../../src/setup.ts";
+import { clickByTestId, getByTestId, waitForTestId } from "../../src/util.ts";
 import { expect, type Page } from "@playwright/test";
 import type { GitButler } from "../../src/setup.ts";
 
@@ -18,4 +19,15 @@ export async function openSingleBranchWorkspace(page: Page): Promise<void> {
 
 export async function expectCurrentBranchChip(page: Page, branchName: string): Promise<void> {
 	await expect(page.getByTestId("chrome-header-current-branch")).toContainText(branchName);
+}
+
+export async function applyBranchFromBranchesView(page: Page, branchName: string): Promise<void> {
+	await clickByTestId(page, "navigation-branches-button");
+	await waitForTestId(page, "branches-view");
+
+	await getByTestId(page, "branches-view").getByText(branchName, { exact: true }).click();
+	await waitForTestId(page, "branches-view-apply-branch-button");
+
+	await clickByTestId(page, "branches-view-apply-branch-button");
+	await waitForTestId(page, "workspace-view");
 }

--- a/e2e/review-apply-fixture.md
+++ b/e2e/review-apply-fixture.md
@@ -1,0 +1,66 @@
+# Review Apply Playwright Fixture
+
+The review-apply Playwright tests exercise the backend-owned `review_apply` API
+without talking to real GitHub.
+
+## Moving Parts
+
+- `playwright/src/fakeGithub.ts` starts a small HTTP server that imitates the
+  GitHub Enterprise API routes the app needs:
+  - `GET /api/v3/user`
+  - `GET /api/v3/repos/acme/widgets/pulls`
+  - `GET /api/v3/repos/acme/widgets/pulls/42`
+- `playwright/scripts/project-with-github-fork-pr.sh` creates the local Git
+  repositories used by the tests:
+  - `remote-project`, the base repository
+  - `fork-project`, a working clone with a fork PR branch
+  - `fork-project-bare`, the fork repository fetched by the backend
+  - `local-clone`, the GitButler project under test
+- `playwright/tests/branches.spec.ts` registers fake GitHub Enterprise
+  credentials with `store_github_enterprise_pat`, opens the Branches view, and
+  applies PR `#42` through the UI.
+
+## Why GitHub Is Fake But Git Fetch Is Real
+
+The fake GitHub server only serves API JSON. It does not implement Git smart
+HTTP. Instead, PR payloads return local filesystem paths as `head.repo.clone_url`
+and `head.repo.ssh_url`.
+
+That means the backend still does real work:
+
+- resolves the PR through forge metadata
+- creates or reuses a Git remote
+- fetches the PR source branch from a real local repository
+- applies the fetched remote-tracking branch through workspace apply
+- records PR metadata on the applied branch
+
+For fork PRs, the payload points at `fork-project-bare`. For same-repository
+PRs, the payload points at `remote-project`.
+
+## Running The Focused Tests
+
+From the repository root:
+
+```bash
+cargo build -p but-server
+corepack pnpm --filter @gitbutler/e2e exec playwright test \
+  --config ./playwright/playwright.config.ts \
+  --tsconfig ./playwright/tsconfig.json \
+  playwright/tests/branches.spec.ts \
+  -g "GitHub review apply"
+```
+
+The group covers:
+
+- fork PR apply, creating the fork remote
+- fork PR apply, reusing an existing matching remote
+- same-repository PR apply from a managed workspace
+- same-repository PR apply from single-branch mode
+- fork PR apply from single-branch mode
+
+## Adding Cases
+
+Prefer extending `startFakeGitHubServer()` options rather than adding another
+fake server. If a new case needs different Git contents, add that branch or file
+to `project-with-github-fork-pr.sh` and keep the PR payload pointing at a local
+repository path so backend fetch behavior remains real and deterministic.

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -411,6 +411,15 @@ export declare function removeBranch(projectId: string, stackId: string, branchN
 export declare function restoreSnapshotWithKind(projectId: string, restoreKind: RestoreKind, sha: string): Promise<void>
 
 /**
+ * Applies a forge review by resolving it to its source branch.
+ *
+ * This fetches the review's head repository through a configured or newly
+ * created remote, applies the fetched remote-tracking branch, and records the
+ * review number on the applied branch metadata.
+ */
+export declare function reviewApply(projectId: string, reviewId: number): Promise<ApplyOutcome>
+
+/**
  * Get the review template content for the given project and relative path.
  *
  * This function determines the forge of a project and retrieves the review template

--- a/packages/but-sdk/src/generated/index.js
+++ b/packages/but-sdk/src/generated/index.js
@@ -579,7 +579,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { absorb, absorptionPlan, apply, applyBranchIntegration, assignHunk, branchCheckout, branchCheckoutNew, branchCreate, branchDetails, branchDiff, branchLand, changesInWorktree, changesInWorktreeWithPerm, commitAmend, commitCreate, commitDetailsWithLineStats, commitDiscard, commitDiscardChanges, commitInsertBlank, commitMove, commitMoveChangesBetween, commitReword, commitSquash, commitUncommit, commitUncommitChanges, discardWorktreeChanges, forgeCompareBranchUrl, forgeInfo, forgeProvider, getInitialBranchIntegration, getRedoTargetSnapshot, getRepoInfo, getReview, getReviewBaseRepoUrl, getReviewMergeStatus, getUndoTargetSnapshot, headInfo, initApplicationNamespace, listAvailableReviewTemplates, listBranches, listCiChecks, listEditors, listProjectsStateless, listReviews, listReviewsForBranch, mergeReview, moveBranch, openInEditor, peelRestoreSnapshot, publishReview, pushStack, removeBranch, restoreSnapshotWithKind, reviewTemplate, setReviewAutoMerge, setReviewDraftiness, setReviewTemplate, tearOffBranch, treeChangeDiffs, unapplyStack, updateBranchName, updateReview, updateReviewFooters, warmCiChecksCache, workspaceBranchAndAncestorsPush, workspaceCheckout, workspaceIntegrateUpstream, WatcherHandle, askpassInit, askpassSubmitPromptResponse, watcherStart } = nativeBinding
+const { absorb, absorptionPlan, apply, applyBranchIntegration, assignHunk, branchCheckout, branchCheckoutNew, branchCreate, branchDetails, branchDiff, branchLand, changesInWorktree, changesInWorktreeWithPerm, commitAmend, commitCreate, commitDetailsWithLineStats, commitDiscard, commitDiscardChanges, commitInsertBlank, commitMove, commitMoveChangesBetween, commitReword, commitSquash, commitUncommit, commitUncommitChanges, discardWorktreeChanges, forgeCompareBranchUrl, forgeInfo, forgeProvider, getInitialBranchIntegration, getRedoTargetSnapshot, getRepoInfo, getReview, getReviewBaseRepoUrl, getReviewMergeStatus, getUndoTargetSnapshot, headInfo, initApplicationNamespace, listAvailableReviewTemplates, listBranches, listCiChecks, listEditors, listProjectsStateless, listReviews, listReviewsForBranch, mergeReview, moveBranch, openInEditor, peelRestoreSnapshot, publishReview, pushStack, removeBranch, restoreSnapshotWithKind, reviewApply, reviewTemplate, setReviewAutoMerge, setReviewDraftiness, setReviewTemplate, tearOffBranch, treeChangeDiffs, unapplyStack, updateBranchName, updateReview, updateReviewFooters, warmCiChecksCache, workspaceBranchAndAncestorsPush, workspaceCheckout, workspaceIntegrateUpstream, WatcherHandle, askpassInit, askpassSubmitPromptResponse, watcherStart } = nativeBinding
 export { absorb }
 export { absorptionPlan }
 export { apply }
@@ -633,6 +633,7 @@ export { publishReview }
 export { pushStack }
 export { removeBranch }
 export { restoreSnapshotWithKind }
+export { reviewApply }
 export { reviewTemplate }
 export { setReviewAutoMerge }
 export { setReviewDraftiness }

--- a/packages/ui/src/lib/utils/testIds.ts
+++ b/packages/ui/src/lib/utils/testIds.ts
@@ -167,6 +167,7 @@ export enum TestId {
 	EditMode = "edit-mode",
 	EditModeSaveAndExitButton = "edit-mode-save-and-exit-button",
 	StacksUnappliedToast = "stacks-unapplied-toast",
+	BranchApplyConflictToast = "branch-apply-conflict-toast",
 	CreateSnapshotModal = "create-snapshot-modal",
 	CreateSnapshotModal_ActionButton = "create-snapshot-modal-action-button",
 	FileListItemContextMenu_Absorb = "file-list-item-context-menu__absorb",


### PR DESCRIPTION
- Switch apply to use the gitbutler/workspace ref even if it didn’t exist
- Recreate workspace even when checked-out branch was already part of a previous workspace
- Update desktop to use the new apply behavior
- Update e2e tests to reflect that the new apply creates a workspace

### TODO
- [x] Add a feature flag for the new apply usage in the desktop application (reuse the same single-branch mode)
- [x] Add an API to apply a PR from the number

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #14532 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #14517 
<!-- GitButler Footer Boundary Bottom -->

