### PR TITLE
Suggest `but commit` in status hint instead of `but stage`

### DIFF
--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -648,7 +648,7 @@ fn print_hint(
     } else if !status_ctx.has_branches {
         "Hint: run `but branch new` to create a new branch to work on"
     } else if has_uncommitted_files {
-        "Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch"
+        "Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m \"message\" --changes <id>` to commit them"
     } else {
         "Hint: run `but help` for all commands"
     };

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -320,7 +320,7 @@ nk:5 a.txt│
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
-Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
 
 "#]]);
 

--- a/crates/but/tests/but/command/commit2.rs
+++ b/crates/but/tests/but/command/commit2.rs
@@ -510,7 +510,7 @@ fn empty_flag_to_force_empty_commit_when_changes_exist() {
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
-Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
 
 "#]]);
 }
@@ -626,7 +626,7 @@ fn commit_above_commit() {
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
 
-Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
 
 "#]]);
 
@@ -673,7 +673,7 @@ fn commit_above_branch() {
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
-Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
 
 "#]]);
 
@@ -722,7 +722,7 @@ fn commit_below_commit() {
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
 
-Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
 
 "#]]);
 
@@ -769,7 +769,7 @@ fn commit_below_branch() {
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
-Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
 
 "#]]);
 
@@ -818,7 +818,7 @@ fn commit_below_branch_with_multiple_commits_treats_branch_as_bucket() {
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
 
-Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
 
 "#]]);
 
@@ -1061,7 +1061,7 @@ fn committing_specific_cli_ids() {
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
-Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
 
 "#]]);
 
@@ -1083,7 +1083,7 @@ Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage 
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
-Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
 
 "#]]);
 }
@@ -1302,7 +1302,7 @@ fn can_commit_with_path_prefix() {
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
-Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
 
 "#]]);
 
@@ -1325,7 +1325,7 @@ Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage 
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
-Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
 
 "#]]);
 }
@@ -1368,7 +1368,7 @@ fn path_prefix_with_mix_of_modifications() {
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
-Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
 
 "#]]);
 
@@ -1567,7 +1567,7 @@ fn committing_below_an_empty_branch() {
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
-Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
 
 "#]]);
 
@@ -1590,7 +1590,7 @@ Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage 
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
-Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
 
 "#]]);
 

--- a/crates/but/tests/but/command/move2.rs
+++ b/crates/but/tests/but/command/move2.rs
@@ -2332,7 +2332,7 @@ fn cannot_move_from_uncommitted() {
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
-Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
 
 "#]]);
 

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -2264,7 +2264,7 @@ Hint: run `but help` for all commands
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
-Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
 
 "#]]);
 
@@ -2335,7 +2335,7 @@ Hint: run `but help` for all commands
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
-Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
 
 "#]]);
 

--- a/crates/but/tests/but/command/snapshots/status/hints/status-hint-with-uncommitted-changes.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/hints/status-hint-with-uncommitted-changes.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="827px" height="218px" xmlns="http://www.w3.org/2000/svg">
+<svg width="995px" height="218px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -39,7 +39,7 @@
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>
-    <tspan x="10px" y="190px"><tspan class="dimmed">Hint: run `but diff` to see uncommitted changes and `but stage &lt;file&gt;` to stage them to a branch</tspan>
+    <tspan x="10px" y="190px"><tspan class="dimmed">Hint: run `but diff` to see uncommitted changes and `but commit &lt;branch&gt; -m "message" --changes &lt;id&gt;` to commit them</tspan>
 </tspan>
     <tspan x="10px" y="208px">
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/long-file-cli-ids-are-aligned.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/long-file-cli-ids-are-aligned.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="827px" height="470px" xmlns="http://www.w3.org/2000/svg">
+<svg width="995px" height="470px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -67,7 +67,7 @@
 </tspan>
     <tspan x="10px" y="424px">
 </tspan>
-    <tspan x="10px" y="442px"><tspan class="dimmed">Hint: run `but diff` to see uncommitted changes and `but stage &lt;file&gt;` to stage them to a branch</tspan>
+    <tspan x="10px" y="442px"><tspan class="dimmed">Hint: run `but diff` to see uncommitted changes and `but commit &lt;branch&gt; -m "message" --changes &lt;id&gt;` to commit them</tspan>
 </tspan>
     <tspan x="10px" y="460px">
 </tspan>

--- a/crates/but/tests/but/command/squash2.rs
+++ b/crates/but/tests/but/command/squash2.rs
@@ -896,7 +896,7 @@ fn amend_uncommitted_files_into_commit() {
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
-Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
 
 "#]]);
 
@@ -923,7 +923,7 @@ Amended 7adb8e6 to create d2f176a
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
-Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
 
 "#]]);
 }
@@ -947,7 +947,7 @@ fn amend_all_uncommitted_changes_into_commit() {
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
-Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
 
 "#]]);
 
@@ -1274,7 +1274,7 @@ Error: --target cannot be an empty branch
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
-Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
 
 "#]]);
     // middle should be considered empty even though there are commits on its parent
@@ -1333,7 +1333,7 @@ Uncommitted f55169f
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
-Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
 
 "#]]);
 
@@ -1395,7 +1395,7 @@ Uncommitted from f55169f
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
-Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
 
 "#]]);
 }


### PR DESCRIPTION
The uncommitted-changes status hint advertised `but stage <file>`, which we no longer want to surface. Point it at `but commit -m "message" --changes <id>` instead, matching the change IDs already shown in the status output.