### PR TITLE
Run TUI commands in the active project directory

### DIFF
--- a/crates/but/src/command/legacy/status/tui/app/command_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/command_mode.rs
@@ -1,5 +1,6 @@
 use std::{ffi::OsString, process::Command};
 
+use but_ctx::Context;
 use crossterm::event::Event;
 use ratatui::backend::Backend;
 use ratatui_textarea::{CursorMove, TextArea};
@@ -35,6 +36,7 @@ impl App {
     pub fn handle_command<T>(
         &mut self,
         message: CommandMessage,
+        ctx: &Context,
         terminal_guard: &mut T,
         out: &mut dyn TuiInputOutputChannel,
         messages: &mut Vec<Message>,
@@ -47,7 +49,7 @@ impl App {
             CommandMessage::Start(kind) => self.handle_command_start(kind),
             CommandMessage::Input(ev) => self.handle_command_input(ev),
             CommandMessage::Confirm => {
-                self.handle_command_confirm(terminal_guard, out, messages)?
+                self.handle_command_confirm(ctx, terminal_guard, out, messages)?
             }
         }
 
@@ -79,6 +81,7 @@ impl App {
 
     fn handle_command_confirm<T>(
         &mut self,
+        ctx: &Context,
         terminal_guard: &mut T,
         out: &mut dyn TuiInputOutputChannel,
         messages: &mut Vec<Message>,
@@ -122,6 +125,8 @@ impl App {
                 cmd
             }
         };
+
+        cmd.current_dir(ctx.workdir_or_fail()?);
 
         let status = cmd.spawn()?.wait()?;
 

--- a/crates/but/src/command/legacy/status/tui/app/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/app/mod.rs
@@ -365,7 +365,7 @@ impl App {
                 self.handle_reword(reword_message, ctx, terminal_guard, messages)?
             }
             Message::Command(command_message) => {
-                self.handle_command(command_message, terminal_guard, out, messages)?
+                self.handle_command(command_message, ctx, terminal_guard, out, messages)?
             }
             Message::Move(move_message) => self.handle_move(move_message, ctx, messages)?,
             Message::NewBranch => {


### PR DESCRIPTION
## 🧢 Changes

Runs commands launched from `but tui` command mode in the active GitButler project directory.

This applies to both built-in `but` command mode and shell command mode.

## ☕️ Reasoning

When `but tui` is launched with `-C <repo>`, the TUI displays and operates on that repo through its active `Context`. However, command mode spawned child processes without setting their working directory, so they inherited the shell’s original cwd.

That could make a user run a command while looking at repo A in the TUI, but accidentally execute it in repo B.

The fix sets the child process cwd to `ctx.workdir_or_fail()?` before spawning.


https://github.com/user-attachments/assets/9719d8a7-cb17-49b4-af21-41fbb0a670a1

