### PR TITLE
Prioritise display of file names in files panel

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.module.css
@@ -14,6 +14,22 @@
 	}
 }
 
+.filePath {
+	color: var(--text-3);
+
+	/* Overflow ellipsis on the left, pioritising filename. */
+	direction: rtl;
+	text-align: left;
+}
+
+.pathLast {
+	color: var(--text-1);
+
+	[data-selection-scope]:focus .fileRow[aria-selected="true"] & {
+		color: var(--text-1-invert);
+	}
+}
+
 .fileStatusBadge {
 	align-self: center;
 	width: 12px;

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
@@ -280,6 +280,10 @@ const FileRow: FC<
 		selectProjectHasCheckedCommits(state, projectId),
 	);
 
+	const lastSepIdx = relativePath.lastIndexOf("/");
+	const mpathInit = lastSepIdx !== -1 ? relativePath.slice(0, lastSepIdx + 1) : null;
+	const pathLast = lastSepIdx !== -1 ? relativePath.slice(lastSepIdx + 1) : relativePath;
+
 	return (
 		<Tooltip.Root disableHoverablePopup>
 			<Tooltip.Trigger
@@ -322,8 +326,9 @@ const FileRow: FC<
 				</div>
 
 				<WorkspaceItemRowLabelContainer>
-					<WorkspaceItemRowLabel singleLine>
-						{relativePath}
+					<WorkspaceItemRowLabel singleLine className={styles.filePath}>
+						{mpathInit}
+						<span className={styles.pathLast}>{pathLast}</span>
 						{item._tag === "Conflict" && " ⚠️"}
 					</WorkspaceItemRowLabel>
 				</WorkspaceItemRowLabelContainer>

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceItemRow.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceItemRow.module.css
@@ -57,6 +57,7 @@
 	column-gap: 6px;
 	flex-grow: 1;
 	min-width: 0;
+	margin-right: 2px;
 	padding-block: calc(
 		(var(--single-line-row-height) - var(--single-line-row-label-line-height)) / 2
 	);


### PR DESCRIPTION
Copies how we render file labels in the diff headers in overflow scenarios, which I personally find far more useful. Assuming this is what we want, let it be known that this causes the label text to shift when the kebab pops in or out.

Before:

<img width="308" height="64" alt="Screenshot 2026-06-30 at 17 30 40" src="https://github.com/user-attachments/assets/45afbacc-72cf-43cb-ad0b-aea488cab64c" />

After:

<img width="301" height="61" alt="Screenshot 2026-06-30 at 17 32 56" src="https://github.com/user-attachments/assets/da3c570c-bbe2-4e54-91b1-365e87666177" />
