### PR TITLE
Handle rebuilding from formerly applied branches

### DIFF
--- a/crates/but-workspace/src/branch/apply.rs
+++ b/crates/but-workspace/src/branch/apply.rs
@@ -255,7 +255,11 @@ pub fn apply(
         branch = upstream_branch_name;
         branch_ref = try_find_validated_ref(repo, branch.as_ref(), "apply")?;
     }
-    if branch_is_already_applied(branch.as_ref(), &ws, meta)? {
+    let branch_has_applied_metadata =
+        branch_has_applied_workspace_metadata(branch.as_ref(), &ws, meta)?;
+    let branch_already_applied =
+        ws.is_reachable_from_entrypoint(branch.as_ref()) && branch_has_applied_metadata;
+    if branch_already_applied {
         let workspace_ref_created = false;
         // When exiting early, don't try to adjust the ws commit.
         return Ok(Outcome {
@@ -266,12 +270,13 @@ pub fn apply(
             conflicting_stacks: Vec::new(),
             applied_branches: Vec::new(),
         });
-    } else if ws.refname_is_segment(branch.as_ref()) {
+    } else if !branch_has_applied_metadata && ws.refname_is_segment(branch.as_ref()) {
         // This means our workspace encloses the desired branch, but it's not checked out yet.
         let commit_to_checkout = ws
             .tip_commit()
             .map(|commit| commit.id)
             .context("Workspace must point to a commit to check out")?;
+        let ws_ref_name = ws.ref_name().map(|rn| rn.to_owned());
         let current_head_commit = ws.graph.entrypoint()?.commit().context(
             "The entrypoint must have a commit - it's equal to HEAD, and we skipped unborn earlier",
         )?;
@@ -280,28 +285,32 @@ pub fn apply(
             commit_to_checkout,
             repo,
             but_core::worktree::checkout::Options {
-                skip_head_update: false,
+                skip_head_update: true,
                 ..Default::default()
             },
         )?;
         let applied_branches = vec![branch.to_owned()];
-        if !branch_has_applied_workspace_metadata(branch.as_ref(), &ws, meta)? {
-            let ws_ref_name = ws
-                .ref_name()
+        if !branch_has_applied_metadata {
+            let ws_ref_name = ws_ref_name
+                .as_ref()
                 .context("Workspace metadata must be available to repair stale applied state")?;
-            let mut ws_md = meta.workspace(ws_ref_name)?;
+            let mut ws_md = meta.workspace(ws_ref_name.as_ref())?;
             add_branch_as_stack_forcefully(&mut ws_md, branch.as_ref(), order, new_stack_id);
             persist_metadata_and_gitconfig(meta, &applied_branches, &ws_md, None)?;
         }
-        let ws_ref_name = ws.ref_name().map(|rn| rn.to_owned());
         let ws = ws
             .graph
             .redo_traversal_with_overlay(
                 repo,
                 meta,
-                Overlay::default().with_entrypoint(commit_to_checkout, ws_ref_name),
+                Overlay::default().with_entrypoint(commit_to_checkout, ws_ref_name.clone()),
             )?
             .into_workspace()?;
+        set_head_to_reference(
+            repo,
+            commit_to_checkout,
+            ws_ref_name.as_ref().map(|rn| rn.as_ref()),
+        )?;
 
         // When exiting early, don't try to adjust the ws commit.
         return Ok(Outcome {
@@ -406,7 +415,6 @@ pub fn apply(
     };
 
     let mut ws_md = meta.workspace(workspace_ref_name_to_update.as_ref())?;
-    let ws_md_orig = ws_md.clone();
     // When HEAD is on a branch that's already in the workspace, applying another branch re-roots
     // the workspace around just that branch plus the ones we apply.
     let head_branch_in_workspace = head_ref_name.as_ref().is_some_and(|head| {
@@ -453,6 +461,7 @@ pub fn apply(
             add_branch_as_stack_forcefully(ws_mut, rn.as_ref(), order, new_stack_id);
         }
     }
+    let ws_md_retry_base = ws_md.clone();
 
     let (local_tracking_config_and_ref_info, commit_to_create_branch_at) =
         if incoming_branch_is_remote_tracking_without_local_tracking {
@@ -502,13 +511,14 @@ pub fn apply(
         .iter()
         .map(|rn| (*rn).to_owned())
         .collect();
-    if all_applied_branches_are_already_visible {
-        let head_id = repo.head_id().context("BUG: we assume HEAD is born here")?;
-        if head_id != ws_ref_id {
-            bail!(
-                "Sanity check failed: we assume HEAD already points to where it must, but it really doesn't: {head_id} != {ws_ref_id}"
-            );
-        }
+    // Take the no-merge shortcut only when the branches to apply are already visible *and* HEAD is
+    // already at the workspace tip - either because it's on the workspace ref, or on a branch that
+    // points at the same commit (e.g. a freshly created ad-hoc workspace, or a detached HEAD on the
+    // sole stack). If HEAD sits on a different commit we must fall through to the merge path to
+    // re-root the workspace around the applied branches, which is what legitimately (re)creates the
+    // workspace commit.
+    let head_id = repo.head_id().context("BUG: we assume HEAD is born here")?;
+    if all_applied_branches_are_already_visible && head_id == ws_ref_id {
         persist_metadata_and_gitconfig(
             meta,
             &branches_to_apply,
@@ -626,7 +636,7 @@ pub fn apply(
         // Now that the merge is done, try to redo the operation one last time with dependent branches instead.
         // Only do that for the still unapplied branches, which should always find some sort of anchor.
         let ws_mut: &mut Workspace = &mut ws_md;
-        *ws_mut = ws_md_orig;
+        *ws_mut = ws_md_retry_base;
         for branch_to_add in branches_to_apply
             .iter()
             .filter(|rn| !unapplied_branches.contains(rn))
@@ -833,18 +843,6 @@ fn remove_conflicting_stacks_from_workspace(
         // TODO: this might as well be 'Unmerged' to keep them in the workspace, but not let them be merged.
         stack.workspacecommit_relation = Outside;
     }
-}
-
-fn branch_is_already_applied(
-    branch: &FullNameRef,
-    ws: &but_graph::Workspace,
-    meta: &impl RefMetadata,
-) -> anyhow::Result<bool> {
-    if !ws.is_reachable_from_entrypoint(branch) {
-        return Ok(false);
-    }
-
-    branch_has_applied_workspace_metadata(branch, ws, meta)
 }
 
 fn branch_has_applied_workspace_metadata(

--- a/crates/but-workspace/tests/fixtures/scenario/ws-ref-ws-commit-three-file-stacks.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/ws-ref-ws-commit-three-file-stacks.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A ws-ref points to a workspace commit with three independent file-backed stacks.
+git init
+
+echo base >base
+git add base
+git commit -m M
+setup_target_to_match_main
+
+git branch B
+git branch C
+git checkout -b A
+  echo A >A
+  git add A
+  git commit -m A
+git checkout B
+  echo B >B
+  git add B
+  git commit -m B
+git checkout C
+  echo C >C
+  git add C
+  git commit -m C
+create_workspace_commit_once A B C

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
@@ -1821,6 +1821,61 @@ fn apply_from_adhoc_checkout_rebuilds_around_current_and_applied() -> anyhow::Re
 }
 
 #[test]
+fn apply_already_applied_branch_from_adhoc_checkout_excludes_other_applied_stacks()
+-> anyhow::Result<()> {
+    let (_tmp, _graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-ws-commit-three-file-stacks",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "B", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 3, "C", StackState::InWorkspace, &[]);
+            },
+        )?;
+    assert_worktree_files(&repo, &["A", "B", "C"], &[]);
+
+    let a_tip_before_apply = id_by_rev(&repo, "A");
+    git(&repo).args(["checkout", "A"]).run();
+    assert_worktree_files(&repo, &["A"], &["B", "C"]);
+
+    let ws = Graph::from_head(
+        &repo,
+        &meta,
+        project_meta(&meta),
+        standard_traversal_options(),
+    )?
+    .into_workspace()?;
+    let out =
+        but_workspace::branch::apply(r("refs/heads/C"), ws, &repo, &mut meta, apply_options())?;
+
+    assert_eq!(out.status, OutcomeStatus::Applied);
+    assert_eq!(
+        id_by_rev(&repo, "A"),
+        a_tip_before_apply,
+        "applying from A must not move A to the workspace commit"
+    );
+    assert_eq!(
+        repo.head_name()?.as_ref().map(|rn| rn.as_bstr()),
+        Some(r("refs/heads/gitbutler/workspace").as_bstr()),
+        "applying from an ad-hoc checkout should switch back to the managed workspace"
+    );
+    assert_worktree_files(&repo, &["A", "C"], &["B"]);
+
+    let ws_md = meta.workspace(WORKSPACE_REF_NAME.try_into().unwrap())?;
+    let in_workspace = |name: &str| {
+        ws_md
+            .stacks
+            .iter()
+            .find(|s| s.name().is_some_and(|n| n.shorten() == name))
+            .map(|s| s.is_in_workspace())
+    };
+    assert_eq!(in_workspace("A"), Some(true));
+    assert_eq!(in_workspace("B"), Some(false));
+    assert_eq!(in_workspace("C"), Some(true));
+    Ok(())
+}
+
+#[test]
 fn new_workspace_exists_elsewhere_and_to_be_applied_branch_exists_there() -> anyhow::Result<()> {
     let (_tmp, ws_graph, repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph(
@@ -4455,7 +4510,7 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
         &mut meta,
         apply_options(),
     )?;
-    insta::assert_debug_snapshot!(out, @r#"
+    insta::assert_debug_snapshot!(out, "already applied branches are a no-op, even when a stack segment is checked out", @r#"
     Outcome {
         workspace_changed: false,
         workspace_ref_created: false,
@@ -4473,12 +4528,18 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
     );
 
     // To apply, we just checkout the surrounding workspace.
+    let b_tip_before_apply = id_by_rev(&repo, "B");
     let out =
         but_workspace::branch::apply(r("refs/heads/A"), ws, &repo, &mut meta, apply_options())?;
     assert_eq!(
         out.status,
         OutcomeStatus::Applied,
         "enclosed branches with commits should report a successful apply"
+    );
+    assert_eq!(
+        id_by_rev(&repo, "B"),
+        b_tip_before_apply,
+        "applying an enclosed branch must not move the previously checked-out branch"
     );
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {

--- a/e2e/playwright/scripts/project-in-single-branch-existing-workspace-apply.sh
+++ b/e2e/playwright/scripts/project-in-single-branch-existing-workspace-apply.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "GIT CONFIG $GIT_CONFIG_GLOBAL"
+echo "DATA DIR $E2E_TEST_APP_DATA_DIR"
+echo "BUT $BUT"
+
+mkdir local-clone
+pushd local-clone
+git init -b main --object-format=sha1
+git commit --allow-empty -m "base"
+
+git checkout main
+git checkout -b feature-foo
+echo "line 1" >> foo.txt
+git add foo.txt
+git commit -m "Add foo.txt"
+
+git checkout main
+git checkout -b bug-fix
+echo "line 1" >> fix.txt
+git add fix.txt
+git commit -m "Add fix.txt"
+
+git checkout main
+"$BUT" setup
+
+"$BUT" apply feature-foo
+"$BUT" apply bug-fix
+test "$(git branch --show-current)" = "gitbutler/workspace"
+
+# Enter single-branch/ad-hoc mode from one of the branches already enclosed by
+# the managed workspace. Applying feature-foo from the UI should return to the
+# managed workspace and keep both branches applied.
+git switch bug-fix
+popd

--- a/e2e/playwright/scripts/project-in-single-branch-existing-workspace-reroot.sh
+++ b/e2e/playwright/scripts/project-in-single-branch-existing-workspace-reroot.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "GIT CONFIG $GIT_CONFIG_GLOBAL"
+echo "DATA DIR $E2E_TEST_APP_DATA_DIR"
+echo "BUT $BUT"
+
+mkdir local-clone
+pushd local-clone
+git init -b main --object-format=sha1
+git commit --allow-empty -m "base"
+
+git checkout main
+git checkout -b A
+echo "line 1" >> A.txt
+git add A.txt
+git commit -m "Add A.txt"
+
+git checkout main
+git checkout -b B
+echo "line 1" >> B.txt
+git add B.txt
+git commit -m "Add B.txt"
+
+git checkout main
+git checkout -b C
+echo "line 1" >> C.txt
+git add C.txt
+git commit -m "Add C.txt"
+
+git checkout main
+"$BUT" setup
+
+"$BUT" apply A
+"$BUT" apply B
+"$BUT" apply C
+test "$(git branch --show-current)" = "gitbutler/workspace"
+
+# Leave the managed workspace through one of its already-applied branches. Applying another
+# already-applied branch from the UI should rebuild the managed workspace around A and C only.
+git switch A
+popd

--- a/e2e/playwright/tests/singleBranch/commitActions.spec.ts
+++ b/e2e/playwright/tests/singleBranch/commitActions.spec.ts
@@ -29,6 +29,7 @@ import {
 	stack,
 } from "../../src/util.ts";
 import { expect } from "@playwright/test";
+import { execFileSync } from "child_process";
 
 test.use({
 	gitbutlerOptions: {
@@ -180,3 +181,65 @@ test("rebuilds an enclosed ad-hoc workspace around the current and applied branc
 	await expect(stack(page, "C")).toBeVisible();
 	await assertCleanWorktree(localClone);
 });
+
+test("re-enters the managed workspace when applying an already-enclosed branch", async ({
+	page,
+	gitbutler,
+}) => {
+	await gitbutler.runScript("project-in-single-branch-existing-workspace-apply.sh");
+	const localClone = gitbutler.pathInWorkdir("local-clone");
+	await assertBranch("bug-fix", localClone);
+	await assertSymbolicHead("bug-fix", localClone);
+	const bugFixTipBeforeApply = git(localClone, ["rev-parse", "bug-fix"]);
+
+	await openSingleBranchWorkspace(page);
+
+	await applyBranchFromBranchesView(page, "feature-foo");
+
+	await assertBranch("gitbutler/workspace", localClone);
+	await expect(getByTestId(page, "chrome-header-current-branch")).toContainText(
+		"gitbutler/workspace",
+	);
+	await expect(getByTestId(page, "chrome-header-current-branch")).not.toContainText("read-only");
+	await expect(getByTestId(page, "chrome-header-switch-back-to-workspace-button")).toHaveCount(0);
+	await expect(getByTestId(page, "branch-card")).toHaveCount(2);
+	await expect(stack(page, "feature-foo")).toBeVisible();
+	await expect(stack(page, "bug-fix")).toBeVisible();
+	expect(git(localClone, ["rev-parse", "bug-fix"])).toBe(bugFixTipBeforeApply);
+	await assertCleanWorktree(localClone);
+});
+
+test("rebuilds managed workspace around checked-out and applied branches", async ({
+	page,
+	gitbutler,
+}) => {
+	await gitbutler.runScript("project-in-single-branch-existing-workspace-reroot.sh");
+	const localClone = gitbutler.pathInWorkdir("local-clone");
+	await assertBranch("A", localClone);
+	await assertSymbolicHead("A", localClone);
+	const aTipBeforeApply = git(localClone, ["rev-parse", "A"]);
+
+	await openSingleBranchWorkspace(page);
+
+	await applyBranchFromBranchesView(page, "C");
+
+	await assertBranch("gitbutler/workspace", localClone);
+	await expect(getByTestId(page, "chrome-header-current-branch")).toContainText(
+		"gitbutler/workspace",
+	);
+	await expect(getByTestId(page, "chrome-header-current-branch")).not.toContainText("read-only");
+	await expect(getByTestId(page, "chrome-header-switch-back-to-workspace-button")).toHaveCount(0);
+	await expect(getByTestId(page, "branch-card")).toHaveCount(2);
+	await expect(stack(page, "A")).toBeVisible();
+	await expect(stack(page, "B")).toHaveCount(0);
+	await expect(stack(page, "C")).toBeVisible();
+	expect(git(localClone, ["rev-parse", "A"])).toBe(aTipBeforeApply);
+	await assertCleanWorktree(localClone);
+});
+
+function git(pathToRepo: string, args: string[]): string {
+	return execFileSync("git", args, {
+		cwd: pathToRepo,
+		encoding: "utf8",
+	}).trim();
+}


### PR DESCRIPTION
Fixes GB-1708

## Summary
Applying a branch from an ad-hoc/single-branch checkout could use stale applied-stack state from the previous managed workspace. In the UI this showed up as `Stack not found`; in the backend it could re-enter the old workspace shape or move the checked-out branch ref while applying.

This changes apply handling so applied metadata is not treated as proof that a branch is applied from the current entrypoint. From an ad-hoc checkout, applying an already-enclosed branch now rebuilds the managed workspace around the checked-out branch plus the branch being applied. For example: A, B, and C were applied; checkout A; apply C; the workspace becomes A + C, with B left unapplied.

The UI also falls back to the normal branch view when a stale stack id cannot be resolved.

## Validation
- Focused Rust coverage for the ad-hoc checkout apply case.
- Dedicated three-stack fixture.
- Playwright coverage for applying an already-enclosed branch and excluding stale previously-applied branches.
- Targeted Rust, desktop type-check, and Playwright validation.