### PR TITLE
Make workspace tests hermetic against user-level settings

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -272,6 +272,10 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       GITBUTLER_TESTS_NO_CLEANUP: "1"
+      # Redirect the app-data dir so any test that loads user-level settings writes here.
+      # The final step asserts nothing did - see 'Assert test hermeticity'.
+      # (a literal path - the `runner` context is not available in job-level `env`)
+      E2E_TEST_APP_DATA_DIR: /tmp/hermeticity-guard
     defaults:
       run:
         shell: bash
@@ -335,6 +339,13 @@ jobs:
         run: |
           set -x
           (cd crates/gitbutler-filemonitor/vendor/debouncer && cargo test)
+      - name: Assert test hermeticity
+        run: |
+          if [ -e "$E2E_TEST_APP_DATA_DIR" ]; then
+            echo "::error::Tests wrote to the user-level app-data dir. Use Context::from_repo_for_testing or but_testsupport::isolated_app_data_dir instead of settings-loading constructors:"
+            find "$E2E_TEST_APP_DATA_DIR"
+            exit 1
+          fi
 
   rust-test-but-api-macros:
     needs: changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1608,6 +1608,7 @@ dependencies = [
  "regex",
  "shell-words",
  "snapbox",
+ "temp-env",
  "termtree",
 ]
 

--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -1266,7 +1266,7 @@ mod tests {
     fn set_default_target_accepts_remote_tracking_ref_and_persists_metadata() -> anyhow::Result<()>
     {
         let (repo, _tmp) = repo_with_feature_branch()?;
-        let mut ctx = but_ctx::Context::from_repo(repo)?.with_memory_app_cache();
+        let mut ctx = but_ctx::Context::from_repo_for_testing(repo)?.with_memory_app_cache();
         let target_ref = gix::refs::FullName::try_from("refs/remotes/origin/main")?;
 
         let project_meta =
@@ -1284,7 +1284,7 @@ mod tests {
     #[test]
     fn set_default_target_rejects_local_branch_refs() -> anyhow::Result<()> {
         let (repo, _tmp) = repo_with_feature_branch()?;
-        let mut ctx = but_ctx::Context::from_repo(repo)?.with_memory_app_cache();
+        let mut ctx = but_ctx::Context::from_repo_for_testing(repo)?.with_memory_app_cache();
         let target_ref = gix::refs::FullName::try_from("refs/heads/feature")?;
 
         let err = super::set_default_target(&mut ctx, target_ref.as_ref(), None)
@@ -1321,7 +1321,7 @@ mod tests {
         let expected_merge_base = repo.merge_base(current_head, target_tip)?.detach();
         assert_ne!(expected_merge_base, target_tip);
 
-        let mut ctx = but_ctx::Context::from_repo(repo)?.with_memory_app_cache();
+        let mut ctx = but_ctx::Context::from_repo_for_testing(repo)?.with_memory_app_cache();
         let project_meta = super::set_default_target(&mut ctx, target_ref.as_ref(), None)?;
 
         assert_eq!(project_meta.target_commit_id, Some(expected_merge_base));
@@ -1333,7 +1333,7 @@ mod tests {
     #[test]
     fn checkout_branch_switches_head_and_returns_workspace() -> anyhow::Result<()> {
         let (repo, _tmp) = repo_with_feature_branch()?;
-        let mut ctx = but_ctx::Context::from_repo(repo)?.with_memory_app_cache();
+        let mut ctx = but_ctx::Context::from_repo_for_testing(repo)?.with_memory_app_cache();
         let branch = gix::refs::FullName::try_from("refs/heads/feature")?;
         let result = super::branch_checkout(&mut ctx, branch)?;
 
@@ -1353,7 +1353,7 @@ mod tests {
     #[test]
     fn checkout_branch_rejects_remote_refs() -> anyhow::Result<()> {
         let (repo, _tmp) = repo_with_feature_branch()?;
-        let mut ctx = but_ctx::Context::from_repo(repo)?.with_memory_app_cache();
+        let mut ctx = but_ctx::Context::from_repo_for_testing(repo)?.with_memory_app_cache();
         let branch = gix::refs::FullName::try_from("refs/remotes/origin/main")?;
 
         let err = super::branch_checkout(&mut ctx, branch)
@@ -1371,7 +1371,7 @@ mod tests {
     {
         let (repo, _tmp) = repo_with_feature_branch()?;
         let target_commit_id = set_project_target_to_feature(&repo)?;
-        let mut ctx = but_ctx::Context::from_repo(repo)?.with_memory_app_cache();
+        let mut ctx = but_ctx::Context::from_repo_for_testing(repo)?.with_memory_app_cache();
 
         let result = super::branch_checkout_new(&mut ctx, Some("new branch".into()))?;
 
@@ -1394,7 +1394,7 @@ mod tests {
     fn branch_checkout_new_rejects_existing_explicit_name() -> anyhow::Result<()> {
         let (repo, _tmp) = repo_with_feature_branch()?;
         set_project_target_to_feature(&repo)?;
-        let mut ctx = but_ctx::Context::from_repo(repo)?.with_memory_app_cache();
+        let mut ctx = but_ctx::Context::from_repo_for_testing(repo)?.with_memory_app_cache();
 
         let err = super::branch_checkout_new(&mut ctx, Some("feature".into()))
             .expect_err("explicit names must not be uniquified");

--- a/crates/but-api/tests/api/branch_apply.rs
+++ b/crates/but-api/tests/api/branch_apply.rs
@@ -3,7 +3,7 @@ fn apply_only_threads_returned_workspace_back_into_context_cache() -> anyhow::Re
     let (repo, _tmp) = crate::support::writable_scenario("checkout-head-info");
     crate::support::persist_default_target(&repo)?;
 
-    let mut ctx = but_ctx::Context::from_repo(repo)?.with_memory_app_cache();
+    let mut ctx = but_ctx::Context::from_repo_for_testing(repo)?.with_memory_app_cache();
     let feature = gix::refs::FullName::try_from("refs/heads/feature")?;
     let sibling = gix::refs::FullName::try_from("refs/heads/sibling")?;
 

--- a/crates/but-api/tests/api/branch_checkout.rs
+++ b/crates/but-api/tests/api/branch_checkout.rs
@@ -16,7 +16,7 @@ fn checkout_returns_head_info_matching_fresh_head_info() -> anyhow::Result<()> {
 "]]
     );
 
-    let mut ctx = but_ctx::Context::from_repo(repo)?.with_memory_app_cache();
+    let mut ctx = but_ctx::Context::from_repo_for_testing(repo)?.with_memory_app_cache();
     let result = but_api::branch::branch_checkout(
         &mut ctx,
         gix::refs::FullName::try_from("refs/heads/feature")?,
@@ -140,7 +140,7 @@ fn checkout_new_returns_head_info_matching_fresh_head_info() -> anyhow::Result<(
     let (repo, _tmp) = crate::support::writable_scenario("checkout-head-info");
     let target_commit_id = crate::support::persist_default_target(&repo)?;
 
-    let mut ctx = but_ctx::Context::from_repo(repo)?.with_memory_app_cache();
+    let mut ctx = but_ctx::Context::from_repo_for_testing(repo)?.with_memory_app_cache();
     let result = but_api::branch::branch_checkout_new(&mut ctx, Some("new branch".into()))?;
 
     {

--- a/crates/but-cherry-apply/tests/cherry_apply/main.rs
+++ b/crates/but-cherry-apply/tests/cherry_apply/main.rs
@@ -18,7 +18,7 @@ mod util {
         let (repo, tmpdir) = but_testsupport::writable_scenario(name);
         // TODO: all this should work without `Context` once it's switched to the new rebase engine,
         //       making this crate either obsolete or proper plumbing.
-        let mut ctx = Context::from_repo(repo)?;
+        let mut ctx = Context::from_repo_for_testing(repo)?;
         // update the vb-toml metadata - trigger reconciliation and write the vb.toml according to what's there.
         {
             let _guard = ctx.exclusive_worktree_access();

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -196,14 +196,6 @@ impl From<ThreadSafeContext> for Context {
     }
 }
 
-impl TryFrom<gix::Repository> for Context {
-    type Error = anyhow::Error;
-
-    fn try_from(repo: gix::Repository) -> Result<Self, Self::Error> {
-        Context::from_repo(repo)
-    }
-}
-
 impl TryFrom<ProjectHandle> for Context {
     type Error = anyhow::Error;
 
@@ -474,18 +466,29 @@ impl Context {
         }
     }
 
-    /// Create a context that already has `repo` initialised and ready to be returned.
+    /// Create a context that already has `repo` initialised and ready to be returned,
+    /// using [compiled-in default settings](AppSettings::default()) so tests stay hermetic -
+    /// user-level settings are neither read nor created.
     ///
-    /// Particularly useful in testing, which might start off with just a Git repository.
+    /// **Note that it does not have support for legacy projects to encourage single-branch compatible code.**
+    pub fn from_repo_for_testing(repo: gix::Repository) -> anyhow::Result<Context> {
+        Self::from_repo_with_settings(repo, AppSettings::default())
+    }
+
+    /// Create a context that already has `repo` initialised and ready to be returned,
+    /// with the given `settings`.
+    ///
     /// **Note that it does not have support for legacy projects to encourage single-branch compatible code.**
     #[expect(
         deprecated,
         reason = "Context owns the deprecated boundary cache and must initialize it."
     )]
-    pub fn from_repo(repo: gix::Repository) -> anyhow::Result<Context> {
+    pub fn from_repo_with_settings(
+        repo: gix::Repository,
+        settings: AppSettings,
+    ) -> anyhow::Result<Context> {
         let gitdir = repo.git_dir().to_owned();
         let project_data_dir = repo.gitbutler_storage_path()?;
-        let settings = app_settings(but_path::app_config_dir()?)?;
         let app_cache_dir = but_path::app_cache_dir().ok();
         let repo_open_mode =
             if repo.open_options().permissions == gix::open::Permissions::isolated() {

--- a/crates/but-ctx/tests/ctx/main.rs
+++ b/crates/but-ctx/tests/ctx/main.rs
@@ -7,52 +7,56 @@ use snapbox::ToDebug;
 
 #[test]
 fn new_from_project_handle_uses_repo_gitdir() -> anyhow::Result<()> {
-    let repo = but_testsupport::read_only_in_memory_scenario("unborn-empty")?;
-    let worktree = repo.workdir().expect("fixture is non-bare").to_owned();
+    but_testsupport::isolated_app_data_dir(|| {
+        let repo = but_testsupport::read_only_in_memory_scenario("unborn-empty")?;
+        let worktree = repo.workdir().expect("fixture is non-bare").to_owned();
 
-    assert!(repo.path().is_relative());
-    for input in [
-        repo.git_dir().to_owned(),
-        repo.workdir().expect("non-bare").to_owned(),
-    ] {
-        let handle = ProjectHandle::from_path(&input)?;
-        let ctx = Context::new_from_project_handle(handle)?;
+        assert!(repo.path().is_relative());
+        for input in [
+            repo.git_dir().to_owned(),
+            repo.workdir().expect("non-bare").to_owned(),
+        ] {
+            let handle = ProjectHandle::from_path(&input)?;
+            let ctx = Context::new_from_project_handle(handle)?;
 
-        let expected_gitdir = gix::path::realpath(ctx.repo.get()?.path())?;
-        let expected_worktree = gix::path::realpath(&worktree)?;
+            let expected_gitdir = gix::path::realpath(ctx.repo.get()?.path())?;
+            let expected_worktree = gix::path::realpath(&worktree)?;
+            assert_eq!(
+                ctx.gitdir, expected_gitdir,
+                "the Git dir is the realpath, so ProjectHandles can be worktrees or git directories"
+            );
+            assert_ne!(ctx.gitdir, repo.path(), "even though we didn't pass it");
+            assert_eq!(
+                ctx.workdir()?.as_deref(),
+                Some(expected_worktree.as_path()),
+                "real-pathiness translates to the worktree"
+            );
+        }
+
+        let ctx = Context::from_repo_for_testing(repo.clone())?;
         assert_eq!(
-            ctx.gitdir, expected_gitdir,
-            "the Git dir is the realpath, so ProjectHandles can be worktrees or git directories"
+            ctx.gitdir,
+            repo.path(),
+            "When creating a context from a repo directly, it will not alter the stored path though."
         );
-        assert_ne!(ctx.gitdir, repo.path(), "even though we didn't pass it");
-        assert_eq!(
-            ctx.workdir()?.as_deref(),
-            Some(expected_worktree.as_path()),
-            "real-pathiness translates to the worktree"
-        );
-    }
-
-    let ctx = Context::from_repo(repo.clone())?;
-    assert_eq!(
-        ctx.gitdir,
-        repo.path(),
-        "When creating a context from a repo directly, it will not alter the stored path though."
-    );
-    Ok(())
+        Ok(())
+    })
 }
 
 #[test]
 fn new_from_project_handle_keeps_repo_cached() -> anyhow::Result<()> {
-    let repo = but_testsupport::read_only_in_memory_scenario("unborn-empty")?;
-    let handle = ProjectHandle::from_path(repo.git_dir())?;
-    let ctx = Context::new_from_project_handle(handle)?;
+    but_testsupport::isolated_app_data_dir(|| {
+        let repo = but_testsupport::read_only_in_memory_scenario("unborn-empty")?;
+        let handle = ProjectHandle::from_path(repo.git_dir())?;
+        let ctx = Context::new_from_project_handle(handle)?;
 
-    assert!(
-        ctx.repo.get_opt().is_some(),
-        "the repository used during construction should be kept in context"
-    );
-    assert!(ctx.to_sync().repo.is_some());
-    Ok(())
+        assert!(
+            ctx.repo.get_opt().is_some(),
+            "the repository used during construction should be kept in context"
+        );
+        assert!(ctx.to_sync().repo.is_some());
+        Ok(())
+    })
 }
 
 #[test]
@@ -65,7 +69,7 @@ fn project_data_dir_comes_from_git_config() -> anyhow::Result<()> {
         .run();
     let repo = open_repo(repo_dir.path())?;
 
-    let ctx = Context::from_repo(repo)?;
+    let ctx = Context::from_repo_for_testing(repo)?;
     assert_eq!(ctx.project_data_dir(), ctx.gitdir.join("gitbutler-custom"));
 
     let db = ctx.db.get_cache()?;
@@ -93,7 +97,7 @@ fn sync_context_preserves_project_data_dir() -> anyhow::Result<()> {
     let repo_dir = TempDir::new()?;
     gix::init(repo_dir.path())?;
     let repo = open_repo(repo_dir.path())?;
-    let ctx = Context::from_repo(repo)?;
+    let ctx = Context::from_repo_for_testing(repo)?;
 
     let sync = ctx.to_sync();
     let restored = sync.into_thread_local();
@@ -115,24 +119,26 @@ fn discover_with_app_channel_uses_requested_project_data_dir() -> anyhow::Result
         .args(["config", "--local", dev_key, "gitbutler-dev"])
         .run();
 
-    let nightly_ctx = Context::discover_with_app_channel(repo_dir.path(), AppChannel::Nightly)?;
-    assert_eq!(
-        nightly_ctx.project_data_dir(),
-        nightly_ctx.gitdir.join("gitbutler-nightly")
-    );
+    but_testsupport::isolated_app_data_dir(|| {
+        let nightly_ctx = Context::discover_with_app_channel(repo_dir.path(), AppChannel::Nightly)?;
+        assert_eq!(
+            nightly_ctx.project_data_dir(),
+            nightly_ctx.gitdir.join("gitbutler-nightly")
+        );
 
-    let dev_ctx = Context::discover_with_app_channel(repo_dir.path(), AppChannel::Dev)?;
-    assert_eq!(
-        dev_ctx.project_data_dir(),
-        dev_ctx.gitdir.join("gitbutler-dev")
-    );
-    Ok(())
+        let dev_ctx = Context::discover_with_app_channel(repo_dir.path(), AppChannel::Dev)?;
+        assert_eq!(
+            dev_ctx.project_data_dir(),
+            dev_ctx.gitdir.join("gitbutler-dev")
+        );
+        Ok(())
+    })
 }
 
 #[test]
 fn set_project_meta_updates_git_config_toml_and_database() -> anyhow::Result<()> {
     let (_tmp, repo, target_commit_id) = run_fixture("project-meta-base")?;
-    let ctx = Context::from_repo(repo)?;
+    let ctx = Context::from_repo_for_testing(repo)?;
     let project_meta = project_meta(target_commit_id, "refs/remotes/origin/main", "fork")?;
 
     snapbox::assert_data_eq!(
@@ -220,7 +226,7 @@ fn set_project_meta_fills_missing_target_commit_id_from_target_ref() -> anyhow::
         let mut target_ref = repo.find_reference("refs/remotes/origin/main")?;
         target_ref.peel_to_commit()?.id
     };
-    let ctx = Context::from_repo(repo)?;
+    let ctx = Context::from_repo_for_testing(repo)?;
 
     ctx.set_project_meta(ProjectMeta {
         target_ref: Some("refs/remotes/origin/main".try_into()?),
@@ -242,7 +248,7 @@ fn set_project_meta_fills_missing_target_commit_id_from_target_ref() -> anyhow::
 #[test]
 fn set_project_meta_clears_missing_target_ref() -> anyhow::Result<()> {
     let (_tmp, repo, _target_commit_id) = run_fixture("project-meta-base")?;
-    let ctx = Context::from_repo(repo)?;
+    let ctx = Context::from_repo_for_testing(repo)?;
 
     ctx.set_project_meta(ProjectMeta {
         target_ref: Some("refs/remotes/origin/missing".try_into()?),
@@ -260,7 +266,7 @@ fn set_project_meta_clears_missing_target_ref() -> anyhow::Result<()> {
 #[test]
 fn project_meta_defaults_when_config_and_toml_are_unset() -> anyhow::Result<()> {
     let (_tmp, repo, _target_commit_id) = run_fixture("project-meta-base")?;
-    let ctx = Context::from_repo(repo)?;
+    let ctx = Context::from_repo_for_testing(repo)?;
 
     snapbox::assert_data_eq!(
         storage_state(&ctx)?.to_debug(),
@@ -319,11 +325,11 @@ StorageState {
 #[test]
 fn project_meta_observes_changes_made_through_other_repository_handles() -> anyhow::Result<()> {
     let (_tmp, repo, target_commit_id) = run_fixture("project-meta-base")?;
-    let ctx = Context::from_repo(repo)?;
+    let ctx = Context::from_repo_for_testing(repo)?;
     assert_eq!(ctx.project_meta()?.target_ref, None);
 
     // Write through an independent handle, like another process would.
-    let other_ctx = Context::from_repo(open_repo(&ctx.gitdir)?)?;
+    let other_ctx = Context::from_repo_for_testing(open_repo(&ctx.gitdir)?)?;
     other_ctx.set_project_meta(project_meta(
         target_commit_id,
         "refs/remotes/origin/main",
@@ -341,7 +347,7 @@ fn project_meta_observes_changes_made_through_other_repository_handles() -> anyh
 #[test]
 fn project_meta_falls_back_to_toml_and_ports_on_first_write() -> anyhow::Result<()> {
     let (_tmp, repo, _target_commit_id) = run_fixture("project-meta-toml")?;
-    let ctx = Context::from_repo(repo)?;
+    let ctx = Context::from_repo_for_testing(repo)?;
 
     snapbox::assert_data_eq!(
         storage_state(&ctx)?.to_debug(),
@@ -452,7 +458,7 @@ StorageState {
 #[test]
 fn project_meta_reads_git_config_when_ported_even_if_toml_differs() -> anyhow::Result<()> {
     let (_tmp, repo, _target_commit_id) = run_fixture("project-meta-ported")?;
-    let ctx = Context::from_repo(repo)?;
+    let ctx = Context::from_repo_for_testing(repo)?;
 
     snapbox::assert_data_eq!(
         storage_state(&ctx)?.to_debug(),
@@ -537,7 +543,7 @@ StorageState {
 #[test]
 fn resync_project_meta_from_legacy_leaves_unported_repos_alone() -> anyhow::Result<()> {
     let (_tmp, repo, _target_commit_id) = run_fixture("project-meta-toml")?;
-    let ctx = Context::from_repo(repo)?;
+    let ctx = Context::from_repo_for_testing(repo)?;
 
     ctx.resync_project_meta_from_legacy()?;
 
@@ -578,7 +584,7 @@ StorageState {
 #[test]
 fn resync_project_meta_from_legacy_rewrites_config_from_toml_when_ported() -> anyhow::Result<()> {
     let (_tmp, repo, _target_commit_id) = run_fixture("project-meta-ported")?;
-    let ctx = Context::from_repo(repo)?;
+    let ctx = Context::from_repo_for_testing(repo)?;
 
     ctx.resync_project_meta_from_legacy()?;
 

--- a/crates/but-debug/tests/debug/dump.rs
+++ b/crates/but-debug/tests/debug/dump.rs
@@ -617,7 +617,9 @@ fn run_dump_with_options(
     }
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
-    but_debug::handle_args(args.into_iter(), &mut stdout, &mut stderr)?;
+    but_testsupport::isolated_app_data_dir(|| {
+        but_debug::handle_args(args.into_iter(), &mut stdout, &mut stderr)
+    })?;
     Ok(DumpOutput {
         stdout: String::from_utf8(stdout)?,
         stderr: String::from_utf8(stderr)?,
@@ -637,7 +639,9 @@ fn run_dump_diagnostics(repo: &Path, output: &Path) -> anyhow::Result<DumpOutput
     ];
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
-    but_debug::handle_args(args.into_iter(), &mut stdout, &mut stderr)?;
+    but_testsupport::isolated_app_data_dir(|| {
+        but_debug::handle_args(args.into_iter(), &mut stdout, &mut stderr)
+    })?;
     Ok(DumpOutput {
         stdout: String::from_utf8(stdout)?,
         stderr: String::from_utf8(stderr)?,

--- a/crates/but-gerrit/tests/gerrit/main.rs
+++ b/crates/but-gerrit/tests/gerrit/main.rs
@@ -28,7 +28,7 @@ fn record_push_metadata_fallback_url() -> anyhow::Result<()> {
         .expect("gb header are set")
         .change_id
         .expect("commit has change id");
-    let ctx = but_ctx::Context::from_repo(repo)?;
+    let ctx = but_ctx::Context::from_repo_for_testing(repo)?;
     let repo = ctx.repo.get()?;
     let mut db = ctx.db.get_cache_mut()?;
     record_push_metadata(&repo, &mut db, candidate_ids, push_output)?;

--- a/crates/but-hunk-dependency/tests/hunk_dependency/ui.rs
+++ b/crates/but-hunk-dependency/tests/hunk_dependency/ui.rs
@@ -342,7 +342,7 @@ mod util {
     fn test_scenario(name: &str) -> anyhow::Result<(TestContext, Context)> {
         // TODO: make this a read-only scenario once we don't rely on vb.toml anymore.
         let (repo, tmpdir) = but_testsupport::writable_scenario(name);
-        let ctx = Context::from_repo(repo)?;
+        let ctx = Context::from_repo_for_testing(repo)?;
         Ok((
             TestContext {
                 tmpdir: Some(tmpdir),

--- a/crates/but-hunk-dependency/tests/hunk_dependency/workspace_dependencies.rs
+++ b/crates/but-hunk-dependency/tests/hunk_dependency/workspace_dependencies.rs
@@ -937,7 +937,7 @@ mod util {
     fn test_scenario(name: &str) -> anyhow::Result<TestContext> {
         // TODO: make this a read-only scenario once we don't rely on vb.toml anymore.
         let (repo, tmpdir) = but_testsupport::writable_scenario(name);
-        let ctx = but_ctx::Context::from_repo(repo)?;
+        let ctx = but_ctx::Context::from_repo_for_testing(repo)?;
 
         Ok(TestContext {
             ctx,

--- a/crates/but-testsupport/Cargo.toml
+++ b/crates/but-testsupport/Cargo.toml
@@ -39,6 +39,7 @@ shell-words = {  workspace = true, optional = true }
 gix-testtools.workspace = true
 gix.workspace = true
 anyhow.workspace = true
+temp-env = "0.3"
 termtree = "0.5.1"
 regex = { workspace = true }
 snapbox = { workspace = true, optional = true, features = ["regex"] }

--- a/crates/but-testsupport/src/lib.rs
+++ b/crates/but-testsupport/src/lib.rs
@@ -158,6 +158,17 @@ pub fn deprecated_stable_env_vars() {
     _ = std::mem::ManuallyDrop::new(env);
 }
 
+/// Run `f` with `E2E_TEST_APP_DATA_DIR` pointing at a temporary directory, so code that
+/// resolves application-wide directories via `but_path` cannot read or write user-level files.
+///
+/// Use this when testing code that loads `AppSettings` from the default location.
+/// Calls are serialized process-wide via `temp_env`'s global mutex, so concurrent
+/// use from parallel tests is safe.
+pub fn isolated_app_data_dir<R>(f: impl FnOnce() -> R) -> R {
+    let tmp = gix_testtools::tempfile::TempDir::new().unwrap();
+    temp_env::with_var("E2E_TEST_APP_DATA_DIR", Some(tmp.path()), f)
+}
+
 /// Utilities for the [`git()`] command.
 pub trait CommandExt {
     /// Run the command successfully or print panic with all available command output.

--- a/crates/but-testsupport/src/sandbox.rs
+++ b/crates/but-testsupport/src/sandbox.rs
@@ -257,7 +257,7 @@ impl Sandbox {
     /// This feature is only meant for higher-level Client or API tests. Plumbing crates must not use the [`but_ctx::Context`].
     #[cfg(feature = "sandbox-but-api")]
     pub fn context(&self) -> but_ctx::Context {
-        but_ctx::Context::from_repo(self.open_repo())
+        but_ctx::Context::from_repo_with_settings(self.open_repo(), self.app_settings().clone())
             .map(but_ctx::Context::with_memory_app_cache)
             .unwrap()
     }

--- a/crates/but-transaction/src/tests.rs
+++ b/crates/but-transaction/src/tests.rs
@@ -46,7 +46,7 @@ fn squashing_three_commits() {
     let [three, two, one] = find_commits(&env, ["1e25c58", "9b3b3d5", "dbdbcea"]);
 
     let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
-    let mut ctx = Context::from_repo(repo)
+    let mut ctx = Context::from_repo_for_testing(repo)
         .map(Context::with_memory_app_cache)
         .unwrap();
 
@@ -99,7 +99,7 @@ fn rollback() {
     let [three, two, one] = find_commits(&env, ["1e25c58", "9b3b3d5", "dbdbcea"]);
 
     let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
-    let mut ctx = Context::from_repo(repo)
+    let mut ctx = Context::from_repo_for_testing(repo)
         .map(Context::with_memory_app_cache)
         .unwrap();
 
@@ -145,7 +145,7 @@ fn create_reference_without_creating_commits() {
     let [three] = find_commits(&env, ["1e25c58"]);
 
     let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
-    let mut ctx = Context::from_repo(repo)
+    let mut ctx = Context::from_repo_for_testing(repo)
         .map(Context::with_memory_app_cache)
         .unwrap();
 
@@ -187,7 +187,7 @@ fn create_reference_relative_to_various_anchors() {
     let [three, two, base] = find_commits(&env, ["1e25c58", "9b3b3d5", "6674d4f"]);
 
     let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
-    let mut ctx = Context::from_repo(repo)
+    let mut ctx = Context::from_repo_for_testing(repo)
         .map(Context::with_memory_app_cache)
         .unwrap();
 
@@ -254,7 +254,7 @@ fn create_reference_then_remove_it_in_same_transaction() {
     let [three] = find_commits(&env, ["1e25c58"]);
 
     let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
-    let mut ctx = Context::from_repo(repo)
+    let mut ctx = Context::from_repo_for_testing(repo)
         .map(Context::with_memory_app_cache)
         .unwrap();
 
@@ -297,7 +297,7 @@ fn create_reference_then_commit_below_anchor_keeps_commit_in_workspace() {
     let [three, base] = find_commits(&env, ["1e25c58", "6674d4f"]);
 
     let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
-    let mut ctx = Context::from_repo(repo)
+    let mut ctx = Context::from_repo_for_testing(repo)
         .map(Context::with_memory_app_cache)
         .unwrap();
 
@@ -368,7 +368,7 @@ fn move_commits_then_commit_relative_to_moved_commit() {
     let [three, one] = find_commits(&env, ["1e25c58", "dbdbcea"]);
 
     let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
-    let mut ctx = Context::from_repo(repo)
+    let mut ctx = Context::from_repo_for_testing(repo)
         .map(Context::with_memory_app_cache)
         .unwrap();
 
@@ -424,7 +424,7 @@ fn move_commits_reorders_multiple_subjects() {
     let [three, two, one] = find_commits(&env, ["1e25c58", "9b3b3d5", "dbdbcea"]);
 
     let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
-    let mut ctx = Context::from_repo(repo)
+    let mut ctx = Context::from_repo_for_testing(repo)
         .map(Context::with_memory_app_cache)
         .unwrap();
 
@@ -466,7 +466,7 @@ fn create_reference_then_commit_relative_to_it() {
     let [three] = find_commits(&env, ["1e25c58"]);
 
     let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
-    let mut ctx = Context::from_repo(repo)
+    let mut ctx = Context::from_repo_for_testing(repo)
         .map(Context::with_memory_app_cache)
         .unwrap();
 
@@ -513,7 +513,7 @@ fn create_reference_is_removed_on_rollback() {
     let [three] = find_commits(&env, ["1e25c58"]);
 
     let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
-    let mut ctx = Context::from_repo(repo)
+    let mut ctx = Context::from_repo_for_testing(repo)
         .map(Context::with_memory_app_cache)
         .unwrap();
 
@@ -556,7 +556,7 @@ fn dynamic_rollback() {
     let [three, two, one] = find_commits(&env, ["1e25c58", "9b3b3d5", "dbdbcea"]);
 
     let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
-    let mut ctx = Context::from_repo(repo)
+    let mut ctx = Context::from_repo_for_testing(repo)
         .map(Context::with_memory_app_cache)
         .unwrap();
 
@@ -620,7 +620,7 @@ fn discarding_three_commits() {
     let [three, two, one] = find_commits(&env, ["1e25c58", "9b3b3d5", "dbdbcea"]);
 
     let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
-    let mut ctx = Context::from_repo(repo)
+    let mut ctx = Context::from_repo_for_testing(repo)
         .map(Context::with_memory_app_cache)
         .unwrap();
 
@@ -676,7 +676,7 @@ fn remove_references() {
     let [three, two, one] = find_commits(&env, ["1e25c58", "9b3b3d5", "dbdbcea"]);
 
     let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
-    let mut ctx = Context::from_repo(repo)
+    let mut ctx = Context::from_repo_for_testing(repo)
         .map(Context::with_memory_app_cache)
         .unwrap();
 

--- a/crates/but-workspace/tests/workspace/shallow_clone.rs
+++ b/crates/but-workspace/tests/workspace/shallow_clone.rs
@@ -32,7 +32,7 @@ fn log_target_first_parent_stops_gracefully_in_shallow_repo() -> anyhow::Result<
         .run();
 
     let repo = open_repo(&clone_dir)?;
-    let ctx = but_ctx::Context::from_repo(repo)?;
+    let ctx = but_ctx::Context::from_repo_for_testing(repo)?;
     let repo = ctx.repo.get()?;
     let head_id = repo.head_id()?;
 

--- a/crates/but-workspace/tests/workspace/target_history.rs
+++ b/crates/but-workspace/tests/workspace/target_history.rs
@@ -34,7 +34,7 @@ fn log_target_first_parent_uses_persisted_target_outside_workspace() -> anyhow::
         .args(["checkout", "-b", "feature", "origin/feature"])
         .run();
 
-    let ctx = but_ctx::Context::from_repo(open_repo(&clone_dir)?)?;
+    let ctx = but_ctx::Context::from_repo_for_testing(open_repo(&clone_dir)?)?;
     let (main_tip, feature_tip) = {
         let repo = ctx.repo.get()?;
         (

--- a/crates/but-worktrees/tests/worktree/main.rs
+++ b/crates/but-worktrees/tests/worktree/main.rs
@@ -12,7 +12,7 @@ mod util {
 
     pub fn test_ctx(name: &str) -> anyhow::Result<TestContext> {
         let (repo, tmpdir) = but_testsupport::writable_scenario(name);
-        let ctx = Context::from_repo(repo)?;
+        let ctx = Context::from_repo_for_testing(repo)?;
 
         Ok(TestContext { ctx, tmpdir })
     }

--- a/crates/but/src/command/agent/mod.rs
+++ b/crates/but/src/command/agent/mod.rs
@@ -742,7 +742,7 @@ fn apply_plan(out: &mut OutputChannel, current_dir: &Path, plan: &Plan) -> Resul
 #[cfg(feature = "legacy")]
 fn run_but_setup(current_dir: &Path, out: &mut OutputChannel) -> Result<()> {
     let repo = gix::discover(current_dir).context("No git repository found for `but setup`.")?;
-    let mut ctx = but_ctx::Context::from_repo(repo)?;
+    let mut ctx = but_ctx::Context::from_repo_with_settings(repo, crate::app_settings()?.clone())?;
     let mut guard = ctx.exclusive_worktree_access();
     crate::command::legacy::setup::repo(&mut ctx, current_dir, out, guard.write_permission())
         .context("Failed to set up GitButler project.")

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -96,6 +96,23 @@ fn early_help_format(args: &[OsString]) -> OutputFormat {
         .unwrap_or_default()
 }
 
+static APP_SETTINGS: std::sync::OnceLock<AppSettings> = std::sync::OnceLock::new();
+
+/// The application settings, loaded from the default path once per process.
+///
+/// Concurrent first calls may load twice with one winner - harmless, and avoids
+/// the still-unstable `OnceLock::get_or_try_init`.
+pub(crate) fn app_settings() -> Result<&'static AppSettings> {
+    if let Some(settings) = APP_SETTINGS.get() {
+        return Ok(settings);
+    }
+    match AppSettings::load_from_default_path_creating_without_customization() {
+        Ok(settings) => Ok(APP_SETTINGS.get_or_init(|| settings)),
+        // A concurrent caller may have initialized while our load failed.
+        Err(err) => APP_SETTINGS.get().ok_or(err),
+    }
+}
+
 /// Handle `args` which must be what's passed by `std::env::args_os()`.
 pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     let theme_preset_from_env: anyhow::Result<theme::ThemePreset> =
@@ -203,7 +220,7 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
         };
         return run_agentlog_command(&args.current_dir, cmd, &mut out);
     }
-    let app_settings = AppSettings::load_from_default_path_creating_without_customization()?;
+    let app_settings = app_settings()?.clone();
 
     let result = match args.cmd.take() {
         Some(cmd @ Subcommands::External(_)) => {
@@ -1242,7 +1259,7 @@ async fn match_subcommand(
                 }
                 _ => command::legacy::setup::find_or_initialize_repo(&args.current_dir, out, init)?,
             };
-            let mut ctx = but_ctx::Context::from_repo(repo)?;
+            let mut ctx = but_ctx::Context::from_repo_with_settings(repo, app_settings.clone())?;
             let mut guard = ctx.exclusive_worktree_access();
             command::legacy::setup::repo(&mut ctx, &args.current_dir, out, guard.write_permission())
                 .context("Failed to set up GitButler project.")

--- a/crates/but/src/setup.rs
+++ b/crates/but/src/setup.rs
@@ -89,6 +89,7 @@ pub fn init_ctx(
     options: InitCtxOptions,
     out: &mut OutputChannel,
 ) -> anyhow::Result<Context> {
+    let app_settings = crate::app_settings()?;
     // lets try to get the repo from the current directory
     let repo = match gix::discover(&args.current_dir) {
         Ok(repo) => repo,
@@ -122,7 +123,10 @@ pub fn init_ctx(
                     match prompt_for_setup(out, &message) {
                         SetupPromptResult::RunSetup => {
                             // Run setup
-                            let mut ctx = Context::from_repo(repo.clone())?;
+                            let mut ctx = Context::from_repo_with_settings(
+                                repo.clone(),
+                                app_settings.clone(),
+                            )?;
                             let mut guard = ctx.exclusive_worktree_access();
                             crate::command::legacy::setup::repo(
                                 &mut ctx,
@@ -148,7 +152,8 @@ pub fn init_ctx(
             };
 
             // Check project setup, prompt for setup if needed
-            let mut ctx = Context::new_from_legacy_project(project)?;
+            let mut ctx =
+                Context::new_from_legacy_project_and_settings(&project, app_settings.clone())?;
             {
                 let mut guard = ctx.exclusive_worktree_access();
                 if let Err(e) = check_project_setup(&ctx, guard.read_permission()) {
@@ -192,7 +197,7 @@ pub fn init_ctx(
         }
         #[cfg(not(feature = "legacy"))]
         {
-            let ctx = but_ctx::Context::from_repo(repo)?;
+            let ctx = but_ctx::Context::from_repo_with_settings(repo, app_settings.clone())?;
             // TODO: this can be implemented once project metadata is available from the project location itself,
             //       i.e. once it was migrated out of `projects.json` into `.git/gitbutler/…`
             let fetch_interval_disabled = 0;

--- a/crates/gitbutler-branch-actions/tests/branch-actions/driverless.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/driverless.rs
@@ -39,7 +39,7 @@ pub fn writable_context(script_name: &str, repo_name: &str) -> Result<(Context, 
     )
     .map_err(anyhow::Error::from_boxed)?;
     let repo = open_repo(tmp.path().join(repo_name).as_path())?;
-    Ok((Context::from_repo(repo)?, tmp))
+    Ok((Context::from_repo_for_testing(repo)?, tmp))
 }
 
 pub fn read_only_context(script_name: &str, repo_name: &str) -> Result<Context> {
@@ -70,7 +70,7 @@ pub fn read_only_context(script_name: &str, repo_name: &str) -> Result<Context> 
     )
     .map_err(anyhow::Error::from_boxed)?;
     let repo = open_repo(root.join(repo_name).as_path())?;
-    Context::from_repo(repo)
+    Context::from_repo_for_testing(repo)
 }
 
 fn seed_fixture(repo: &gix::Repository, script_name: &str, repo_name: &str) -> Result<()> {

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/init.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/init.rs
@@ -267,7 +267,8 @@ fn bootstrap_missing_target_preserves_existing_workspace_ref() -> anyhow::Result
     })?;
     drop(repo);
 
-    let mut reopened: Context = project_id.clone().try_into()?;
+    let mut reopened: Context =
+        but_testsupport::isolated_app_data_dir(|| project_id.clone().try_into())?;
     assert!(
         gitbutler_stack::VirtualBranchesHandle::new(reopened.project_data_dir())
             .read_file()?

--- a/crates/gitbutler-edit-mode/tests/edit_mode.rs
+++ b/crates/gitbutler-edit-mode/tests/edit_mode.rs
@@ -34,7 +34,7 @@ fn command_ctx(folder: &str) -> Result<(Context, TempDir)> {
     )
     .map_err(anyhow::Error::from_boxed)?;
     let repo = open_repo(tmp.path().join(&folder).as_path())?;
-    let ctx = Context::from_repo(repo)?;
+    let ctx = Context::from_repo_for_testing(repo)?;
     Ok((ctx, tmp))
 }
 

--- a/crates/gitbutler-operating-modes/tests/operating_modes.rs
+++ b/crates/gitbutler-operating-modes/tests/operating_modes.rs
@@ -22,7 +22,7 @@ fn new_case() -> Case {
     )
     .unwrap();
     let repo = open_repo(tmp.path()).unwrap();
-    let ctx = Context::from_repo(repo).unwrap();
+    let ctx = Context::from_repo_for_testing(repo).unwrap();
     std::fs::create_dir_all(ctx.project_data_dir()).unwrap();
 
     Case { ctx, _tmp: tmp }

--- a/crates/gitbutler-stack/tests/stack.rs
+++ b/crates/gitbutler-stack/tests/stack.rs
@@ -762,7 +762,7 @@ fn command_ctx(name: &str) -> Result<(Context, TempDir)> {
     )
     .map_err(anyhow::Error::from_boxed)?;
     let repo = open_repo(tmp.path().join(name).as_path())?;
-    Ok((Context::from_repo(repo)?, tmp))
+    Ok((Context::from_repo_for_testing(repo)?, tmp))
 }
 
 fn seed_metadata(repo: &gix::Repository, name: &str) -> Result<()> {


### PR DESCRIPTION
Tests were reading the real user `settings.json` — flip `unapplyV3Pgm` in your settings and the `but` TUI snapshot tests fail (`Expected to be in open workspace mode`). Root cause: `Context::from_repo` loaded AppSettings from the user config dir, and ~40 test call sites used it.

### What changed

`from_repo` is gone; callers now pick one:

```rust
Context::from_repo_for_testing(repo)             // compiled-in defaults, no disk
Context::from_repo_with_settings(repo, settings) // explicit, for production
```

- Tests that need the real settings-loading constructors (`discover`, `new_from_project_handle`, but-debug's `handle_args`) wrap in the new `but_testsupport::isolated_app_data_dir`, which points `E2E_TEST_APP_DATA_DIR` at a temp dir.
- The `but` binary loads settings once per process (`crate::app_settings()`, a `OnceLock`) instead of re-reading the file in `init_ctx`.
- CI: the rust-test job redirects `E2E_TEST_APP_DATA_DIR` and a final step fails if any test created files there, so this can't quietly regress.

### Verification

Ran the whole workspace suite with `E2E_TEST_APP_DATA_DIR` pointing at a nonexistent dir and checked it stays absent. One intentional exception: but-core's login-shell test runs your real shell, so it does whatever your zshrc does (on CI: nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)