### PR TITLE
watcher: emit on local ref updates

### DIFF
--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -149,12 +149,17 @@ impl Handler {
                 FETCH_HEAD => {
                     self.emit_app_event(Change::GitFetch(project_id.clone()))?;
                 }
-                // Watch all local branches. Only emit activity if the HEAD points to that ref.
-                _ if file_name.starts_with(LOCAL_REFS_DIR) && file_name == head_ref_name => {
-                    self.emit_app_event(Change::GitActivity {
-                        project_id: project_id.clone(),
-                        head_sha: head_sha.clone(),
-                    })?;
+                // Watch all local branches. HEAD ref changes affect the current
+                // commit, while other branch refs can change workspace topology.
+                _ if file_name.starts_with(LOCAL_REFS_DIR) => {
+                    if file_name == head_ref_name {
+                        self.emit_app_event(Change::GitActivity {
+                            project_id: project_id.clone(),
+                            head_sha: head_sha.clone(),
+                        })?;
+                    } else {
+                        saw_workspace_activity = true;
+                    }
                 }
                 // Remote-ref updates and the refresh sentinel both mean "re-read
                 // workspace state"; coalesce into one emission after the loop.

--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -151,7 +151,7 @@ impl Handler {
                 }
                 // Watch all local branches. HEAD ref changes affect the current
                 // commit, while other branch refs can change workspace topology.
-                _ if file_name.starts_with(LOCAL_REFS_DIR) => {
+                _ if file_name.starts_with(LOCAL_REFS_DIR) && !file_name.ends_with(".lock") => {
                     if file_name == head_ref_name {
                         self.emit_app_event(Change::GitActivity {
                             project_id: project_id.clone(),


### PR DESCRIPTION
Emit if there were local ref changes (added, deleted, moved) as
workspace activity.