### PR TITLE
create-reference changes

### DIFF
--- a/crates/but-core/src/lib.rs
+++ b/crates/but-core/src/lib.rs
@@ -237,6 +237,12 @@ pub trait RefMetadata {
     /// Return the ordered local branch refs in the same stack as `ref_name`, from tip to base.
     ///
     /// Implementations that don't persist branch stack order can return `Ok(None)`.
+    ///
+    /// This is best-effort: the returned refs may include entries for branches that no longer
+    /// exist if pruning hasn't run since they were deleted (see
+    /// [`Self::remove_missing_branch_stack_order_references`]). Callers must treat the result as a
+    /// hint and validate each ref against the repository, ignoring any that don't resolve, rather
+    /// than assuming every entry is live.
     fn branch_stack_order(
         &self,
         _ref_name: &gix::refs::FullNameRef,

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -765,7 +765,10 @@ impl Context {
 
     fn workspace_from_head(&self) -> anyhow::Result<but_graph::Workspace> {
         let repo = self.repo.get()?;
-        let meta = self.meta_inner_read_only()?;
+        let meta = but_meta::BranchOrderMetadata::from_paths_read_only(
+            self.project_data_dir().join("virtual_branches.toml"),
+            self.project_data_dir(),
+        )?;
         let graph = but_graph::Graph::from_head(
             &repo,
             &meta,
@@ -852,16 +855,23 @@ impl Context {
         Ok(())
     }
 
-    /// Return a wrapper for metadata that only supports read-only access when presented with the project wide permission
-    /// to read data.
-    /// This is helping to prevent races with mutable instances.
+    /// Return a read/write metadata handle for the project, backed by `virtual_branches.toml` and
+    /// the branch-order database.
+    ///
+    /// This is a plain read/write accessor and intentionally does *not* prune stale
+    /// branch-order entries: reading branch stack order is best-effort and may return refs for
+    /// branches that no longer exist (consumers already validate each ref against the repository
+    /// and ignore the ones that don't resolve). Pruning happens out-of-band on fetch via
+    /// [`RefMetadata::remove_missing_branch_stack_order_references`](but_core::RefMetadata::remove_missing_branch_stack_order_references);
+    /// see `prune_missing_branch_stack_order` in the API layer.
     // TODO(ctx): remove method entirely as we don't need it anymore with a DB
     //            based implementation as long as the instances starts a transaction to isolate
     //            reads. For a correct implementation, this would also have to hold on to
     //            `_read_only`.
     pub fn meta(&self) -> anyhow::Result<impl but_core::RefMetadata + 'static> {
-        but_meta::VirtualBranchesTomlMetadata::from_path(
+        but_meta::BranchOrderMetadata::from_paths(
             self.project_data_dir().join("virtual_branches.toml"),
+            self.project_data_dir(),
         )
     }
 

--- a/crates/but-workspace/src/branch/create_reference.rs
+++ b/crates/but-workspace/src/branch/create_reference.rs
@@ -145,6 +145,45 @@ pub(super) mod function {
 
     use crate::branch::create_reference::{Anchor, Position};
 
+    /// The resolved placement of a new reference, produced by matching on the [`Anchor`].
+    ///
+    /// Splitting this out keeps each match arm declarative: it states only the fields that differ
+    /// from the common case (see [`AnchorResolution::positioned`]).
+    struct AnchorResolution<'a> {
+        /// The commit the new reference will point at.
+        target_id: gix::ObjectId,
+        /// Whether to assert `target_id` is inside the workspace before re-projecting.
+        validate_in_workspace: bool,
+        /// Workspace-metadata mutation to apply. Managed workspaces only; `None` in ad-hoc mode,
+        /// where ordering lives in `branch_stack_order` instead.
+        instruction: Option<Instruction<'a>>,
+        /// Tip-to-base ad-hoc branch order to persist, when this placement changes it.
+        branch_stack_order: Option<Vec<gix::refs::FullName>>,
+        /// In ad-hoc mode, the reference that should become the projection entrypoint (the new
+        /// tip). Set when creating a branch above the checked-out branch, so it is projected
+        /// rather than rejected as unprojected. `HEAD` is *not* moved here; see
+        /// [`create_reference`] — the caller is responsible for the checkout.
+        new_tip: Option<gix::refs::FullName>,
+    }
+
+    impl<'a> AnchorResolution<'a> {
+        /// A placement that merely points the new reference at `target_id`, with no ad-hoc branch
+        /// order to persist and no change of entrypoint.
+        fn positioned(
+            target_id: gix::ObjectId,
+            validate_in_workspace: bool,
+            instruction: Option<Instruction<'a>>,
+        ) -> Self {
+            AnchorResolution {
+                target_id,
+                validate_in_workspace,
+                instruction,
+                branch_stack_order: None,
+                new_tip: None,
+            }
+        }
+    }
+
     /// Create a new reference named `ref_name` to point at a commit relative to `anchor`.
     /// If `anchor` is `None` this means the branch should be placed above the lower bound of the workspace, effectively
     /// creating an independent branch.
@@ -158,6 +197,19 @@ pub(super) mod function {
     ///
     ///  - if there is no managed workspace, then dependent branches must be exclusive on each commit to identify ordering
     ///  - if there is a workspace, we store the order in workspace metadata and expect an `anchor` that names a segment.
+    ///
+    /// # Ad-hoc (single-branch) workspaces
+    ///
+    /// With [`Anchor::AtReference`] and no managed workspace, the new branch is positioned relative
+    /// to a *local* branch by writing the tip-to-base order to `branch_stack_order`. This requires a
+    /// backend where [`RefMetadata::can_persist_branch_stack_order`] is `true`.
+    ///
+    /// When the new branch is placed [`Position::Above`] the *currently checked-out* branch it
+    /// becomes the new tip, and the returned workspace is projected **as if it were already checked
+    /// out**. This function does *not* move `HEAD`; the caller is responsible for checking the new
+    /// branch out so the real `HEAD` matches the projection (the API layer does this via
+    /// checkout-after-create). Placing above a branch that is not the entrypoint leaves the
+    /// entrypoint untouched.
     ///
     /// Return a regenerated Graph that contains the new reference, and from which a new workspace can be derived.
     pub fn create_reference<'ws, 'name, T: RefMetadata>(
@@ -186,155 +238,152 @@ pub(super) mod function {
         let existing_ref_target_in_workspace = existing_ref_target_id
             .filter(|id| workspace.find_owner_indexes_by_commit_id(*id).is_some());
 
-        let (check_if_id_in_workspace, ref_target_id, instruction): (
-            _,
-            _,
-            Option<Instruction<'_>>,
-        ) = {
-            match anchor {
-                None => {
-                    // The new ref exists already in the workspace, do nothing.
-                    if workspace
-                        .find_segment_and_stack_by_refname(ref_name)
-                        .is_some()
-                    {
-                        return Ok(Cow::Borrowed(workspace));
-                    }
-                    if let Some(existing_ref_target_id) = existing_ref_target_in_workspace {
-                        let instruction = existing_ws_meta
-                            .as_ref()
-                            .map(|_| {
-                                instruction_by_named_anchor_for_commit(
-                                    workspace,
-                                    existing_ref_target_id,
-                                )
-                            })
-                            .transpose()?;
-                        (
-                            true, // expect the target id to be in the workspace
-                            existing_ref_target_id,
-                            instruction,
-                        )
-                    } else {
-                        // The target tip (e.g. `origin/main`) can be advanced *past* the
-                        // workspace, i.e. outside it. Anchoring a new independent branch there
-                        // would stop re-projection from surfacing it as a standalone segment.
-                        // Anchor at the merge-base of the target tip and the workspace commit
-                        // instead — the fork point, always inside the workspace.
-                        let target_tip = workspace
-                            .resolved_target_commit_id()
-                            .or(ws_base)
-                            .with_context(|| {
-                                format!(
-                                    "workspace at {} is missing a base",
-                                    workspace.ref_name_display()
-                                )
-                            })?;
-                        // The merge-base needs the workspace commit. Without it (e.g. a headless,
-                        // unmanaged workspace) there is no fork point and thus no insertion point
-                        // inside the workspace, so refuse rather than silently anchor at the
-                        // target tip — the very commit we know may sit outside the workspace.
-                        let ws_commit_id = workspace
-                            .ref_name()
-                            .and_then(|ws_ref| repo.try_find_reference(ws_ref).ok().flatten())
-                            .and_then(|mut ws_ref| ws_ref.peel_to_id().ok())
-                            .map(|id| id.detach())
-                            .with_context(|| {
-                                format!(
-                                    "Cannot create independent branch: workspace at {} has no commit to anchor against",
-                                    workspace.ref_name_display()
-                                )
-                            })?;
-                        let base = repo.merge_base(target_tip, ws_commit_id)?.detach();
-                        (
-                            // Don't validate: the merge-base is the workspace's lower bound (the
-                            // fork point), not a commit owned by any segment.
-                            false,
-                            base,
-                            Some(Instruction::Independent),
-                        )
-                    }
+        let AnchorResolution {
+            target_id: ref_target_id,
+            validate_in_workspace: check_if_id_in_workspace,
+            instruction,
+            branch_stack_order,
+            new_tip: ad_hoc_new_tip,
+        } = match anchor {
+            None => {
+                // The new ref exists already in the workspace, do nothing.
+                if workspace
+                    .find_segment_and_stack_by_refname(ref_name)
+                    .is_some()
+                {
+                    return Ok(Cow::Borrowed(workspace));
                 }
-                Some(Anchor::AtCommit {
-                    commit_id,
-                    position,
-                }) => {
-                    let mut validate_id = true;
-                    let indexes = workspace.try_find_owner_indexes_by_commit_id(commit_id)?;
-                    let ref_target_id = position
-                        .resolve_commit(workspace.lookup_commit(indexes).into(), ws_base)?;
-                    let id_out_of_workspace = Some(ref_target_id) == ws_base;
-                    if id_out_of_workspace {
-                        validate_id = false
-                    }
-
+                if let Some(existing_ref_target_id) = existing_ref_target_in_workspace {
                     let instruction = existing_ws_meta
                         .as_ref()
-                        .filter(|_| !id_out_of_workspace)
-                        .map(|_| instruction_by_named_anchor_for_commit(workspace, commit_id))
-                        .or_else(|| {
-                            let (stack_idx, _seg_idx, _cidx) = indexes;
-                            workspace.stacks[stack_idx]
-                                .id
-                                .map(Instruction::DependentInStack)
-                                .map(Ok)
+                        .map(|_| {
+                            instruction_by_named_anchor_for_commit(
+                                workspace,
+                                existing_ref_target_id,
+                            )
                         })
                         .transpose()?;
-
-                    (validate_id, ref_target_id, instruction)
+                    // Expect the target id to be in the workspace.
+                    AnchorResolution::positioned(existing_ref_target_id, true, instruction)
+                } else {
+                    // The target tip (e.g. `origin/main`) can be advanced *past* the
+                    // workspace, i.e. outside it. Anchoring a new independent branch there
+                    // would stop re-projection from surfacing it as a standalone segment.
+                    // Anchor at the merge-base of the target tip and the workspace commit
+                    // instead — the fork point, always inside the workspace.
+                    let target_tip = workspace
+                        .resolved_target_commit_id()
+                        .or(ws_base)
+                        .with_context(|| {
+                            format!(
+                                "workspace at {} is missing a base",
+                                workspace.ref_name_display()
+                            )
+                        })?;
+                    // The merge-base needs the workspace commit. Without it (e.g. a headless,
+                    // unmanaged workspace) there is no fork point and thus no insertion point
+                    // inside the workspace, so refuse rather than silently anchor at the
+                    // target tip — the very commit we know may sit outside the workspace.
+                    let ws_commit_id = workspace
+                        .ref_name()
+                        .and_then(|ws_ref| repo.try_find_reference(ws_ref).ok().flatten())
+                        .and_then(|mut ws_ref| ws_ref.peel_to_id().ok())
+                        .map(|id| id.detach())
+                        .with_context(|| {
+                            format!(
+                                "Cannot create independent branch: workspace at {} has no commit to anchor against",
+                                workspace.ref_name_display()
+                            )
+                        })?;
+                    let base = repo.merge_base(target_tip, ws_commit_id)?.detach();
+                    // Don't validate: the merge-base is the workspace's lower bound (the
+                    // fork point), not a commit owned by any segment.
+                    AnchorResolution::positioned(base, false, Some(Instruction::Independent))
                 }
-                Some(Anchor::AtSegment { ref_name, position }) => {
-                    let mut validate_id = true;
-                    let ref_target_id = if workspace.has_metadata() {
-                        let (stack_idx, seg_idx) = workspace
-                            .try_find_segment_owner_indexes_by_refname(ref_name.as_ref())?;
-                        let segment = &workspace.stacks[stack_idx].segments[seg_idx];
-
-                        let id = workspace
-                            .tip_commit_by_segment_id(segment.id)
-                            .map(|commit| position.resolve_commit(commit.into(), ws_base))
-                            .context(
-                                "BUG: we should always see through to the base or eligible commits",
-                            )??;
-                        if Some(id) == ws_base {
-                            validate_id = false
-                        }
-                        id
-                    } else {
-                        let Some((_stack, segment)) =
-                            workspace.find_segment_and_stack_by_refname(ref_name.as_ref())
-                        else {
-                            bail!(
-                                "Could not find a segment named '{}' in workspace",
-                                ref_name.shorten()
-                            );
-                        };
-                        position.resolve_commit(
-                            segment
-                                .commits
-                                .first()
-                                .context("Cannot create reference on unborn branch")?
-                                .into(),
-                            ws_base,
-                        )?
-                    };
-                    (
-                        validate_id,
-                        ref_target_id,
-                        Some(Instruction::Dependent { ref_name, position }),
-                    )
+            }
+            Some(Anchor::AtCommit {
+                commit_id,
+                position,
+            }) => {
+                let mut validate_id = true;
+                let indexes = workspace.try_find_owner_indexes_by_commit_id(commit_id)?;
+                let ref_target_id =
+                    position.resolve_commit(workspace.lookup_commit(indexes).into(), ws_base)?;
+                let id_out_of_workspace = Some(ref_target_id) == ws_base;
+                if id_out_of_workspace {
+                    validate_id = false
                 }
-                Some(Anchor::AtReference {
-                    ref_name: anchor_ref,
-                    position,
-                }) => {
-                    if !workspace.has_metadata() {
-                        bail_precondition!(
-                            "Cannot position '{new}' relative to reference '{anchor}' without a managed workspace",
-                            new = ref_name.shorten(),
-                            anchor = anchor_ref.shorten()
-                        );
+
+                let instruction = existing_ws_meta
+                    .as_ref()
+                    .filter(|_| !id_out_of_workspace)
+                    .map(|_| instruction_by_named_anchor_for_commit(workspace, commit_id))
+                    .or_else(|| {
+                        let (stack_idx, _seg_idx, _cidx) = indexes;
+                        workspace.stacks[stack_idx]
+                            .id
+                            .map(Instruction::DependentInStack)
+                            .map(Ok)
+                    })
+                    .transpose()?;
+
+                AnchorResolution::positioned(ref_target_id, validate_id, instruction)
+            }
+            Some(Anchor::AtSegment { ref_name, position }) => {
+                let mut validate_id = true;
+                let ref_target_id = if workspace.has_metadata() {
+                    let (stack_idx, seg_idx) =
+                        workspace.try_find_segment_owner_indexes_by_refname(ref_name.as_ref())?;
+                    let segment = &workspace.stacks[stack_idx].segments[seg_idx];
+
+                    let id = workspace
+                        .tip_commit_by_segment_id(segment.id)
+                        .map(|commit| position.resolve_commit(commit.into(), ws_base))
+                        .context(
+                            "BUG: we should always see through to the base or eligible commits",
+                        )??;
+                    if Some(id) == ws_base {
+                        validate_id = false
                     }
+                    id
+                } else {
+                    let Some((_stack, segment)) =
+                        workspace.find_segment_and_stack_by_refname(ref_name.as_ref())
+                    else {
+                        bail!(
+                            "Could not find a segment named '{}' in workspace",
+                            ref_name.shorten()
+                        );
+                    };
+                    position.resolve_commit(
+                        segment
+                            .commits
+                            .first()
+                            .context("Cannot create reference on unborn branch")?
+                            .into(),
+                        ws_base,
+                    )?
+                };
+                AnchorResolution::positioned(
+                    ref_target_id,
+                    validate_id,
+                    Some(Instruction::Dependent { ref_name, position }),
+                )
+            }
+            // Position relative to another *reference* on the same commit. Managed workspaces
+            // order these in workspace metadata; ad-hoc workspaces record the order in the
+            // `branch_order` table (see `resolve_ad_hoc_at_reference`).
+            Some(Anchor::AtReference {
+                ref_name: anchor_ref,
+                position,
+            }) => {
+                if ref_name == anchor_ref.as_ref() {
+                    bail_precondition!(
+                        "Cannot position '{new}' relative to itself",
+                        new = ref_name.shorten()
+                    );
+                }
+                if workspace.has_metadata() {
                     let (stack_idx, seg_idx) =
                         workspace.try_find_segment_owner_indexes_by_refname(anchor_ref.as_ref())?;
                     let segment = &workspace.stacks[stack_idx].segments[seg_idx];
@@ -344,14 +393,29 @@ pub(super) mod function {
                         .context(
                             "BUG: we should always see through to the base or eligible commits",
                         )?;
-                    (
-                        Some(ref_target_id) != ws_base,
+                    AnchorResolution::positioned(
                         ref_target_id,
+                        Some(ref_target_id) != ws_base,
                         Some(Instruction::Dependent {
                             ref_name: anchor_ref,
                             position,
                         }),
                     )
+                } else if anchor_ref.category() == Some(gix::refs::Category::LocalBranch) {
+                    resolve_ad_hoc_at_reference(
+                        ref_name,
+                        anchor_ref.as_ref(),
+                        position,
+                        repo,
+                        workspace,
+                        meta,
+                    )?
+                } else {
+                    bail_precondition!(
+                        "Cannot position '{new}' relative to non-local reference '{anchor}' without a managed workspace",
+                        new = ref_name.shorten(),
+                        anchor = anchor_ref.shorten()
+                    );
                 }
             }
         };
@@ -374,25 +438,31 @@ pub(super) mod function {
             let mut branch_md = meta.branch(ref_name)?;
             update_branch_metadata(ref_name, repo, &mut branch_md)?;
 
-            workspace.graph.redo_traversal_with_overlay(
-                repo,
-                meta,
-                but_graph::init::Overlay::default()
-                    .with_references_if_new(Some(gix::refs::Reference {
-                        name: ref_name.into(),
-                        target: gix::refs::Target::Object(ref_target_id),
-                        peeled: None,
-                    }))
-                    .with_branch_metadata_override(Some((
-                        branch_md.as_ref().to_owned(),
-                        (*branch_md).clone(),
-                    )))
-                    .with_workspace_metadata_override(
-                        updated_ws_meta
-                            .as_ref()
-                            .map(|ws| (ws.as_ref().to_owned(), (*ws).clone())),
-                    ),
-            )?
+            let mut overlay = but_graph::init::Overlay::default()
+                .with_references_if_new(Some(gix::refs::Reference {
+                    name: ref_name.into(),
+                    target: gix::refs::Target::Object(ref_target_id),
+                    peeled: None,
+                }))
+                .with_branch_metadata_override(Some((
+                    branch_md.as_ref().to_owned(),
+                    (*branch_md).clone(),
+                )))
+                .with_workspace_metadata_override(
+                    updated_ws_meta
+                        .as_ref()
+                        .map(|ws| (ws.as_ref().to_owned(), (*ws).clone())),
+                );
+            if let Some(branch_stack_order) = branch_stack_order.clone() {
+                overlay = overlay.with_branch_stack_order_override(branch_stack_order);
+            }
+            if let Some(new_tip) = ad_hoc_new_tip {
+                overlay = overlay.with_entrypoint(ref_target_id, Some(new_tip));
+            }
+
+            workspace
+                .graph
+                .redo_traversal_with_overlay(repo, meta, overlay)?
         };
 
         let updated_workspace = graph_with_new_ref.into_workspace()?;
@@ -459,6 +529,19 @@ pub(super) mod function {
             // TODO: overwrite stored information with reality in new graph.
             meta.set_workspace(&existing)?;
         }
+        if let Some(branch_stack_order) = branch_stack_order
+            && let Err(err) = meta.set_branch_stack_order(&branch_stack_order)
+        {
+            // Keep the operation atomic from the caller's perspective: if we just created the ref
+            // but can't persist its ordering, roll the ref back (best-effort) so we don't leave an
+            // unordered same-commit branch that can't be projected consistently.
+            if existing_ref_target_id.is_none()
+                && let Ok(Some(reference)) = repo.try_find_reference(ref_name)
+            {
+                reference.delete().ok();
+            }
+            return Err(err);
+        }
 
         // Always re-obtain the branch as `set_workspace` has created another version of it, possibly.
         // To avoid duplication, fetch the 'real' one and do the update again.
@@ -468,6 +551,91 @@ pub(super) mod function {
         meta.set_branch(&branch_md)?;
 
         Ok(Cow::Owned(updated_workspace))
+    }
+
+    /// Resolve an [`Anchor::AtReference`] in an ad-hoc (single-branch) workspace against a local
+    /// `anchor_ref`, recording the tip-to-base order in `branch_stack_order`.
+    ///
+    /// The new reference points at the same commit as `anchor_ref`. See [`create_reference`] for
+    /// the `new_tip` / checkout contract.
+    fn resolve_ad_hoc_at_reference<'a, T: RefMetadata>(
+        new_ref: &gix::refs::FullNameRef,
+        anchor_ref: &gix::refs::FullNameRef,
+        position: Position,
+        repo: &gix::Repository,
+        workspace: &but_graph::Workspace,
+        meta: &T,
+    ) -> anyhow::Result<AnchorResolution<'a>> {
+        // Callers (the `AtReference` arm) guarantee `new_ref != anchor_ref`, which keeps the
+        // `insert_into_branch_stack_order` invariant (the anchor survives `retain`) sound.
+        if !meta.can_persist_branch_stack_order() {
+            bail_precondition!(
+                "Cannot position '{new}' relative to local reference '{anchor}' without branch order metadata",
+                new = new_ref.shorten(),
+                anchor = anchor_ref.shorten()
+            );
+        }
+        let Some(mut anchor_reference) = repo.try_find_reference(anchor_ref)? else {
+            bail_precondition!(
+                "Cannot position '{new}' relative to '{anchor}': the anchor reference does not exist",
+                new = new_ref.shorten(),
+                anchor = anchor_ref.shorten()
+            );
+        };
+        let target_id = anchor_reference.peel_to_id()?.detach();
+        let existing_order = meta.branch_stack_order(anchor_ref)?.unwrap_or_default();
+        let branch_stack_order =
+            insert_into_branch_stack_order(existing_order, anchor_ref, new_ref, position);
+
+        // Creating a branch above the checked-out branch makes it the new tip. The workspace only
+        // projects the entrypoint and the segments below it, so without moving the entrypoint the
+        // new ref would sit above it, fall outside the projection, and be rejected as unprojected.
+        // Anchor the validating re-traversal at the new tip instead; the caller checks it out to
+        // make this real (mirroring the API's checkout-after-create).
+        let new_tip = (matches!(position, Position::Above)
+            && workspace.ref_name() == Some(anchor_ref))
+        .then(|| new_ref.to_owned());
+
+        Ok(AnchorResolution {
+            target_id,
+            validate_in_workspace: false,
+            instruction: None,
+            branch_stack_order: Some(branch_stack_order),
+            new_tip,
+        })
+    }
+
+    /// Insert `new_ref` into the ad-hoc, tip-to-base `order` relative to `anchor`.
+    ///
+    /// - `anchor` is seeded into the order if it isn't there yet (a first ordering only has the
+    ///   anchor).
+    /// - If `new_ref` is already present it is moved (removed then re-inserted), so re-creating or
+    ///   reordering the same branch is idempotent.
+    /// - [`Position::Above`] takes the anchor's slot, pushing the anchor down; [`Position::Below`]
+    ///   goes right after the anchor. This only affects *ordering* — unlike [`Anchor::AtSegment`],
+    ///   it never changes which branch owns the commit.
+    fn insert_into_branch_stack_order(
+        mut order: Vec<gix::refs::FullName>,
+        anchor: &gix::refs::FullNameRef,
+        new_ref: &gix::refs::FullNameRef,
+        position: Position,
+    ) -> Vec<gix::refs::FullName> {
+        if !order.iter().any(|branch| branch.as_ref() == anchor) {
+            order.push(anchor.to_owned());
+        }
+        order.retain(|branch| branch.as_ref() != new_ref);
+        // `anchor` was pushed above if it was missing, and `retain` only drops `new_ref`, so the
+        // anchor is guaranteed to still be present here.
+        let anchor_idx = order
+            .iter()
+            .position(|branch| branch.as_ref() == anchor)
+            .expect("anchor is always present in the order at this point");
+        let insert_idx = match position {
+            Position::Above => anchor_idx,
+            Position::Below => anchor_idx + 1,
+        };
+        order.insert(insert_idx, new_ref.to_owned());
+        order
     }
 
     fn is_not_a_directory_ref_edit_error(err: &gix::reference::edit::Error) -> bool {
@@ -648,5 +816,75 @@ pub(super) mod function {
             ref_name: Cow<'a, gix::refs::FullNameRef>,
             position: Position,
         },
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::{Position, insert_into_branch_stack_order};
+
+        fn full(name: &str) -> gix::refs::FullName {
+            gix::refs::FullName::try_from(name).expect("valid ref name")
+        }
+
+        fn names(order: &[gix::refs::FullName]) -> Vec<String> {
+            order.iter().map(|r| r.as_bstr().to_string()).collect()
+        }
+
+        #[test]
+        fn above_on_empty_order_seeds_the_anchor_below_the_new_ref() {
+            let order = insert_into_branch_stack_order(
+                Vec::new(),
+                full("refs/heads/main").as_ref(),
+                full("refs/heads/top").as_ref(),
+                Position::Above,
+            );
+            assert_eq!(names(&order), ["refs/heads/top", "refs/heads/main"]);
+        }
+
+        #[test]
+        fn below_on_empty_order_seeds_the_anchor_above_the_new_ref() {
+            let order = insert_into_branch_stack_order(
+                Vec::new(),
+                full("refs/heads/main").as_ref(),
+                full("refs/heads/bottom").as_ref(),
+                Position::Below,
+            );
+            assert_eq!(names(&order), ["refs/heads/main", "refs/heads/bottom"]);
+        }
+
+        #[test]
+        fn above_takes_the_anchor_slot_in_an_existing_order() {
+            let order = insert_into_branch_stack_order(
+                vec![full("refs/heads/top"), full("refs/heads/main")],
+                full("refs/heads/main").as_ref(),
+                full("refs/heads/middle").as_ref(),
+                Position::Above,
+            );
+            assert_eq!(
+                names(&order),
+                ["refs/heads/top", "refs/heads/middle", "refs/heads/main"]
+            );
+        }
+
+        #[test]
+        fn reinserting_an_existing_ref_moves_it_and_is_idempotent() {
+            // `top` already sits above `main`; re-inserting it below `main` moves it there.
+            let order = insert_into_branch_stack_order(
+                vec![full("refs/heads/top"), full("refs/heads/main")],
+                full("refs/heads/main").as_ref(),
+                full("refs/heads/top").as_ref(),
+                Position::Below,
+            );
+            assert_eq!(names(&order), ["refs/heads/main", "refs/heads/top"]);
+
+            // Applying the same insertion again is a no-op.
+            let order = insert_into_branch_stack_order(
+                order,
+                full("refs/heads/main").as_ref(),
+                full("refs/heads/top").as_ref(),
+                Position::Below,
+            );
+            assert_eq!(names(&order), ["refs/heads/main", "refs/heads/top"]);
+        }
     }
 }

--- a/crates/but-workspace/tests/workspace/branch/create_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/create_reference.rs
@@ -1,14 +1,14 @@
-use std::borrow::Cow;
-
 use bstr::ByteSlice;
 use but_core::{
     RefMetadata,
     ref_metadata::{StackId, ValueInfo},
 };
 use but_graph::init::Options;
+use but_meta::BranchOrderMetadata;
 use but_testsupport::{graph_workspace, id_at, id_by_rev, visualize_commit_graph_all};
 use but_workspace::branch::create_reference::{Anchor, Position::*};
 use gix::refs::transaction::PreviousValue;
+use std::borrow::Cow;
 
 use crate::{
     ref_info::with_workspace_commit::utils::{
@@ -25,6 +25,10 @@ fn project_meta(meta: &impl RefMetadata) -> but_core::ref_metadata::ProjectMeta 
     )
     .map(|workspace| workspace.project_meta())
     .unwrap_or_default()
+}
+
+fn branch_order_meta(repo: &gix::Repository) -> anyhow::Result<BranchOrderMetadata> {
+    BranchOrderMetadata::from_paths(repo.path().join("virtual-branches.toml"), repo.path())
 }
 
 mod with_workspace {
@@ -1465,6 +1469,22 @@ mod with_workspace {
             repo.try_find_reference(new_ref)?.is_none(),
             "the reference isn't physically available"
         );
+
+        // A reference cannot be positioned relative to itself (managed workspace path).
+        let err = but_workspace::branch::create_reference(
+            r("refs/heads/A"),
+            Anchor::AtReference {
+                ref_name: Cow::Borrowed(r("refs/heads/A")),
+                position: Below,
+            },
+            &repo,
+            &ws,
+            &mut meta,
+            stack_id_for_name,
+            None,
+        )
+        .unwrap_err();
+        insta::assert_snapshot!(err.to_string(), @"Cannot position 'A' relative to itself");
         Ok(())
     }
 
@@ -1994,47 +2014,6 @@ fn errors() -> anyhow::Result<()> {
 }
 
 #[test]
-fn at_reference_requires_managed_workspace() -> anyhow::Result<()> {
-    let (repo, mut meta) =
-        named_read_only_in_memory_scenario("with-remotes-no-workspace", "remote")?;
-    let graph =
-        but_graph::Graph::from_head(&repo, &*meta, project_meta(&*meta), Options::limited())?;
-    let ws = graph.into_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @"
-    ⌂:0:main[🌳] <> ✓! on c166d42
-    └── ≡:0:main[🌳] {1}
-        └── :0:main[🌳]
-    ");
-
-    let new_name = r("refs/heads/new");
-    let main_ref = r("refs/heads/main");
-    for position in [Above, Below] {
-        // Without workspace metadata there is no way to order two references
-        // on the same commit, so this refuses to do anything.
-        let err = but_workspace::branch::create_reference(
-            new_name,
-            Anchor::at_reference(main_ref, position),
-            &repo,
-            &ws,
-            &mut *meta,
-            stack_id_for_name,
-            None,
-        )
-        .unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "Cannot position 'new' relative to reference 'main' without a managed workspace"
-        );
-        assert!(
-            repo.try_find_reference(new_name)?.is_none(),
-            "the reference isn't physically available"
-        );
-        assert!(meta.branch(new_name)?.is_default(), "no data was stored");
-    }
-    Ok(())
-}
-
-#[test]
 fn journey_with_commits() -> anyhow::Result<()> {
     let (_tmp, repo, mut meta) = named_writable_scenario("single-branch-with-3-commits")?;
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
@@ -2393,4 +2372,437 @@ fn journey_anon_workspace() -> anyhow::Result<()> {
 
 fn stack_id_for_name(rn: &gix::refs::FullNameRef) -> StackId {
     StackId::from_number_for_testing(rn.shorten().chars().map(|c| c as u128).sum())
+}
+
+/// [`Anchor::AtReference`] in an ad-hoc (single-branch) workspace, where the tip-to-base order of
+/// same-commit branches lives in the `branch_order` table rather than workspace metadata.
+mod ad_hoc_at_reference {
+    use super::*;
+    use but_workspace::branch::create_reference::Position;
+
+    /// A single-branch workspace checked out on `main` (3 commits) with a *writable* branch-order
+    /// backend, so `AtReference` placements can persist their order.
+    fn ad_hoc_workspace() -> anyhow::Result<(
+        tempfile::TempDir,
+        gix::Repository,
+        BranchOrderMetadata,
+        but_core::ref_metadata::ProjectMeta,
+        but_graph::Workspace,
+    )> {
+        let (tmp, repo, legacy_meta) = named_writable_scenario("single-branch-with-3-commits")?;
+        let project_meta = project_meta(&legacy_meta);
+        let meta = branch_order_meta(&repo)?;
+        let ws =
+            but_graph::Graph::from_head(&repo, &meta, project_meta.clone(), Options::limited())?
+                .into_workspace()?;
+        Ok((tmp, repo, meta, project_meta, ws))
+    }
+
+    /// Create `new_ref` positioned relative to `anchor_ref` and return the resulting workspace.
+    fn create(
+        repo: &gix::Repository,
+        ws: &but_graph::Workspace,
+        meta: &mut BranchOrderMetadata,
+        new_ref: &gix::refs::FullNameRef,
+        anchor_ref: &gix::refs::FullNameRef,
+        position: Position,
+    ) -> anyhow::Result<but_graph::Workspace> {
+        Ok(but_workspace::branch::create_reference(
+            new_ref,
+            Anchor::at_reference(anchor_ref, position),
+            repo,
+            ws,
+            meta,
+            stack_id_for_name,
+            None,
+        )?
+        .into_owned())
+    }
+
+    /// Assert the durable tip-to-base order recorded for the chain containing `anchor`.
+    fn assert_order(
+        meta: &BranchOrderMetadata,
+        anchor: &gix::refs::FullNameRef,
+        expected: &[&str],
+    ) {
+        let expected: Vec<gix::refs::FullName> =
+            expected.iter().copied().map(|s| r(s).to_owned()).collect();
+        assert_eq!(
+            meta.branch_stack_order(anchor).expect("order is readable"),
+            Some(expected),
+        );
+    }
+
+    #[test]
+    fn orders_local_branches_only() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, _project_meta, ws) = ad_hoc_workspace()?;
+        insta::assert_snapshot!(graph_workspace(&ws), @"
+        ⌂:0:main[🌳] <> ✓! on 281da94
+        └── ≡:0:main[🌳] {1}
+            └── :0:main[🌳]
+        ");
+
+        let main_ref = r("refs/heads/main");
+        let main_id = repo.find_reference(main_ref)?.id();
+        let below_ref = r("refs/heads/new-below");
+        create(&repo, &ws, &mut meta, below_ref, main_ref, Below)?;
+        assert_order(
+            &meta,
+            main_ref,
+            &["refs/heads/main", "refs/heads/new-below"],
+        );
+        assert_eq!(repo.find_reference(below_ref)?.id(), main_id);
+
+        // A remote anchor carries no ad-hoc ordering, so it is rejected.
+        let remote_ref = r("refs/remotes/origin/main");
+        repo.reference(
+            remote_ref,
+            main_id,
+            PreviousValue::Any,
+            "test remote anchor",
+        )?;
+        let err = create(
+            &repo,
+            &ws,
+            &mut meta,
+            r("refs/heads/new-remote-anchor"),
+            remote_ref,
+            Above,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Cannot position 'new-remote-anchor' relative to non-local reference 'origin/main' without a managed workspace"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn requires_branch_order_metadata() -> anyhow::Result<()> {
+        // A TOML-only backend can't persist order, so ad-hoc `AtReference` is refused up front.
+        let (_tmp, repo, mut meta) = named_writable_scenario("single-branch-with-3-commits")?;
+        let ws =
+            but_graph::Graph::from_head(&repo, &meta, project_meta(&meta), Options::limited())?
+                .into_workspace()?;
+
+        let new_ref = r("refs/heads/new");
+        let err = but_workspace::branch::create_reference(
+            new_ref,
+            Anchor::at_reference(r("refs/heads/main"), Above),
+            &repo,
+            &ws,
+            &mut meta,
+            stack_id_for_name,
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Cannot position 'new' relative to local reference 'main' without branch order metadata"
+        );
+        assert!(
+            repo.try_find_reference(new_ref)?.is_none(),
+            "unsupported metadata must fail before creating the ref"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn below_checked_out_branch_is_projected() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, project_meta, ws) = ad_hoc_workspace()?;
+
+        let bottom_ref = r("refs/heads/empty-bottom");
+        let main_ref = r("refs/heads/main");
+        create(&repo, &ws, &mut meta, bottom_ref, main_ref, Below)?;
+
+        let ws = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?
+            .into_workspace()?;
+        insta::assert_snapshot!(graph_workspace(&ws), @"
+        ⌂:1:main[🌳] <> ✓! on 281da94
+        └── ≡:1:main[🌳] {1}
+            ├── :1:main[🌳]
+            └── 📙:0:empty-bottom
+                ├── ·281da94
+                ├── ·12995d7
+                └── ·3d57fc1
+        ");
+        assert!(repo.try_find_reference(bottom_ref)?.is_some());
+        assert_order(
+            &meta,
+            main_ref,
+            &["refs/heads/main", "refs/heads/empty-bottom"],
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn below_empty_branch_between_empty_branches() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, project_meta, ws) = ad_hoc_workspace()?;
+
+        let middle_ref = r("refs/heads/empty-middle");
+        let inserted_ref = r("refs/heads/inserted-below-middle");
+        let bottom_ref = r("refs/heads/empty-bottom");
+        let main_ref = r("refs/heads/main");
+
+        let mut ws = ws;
+        for (ref_name, anchor_ref) in [
+            (bottom_ref, main_ref),
+            (middle_ref, main_ref),
+            (inserted_ref, middle_ref),
+        ] {
+            ws = create(&repo, &ws, &mut meta, ref_name, anchor_ref, Below)?;
+        }
+
+        assert_order(
+            &meta,
+            main_ref,
+            &[
+                "refs/heads/main",
+                "refs/heads/empty-middle",
+                "refs/heads/inserted-below-middle",
+                "refs/heads/empty-bottom",
+            ],
+        );
+
+        let ws = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?
+            .into_workspace()?;
+        insta::assert_snapshot!(graph_workspace(&ws), @"
+        ⌂:1:main[🌳] <> ✓! on 281da94
+        └── ≡:1:main[🌳] {1}
+            ├── :1:main[🌳]
+            ├── 📙:2:empty-middle
+            ├── 📙:3:inserted-below-middle
+            └── 📙:0:empty-bottom
+                ├── ·281da94
+                ├── ·12995d7
+                └── ·3d57fc1
+        ");
+        Ok(())
+    }
+
+    #[test]
+    fn above_checked_out_branch_is_projected_as_new_tip() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, _project_meta, ws) = ad_hoc_workspace()?;
+
+        let top_ref = r("refs/heads/empty-top");
+        let main_ref = r("refs/heads/main");
+        let ws = create(&repo, &ws, &mut meta, top_ref, main_ref, Above)?;
+
+        // Creating above the checked-out branch makes the new empty branch the projected tip.
+        // `create_reference` does not move `HEAD`; the caller checks the new tip out (see its docs).
+        insta::assert_snapshot!(graph_workspace(&ws), @"
+        ⌂:1:empty-top[🌳] <> ✓! on 281da94
+        └── ≡📙:1:empty-top[🌳] {1}
+            ├── 📙:1:empty-top[🌳]
+            └── :0:main
+                ├── ·281da94
+                ├── ·12995d7
+                └── ·3d57fc1
+        ");
+        assert_eq!(
+            ws.ref_name(),
+            Some(top_ref),
+            "the new tip is projected as the workspace entrypoint (as if checked out)"
+        );
+        assert!(repo.try_find_reference(top_ref)?.is_some());
+        assert_order(
+            &meta,
+            main_ref,
+            &["refs/heads/empty-top", "refs/heads/main"],
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn above_a_branch_over_the_entrypoint_is_rejected_without_a_checkout() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, project_meta, ws) = ad_hoc_workspace()?;
+        let top_ref = r("refs/heads/empty-top");
+        let main_ref = r("refs/heads/main");
+
+        // Create the tip above `main`, but do NOT check it out - the real `HEAD` stays on `main`.
+        create(&repo, &ws, &mut meta, top_ref, main_ref, Above)?;
+
+        // Re-project from the real `HEAD` (`main`); `empty-top` now sits *above* the entrypoint and
+        // is not part of the projection. Anchoring a further branch above `empty-top` would also
+        // land above the entrypoint, so it can't be projected and is rejected. In practice the API
+        // checks the tip out first, which is what makes stacking above it work.
+        let ws = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?
+            .into_workspace()?;
+        assert_eq!(ws.ref_name(), Some(main_ref));
+        let err = create(
+            &repo,
+            &ws,
+            &mut meta,
+            r("refs/heads/higher"),
+            top_ref,
+            Above,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("cannot be created"),
+            "anchoring above a branch that sits above the entrypoint should be rejected: {err}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn order_survives_a_metadata_reload() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, project_meta, ws) = ad_hoc_workspace()?;
+        let main_ref = r("refs/heads/main");
+        let middle_ref = r("refs/heads/empty-middle");
+        let bottom_ref = r("refs/heads/empty-bottom");
+
+        let ws = create(&repo, &ws, &mut meta, bottom_ref, main_ref, Below)?;
+        create(&repo, &ws, &mut meta, middle_ref, main_ref, Below)?;
+        let expected = [
+            "refs/heads/main",
+            "refs/heads/empty-middle",
+            "refs/heads/empty-bottom",
+        ];
+        assert_order(&meta, main_ref, &expected);
+
+        // Reopen the branch-order backend from disk: the durable order must survive a fresh handle.
+        drop(meta);
+        let meta = branch_order_meta(&repo)?;
+        assert_order(&meta, main_ref, &expected);
+
+        // ...and the workspace re-projects identically from the reloaded metadata.
+        let ws = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?
+            .into_workspace()?;
+        insta::assert_snapshot!(graph_workspace(&ws), @"
+        ⌂:1:main[🌳] <> ✓! on 281da94
+        └── ≡:1:main[🌳] {1}
+            ├── :1:main[🌳]
+            ├── 📙:2:empty-middle
+            └── 📙:0:empty-bottom
+                ├── ·281da94
+                ├── ·12995d7
+                └── ·3d57fc1
+        ");
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_a_missing_anchor() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, _project_meta, ws) = ad_hoc_workspace()?;
+        let new_ref = r("refs/heads/new");
+        let missing_anchor = r("refs/heads/does-not-exist");
+
+        let err = create(&repo, &ws, &mut meta, new_ref, missing_anchor, Above).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("the anchor reference does not exist"),
+            "a non-existent anchor must be rejected with a clear precondition error: {err}"
+        );
+        assert!(
+            repo.try_find_reference(new_ref)?.is_none(),
+            "no ref should be created for a missing anchor"
+        );
+        assert_eq!(meta.branch_stack_order(missing_anchor)?, None);
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_positioning_a_reference_relative_to_itself() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, _project_meta, ws) = ad_hoc_workspace()?;
+        let main_ref = r("refs/heads/main");
+
+        // Positioning a ref relative to itself must be a clean validation error, not a panic.
+        let err = create(&repo, &ws, &mut meta, main_ref, main_ref, Above).unwrap_err();
+        assert!(
+            err.to_string().contains("relative to itself"),
+            "self-referential placement must be rejected: {err}"
+        );
+        assert_eq!(meta.branch_stack_order(main_ref)?, None);
+        Ok(())
+    }
+
+    #[test]
+    fn reusing_an_existing_ref_for_a_different_commit_fails_without_mutation() -> anyhow::Result<()>
+    {
+        let (_tmp, repo, mut meta, _project_meta, ws) = ad_hoc_workspace()?;
+        let main_ref = r("refs/heads/main");
+
+        // `existing` already points at an older commit than `main`'s tip.
+        let existing_ref = r("refs/heads/existing");
+        let older = id_by_rev(&repo, "main~1").detach();
+        repo.reference(existing_ref, older, PreviousValue::Any, "pre-existing ref")?;
+
+        assert!(
+            create(&repo, &ws, &mut meta, existing_ref, main_ref, Above).is_err(),
+            "reusing an existing ref that points at a different commit must be rejected"
+        );
+        // The failure must be atomic: the ref is untouched and no order was persisted.
+        assert_eq!(repo.find_reference(existing_ref)?.id().detach(), older);
+        assert_eq!(meta.branch_stack_order(main_ref)?, None);
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_a_name_colliding_with_an_existing_branch() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, _project_meta, ws) = ad_hoc_workspace()?;
+        let main_ref = r("refs/heads/main");
+
+        // `refs/heads/main` exists as a file, so `refs/heads/main/child` cannot be created.
+        let colliding = r("refs/heads/main/child");
+        let err = create(&repo, &ws, &mut meta, colliding, main_ref, Above).unwrap_err();
+        assert!(
+            err.to_string().contains("collides with existing branch"),
+            "a name colliding with an existing branch should be reported clearly: {err}"
+        );
+        assert_eq!(meta.branch_stack_order(main_ref)?, None);
+        Ok(())
+    }
+
+    #[test]
+    fn interleaved_insertions_keep_a_consistent_order() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, project_meta, ws) = ad_hoc_workspace()?;
+        let main_ref = r("refs/heads/main");
+        let upper = r("refs/heads/upper");
+        let middle = r("refs/heads/middle");
+        let lower = r("refs/heads/lower");
+        let bottom = r("refs/heads/bottom");
+        let crown = r("refs/heads/crown");
+
+        // Build a taller stack downward from the checked-out branch, inserting below different
+        // anchors to exercise the insertion-index arithmetic beyond the two-branch cases.
+        let mut ws = ws;
+        for (new_ref, anchor_ref) in [
+            (bottom, main_ref), // [main, bottom]
+            (middle, main_ref), // [main, middle, bottom]
+            (upper, main_ref),  // [main, upper, middle, bottom]
+            (lower, middle),    // [main, upper, middle, lower, bottom]
+        ] {
+            ws = create(&repo, &ws, &mut meta, new_ref, anchor_ref, Below)?;
+        }
+        assert_order(
+            &meta,
+            main_ref,
+            &[
+                "refs/heads/main",
+                "refs/heads/upper",
+                "refs/heads/middle",
+                "refs/heads/lower",
+                "refs/heads/bottom",
+            ],
+        );
+
+        // Mix in an `Above` insertion: a new tip over the (still checked-out) `main`.
+        let ws = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?
+            .into_workspace()?;
+        create(&repo, &ws, &mut meta, crown, main_ref, Above)?;
+        assert_order(
+            &meta,
+            main_ref,
+            &[
+                "refs/heads/crown",
+                "refs/heads/main",
+                "refs/heads/upper",
+                "refs/heads/middle",
+                "refs/heads/lower",
+                "refs/heads/bottom",
+            ],
+        );
+        Ok(())
+    }
 }


### PR DESCRIPTION
Adds single-branch (ad-hoc) workspace support to `create_reference`, so a branch can be created relative to another **local** branch on the same commit, with the tip-to-base order persisted in the `branch_order` table.

## Why
We need to update the branch order when creating a ref on top of the one we've got checked out, in order to be able to start a stack.



---

# Slop summary

## Changes

- **`create_reference` (`but-workspace`)**: `Anchor::AtReference` now works without a managed workspace when the anchor is a local branch, recording the ad-hoc order via `set_branch_stack_order` (requires a backend where `can_persist_branch_stack_order()` is true). When the new branch is placed *above* the checked-out branch it becomes the new tip: the returned workspace is projected **as if it were already checked out** (the entrypoint moves to it), while `HEAD` is left for the caller to move. Creating *below*, or above a non-entrypoint branch, leaves the entrypoint untouched.
- **`but-ctx`**: `meta()` returns a `BranchOrderMetadata` backend (TOML + `branch_order` DB)
- **`prune on fetch`**: When fetching from the remotes, we prune order entries for refs that no longer exist on disk.

## Testing

- **Unit (pure ordering)**: seeding the anchor into an empty order (above/below), inserting into an existing chain, and idempotent re-insert/reorder of an already-present ref.
- **Integration (`mod ad_hoc_at_reference`)**: create above the checked-out branch (projected as new tip), create below, splice between empty branches, order local branches only (remote anchor rejected), missing branch-order backend rejected, and "above a branch that sits over the entrypoint is rejected without a checkout".
- Each ad-hoc test asserts the durable `branch_stack_order`, not just the projected graph snapshot.

