### PR TITLE
fix(tui): remove unnecessary dev-only flag

### DIFF
--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -905,14 +905,6 @@ pub enum Subcommands {
         #[cfg(feature = "tui-profiling")]
         #[clap(long)]
         quit_after: Option<u64>,
-        /// Quit after rendering the full diff.
-        ///
-        /// Implies `--diff`.
-        ///
-        /// Requires `tui-profiling` feature.
-        #[cfg(feature = "tui-profiling")]
-        #[clap(long)]
-        quit_after_rendering_full_diff: bool,
         /// Run the TUI with an in-memory terminal and no terminal event polling.
         ///
         /// Requires `tui-profiling` feature.

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -121,7 +121,6 @@ pub struct TuiLaunchOptions {
     pub skip_status_after: bool,
     pub show_diff: bool,
     pub select_commit: Option<gix::ObjectId>,
-    pub quit_after_rendering_full_diff: bool,
 }
 
 #[derive(Debug, Default, Copy, Clone)]

--- a/crates/but/src/command/legacy/status/tui/details.rs
+++ b/crates/but/src/command/legacy/status/tui/details.rs
@@ -108,13 +108,6 @@ impl Details {
         }
     }
 
-    pub fn is_finished_rendering(&self) -> bool {
-        match &self.line_reader {
-            ChannelLineReader::NotStarted | ChannelLineReader::Started { .. } => false,
-            ChannelLineReader::Finished | ChannelLineReader::Failed => true,
-        }
-    }
-
     pub fn is_polling_thread(&self) -> bool {
         match &self.line_reader {
             ChannelLineReader::NotStarted

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -337,11 +337,6 @@ where
 
     if app.details.update(ctx, selection, app.is_details_visible)? {
         app.should_render = true;
-
-        if app.launch_options.quit_after_rendering_full_diff && app.details.is_finished_rendering()
-        {
-            app.outcome = Some(TuiOutcome::None);
-        }
     }
 
     if let Some(file_browser) = &mut app.file_browser

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -780,8 +780,6 @@ async fn match_subcommand(
             diff,
             #[cfg(feature = "tui-profiling")]
             select_commit,
-            #[cfg(feature = "tui-profiling")]
-            quit_after_rendering_full_diff,
         } => {
             use crate::command::legacy::status::{StatusFlags, StatusRenderMode, TuiLaunchOptions};
 
@@ -806,13 +804,8 @@ async fn match_subcommand(
                 quit_after,
                 headless,
                 skip_status_after,
-                show_diff: if quit_after_rendering_full_diff {
-                    true
-                } else {
-                    diff
-                },
+                show_diff: diff,
                 select_commit,
-                quit_after_rendering_full_diff,
             };
             #[cfg(not(feature = "tui-profiling"))]
             let _options = TuiLaunchOptions::default();


### PR DESCRIPTION
With how the new diff renderer works this flag doesn't make sense.