### PR TITLE
Add AI conflict resolution for conflicted commits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,6 +972,7 @@ dependencies = [
  "but-graph",
  "but-hunk-assignment",
  "but-hunk-dependency",
+ "but-llm",
  "but-oplog",
  "but-path",
  "but-rebase",

--- a/apps/desktop/src/components/commit/CommitContextMenu.svelte
+++ b/apps/desktop/src/components/commit/CommitContextMenu.svelte
@@ -10,6 +10,7 @@
 	interface LocalCommitContextData extends BaseContextData {
 		commitStatus: "LocalOnly" | "LocalAndRemote";
 		stackId?: string;
+		hasConflicts?: boolean;
 		onUncommitClick: (event: MouseEvent) => void;
 		onEditMessageClick: (event: MouseEvent) => void;
 		/** When set, indicates multiple commits are selected. */
@@ -44,12 +45,19 @@
 		position: { coords?: { x: number; y: number }; element?: HTMLElement };
 		data: CommitContextData;
 	};
+
+	// Commits with an AI resolution in flight. Module-scoped because the menu
+	// instance (and its mutation state) is destroyed when the menu closes,
+	// while the resolution keeps running.
+	const resolvingCommits = new Set<string>();
 </script>
 
 <script lang="ts">
 	import IrcSendToSubmenus from "$components/diff/IrcSendToSubmenus.svelte";
+	import { AI_SERVICE } from "$lib/ai/service";
 	import { CLIPBOARD_SERVICE } from "$lib/backend/clipboard";
 	import { URL_SERVICE } from "$lib/backend/url";
+	import { projectAiGenEnabled } from "$lib/config/config";
 	import { rewrapCommitMessage } from "$lib/config/uiFeatureFlags";
 	import { DIFF_SERVICE } from "$lib/hunks/diffService.svelte";
 	import { IRC_API_SERVICE } from "$lib/irc/ircApiService";
@@ -57,6 +65,7 @@
 	import { buildSharedCommitPayload } from "$lib/irc/sharedStack";
 	import { editPatch } from "$lib/mode/editPatchUtils";
 	import { MODE_SERVICE } from "$lib/mode/modeService";
+	import { dismissToast, showToast } from "$lib/notifications/toasts";
 	import { PROJECTS_SERVICE } from "$lib/project/projectsService";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { inject, injectOptional } from "@gitbutler/core/context";
@@ -92,8 +101,34 @@
 	const diffService = inject(DIFF_SERVICE);
 	const ircApiService = inject(IRC_API_SERVICE);
 	const projectsService = inject(PROJECTS_SERVICE);
+	const aiService = inject(AI_SERVICE);
 	const [insertBlankCommitInBranch, commitInsertion] = stackService.insertBlankCommit.useMutation();
 	const [createRef, refCreation] = stackService.createReference;
+	const [resolveConflictsAi, aiResolution] = stackService.resolveCommitConflictsAi;
+
+	const aiGenEnabled = $derived(projectAiGenEnabled(projectId));
+	const commitHasConflicts = $derived(
+		contextData !== undefined && "hasConflicts" in contextData && !!contextData.hasConflicts,
+	);
+	let aiConfigurationValid = $state(false);
+
+	// Validating the AI configuration costs several backend calls, so only do
+	// it for the rare rows that can actually offer the AI-resolve action.
+	$effect(() => {
+		if (!commitHasConflicts || !$aiGenEnabled) return;
+		let stale = false;
+		aiService.validateConfiguration().then(
+			(valid) => {
+				if (!stale) aiConfigurationValid = valid;
+			},
+			() => {
+				if (!stale) aiConfigurationValid = false;
+			},
+		);
+		return () => {
+			stale = true;
+		};
+	});
 
 	const projectQuery = $derived(projectsService.getProject(projectId));
 	const projectTitle = $derived(projectQuery.response?.title ?? projectId);
@@ -146,6 +181,40 @@
 			stackId,
 			projectId,
 		});
+	}
+
+	async function handleResolveConflictsAi(commitId: string, stackId: string) {
+		if (isReadOnly || !$aiGenEnabled || !aiConfigurationValid) return;
+		if (resolvingCommits.has(commitId)) return;
+		resolvingCommits.add(commitId);
+		const progressToastId = `resolve-conflicts-ai-${commitId}`;
+		showToast({
+			id: progressToastId,
+			style: "info",
+			title: "Resolving conflicts with AI…",
+			message: "This can take a moment. The resolution is applied when it completes.",
+		});
+		try {
+			const result = await resolveConflictsAi({ projectId, stackId, commitId });
+			dismissToast(progressToastId);
+			const fileList = result.files
+				.map((file) => `- \`${file.path}\` — ${file.reasoning}`)
+				.join("\n");
+			showToast({
+				style: "success",
+				title: "Conflicts resolved with AI",
+				message: `${result.summary ?? ""}\n\n${fileList}\n\nIf this isn't right, undo it from the operations history.`,
+			});
+		} catch (error: unknown) {
+			dismissToast(progressToastId);
+			showToast({
+				style: "danger",
+				title: "Failed to resolve conflicts with AI",
+				error,
+			});
+		} finally {
+			resolvingCommits.delete(commitId);
+		}
 	}
 
 	async function sendCommitToChannel(
@@ -261,6 +330,20 @@
 								}
 							}}
 						/>
+						{#if contextData.hasConflicts && $aiGenEnabled && aiConfigurationValid}
+							<ContextMenuItem
+								label="Resolve conflicts with AI"
+								icon="ai"
+								testId={TestId.CommitRowContextMenu_ResolveConflictsAi}
+								disabled={isReadOnly || aiResolution.current.isLoading}
+								onclick={() => {
+									if (!isReadOnly && contextData.stackId) {
+										handleResolveConflictsAi(commitId, contextData.stackId);
+										close();
+									}
+								}}
+							/>
+						{/if}
 					</ContextMenuSection>
 				{/if}
 			{/if}

--- a/apps/desktop/src/components/commit/CommitView.svelte
+++ b/apps/desktop/src/components/commit/CommitView.svelte
@@ -205,6 +205,7 @@
 					commitId: commit.id,
 					commitMessage: commit.message,
 					commitStatus: commit.state.type,
+					hasConflicts: commit.hasConflicts,
 					commitUrl: forgeInfo ? commitUrl(forgeInfo, commit.id) : undefined,
 					onUncommitClick: () => handleUncommit(),
 					onEditMessageClick: () => {

--- a/apps/desktop/src/components/views/BranchCommitList.svelte
+++ b/apps/desktop/src/components/views/BranchCommitList.svelte
@@ -439,6 +439,7 @@
 									commitId,
 									commitMessage: commit.message,
 									commitStatus: commit.state.type,
+									hasConflicts: commit.hasConflicts,
 									commitUrl: forgeInfo ? commitUrl(forgeInfo, commitId) : undefined,
 									onUncommitClick: () => handleUncommit(commit.id),
 									onEditMessageClick: () => startEditingCommitMessage(commit.id),

--- a/apps/desktop/src/lib/stacks/stackEndpoints.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.ts
@@ -25,6 +25,7 @@ import type {
 import type { BackendEndpointBuilder } from "$lib/state/backendApi";
 import type {
 	AbsorptionTarget,
+	AiResolutionResult,
 	BranchLandResult,
 	CommitAbsorption,
 	BranchDetails,
@@ -451,6 +452,26 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 			transformResponse: (response: CommitRewordResult) => response.newCommit,
 			invalidatesTags: (_result, _error, { stackId }) => [
 				invalidatesList(ReduxTag.HeadSha),
+				...(stackId ? [invalidatesItem(ReduxTag.StackDetails, stackId)] : []),
+			],
+		}),
+		resolveCommitConflictsAi: build.mutation<
+			AiResolutionResult,
+			{ projectId: string; stackId?: string; commitId: string }
+		>({
+			extraOptions: {
+				command: "resolve_commit_conflicts_ai",
+				actionName: "Resolve Conflicts with AI",
+			},
+			query: ({ projectId, commitId }) => ({
+				projectId,
+				commitId,
+				dryRun: false,
+			}),
+			invalidatesTags: (_result, _error, { stackId }) => [
+				invalidatesList(ReduxTag.HeadSha),
+				invalidatesList(ReduxTag.BranchChanges),
+				invalidatesList(ReduxTag.WorktreeChanges),
 				...(stackId ? [invalidatesItem(ReduxTag.StackDetails, stackId)] : []),
 			],
 		}),

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -550,6 +550,10 @@ export class StackService {
 		return this.backendApi.endpoints.updateCommitMessage.useMutation();
 	}
 
+	get resolveCommitConflictsAi() {
+		return this.backendApi.endpoints.resolveCommitConflictsAi.useMutation();
+	}
+
 	get newBranch() {
 		return this.backendApi.endpoints.newBranch.useMutation();
 	}

--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -103,6 +103,7 @@ but-gitlab.workspace = true
 # 'legacy' is needed while this is only a sketch of what the oplog could be.
 # For single-branch testing, we also want the oplog and just take it as it is.
 but-oplog = { workspace = true, features = ["legacy"] }
+but-llm.workspace = true
 but-askpass = { workspace = true, optional = true }
 itertools.workspace = true
 
@@ -154,6 +155,7 @@ objc2-foundation = { version = "0.3.2", default-features = false, features = ["s
 [dev-dependencies]
 but-api = { path = ".", features = ["legacy"] }
 but-testsupport.workspace = true
+gitbutler-oplog.workspace = true
 snapbox.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["full"] }

--- a/crates/but-api/src/lib.rs
+++ b/crates/but-api/src/lib.rs
@@ -39,6 +39,9 @@ pub mod land;
 /// Functions that operate commits
 pub mod commit;
 
+/// Resolve the conflicts of a conflicted commit with an LLM.
+pub mod resolve;
+
 /// Functions that show what changed in various Git entities, like trees, commits and the worktree.
 pub mod diff;
 

--- a/crates/but-api/src/resolve/apply.rs
+++ b/crates/but-api/src/resolve/apply.rs
@@ -1,0 +1,347 @@
+//! Validate a model response against the request, splice the resolved hunks
+//! into the merged blobs, and rewrite the conflicted commit into a normal one.
+
+use anyhow::{Context as _, bail};
+use bstr::ByteSlice;
+use but_core::DryRun;
+use but_core::commit::Headers;
+use but_core::sync::RepoExclusive;
+use but_rebase::commit::DateMode;
+use but_rebase::graph_rebase::{Editor, LookupStep as _, Step};
+
+use super::context::{FileConflict, ResolutionRequest, is_marker_shaped, scan_conflict_blocks};
+use super::prompt::ResolutionResponse;
+use crate::WorkspaceState;
+
+/// A validated, spliced resolution, aligned index-for-index with the
+/// request's files.
+#[derive(Debug)]
+pub(crate) struct ValidatedFile {
+    /// The full file content with every conflict block replaced by its resolution.
+    pub resolved_text: String,
+    /// The per-hunk replacement contents, in file order.
+    pub hunks: Vec<String>,
+    /// The model's per-file reasoning.
+    pub reasoning: String,
+}
+
+/// Check `response` against `request` and splice the resolutions into the
+/// merged blobs. Any mismatch fails validation so the caller can retry the
+/// model once before giving up. Nothing is written to the repository here.
+pub(crate) fn validate(
+    request: &ResolutionRequest,
+    response: &ResolutionResponse,
+) -> anyhow::Result<Vec<ValidatedFile>> {
+    // Both sides of the path comparison are normalized: models tend to add
+    // `./` or backslashes, and request paths are matched under the same rules
+    // so a path that normalizes differently can never silently mismatch.
+    let mut request_paths = std::collections::BTreeSet::new();
+    for file in &request.files {
+        if !request_paths.insert(normalize_path(&file.path)) {
+            bail!(
+                "Two conflicted paths normalize to the same value ({:?}); resolve this commit manually instead",
+                normalize_path(&file.path)
+            );
+        }
+    }
+
+    let mut resolutions_by_path = std::collections::BTreeMap::new();
+    for resolution in &response.resolutions {
+        let path = normalize_path(&resolution.path);
+        if resolutions_by_path
+            .insert(path.clone(), resolution)
+            .is_some()
+        {
+            bail!("The model returned more than one resolution for \"{path}\"");
+        }
+    }
+
+    let mut validated = Vec::with_capacity(request.files.len());
+    for file in &request.files {
+        let resolution = resolutions_by_path
+            .remove(&normalize_path(&file.path))
+            .with_context(|| {
+                format!(
+                    "The model returned no resolution for the conflicted file \"{}\"",
+                    file.path
+                )
+            })?;
+        if resolution.hunks.len() != file.hunks.len() {
+            bail!(
+                "The model returned {} resolved hunks for \"{}\" but the file has {} conflicts",
+                resolution.hunks.len(),
+                file.path,
+                file.hunks.len()
+            );
+        }
+        if resolution.reasoning.trim().is_empty() {
+            bail!("The model returned no reasoning for \"{}\"", file.path);
+        }
+        let hunks: Vec<String> = resolution
+            .hunks
+            .iter()
+            .map(|hunk| hunk.resolved_content.clone())
+            .collect();
+        let resolved_text = splice_resolved_file(file, &hunks)?;
+        // The inputs were verified to be free of marker-shaped content when
+        // the request was built, so any marker-shaped line in the spliced
+        // output can only come from the model.
+        if let Some(marker) = resolved_text
+            .lines()
+            .find(|line| is_marker_shaped(line.strip_suffix('\r').unwrap_or(line)))
+        {
+            bail!(
+                "The model's resolution for \"{}\" still contains a conflict marker ({marker:?})",
+                file.path
+            );
+        }
+        validated.push(ValidatedFile {
+            resolved_text,
+            hunks,
+            reasoning: resolution.reasoning.clone(),
+        });
+    }
+
+    if let Some(path) = resolutions_by_path.into_keys().next() {
+        bail!("The model returned a resolution for \"{path}\", which was not requested");
+    }
+
+    Ok(validated)
+}
+
+/// Replace each conflict block in the merged text with its resolved content.
+///
+/// Non-conflicted lines are copied byte-for-byte including their own line
+/// terminators, so mixed-EOL files stay untouched outside conflict regions.
+/// Only the inserted resolution lines use the file's dominant EOL style, and a
+/// single trailing newline on a resolution is dropped since the block's own
+/// terminator is preserved.
+fn splice_resolved_file(file: &FileConflict, resolutions: &[String]) -> anyhow::Result<String> {
+    let eol = if file.merged_text.contains("\r\n") {
+        "\r\n"
+    } else {
+        "\n"
+    };
+    // Raw lines keep their terminators; the stripped view drives the scanner.
+    let raw_lines: Vec<&str> = file.merged_text.split_inclusive('\n').collect();
+    let stripped_lines: Vec<&str> = raw_lines
+        .iter()
+        .map(|line| strip_terminator(line))
+        .collect();
+    let blocks = scan_conflict_blocks(&stripped_lines);
+    if blocks.len() != resolutions.len() {
+        bail!(
+            "BUG: found {} conflict blocks in \"{}\" while splicing, but validated {} resolutions",
+            blocks.len(),
+            file.path,
+            resolutions.len()
+        );
+    }
+
+    let mut result = String::with_capacity(file.merged_text.len());
+    let mut line = 0;
+    for (block, resolution) in blocks.iter().zip(resolutions) {
+        for raw in &raw_lines[line..block.start] {
+            result.push_str(raw);
+        }
+        let resolution = resolution
+            .strip_suffix('\n')
+            .map(|r| r.strip_suffix('\r').unwrap_or(r))
+            .unwrap_or(resolution);
+        if !resolution.is_empty() {
+            let block_is_terminated = raw_lines[block.end].ends_with('\n');
+            for (index, resolved_line) in resolution
+                .split('\n')
+                .map(|l| l.strip_suffix('\r').unwrap_or(l))
+                .enumerate()
+            {
+                if index > 0 {
+                    result.push_str(eol);
+                }
+                result.push_str(resolved_line);
+            }
+            if block_is_terminated {
+                result.push_str(eol);
+            }
+        }
+        line = block.end + 1;
+    }
+    for raw in &raw_lines[line..] {
+        result.push_str(raw);
+    }
+    Ok(result)
+}
+
+fn strip_terminator(line: &str) -> &str {
+    let line = line.strip_suffix('\n').unwrap_or(line);
+    line.strip_suffix('\r').unwrap_or(line)
+}
+
+/// Normalize a path for comparison: trim, backslashes to slashes, strip a
+/// leading `./`, collapse duplicate slashes. Applied to both request and
+/// response paths.
+fn normalize_path(path: &str) -> String {
+    let mut normalized = path.trim().replace('\\', "/");
+    while normalized.contains("//") {
+        normalized = normalized.replace("//", "/");
+    }
+    normalized
+        .strip_prefix("./")
+        .map(str::to_owned)
+        .unwrap_or(normalized)
+}
+
+/// Write the resolved blobs and tree, rewrite the conflicted commit into a
+/// normal commit (resolved tree, stripped message, conflict header removed),
+/// and rebase its descendants.
+///
+/// Returns the rewritten commit's final id and the resulting workspace state.
+pub(crate) fn apply(
+    ctx: &mut but_ctx::Context,
+    request: &ResolutionRequest,
+    validated: &[ValidatedFile],
+    dry_run: DryRun,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<(gix::ObjectId, WorkspaceState)> {
+    let mut meta = ctx.meta()?;
+    let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
+
+    let mut tree_editor = repo.edit_tree(request.merged_tree_id)?;
+    for (file, resolution) in request.files.iter().zip(validated) {
+        let blob_id = repo.write_blob(resolution.resolved_text.as_bytes())?;
+        tree_editor.upsert(file.rela_path.as_bstr(), file.entry_kind, blob_id)?;
+    }
+    let resolved_tree_id = tree_editor.write()?.detach();
+
+    let mut editor = Editor::create(&mut ws, &mut meta, &repo)?;
+    let (target_selector, mut commit) = editor.find_selectable_commit(request.commit_id)?;
+    commit.tree = resolved_tree_id;
+    commit.message = but_core::commit::strip_conflict_markers(commit.message.as_ref());
+    if let Some(headers) = Headers::try_from_commit(&commit) {
+        Headers {
+            conflicted: None,
+            ..headers
+        }
+        .set_in_commit(&mut commit);
+    }
+    let new_id = editor.new_commit(commit, DateMode::CommitterUpdateAuthorKeep)?;
+    editor.replace(target_selector, Step::new_pick(new_id))?;
+
+    let rebase = editor.rebase()?;
+    let new_commit = rebase.lookup_pick(target_selector)?;
+    let workspace = WorkspaceState::from_successful_rebase(rebase, &repo, dry_run)?;
+
+    Ok((new_commit, workspace))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resolve::context::split_lines;
+
+    fn test_file(merged_text: &str) -> FileConflict {
+        let lines = split_lines(merged_text);
+        let blocks = scan_conflict_blocks(&lines);
+        FileConflict {
+            path: "file.txt".into(),
+            rela_path: "file.txt".into(),
+            entry_kind: gix::objs::tree::EntryKind::Blob,
+            merged_text: merged_text.to_owned(),
+            hunks: blocks
+                .iter()
+                .map(|_| super::super::context::ConflictHunk {
+                    context_before: String::new(),
+                    ours: String::new(),
+                    base: None,
+                    theirs: String::new(),
+                    context_after: String::new(),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn splice_replaces_blocks_and_preserves_surroundings() {
+        let file = test_file(
+            "before\n<<<<<<< gitbutler-resolve-ours\na\n=======\nb\n>>>>>>> gitbutler-resolve-theirs\nbetween\n<<<<<<< gitbutler-resolve-ours\nc\n=======\nd\n>>>>>>> gitbutler-resolve-theirs\nafter\n",
+        );
+        let result =
+            splice_resolved_file(&file, &["merged one".to_owned(), "merged two".to_owned()])
+                .unwrap();
+        assert_eq!(result, "before\nmerged one\nbetween\nmerged two\nafter\n");
+    }
+
+    #[test]
+    fn splice_empty_resolution_deletes_the_block() {
+        let file = test_file(
+            "before\n<<<<<<< gitbutler-resolve-ours\na\n=======\nb\n>>>>>>> gitbutler-resolve-theirs\nafter\n",
+        );
+        let result = splice_resolved_file(&file, &[String::new()]).unwrap();
+        assert_eq!(result, "before\nafter\n");
+    }
+
+    #[test]
+    fn splice_preserves_crlf() {
+        let file = test_file(
+            "a\r\n<<<<<<< gitbutler-resolve-ours\r\nx\r\n=======\r\ny\r\n>>>>>>> gitbutler-resolve-theirs\r\nb\r\n",
+        );
+        let result = splice_resolved_file(&file, &["merged".to_owned()]).unwrap();
+        assert_eq!(result, "a\r\nmerged\r\nb\r\n");
+    }
+
+    /// Mixed-EOL files must keep every non-conflicted line's own terminator —
+    /// only inserted resolution lines use the dominant EOL.
+    #[test]
+    fn splice_preserves_mixed_eol_outside_conflicts() {
+        let file = test_file(
+            "line1\nwin\r\nline3\n<<<<<<< gitbutler-resolve-ours\na\n=======\nb\n>>>>>>> gitbutler-resolve-theirs\nline4\n",
+        );
+        let result = splice_resolved_file(&file, &["merged".to_owned()]).unwrap();
+        assert_eq!(
+            result, "line1\nwin\r\nline3\nmerged\r\nline4\n",
+            "non-conflicted lines keep their own terminators; the inserted line uses the dominant (CRLF) EOL"
+        );
+    }
+
+    /// A CRLF that only exists inside the replaced conflict block must not
+    /// change any line outside it.
+    #[test]
+    fn splice_ignores_eol_of_deleted_block_content() {
+        let file = test_file(
+            "line1\n<<<<<<< gitbutler-resolve-ours\na\r\n=======\nb\n>>>>>>> gitbutler-resolve-theirs\nline2\n",
+        );
+        let result = splice_resolved_file(&file, &[String::new()]).unwrap();
+        assert_eq!(result, "line1\nline2\n");
+    }
+
+    #[test]
+    fn splice_strips_a_single_trailing_newline_from_resolutions() {
+        let file = test_file(
+            "before\n<<<<<<< gitbutler-resolve-ours\na\n=======\nb\n>>>>>>> gitbutler-resolve-theirs\nafter\n",
+        );
+        let result = splice_resolved_file(&file, &["merged\n".to_owned()]).unwrap();
+        assert_eq!(result, "before\nmerged\nafter\n");
+        // An intentional blank line (two newlines) keeps one.
+        let result = splice_resolved_file(&file, &["merged\n\n".to_owned()]).unwrap();
+        assert_eq!(result, "before\nmerged\n\nafter\n");
+    }
+
+    #[test]
+    fn splice_without_trailing_newline_at_eof() {
+        let file = test_file(
+            "before\n<<<<<<< gitbutler-resolve-ours\na\n=======\nb\n>>>>>>> gitbutler-resolve-theirs",
+        );
+        let result = splice_resolved_file(&file, &["merged".to_owned()]).unwrap();
+        assert_eq!(
+            result, "before\nmerged",
+            "an unterminated closing marker keeps the file unterminated"
+        );
+    }
+
+    #[test]
+    fn path_normalization() {
+        assert_eq!(normalize_path("./src//main.rs "), "src/main.rs");
+        assert_eq!(normalize_path("src\\main.rs"), "src/main.rs");
+        assert_eq!(normalize_path("plain.txt"), "plain.txt");
+    }
+}

--- a/crates/but-api/src/resolve/context.rs
+++ b/crates/but-api/src/resolve/context.rs
@@ -1,0 +1,521 @@
+//! Build the conflict-resolution request for a conflicted commit, entirely in memory.
+//!
+//! The conflicted commit stores its merge inputs as trees (`.conflict-base-0`,
+//! `.conflict-side-0/1`), so re-merging them reproduces the conflicts without a
+//! checkout: the merged blobs carry standard conflict markers which are parsed
+//! into per-hunk ours/base/theirs sections here.
+
+use anyhow::{Context as _, bail};
+use bstr::{BString, ByteSlice};
+use but_core::RepositoryExt as _;
+use but_error::Code;
+
+/// The maximum size of a conflicted file to send to the model.
+const MAX_FILE_SIZE: usize = 1024 * 1024;
+/// How many lines of surrounding context to include per conflict hunk.
+const CONTEXT_LINES: usize = 3;
+
+/// Sentinel side labels passed to the merge so that machine-generated marker
+/// lines are exactly known strings. The scanner matches marker lines exactly,
+/// so file content that merely looks like a conflict marker (patches, test
+/// fixtures, docs) can never open or close a block.
+const OURS_MARKER: &str = "<<<<<<< gitbutler-resolve-ours";
+const BASE_MARKER: &str = "||||||| gitbutler-resolve-base";
+const THEIRS_MARKER: &str = ">>>>>>> gitbutler-resolve-theirs";
+const SEPARATOR: &str = "=======";
+
+fn merge_labels() -> gix::merge::blob::builtin_driver::text::Labels<'static> {
+    gix::merge::blob::builtin_driver::text::Labels {
+        ancestor: Some("gitbutler-resolve-base".into()),
+        current: Some("gitbutler-resolve-ours".into()),
+        other: Some("gitbutler-resolve-theirs".into()),
+    }
+}
+
+/// One conflicted region of a file, with the content of each side and a few
+/// lines of surrounding context.
+#[derive(Debug, Clone)]
+pub struct ConflictHunk {
+    /// Unconflicted lines directly before the conflict, clamped to the previous conflict.
+    pub context_before: String,
+    /// The content of the *ours* side, i.e. the new base the commit is rebased onto.
+    pub ours: String,
+    /// The content of the common ancestor, if the merge produced diff3-style markers.
+    pub base: Option<String>,
+    /// The content of the *theirs* side, i.e. the conflicted commit's own version.
+    pub theirs: String,
+    /// Unconflicted lines directly after the conflict, clamped to the next conflict.
+    pub context_after: String,
+}
+
+/// A conflicted file together with its merged marker text and extracted hunks.
+#[derive(Debug, Clone)]
+pub struct FileConflict {
+    /// The repo-relative path, lossily decoded for display and prompting.
+    pub path: String,
+    /// The exact repo-relative path as stored in the tree.
+    pub rela_path: BString,
+    /// The kind of the merged tree entry, preserved when writing the resolved blob.
+    pub entry_kind: gix::objs::tree::EntryKind,
+    /// The full content of the merged blob, still containing conflict markers.
+    pub merged_text: String,
+    /// The conflicts found in `merged_text`, in file order.
+    pub hunks: Vec<ConflictHunk>,
+}
+
+/// Everything needed to prompt for and apply a resolution of one conflicted commit.
+#[derive(Debug, Clone)]
+pub struct ResolutionRequest {
+    /// The conflicted commit to resolve.
+    pub commit_id: gix::ObjectId,
+    /// The commit's message with the conflict markers stripped.
+    pub commit_message: String,
+    /// The title of the commit's parent, i.e. the new base it was rebased onto.
+    pub parent_message: Option<String>,
+    /// The tree produced by re-merging the commit's conflict trees, with markers in blobs.
+    pub merged_tree_id: gix::ObjectId,
+    /// All conflicted files, sorted by path.
+    pub files: Vec<FileConflict>,
+}
+
+/// Re-merge the conflict trees of `commit_id` and extract all conflict hunks.
+///
+/// Fails with a "resolve manually" style error for conflicts that have no
+/// marker block to splice a resolution into: side deletions, non-blob entries,
+/// binary or oversized files.
+pub fn build_request(
+    repo: &gix::Repository,
+    commit_id: gix::ObjectId,
+) -> anyhow::Result<ResolutionRequest> {
+    use gix::prelude::ObjectIdExt as _;
+
+    let commit = but_core::Commit::from_id(commit_id.attach(repo))?;
+    let Some((base, ours, theirs)) = commit.conflicted_tree_ids()? else {
+        bail!(
+            anyhow::anyhow!(Code::Validation)
+                .context(format!("Commit {commit_id} is not conflicted"))
+        );
+    };
+
+    let commit_message = but_core::commit::strip_conflict_markers(commit.message.as_ref())
+        .to_str_lossy()
+        .into_owned();
+    let parent_message = commit
+        .parents
+        .first()
+        .and_then(|parent_id| but_core::Commit::from_id(parent_id.attach(repo)).ok())
+        .map(|parent| commit_title(&parent));
+
+    let repo = repo.clone().for_tree_diffing()?;
+    // Merge without favoring a side to reproduce the actual conflicts, and
+    // force diff3-style markers so every hunk carries the common ancestor.
+    let mut options: gix::merge::plumbing::tree::Options = repo.tree_merge_options()?.into();
+    options.blob_merge.text.conflict = gix::merge::blob::builtin_driver::text::Conflict::Keep {
+        style: gix::merge::blob::builtin_driver::text::ConflictStyle::Diff3,
+        marker_size: 7.try_into().expect("non-zero constant"),
+    };
+    let mut outcome = repo.merge_trees(base, ours, theirs, merge_labels(), options.into())?;
+    let merged_tree_id = outcome.tree.write()?.detach();
+
+    let mut index = repo.index_from_tree(&merged_tree_id)?;
+    if !outcome.index_changed_after_applying_conflicts(
+        &mut index,
+        gix::merge::tree::TreatAsUnresolved::git(),
+        gix::merge::tree::apply_index_entries::RemovalMode::Mark,
+    ) {
+        bail!(
+            "Re-merging the conflicting trees of commit {commit_id} yielded no conflicts to resolve"
+        );
+    }
+
+    let mut sides_by_path: std::collections::BTreeMap<BString, ConflictSides> = Default::default();
+    for entry in index.entries() {
+        use gix::index::entry::Stage;
+        let sides = sides_by_path
+            .entry(entry.path(&index).to_owned())
+            .or_default();
+        match entry.stage() {
+            Stage::Unconflicted => continue,
+            Stage::Base => sides.base = true,
+            Stage::Ours => sides.ours = true,
+            Stage::Theirs => sides.theirs = true,
+        }
+    }
+    sides_by_path.retain(|_, sides| sides.base || sides.ours || sides.theirs);
+
+    let merged_tree = repo.find_tree(merged_tree_id)?;
+    let mut files = Vec::with_capacity(sides_by_path.len());
+    for (rela_path, sides) in sides_by_path {
+        let path = rela_path.to_str_lossy().into_owned();
+        if !(sides.ours && sides.theirs) {
+            bail!(
+                "The conflict in \"{path}\" involves a deletion or rename and cannot be resolved automatically. Resolve this commit manually instead."
+            );
+        }
+        let entry = merged_tree
+            .lookup_entry(rela_path.split(|b| *b == b'/'))?
+            .with_context(|| {
+                format!("Conflicted path \"{path}\" is missing from the merged tree")
+            })?;
+        let entry_kind = entry.mode().kind();
+        if !matches!(
+            entry_kind,
+            gix::objs::tree::EntryKind::Blob | gix::objs::tree::EntryKind::BlobExecutable
+        ) {
+            bail!(
+                "The conflict in \"{path}\" is not a regular file and cannot be resolved automatically. Resolve this commit manually instead."
+            );
+        }
+        let blob = entry.object()?.into_blob();
+        if blob.data.len() > MAX_FILE_SIZE {
+            bail!(
+                "The conflicted file \"{path}\" exceeds the 1MB size limit for automatic resolution. Resolve this commit manually instead."
+            );
+        }
+        let merged_text = std::str::from_utf8(&blob.data)
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "The conflicted file \"{path}\" is binary or not valid UTF-8 and cannot be resolved automatically. Resolve this commit manually instead."
+                )
+            })?
+            .to_owned();
+        let lines = split_lines(&merged_text);
+        let blocks = scan_conflict_blocks(&lines);
+        // Content that merely looks like a conflict marker cannot open or
+        // close a block (markers are matched exactly and positionally), but it
+        // would confuse the section decomposition or any later marker-based
+        // reader of the resolved file, so hand such files to manual resolution.
+        if let Some(line) = find_ambiguous_marker_line(&lines, &blocks) {
+            bail!(
+                "The conflicted file \"{path}\" contains content that is ambiguous with conflict markers ({line:?}) and cannot be resolved automatically. Resolve this commit manually instead."
+            );
+        }
+        if blocks.is_empty() {
+            bail!(
+                "No conflict markers were found in the conflicted file \"{path}\". Resolve this commit manually instead."
+            );
+        }
+        let hunks = extract_hunks(&lines, &blocks);
+        files.push(FileConflict {
+            path,
+            rela_path,
+            entry_kind,
+            merged_text,
+            hunks,
+        });
+    }
+
+    if files.is_empty() {
+        bail!("Commit {commit_id} has no conflicted files to resolve");
+    }
+
+    Ok(ResolutionRequest {
+        commit_id,
+        commit_message,
+        parent_message,
+        merged_tree_id,
+        files,
+    })
+}
+
+#[derive(Debug, Default)]
+struct ConflictSides {
+    base: bool,
+    ours: bool,
+    theirs: bool,
+}
+
+fn commit_title(commit: &but_core::Commit<'_>) -> String {
+    gix::objs::commit::MessageRef::from_bytes(
+        but_core::commit::strip_conflict_markers(commit.message.as_ref()).as_ref(),
+    )
+    .title
+    .trim_ascii_end()
+    .to_str_lossy()
+    .chars()
+    .take(80)
+    .collect()
+}
+
+/// A well-formed conflict block found in marker text, as line ranges.
+#[derive(Debug, Clone)]
+pub(crate) struct ConflictBlock {
+    /// Line index of the `<<<<<<<` marker.
+    pub start: usize,
+    /// Line index of the `>>>>>>>` marker.
+    pub end: usize,
+    /// Content lines of the *ours* section.
+    pub ours: std::ops::Range<usize>,
+    /// Content lines of the *base* section, present with diff3-style markers.
+    pub base: Option<std::ops::Range<usize>>,
+    /// Content lines of the *theirs* section.
+    pub theirs: std::ops::Range<usize>,
+}
+
+/// Whether `line` is shaped like a `<<<<<<<` / `|||||||` / `>>>>>>>` conflict
+/// marker of any origin: seven (or more, for nested-merge sizes) marker
+/// characters followed by nothing or a space.
+///
+/// A lone `=======` is deliberately not treated as marker-shaped — it cannot
+/// open or close a block by itself and legitimately occurs as e.g. an RST
+/// heading underline.
+pub(crate) fn is_marker_shaped(line: &str) -> bool {
+    let bytes = line.as_bytes();
+    let Some(&first) = bytes.first() else {
+        return false;
+    };
+    if !matches!(first, b'<' | b'|' | b'>') {
+        return false;
+    }
+    let run = bytes.iter().take_while(|byte| **byte == first).count();
+    run >= 7 && (bytes.len() == run || bytes[run] == b' ')
+}
+
+/// The first line of file content that could be mistaken for a conflict
+/// marker: a marker-shaped line (including a sentinel-marker lookalike)
+/// anywhere but at a block's own marker positions, or a lone `=======` inside
+/// a block, where the scanner would bind it as the section separator.
+///
+/// A lone `=======` outside all blocks is fine — it can only be content.
+fn find_ambiguous_marker_line<'a>(lines: &[&'a str], blocks: &[ConflictBlock]) -> Option<&'a str> {
+    let marker_positions: std::collections::HashSet<usize> = blocks
+        .iter()
+        .flat_map(|block| {
+            [
+                Some(block.start),
+                Some(block.end),
+                Some(block.theirs.start - 1),
+            ]
+            .into_iter()
+            .chain([block.base.as_ref().map(|base| base.start - 1)])
+            .flatten()
+        })
+        .collect();
+
+    lines.iter().enumerate().find_map(|(index, line)| {
+        if marker_positions.contains(&index) {
+            return None;
+        }
+        let inside_a_block = || {
+            blocks
+                .iter()
+                .any(|block| index > block.start && index < block.end)
+        };
+        (is_marker_shaped(line) || (*line == SEPARATOR && inside_a_block())).then_some(*line)
+    })
+}
+
+/// Split marker text into lines, treating `\r\n` and `\n` alike.
+pub(crate) fn split_lines(text: &str) -> Vec<&str> {
+    text.split('\n')
+        .map(|line| line.strip_suffix('\r').unwrap_or(line))
+        .collect()
+}
+
+/// Find all well-formed conflict blocks in `lines`.
+///
+/// A block requires an ours marker, a separator, and a closing theirs marker;
+/// anything else (stray or malformed markers) is treated as plain content.
+/// This scanner is shared by hunk extraction and resolution splicing so both
+/// always agree on the number and position of conflicts.
+pub(crate) fn scan_conflict_blocks(lines: &[&str]) -> Vec<ConflictBlock> {
+    let mut blocks = Vec::new();
+    let mut i = 0;
+    while i < lines.len() {
+        if lines[i] != OURS_MARKER {
+            i += 1;
+            continue;
+        }
+        let mut base_start = None;
+        let mut separator = None;
+        let mut close = None;
+        for (j, line) in lines.iter().enumerate().skip(i + 1) {
+            if separator.is_none() && base_start.is_none() && *line == BASE_MARKER {
+                base_start = Some(j);
+            } else if separator.is_none() && *line == SEPARATOR {
+                separator = Some(j);
+            } else if separator.is_some() && *line == THEIRS_MARKER {
+                close = Some(j);
+                break;
+            }
+        }
+        let (Some(separator), Some(close)) = (separator, close) else {
+            i += 1;
+            continue;
+        };
+        blocks.push(ConflictBlock {
+            start: i,
+            end: close,
+            ours: (i + 1)..base_start.unwrap_or(separator),
+            base: base_start.map(|base_start| (base_start + 1)..separator),
+            theirs: (separator + 1)..close,
+        });
+        i = close + 1;
+    }
+    blocks
+}
+
+fn extract_hunks(lines: &[&str], blocks: &[ConflictBlock]) -> Vec<ConflictHunk> {
+    let join = |range: std::ops::Range<usize>| lines[range].join("\n");
+
+    blocks
+        .iter()
+        .enumerate()
+        .map(|(index, block)| {
+            let previous_end = if index == 0 {
+                0
+            } else {
+                blocks[index - 1].end + 1
+            };
+            let next_start = blocks
+                .get(index + 1)
+                .map(|next| next.start)
+                .unwrap_or(lines.len());
+            let context_before_start = block.start.saturating_sub(CONTEXT_LINES).max(previous_end);
+            let context_after_end = (block.end + 1 + CONTEXT_LINES).min(next_start);
+
+            ConflictHunk {
+                context_before: join(context_before_start..block.start),
+                ours: join(block.ours.clone()),
+                base: block.base.clone().map(join),
+                theirs: join(block.theirs.clone()),
+                context_after: join((block.end + 1)..context_after_end),
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TWO_WAY: &str = "line 1\nline 2\n<<<<<<< gitbutler-resolve-ours\nour change\n=======\ntheir change\n>>>>>>> gitbutler-resolve-theirs\nline 3\n";
+    const DIFF3: &str = "start\n<<<<<<< gitbutler-resolve-ours\nours\n||||||| gitbutler-resolve-base\noriginal\n=======\ntheirs\n>>>>>>> gitbutler-resolve-theirs\nend\n";
+
+    fn extract_hunks(text: &str) -> Vec<ConflictHunk> {
+        let lines = split_lines(text);
+        let blocks = scan_conflict_blocks(&lines);
+        super::extract_hunks(&lines, &blocks)
+    }
+
+    fn ambiguous_line(text: &str) -> Option<String> {
+        let lines = split_lines(text);
+        let blocks = scan_conflict_blocks(&lines);
+        find_ambiguous_marker_line(&lines, &blocks).map(str::to_owned)
+    }
+
+    #[test]
+    fn two_way_markers_are_extracted() {
+        let hunks = extract_hunks(TWO_WAY);
+        assert_eq!(hunks.len(), 1);
+        assert_eq!(hunks[0].ours, "our change");
+        assert_eq!(hunks[0].theirs, "their change");
+        assert_eq!(hunks[0].base, None);
+        assert_eq!(hunks[0].context_before, "line 1\nline 2");
+        assert_eq!(hunks[0].context_after, "line 3\n");
+    }
+
+    #[test]
+    fn diff3_markers_include_base() {
+        let hunks = extract_hunks(DIFF3);
+        assert_eq!(hunks.len(), 1);
+        assert_eq!(hunks[0].ours, "ours");
+        assert_eq!(hunks[0].base.as_deref(), Some("original"));
+        assert_eq!(hunks[0].theirs, "theirs");
+    }
+
+    #[test]
+    fn adjacent_hunks_clamp_context() {
+        let text = "a\n<<<<<<< gitbutler-resolve-ours\n1\n=======\n2\n>>>>>>> gitbutler-resolve-theirs\nb\n<<<<<<< gitbutler-resolve-ours\n3\n=======\n4\n>>>>>>> gitbutler-resolve-theirs\nc\n";
+        let hunks = extract_hunks(text);
+        assert_eq!(hunks.len(), 2);
+        assert_eq!(hunks[0].context_after, "b");
+        assert_eq!(hunks[1].context_before, "b");
+    }
+
+    #[test]
+    fn malformed_markers_are_ignored() {
+        let text = "a\n<<<<<<< gitbutler-resolve-ours\nno separator or close\n";
+        assert!(extract_hunks(text).is_empty());
+        let text = "=======\n>>>>>>> gitbutler-resolve-theirs\n";
+        assert!(extract_hunks(text).is_empty());
+    }
+
+    #[test]
+    fn crlf_lines_are_handled() {
+        let text = "a\r\n<<<<<<< gitbutler-resolve-ours\r\nx\r\n=======\r\ny\r\n>>>>>>> gitbutler-resolve-theirs\r\nb\r\n";
+        let hunks = extract_hunks(text);
+        assert_eq!(hunks.len(), 1);
+        assert_eq!(hunks[0].ours, "x");
+        assert_eq!(hunks[0].theirs, "y");
+    }
+
+    #[test]
+    fn only_exact_machine_markers_open_blocks() {
+        for lookalike in ["<<<<<<<", "<<<<<<< ours", "<<<<<<< HEAD"] {
+            let text = format!("{lookalike}\nx\n=======\ny\n>>>>>>> gitbutler-resolve-theirs\n");
+            assert!(
+                extract_hunks(&text).is_empty(),
+                "{lookalike:?} must not open a block"
+            );
+        }
+    }
+
+    /// A marker-shaped line inside a side's content must not close the block
+    /// early — only the exact machine-generated closing marker ends it.
+    #[test]
+    fn content_marker_lines_do_not_close_blocks_early() {
+        let text = "before\n<<<<<<< gitbutler-resolve-ours\nour code\n=======\ntheir code part 1\n>>>>>>> fixture-line\ntheir code part 2\n>>>>>>> gitbutler-resolve-theirs\nafter\n";
+        let hunks = extract_hunks(text);
+        assert_eq!(hunks.len(), 1);
+        assert_eq!(
+            hunks[0].theirs, "their code part 1\n>>>>>>> fixture-line\ntheir code part 2",
+            "the fixture line must remain part of the theirs content"
+        );
+    }
+
+    #[test]
+    fn marker_shaped_detection() {
+        assert!(is_marker_shaped("<<<<<<< HEAD"));
+        assert!(is_marker_shaped("<<<<<<<"));
+        assert!(is_marker_shaped(">>>>>>>>>>> nested-size-marker"));
+        assert!(is_marker_shaped("||||||| base"));
+        assert!(
+            !is_marker_shaped("======="),
+            "lone separators are legal content"
+        );
+        assert!(!is_marker_shaped("<<<<<<no"));
+        assert!(!is_marker_shaped("plain line"));
+    }
+
+    #[test]
+    fn marker_like_content_is_flagged_as_ambiguous() {
+        // Marker-shaped content anywhere, including sentinel lookalikes and
+        // exact sentinels outside their block positions.
+        assert_eq!(
+            ambiguous_line(&format!("a\n<<<<<<< HEAD\nb\n{TWO_WAY}")).as_deref(),
+            Some("<<<<<<< HEAD")
+        );
+        assert_eq!(
+            ambiguous_line(&format!("a\n{THEIRS_MARKER}\nb\n{TWO_WAY}")).as_deref(),
+            Some(THEIRS_MARKER)
+        );
+        // A lone separator inside a block gets mis-bound as the section
+        // separator, which displaces the real markers to non-marker positions
+        // and must be flagged; outside all blocks it is harmless content.
+        let separator_in_ours = "<<<<<<< gitbutler-resolve-ours\nTitle\n=======\nours body\n||||||| gitbutler-resolve-base\nbase\n=======\ntheirs\n>>>>>>> gitbutler-resolve-theirs\n";
+        assert!(ambiguous_line(separator_in_ours).is_some());
+        let separator_in_theirs = "<<<<<<< gitbutler-resolve-ours\nours\n=======\nTitle\n=======\ntheirs\n>>>>>>> gitbutler-resolve-theirs\n";
+        assert_eq!(
+            ambiguous_line(separator_in_theirs).as_deref(),
+            Some("=======")
+        );
+        assert_eq!(
+            ambiguous_line(&format!("Heading\n=======\n\n{DIFF3}")),
+            None
+        );
+        // The machine markers themselves are not ambiguous.
+        assert_eq!(ambiguous_line(TWO_WAY), None);
+        assert_eq!(ambiguous_line(DIFF3), None);
+    }
+}

--- a/crates/but-api/src/resolve/mod.rs
+++ b/crates/but-api/src/resolve/mod.rs
@@ -1,0 +1,248 @@
+//! Resolve the conflicts of a conflicted commit with an LLM.
+//!
+//! GitButler keeps conflicts as first-class committed state: a conflicted
+//! commit carries its merge inputs as trees. This module re-merges those trees
+//! in memory, sends the conflict hunks to the configured LLM as a single-shot,
+//! no-tools request, splices the returned per-hunk resolutions back
+//! deterministically, and rewrites the commit into a normal one, rebasing its
+//! descendants. The workspace never enters edit mode and the exclusive
+//! worktree lock is held only for the final apply step — not while the model
+//! is thinking. Disagreement with the result is handled by the oplog: the
+//! operation records an undo point.
+
+use anyhow::Context as _;
+use but_api_macros::but_api;
+use but_core::DryRun;
+use but_core::sync::RepoExclusive;
+use but_llm::{ChatMessage, LLMProvider};
+use but_oplog::legacy::{OperationKind, SnapshotDetails};
+use serde::Serialize;
+use tracing::instrument;
+
+use crate::WorkspaceState;
+
+mod apply;
+mod context;
+mod prompt;
+
+pub use context::{ConflictHunk, FileConflict, ResolutionRequest};
+pub use prompt::{FileResolution, HunkResolution, ResolutionResponse, SYSTEM_PROMPT};
+
+/// How one conflicted file was resolved, for display to the user.
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct ResolvedFile {
+    /// The repo-relative path of the file.
+    pub path: String,
+    /// The content that replaced each conflict block, in file order.
+    pub hunks: Vec<String>,
+    /// The model's explanation of its decision for this file.
+    pub reasoning: String,
+}
+
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(ResolvedFile);
+
+/// The outcome of resolving a conflicted commit with AI.
+#[derive(Debug, Clone)]
+pub struct AiResolutionResult {
+    /// The conflicted commit that was resolved.
+    pub commit_id: gix::ObjectId,
+    /// The rewritten, no-longer-conflicted commit.
+    pub new_commit: gix::ObjectId,
+    /// A short model-authored markdown summary of the conflict and resolution.
+    pub summary: Option<String>,
+    /// The per-file resolutions that were applied.
+    pub files: Vec<ResolvedFile>,
+    /// Workspace state after the resolution.
+    pub workspace: WorkspaceState,
+}
+
+/// Resolve all conflicts of the conflicted commit `commit_id` using the LLM
+/// configured in the user's git configuration, apply the result, and rebase
+/// descendants.
+///
+/// This acquires shared worktree access while gathering the conflicts, holds
+/// no lock during the model call, and acquires exclusive worktree access for
+/// the apply step. An oplog snapshot records an undo point on success. When
+/// `dry_run` is enabled, the returned workspace previews the resolution
+/// without materializing the rebase and no oplog entry is persisted.
+///
+/// Fails without changing anything if no AI provider is configured, if the
+/// commit is not conflicted, if a conflict cannot be resolved automatically
+/// (deletions, binaries, oversized files), or if the model response does not
+/// validate against the request after one retry.
+#[but_api(try_from = crate::resolve::json::AiResolutionResult)]
+#[instrument(err(Debug))]
+pub fn resolve_commit_conflicts_ai(
+    ctx: &mut but_ctx::Context,
+    commit_id: gix::ObjectId,
+    dry_run: DryRun,
+) -> anyhow::Result<AiResolutionResult> {
+    // The repository's resolved configuration, so repo-local AI settings
+    // (`but config ai --local`) take precedence over global ones.
+    let llm = {
+        let repo = ctx.repo.get()?;
+        let config = repo.config_snapshot();
+        LLMProvider::from_git_config(config.plumbing()).context(
+            "AI is not configured. Configure an AI provider in the GitButler settings first.",
+        )?
+    };
+    resolve_commit_conflicts_with(ctx, commit_id, dry_run, |request| {
+        let model = llm.model_or_default();
+        llm.structured_output::<ResolutionResponse>(
+            SYSTEM_PROMPT,
+            vec![ChatMessage::User(prompt::render_user_message(request))],
+            &model,
+        )?
+        .context("The AI model returned no response")
+    })
+}
+
+/// Like [`resolve_commit_conflicts_ai()`], but with the model call injected as
+/// `resolve`, so tests and other frontends can supply resolutions without
+/// network access.
+///
+/// `resolve` is called once, and once more if it errors (truncated or
+/// malformed model output) or if its response fails validation against the
+/// request.
+pub fn resolve_commit_conflicts_with(
+    ctx: &mut but_ctx::Context,
+    commit_id: gix::ObjectId,
+    dry_run: DryRun,
+    resolve: impl Fn(&ResolutionRequest) -> anyhow::Result<ResolutionResponse>,
+) -> anyhow::Result<AiResolutionResult> {
+    let request = {
+        let _guard = ctx.shared_worktree_access();
+        let repo = ctx.repo.get()?;
+        context::build_request(&repo, commit_id)?
+    };
+
+    // The model call happens without any worktree lock; the request is plain
+    // data and the apply step below re-reads the workspace under the exclusive
+    // lock, so it fails closed if the commit changed in the meantime.
+    let attempt = || -> anyhow::Result<_> {
+        let response = resolve(&request)?;
+        let validated = apply::validate(&request, &response)?;
+        Ok((validated, response.summary))
+    };
+    let (validated, summary) = match attempt() {
+        Ok(outcome) => outcome,
+        Err(first_failure) => {
+            tracing::warn!(
+                error = ?first_failure,
+                "AI conflict-resolution attempt failed, retrying once"
+            );
+            attempt()?
+        }
+    };
+
+    let mut guard = ctx.exclusive_worktree_access();
+    // The workspace graph may have been cached before or during the model
+    // call; the commit-presence check in apply must run against the state
+    // under this exclusive lock, not a stale cache.
+    ctx.invalidate_workspace_cache()?;
+    finish_with_perm(
+        ctx,
+        &request,
+        validated,
+        summary,
+        dry_run,
+        guard.write_permission(),
+    )
+}
+
+fn finish_with_perm(
+    ctx: &mut but_ctx::Context,
+    request: &ResolutionRequest,
+    validated: Vec<apply::ValidatedFile>,
+    summary: Option<String>,
+    dry_run: DryRun,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<AiResolutionResult> {
+    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
+        ctx,
+        SnapshotDetails::new(OperationKind::ResolveConflictsAi),
+        perm.read_permission(),
+        dry_run,
+    );
+
+    let res = apply::apply(ctx, request, &validated, dry_run, perm);
+    if let Some(snapshot) = maybe_oplog_entry
+        && res.is_ok()
+    {
+        snapshot.commit(ctx, perm).ok();
+    }
+    let (new_commit, workspace) = res?;
+
+    let files = request
+        .files
+        .iter()
+        .zip(validated)
+        .map(|(file, validated)| ResolvedFile {
+            path: file.path.clone(),
+            hunks: validated.hunks,
+            reasoning: validated.reasoning,
+        })
+        .collect();
+
+    Ok(AiResolutionResult {
+        commit_id: request.commit_id,
+        new_commit,
+        summary,
+        files,
+        workspace,
+    })
+}
+
+/// JSON transport types for this module.
+pub mod json {
+    use serde::Serialize;
+
+    use crate::json::HexHash;
+
+    /// JSON transport type for the outcome of an AI conflict resolution.
+    #[derive(Debug, Serialize)]
+    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+    #[serde(rename_all = "camelCase")]
+    pub struct AiResolutionResult {
+        /// The conflicted commit that was resolved.
+        #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
+        pub commit_id: HexHash,
+        /// The rewritten, no-longer-conflicted commit.
+        #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
+        pub new_commit: HexHash,
+        /// A short model-authored markdown summary of the conflict and resolution.
+        pub summary: Option<String>,
+        /// The per-file resolutions that were applied.
+        pub files: Vec<super::ResolvedFile>,
+        /// Workspace state after the resolution.
+        pub workspace: crate::json::WorkspaceState,
+    }
+
+    #[cfg(feature = "export-schema")]
+    but_schemars::register_sdk_type!(AiResolutionResult);
+
+    impl TryFrom<super::AiResolutionResult> for AiResolutionResult {
+        type Error = anyhow::Error;
+
+        fn try_from(value: super::AiResolutionResult) -> Result<Self, Self::Error> {
+            let super::AiResolutionResult {
+                commit_id,
+                new_commit,
+                summary,
+                files,
+                workspace,
+            } = value;
+
+            Ok(Self {
+                commit_id: commit_id.into(),
+                new_commit: new_commit.into(),
+                summary,
+                files,
+                workspace: workspace.try_into()?,
+            })
+        }
+    }
+}

--- a/crates/but-api/src/resolve/prompt.rs
+++ b/crates/but-api/src/resolve/prompt.rs
@@ -1,0 +1,202 @@
+//! The prompt and structured response contract for AI conflict resolution.
+//!
+//! The model only ever returns the merged replacement text for each conflict
+//! block — never whole files — and the application splices those hunks back
+//! into the merged blob deterministically.
+//!
+//! The response shape is deserialized by the provider's structured-output
+//! support. The OpenAI path enforces the schema with strict mode, but other
+//! providers only embed the schema in the prompt, so the system prompt also
+//! spells out the exact JSON contract — without it, models drift to their own
+//! field names and deserialization fails.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::context::{ConflictHunk, ResolutionRequest};
+
+/// The system message sent along with every conflict-resolution request.
+pub const SYSTEM_PROMPT: &str = "\
+You are an expert Git conflict resolver. Analyze conflicts that occurred while a commit was rebased and produce correct, clean resolutions.
+
+You will receive:
+- The message of the conflicted commit (its intent) and the title of the new base it was rebased onto
+- For each conflicted file, the conflicts as ours/base/theirs sections with surrounding context
+- \"Ours\" is the state of the new base the commit is rebased onto; \"theirs\" is this commit's own version; \"base\" is their common ancestor
+
+Your job:
+1. Understand the INTENT behind each side's changes
+2. Resolve each conflict by producing the correct merged content for each conflict hunk
+3. Explain your reasoning per file — terse but specific enough to verify the decision
+4. Produce a brief markdown summary orienting the user to the conflict and resolution
+
+Resolution guidelines:
+- Make MINIMAL changes — do not refactor, reformat, or alter code outside conflicted regions
+- When both sides add complementary code (e.g., different imports), combine them
+- When both sides modify the same code differently, use the commit message to decide what this commit intends
+- When one side deletes code the other modifies, check whether the content was relocated rather than simply removed — accept the deletion only when it was intentional
+- When conflicts involve dependency manifests or lock files, ensure version constraints and entries remain consistent across the resolved file
+- Preserve correctness: imports, types, formatting must remain valid
+- When in doubt, prefer backward compatibility
+
+Respond ONLY with a single JSON object in exactly this shape:
+{
+  \"summary\": \"### Conflicting changes\\n<1-2 sentences: what each side did and where they collided>\\n\\n### Resolution\\n<1 sentence: how you resolved it; bold any trade-off where a side's change was dropped>\",
+  \"resolutions\": [
+    {
+      \"path\": \"relative/file/path.py\",
+      \"hunks\": [
+        { \"resolvedContent\": \"merged content that replaces conflict 1\" },
+        { \"resolvedContent\": \"merged content that replaces conflict 2\" }
+      ],
+      \"reasoning\": \"What each side changed in this file, what you kept, and what you dropped or overrode.\"
+    }
+  ]
+}
+
+Field rules:
+- Return a data object in this shape — never the JSON schema itself.
+- \"resolutions\" is REQUIRED: exactly one entry per conflicted file from the input, with \"path\" copied exactly as given.
+- \"hunks\" is an ordered array with one entry per conflict, matching the \"Conflict 1 of N\", \"Conflict 2 of N\" order from the input. Each \"resolvedContent\" is ONLY the merged content that replaces that specific conflict block — no surrounding non-conflicted code and no conflict markers. To accept one side entirely, return that side's content verbatim. For an intentional deletion, use an empty string.
+- \"reasoning\" is required per file: terse, direct prose — enough detail to verify the decision, typically 1-4 sentences.
+- \"summary\" may be null; when present it is a markdown banner with exactly the two \"###\" headings shown above.";
+
+/// The structured response produced by the model.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolutionResponse {
+    #[schemars(
+        description = "A brief markdown summary with exactly two '###' headings: 'Conflicting changes' (1-2 sentences on what each side did and where they collided) then 'Resolution' (1 sentence on how it was resolved; bold any trade-off where a side's change was dropped). Write natural prose a developer would say to a teammate; per-file detail belongs in the per-file reasoning, not here."
+    )]
+    /// A short model-authored markdown summary of the conflict and its resolution.
+    #[serde(default)]
+    pub summary: Option<String>,
+    /// One entry per conflicted file that was provided in the request.
+    pub resolutions: Vec<FileResolution>,
+}
+
+/// The model's resolution for a single conflicted file.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct FileResolution {
+    #[schemars(description = "The file path, exactly as given in the input.")]
+    /// The repo-relative path of the resolved file, matching the request.
+    pub path: String,
+    #[schemars(
+        description = "An ordered array with one entry per conflict in the file, matching the 'Conflict 1 of N', 'Conflict 2 of N' order from the input."
+    )]
+    /// The per-conflict resolutions, in input order.
+    pub hunks: Vec<HunkResolution>,
+    #[schemars(
+        description = "Terse, direct prose — enough detail to verify the decision, not a wall of text. State what each side did in this file, what you kept, and any trade-off. Typically 1-4 sentences."
+    )]
+    /// The model's per-file explanation of its decision.
+    pub reasoning: String,
+}
+
+/// The replacement content for a single conflict block.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct HunkResolution {
+    #[schemars(
+        description = "ONLY the merged content that replaces this specific conflict block (the region between <<<<<<< and >>>>>>>). Do NOT include surrounding non-conflicted code — the application splices each resolution into the original file automatically. To accept one side entirely, return that side's content verbatim. For an intentional deletion, use an empty string."
+    )]
+    /// The merged text that replaces the conflict block, without any markers.
+    pub resolved_content: String,
+}
+
+/// Render the user message for `request`, one `Conflict N of M` section per hunk.
+pub fn render_user_message(request: &ResolutionRequest) -> String {
+    let mut out = String::new();
+
+    out.push_str(&format!(
+        "Conflicts occurred while the commit below was rebased onto a new base{}.\n",
+        request
+            .parent_message
+            .as_deref()
+            .map(|title| format!(" (\"{title}\")"))
+            .unwrap_or_default()
+    ));
+    out.push_str("\"Ours\" is the new base's version, \"theirs\" is the commit's own version.\n\n");
+    out.push_str("## Commit message of the conflicted commit\n");
+    out.push_str(&fenced_block(&request.commit_message, ""));
+    out.push('\n');
+
+    for file in &request.files {
+        out.push_str(&format!("## File: {}\n\n", sanitize_path(&file.path)));
+        let lang = language_tag(&file.path);
+        let total = file.hunks.len();
+        for (index, hunk) in file.hunks.iter().enumerate() {
+            out.push_str(&format!("### Conflict {} of {total}\n\n", index + 1));
+            render_hunk(&mut out, hunk, lang);
+        }
+    }
+
+    out
+}
+
+fn render_hunk(out: &mut String, hunk: &ConflictHunk, lang: &str) {
+    if !hunk.context_before.is_empty() {
+        out.push_str("Context before:\n");
+        out.push_str(&fenced_block(&hunk.context_before, lang));
+    }
+    out.push_str("Ours (new base):\n");
+    out.push_str(&fenced_block(&hunk.ours, lang));
+    if let Some(base) = &hunk.base {
+        out.push_str("Base (common ancestor):\n");
+        out.push_str(&fenced_block(base, lang));
+    }
+    out.push_str("Theirs (this commit):\n");
+    out.push_str(&fenced_block(&hunk.theirs, lang));
+    if !hunk.context_after.is_empty() {
+        out.push_str("Context after:\n");
+        out.push_str(&fenced_block(&hunk.context_after, lang));
+    }
+}
+
+/// Wrap `content` in a code fence that is longer than any backtick run inside
+/// it, so content containing fences can never break out of the framing.
+fn fenced_block(content: &str, lang: &str) -> String {
+    let longest_backtick_run = content.split(|c| c != '`').map(str::len).max().unwrap_or(0);
+    let fence = "`".repeat((longest_backtick_run + 1).max(3));
+    format!("{fence}{lang}\n{content}\n{fence}\n\n")
+}
+
+/// Derive a fence language tag from the file extension, letters and digits only.
+fn language_tag(path: &str) -> &str {
+    let extension = path.rsplit('.').next().unwrap_or_default();
+    if !extension.is_empty()
+        && extension.len() < path.len()
+        && extension.chars().all(|c| c.is_ascii_alphanumeric())
+    {
+        extension
+    } else {
+        ""
+    }
+}
+
+/// Strip characters from a path that would break markdown headings.
+fn sanitize_path(path: &str) -> String {
+    path.chars()
+        .filter(|c| !matches!(c, '\r' | '\n' | '`'))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fences_grow_beyond_embedded_backticks() {
+        let block = fenced_block("code with ```` four backticks", "rs");
+        assert!(block.starts_with("`````rs\n"));
+        assert!(block.trim_end().ends_with("`````"));
+    }
+
+    #[test]
+    fn language_tags_are_validated() {
+        assert_eq!(language_tag("src/main.rs"), "rs");
+        assert_eq!(language_tag("Makefile"), "");
+        assert_eq!(language_tag("weird.c++"), "");
+    }
+}

--- a/crates/but-api/tests/api/main.rs
+++ b/crates/but-api/tests/api/main.rs
@@ -1,3 +1,4 @@
 mod branch_apply;
 mod branch_checkout;
+mod resolve_ai;
 mod support;

--- a/crates/but-api/tests/api/resolve_ai.rs
+++ b/crates/but-api/tests/api/resolve_ai.rs
@@ -1,0 +1,194 @@
+use anyhow::Result;
+use but_api::resolve::{
+    FileResolution, HunkResolution, ResolutionResponse, resolve_commit_conflicts_with,
+};
+use but_core::DryRun;
+use gitbutler_oplog::OplogExt as _;
+use gix::prelude::ObjectIdExt as _;
+
+fn conflicted_context() -> Result<(but_ctx::Context, gix::ObjectId, tempfile::TempDir)> {
+    let (repo, tmp) = crate::support::writable_scenario("resolve-ai-conflicted-commit");
+    crate::support::persist_default_target(&repo)?;
+    let conflicted_commit = repo.rev_parse_single("refs/tags/conflicted")?.detach();
+    let ctx = but_ctx::Context::from_repo(repo)?.with_memory_app_cache();
+    Ok((ctx, conflicted_commit, tmp))
+}
+
+fn merged_response(path: &str, content: &str) -> ResolutionResponse {
+    ResolutionResponse {
+        summary: Some("### Conflicting changes\nBoth sides changed line two.".into()),
+        resolutions: vec![FileResolution {
+            path: path.into(),
+            hunks: vec![HunkResolution {
+                resolved_content: content.into(),
+            }],
+            reasoning: "Combined both changes of line two.".into(),
+        }],
+    }
+}
+
+#[test]
+fn resolves_conflicted_commit_and_rebases_descendants() -> Result<()> {
+    let (mut ctx, conflicted_commit, _tmp) = conflicted_context()?;
+
+    let result =
+        resolve_commit_conflicts_with(&mut ctx, conflicted_commit, DryRun::No, |request| {
+            assert_eq!(request.files.len(), 1, "one conflicted file expected");
+            let file = &request.files[0];
+            assert_eq!(file.path, "conflict");
+            assert_eq!(file.hunks.len(), 1, "one conflict hunk expected");
+            let hunk = &file.hunks[0];
+            assert_eq!(hunk.ours, "line two changed by the new base");
+            assert_eq!(hunk.theirs, "line two changed by this commit");
+            assert_eq!(
+                hunk.base.as_deref(),
+                Some("line two"),
+                "diff3 markers should carry the common ancestor"
+            );
+            assert!(request.commit_message.contains("Change line two"));
+            Ok(merged_response(
+                "conflict",
+                "line two changed by both sides",
+            ))
+        })?;
+
+    assert_eq!(result.commit_id, conflicted_commit);
+    assert_ne!(result.new_commit, conflicted_commit);
+    assert_eq!(result.files.len(), 1);
+    assert!(result.summary.is_some());
+
+    {
+        let repo = ctx.repo.get()?;
+
+        // The rewritten commit is a normal commit with the resolution spliced in.
+        let new_commit = but_core::Commit::from_id(result.new_commit.attach(&repo))?;
+        assert!(!new_commit.is_conflicted(), "conflict state must be gone");
+        assert_eq!(
+            new_commit.message.to_string(),
+            "Change line two",
+            "conflict markers must be stripped from the message"
+        );
+        let resolved_blob = repo
+            .rev_parse_single(format!("{}:conflict", result.new_commit).as_str())?
+            .object()?;
+        assert_eq!(
+            resolved_blob.data.as_slice(),
+            b"line one\nline two changed by both sides\nline three\n"
+        );
+        let untouched_blob = repo
+            .rev_parse_single(format!("{}:file", result.new_commit).as_str())?
+            .object()?;
+        assert_eq!(
+            untouched_blob.data.as_slice(),
+            b"unrelated\n",
+            "non-conflicted files must be preserved byte for byte"
+        );
+
+        // The descendant was rebased on top and picked up the resolution.
+        let descendant = repo
+            .rev_parse_single("refs/heads/branchy")?
+            .object()?
+            .into_commit();
+        assert_eq!(
+            descendant.decode()?.parents().next(),
+            Some(result.new_commit),
+            "the descendant must now sit on the rewritten commit"
+        );
+        let descendant_conflict = repo
+            .rev_parse_single("refs/heads/branchy:conflict")?
+            .object()?;
+        assert_eq!(
+            descendant_conflict.data.as_slice(),
+            b"line one\nline two changed by both sides\nline three\n",
+            "the descendant must inherit the resolution"
+        );
+        let descendant_later = repo
+            .rev_parse_single("refs/heads/branchy:later")?
+            .object()?;
+        assert_eq!(descendant_later.data.as_slice(), b"descendant\n");
+    }
+
+    // An undo point was recorded.
+    let snapshots = ctx
+        .snapshots_iter(None, Vec::new(), None)?
+        .collect::<Result<Vec<_>>>()?;
+    assert!(
+        snapshots.iter().any(|snapshot| {
+            snapshot.details.as_ref().is_some_and(|details| {
+                matches!(
+                    details.operation,
+                    but_oplog::legacy::OperationKind::ResolveConflictsAi
+                )
+            })
+        }),
+        "an oplog snapshot with the AI-resolve operation must exist"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn invalid_response_is_retried_once_then_fails_without_changes() -> Result<()> {
+    let (mut ctx, conflicted_commit, _tmp) = conflicted_context()?;
+    let calls = std::cell::Cell::new(0);
+
+    let err = resolve_commit_conflicts_with(&mut ctx, conflicted_commit, DryRun::No, |_request| {
+        calls.set(calls.get() + 1);
+        // Wrong path: never matches the requested file.
+        Ok(merged_response("wrong-path", "content"))
+    })
+    .unwrap_err();
+
+    assert_eq!(calls.get(), 2, "the model must be retried exactly once");
+    assert!(
+        err.to_string().contains("conflict"),
+        "error should name the file: {err}"
+    );
+
+    let repo = ctx.repo.get()?;
+    let commit = but_core::Commit::from_id(conflicted_commit.attach(&repo))?;
+    assert!(
+        commit.is_conflicted(),
+        "the conflicted commit must be left untouched on failure"
+    );
+    Ok(())
+}
+
+#[test]
+fn resolution_with_leaked_markers_is_rejected() -> Result<()> {
+    let (mut ctx, conflicted_commit, _tmp) = conflicted_context()?;
+
+    let err = resolve_commit_conflicts_with(&mut ctx, conflicted_commit, DryRun::No, |_request| {
+        Ok(merged_response(
+            "conflict",
+            "<<<<<<< ours\nstill conflicted\n=======\noops\n>>>>>>> theirs",
+        ))
+    })
+    .unwrap_err();
+
+    assert!(
+        err.to_string().contains("conflict marker"),
+        "unexpected error: {err}"
+    );
+    Ok(())
+}
+
+#[test]
+fn unconflicted_commit_is_rejected() -> Result<()> {
+    let (mut ctx, _conflicted_commit, _tmp) = conflicted_context()?;
+    let normal_commit = {
+        let repo = ctx.repo.get()?;
+        repo.rev_parse_single("refs/heads/main")?.detach()
+    };
+
+    let err = resolve_commit_conflicts_with(&mut ctx, normal_commit, DryRun::No, |_request| {
+        unreachable!("the model must not be called for an unconflicted commit")
+    })
+    .unwrap_err();
+
+    assert!(
+        err.to_string().contains("not conflicted"),
+        "unexpected error: {err}"
+    );
+    Ok(())
+}

--- a/crates/but-api/tests/fixtures/scenario/resolve-ai-conflicted-commit.sh
+++ b/crates/but-api/tests/fixtures/scenario/resolve-ai-conflicted-commit.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+git init
+echo "A workspace whose stack contains a conflicted commit with a descendant" >.git/description
+
+git config user.name GitButler
+git config user.email gitbutler@example.com
+
+echo unrelated >file
+git add . && git commit -m "init"
+
+mkdir -p .git/refs/remotes/origin
+cp .git/refs/heads/main .git/refs/remotes/origin/main
+
+cat <<EOF >>.git/config
+[remote "origin"]
+	url = ./fake/local/path/which-is-fine-as-we-dont-fetch-or-push
+	fetch = +refs/heads/*:refs/remotes/origin/*
+EOF
+
+# A conflicted commit as GitButler would write it after a rebase: the merge
+# inputs are kept as trees, the commit tree is auto-resolved favoring "ours",
+# and the conflict is recorded in the message trailer plus the legacy header.
+#
+# The content conflict: base, ours (the new base), and theirs (the commit's own
+# version) each have a different middle line in "conflict".
+unrelated_blob=$(git rev-parse HEAD:file)
+base_blob=$(printf "line one\nline two\nline three\n" | git hash-object -wt blob --stdin)
+ours_blob=$(printf "line one\nline two changed by the new base\nline three\n" | git hash-object -wt blob --stdin)
+theirs_blob=$(printf "line one\nline two changed by this commit\nline three\n" | git hash-object -wt blob --stdin)
+conflict_files_blob=$(git hash-object -wt blob --stdin <<EOF
+ancestorEntries = [ "conflict" ]
+ourEntries = [ "conflict" ]
+theirEntries = [ "conflict" ]
+EOF
+)
+
+git read-tree --empty
+git update-index --add --cacheinfo 100644 "$unrelated_blob" ".auto-resolution/file"
+git update-index --add --cacheinfo 100644 "$ours_blob" ".auto-resolution/conflict"
+git update-index --add --cacheinfo 100644 "$unrelated_blob" ".conflict-base-0/file"
+git update-index --add --cacheinfo 100644 "$base_blob" ".conflict-base-0/conflict"
+git update-index --add --cacheinfo 100644 "$conflict_files_blob" ".conflict-files"
+git update-index --add --cacheinfo 100644 "$unrelated_blob" ".conflict-side-0/file"
+git update-index --add --cacheinfo 100644 "$ours_blob" ".conflict-side-0/conflict"
+git update-index --add --cacheinfo 100644 "$unrelated_blob" ".conflict-side-1/file"
+git update-index --add --cacheinfo 100644 "$theirs_blob" ".conflict-side-1/conflict"
+conflict_tree=$(git write-tree)
+
+conflict_commit=$(git hash-object -wt commit --stdin <<EOF
+tree $conflict_tree
+parent $(git rev-parse HEAD)
+author GitButler <gitbutler@example.com> 1730625617 +0100
+committer GitButler <gitbutler@example.com> 1730625617 +0100
+gitbutler-headers-version 2
+change-id 00000000-0000-0000-0000-000000000001
+gitbutler-conflicted 1
+
+[conflict] Change line two
+
+GitButler-Conflict: fixture marker
+
+EOF
+)
+git tag conflicted "$conflict_commit"
+
+# A normal descendant of the conflicted commit. Its tree is built on the
+# conflicted commit's auto-resolution, like the rebase engine would do.
+later_blob=$(printf "descendant\n" | git hash-object -wt blob --stdin)
+git read-tree --empty
+git update-index --add --cacheinfo 100644 "$unrelated_blob" "file"
+git update-index --add --cacheinfo 100644 "$ours_blob" "conflict"
+git update-index --add --cacheinfo 100644 "$later_blob" "later"
+descendant_tree=$(git write-tree)
+descendant_commit=$(git commit-tree "$descendant_tree" -p "$conflict_commit" -m "descendant")
+git update-ref refs/heads/branchy "$descendant_commit"
+
+git symbolic-ref HEAD refs/heads/branchy
+git reset --hard >/dev/null

--- a/crates/but-llm/src/openai_utils.rs
+++ b/crates/but-llm/src/openai_utils.rs
@@ -494,13 +494,17 @@ async fn structured_output<T: serde::Serialize + DeserializeOwned + JsonSchema>(
     model: String,
 ) -> anyhow::Result<Option<T>> {
     let schema = schema_for!(T);
-    let schema_value = serde_json::to_value(&schema)?;
+    let mut schema_value = serde_json::to_value(&schema)?;
+    make_schema_strict(&mut schema_value);
+    // `strict` makes OpenAI constrain the output to the schema. Without it the
+    // schema is only advisory, and models occasionally answer with the schema
+    // document itself instead of an instance of it.
     let response_format = ResponseFormat::JsonSchema {
         json_schema: ResponseFormatJsonSchema {
             description: None,
             name: "structured_response".into(),
             schema: Some(schema_value),
-            strict: Some(false),
+            strict: Some(true),
         },
     };
 
@@ -519,6 +523,39 @@ async fn structured_output<T: serde::Serialize + DeserializeOwned + JsonSchema>(
     }
 
     Ok(None)
+}
+
+/// Rewrite a schemars-generated schema to satisfy OpenAI's strict
+/// structured-output requirements: every object schema must list all of its
+/// properties as required and forbid additional properties, and the `$schema`
+/// marker is not part of the accepted vocabulary.
+fn make_schema_strict(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            map.remove("$schema");
+            // Emitted by schemars for `#[serde(default)]` fields; not part of
+            // the strict-mode vocabulary.
+            map.remove("default");
+            if let Some(serde_json::Value::Object(properties)) = map.get("properties") {
+                let all_properties = properties
+                    .keys()
+                    .cloned()
+                    .map(serde_json::Value::String)
+                    .collect();
+                map.insert("required".into(), serde_json::Value::Array(all_properties));
+                map.insert("additionalProperties".into(), false.into());
+            }
+            for nested in map.values_mut() {
+                make_schema_strict(nested);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for nested in items {
+                make_schema_strict(nested);
+            }
+        }
+        _ => {}
+    }
 }
 
 async fn response(
@@ -692,4 +729,57 @@ async fn tool_calling_stream(
     }
 
     Ok((None, response_text))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::make_schema_strict;
+    use serde_json::json;
+
+    #[test]
+    fn schemas_are_rewritten_for_strict_mode() {
+        let mut schema = json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "title": "Response",
+            "type": "object",
+            "properties": {
+                "summary": { "type": ["string", "null"], "default": null },
+                "items": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/Item" }
+                }
+            },
+            "required": ["items"],
+            "$defs": {
+                "Item": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" }
+                    }
+                }
+            }
+        });
+        make_schema_strict(&mut schema);
+
+        assert_eq!(schema.get("$schema"), None);
+        assert_eq!(schema["properties"]["summary"].get("default"), None);
+        let mut required: Vec<&str> = schema["required"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|value| value.as_str().unwrap())
+            .collect();
+        required.sort_unstable();
+        assert_eq!(
+            required,
+            ["items", "summary"],
+            "every property must be required, including nullable ones"
+        );
+        assert_eq!(schema["additionalProperties"], json!(false));
+        assert_eq!(schema["$defs"]["Item"]["required"], json!(["name"]));
+        assert_eq!(
+            schema["$defs"]["Item"]["additionalProperties"],
+            json!(false)
+        );
+    }
 }

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -390,6 +390,9 @@ pub enum Subcommands {
     /// 4. Finalize resolution: `but resolve finish`
     ///    Or cancel: `but resolve cancel`
     ///
+    /// Alternatively, resolve with AI in one step: `but resolve <commit-id> --ai`,
+    /// or `but resolve --ai` to resolve all conflicted commits, oldest first.
+    ///
     /// When in resolution mode, `but status` will also show that you're resolving conflicts.
     ///
     #[cfg(feature = "legacy")]
@@ -400,6 +403,13 @@ pub enum Subcommands {
         cmd: Option<resolve::Subcommands>,
         /// Commit ID to enter resolution mode for (when no subcommand is provided)
         commit: Option<String>,
+        /// Resolve the conflicts with the configured AI model and apply the result.
+        ///
+        /// With a commit ID this resolves only that commit; without one it
+        /// resolves all conflicted commits in the workspace, oldest first.
+        /// Undo the result with `but undo`.
+        #[clap(long)]
+        ai: bool,
     },
 
     /// Unapply a branch from the workspace.

--- a/crates/but/src/command/legacy/oplog.rs
+++ b/crates/but/src/command/legacy/oplog.rs
@@ -165,6 +165,7 @@ pub(crate) fn show_oplog(
                     | OperationKind::MoveCommitFile
                     | OperationKind::FileChanges
                     | OperationKind::EnterEditMode
+                    | OperationKind::ResolveConflictsAi
                     | OperationKind::SyncWorkspace
                     | OperationKind::CreateDependentBranch
                     | OperationKind::RemoveDependentBranch
@@ -186,9 +187,9 @@ pub(crate) fn show_oplog(
 
             let operation_colored = match operation_type {
                 OperationKind::CreateCommit => t.success.paint(operation_type.kind_str()),
-                OperationKind::UpdateCommitMessage | OperationKind::AmendCommit => {
-                    t.attention.paint(operation_type.kind_str())
-                }
+                OperationKind::UpdateCommitMessage
+                | OperationKind::AmendCommit
+                | OperationKind::ResolveConflictsAi => t.attention.paint(operation_type.kind_str()),
                 OperationKind::UndoCommit
                 | OperationKind::RestoreFromSnapshot
                 | OperationKind::RestoreFromSnapshotViaUndo

--- a/crates/but/src/command/legacy/resolve.rs
+++ b/crates/but/src/command/legacy/resolve.rs
@@ -27,7 +27,14 @@ pub(crate) fn handle(
     out: &mut OutputChannel,
     cmd: Option<Subcommands>,
     commit_id: Option<String>,
+    ai: bool,
 ) -> Result<()> {
+    if ai {
+        if cmd.is_some() {
+            bail!("--ai cannot be combined with a resolve subcommand");
+        }
+        return resolve_with_ai(ctx, out, commit_id.as_deref());
+    }
     match cmd {
         Some(Subcommands::Status) => show_status(ctx, out),
         Some(Subcommands::Finish) => finish_resolution(ctx, out),
@@ -51,10 +58,8 @@ pub(crate) fn handle(
     }
 }
 
-fn enter_resolution(ctx: &mut Context, out: &mut OutputChannel, commit_id_str: &str) -> Result<()> {
-    let t = theme::get();
-    use gix::{prelude::ObjectIdExt as _, revision::walk::Sorting};
-
+/// Resolve a user-provided commit identifier (CLI ID or partial SHA) to an object id.
+fn parse_commit_id(ctx: &mut Context, commit_id_str: &str) -> Result<gix::ObjectId> {
     // Create an IdMap to resolve commit IDs (supports both CLI IDs and partial SHAs)
     let id_map = IdMap::legacy_new_from_context(ctx, None)?;
 
@@ -74,10 +79,17 @@ fn enter_resolution(ctx: &mut Context, out: &mut OutputChannel, commit_id_str: &
     }
 
     // Extract the commit OID from the matched CliId
-    let commit_gix_oid = match &matches[0] {
-        CliId::Commit { commit_id, .. } => *commit_id,
+    match &matches[0] {
+        CliId::Commit { commit_id, .. } => Ok(*commit_id),
         _ => bail!("'{commit_id_str}' does not refer to a commit"),
-    };
+    }
+}
+
+fn enter_resolution(ctx: &mut Context, out: &mut OutputChannel, commit_id_str: &str) -> Result<()> {
+    let t = theme::get();
+    use gix::{prelude::ObjectIdExt as _, revision::walk::Sorting};
+
+    let commit_gix_oid = parse_commit_id(ctx, commit_id_str)?;
 
     // Get the commit and check if it's conflicted
     let repo = ctx.repo.get()?;
@@ -393,6 +405,182 @@ fn cancel_resolution(ctx: &mut Context, out: &mut OutputChannel, force: bool) ->
     }
 
     Ok(())
+}
+
+/// Resolve conflicts with the configured AI model: one commit when
+/// `commit_id_str` is given, otherwise every conflicted commit in the
+/// workspace, oldest first.
+fn resolve_with_ai(
+    ctx: &mut Context,
+    out: &mut OutputChannel,
+    commit_id_str: Option<&str>,
+) -> Result<()> {
+    let t = theme::get();
+    let mode = operating_mode(ctx)?.operating_mode;
+    if matches!(mode, OperatingMode::Edit(_)) {
+        bail!(
+            "You are in conflict resolution mode. Finish with `but resolve finish` or cancel with `but resolve cancel` before using --ai."
+        );
+    }
+
+    let mut results = Vec::new();
+    if let Some(commit_id_str) = commit_id_str {
+        let commit_oid = parse_commit_id(ctx, commit_id_str)?;
+        results.push(resolve_one_with_ai(ctx, out, commit_oid)?);
+    } else {
+        // Resolving a commit rebases its descendants, which changes their ids
+        // and can change (or clear) their conflicts — so re-discover the
+        // oldest conflicted commit after every resolution.
+        loop {
+            let Some(commit_oid) = oldest_conflicted_commit(ctx)? else {
+                break;
+            };
+            results.push(resolve_one_with_ai(ctx, out, commit_oid)?);
+        }
+    }
+
+    // A single JSON document for the whole invocation, regardless of how many
+    // commits were resolved.
+    if let Some(json_out) = out.for_json() {
+        let results = results
+            .iter()
+            .map(|result| {
+                serde_json::json!({
+                    "commit_id": result.commit_id.to_string(),
+                    "new_commit_id": result.new_commit.to_string(),
+                    "summary": result.summary,
+                    "files": result
+                        .files
+                        .iter()
+                        .map(|file| {
+                            serde_json::json!({
+                                "path": file.path,
+                                "reasoning": file.reasoning,
+                            })
+                        })
+                        .collect::<Vec<_>>(),
+                })
+            })
+            .collect::<Vec<_>>();
+        json_out.write_value(serde_json::json!({ "resolved": results }))?;
+    }
+
+    if results.is_empty() {
+        if let Some(human_out) = out.for_human() {
+            writeln!(
+                human_out,
+                "{}",
+                t.success.paint("No conflicted commits found.")
+            )?;
+        }
+        return Ok(());
+    }
+
+    if let Some(human_out) = out.for_human() {
+        // The rebase of descendants can leave (or newly introduce) conflicted
+        // commits; in single-commit mode nothing else surfaces that. Commits
+        // are listed once per branch that contains them, so count unique ids.
+        let remaining = find_conflicted_commits(ctx)?
+            .values()
+            .flatten()
+            .map(|commit| commit.commit_oid)
+            .collect::<HashSet<_>>()
+            .len();
+        if remaining > 0 {
+            writeln!(
+                human_out,
+                "{}",
+                t.attention.paint(format!(
+                    "{remaining} commit{} still conflicted — run `but resolve --ai` or `but status` to see them.",
+                    if remaining == 1 { " is" } else { "s are" }
+                ))
+            )?;
+        }
+        writeln!(
+            human_out,
+            "{}",
+            t.hint
+                .paint("If you disagree with a resolution, run `but undo` to revert it.")
+        )?;
+    }
+    Ok(())
+}
+
+/// The first conflicted commit in the oldest-first ordering of
+/// [`find_conflicted_commits()`], if any.
+fn oldest_conflicted_commit(ctx: &mut Context) -> Result<Option<gix::ObjectId>> {
+    Ok(find_conflicted_commits(ctx)?
+        .into_values()
+        .flatten()
+        .next()
+        .map(|commit| commit.commit_oid))
+}
+
+fn resolve_one_with_ai(
+    ctx: &mut Context,
+    out: &mut OutputChannel,
+    commit_oid: gix::ObjectId,
+) -> Result<but_api::resolve::AiResolutionResult> {
+    let t = theme::get();
+    {
+        let repo = ctx.repo.get()?;
+        let short_id = shorten_object_id(&repo, commit_oid);
+        drop(repo);
+        let mut progress = out.progress_channel();
+        writeln!(
+            progress,
+            "{} {}{}",
+            t.important.paint("Resolving conflicts in commit"),
+            t.commit_id.paint(short_id),
+            t.important.paint(" with AI…")
+        )?;
+    }
+
+    let result =
+        but_api::resolve::resolve_commit_conflicts_ai(ctx, commit_oid, but_core::DryRun::No)?;
+
+    if let Some(human_out) = out.for_human() {
+        let repo = ctx.repo.get()?;
+        writeln!(
+            human_out,
+            "{} {} {} {}",
+            t.success.paint("✓ Resolved"),
+            t.commit_id
+                .paint(shorten_object_id(&repo, result.commit_id)),
+            t.success.paint("→"),
+            t.commit_id
+                .paint(shorten_object_id(&repo, result.new_commit)),
+        )?;
+        if let Some(summary) = &result.summary {
+            writeln!(human_out)?;
+            writeln!(human_out, "{}", sanitize_model_text(summary))?;
+        }
+        writeln!(human_out)?;
+        for file in &result.files {
+            writeln!(
+                human_out,
+                "  {} {}",
+                t.sym().success,
+                t.success.paint(&file.path)
+            )?;
+            writeln!(
+                human_out,
+                "    {}",
+                t.hint.paint(sanitize_model_text(&file.reasoning))
+            )?;
+        }
+        writeln!(human_out)?;
+    }
+
+    Ok(result)
+}
+
+/// Strip control characters (including ANSI escape sequences) from
+/// model-authored text before printing it to the terminal.
+fn sanitize_model_text(text: &str) -> String {
+    text.chars()
+        .filter(|c| !c.is_control() || matches!(c, '\n' | '\t'))
+        .collect()
 }
 
 /// Structure to hold information about a conflicted commit

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -1418,7 +1418,7 @@ async fn match_subcommand(
                 .map_err(CliError::from)
         }
         #[cfg(feature = "legacy")]
-        Subcommands::Resolve { cmd, commit } => {
+        Subcommands::Resolve { cmd, commit, ai } => {
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
@@ -1427,7 +1427,7 @@ async fn match_subcommand(
                 },
                 out,
             )?;
-            command::legacy::resolve::handle(&mut ctx, out, cmd, commit)
+            command::legacy::resolve::handle(&mut ctx, out, cmd, commit, ai)
                 .context("Failed to handle conflict resolution.")
                 .emit_metrics(metrics_ctx)
                 .show_root_cause_error_then_exit_without_destructors(output)

--- a/crates/gitbutler-oplog/src/entry.rs
+++ b/crates/gitbutler-oplog/src/entry.rs
@@ -177,6 +177,7 @@ pub enum OperationKind {
     MoveCommitFile,
     FileChanges,
     EnterEditMode,
+    ResolveConflictsAi,
     SyncWorkspace,
     CreateDependentBranch,
     RemoveDependentBranch,
@@ -237,6 +238,7 @@ impl OperationKind {
             | OperationKind::UpdateDependentBranchDescription
             | OperationKind::UpdateDependentBranchPrNumber => "UPDATE_BRANCH",
             OperationKind::SplitBranch => "SPLIT_BRANCH",
+            OperationKind::ResolveConflictsAi => "AI_RESOLVE",
             OperationKind::StashIntoBranch
             | OperationKind::SetBaseBranch
             | OperationKind::MergeUpstream
@@ -291,6 +293,7 @@ impl OperationKind {
             OperationKind::MoveCommitFile => "Moved file",
             OperationKind::FileChanges => "Updated file changes",
             OperationKind::EnterEditMode => "Entered edit mode",
+            OperationKind::ResolveConflictsAi => "Resolved conflicts with AI",
             OperationKind::SyncWorkspace => "Synced workspace",
             OperationKind::CreateDependentBranch => "Created branch",
             OperationKind::RemoveDependentBranch => "Removed branch",
@@ -347,6 +350,7 @@ impl OperationKind {
             OperationKind::MoveCommitFile => "MoveCommitFile",
             OperationKind::FileChanges => "FileChanges",
             OperationKind::EnterEditMode => "EnterEditMode",
+            OperationKind::ResolveConflictsAi => "ResolveConflictsAi",
             OperationKind::SyncWorkspace => "SyncWorkspace",
             OperationKind::CreateDependentBranch => "CreateDependentBranch",
             OperationKind::RemoveDependentBranch => "RemoveDependentBranch",
@@ -403,6 +407,7 @@ impl OperationKind {
             "MoveCommitFile" => Self::MoveCommitFile,
             "FileChanges" => Self::FileChanges,
             "EnterEditMode" => Self::EnterEditMode,
+            "ResolveConflictsAi" => Self::ResolveConflictsAi,
             "SyncWorkspace" => Self::SyncWorkspace,
             "CreateDependentBranch" => Self::CreateDependentBranch,
             "RemoveDependentBranch" => Self::RemoveDependentBranch,

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -14,7 +14,9 @@
 use std::sync::Arc;
 
 use anyhow::{Context, bail};
-use but_api::{branch, commit, diff, github, gitlab, land, legacy, open, platform, workspace};
+use but_api::{
+    branch, commit, diff, github, gitlab, land, legacy, open, platform, resolve, workspace,
+};
 #[cfg(feature = "irc")]
 use but_irc::IrcManager;
 use but_settings::AppSettingsWithDiskSync;
@@ -523,6 +525,7 @@ fn main() -> anyhow::Result<()> {
                 commit::uncommit::tauri_commit_uncommit::commit_uncommit,
                 workspace::tauri_workspace_integrate_upstream::workspace_integrate_upstream,
                 land::tauri_branch_land::branch_land,
+                resolve::tauri_resolve_commit_conflicts_ai::resolve_commit_conflicts_ai,
                 platform::tauri_build_type::build_type,
             ])
             .menu(menu::build)

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -656,6 +656,20 @@ export type AbsorptionTarget = {
   type: "all";
 };
 
+/** JSON transport type for the outcome of an AI conflict resolution. */
+export type AiResolutionResult = {
+  /** The conflicted commit that was resolved. */
+  commitId: string;
+  /** The rewritten, no-longer-conflicted commit. */
+  newCommit: string;
+  /** A short model-authored markdown summary of the conflict and resolution. */
+  summary: string | null;
+  /** The per-file resolutions that were applied. */
+  files: Array<ResolvedFile>;
+  /** Workspace state after the resolution. */
+  workspace: WorkspaceState;
+};
+
 export type ApiProject = {
   name: string;
   description: string | null;
@@ -2079,7 +2093,7 @@ export type OperatingMode = {
   subject: EditModeMetadata;
 };
 
-export type OperationKind = "CreateCommit" | "CreateBranch" | "StashIntoBranch" | "SetBaseBranch" | "MergeUpstream" | "UpdateWorkspaceBase" | "MoveHunk" | "UpdateBranchName" | "UpdateBranchNotes" | "ReorderBranches" | "UpdateBranchRemoteName" | "GenericBranchUpdate" | "DeleteBranch" | "ApplyBranch" | "DiscardLines" | "DiscardHunk" | "DiscardFile" | "DiscardChanges" | "Discard" | "AmendCommit" | "Absorb" | "AutoCommit" | "UndoCommit" | "DiscardCommit" | "UnapplyBranch" | "CherryPick" | "SquashCommit" | "UpdateCommitMessage" | "MoveCommit" | "MoveBranch" | "TearOffBranch" | "ReorderCommit" | "InsertBlankCommit" | "MoveCommitFile" | "FileChanges" | "EnterEditMode" | "SyncWorkspace" | "CreateDependentBranch" | "RemoveDependentBranch" | "UpdateDependentBranchName" | "UpdateDependentBranchDescription" | "UpdateDependentBranchPrNumber" | "AutoHandleChangesBefore" | "AutoHandleChangesAfter" | "SplitBranch" | "CleanWorkspace" | "OnDemandSnapshot" | "Unknown" | "RestoreFromSnapshotViaUndo" | "RestoreFromSnapshotViaRedo" | "RestoreFromSnapshot";
+export type OperationKind = "CreateCommit" | "CreateBranch" | "StashIntoBranch" | "SetBaseBranch" | "MergeUpstream" | "UpdateWorkspaceBase" | "MoveHunk" | "UpdateBranchName" | "UpdateBranchNotes" | "ReorderBranches" | "UpdateBranchRemoteName" | "GenericBranchUpdate" | "DeleteBranch" | "ApplyBranch" | "DiscardLines" | "DiscardHunk" | "DiscardFile" | "DiscardChanges" | "Discard" | "AmendCommit" | "Absorb" | "AutoCommit" | "UndoCommit" | "DiscardCommit" | "UnapplyBranch" | "CherryPick" | "SquashCommit" | "UpdateCommitMessage" | "MoveCommit" | "MoveBranch" | "TearOffBranch" | "ReorderCommit" | "InsertBlankCommit" | "MoveCommitFile" | "FileChanges" | "EnterEditMode" | "ResolveConflictsAi" | "SyncWorkspace" | "CreateDependentBranch" | "RemoveDependentBranch" | "UpdateDependentBranchName" | "UpdateDependentBranchDescription" | "UpdateDependentBranchPrNumber" | "AutoHandleChangesBefore" | "AutoHandleChangesAfter" | "SplitBranch" | "CleanWorkspace" | "OnDemandSnapshot" | "Unknown" | "RestoreFromSnapshotViaUndo" | "RestoreFromSnapshotViaRedo" | "RestoreFromSnapshot";
 
 /** What kind of apply operation completed. */
 export type OutcomeStatus = "alreadyApplied" | "applied" | "conflictAborted";
@@ -2300,6 +2314,16 @@ export type ResolutionApproach = {
   type: "unapply";
 } | {
   type: "delete";
+};
+
+/** How one conflicted file was resolved, for display to the user. */
+export type ResolvedFile = {
+  /** The repo-relative path of the file. */
+  path: string;
+  /** The content that replaced each conflict block, in file order. */
+  hunks: Array<string>;
+  /** The model's explanation of its decision for this file. */
+  reasoning: string;
 };
 
 /** The kind of restore to perform. */

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -656,6 +656,20 @@ export type AbsorptionTarget = {
   type: "all";
 };
 
+/** JSON transport type for the outcome of an AI conflict resolution. */
+export type AiResolutionResult = {
+  /** The conflicted commit that was resolved. */
+  commitId: string;
+  /** The rewritten, no-longer-conflicted commit. */
+  newCommit: string;
+  /** A short model-authored markdown summary of the conflict and resolution. */
+  summary: string | null;
+  /** The per-file resolutions that were applied. */
+  files: Array<ResolvedFile>;
+  /** Workspace state after the resolution. */
+  workspace: WorkspaceState;
+};
+
 export type ApiProject = {
   name: string;
   description: string | null;
@@ -2079,7 +2093,7 @@ export type OperatingMode = {
   subject: EditModeMetadata;
 };
 
-export type OperationKind = "CreateCommit" | "CreateBranch" | "StashIntoBranch" | "SetBaseBranch" | "MergeUpstream" | "UpdateWorkspaceBase" | "MoveHunk" | "UpdateBranchName" | "UpdateBranchNotes" | "ReorderBranches" | "UpdateBranchRemoteName" | "GenericBranchUpdate" | "DeleteBranch" | "ApplyBranch" | "DiscardLines" | "DiscardHunk" | "DiscardFile" | "DiscardChanges" | "Discard" | "AmendCommit" | "Absorb" | "AutoCommit" | "UndoCommit" | "DiscardCommit" | "UnapplyBranch" | "CherryPick" | "SquashCommit" | "UpdateCommitMessage" | "MoveCommit" | "MoveBranch" | "TearOffBranch" | "ReorderCommit" | "InsertBlankCommit" | "MoveCommitFile" | "FileChanges" | "EnterEditMode" | "SyncWorkspace" | "CreateDependentBranch" | "RemoveDependentBranch" | "UpdateDependentBranchName" | "UpdateDependentBranchDescription" | "UpdateDependentBranchPrNumber" | "AutoHandleChangesBefore" | "AutoHandleChangesAfter" | "SplitBranch" | "CleanWorkspace" | "OnDemandSnapshot" | "Unknown" | "RestoreFromSnapshotViaUndo" | "RestoreFromSnapshotViaRedo" | "RestoreFromSnapshot";
+export type OperationKind = "CreateCommit" | "CreateBranch" | "StashIntoBranch" | "SetBaseBranch" | "MergeUpstream" | "UpdateWorkspaceBase" | "MoveHunk" | "UpdateBranchName" | "UpdateBranchNotes" | "ReorderBranches" | "UpdateBranchRemoteName" | "GenericBranchUpdate" | "DeleteBranch" | "ApplyBranch" | "DiscardLines" | "DiscardHunk" | "DiscardFile" | "DiscardChanges" | "Discard" | "AmendCommit" | "Absorb" | "AutoCommit" | "UndoCommit" | "DiscardCommit" | "UnapplyBranch" | "CherryPick" | "SquashCommit" | "UpdateCommitMessage" | "MoveCommit" | "MoveBranch" | "TearOffBranch" | "ReorderCommit" | "InsertBlankCommit" | "MoveCommitFile" | "FileChanges" | "EnterEditMode" | "ResolveConflictsAi" | "SyncWorkspace" | "CreateDependentBranch" | "RemoveDependentBranch" | "UpdateDependentBranchName" | "UpdateDependentBranchDescription" | "UpdateDependentBranchPrNumber" | "AutoHandleChangesBefore" | "AutoHandleChangesAfter" | "SplitBranch" | "CleanWorkspace" | "OnDemandSnapshot" | "Unknown" | "RestoreFromSnapshotViaUndo" | "RestoreFromSnapshotViaRedo" | "RestoreFromSnapshot";
 
 /** What kind of apply operation completed. */
 export type OutcomeStatus = "alreadyApplied" | "applied" | "conflictAborted";
@@ -2300,6 +2314,16 @@ export type ResolutionApproach = {
   type: "unapply";
 } | {
   type: "delete";
+};
+
+/** How one conflicted file was resolved, for display to the user. */
+export type ResolvedFile = {
+  /** The repo-relative path of the file. */
+  path: string;
+  /** The content that replaced each conflict block, in file order. */
+  hunks: Array<string>;
+  /** The model's explanation of its decision for this file. */
+  reasoning: string;
 };
 
 /** The kind of restore to perform. */

--- a/packages/ui/src/lib/utils/testIds.ts
+++ b/packages/ui/src/lib/utils/testIds.ts
@@ -46,6 +46,7 @@ export enum TestId {
 	CommitRowContextMenu_UncommitMenuButton = "commit-row-context-menu-uncommit-menu-btn",
 	CommitRowContextMenu_EditMessageMenuButton = "commit-row-context-menu-edit-message-menu-btn",
 	CommitRowContextMenu_EditCommit = "commit-row-context-menu-edit-commit",
+	CommitRowContextMenu_ResolveConflictsAi = "commit-row-context-menu-resolve-conflicts-ai",
 	CommitRowContextMenu_SquashSelected = "commit-row-context-menu-squash-selected",
 	CommitRowContextMenu_UncommitSelected = "commit-row-context-menu-uncommit-selected",
 	NewCommitView = "new-commit-view",


### PR DESCRIPTION
## What

A new API that resolves a conflicted commit's conflicts with the configured LLM in one shot, plus the surfaces to use it:

- `but_api::resolve::resolve_commit_conflicts_ai(ctx, commit_id, dry_run)`
- `but resolve <commit> --ai`, and `but resolve --ai` to resolve all conflicted commits oldest-first
- A "Resolve conflicts with AI" right-click action on conflicted commits in the desktop app, shown when AI is enabled for the project

## How

GitButler already stores a conflicted commit's merge inputs as trees (`.conflict-base-0`, `.conflict-side-0/1`), so the whole flow runs without edit mode and without touching the working tree:

1. Re-merge the stored trees in memory with diff3 markers and sentinel labels. Markers are matched exactly and positionally, so file content that merely looks like a marker can never open, close, or garble a block — such files bail to manual resolution instead.
2. Send the conflict hunks (ours/base/theirs + context, plus the commit message for intent) as a single structured LLM request. No lock is held during the model call; one retry on any failure.
3. Validate strictly: exact paths, exact hunk counts per file, no conflict markers anywhere in the spliced output. Nothing is written unless everything validates.
4. Splice each resolved hunk back deterministically — non-conflicted lines are copied byte-for-byte with their own line terminators, so the model structurally cannot alter code outside the conflicts (borrowed from GitHub Desktop's Copilot design, adapted to committed conflicts).
5. Rewrite the commit into a normal one (resolved tree, stripped `[conflict]` message, cleared header) and rebase descendants with the existing graph_rebase machinery, under the exclusive lock with a freshly read workspace so concurrent changes fail closed.

An oplog snapshot (`OperationKind::ResolveConflictsAi`) records an undo point, so a disagreeable resolution is one `but undo` away.

Deliberately out of scope for now: a dry-run review UI (the `dry_run` parameter and result payload already support it), rename/delete/binary conflicts (bail to manual), and PR-context enrichment for the prompt.

## Also included

A separate commit enables strict structured output on the but-llm OpenAI path. Without it the JSON schema is only advisory and models occasionally answer with the schema document itself instead of an instance, breaking every `structured_output` caller. The schemars output is rewritten to strict-mode requirements (all properties required, `additionalProperties: false`, `$schema`/`default` stripped) before sending.