### PR TITLE
tests: checkout with correct baseline

### DIFF
--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/mod.rs
@@ -184,7 +184,7 @@ impl TestRepo {
         )
         .expect("failed to commit");
         but_core::worktree::safe_checkout(
-            parent,
+            tree_id,
             commit_id,
             &repo,
             but_core::worktree::checkout::Options {


### PR DESCRIPTION
In this function, any changes in the working directory has already been committed, so all such changes need to be part of the baseline when checking out another commit (if not they would be double-counted: once as part of a dirty working directory and once as part of the commit being checked out).
