### PR TITLE
fix(tui): fix detail view stalling on slow IO

### DIFF
--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -440,8 +440,8 @@ fn get_branches_without_prs(
 }
 
 fn get_branch_names(project: &Project, branch_id: &str) -> anyhow::Result<Vec<String>> {
-    let mut ctx = Context::new_from_legacy_project(project.clone())?;
-    let id_map = IdMap::legacy_new_from_context(&mut ctx, None)?;
+    let ctx = Context::new_from_legacy_project(project.clone())?;
+    let id_map = IdMap::legacy_new_from_context(&ctx, None)?;
     let branch_ids = id_map
         .parse_using_context(branch_id, &ctx)?
         .iter()

--- a/crates/but/src/command/legacy/status/tui/app/details_layout.rs
+++ b/crates/but/src/command/legacy/status/tui/app/details_layout.rs
@@ -146,6 +146,7 @@ impl App {
                 self.backstack.push_open_details_view(false);
             }
         } else {
+            self.details.on_hidden();
             self.backstack.remove_open_details_view();
             if matches!(&*self.mode, Mode::Details(..)) {
                 messages.push(Message::UnfocusDetails);

--- a/crates/but/src/command/legacy/status/tui/details.rs
+++ b/crates/but/src/command/legacy/status/tui/details.rs
@@ -3,7 +3,6 @@ use std::{
     fmt::Display,
     sync::{
         Arc,
-        atomic::AtomicUsize,
         mpsc::{Sender, TryRecvError},
     },
     time::{Duration, Instant},
@@ -25,6 +24,7 @@ use crate::{
     CliId,
     command::legacy::status::tui::{
         Message, count_allocations,
+        details::worker::Worker,
         highlight::{self, Highlights},
     },
     theme::Theme,
@@ -34,6 +34,8 @@ use crate::{
         string_interning::Strings,
     },
 };
+
+mod worker;
 
 const CHANNEL_SIZE: usize = 1024;
 
@@ -66,6 +68,7 @@ pub struct Details {
     cache: Cache,
     out_of_band_messages_tx: Sender<Message>,
     pub highlights: Highlights<SectionId>,
+    worker: Worker,
 }
 
 #[derive(Debug, Default)]
@@ -98,13 +101,14 @@ impl Details {
             syntax_set: OnDemand::new(|| Ok(SyntaxSet::load_defaults_newlines())).into(),
             syntax_theme: OnDemand::new(|| theme.load_syntax_highlighting_theme()).into(),
             strings: Default::default(),
-            selected_section: Cell::default(),
+            selected_section: Default::default(),
             line_reader: Default::default(),
             scroll: Default::default(),
             layout_cache: Default::default(),
             cache: Default::default(),
             out_of_band_messages_tx,
             highlights: Default::default(),
+            worker: Worker::new(),
         }
     }
 
@@ -117,12 +121,16 @@ impl Details {
         }
     }
 
-    pub fn num_threads(&self) -> usize {
-        NUM_THREADS.load(std::sync::atomic::Ordering::SeqCst)
+    pub fn worker_is_busy(&self) -> bool {
+        self.worker.is_busy()
     }
 
     pub fn cache_size(&self) -> usize {
         self.cache.num_lines
+    }
+
+    pub fn on_hidden(&mut self) {
+        self.reset_line_reader();
     }
 
     pub fn update(
@@ -133,7 +141,7 @@ impl Details {
     ) -> anyhow::Result<bool> {
         if !is_visible {
             self.clear_lines();
-            self.line_reader = Default::default();
+            self.reset_line_reader();
             self.reset_scroll();
             return Ok(false);
         }
@@ -141,21 +149,21 @@ impl Details {
         let (selection, selection_did_change) = match (self.selection.as_ref(), new_selection) {
             (None, None) => {
                 // no selection
-                self.line_reader = Default::default();
+                self.reset_line_reader();
 
                 return Ok(false);
             }
             (None, Some(new)) => {
                 // selected something
                 self.selection = Some(new.clone());
-                self.line_reader = Default::default();
+                self.reset_line_reader();
 
                 (new, true)
             }
             (Some(_), None) => {
                 // deselected
                 self.selection = None;
-                self.line_reader = Default::default();
+                self.reset_line_reader();
                 self.clear_lines();
                 self.reset_scroll();
 
@@ -169,7 +177,7 @@ impl Details {
                 } else {
                     // selected something new
                     self.selection = Some(new.clone());
-                    self.line_reader = Default::default();
+                    self.reset_line_reader();
                     (new, true)
                 }
             }
@@ -267,6 +275,7 @@ impl Details {
                 )
             }
             CliId::Stack { .. } => {
+                self.reset_line_reader();
                 self.clear_lines();
                 self.reset_scroll();
                 push_line(
@@ -282,6 +291,7 @@ impl Details {
                 Ok(true)
             }
             CliId::PathPrefix { .. } => {
+                self.reset_line_reader();
                 self.clear_lines();
                 self.reset_scroll();
                 Ok(true)
@@ -352,8 +362,6 @@ impl Details {
             }
         }
 
-        let num_threads_guard = NumThreadsGuard::new();
-
         match &mut self.line_reader {
             ChannelLineReader::NotStarted => {
                 tracing::debug!("spawning thread");
@@ -373,10 +381,7 @@ impl Details {
                 let ctx = ctx.to_sync();
                 let error_tx = self.out_of_band_messages_tx.clone();
 
-                // spawning a new thread immediately here without a pool is fine since, if the
-                // selection changes the previous will thread will end when it tries to send on
-                // the, now disconnected, channel
-                let thread = std::thread::spawn(move || {
+                self.worker.replace_next_job(move || {
                     let mut ctx = ctx.into_thread_local();
                     let mut id_gen = IdGen::new(strings);
 
@@ -401,15 +406,7 @@ impl Details {
                             Err(_) => {}
                         }
                     });
-
-                    drop(num_threads_guard);
                 });
-
-                if cfg!(test) {
-                    // we don't bother with threads during tests since that makes since
-                    // non-deterministic, so just run the thread to completion right now
-                    thread.join().unwrap();
-                }
 
                 Ok(true)
             }
@@ -747,6 +744,7 @@ impl Details {
     }
 
     fn restore_cached_lines(&mut self, cached_lines: Vec<DetailsLine>) {
+        self.worker.clear_next_job();
         self.clear_lines();
         self.reset_scroll();
         self.line_reader = ChannelLineReader::Finished;
@@ -759,6 +757,11 @@ impl Details {
         self.lines.clear();
         self.sections.clear();
         self.selected_section.set(SelectedSection::None);
+    }
+
+    fn reset_line_reader(&mut self) {
+        self.line_reader = Default::default();
+        self.worker.clear_next_job();
     }
 
     fn update_selected_section_for_visible_range(
@@ -934,24 +937,6 @@ fn extend_section_list(sections: &mut Vec<Section>, line_index: usize, line: &De
         first_line: line_index,
         last_line: line_index,
     });
-}
-
-/// Counter for tracking how many threads we're currently running.
-static NUM_THREADS: AtomicUsize = AtomicUsize::new(0);
-
-struct NumThreadsGuard;
-
-impl NumThreadsGuard {
-    fn new() -> Self {
-        NUM_THREADS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-        Self
-    }
-}
-
-impl Drop for NumThreadsGuard {
-    fn drop(&mut self) {
-        NUM_THREADS.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
-    }
 }
 
 #[derive(Debug, Default)]

--- a/crates/but/src/command/legacy/status/tui/details/worker.rs
+++ b/crates/but/src/command/legacy/status/tui/details/worker.rs
@@ -1,0 +1,140 @@
+use std::sync::{Arc, Condvar, Mutex, atomic::AtomicBool};
+
+/// A background worker that performs arbitrary jobs while maintaining a "next job".
+///
+/// Submitting a new job to the worker replaces any previous jobs. It essentially has a queue with
+/// a max length of 1.
+///
+/// This exists to prevent a scenario where we're performing some job (such as loading diffs) which
+/// holds an exclusive lock on some resource that block other jobs and builds a large queue.
+///
+/// The TUI's detail view needs this because it starts loading diffs immediately when an item is
+/// selected so if you scroll quickly we don't wanna build a big queue of diffs to load, we just
+/// wanna finish the current one and load whatever the next diff is. LIFO style.
+pub struct Worker {
+    shared: Arc<Shared>,
+    exclusives: Arc<Mutex<Exclusives>>,
+}
+
+impl std::fmt::Debug for Worker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Worker").finish_non_exhaustive()
+    }
+}
+
+#[derive(Default)]
+struct Shared {
+    condvar: Condvar,
+    is_busy: AtomicBool,
+    worker_dropped: AtomicBool,
+}
+
+#[derive(Default)]
+struct Exclusives {
+    next_job: Option<Box<dyn FnOnce() + Send + 'static>>,
+}
+
+impl Worker {
+    pub fn new() -> Self {
+        let worker = Self {
+            shared: Default::default(),
+            exclusives: Default::default(),
+        };
+
+        if cfg!(test) {
+            // dont bother with threads during tests since that makes timing non-deterministic
+        } else {
+            let shared = Arc::clone(&worker.shared);
+            let exclusives = Arc::clone(&worker.exclusives);
+            std::thread::spawn(move || {
+                run_worker(shared, exclusives);
+            });
+        }
+
+        worker
+    }
+
+    pub fn replace_next_job<F>(&mut self, job: F)
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        self.replace_next_job_inner(Some(Box::new(job)));
+    }
+
+    pub fn clear_next_job(&mut self) {
+        self.replace_next_job_inner(None);
+    }
+
+    fn replace_next_job_inner(&mut self, job: Option<Box<dyn FnOnce() + Send + 'static>>) {
+        if cfg!(test) {
+            // dont bother with threads during tests since that makes timing non-deterministic
+            if let Some(job) = job {
+                job();
+            }
+        } else {
+            let has_job = job.is_some();
+
+            let mut lock = self.exclusives.lock().unwrap();
+            lock.next_job = job;
+            drop(lock);
+
+            if has_job {
+                self.shared.condvar.notify_one();
+            }
+        }
+    }
+
+    pub fn is_busy(&self) -> bool {
+        self.shared
+            .is_busy
+            .load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+impl Drop for Worker {
+    fn drop(&mut self) {
+        self.shared
+            .worker_dropped
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        self.shared.condvar.notify_one();
+    }
+}
+
+fn run_worker(shared: Arc<Shared>, exclusives: Arc<Mutex<Exclusives>>) {
+    loop {
+        if shared
+            .worker_dropped
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            break;
+        }
+
+        let mut lock = exclusives.lock().unwrap();
+        let next_job = if let Some(job) = lock.next_job.take() {
+            drop(lock);
+            Some(job)
+        } else {
+            let mut lock = shared.condvar.wait(lock).unwrap();
+            let job = lock.next_job.take();
+            drop(lock);
+            job
+        };
+
+        if shared
+            .worker_dropped
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            break;
+        }
+
+        if let Some(job) = next_job {
+            shared
+                .is_busy
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            job();
+            shared
+                .is_busy
+                .store(false, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+}

--- a/crates/but/src/command/legacy/status/tui/render.rs
+++ b/crates/but/src/command/legacy/status/tui/render.rs
@@ -1304,12 +1304,12 @@ fn render_debug(app: &App, area: Rect, frame: &mut Frame) {
     );
 
     let details_selection = String::new();
-    let details_num_threads = format!("Threads: {}", app.details.num_threads());
+    let details_worker_busy = format!("Worker busy: {}", app.details.worker_is_busy());
     let details_cache_size = format!("Cache size: {} lines", app.details.cache_size());
     let details_selection = once(ListItem::new("Details").black().on_blue()).chain(
         details_selection
             .lines()
-            .chain(details_num_threads.lines())
+            .chain(details_worker_busy.lines())
             .chain(details_cache_size.lines())
             .take(100)
             .map(|line| ListItem::new(line.to_owned())),

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -686,7 +686,7 @@ impl IdMap {
     // Use `new_from_context` instead - it takes `perm`, and forces you to think about repository locks
     // in the light of mutations.
     pub fn legacy_new_from_context(
-        ctx: &mut Context,
+        ctx: &Context,
         assignments: Option<Vec<HunkAssignment>>,
     ) -> anyhow::Result<Self> {
         let guard = ctx.shared_worktree_access();

--- a/crates/but/src/utils/diff_rendering.rs
+++ b/crates/but/src/utils/diff_rendering.rs
@@ -394,7 +394,7 @@ pub struct Options {
 
 pub fn render_commit(
     commit: ObjectId,
-    ctx: &mut Context,
+    ctx: &Context,
     theme: &'static Theme,
     id_gen: &mut IdGen<'_>,
     options: Options,
@@ -477,7 +477,7 @@ pub fn render_commit(
 
 pub fn render_branch(
     name: String,
-    ctx: &mut Context,
+    ctx: &Context,
     theme: &'static Theme,
     id_gen: &mut IdGen<'_>,
     options: Options,
@@ -502,7 +502,7 @@ pub fn render_branch(
 }
 
 pub fn render_uncommitted(
-    ctx: &mut Context,
+    ctx: &Context,
     theme: &'static Theme,
     id_gen: &mut IdGen<'_>,
     options: Options,
@@ -600,7 +600,7 @@ pub fn render_committed_file(
     commit: ObjectId,
     path: BString,
     id: ShortId,
-    ctx: &mut Context,
+    ctx: &Context,
     theme: &'static Theme,
     id_gen: &mut IdGen<'_>,
     options: Options,
@@ -1013,7 +1013,7 @@ fn compute_line_stats_from_uncommitted_hunks(
 }
 
 fn filter_uncommitted_hunks<'a, F>(
-    ctx: &'a mut Context,
+    ctx: &'a Context,
     id_map: &'a IdMap,
     mut filter: F,
 ) -> anyhow::Result<Vec<(&'a str, Arc<CliId>, &'a UncommittedHunk)>>


### PR DESCRIPTION
This fixes a bug in the TUI's detail view where slow IO would cause it to stall and appear to be stuck in the "Loading..." state.

### Root cause

Previously when you changed your selection we'd immediately spawn a new thread to load the diff. That thread would acquire an exclusive lock on the sqlite database (because of assignment related things) while loading the diff. The thread would block until it could get the lock which meant if you changed the selection quickly by scrolling up and down, we'd essentially create a queue of threads that would all block on getting the lock.

### The fix

This fixes that by instead spawning a single thread that you can submit jobs to. The thread holds a LIFO slot that points to the next job and when you submit a new job we replace the contents of that slot, thus dropping the previously enqueued work.

When the selection changes in the TUI we just replace the contents of the LIFO slot so it'll be picked up by the worker when it finishes its current job. Thus we don't create a queue and things dont appear to stall.

We cannot cancel any already running work since its blocking.