### PR TITLE
fix(ai): sort changed files by path for deterministic commit messages

### DIFF
--- a/apps/desktop/src/lib/ai/service.test.ts
+++ b/apps/desktop/src/lib/ai/service.test.ts
@@ -459,14 +459,10 @@ describe.concurrent("buildDiff", () => {
 		expect(buildDiff([hunk1], 100).length).to.eq(100);
 	});
 
-	test("When provided multiple hunks, it joins them together with newlines", () => {
-		const expectedOutput1 = `${hunk1.filePath} - ${hunk1.diff}\n${hunk2.filePath} - ${hunk2.diff}`;
-		const expectedOutput2 = `${hunk2.filePath} - ${hunk2.diff}\n${hunk1.filePath} - ${hunk1.diff}`;
+	test("When provided multiple hunks, it sorts them by file path", () => {
+		const expectedOutput = `${hunk1.filePath} - ${hunk1.diff}\n${hunk2.filePath} - ${hunk2.diff}`;
 
-		const outputMatchesExpectedValue = [expectedOutput1, expectedOutput2].includes(
-			buildDiff([hunk1, hunk2], 10000),
-		);
-
-		expect(outputMatchesExpectedValue).toBeTruthy();
+		expect(buildDiff([hunk1, hunk2], 10000)).to.eq(expectedOutput);
+		expect(buildDiff([hunk2, hunk1], 10000)).to.eq(expectedOutput);
 	});
 });

--- a/apps/desktop/src/lib/ai/service.ts
+++ b/apps/desktop/src/lib/ai/service.ts
@@ -110,16 +110,11 @@ export interface DiffInput {
 
 // Exported for testing only
 export function buildDiff(hunks: DiffInput[], limit: number) {
-	return shuffle(hunks.map((h) => `${h.filePath} - ${h.diff}`))
+	return hunks
+		.map((h) => `${h.filePath} - ${h.diff}`)
+		.sort()
 		.join("\n")
 		.slice(0, limit);
-}
-
-function shuffle<T>(items: T[]): T[] {
-	return items
-		.map((item) => ({ item, value: Math.random() }))
-		.sort(({ value: a }, { value: b }) => a - b)
-		.map((item) => item.item);
 }
 
 export const AI_SERVICE = new InjectionToken<AIService>("AI Service");


### PR DESCRIPTION
﻿## Description

Replaces the random shuffle in uildDiff() with a deterministic sort by file path.

### Problem

When generating an AI commit message, uildDiff() calls shuffle() which uses Math.random() to randomize the file order. Regenerating on the same working tree produces a different file order each time, which:
- Causes the AI to generate different commit messages for identical input
- Invalidates the local runtime's prompt cache on each regeneration

### Fix

- Remove the shuffle() function entirely
- Sort the formatted diff entries by their string representation (which starts with the file path)
- The upstream inputs are already file-tree sorted via sortLikeFileTree() — this preserves that stable order instead of overriding it with randomness

### Test update

The multi-hunk test previously accepted either ordering (shuffle was non-deterministic). Now it asserts a single expected output and verifies that both input orders produce the same result.

Fixes #14485
