### PR TITLE
feat(cli): experimental `_diff2` command

### DIFF
--- a/crates/but/src/args/diff2.rs
+++ b/crates/but/src/args/diff2.rs
@@ -1,0 +1,7 @@
+use crate::args::atoms::CliIdArg;
+
+#[derive(Debug, clap::Parser)]
+#[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
+pub struct Platform {
+    pub target: Option<CliIdArg>,
+}

--- a/crates/but/src/args/metrics.rs
+++ b/crates/but/src/args/metrics.rs
@@ -19,6 +19,7 @@ pub enum CommandName {
     Move,
     Move2,
     Diff,
+    Diff2,
     Edit,
     Show,
     Commit,

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -271,6 +271,11 @@ pub enum Subcommands {
     #[clap(hide = true, name = "_move2")]
     _Move2(move2::Platform),
 
+    #[cfg(all(feature = "legacy", feature = "but-2"))]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
+    #[clap(hide = true, name = "_diff2")]
+    _Diff2(diff2::Platform),
+
     /// Stages a file or hunk to a specific branch.
     ///
     /// Without arguments, opens an interactive TUI for selecting files and hunks to stage.
@@ -1372,6 +1377,8 @@ pub mod commit;
 #[cfg(feature = "legacy")]
 pub mod commit2;
 pub mod config;
+#[cfg(feature = "legacy")]
+pub mod diff2;
 #[cfg(feature = "legacy")]
 pub mod move2;
 pub mod skill;

--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -80,6 +80,8 @@ fn print_grouped_with_truncation(
                 SubcommandDiscriminant::Status => Group::Inspection,
                 #[cfg(feature = "legacy")]
                 SubcommandDiscriminant::Diff => Group::Inspection,
+                #[cfg(all(feature = "legacy", feature = "but-2"))]
+                SubcommandDiscriminant::_Diff2 => Group::Inspection,
                 #[cfg(feature = "legacy")]
                 SubcommandDiscriminant::Show => Group::Inspection,
 

--- a/crates/but/src/command/legacy/diff2.rs
+++ b/crates/but/src/command/legacy/diff2.rs
@@ -1,0 +1,234 @@
+use bstr::BString;
+use but_ctx::Context;
+use gix::{ObjectId, refs::FullName};
+use serde::Serialize;
+use syntect::parsing::SyntaxSet;
+
+use crate::{
+    CliResult, IdMap,
+    args::{
+        atoms::{Purpose, ResolvedCliIdArg},
+        diff2::Platform,
+    },
+    bad_input,
+    id::{ShortId, UncommittedHunkOrFile},
+    theme::{Paint as _, Theme},
+    utils::{
+        CliOutput, CliOutputHuman, IntermediateChannel, WriteWithUtils,
+        diff_rendering::{self, DetailsLine, DiffLineWriter, IdGen, WithSyntaxHighlighting},
+        string_interning::Strings,
+    },
+};
+
+#[derive(Debug)]
+pub struct DiffOutcome<'a> {
+    ctx: &'a mut Context,
+    target: DiffOperation,
+}
+
+impl CliOutputHuman for DiffOutcome<'_> {
+    fn on_human(self, out: &mut dyn WriteWithUtils, theme: &'static Theme) -> anyhow::Result<()> {
+        let Self { ctx, target } = self;
+
+        let syntax_set = SyntaxSet::load_defaults_newlines();
+        let syntax_theme = theme.load_syntax_highlighting_theme()?;
+
+        let strings = Strings::default();
+        let writer = DiffWriter { out };
+        let mut writer =
+            WithSyntaxHighlighting::new(writer, strings.clone(), &syntax_set, &syntax_theme);
+        let mut id_gen = IdGen::new(strings);
+
+        let options = diff_rendering::Options {
+            skip_commit_header: true,
+            skip_line_stats: true,
+        };
+
+        match target {
+            DiffOperation::Uncommitted => {
+                diff_rendering::render_uncommitted(ctx, theme, &mut id_gen, options, &mut writer)?;
+            }
+            DiffOperation::Commit { commit } => {
+                diff_rendering::render_commit(
+                    commit,
+                    ctx,
+                    theme,
+                    &mut id_gen,
+                    options,
+                    &mut writer,
+                )?;
+            }
+            DiffOperation::Branch { branch } => {
+                let branch = branch.shorten().to_string();
+                diff_rendering::render_branch(
+                    branch,
+                    ctx,
+                    theme,
+                    &mut id_gen,
+                    options,
+                    &mut writer,
+                )?;
+            }
+            DiffOperation::UncommittedHunkOrFile { hunk } => {
+                diff_rendering::render_uncommitted_hunk(
+                    *hunk,
+                    ctx,
+                    theme,
+                    &mut id_gen,
+                    options,
+                    &mut writer,
+                )?;
+            }
+            DiffOperation::CommittedFile {
+                commit_id,
+                path,
+                id,
+            } => {
+                diff_rendering::render_committed_file(
+                    commit_id,
+                    path,
+                    id,
+                    ctx,
+                    theme,
+                    &mut id_gen,
+                    options,
+                    &mut writer,
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl CliOutput for DiffOutcome<'_> {
+    fn on_shell(self, out: &mut dyn WriteWithUtils) -> anyhow::Result<()> {
+        self.on_human(out, crate::theme::get())
+    }
+
+    fn on_json(self) -> impl Serialize {
+        // TODO(david)
+
+        #[derive(Serialize)]
+        struct Output {}
+
+        Output {}
+    }
+}
+
+struct DiffWriter<'a> {
+    out: &'a mut dyn WriteWithUtils,
+}
+
+impl DiffLineWriter for DiffWriter<'_> {
+    fn write(&mut self, line: DetailsLine) -> anyhow::Result<()> {
+        match line {
+            DetailsLine::Text {
+                id: _,
+                line,
+                skip_when_copying_hunk: _,
+            } => {
+                let line_style = line.style;
+                for span in line.spans {
+                    let rendered = line_style.patch(span.style).paint(&span.content);
+                    write!(self.out, "{rendered}")?;
+                }
+                writeln!(self.out)?;
+            }
+            DetailsLine::TextToWrap { id: _, text } => {
+                writeln!(self.out, "{text}")?;
+            }
+            DetailsLine::Code(code_line) => {
+                let highlighted_line = code_line.highlighted_line.borrow();
+                let highlighted_line = highlighted_line
+                    .as_ref()
+                    .expect("WithSyntaxHighlighting ensures the line is highlighted");
+
+                for span in highlighted_line {
+                    let rendered = span.style.paint(&span.content);
+                    write!(self.out, "{rendered}")?;
+                }
+                writeln!(self.out)?;
+            }
+            DetailsLine::SectionSeparator => {
+                writeln!(self.out)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+pub fn diff<'a>(
+    ctx: &'a mut Context,
+    _out: IntermediateChannel<'_>,
+    args: Platform,
+) -> CliResult<DiffOutcome<'a>> {
+    let guard = ctx.shared_worktree_access();
+    let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
+
+    let op = resolve(ctx, &id_map, args)?;
+    Ok(run(ctx, op)?)
+}
+
+fn resolve(ctx: &Context, id_map: &IdMap, args: Platform) -> CliResult<DiffOperation> {
+    let Platform { target } = args;
+
+    let resolved_target = if let Some(target) = target {
+        let repo = ctx.repo.get()?;
+        target.resolve_in_workspace(&repo, id_map, Purpose::Target, None)?
+    } else {
+        ResolvedCliIdArg::Uncommitted
+    };
+
+    match resolved_target {
+        ResolvedCliIdArg::Uncommitted => Ok(DiffOperation::Uncommitted),
+        ResolvedCliIdArg::Commit(commit) => Ok(DiffOperation::Commit { commit }),
+        ResolvedCliIdArg::Branch(branch) => {
+            let branch = branch.resolve_local_branch_name()?;
+            Ok(DiffOperation::Branch { branch })
+        }
+        ResolvedCliIdArg::UncommittedHunkOrFile(hunk) => {
+            Ok(DiffOperation::UncommittedHunkOrFile { hunk })
+        }
+        ResolvedCliIdArg::CommittedFile {
+            commit_id,
+            path,
+            id,
+        } => Ok(DiffOperation::CommittedFile {
+            commit_id,
+            path,
+            id,
+        }),
+        ResolvedCliIdArg::Stack => {
+            Err(bad_input("viewing diffs for stack assignments is not supported").into())
+        }
+        ResolvedCliIdArg::PathPrefix => {
+            // TODO(david)
+            Err(anyhow::anyhow!("path prefix targets are not yet implemented").into())
+        }
+    }
+}
+
+fn run(ctx: &mut Context, op: DiffOperation) -> anyhow::Result<DiffOutcome<'_>> {
+    Ok(DiffOutcome { ctx, target: op })
+}
+
+#[derive(Debug)]
+enum DiffOperation {
+    Uncommitted,
+    Commit {
+        commit: ObjectId,
+    },
+    Branch {
+        branch: FullName,
+    },
+    UncommittedHunkOrFile {
+        hunk: Box<UncommittedHunkOrFile>,
+    },
+    CommittedFile {
+        commit_id: ObjectId,
+        path: BString,
+        id: ShortId,
+    },
+}

--- a/crates/but/src/command/legacy/mod.rs
+++ b/crates/but/src/command/legacy/mod.rs
@@ -13,6 +13,8 @@ pub mod commit;
 pub mod commit2;
 pub mod commit_message_prep;
 pub mod diff;
+#[cfg(all(feature = "legacy", feature = "but-2"))]
+pub mod diff2;
 pub mod discard;
 pub mod forge;
 pub mod land;

--- a/crates/but/src/command/legacy/status/tui/details.rs
+++ b/crates/but/src/command/legacy/status/tui/details.rs
@@ -19,7 +19,7 @@ use ratatui::{
     style::{Color, Stylize as _},
     text::Line,
 };
-use syntect::{highlighting, parsing::SyntaxSet};
+use syntect::{easy::HighlightLines, highlighting, parsing::SyntaxSet};
 
 use crate::{
     CliId,
@@ -184,8 +184,15 @@ impl Details {
                     ctx,
                     Some(CacheKey::Commit(commit)),
                     selection_did_change,
-                    move |ctx, theme, id_gen, line_writer| {
-                        diff_rendering::render_commit(commit, ctx, theme, id_gen, line_writer)
+                    move |ctx, theme, id_gen, line_writer, options| {
+                        diff_rendering::render_commit(
+                            commit,
+                            ctx,
+                            theme,
+                            id_gen,
+                            options,
+                            line_writer,
+                        )
                     },
                 )
             }
@@ -195,8 +202,15 @@ impl Details {
                     ctx,
                     None,
                     selection_did_change,
-                    move |ctx, theme, id_gen, line_writer| {
-                        diff_rendering::render_branch(name, ctx, theme, id_gen, line_writer)
+                    move |ctx, theme, id_gen, line_writer, options| {
+                        diff_rendering::render_branch(
+                            name,
+                            ctx,
+                            theme,
+                            id_gen,
+                            options,
+                            line_writer,
+                        )
                     },
                 )
             }
@@ -204,8 +218,8 @@ impl Details {
                 ctx,
                 None,
                 selection_did_change,
-                move |ctx, theme, id_gen, line_writer| {
-                    diff_rendering::render_uncommitted(ctx, theme, id_gen, line_writer)
+                move |ctx, theme, id_gen, line_writer, options| {
+                    diff_rendering::render_uncommitted(ctx, theme, id_gen, options, line_writer)
                 },
             ),
             CliId::UncommittedHunkOrFile(uncommitted) => {
@@ -214,12 +228,13 @@ impl Details {
                     ctx,
                     None,
                     selection_did_change,
-                    move |ctx, theme, id_gen, line_writer| {
+                    move |ctx, theme, id_gen, line_writer, options| {
                         diff_rendering::render_uncommitted_hunk(
                             uncommitted,
                             ctx,
                             theme,
                             id_gen,
+                            options,
                             line_writer,
                         )
                     },
@@ -237,7 +252,7 @@ impl Details {
                     ctx,
                     None,
                     selection_did_change,
-                    move |ctx, theme, id_gen, line_writer| {
+                    move |ctx, theme, id_gen, line_writer, options| {
                         diff_rendering::render_committed_file(
                             commit,
                             path,
@@ -245,6 +260,7 @@ impl Details {
                             ctx,
                             theme,
                             id_gen,
+                            options,
                             line_writer,
                         )
                     },
@@ -286,6 +302,7 @@ impl Details {
                 &'static Theme,
                 &mut IdGen<'_>,
                 &mut dyn DiffLineWriter,
+                diff_rendering::Options,
             ) -> anyhow::Result<()>
             + Clone
             + Send
@@ -319,6 +336,7 @@ impl Details {
                 &'static Theme,
                 &mut IdGen<'_>,
                 &mut dyn DiffLineWriter,
+                diff_rendering::Options,
             ) -> anyhow::Result<()>
             + Send
             + 'static,
@@ -363,8 +381,14 @@ impl Details {
                     let mut id_gen = IdGen::new(strings);
 
                     count_allocations("details fetch diff", || {
-                        match f(&mut ctx, theme, &mut id_gen, &mut line_writer)
-                            .context("failed rendering commit diff")
+                        match f(
+                            &mut ctx,
+                            theme,
+                            &mut id_gen,
+                            &mut line_writer,
+                            diff_rendering::Options::default(),
+                        )
+                        .context("failed rendering commit diff")
                         {
                             Ok(()) => {
                                 _ = line_writer.tx.send(RenderThreadMessage::Finished);
@@ -464,6 +488,7 @@ impl Details {
 
         let syntax_set = self.syntax_set.get().unwrap();
         let syntax_theme = self.syntax_theme.get().unwrap();
+        let mut highlight_lines = None;
 
         let section_selected_bg = self.theme.discrete_selection_highlight.bg.unwrap();
 
@@ -513,6 +538,7 @@ impl Details {
                 section_selected_bg,
                 &syntax_set,
                 &syntax_theme,
+                &mut highlight_lines,
                 frame,
             );
 
@@ -600,7 +626,7 @@ impl Details {
     }
 
     #[expect(clippy::too_many_arguments)]
-    fn render_details_line(
+    fn render_details_line<'a>(
         &self,
         line: &DetailsLine,
         skip_display_lines: usize,
@@ -608,8 +634,9 @@ impl Details {
         width: u16,
         tui_has_focus: bool,
         section_selected_bg: Color,
-        syntax_set: &SyntaxSet,
-        syntax_theme: &highlighting::Theme,
+        syntax_set: &'a SyntaxSet,
+        syntax_theme: &'a syntect::highlighting::Theme,
+        highlight_lines: &mut Option<HighlightLines<'a>>,
         frame: &mut Frame,
     ) -> RenderedLine {
         match line {
@@ -618,6 +645,8 @@ impl Details {
                 id,
                 skip_when_copying_hunk: _,
             } => {
+                *highlight_lines = None;
+
                 if skip_display_lines == 0 {
                     let Some(line_area) = areas.next() else {
                         return RenderedLine::viewport_filled();
@@ -637,6 +666,8 @@ impl Details {
                 }
             }
             DetailsLine::TextToWrap { text, id } => {
+                *highlight_lines = None;
+
                 for line in wrapped_text_lines(text, width).skip(skip_display_lines) {
                     let Some(line_area) = areas.next() else {
                         return RenderedLine::viewport_filled();
@@ -657,15 +688,25 @@ impl Details {
                         return RenderedLine::viewport_filled();
                     };
 
-                    let id = line.id;
+                    if highlight_lines.is_none() {
+                        let syntax = line.syntax(syntax_set);
+                        *highlight_lines = Some(HighlightLines::new(syntax, syntax_theme));
+                    }
 
+                    let id = line.id;
                     let mut strings = self.strings.lock();
-                    line.ensure_highlighted(syntax_set, syntax_theme, self.theme, &mut strings);
+
+                    line.ensure_highlighted(
+                        syntax_set,
+                        highlight_lines.as_mut().unwrap(),
+                        self.theme,
+                        &mut strings,
+                    );
 
                     let highlighted_line = line.highlighted_line.borrow();
                     let highlighted_line = highlighted_line
                         .as_ref()
-                        .expect("ensure_highlighted was just called");
+                        .expect("line should have been highlighted by now");
 
                     if self.section_is_highlighted(id) {
                         frame.render_widget(
@@ -683,6 +724,8 @@ impl Details {
                 }
             }
             DetailsLine::SectionSeparator => {
+                *highlight_lines = None;
+
                 if skip_display_lines == 0 {
                     let Some(line_area) = areas.next() else {
                         return RenderedLine::viewport_filled();

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -189,6 +189,11 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
         out.request_pager();
     }
 
+    #[cfg(all(feature = "legacy", feature = "but-2"))]
+    if matches!(&args.cmd, Some(Subcommands::_Diff2(_))) {
+        out.request_pager();
+    }
+
     if let (Err(theme_preset_err), Some(out)) = (theme_preset_from_env, out.for_human_ui()) {
         writeln!(
             out,
@@ -1102,6 +1107,27 @@ async fn match_subcommand(
                 command::legacy::move2::r#move(&mut ctx, IntermediateChannel::new(out), move_args)
                     .emit_metrics(metrics_ctx)?;
             out.print_cli_output_human(outcome)?;
+            Ok(())
+        }
+        #[cfg(all(feature = "legacy", feature = "but-2"))]
+        Subcommands::_Diff2(diff_args) => {
+            use crate::utils::{IntermediateChannel, OutputChannelExt};
+
+            let status_after = args.status_after;
+            let mut ctx = setup::init_ctx(
+                &args,
+                InitCtxOptions {
+                    background_sync: BackgroundSync::Enabled { silent: false },
+                    ..Default::default()
+                },
+                out,
+            )?;
+            out.begin_status_after(status_after);
+
+            let outcome =
+                command::legacy::diff2::diff(&mut ctx, IntermediateChannel::new(out), diff_args)
+                    .emit_metrics(metrics_ctx)?;
+            out.print_cli_output(outcome)?;
             Ok(())
         }
         #[cfg(feature = "legacy")]

--- a/crates/but/src/utils/diff_rendering.rs
+++ b/crates/but/src/utils/diff_rendering.rs
@@ -22,7 +22,10 @@ use ratatui::{
     style::{Color, Stylize as _},
     text::{Line, Span},
 };
-use syntect::{easy::HighlightLines, highlighting, parsing::SyntaxSet};
+use syntect::{
+    easy::HighlightLines,
+    parsing::{SyntaxReference, SyntaxSet},
+};
 use unicode_width::UnicodeWidthStr as _;
 
 use crate::{
@@ -130,6 +133,71 @@ pub trait DiffLineWriter {
     }
 }
 
+#[cfg(feature = "but-2")]
+pub struct WithSyntaxHighlighting<'a, T> {
+    inner: T,
+    strings: Strings,
+    syntax_set: &'a SyntaxSet,
+    syntax_theme: &'a syntect::highlighting::Theme,
+    highlight_lines: Option<HighlightLines<'a>>,
+    theme: &'static Theme,
+}
+
+#[cfg(feature = "but-2")]
+impl<'a, T> WithSyntaxHighlighting<'a, T> {
+    pub fn new(
+        inner: T,
+        strings: Strings,
+        syntax_set: &'a SyntaxSet,
+        syntax_theme: &'a syntect::highlighting::Theme,
+    ) -> Self {
+        Self {
+            inner,
+            strings,
+            syntax_set,
+            syntax_theme,
+            highlight_lines: None,
+            theme: crate::theme::get(),
+        }
+    }
+}
+
+#[cfg(feature = "but-2")]
+impl<T> DiffLineWriter for WithSyntaxHighlighting<'_, T>
+where
+    T: DiffLineWriter,
+{
+    fn write(&mut self, line: DetailsLine) -> anyhow::Result<()> {
+        match line {
+            DetailsLine::Code(code_line) => {
+                if self.highlight_lines.is_none() {
+                    let syntax = code_line.syntax(self.syntax_set);
+                    self.highlight_lines = Some(HighlightLines::new(syntax, self.syntax_theme));
+                }
+
+                let highlight_lines = self.highlight_lines.as_mut().unwrap();
+
+                let mut strings = self.strings.lock();
+
+                code_line.ensure_highlighted(
+                    self.syntax_set,
+                    highlight_lines,
+                    self.theme,
+                    &mut strings,
+                );
+
+                self.inner.write(DetailsLine::Code(code_line))?;
+            }
+            other => {
+                self.highlight_lines = None;
+                self.inner.write(other)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum DetailsLine {
@@ -168,50 +236,33 @@ impl DetailsCodeLine {
     pub fn ensure_highlighted(
         &self,
         syntax_set: &SyntaxSet,
-        syntax_theme: &highlighting::Theme,
+        highlight_lines: &mut HighlightLines<'_>,
         theme: &'static Theme,
         strings: &mut SharedStrings,
     ) {
-        let Self {
-            highlighted_line,
-            line_numbers,
-            path,
-            line_start_end: _,
-            diff: _,
-            id: _,
-        } = self;
-
-        if highlighted_line.borrow().is_some() {
+        if self.highlighted_line.borrow().is_some() {
             return;
         }
 
-        let syntax = {
-            let path = path.to_path_lossy();
-            path.extension()
-                .and_then(|ext| syntax_set.find_syntax_by_extension(ext.to_str()?))
-                .or_else(|| {
-                    path.file_name().and_then(|file_name| {
-                        syntax_set.find_syntax_by_extension(file_name.to_str()?)
-                    })
-                })
-                .unwrap_or_else(|| syntax_set.find_syntax_plain_text())
-        };
-
-        // TODO: creating a new `HighlightLines` per line isn't ideal. Instead we should have reuse
-        // two `HighlightLines` per hunk. One for added+context lines and one for deleted lines.
-        // That should highlight correctly across lines and reuse internal buffers better.
-        //
-        // Remember to advance both `HighlightLines` on context lines.
-        let mut highlight_lines = HighlightLines::new(syntax, syntax_theme);
-
         self.with_line_from_diff(|line| {
-            let bg = line_numbers.kind.bg(theme);
-            let line_numbers = line_numbers.spans(strings, theme);
-            *highlighted_line.borrow_mut() =
+            let bg = self.line_numbers.kind.bg(theme);
+            let line_numbers = self.line_numbers.spans(strings, theme);
+            *self.highlighted_line.borrow_mut() =
                 Some(Line::from_iter(line_numbers.into_iter().chain(
-                    syntax_highlight(line, bg, &mut highlight_lines, syntax_set),
+                    syntax_highlight(line, bg, highlight_lines, syntax_set),
                 )));
         });
+    }
+
+    pub fn syntax<'a>(&self, syntax_set: &'a SyntaxSet) -> &'a SyntaxReference {
+        let path = self.path.to_path_lossy();
+        path.extension()
+            .and_then(|ext| syntax_set.find_syntax_by_extension(ext.to_str()?))
+            .or_else(|| {
+                path.file_name()
+                    .and_then(|file_name| syntax_set.find_syntax_by_extension(file_name.to_str()?))
+            })
+            .unwrap_or_else(|| syntax_set.find_syntax_plain_text())
     }
 
     pub fn with_line_from_diff<F, T>(&self, f: F) -> T
@@ -335,11 +386,18 @@ impl CodeLineNumbers {
     }
 }
 
+#[derive(Debug, Copy, Clone, Default)]
+pub struct Options {
+    pub skip_commit_header: bool,
+    pub skip_line_stats: bool,
+}
+
 pub fn render_commit(
     commit: ObjectId,
     ctx: &mut Context,
     theme: &'static Theme,
     id_gen: &mut IdGen<'_>,
+    options: Options,
     out: &mut dyn DiffLineWriter,
 ) -> anyhow::Result<()> {
     let mut id_gen = id_gen.scoped("commits");
@@ -350,40 +408,42 @@ pub fn render_commit(
 
     let header_id = id_gen.new_id("header");
 
-    out.write_selectable_text(
-        header_id,
-        Line::from_iter([
-            Span::raw(format!("{:<11}", "Commit ID:")),
-            Span::styled(commit.to_hex().to_string(), theme.commit_id),
-        ]),
-    )?;
-    out.write_selectable_text(
-        header_id,
-        Line::from_iter(
-            once(Span::raw(format!("{:<11}", "Author:")))
-                .chain(render_signature(&commit_details.commit.author, theme)),
-        ),
-    )?;
-    out.write_selectable_text(
-        header_id,
-        Line::from_iter(
-            once(Span::raw(format!("{:<11}", "Committer:")))
-                .chain(render_signature(&commit_details.commit.committer, theme)),
-        ),
-    )?;
-
-    out.write_empty_line(header_id)?;
-
-    let message = commit_details.commit.message.to_string();
-    if message.is_empty() {
+    if !options.skip_commit_header {
         out.write_selectable_text(
             header_id,
-            Line::from("(no commit message)").style(theme.hint),
+            Line::from_iter([
+                Span::raw(format!("{:<11}", "Commit ID:")),
+                Span::styled(commit.to_hex().to_string(), theme.commit_id),
+            ]),
         )?;
-    } else {
-        out.write_text_to_wrap(header_id, message)?;
+        out.write_selectable_text(
+            header_id,
+            Line::from_iter(
+                once(Span::raw(format!("{:<11}", "Author:")))
+                    .chain(render_signature(&commit_details.commit.author, theme)),
+            ),
+        )?;
+        out.write_selectable_text(
+            header_id,
+            Line::from_iter(
+                once(Span::raw(format!("{:<11}", "Committer:")))
+                    .chain(render_signature(&commit_details.commit.committer, theme)),
+            ),
+        )?;
+
+        out.write_empty_line(header_id)?;
+
+        let message = commit_details.commit.message.to_string();
+        if message.is_empty() {
+            out.write_selectable_text(
+                header_id,
+                Line::from("(no commit message)").style(theme.hint),
+            )?;
+        } else {
+            out.write_text_to_wrap(header_id, message)?;
+        }
+        out.write_empty_line(header_id)?;
     }
-    out.write_empty_line(header_id)?;
 
     let tree_changes = commit_details
         .diff_with_first_parent
@@ -393,10 +453,12 @@ pub fn render_commit(
 
     let tree_changes = tree_changes_with_patches(ctx, tree_changes);
 
-    let mut line_stats = LineStats::default();
-    compute_line_stats_from_tree_changes(&tree_changes, &mut line_stats);
-    out.write_selectable_text(header_id, render_line_stats(line_stats))?;
-    out.write_section_separator()?;
+    if !options.skip_line_stats {
+        let mut line_stats = LineStats::default();
+        compute_line_stats_from_tree_changes(&tree_changes, &mut line_stats);
+        out.write_selectable_text(header_id, render_line_stats(line_stats))?;
+        out.write_section_separator()?;
+    }
 
     render_tree_changes(tree_changes, theme, &mut id_gen, out)?;
 
@@ -408,6 +470,7 @@ pub fn render_branch(
     ctx: &mut Context,
     theme: &'static Theme,
     id_gen: &mut IdGen<'_>,
+    options: Options,
     out: &mut dyn DiffLineWriter,
 ) -> anyhow::Result<()> {
     let mut id_gen = id_gen.scoped("branches");
@@ -416,10 +479,12 @@ pub fn render_branch(
     let tree_changes = but_api::branch::branch_diff(ctx, name.clone())?;
     let tree_changes = tree_changes_with_patches(ctx, tree_changes.changes);
 
-    let mut line_stats = LineStats::default();
-    compute_line_stats_from_tree_changes(&tree_changes, &mut line_stats);
-    out.write_selectable_text(id_gen.new_id("line_stats"), render_line_stats(line_stats))?;
-    out.write_section_separator()?;
+    if !options.skip_line_stats {
+        let mut line_stats = LineStats::default();
+        compute_line_stats_from_tree_changes(&tree_changes, &mut line_stats);
+        out.write_selectable_text(id_gen.new_id("line_stats"), render_line_stats(line_stats))?;
+        out.write_section_separator()?;
+    }
 
     render_tree_changes(tree_changes, theme, &mut id_gen, out)?;
 
@@ -430,6 +495,7 @@ pub fn render_uncommitted(
     ctx: &mut Context,
     theme: &'static Theme,
     id_gen: &mut IdGen<'_>,
+    options: Options,
     out: &mut dyn DiffLineWriter,
 ) -> anyhow::Result<()> {
     let mut id_gen = id_gen.scoped("uncommitted");
@@ -440,11 +506,13 @@ pub fn render_uncommitted(
         hunk_assignment.stack_id.is_none()
     })?;
 
-    let line_stats = render_line_stats(compute_line_stats_from_uncommitted_hunks(
-        &uncommitted_hunks,
-    ));
-    out.write_selectable_text(id_gen.new_id("line_stats"), line_stats)?;
-    out.write_section_separator()?;
+    if !options.skip_line_stats {
+        let line_stats = render_line_stats(compute_line_stats_from_uncommitted_hunks(
+            &uncommitted_hunks,
+        ));
+        out.write_selectable_text(id_gen.new_id("line_stats"), line_stats)?;
+        out.write_section_separator()?;
+    }
 
     for (pos, (raw_id, _cli_id, UncommittedHunk { hunk_assignment })) in
         uncommitted_hunks.into_iter().with_position()
@@ -474,6 +542,7 @@ pub fn render_uncommitted_hunk(
     ctx: &mut Context,
     theme: &'static Theme,
     id_gen: &mut IdGen<'_>,
+    options: Options,
     out: &mut dyn DiffLineWriter,
 ) -> anyhow::Result<()> {
     let mut id_gen = id_gen.scoped("hunk");
@@ -485,11 +554,13 @@ pub fn render_uncommitted_hunk(
         uncommitted_hunk_matches_selection(hunk_assignment, &hunk)
     })?;
 
-    let line_stats = render_line_stats(compute_line_stats_from_uncommitted_hunks(
-        &uncommitted_hunks,
-    ));
-    out.write_selectable_text(id_gen.new_id("line_stats"), line_stats)?;
-    out.write_section_separator()?;
+    if !options.skip_line_stats {
+        let line_stats = render_line_stats(compute_line_stats_from_uncommitted_hunks(
+            &uncommitted_hunks,
+        ));
+        out.write_selectable_text(id_gen.new_id("line_stats"), line_stats)?;
+        out.write_section_separator()?;
+    }
 
     for (pos, (raw_id, _cli_id, UncommittedHunk { hunk_assignment })) in
         uncommitted_hunks.into_iter().with_position()
@@ -514,6 +585,7 @@ pub fn render_uncommitted_hunk(
     Ok(())
 }
 
+#[expect(clippy::too_many_arguments)]
 pub fn render_committed_file(
     commit: ObjectId,
     path: BString,
@@ -521,6 +593,7 @@ pub fn render_committed_file(
     ctx: &mut Context,
     theme: &'static Theme,
     id_gen: &mut IdGen<'_>,
+    options: Options,
     out: &mut dyn DiffLineWriter,
 ) -> anyhow::Result<()> {
     let mut id_gen = id_gen.scoped("committed_file");
@@ -538,10 +611,12 @@ pub fn render_committed_file(
         .collect::<Vec<_>>();
     let tree_changes = tree_changes_with_patches(ctx, tree_changes);
 
-    let mut line_stats = LineStats::default();
-    compute_line_stats_from_tree_changes(&tree_changes, &mut line_stats);
-    out.write_selectable_text(id_gen.new_id("line_stats"), render_line_stats(line_stats))?;
-    out.write_section_separator()?;
+    if !options.skip_line_stats {
+        let mut line_stats = LineStats::default();
+        compute_line_stats_from_tree_changes(&tree_changes, &mut line_stats);
+        out.write_selectable_text(id_gen.new_id("line_stats"), render_line_stats(line_stats))?;
+        out.write_section_separator()?;
+    }
 
     render_tree_changes(tree_changes, theme, &mut id_gen, out)?;
 

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -92,6 +92,8 @@ impl Subcommands {
             Subcommands::Rub { .. } => Rub,
             #[cfg(feature = "legacy")]
             Subcommands::Diff { .. } => Diff,
+            #[cfg(all(feature = "legacy", feature = "but-2"))]
+            Subcommands::_Diff2(..) => Diff2,
             #[cfg(feature = "legacy")]
             Subcommands::Show { .. } => Show,
             #[cfg(feature = "legacy")]

--- a/crates/but/src/utils/output_channel/experimental.rs
+++ b/crates/but/src/utils/output_channel/experimental.rs
@@ -40,7 +40,7 @@ impl<'out> IntermediateChannel<'out> {
 }
 
 pub trait CliOutputHuman {
-    fn on_human(self, out: &mut dyn WriteWithUtils, theme: &Theme) -> anyhow::Result<()>;
+    fn on_human(self, out: &mut dyn WriteWithUtils, theme: &'static Theme) -> anyhow::Result<()>;
 }
 
 #[allow(dead_code)]
@@ -49,7 +49,7 @@ pub trait CliOutput: CliOutputHuman {
 
     fn on_json(self) -> impl serde::Serialize;
 
-    fn on_agent(self, out: &mut dyn WriteWithUtils, theme: &Theme) -> anyhow::Result<()>
+    fn on_agent(self, out: &mut dyn WriteWithUtils, theme: &'static Theme) -> anyhow::Result<()>
     where
         Self: Sized,
     {

--- a/crates/but/tests/but/command/diff2.rs
+++ b/crates/but/tests/but/command/diff2.rs
@@ -1,0 +1,59 @@
+use crate::utils::Sandbox;
+
+#[test]
+fn uncommitted() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.file(
+        "file",
+        r#"
+items = ["ink ribbon", "old key", "green herb", "crank", "lighter"]
+
+puts "You check the desk drawer..."
+sleep 0.8
+
+found = items.sample
+
+if found == "green herb"
+  puts "You found a #{found}."
+  puts "You feel just a little better."
+else
+  puts "You found an #{found}." rescue puts "You found a #{found}."
+  puts "Probably useful somewhere."
+end
+
+puts "\nA distant door unlocks."
+"#,
+    );
+
+    env.but("_diff2")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+───────────╮
+ qs:d file │
+───────────╯
+ 
+@@ -1,0 +1,17 @@
+────────────────
+  ┊  1 │ +
+  ┊  2 │ +items = ["ink ribbon", "old key", "green herb", "crank", "lighter"]
+  ┊  3 │ +
+  ┊  4 │ +puts "You check the desk drawer..."
+  ┊  5 │ +sleep 0.8
+  ┊  6 │ +
+  ┊  7 │ +found = items.sample
+  ┊  8 │ +
+  ┊  9 │ +if found == "green herb"
+  ┊ 10 │ +  puts "You found a #{found}."
+  ┊ 11 │ +  puts "You feel just a little better."
+  ┊ 12 │ +else
+  ┊ 13 │ +  puts "You found an #{found}." rescue puts "You found a #{found}."
+  ┊ 14 │ +  puts "Probably useful somewhere."
+  ┊ 15 │ +end
+  ┊ 16 │ +
+  ┊ 17 │ +puts "/nA distant door unlocks."
+
+"#]]);
+}

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -19,6 +19,8 @@ mod commit2;
 mod config;
 #[cfg(feature = "legacy")]
 mod diff;
+#[cfg(all(feature = "legacy", feature = "but-2"))]
+mod diff2;
 #[cfg(feature = "legacy")]
 mod discard;
 #[cfg(unix)]


### PR DESCRIPTION
A new diff command using the diff rendering as the TUI.

Also fixes a bug with syntax highlighting where expressions spanning multiple lines wouldn't be highlighted correctly, such as multiline strings or block comments.