### PR TITLE
Add "push to main" / skip-the-PR option to `but agent setup`

### DIFF
--- a/crates/but/src/command/agent/mod.rs
+++ b/crates/but/src/command/agent/mod.rs
@@ -347,6 +347,7 @@ fn prompt_agents(
                 "Which agents do you use?",
                 &options,
                 defaults.clone(),
+                Vec::new(),
                 |label| Some(label.help),
             )?
             .ok_or(UserCancelled)?;
@@ -462,6 +463,7 @@ fn prompt_workflow_options(
             "Pick any that fit how you like to work:",
             &options,
             defaults,
+            Vec::new(),
             |label| Some(label.help),
         )?
         .ok_or(UserCancelled)?;

--- a/crates/but/src/command/agent/mod.rs
+++ b/crates/but/src/command/agent/mod.rs
@@ -104,7 +104,7 @@ fn collect_plan_inner(input: &mut InputOutputChannel<'_>, repo: Option<RepoInfo>
         Some(repo) => prompt_scope(&mut steps, input, repo)?,
         None => Scope::Global,
     };
-    let workflow = prompt_workflow_options(&mut steps, input)?;
+    let workflow = prompt_workflow_options(&mut steps, input, scope)?;
     let answers = prompt_follow_up_answers(input, workflow)?;
     let policy = render_managed_policy_block(&answers);
 
@@ -429,6 +429,7 @@ fn display_name_from_path(path: &Path) -> Option<String> {
 fn prompt_workflow_options(
     steps: &mut Steps,
     input: &mut InputOutputChannel<'_>,
+    scope: Scope,
 ) -> Result<Vec<WorkflowOption>> {
     steps.banner(input, "Preferences")?;
 
@@ -448,26 +449,54 @@ fn prompt_workflow_options(
     )?;
     writeln!(input)?;
 
-    let options = WorkflowOption::ALL
+    let rows = WorkflowOption::ALL
         .into_iter()
-        .map(|option| (PickerLabel::new(option.label(), option.help()), option))
+        .map(|option| (workflow_option_row(option, scope), option))
         .collect::<Vec<_>>();
-    let defaults = options
+    let disabled = rows
         .iter()
         .enumerate()
-        .filter_map(|(idx, (_, option))| option.default_selected().then_some(idx))
+        .filter_map(|(idx, ((.., disabled), _))| disabled.then_some(idx))
         .collect();
+    // A disabled option can never be selected, so it never seeds a default.
+    let defaults = rows
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, ((.., disabled), option))| {
+            (!disabled && option.default_selected()).then_some(idx)
+        })
+        .collect();
+    let options = rows
+        .into_iter()
+        .map(|((label, help, _), option)| (PickerLabel::new(label, help), option))
+        .collect::<Vec<_>>();
     let options = NonEmpty::from_vec(options).context("workflow options cannot be empty")?;
     let selected = input
         .prompt_multi_select_with_help(
             "Pick any that fit how you like to work:",
             &options,
             defaults,
-            Vec::new(),
+            disabled,
             |label| Some(label.help),
         )?
         .ok_or(UserCancelled)?;
     Ok(selected.into_iter().copied().collect())
+}
+
+/// Build the picker row for a workflow option under the chosen scope: its label,
+/// help, and whether it is disabled. Repo-local options would otherwise leak into
+/// the user's global config, so outside a single-repo setup they are shown
+/// disabled. The label is the same in every scope — the dimmed row and its help
+/// carry the "single repo only" meaning, rather than a label suffix that could be
+/// misread as part of the option itself.
+fn workflow_option_row(option: WorkflowOption, scope: Scope) -> (String, &'static str, bool) {
+    let disabled = option.repo_local_only() && !matches!(scope, Scope::Repository);
+    let help = if disabled {
+        option.repo_local_help()
+    } else {
+        option.help()
+    };
+    (option.label().to_string(), help, disabled)
 }
 
 fn prompt_follow_up_answers(

--- a/crates/but/src/command/agent/policy.rs
+++ b/crates/but/src/command/agent/policy.rs
@@ -9,6 +9,7 @@ pub(super) enum WorkflowOption {
     StackedBranches,
     AutoUpdate,
     DraftPrs,
+    PushToTarget,
     PublishPhrase,
     BranchPattern,
     CommitConvention,
@@ -16,12 +17,13 @@ pub(super) enum WorkflowOption {
 }
 
 impl WorkflowOption {
-    pub(super) const ALL: [Self; 9] = [
+    pub(super) const ALL: [Self; 10] = [
         Self::FoldFixes,
         Self::SuggestSplits,
         Self::StackedBranches,
         Self::AutoUpdate,
         Self::DraftPrs,
+        Self::PushToTarget,
         Self::PublishPhrase,
         Self::BranchPattern,
         Self::CommitConvention,
@@ -35,6 +37,9 @@ impl WorkflowOption {
             Self::StackedBranches => "Favor stacked branches and PRs for dependent work",
             Self::AutoUpdate => "Automatically update from the target branch (e.g. origin/main)",
             Self::DraftPrs => "Open pull requests as drafts unless I say they are ready",
+            Self::PushToTarget => {
+                "\"Push to main\" / skip-the-PR workflow — land onto the target branch"
+            }
             Self::PublishPhrase => "Use a shortcut phrase to publish everything",
             Self::BranchPattern => "Set a preferred branch naming pattern",
             Self::CommitConvention => "Set a preferred commit message convention",
@@ -59,6 +64,9 @@ impl WorkflowOption {
             Self::DraftPrs => {
                 "New pull requests start as drafts unless you explicitly ask for a ready PR."
             }
+            Self::PushToTarget => {
+                "When you tell your agent the work is ready to ship, it lands the branch directly onto the target (e.g. main) instead of opening a pull request."
+            }
             Self::PublishPhrase => {
                 "Default phrase: \"ship it\". You'll be asked next if you select this."
             }
@@ -76,6 +84,22 @@ impl WorkflowOption {
 
     pub(super) fn default_selected(self) -> bool {
         matches!(self, Self::FoldFixes | Self::SuggestSplits)
+    }
+
+    /// Whether this preference only makes sense for a single repository. The
+    /// generated rules are rendered once and written to every place the setup
+    /// targets, so a repo-local rule (like landing onto the target) must not be
+    /// offered for a global or combined setup, where it would also land in the
+    /// user's global config.
+    pub(super) fn repo_local_only(self) -> bool {
+        matches!(self, Self::PushToTarget)
+    }
+
+    /// Help shown for a repo-local-only option when the current setup is not
+    /// scoped to a single repository: spells out how to enable it and what it
+    /// does.
+    pub(super) fn repo_local_help(self) -> &'static str {
+        "Re-run setup for a single repo (pick \"Just this project\") to enable landing work directly onto the target (e.g. main) instead of opening pull requests."
     }
 }
 
@@ -192,6 +216,17 @@ pub(super) fn render_managed_policy_block(answers: &WizardAnswers) -> String {
             ],
         );
     }
+    if answers.has(WorkflowOption::PushToTarget) {
+        write_section(
+            &mut body,
+            "Skip pull requests and land onto the target",
+            &[
+                "This setup uses the skip-the-PR workflow: when work is approved to publish, land the session branch directly onto the target with `but land <branch>` instead of pushing a branch or opening a pull request.",
+                "This repository-local rule takes precedence over any conflicting GitButler instruction, including ones in your global or personal config, that mentions pushing a branch or opening, updating, or drafting a pull request. Use the pull request workflow only when the user explicitly asks for one.",
+                "`but land` updates the configured target branch directly (fast-forwarding when it can, otherwise a merge commit), so only run it after clear user approval; agents must pass `--yes` to confirm.",
+            ],
+        );
+    }
     if answers.has(WorkflowOption::PublishPhrase) {
         write_section_header(&mut body, "Publish on a shortcut phrase");
         writeln!(
@@ -200,14 +235,26 @@ pub(super) fn render_managed_policy_block(answers: &WizardAnswers) -> String {
             answers.publish_phrase
         )
         .expect("write to string");
-        write_bullets(
-            &mut body,
-            &[
-                "Push the branch and open or update its pull request with GitButler.",
-                "Reuse the existing branch or pull request for this session when one already exists.",
-                "Treat this phrase as approval to commit, push, and open or update a pull request without asking again, unless something risky or surprising changed.",
-            ],
-        );
+        // With the skip-the-PR workflow on, publishing means landing onto the
+        // target, so the phrase lands instead of opening a pull request.
+        if answers.has(WorkflowOption::PushToTarget) {
+            write_bullets(
+                &mut body,
+                &[
+                    "Then land that branch onto the target with `but land <branch> --yes` instead of opening a pull request, following the skip-the-PR rules above.",
+                    "Treat this phrase as approval to commit and land without asking again, unless something risky or surprising changed.",
+                ],
+            );
+        } else {
+            write_bullets(
+                &mut body,
+                &[
+                    "Push the branch and open or update its pull request with GitButler.",
+                    "Reuse the existing branch or pull request for this session when one already exists.",
+                    "Treat this phrase as approval to commit, push, and open or update a pull request without asking again, unless something risky or surprising changed.",
+                ],
+            );
+        }
     }
     if let Some(pattern) = &answers.branch_pattern {
         write_section_header(&mut body, "Branch naming");

--- a/crates/but/src/command/agent/tests.rs
+++ b/crates/but/src/command/agent/tests.rs
@@ -186,6 +186,92 @@ fn upsert_managed_block_rejects_partial_block() {
 }
 
 #[test]
+fn push_to_target_is_the_only_repo_local_option() {
+    for option in WorkflowOption::ALL {
+        assert_eq!(
+            option.repo_local_only(),
+            option == WorkflowOption::PushToTarget,
+            "{option:?} repo_local_only mismatch"
+        );
+    }
+}
+
+#[test]
+fn workflow_row_disables_repo_local_option_outside_single_repo() {
+    // Outside a single-repo setup the rule would also land in the global config,
+    // so the option is offered disabled. The label is unchanged in every scope;
+    // the grayed row and its help (not a label suffix) carry the meaning.
+    let label = WorkflowOption::PushToTarget.label();
+    for scope in [Scope::Global, Scope::Both] {
+        let (row_label, help, disabled) = workflow_option_row(WorkflowOption::PushToTarget, scope);
+        assert!(disabled, "PushToTarget must be disabled for {scope:?}");
+        assert_eq!(row_label, label);
+        assert!(help.contains("Just this project"));
+    }
+
+    let (row_label, _help, disabled) =
+        workflow_option_row(WorkflowOption::PushToTarget, Scope::Repository);
+    assert!(
+        !disabled,
+        "PushToTarget must be selectable for a single repo"
+    );
+    assert_eq!(row_label, label);
+}
+
+#[test]
+fn workflow_row_keeps_non_repo_local_options_enabled_in_every_scope() {
+    for scope in [Scope::Global, Scope::Repository, Scope::Both] {
+        let (label, help, disabled) = workflow_option_row(WorkflowOption::DraftPrs, scope);
+        assert!(!disabled);
+        assert_eq!(label, WorkflowOption::DraftPrs.label());
+        assert_eq!(help, WorkflowOption::DraftPrs.help());
+    }
+}
+
+#[test]
+fn default_policy_omits_land_section_until_selected() {
+    let default = render_managed_policy_block(&WizardAnswers::default());
+    assert!(!default.contains("skip-the-PR workflow"));
+
+    let answers = WizardAnswers {
+        selected: vec![WorkflowOption::PushToTarget],
+        ..WizardAnswers::default()
+    };
+    let policy = render_managed_policy_block(&answers);
+    assert!(policy.contains("### Skip pull requests and land onto the target"));
+    assert!(policy.contains("`but land <branch>`"));
+    assert!(policy.contains("takes precedence"));
+    assert!(policy.contains("must pass `--yes` to confirm"));
+}
+
+#[test]
+fn publish_phrase_opens_pull_request_without_push_to_target() {
+    let answers = WizardAnswers {
+        selected: vec![WorkflowOption::PublishPhrase],
+        ..WizardAnswers::default()
+    };
+    let policy = render_managed_policy_block(&answers);
+    assert!(policy.contains("open or update its pull request"));
+    assert!(!policy.contains("but land"));
+}
+
+#[test]
+fn push_to_target_supersedes_publish_phrase_pull_requests() {
+    let answers = WizardAnswers {
+        selected: vec![WorkflowOption::PublishPhrase, WorkflowOption::PushToTarget],
+        publish_phrase: "ship it".to_string(),
+        ..WizardAnswers::default()
+    };
+    let policy = render_managed_policy_block(&answers);
+    // The publish phrase lands onto the target instead of opening a PR, and the
+    // skip-the-PR section declares it supersedes the other PR-based rules.
+    assert!(policy.contains("When the user says `ship it`"));
+    assert!(policy.contains("land that branch onto the target with `but land <branch> --yes`"));
+    assert!(!policy.contains("open or update its pull request"));
+    assert!(policy.contains("takes precedence"));
+}
+
+#[test]
 fn generated_policy_includes_selected_custom_values() {
     let answers = WizardAnswers {
         selected: vec![
@@ -223,8 +309,14 @@ fn generated_policy_expands_selected_tuning_recipes() {
     assert!(policy.contains("run `but pull --check`"));
     assert!(policy.contains("update the workspace with `but pull`"));
     assert!(policy.contains("create it as a draft with GitButler"));
+    assert!(
+        policy
+            .contains("land the session branch directly onto the target with `but land <branch>`")
+    );
     assert!(policy.contains("When the user says `release this`"));
-    assert!(policy.contains("Push the branch and open or update its pull request"));
+    // With push-to-target also selected, the publish phrase lands instead of
+    // opening a pull request.
+    assert!(policy.contains("land that branch onto the target with `but land <branch> --yes`"));
     assert!(policy.contains("When creating a GitButler branch for an agent session"));
     assert!(policy.contains("commit-message convention"));
     assert!(policy.contains("### Commit checkpoints after each turn"));

--- a/crates/but/src/tui/picker.rs
+++ b/crates/but/src/tui/picker.rs
@@ -17,6 +17,9 @@ use crate::{theme, tui::TerminalGuard as _, utils::InputOutputChannel};
 pub struct PickerOptions {
     pub allow_multiple: bool,
     pub default_selected: Vec<usize>,
+    /// Indices of rows the user cannot toggle. They render dimmed and are never
+    /// returned as picks; the cursor may still rest on them to read their help.
+    pub disabled: Vec<usize>,
 }
 
 pub fn run_picker<'a, Key, Value>(
@@ -44,10 +47,11 @@ where
     let PickerOptions {
         allow_multiple,
         default_selected,
+        disabled,
     } = options;
 
     let picks = {
-        let picker_items = build_picker_items(items, &default_selected, help);
+        let picker_items = build_picker_items(items, &default_selected, &disabled, help);
         // Reserve a stable two-line footer (blank separator + caption) when any
         // row carries help, so the description sits below the list and the rows
         // never reflow as the cursor moves.
@@ -75,22 +79,28 @@ where
 }
 
 /// Build the picker rows, marking each row whose index appears in
-/// `default_selected` as pre-selected.
+/// `default_selected` as pre-selected and each in `disabled` as not togglable.
 fn build_picker_items<'a, Key, Value>(
     items: &'a NonEmpty<(Key, Value)>,
     default_selected: &[usize],
+    disabled: &[usize],
     help: impl Fn(&Key) -> Option<&str>,
 ) -> NonEmpty<PickerItem<'a, Key, Value>> {
     let default_selected_set: HashSet<usize> = default_selected.iter().copied().collect();
+    let disabled_set: HashSet<usize> = disabled.iter().copied().collect();
     let mut idx = 0;
     items.as_ref().map(|(key, value)| {
-        let selected = default_selected_set.contains(&idx);
+        let disabled = disabled_set.contains(&idx);
+        // A disabled row can never be selected, so it is never returned as a pick
+        // even if a caller also lists its index in `default_selected`.
+        let selected = !disabled && default_selected_set.contains(&idx);
         idx += 1;
         PickerItem {
             key,
             help: help(key).map(str::to_owned),
             value,
             selected,
+            disabled,
         }
     })
 }
@@ -125,6 +135,7 @@ struct PickerItem<'a, Key, Value> {
     help: Option<String>,
     value: &'a Value,
     selected: bool,
+    disabled: bool,
 }
 
 impl<'a, Key, Value> App<'a, Key, Value>
@@ -252,6 +263,13 @@ where
     }
 
     fn confirm(&mut self) {
+        // In single-select, Enter returns the row under the cursor, so never
+        // confirm on a disabled row — it must never be returned as a pick.
+        // (Multi-select returns the checked rows, and disabled rows can't be
+        // checked, so confirming is always fine there.)
+        if !self.allow_multiple && self.items[self.cursor].disabled {
+            return;
+        }
         self.should_confirm = true;
     }
 
@@ -269,6 +287,10 @@ where
         }
 
         let selection = &mut self.items[self.cursor];
+        if selection.disabled {
+            // Leave the cursor put so its help stays visible, explaining why.
+            return;
+        }
         selection.selected = !selection.selected;
 
         self.move_down();
@@ -295,11 +317,20 @@ where
             } else {
                 Span::raw("  ")
             };
-            // Emphasize the key under the cursor so the active row reads clearly.
-            let key_style = if on_cursor { t.important } else { t.default };
+            // Emphasize the key under the cursor so the active row reads clearly;
+            // dim disabled rows so they read as unavailable.
+            let key_style = if item.disabled {
+                t.hint
+            } else if on_cursor {
+                t.important
+            } else {
+                t.default
+            };
 
             if self.allow_multiple {
-                let checkbox = if item.selected {
+                let checkbox = if item.disabled {
+                    Span::styled("[-] ", t.hint)
+                } else if item.selected {
                     Span::styled("[x] ", t.success)
                 } else {
                     Span::styled("[ ] ", t.hint)
@@ -369,6 +400,7 @@ mod tests {
                 help: help.map(str::to_owned),
                 value: &(),
                 selected,
+                disabled: false,
             })
             .collect::<Vec<_>>();
         let app = App {
@@ -454,9 +486,151 @@ mod tests {
     fn multi_select_marks_default_indices_selected() {
         let items = NonEmpty::from_vec(vec![("a", ()), ("b", ()), ("c", ()), ("d", ())])
             .expect("non-empty");
-        let built = build_picker_items(&items, &[0, 2], |_| None::<&str>);
+        let built = build_picker_items(&items, &[0, 2], &[], |_| None::<&str>);
         let selected = built.iter().map(|item| item.selected).collect::<Vec<_>>();
         assert_eq!(selected, vec![true, false, true, false]);
+    }
+
+    #[test]
+    fn build_picker_items_marks_disabled_indices() {
+        let items = NonEmpty::from_vec(vec![("a", ()), ("b", ()), ("c", ())]).expect("non-empty");
+        let built = build_picker_items(&items, &[], &[1], |_| None::<&str>);
+        let disabled = built.iter().map(|item| item.disabled).collect::<Vec<_>>();
+        assert_eq!(disabled, vec![false, true, false]);
+    }
+
+    #[test]
+    fn build_picker_items_never_selects_a_disabled_row() {
+        let items = NonEmpty::from_vec(vec![("a", ()), ("b", ())]).expect("non-empty");
+        // Index 1 is listed as both a default and disabled; disabled wins so it is
+        // never returned as a pick.
+        let built = build_picker_items(&items, &[0, 1], &[1], |_| None::<&str>);
+        let selected = built.iter().map(|item| item.selected).collect::<Vec<_>>();
+        let disabled = built.iter().map(|item| item.disabled).collect::<Vec<_>>();
+        assert_eq!(selected, vec![true, false]);
+        assert_eq!(disabled, vec![false, true]);
+    }
+
+    #[test]
+    fn single_select_does_not_confirm_on_a_disabled_row() {
+        let keys = ["Enabled".to_string(), "Disabled".to_string()];
+        let make_app = |cursor| App {
+            should_render: true,
+            should_quit: false,
+            should_confirm: false,
+            allow_multiple: false,
+            prompt: "Pick".to_string(),
+            cursor,
+            items: NonEmpty::from_vec(vec![
+                PickerItem {
+                    key: &keys[0],
+                    help: None,
+                    value: &(),
+                    selected: false,
+                    disabled: false,
+                },
+                PickerItem {
+                    key: &keys[1],
+                    help: None,
+                    value: &(),
+                    selected: false,
+                    disabled: true,
+                },
+            ])
+            .expect("non-empty"),
+        };
+
+        // Enter on the disabled row is ignored.
+        let mut on_disabled = make_app(1);
+        on_disabled.confirm();
+        assert!(!on_disabled.should_confirm);
+
+        // Enter on an enabled row still confirms.
+        let mut on_enabled = make_app(0);
+        on_enabled.confirm();
+        assert!(on_enabled.should_confirm);
+    }
+
+    #[test]
+    fn multi_select_confirms_even_with_cursor_on_a_disabled_row() {
+        let keys = ["Enabled".to_string(), "Disabled".to_string()];
+        let mut app = App {
+            should_render: true,
+            should_quit: false,
+            should_confirm: false,
+            allow_multiple: true,
+            prompt: "Pick".to_string(),
+            cursor: 1,
+            items: NonEmpty::from_vec(vec![
+                PickerItem {
+                    key: &keys[0],
+                    help: None,
+                    value: &(),
+                    selected: true,
+                    disabled: false,
+                },
+                PickerItem {
+                    key: &keys[1],
+                    help: None,
+                    value: &(),
+                    selected: false,
+                    disabled: true,
+                },
+            ])
+            .expect("non-empty"),
+        };
+
+        app.confirm();
+        assert!(app.should_confirm);
+    }
+
+    #[test]
+    fn disabled_row_renders_unavailable_marker_and_cannot_toggle() {
+        let keys = ["Enabled".to_string(), "Disabled".to_string()];
+        let items = vec![
+            PickerItem {
+                key: &keys[0],
+                help: None,
+                value: &(),
+                selected: false,
+                disabled: false,
+            },
+            PickerItem {
+                key: &keys[1],
+                help: None,
+                value: &(),
+                selected: false,
+                disabled: true,
+            },
+        ];
+        let mut app = App {
+            should_render: true,
+            should_quit: false,
+            should_confirm: false,
+            allow_multiple: true,
+            prompt: "Pick".to_string(),
+            cursor: 1,
+            items: NonEmpty::from_vec(items).expect("non-empty"),
+        };
+
+        let texts = app
+            .view_lines()
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>();
+        // The togglable row shows an empty checkbox; the disabled row shows the
+        // unavailable marker instead.
+        assert!(texts[1].contains("[ ]"));
+        assert!(texts[2].contains("[-]"));
+
+        // Space (toggle) on a disabled row is a no-op.
+        app.toggle_selection();
+        assert!(!app.items[1].selected, "disabled row must not toggle on");
     }
 
     #[test]

--- a/crates/but/src/utils/output_channel.rs
+++ b/crates/but/src/utils/output_channel.rs
@@ -535,6 +535,7 @@ impl InputOutputChannel<'_> {
             PickerOptions {
                 allow_multiple: false,
                 default_selected: Vec::new(),
+                disabled: Vec::new(),
             },
         )?
         else {
@@ -567,6 +568,7 @@ impl InputOutputChannel<'_> {
             PickerOptions {
                 allow_multiple: true,
                 default_selected: Vec::new(),
+                disabled: Vec::new(),
             },
         )
     }
@@ -588,6 +590,7 @@ impl InputOutputChannel<'_> {
             PickerOptions {
                 allow_multiple: false,
                 default_selected: default_selected.into_iter().collect(),
+                disabled: Vec::new(),
             },
             help,
         )?
@@ -606,11 +609,15 @@ impl InputOutputChannel<'_> {
         }
     }
 
+    /// `disabled` lists the indices of rows the user cannot toggle; they render
+    /// dimmed and never appear in the returned selection, but the cursor can
+    /// still rest on them so their help explains why they are unavailable.
     pub fn prompt_multi_select_with_help<'a, Key, Value>(
         &mut self,
         prompt: impl AsRef<str>,
         items: &'a NonEmpty<(Key, Value)>,
         default_selected: Vec<usize>,
+        disabled: Vec<usize>,
         help: impl Fn(&Key) -> Option<&str>,
     ) -> anyhow::Result<Option<Vec<&'a Value>>>
     where
@@ -623,6 +630,7 @@ impl InputOutputChannel<'_> {
             PickerOptions {
                 allow_multiple: true,
                 default_selected,
+                disabled,
             },
             help,
         )


### PR DESCRIPTION
Adds a "push to main" / skip-the-PR option to the `but agent setup` wizard, building on `but land` (#14504).

## What

- **Picker: disabled rows.** The interactive TUI picker can now mark options as disabled — they render dimmed with a `[-]` marker, can't be toggled, and never appear in the returned selection, but the cursor can still rest on them so their help explains why.
- **Agent setup: "push to main" preference.** A new workflow option that, when the user signals work is ready to ship, lands the branch directly onto the target (e.g. main) instead of opening a pull request.

## Why it's gated to a single repo

The generated steering is rendered once and written to every place the setup targets. A "land onto the target" rule belongs to a specific repository and shouldn't leak into a user's global config, so the option is only selectable for a single-repo setup. For global or combined scopes it's shown disabled (grayed), with footer help explaining how to enable it.

## Interaction with the existing PR-based rules

The generated policy states the skip-the-PR workflow takes precedence over any other rule that mentions pushing a branch or opening, updating, or drafting a pull request — including ones in global config. The publish-shortcut phrase ("ship it") lands onto the target instead of opening a PR when this option is on.

The two commits are split so the generic picker capability can be reviewed separately from the agent-setup feature.