### PR TITLE
feat(but): implement moving committed files with `_move2`

### DIFF
--- a/crates/but/src/command/legacy/move2.rs
+++ b/crates/but/src/command/legacy/move2.rs
@@ -33,9 +33,10 @@ pub enum MoveOutcome {
     },
     Changes {
         source_commit_id: gix::ObjectId,
-        changes: NonEmpty<DiffSpec>,
+        num_changes: usize,
         target: Option<MoveTarget>,
         new_branch_name: Option<FullName>,
+        new_commit_id: gix::ObjectId,
     },
 }
 
@@ -59,19 +60,21 @@ impl CliOutputHuman for MoveOutcome {
             }
             Self::Changes {
                 source_commit_id,
-                changes,
+                num_changes,
                 target,
                 new_branch_name,
+                new_commit_id,
             } => {
                 write!(
                     out,
-                    "Moved {} changes from {}",
-                    changes.len(),
-                    theme::Commit(source_commit_id)
+                    "Moved {} changes from {} to new commit {}",
+                    num_changes,
+                    theme::Commit(source_commit_id),
+                    theme::Commit(new_commit_id),
                 )?;
 
                 if let Some(new_branch_name) = new_branch_name {
-                    write!(out, " to new branch {}", theme::Branch(new_branch_name))?;
+                    write!(out, " on new branch {}", theme::Branch(new_branch_name))?;
                 }
 
                 if let Some(target) = target {
@@ -504,6 +507,7 @@ fn resolve_sources(
     let mut args: Vec<CliIdArg> = vec![];
 
     for unresolved_source in sources {
+        let source_str = unresolved_source.to_string();
         args.push(unresolved_source.clone());
 
         match unresolved_source.resolve_in_workspace(repo, id_map, Purpose::Source, None)? {
@@ -515,32 +519,47 @@ fn resolve_sources(
             } => {
                 file_sources.push((commit_id, path));
             }
-            _ => return Err(bad_input("TODO").into()),
+            resolved => {
+                return Err(bad_input(format!("Cannot pass {resolved} as source"))
+                    .arg_value(source_str)
+                    .arg_name("<SOURCES>")
+                    .hint("Sources must be commits or committed files")
+                    .into());
+            }
         }
     }
 
-    match (commit_sources.is_empty(), file_sources.is_empty()) {
-        (false, true) => {
-            let sources = NonEmpty::from_vec(commit_sources)
-                .expect("BUG: Empty sources should not be possible as it's a required argument");
+    match (
+        NonEmpty::from_vec(commit_sources),
+        NonEmpty::from_vec(file_sources),
+    ) {
+        (Some(resolved_commits), None) => {
             let args = NonEmpty::from_vec(args).expect(
                 "BUG: Source arguments cannot be empty if resolved arguments are non-empty",
             );
 
             Ok(ResolvedSources::Commits {
-                resolved_commits: sources,
+                resolved_commits,
                 args,
             })
         }
-        (true, false) => {
+        (None, Some(files)) => {
             let mut builder = DiffSpecBuilder::new(db, repo, ws, context_lines);
-            // TODO validate single source commit ID
-            let (source_commit_id, _) = *file_sources.first().unwrap();
-            for (commit_id, path) in file_sources {
+            let source_commit_id = files.first().0;
+            for (commit_id, path) in files.into_iter() {
+                if commit_id != source_commit_id {
+                    return Err(
+                        bad_input("Cannot move changes from multiple commits")
+                            .hint("Move changes from a single commit at first, then squash additional changes into the new commit")
+                            .into()
+                    );
+                }
+
                 builder.push_changes_from_committed_file(commit_id, path.as_bstr())?;
             }
 
-            // TODO sort diffspecs
+            // It doesn't appear as if we need to sort DiffSpecs when they're resolved on a file
+            // level. For the future hunk level DiffSpecs we may need to, however.
             let changes = NonEmpty::from_vec(builder.into_diff_specs())
                 .expect("BUG: Cannot possibly not have any changes here");
 
@@ -549,8 +568,11 @@ fn resolve_sources(
                 changes,
             )))
         }
-        (false, false) => todo!("Mixed sources warning"),
-        (true, true) => todo!("No sources warning"),
+        (Some(_), Some(_)) => Err(bad_input("Mixing source types is not allowed")
+            .hint("You can only move one kind of source (e.g. commits) at a time")
+            .arg_name("<SOURCES>")
+            .into()),
+        (None, None) => panic!("BUG: It should not be possible to omit sources"),
     }
 }
 
@@ -560,69 +582,62 @@ fn run(
     perm: &mut RepoExclusive,
     move_op: MoveOperation,
 ) -> CliResult<MoveOutcome> {
-    let snapshot_details = SnapshotDetails::new(OperationKind::MoveCommit);
-    let (new_branch_name, _ws) = but_transaction::with_transaction_with_perm(
+    let snapshot_details = match &move_op {
+        MoveOperation::CommitsRelativeTo(_) | MoveOperation::CommitsToNewBranch(_) => {
+            SnapshotDetails::new(OperationKind::MoveCommit)
+        }
+        MoveOperation::ChangesRelativeTo(_) | MoveOperation::ChangesToNewBranch(_) => {
+            SnapshotDetails::new(OperationKind::MoveCommitFile)
+        }
+    };
+    let (outcome, _ws) = but_transaction::with_transaction_with_perm(
         ctx,
         meta,
         perm,
         snapshot_details,
         DryRun::No,
         |mut tx| {
-            let new_branch_name = match move_op.clone() {
-                MoveOperation::CommitsRelativeTo(op) => op.execute(&mut tx)?,
-                MoveOperation::CommitsToNewBranch(op) => Some(op.execute(&mut tx)?),
+            let outcome = match move_op {
+                MoveOperation::CommitsRelativeTo(op) => MoveOutcome::Commits {
+                    sources: op.sources.clone(),
+                    target: Some(op.target.clone()),
+                    new_branch_name: op.execute(&mut tx)?,
+                },
+                MoveOperation::CommitsToNewBranch(op) => MoveOutcome::Commits {
+                    sources: op.sources.clone(),
+                    target: None,
+                    new_branch_name: Some(op.execute(&mut tx)?),
+                },
                 MoveOperation::ChangesRelativeTo(op) => {
-                    // TODO use new commit id
-                    let (_, new_branch_name) = op.execute(&mut tx)?;
-                    new_branch_name
+                    let target = op.target.clone();
+                    let num_changes = op.changes.len();
+                    let source_commit_id = op.source_commit_id;
+                    let (new_commit_id, new_branch_name) = op.execute(&mut tx)?;
+                    MoveOutcome::Changes {
+                        source_commit_id,
+                        num_changes,
+                        target: Some(target),
+                        new_branch_name,
+                        new_commit_id,
+                    }
                 }
                 MoveOperation::ChangesToNewBranch(op) => {
-                    let (_, new_branch_name) = op.execute(&mut tx)?;
-                    Some(new_branch_name)
+                    let num_changes = op.changes.len();
+                    let source_commit_id = op.source_commit_id;
+                    let (new_commit_id, new_branch_name) = op.execute(&mut tx)?;
+                    MoveOutcome::Changes {
+                        source_commit_id,
+                        num_changes,
+                        target: None,
+                        new_branch_name: Some(new_branch_name),
+                        new_commit_id,
+                    }
                 }
             };
 
-            Ok(but_transaction::Commit(new_branch_name))
+            Ok(but_transaction::Commit(outcome))
         },
     )?;
-
-    let outcome = match move_op {
-        MoveOperation::CommitsRelativeTo(MoveCommitsRelativeToOperation { sources, target }) => {
-            MoveOutcome::Commits {
-                sources,
-                target: Some(target),
-                new_branch_name,
-            }
-        }
-        MoveOperation::CommitsToNewBranch(MoveCommitsToNewBranchOperation {
-            sources,
-            branch_name: _,
-        }) => MoveOutcome::Commits {
-            sources,
-            target: None,
-            new_branch_name,
-        },
-        MoveOperation::ChangesRelativeTo(MoveChangesRelativeToOperation {
-            source_commit_id,
-            changes,
-            target,
-        }) => MoveOutcome::Changes {
-            source_commit_id,
-            changes,
-            target: Some(target),
-            new_branch_name,
-        },
-        MoveOperation::ChangesToNewBranch(MoveChangesToNewBranchOperation {
-            source_commit_id,
-            changes,
-            branch_name: _,
-        }) => MoveOutcome::Changes {
-            source_commit_id,
-            changes,
-            target: None,
-            new_branch_name,
-        },
-    };
 
     Ok(outcome)
 }

--- a/crates/but/src/command/legacy/move2.rs
+++ b/crates/but/src/command/legacy/move2.rs
@@ -1,6 +1,7 @@
 use std::fmt::Display;
 
-use but_core::{DryRun, RefMetadata, ref_metadata::StackId, sync::RepoExclusive};
+use bstr::{BString, ByteSlice};
+use but_core::{DiffSpec, DryRun, RefMetadata, ref_metadata::StackId, sync::RepoExclusive};
 use but_ctx::Context;
 use but_rebase::graph_rebase::mutate::RelativeTo;
 use but_transaction::Transaction;
@@ -13,37 +14,70 @@ use nonempty::NonEmpty;
 use crate::{
     CliResult, IdMap,
     args::{
-        atoms::{BranchArg, BranchOrCommit, CliIdArg, Purpose},
+        atoms::{BranchArg, BranchOrCommit, CliIdArg, Purpose, ResolvedCliIdArg},
         move2::Platform,
     },
     bad_input,
     theme::{self, Theme},
-    utils::{CliOutputHuman, IntermediateChannel, WriteWithUtils, targeting::Side},
+    utils::{
+        CliOutputHuman, IntermediateChannel, WriteWithUtils, diff_specs::DiffSpecBuilder,
+        targeting::Side,
+    },
 };
 
-pub struct MoveOutcome {
-    pub sources: NonEmpty<gix::ObjectId>,
-    pub target: Option<MoveTarget>,
-    pub new_branch_name: Option<FullName>,
+pub enum MoveOutcome {
+    Commits {
+        sources: NonEmpty<gix::ObjectId>,
+        target: Option<MoveTarget>,
+        new_branch_name: Option<FullName>,
+    },
+    Changes {
+        source_commit_id: gix::ObjectId,
+        changes: NonEmpty<DiffSpec>,
+        target: Option<MoveTarget>,
+        new_branch_name: Option<FullName>,
+    },
 }
 
 impl CliOutputHuman for MoveOutcome {
     fn on_human(self, out: &mut dyn WriteWithUtils, _theme: &Theme) -> anyhow::Result<()> {
-        let Self {
-            sources,
-            target,
-            new_branch_name,
-        } = self;
-        let sources = sources.into_iter().map(theme::Commit).join(", ");
+        match self {
+            Self::Commits {
+                sources,
+                target,
+                new_branch_name,
+            } => {
+                let sources = sources.into_iter().map(theme::Commit).join(", ");
+                write!(out, "Moved {sources}")?;
+                if let Some(new_branch_name) = new_branch_name {
+                    write!(out, " to new branch {}", theme::Branch(new_branch_name))?;
+                }
 
-        write!(out, "Moved {sources}")?;
+                if let Some(target) = target {
+                    write!(out, " {target}")?;
+                }
+            }
+            Self::Changes {
+                source_commit_id,
+                changes,
+                target,
+                new_branch_name,
+            } => {
+                write!(
+                    out,
+                    "Moved {} changes from {}",
+                    changes.len(),
+                    theme::Commit(source_commit_id)
+                )?;
 
-        if let Some(new_branch_name) = new_branch_name {
-            write!(out, " to new branch {}", theme::Branch(new_branch_name))?;
-        }
+                if let Some(new_branch_name) = new_branch_name {
+                    write!(out, " to new branch {}", theme::Branch(new_branch_name))?;
+                }
 
-        if let Some(target) = target {
-            write!(out, " {target}")?;
+                if let Some(target) = target {
+                    write!(out, " {target}")?;
+                }
+            }
         }
 
         writeln!(out)?;
@@ -68,8 +102,10 @@ pub fn r#move(
 
 #[derive(Clone)]
 enum MoveOperation {
-    RelativeTo(MoveCommitsRelativeToOperation),
-    ToNewBranch(MoveCommitsToNewBranchOperation),
+    CommitsRelativeTo(MoveCommitsRelativeToOperation),
+    CommitsToNewBranch(MoveCommitsToNewBranchOperation),
+    ChangesRelativeTo(MoveChangesRelativeToOperation),
+    ChangesToNewBranch(MoveChangesToNewBranchOperation),
 }
 
 #[derive(Clone)]
@@ -141,6 +177,97 @@ impl MoveCommitsToNewBranchOperation {
 }
 
 #[derive(Clone)]
+struct MoveChangesRelativeToOperation {
+    source_commit_id: gix::ObjectId,
+    changes: NonEmpty<DiffSpec>,
+    target: MoveTarget,
+}
+
+impl MoveChangesRelativeToOperation {
+    fn execute(
+        self,
+        tx: &mut Transaction<'_, '_, impl RefMetadata>,
+    ) -> anyhow::Result<(gix::ObjectId, Option<FullName>)> {
+        let Self {
+            target,
+            changes,
+            source_commit_id,
+        } = self;
+
+        let (relative_to, side, new_branch_name) = match target {
+            MoveTarget::Commit { commit_id, side } => {
+                (RelativeTo::Commit(commit_id), side.into(), None)
+            }
+            MoveTarget::BranchBucket { name, side } => {
+                let new_branch_name = but_core::branch::unique_canned_refname(tx.repo())?;
+                let anchor = Anchor::at_segment(name.as_ref(), side.into());
+                tx.create_reference(
+                    new_branch_name.as_ref(),
+                    anchor,
+                    |_| StackId::generate(),
+                    Some(0),
+                )?;
+                (
+                    RelativeTo::Reference(new_branch_name.clone()),
+                    Side::Below.into(),
+                    Some(new_branch_name),
+                )
+            }
+            MoveTarget::BranchTip { name } => {
+                (RelativeTo::Reference(name), Side::Below.into(), None)
+            }
+        };
+
+        let empty_commit_id = tx.insert_blank_commit(relative_to, side)?;
+        let new_commit_id =
+            tx.move_committed_changes_between(source_commit_id, empty_commit_id, changes.into())?;
+
+        Ok((new_commit_id, new_branch_name))
+    }
+}
+
+#[derive(Clone)]
+struct MoveChangesToNewBranchOperation {
+    source_commit_id: gix::ObjectId,
+    changes: NonEmpty<DiffSpec>,
+    branch_name: Option<FullName>,
+}
+
+impl MoveChangesToNewBranchOperation {
+    fn execute(
+        self,
+        tx: &mut Transaction<'_, '_, impl RefMetadata>,
+    ) -> anyhow::Result<(gix::ObjectId, FullName)> {
+        let Self {
+            source_commit_id,
+            changes,
+            branch_name,
+        } = self;
+
+        let new_branch_name = if let Some(branch_name) = branch_name {
+            branch_name
+        } else {
+            but_core::branch::unique_canned_refname(tx.repo())?
+        };
+
+        tx.create_reference(
+            new_branch_name.as_ref(),
+            None,
+            |_| StackId::generate(),
+            Some(0),
+        )?;
+
+        let empty_commit_id = tx.insert_blank_commit(
+            RelativeTo::Reference(new_branch_name.clone()),
+            Side::Below.into(),
+        )?;
+        let new_commit_id =
+            tx.move_committed_changes_between(source_commit_id, empty_commit_id, changes.into())?;
+        Ok((new_commit_id, new_branch_name))
+    }
+}
+
+#[derive(Clone)]
 pub enum MoveTarget {
     /// Place the commit relative to this commit, within the same branch.
     Commit {
@@ -185,55 +312,91 @@ fn resolve(
         branch,
     } = args;
 
-    let (repo, ws, _db) = ctx.workspace_and_db_with_perm(perm.read_permission())?;
+    let context_lines = ctx.settings.context_lines;
+    let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(perm.read_permission())?;
+
+    let resolved_sources = resolve_sources(&repo, &ws, &mut db, context_lines, id_map, sources)?;
 
     match (branch, above, below) {
         (Some(Some(branch)), None, None) => {
-            let resolved_sources = sources
-                .into_iter()
-                .map(|source| source.resolve_commit_in_workspace(&repo, id_map))
-                .collect::<CliResult<Vec<_>>>()?;
-            let sources = NonEmpty::from_vec(resolved_sources)
-                .expect("BUG: Empty sources should not be possible as it's a required argument");
-
-            match branch.try_resolve_branch(&repo, id_map)? {
-                Some(branch) => Ok(MoveOperation::RelativeTo(MoveCommitsRelativeToOperation {
-                    sources,
-                    target: MoveTarget::BranchTip {
-                        name: branch.resolve_local_branch_name()?,
+            match (branch.try_resolve_branch(&repo, id_map)?, resolved_sources) {
+                (
+                    Some(branch),
+                    ResolvedSources::Commits {
+                        resolved_commits: sources,
+                        ..
                     },
-                })),
-                None => {
+                ) => Ok(MoveOperation::CommitsRelativeTo(
+                    MoveCommitsRelativeToOperation {
+                        sources,
+                        target: MoveTarget::BranchTip {
+                            name: branch.resolve_local_branch_name()?,
+                        },
+                    },
+                )),
+                (
+                    None,
+                    ResolvedSources::Commits {
+                        resolved_commits: sources,
+                        ..
+                    },
+                ) => {
                     let branch_name =
                         BranchArg(branch.to_string()).resolve_for_creation(&repo, &ws)?;
-                    Ok(MoveOperation::ToNewBranch(
+                    Ok(MoveOperation::CommitsToNewBranch(
                         MoveCommitsToNewBranchOperation {
                             sources,
                             branch_name: Some(branch_name),
                         },
                     ))
                 }
+                (Some(branch), ResolvedSources::CommittedChanges((source_commit_id, changes))) => {
+                    Ok(MoveOperation::ChangesRelativeTo(
+                        MoveChangesRelativeToOperation {
+                            source_commit_id,
+                            changes,
+                            target: MoveTarget::BranchTip {
+                                name: branch.resolve_local_branch_name()?,
+                            },
+                        },
+                    ))
+                }
+                (None, ResolvedSources::CommittedChanges((source_commit_id, changes))) => {
+                    let branch_name =
+                        BranchArg(branch.to_string()).resolve_for_creation(&repo, &ws)?;
+                    Ok(MoveOperation::ChangesToNewBranch(
+                        MoveChangesToNewBranchOperation {
+                            source_commit_id,
+                            changes,
+                            branch_name: Some(branch_name),
+                        },
+                    ))
+                }
             }
         }
-        (Some(None), None, None) => {
-            let resolved_sources = sources
-                .into_iter()
-                .map(|source| source.resolve_commit_in_workspace(&repo, id_map))
-                .collect::<CliResult<Vec<_>>>()?;
-            let sources = NonEmpty::from_vec(resolved_sources)
-                .expect("BUG: Empty sources should not be possible as it's a required argument");
-            Ok(MoveOperation::ToNewBranch(
+        (Some(None), None, None) => match resolved_sources {
+            ResolvedSources::Commits {
+                resolved_commits: sources,
+                ..
+            } => Ok(MoveOperation::CommitsToNewBranch(
                 MoveCommitsToNewBranchOperation {
                     sources,
                     branch_name: None,
                 },
-            ))
-        }
+            )),
+            ResolvedSources::CommittedChanges((source_commit_id, changes)) => Ok(
+                MoveOperation::ChangesToNewBranch(MoveChangesToNewBranchOperation {
+                    source_commit_id,
+                    changes,
+                    branch_name: None,
+                }),
+            ),
+        },
         (None, Some(above), None) => {
-            create_move_above_or_below_op(&repo, id_map, sources, above, Side::Above)
+            create_move_above_or_below_op(&repo, id_map, resolved_sources, above, Side::Above)
         }
         (None, None, Some(below)) => {
-            create_move_above_or_below_op(&repo, id_map, sources, below, Side::Below)
+            create_move_above_or_below_op(&repo, id_map, resolved_sources, below, Side::Below)
         }
         _ => unreachable!("BUG: Targeting group is required"),
     }
@@ -242,7 +405,7 @@ fn resolve(
 fn create_move_above_or_below_op(
     repo: &gix::Repository,
     id_map: &IdMap,
-    sources: impl IntoIterator<Item = CliIdArg>,
+    resolved_sources: ResolvedSources,
     unresolved_target: CliIdArg,
     side: Side,
 ) -> CliResult<MoveOperation> {
@@ -259,32 +422,136 @@ fn create_move_above_or_below_op(
         }
     };
 
-    let sources = sources
-        .into_iter()
-        .map(|source| {
-            let resolved_source = source.resolve_commit_in_workspace(repo, id_map)?;
-
-            match &target {
-                MoveTarget::Commit { commit_id, .. } if commit_id == &resolved_source => {
-                    return Err(bad_input("Source cannot also be target")
-                        .arg_value(source.to_string())
-                        .arg_name(format!("--{side}"))
-                        .hint(format!("Trying to move items {side} '{source}'? Remove '{source}' from '<SOURCES>' and try again!"))
-                        .into());
+    match resolved_sources {
+        ResolvedSources::Commits {
+            resolved_commits,
+            args,
+        } => {
+            if let MoveTarget::Commit {
+                commit_id: target_commit_id,
+                ..
+            } = &target
+            {
+                for (i, source_commit_id) in resolved_commits.iter().enumerate() {
+                    if source_commit_id == target_commit_id {
+                        let unresolved_source = args
+                            .get(i)
+                            .expect("BUG: No CLI argument for resolved commit id");
+                        return Err(bad_input("Source cannot also be target")
+                            .arg_value(unresolved_source.to_string())
+                            .arg_name(format!("--{side}"))
+                            .hint(format!("Trying to move items {side} '{unresolved_source}'? Remove '{unresolved_source}' from '<SOURCES>' and try again!"))
+                            .into());
+                    }
                 }
-                _ => (),
             }
 
-            Ok(resolved_source)
-        })
-        .collect::<CliResult<Vec<_>>>()?;
-    let sources = NonEmpty::from_vec(sources)
-        .expect("BUG: Empty sources should not be possible as it's a required argument");
+            Ok(MoveOperation::CommitsRelativeTo(
+                MoveCommitsRelativeToOperation {
+                    sources: resolved_commits,
+                    target,
+                },
+            ))
+        }
+        ResolvedSources::CommittedChanges((source_commit_id, changes)) => Ok(
+            MoveOperation::ChangesRelativeTo(MoveChangesRelativeToOperation {
+                changes,
+                source_commit_id,
+                target,
+            }),
+        ),
+    }
+}
 
-    Ok(MoveOperation::RelativeTo(MoveCommitsRelativeToOperation {
-        sources,
-        target,
-    }))
+enum ResolvedSources {
+    Commits {
+        resolved_commits: NonEmpty<gix::ObjectId>,
+        /// We need the original arguments for error information to users. They are in the same
+        /// order as the resolved commits - access by index!
+        args: NonEmpty<CliIdArg>,
+    },
+    CommittedChanges((gix::ObjectId, NonEmpty<DiffSpec>)),
+}
+
+impl Display for ResolvedSources {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Commits {
+                resolved_commits,
+                args: _,
+            } => {
+                let sources = resolved_commits
+                    .iter()
+                    .map(|commit| theme::Commit(*commit).to_string())
+                    .join(", ");
+                write!(f, "{sources}")
+            }
+            Self::CommittedChanges(_) => Ok(()),
+        }
+    }
+}
+
+fn resolve_sources(
+    repo: &gix::Repository,
+    ws: &but_graph::Workspace,
+    db: &mut but_db::DbHandle,
+    context_lines: u32,
+    id_map: &IdMap,
+    sources: impl IntoIterator<Item = CliIdArg>,
+) -> CliResult<ResolvedSources> {
+    let mut commit_sources: Vec<gix::ObjectId> = vec![];
+    let mut file_sources: Vec<(gix::ObjectId, BString)> = vec![];
+    let mut args: Vec<CliIdArg> = vec![];
+
+    for unresolved_source in sources {
+        args.push(unresolved_source.clone());
+
+        match unresolved_source.resolve_in_workspace(repo, id_map, Purpose::Source, None)? {
+            ResolvedCliIdArg::Commit(source_commit_id) => commit_sources.push(source_commit_id),
+            ResolvedCliIdArg::CommittedFile {
+                commit_id,
+                path,
+                id: _,
+            } => {
+                file_sources.push((commit_id, path));
+            }
+            _ => return Err(bad_input("TODO").into()),
+        }
+    }
+
+    match (commit_sources.is_empty(), file_sources.is_empty()) {
+        (false, true) => {
+            let sources = NonEmpty::from_vec(commit_sources)
+                .expect("BUG: Empty sources should not be possible as it's a required argument");
+            let args = NonEmpty::from_vec(args).expect(
+                "BUG: Source arguments cannot be empty if resolved arguments are non-empty",
+            );
+
+            Ok(ResolvedSources::Commits {
+                resolved_commits: sources,
+                args,
+            })
+        }
+        (true, false) => {
+            let mut builder = DiffSpecBuilder::new(db, repo, ws, context_lines);
+            // TODO validate single source commit ID
+            let (source_commit_id, _) = *file_sources.first().unwrap();
+            for (commit_id, path) in file_sources {
+                builder.push_changes_from_committed_file(commit_id, path.as_bstr())?;
+            }
+
+            // TODO sort diffspecs
+            let changes = NonEmpty::from_vec(builder.into_diff_specs())
+                .expect("BUG: Cannot possibly not have any changes here");
+
+            Ok(ResolvedSources::CommittedChanges((
+                source_commit_id,
+                changes,
+            )))
+        }
+        (false, false) => todo!("Mixed sources warning"),
+        (true, true) => todo!("No sources warning"),
+    }
 }
 
 fn run(
@@ -302,8 +569,17 @@ fn run(
         DryRun::No,
         |mut tx| {
             let new_branch_name = match move_op.clone() {
-                MoveOperation::RelativeTo(op) => op.execute(&mut tx)?,
-                MoveOperation::ToNewBranch(op) => Some(op.execute(&mut tx)?),
+                MoveOperation::CommitsRelativeTo(op) => op.execute(&mut tx)?,
+                MoveOperation::CommitsToNewBranch(op) => Some(op.execute(&mut tx)?),
+                MoveOperation::ChangesRelativeTo(op) => {
+                    // TODO use new commit id
+                    let (_, new_branch_name) = op.execute(&mut tx)?;
+                    new_branch_name
+                }
+                MoveOperation::ChangesToNewBranch(op) => {
+                    let (_, new_branch_name) = op.execute(&mut tx)?;
+                    Some(new_branch_name)
+                }
             };
 
             Ok(but_transaction::Commit(new_branch_name))
@@ -311,18 +587,38 @@ fn run(
     )?;
 
     let outcome = match move_op {
-        MoveOperation::RelativeTo(MoveCommitsRelativeToOperation { sources, target }) => {
-            MoveOutcome {
+        MoveOperation::CommitsRelativeTo(MoveCommitsRelativeToOperation { sources, target }) => {
+            MoveOutcome::Commits {
                 sources,
                 target: Some(target),
                 new_branch_name,
             }
         }
-        MoveOperation::ToNewBranch(MoveCommitsToNewBranchOperation {
+        MoveOperation::CommitsToNewBranch(MoveCommitsToNewBranchOperation {
             sources,
             branch_name: _,
-        }) => MoveOutcome {
+        }) => MoveOutcome::Commits {
             sources,
+            target: None,
+            new_branch_name,
+        },
+        MoveOperation::ChangesRelativeTo(MoveChangesRelativeToOperation {
+            source_commit_id,
+            changes,
+            target,
+        }) => MoveOutcome::Changes {
+            source_commit_id,
+            changes,
+            target: Some(target),
+            new_branch_name,
+        },
+        MoveOperation::ChangesToNewBranch(MoveChangesToNewBranchOperation {
+            source_commit_id,
+            changes,
+            branch_name: _,
+        }) => MoveOutcome::Changes {
+            source_commit_id,
+            changes,
             target: None,
             new_branch_name,
         },

--- a/crates/but/tests/but/command/move2.rs
+++ b/crates/but/tests/but/command/move2.rs
@@ -963,7 +963,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 1 changes from 9ac4652 below commit fe12bcd
+Moved 1 changes from 9ac4652 to new commit 8e35f84 below commit fe12bcd
 
 "#]]);
 
@@ -1016,7 +1016,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 1 changes from fe12bcd above commit 9ac4652
+Moved 1 changes from fe12bcd to new commit c019027 above commit 9ac4652
 
 "#]]);
 
@@ -1069,7 +1069,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 1 changes from 9ac4652 to new branch 'a-branch-1' below branch 'A'
+Moved 1 changes from 9ac4652 to new commit 8e35f84 on new branch 'a-branch-1' below branch 'A'
 
 "#]]);
 
@@ -1124,7 +1124,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 1 changes from fe12bcd to new branch 'a-branch-1' above branch 'A'
+Moved 1 changes from fe12bcd to new commit c019027 on new branch 'a-branch-1' above branch 'A'
 
 "#]]);
 
@@ -1182,7 +1182,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 1 changes from d3e2ba3 to the tip of branch 'A'
+Moved 1 changes from d3e2ba3 to new commit be174de to the tip of branch 'A'
 
 "#]]);
 
@@ -1238,7 +1238,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 1 changes from 9ac4652 to new branch 'new-branch'
+Moved 1 changes from 9ac4652 to new commit 8e35f84 on new branch 'new-branch'
 
 "#]]);
 
@@ -1294,7 +1294,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 1 changes from 9ac4652 to new branch 'a-branch-1'
+Moved 1 changes from 9ac4652 to new commit 8e35f84 on new branch 'a-branch-1'
 
 "#]]);
 
@@ -1318,6 +1318,183 @@ Moved 1 changes from 9ac4652 to new branch 'a-branch-1'
 ┴ 1bbc04b (common base) 2000-01-02 add Base
 
 Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn move_file_should_be_order_independent() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.file("new", "Some data");
+    env.but("_commit2 -m 'Add new file'").assert().success();
+    std::fs::rename(
+        env.projects_root().join("new"),
+        env.projects_root().join("moved"),
+    )
+    .unwrap();
+    env.file("new/file", "Stuff");
+    env.file("unrelated", "This should stay here :)");
+    env.but("_commit2 -m 'Prepare for moves!'")
+        .assert()
+        .success();
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄br [a-branch-1]
+┊●   e3d3e3a Prepare for moves!
+┊│     e3:ul R moved
+┊│     e3:py A new/file
+┊│     e3:tt A unrelated
+┊●   24ac1e5 Add new file
+┊│     24:nx A new
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 e3:py e3:ul --above e3")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved 2 changes from e3d3e3a to new commit 99ef17e above commit e3d3e3a
+
+"#]]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄br [a-branch-1]
+┊●   99ef17e (no commit message)
+┊│     99:ul R moved
+┊│     99:py A new/file
+┊●   f94e59f Prepare for moves!
+┊│     f9:tt A unrelated
+┊●   24ac1e5 Add new file
+┊│     24:nx A new
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("undo").assert().success();
+
+    env.but("_move2 e3:ul e3:py --above e3")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved 2 changes from e3d3e3a to new commit 99ef17e above commit e3d3e3a
+
+"#]]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄br [a-branch-1]
+┊●   99ef17e (no commit message)
+┊│     99:ul R moved
+┊│     99:py A new/file
+┊●   f94e59f Prepare for moves!
+┊│     f9:tt A unrelated
+┊●   24ac1e5 Add new file
+┊│     24:nx A new
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn move_file_from_multiple_source_commits_is_not_allowed() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┊╭┄h0 [B]
+┊●   d3e2ba3 add B
+┊│     d3:pl A B
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 94:tm d3:pl -b")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: Cannot move changes from multiple commits
+
+Hint: Move changes from a single commit at first, then squash additional changes into the new commit
+
+"#]]);
+}
+
+#[test]
+fn mixing_commits_and_changes_is_not_allowed() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A", "B"]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊│     9a:wu A second
+┊●   fe12bcd add first
+┊│     fe:lz A first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 9a fe:lz -b")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: Bad input for '<SOURCES>'
+
+Mixing source types is not allowed
+
+Hint: You can only move one kind of source (e.g. commits) at a time
 
 "#]]);
 }
@@ -1411,6 +1588,25 @@ For more information, try '--help'.
 }
 
 #[test]
+fn must_specify_source() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.but("_move2 -b")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+error: the following required arguments were not provided:
+  <SOURCES>...
+
+Usage: but _move2 <--above <BRANCH_OR_COMMIT>|--below <BRANCH_OR_COMMIT>|--branch [<BRANCH>]> <SOURCES>...
+
+For more information, try '--help'.
+
+"#]]);
+}
+
+#[test]
 fn source_cannot_be_target() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
     env.setup_metadata(&["A"]);
@@ -1436,6 +1632,84 @@ Error: Bad input '9a' for '--below'
 Source cannot also be target
 
 Hint: Trying to move items below '9a'? Remove '9a' from '<SOURCES>' and try again!
+
+"#]]);
+}
+
+#[test]
+fn cannot_move_from_uncommitted() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    env.file("file", "some text");
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted]
+┊   qs A file
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+
+"#]]);
+
+    env.but("_move2 qs -b A")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: Bad input 'qs' for '<SOURCES>'
+
+Cannot pass uncommitted file or hunk as source
+
+Hint: Sources must be commits or committed files
+
+"#]]);
+    env.but("_move2 zz -b A")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: Bad input 'zz' for '<SOURCES>'
+
+Cannot pass uncommitted changes as source
+
+Hint: Sources must be commits or committed files
+
+"#]]);
+}
+
+#[test]
+fn cannot_move_to_uncommitted() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&[]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 94 --below zz")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: Expected a commit or a branch, got uncommitted changes
 
 "#]]);
 }

--- a/crates/but/tests/but/command/move2.rs
+++ b/crates/but/tests/but/command/move2.rs
@@ -936,6 +936,393 @@ Hint: run `but help` for all commands
 }
 
 #[test]
+fn move_file_below_commit_creates_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊│     9a:wu A second
+┊●   fe12bcd add first
+┊│     fe:lz A first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 9a:wu --below fe")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved 1 changes from 9ac4652 below commit fe12bcd
+
+"#]]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   01a55b8 add second (no changes)
+┊●   12b9152 add first
+┊│     12:lz A first
+┊●   8e35f84 (no commit message)
+┊│     8e:wu A second
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn move_file_above_commit_creates_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊│     9a:wu A second
+┊●   fe12bcd add first
+┊│     fe:lz A first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 fe:lz --above 9a")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved 1 changes from fe12bcd above commit 9ac4652
+
+"#]]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   c019027 (no commit message)
+┊│     c0:lz A first
+┊●   38b1f1a add second
+┊│     38:wu A second
+┊●   d8dfd0f add first (no changes)
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn move_file_below_branch_creates_branch_and_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊│     9a:wu A second
+┊●   fe12bcd add first
+┊│     fe:lz A first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 9a:wu --below A")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved 1 changes from 9ac4652 to new branch 'a-branch-1' below branch 'A'
+
+"#]]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   01a55b8 add second (no changes)
+┊●   12b9152 add first
+┊│     12:lz A first
+┊│
+┊├┄br [a-branch-1]
+┊●   8e35f84 (no commit message)
+┊│     8e:wu A second
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn move_file_above_branch_creates_branch_and_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊│     9a:wu A second
+┊●   fe12bcd add first
+┊│     fe:lz A first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 fe:lz --above A")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved 1 changes from fe12bcd to new branch 'a-branch-1' above branch 'A'
+
+"#]]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄br [a-branch-1]
+┊●   c019027 (no commit message)
+┊│     c0:lz A first
+┊│
+┊├┄g0 [A]
+┊●   38b1f1a add second
+┊│     38:wu A second
+┊●   d8dfd0f add first (no changes)
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn move_file_to_branch_tip_creates_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┊╭┄h0 [B]
+┊●   d3e2ba3 add B
+┊│     d3:pl A B
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 d3:pl --branch A")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved 1 changes from d3e2ba3 to the tip of branch 'A'
+
+"#]]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   be174de (no commit message)
+┊│     be:pl A B
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┊╭┄h0 [B]
+┊●   5bbe27c add B (no changes)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn move_file_to_non_existing_branch_tip_creates_unstacked_branch_and_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊│     9a:wu A second
+┊●   fe12bcd add first
+┊│     fe:lz A first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 9a:wu --branch new-branch")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved 1 changes from 9ac4652 to new branch 'new-branch'
+
+"#]]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   810e515 add second (no changes)
+┊●   fe12bcd add first
+┊│     fe:lz A first
+├╯
+┊
+┊╭┄ne [new-branch]
+┊●   8e35f84 (no commit message)
+┊│     8e:wu A second
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn move_file_branch_without_argument_creates_unstacked_branch_with_canned_name_and_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   9ac4652 add second
+┊│     9a:wu A second
+┊●   fe12bcd add first
+┊│     fe:lz A first
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_move2 9a:wu --branch")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved 1 changes from 9ac4652 to new branch 'a-branch-1'
+
+"#]]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   810e515 add second (no changes)
+┊●   fe12bcd add first
+┊│     fe:lz A first
+├╯
+┊
+┊╭┄br [a-branch-1]
+┊●   8e35f84 (no commit message)
+┊│     8e:wu A second
+├╯
+┊
+┴ 1bbc04b (common base) 2000-01-02 add Base
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
 fn targeting_unapplied_branch_errors() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks-one-empty");
     env.setup_metadata(&["A", "B"]);


### PR DESCRIPTION
Adds the ability to move committed files with `_move2`. The only reason we cannot move committed hunks is that there is currently no way to address them through `but`. As soon as we can do that we'll be able to add support for moving them here.

This is limited to moving files from a single source commit at a time due to API limitations. We could add a naive implementation that allows moving committed files from multiple source commits by just calling into the underlying API once per commit, but I think that'll run into ordering issues, so for a first stab we just say "nah".

`_squash2` has these same limitations.