### PR TITLE
Clean up stack + branch context menus outside workspace mode

### DIFF
--- a/apps/desktop/src/components/branch/BranchHeaderContextMenu.svelte
+++ b/apps/desktop/src/components/branch/BranchHeaderContextMenu.svelte
@@ -25,6 +25,7 @@
 	import { projectAiGenEnabled } from "$lib/config/config";
 	import { FORGE_INFO_SERVICE } from "$lib/forge/forgeInfo.svelte";
 	import { PR_SERVICE } from "$lib/forge/prService.svelte";
+	import { MODE_SERVICE } from "$lib/mode/modeService";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import {
@@ -64,6 +65,13 @@
 	const promptService = inject(PROMPT_SERVICE);
 	const urlService = inject(URL_SERVICE);
 	const clipboardService = inject(CLIPBOARD_SERVICE);
+	const modeService = inject(MODE_SERVICE);
+
+	// The app layout keeps rendering stack UI in Edit and single-branch
+	// OutsideWorkspace modes (see routes/[projectId]/+layout.svelte), but the
+	// backend refuses stack/branch mutations there.
+	const mode = $derived(modeService.mode(projectId));
+	const isOpenWorkspace = $derived(mode.response?.type === "OpenWorkspace");
 
 	const forgeInfoQuery = $derived(forgeInfoService.get(projectId));
 	const forgeInfo = $derived(forgeInfoQuery.response);
@@ -201,7 +209,7 @@
 				disabled={!branchName}
 			/>
 		</ContextMenuSection>
-		{#if stackId}
+		{#if stackId && isOpenWorkspace}
 			<ContextMenuSection>
 				<ContextMenuItemSubmenu
 					label="Create branch"
@@ -362,7 +370,8 @@
 					label="Unapply Stack"
 					icon="eject"
 					testId={TestId.BranchHeaderContextMenu_UnapplyBranch}
-					disabled={isReadOnly}
+					disabled={isReadOnly || !isOpenWorkspace}
+					caption={!isOpenWorkspace ? "Only available in workspace mode" : undefined}
 					onclick={async () => {
 						try {
 							await stackService.unapply({ projectId, stackId });

--- a/apps/desktop/src/components/stack/StackDragHandle.svelte
+++ b/apps/desktop/src/components/stack/StackDragHandle.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import CollapseStackButton from "$components/branch/CollapseStackButton.svelte";
+	import { MODE_SERVICE } from "$lib/mode/modeService";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import { ContextMenuItem, ContextMenuSection, Icon, KebabButton } from "@gitbutler/ui";
@@ -17,10 +18,18 @@
 	let { stackId, projectId, disabled = false, onFold }: Props = $props();
 
 	const stackService = inject(STACK_SERVICE);
+	const modeService = inject(MODE_SERVICE);
 
 	// Get all stacks to determine if we can move left/right
 	const stacksQuery = $derived(stackService.stacks(projectId));
 	const stacks = $derived(stacksQuery.response ?? []);
+
+	// The `AppLayout` also renders in `Edit` and single-branch `OutsideWorkspace`
+	// modes (see routes/[projectId]/+layout.svelte). Backend stack ops require
+	// `OpenWorkspace` though, so the menu item would fail with a toast if the
+	// user clicked it in those transitional states.
+	const mode = $derived(modeService.mode(projectId));
+	const isOpenWorkspace = $derived(mode.response?.type === "OpenWorkspace");
 
 	const currentStackIndex = $derived(
 		stackId ? stacks.findIndex((stack: Stack) => stack.id === stackId) : -1,
@@ -95,30 +104,34 @@
 
 	<KebabButton minimal>
 		{#snippet contextMenu({ close })}
-			<ContextMenuSection>
-				<ContextMenuItem
-					label="Move to leftmost"
-					icon="leftmost-lane"
-					disabled={!canMoveLeft}
-					onclick={() => {
-						moveStackLeft();
-						close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Move to rightmost"
-					icon="rightmost-lane"
-					disabled={!canMoveRight}
-					onclick={() => {
-						moveStackRight();
-						close();
-					}}
-				/>
-			</ContextMenuSection>
+			{#if isOpenWorkspace}
+				<ContextMenuSection>
+					<ContextMenuItem
+						label="Move to leftmost"
+						icon="leftmost-lane"
+						disabled={!canMoveLeft}
+						onclick={() => {
+							moveStackLeft();
+							close();
+						}}
+					/>
+					<ContextMenuItem
+						label="Move to rightmost"
+						icon="rightmost-lane"
+						disabled={!canMoveRight}
+						onclick={() => {
+							moveStackRight();
+							close();
+						}}
+					/>
+				</ContextMenuSection>
+			{/if}
 			<ContextMenuSection>
 				<ContextMenuItem
 					label="Unapply stack"
 					icon="eject"
+					disabled={!isOpenWorkspace}
+					caption={!isOpenWorkspace ? "Only available in workspace mode" : undefined}
 					onclick={() => {
 						unapplyStack();
 						close();


### PR DESCRIPTION
## What

Two context menus stop offering unusable options when the operating mode isn't `OpenWorkspace`.

**Stack lane kebab (`StackDragHandle.svelte`):**
- Hide the "Move to leftmost/rightmost" section entirely (in single-branch mode there's one stack anyway).
- Grey out "Unapply stack" with caption "Only available in workspace mode".

**Branch header kebab (`BranchHeaderContextMenu.svelte`):**
- Hide the branch-write section — Create branch / Add empty commit / Squash all / Generate name / Rename / Delete. None of it works without an open workspace.
- Grey out "Unapply Stack" with the same caption.
- Read-only items (Copy branch name, Open in browser, PR submenu) stay visible.

## Fix

Both files inject `MODE_SERVICE` and derive `isOpenWorkspace = mode.response?.type === "OpenWorkspace"`. Same shape as the AppHeader guard from #14450.

## Test plan

- [x] `pnpm exec svelte-check`
- [ ] Manual: enter edit mode, open both kebab menus — write sections gone, Unapply greyed out with caption; Copy branch name and Open in browser still work
