### PR TITLE
fix(forge): honor project forge_override for self-hosted forges

### DIFF
--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -23,6 +23,15 @@ pub fn push_remote_url(project_meta: &ProjectMeta, repo: &gix::Repository) -> Re
     project_meta.push_remote_url(repo)
 }
 
+/// Parse the project's saved forge preference (the Settings forge picker's
+/// `forge_override`) into a `ForgeName`. It's the last-resort fallback passed to
+/// `derive_forge_repo_info` so a forge the remote URL and configured accounts
+/// can't identify - e.g. self-hosted GitLab before an account is added - still
+/// resolves (#14319). `None` means no usable preference.
+fn forge_override(saved: Option<&str>) -> Option<ForgeName> {
+    saved.and_then(ForgeName::from_override_str)
+}
+
 fn review_template_content(file: FileInfo) -> Result<String> {
     if file.size.is_none() {
         return Ok(String::new());
@@ -49,7 +58,10 @@ pub fn pr_templates(ctx: &but_ctx::Context, forge: ForgeName) -> Result<Vec<Stri
 pub fn forge_provider(ctx: &Context) -> Result<Option<ForgeName>> {
     let project_meta = ctx.project_meta()?;
     let repo = ctx.repo.get()?;
-    let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&project_meta, &repo)?);
+    let forge_repo_info = but_forge::derive_forge_repo_info(
+        &remote_url(&project_meta, &repo)?,
+        forge_override(ctx.legacy_project.forge_override.as_deref()),
+    );
     Ok(forge_repo_info.map(|info| info.forge))
 }
 
@@ -60,7 +72,10 @@ pub fn forge_provider(ctx: &Context) -> Result<Option<ForgeName>> {
 pub fn forge_info(ctx: &Context) -> Result<Option<but_forge::ForgeInfo>> {
     let project_meta = ctx.project_meta()?;
     let repo = ctx.repo.get()?;
-    Ok(but_forge::forge_info(&remote_url(&project_meta, &repo)?))
+    Ok(but_forge::forge_info(
+        &remote_url(&project_meta, &repo)?,
+        forge_override(ctx.legacy_project.forge_override.as_deref()),
+    ))
 }
 
 /// Web compare URL for a branch — drives the "Open in browser"
@@ -81,6 +96,7 @@ pub fn forge_compare_branch_url(
         &base,
         &branch,
         fork.as_deref(),
+        forge_override(ctx.legacy_project.forge_override.as_deref()),
     ))
 }
 
@@ -90,7 +106,10 @@ pub fn forge_compare_branch_url(
 pub fn list_available_review_templates(ctx: &Context) -> Result<Vec<String>> {
     let project_meta = ctx.project_meta()?;
     let repo = ctx.repo.get()?;
-    let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&project_meta, &repo)?);
+    let forge_repo_info = but_forge::derive_forge_repo_info(
+        &remote_url(&project_meta, &repo)?,
+        forge_override(ctx.legacy_project.forge_override.as_deref()),
+    );
     let forge = &forge_repo_info
         .as_ref()
         .context("No forge could be determined for this repository branch")?
@@ -147,7 +166,10 @@ but_schemars::register_sdk_type!(ReviewTemplateInfo);
 pub fn review_template(ctx: &Context) -> Result<Option<ReviewTemplateInfo>> {
     let project_meta = ctx.project_meta()?;
     let repo = ctx.repo.get()?;
-    let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&project_meta, &repo)?);
+    let forge_repo_info = but_forge::derive_forge_repo_info(
+        &remote_url(&project_meta, &repo)?,
+        forge_override(ctx.legacy_project.forge_override.as_deref()),
+    );
     let forge = &forge_repo_info
         .as_ref()
         .context("No forge could be determined for this repository branch")?
@@ -190,7 +212,10 @@ pub fn set_review_template(ctx: &but_ctx::Context, template_path: Option<String>
     let mut git_config = repo.git_settings()?;
 
     let project_meta = ctx.project_meta()?;
-    let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&project_meta, &repo)?);
+    let forge_repo_info = but_forge::derive_forge_repo_info(
+        &remote_url(&project_meta, &repo)?,
+        forge_override(ctx.legacy_project.forge_override.as_deref()),
+    );
     let forge = &forge_repo_info
         .as_ref()
         .context("No forge could be determined for this repository branch")?
@@ -222,7 +247,10 @@ pub fn list_reviews(
     let (storage, forge_repo_info, preferred_forge_user) = {
         let project_meta = ctx.project_meta()?;
         let repo = ctx.repo.get()?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&project_meta, &repo)?);
+        let forge_repo_info = but_forge::derive_forge_repo_info(
+            &remote_url(&project_meta, &repo)?,
+            forge_override(ctx.legacy_project.forge_override.as_deref()),
+        );
 
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
@@ -257,8 +285,11 @@ pub fn review_apply(
         let project_meta = ctx.project_meta()?;
         let repo = ctx.repo.get()?;
         let remote_url = project_meta.remote_url_with_fallback(&repo)?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url)
-            .context("No supported forge could be determined for this repository")?;
+        let forge_repo_info = but_forge::derive_forge_repo_info(
+            &remote_url,
+            forge_override(ctx.legacy_project.forge_override.as_deref()),
+        )
+        .context("No supported forge could be determined for this repository")?;
         let target_protocol = forge_repo_info.protocol.clone();
         (
             forge_repo_info,
@@ -366,8 +397,10 @@ fn remote_urls_match(configured: &str, candidate: &str) -> bool {
     if configured == candidate {
         return true;
     }
-    let configured_info = but_forge::derive_forge_repo_info(configured);
-    let candidate_info = but_forge::derive_forge_repo_info(candidate);
+    // This compares two arbitrary remote URLs for identity, so the project's
+    // forge override doesn't apply - resolve each purely from its URL.
+    let configured_info = but_forge::derive_forge_repo_info(configured, None);
+    let candidate_info = but_forge::derive_forge_repo_info(candidate, None);
     configured_info.is_some() && configured_info == candidate_info
 }
 
@@ -557,7 +590,10 @@ pub async fn get_review_base_repo_url(
         let ctx = ctx.into_thread_local();
         let project_meta = ctx.project_meta()?;
         let repo = ctx.repo.get()?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&project_meta, &repo)?);
+        let forge_repo_info = but_forge::derive_forge_repo_info(
+            &remote_url(&project_meta, &repo)?,
+            forge_override(ctx.legacy_project.forge_override.as_deref()),
+        );
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
             forge_repo_info,
@@ -583,7 +619,10 @@ pub async fn get_review_merge_status(
         let ctx = ctx.into_thread_local();
         let project_meta = ctx.project_meta()?;
         let repo = ctx.repo.get()?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&project_meta, &repo)?);
+        let forge_repo_info = but_forge::derive_forge_repo_info(
+            &remote_url(&project_meta, &repo)?,
+            forge_override(ctx.legacy_project.forge_override.as_deref()),
+        );
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
             forge_repo_info,
@@ -605,8 +644,11 @@ pub fn get_review(ctx: &Context, review_id: usize) -> Result<but_forge::ForgeRev
     let (storage, forge_repo_info, preferred_forge_user) = {
         let project_meta = ctx.project_meta()?;
         let repo = ctx.repo.get()?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&project_meta, &repo)?)
-            .context("No forge could be determined for this repository.")?;
+        let forge_repo_info = but_forge::derive_forge_repo_info(
+            &remote_url(&project_meta, &repo)?,
+            forge_override(ctx.legacy_project.forge_override.as_deref()),
+        )
+        .context("No forge could be determined for this repository.")?;
 
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
@@ -632,8 +674,10 @@ pub async fn get_repo_info(ctx: ThreadSafeContext) -> Result<but_forge::RepoInfo
         let ctx = ctx.into_thread_local();
         let project_meta = ctx.project_meta()?;
         let repo_ = ctx.repo.get()?;
-        let forge_repo_info =
-            but_forge::derive_forge_repo_info(&remote_url(&project_meta, &repo_)?);
+        let forge_repo_info = but_forge::derive_forge_repo_info(
+            &remote_url(&project_meta, &repo_)?,
+            forge_override(ctx.legacy_project.forge_override.as_deref()),
+        );
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
             forge_repo_info,
@@ -658,7 +702,10 @@ pub fn list_ci_checks(
     let (storage, forge_repo_info, preferred_forge_user) = {
         let project_meta = ctx.project_meta()?;
         let repo = ctx.repo.get()?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&project_meta, &repo)?);
+        let forge_repo_info = but_forge::derive_forge_repo_info(
+            &remote_url(&project_meta, &repo)?,
+            forge_override(ctx.legacy_project.forge_override.as_deref()),
+        );
 
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
@@ -690,12 +737,17 @@ pub async fn publish_review(
         let repo = ctx.repo.get()?;
         let base_remote_url = remote_url(&project_meta, &repo)?;
         let push_remote_url = push_remote_url(&project_meta, &repo)?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&base_remote_url)
-            .context("No forge could be determined for this repository branch")?;
+        let forge_repo_info = but_forge::derive_forge_repo_info(
+            &base_remote_url,
+            forge_override(ctx.legacy_project.forge_override.as_deref()),
+        )
+        .context("No forge could be determined for this repository branch")?;
         let forge_push_repo_info = if base_remote_url != push_remote_url {
-            let info = but_forge::derive_forge_repo_info(&push_remote_url).context(
-                "Failed to derive forge repository information from the push remote URL.",
-            )?;
+            let info = but_forge::derive_forge_repo_info(
+                &push_remote_url,
+                forge_override(ctx.legacy_project.forge_override.as_deref()),
+            )
+            .context("Failed to derive forge repository information from the push remote URL.")?;
             Some(info)
         } else {
             None
@@ -731,7 +783,10 @@ pub async fn merge_review(
         let ctx = ctx.into_thread_local();
         let project_meta = ctx.project_meta()?;
         let repo = ctx.repo.get()?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&project_meta, &repo)?);
+        let forge_repo_info = but_forge::derive_forge_repo_info(
+            &remote_url(&project_meta, &repo)?,
+            forge_override(ctx.legacy_project.forge_override.as_deref()),
+        );
 
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
@@ -762,7 +817,10 @@ pub async fn set_review_auto_merge(
         let ctx = ctx.into_thread_local();
         let project_meta = ctx.project_meta()?;
         let repo = ctx.repo.get()?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&project_meta, &repo)?);
+        let forge_repo_info = but_forge::derive_forge_repo_info(
+            &remote_url(&project_meta, &repo)?,
+            forge_override(ctx.legacy_project.forge_override.as_deref()),
+        );
 
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
@@ -793,7 +851,10 @@ pub async fn set_review_draftiness(
         let ctx = ctx.into_thread_local();
         let project_meta = ctx.project_meta()?;
         let repo = ctx.repo.get()?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&project_meta, &repo)?);
+        let forge_repo_info = but_forge::derive_forge_repo_info(
+            &remote_url(&project_meta, &repo)?,
+            forge_override(ctx.legacy_project.forge_override.as_deref()),
+        );
 
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
@@ -828,7 +889,10 @@ pub async fn update_review(
         let ctx = ctx.into_thread_local();
         let project_meta = ctx.project_meta()?;
         let repo = ctx.repo.get()?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&project_meta, &repo)?);
+        let forge_repo_info = but_forge::derive_forge_repo_info(
+            &remote_url(&project_meta, &repo)?,
+            forge_override(ctx.legacy_project.forge_override.as_deref()),
+        );
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
             forge_repo_info,
@@ -858,7 +922,10 @@ pub async fn update_review_footers(
         let ctx = ctx.into_thread_local();
         let project_meta = ctx.project_meta()?;
         let repo = ctx.repo.get()?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&project_meta, &repo)?);
+        let forge_repo_info = but_forge::derive_forge_repo_info(
+            &remote_url(&project_meta, &repo)?,
+            forge_override(ctx.legacy_project.forge_override.as_deref()),
+        );
 
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
@@ -887,7 +954,10 @@ pub async fn list_reviews_for_branch(
         let ctx = ctx.into_thread_local();
         let project_meta = ctx.project_meta()?;
         let repo = ctx.repo.get()?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&project_meta, &repo)?);
+        let forge_repo_info = but_forge::derive_forge_repo_info(
+            &remote_url(&project_meta, &repo)?,
+            forge_override(ctx.legacy_project.forge_override.as_deref()),
+        );
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
             forge_repo_info,

--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -953,7 +953,16 @@ fn resolve_review_map(
     ctx: ThreadSafeContext,
     base_branch: &BaseBranch,
 ) -> Result<HashMap<String, but_forge::ForgeReview>> {
-    let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+    let ctx = ctx.into_thread_local();
+    // Honor the project's saved forge override so self-hosted forges resolve
+    // (and their reviews show up) before an account is configured - see #14319.
+    let forge_repo_info = but_forge::derive_forge_repo_info(
+        &base_branch.remote_url,
+        ctx.legacy_project
+            .forge_override
+            .as_deref()
+            .and_then(but_forge::ForgeName::from_override_str),
+    );
     let Some(forge_repo_info) = forge_repo_info.as_ref() else {
         // No forge? No problem!
         // If there's no forge associated with the base branch, there can't be any reviews.
@@ -965,7 +974,6 @@ fn resolve_review_map(
         local: None,
         applied: Some(true),
     });
-    let ctx = ctx.into_thread_local();
     let (branches, preferred_forge_user) = {
         let preferred_forge_user = ctx.legacy_project.preferred_forge_user.clone();
         (list_branches(&ctx, filter)?, preferred_forge_user)

--- a/crates/but-forge/src/forge.rs
+++ b/crates/but-forge/src/forge.rs
@@ -11,6 +11,27 @@ pub enum ForgeName {
     Azure,
 }
 
+impl ForgeName {
+    /// Parse a project's stored `forge_override` string (the value the Settings
+    /// forge picker saves) into a `ForgeName`.
+    ///
+    /// Returns `None` for `"default"` or any unrecognized value, meaning "no
+    /// override". The accepted spellings match this enum's `lowercase` serde
+    /// representation.
+    pub fn from_override_str(value: &str) -> Option<Self> {
+        // Case- and whitespace-insensitive so any legacy spelling of a saved
+        // preference still resolves; unknown values (incl. "default") mean "no
+        // override".
+        match value.trim().to_ascii_lowercase().as_str() {
+            "github" => Some(ForgeName::GitHub),
+            "gitlab" => Some(ForgeName::GitLab),
+            "bitbucket" => Some(ForgeName::Bitbucket),
+            "azure" => Some(ForgeName::Azure),
+            _ => None,
+        }
+    }
+}
+
 #[cfg(feature = "export-schema")]
 but_schemars::register_sdk_type!(ForgeName);
 

--- a/crates/but-forge/src/forge_info.rs
+++ b/crates/but-forge/src/forge_info.rs
@@ -56,8 +56,11 @@ pub struct ForgeCapabilities {
 but_schemars::register_sdk_type!(ForgeCapabilities);
 
 /// Build the per-project ForgeInfo from the project's remote URL.
-pub fn forge_info(remote_url: &str) -> Option<ForgeInfo> {
-    let repo_info = crate::derive_forge_repo_info(remote_url)?;
+///
+/// `override_forge` is the project's saved forge preference, applied as a last
+/// resort when the URL and configured accounts don't identify a forge (#14319).
+pub fn forge_info(remote_url: &str, override_forge: Option<ForgeName>) -> Option<ForgeInfo> {
+    let repo_info = crate::derive_forge_repo_info(remote_url, override_forge)?;
     let base_url = build_base_url(remote_url, &repo_info);
     let (commit_path, pr_path) = url_paths(&repo_info.forge);
     let (unit, posthog) = label_for(&repo_info.forge);
@@ -80,8 +83,9 @@ pub fn compare_branch_url(
     base: &str,
     branch: &str,
     fork: Option<&str>,
+    override_forge: Option<ForgeName>,
 ) -> Option<String> {
-    let repo_info = crate::derive_forge_repo_info(remote_url)?;
+    let repo_info = crate::derive_forge_repo_info(remote_url, override_forge)?;
     let base_url = build_base_url(remote_url, &repo_info);
     let head = match fork {
         Some(f) => format!("{f}:{branch}"),
@@ -212,8 +216,27 @@ mod tests {
     // `derive_forge_repo_info` never falls back to account storage.
 
     #[test]
+    fn self_hosted_base_url_built_from_override_repo_info() {
+        // On the #14319 override path, `derive_forge_repo_info` fabricates
+        // `ForgeRepoInfo` exactly as the account path would - owner/repo parsed
+        // from the URL - so `build_base_url` must produce the self-hosted web
+        // URL from it, taking the host from the remote rather than a hardcoded
+        // per-forge default.
+        let repo_info = ForgeRepoInfo {
+            forge: ForgeName::GitLab,
+            owner: "group".into(),
+            repo: "repo".into(),
+            protocol: "https".into(),
+        };
+        assert_eq!(
+            build_base_url("https://git.selfhosted.example/group/repo.git", &repo_info),
+            "https://git.selfhosted.example/group/repo"
+        );
+    }
+
+    #[test]
     fn azure_https_base_url_keeps_org_project_and_repo() {
-        let info = forge_info("https://dev.azure.com/myorg/myproject/_git/myrepo").unwrap();
+        let info = forge_info("https://dev.azure.com/myorg/myproject/_git/myrepo", None).unwrap();
         assert_eq!(info.name, ForgeName::Azure);
         // Regression: the org and repo segments must both survive — the
         // GenericProvider used to drop the repo name entirely.
@@ -225,7 +248,7 @@ mod tests {
 
     #[test]
     fn azure_ssh_base_url_uses_browsable_https_host() {
-        let info = forge_info("git@ssh.dev.azure.com:v3/myorg/myproject/myrepo").unwrap();
+        let info = forge_info("git@ssh.dev.azure.com:v3/myorg/myproject/myrepo", None).unwrap();
         assert_eq!(info.name, ForgeName::Azure);
         // ssh.dev.azure.com → dev.azure.com, and org/project/repo intact.
         assert_eq!(
@@ -241,6 +264,7 @@ mod tests {
             "main",
             "feature",
             None,
+            None,
         )
         .unwrap();
         assert_eq!(
@@ -251,7 +275,7 @@ mod tests {
 
     #[test]
     fn github_ssh_base_url_and_fork_compare() {
-        let info = forge_info("git@github.com:owner/repo.git").unwrap();
+        let info = forge_info("git@github.com:owner/repo.git", None).unwrap();
         assert_eq!(info.name, ForgeName::GitHub);
         assert_eq!(info.base_url, "https://github.com/owner/repo");
 
@@ -260,6 +284,7 @@ mod tests {
             "main",
             "feat",
             Some("fork"),
+            None,
         )
         .unwrap();
         assert_eq!(
@@ -270,8 +295,14 @@ mod tests {
 
     #[test]
     fn gitlab_compare_url() {
-        let url =
-            compare_branch_url("https://gitlab.com/group/repo.git", "main", "feat", None).unwrap();
+        let url = compare_branch_url(
+            "https://gitlab.com/group/repo.git",
+            "main",
+            "feat",
+            None,
+            None,
+        )
+        .unwrap();
         assert_eq!(url, "https://gitlab.com/group/repo/-/compare/main...feat");
     }
 
@@ -281,6 +312,7 @@ mod tests {
             "https://bitbucket.org/owner/repo.git",
             "release/1.0",
             "feat",
+            None,
             None,
         )
         .unwrap();
@@ -299,13 +331,13 @@ mod tests {
 
     /// Compose what the frontend `commitUrl(forge, sha)` helper produces.
     fn composed_commit_url(remote: &str, sha: &str) -> String {
-        let info = forge_info(remote).unwrap();
+        let info = forge_info(remote, None).unwrap();
         format!("{}{}{}", info.base_url, info.commit_url_path, sha)
     }
 
     /// Compose what the frontend `prUrl(forge, number)` helper produces.
     fn composed_pr_url(remote: &str, number: i64) -> String {
-        let info = forge_info(remote).unwrap();
+        let info = forge_info(remote, None).unwrap();
         format!("{}{}{}", info.base_url, info.pr_url_path, number)
     }
 
@@ -323,7 +355,7 @@ mod tests {
 
     #[test]
     fn gitlab_commit_and_mr_urls() {
-        let info = forge_info("https://gitlab.com/group/repo.git").unwrap();
+        let info = forge_info("https://gitlab.com/group/repo.git", None).unwrap();
         assert!(info.capabilities.checks);
         assert_eq!(
             composed_commit_url("https://gitlab.com/group/repo.git", "abc123"),

--- a/crates/but-forge/src/lib.rs
+++ b/crates/but-forge/src/lib.rs
@@ -37,7 +37,7 @@ fn determine_forge_from_host(host: &str) -> Option<ForgeName> {
 
 /// Derive the forge repository information from a remote URL.
 ///
-/// The forge type is resolved by [`resolve_forge_name`]: the URL host first,
+/// The forge type is resolved by `resolve_forge_name`: the URL host first,
 /// then a match against configured accounts' custom hosts, and finally the
 /// project's `override_forge` (from its stored `forge_override`) as a last
 /// resort. Pass `None` for `override_forge` when no project preference applies,

--- a/crates/but-forge/src/lib.rs
+++ b/crates/but-forge/src/lib.rs
@@ -37,22 +37,24 @@ fn determine_forge_from_host(host: &str) -> Option<ForgeName> {
 
 /// Derive the forge repository information from a remote URL.
 ///
-/// If the forge type can't be determined by simply looking for keywords in the repositories URL,
-/// look through all the known accounts and try to match their custom host strings to the repository's URL host.
-/// Looking at the known accounts involves retrieving data from storage, so that is a bit more expensive
-/// and that's why it's a fallback mechanism.
-pub fn derive_forge_repo_info(url: &str) -> Option<ForgeRepoInfo> {
+/// The forge type is resolved by [`resolve_forge_name`]: the URL host first,
+/// then a match against configured accounts' custom hosts, and finally the
+/// project's `override_forge` (from its stored `forge_override`) as a last
+/// resort. Pass `None` for `override_forge` when no project preference applies,
+/// e.g. when comparing two arbitrary remote URLs for identity.
+pub fn derive_forge_repo_info(
+    url: &str,
+    override_forge: Option<ForgeName>,
+) -> Option<ForgeRepoInfo> {
     let git_url = GitUrl::parse(url).ok()?;
     let host = git_url.host()?;
     let protocol = git_url.scheme()?;
 
     let provider_info: GenericProvider = git_url.provider_info().ok()?;
-    // Attempt to figure out the forge by looking at the host string and
-    // falling back to matching it to the known accounts custom host URL.
-    let forge = determine_forge_from_host(host).or_else(|| {
-        // Only fetch the accounts if it can't determine the forge type from the repository's host.
-        let accounts = get_all_forge_accounts().unwrap_or_default();
-        match_host_to_accounts_custom_host(host, &accounts)
+    let forge = resolve_forge_name(host, override_forge, || {
+        // Only fetch the accounts if the forge type can't be determined from the
+        // repository's host - reading them involves retrieving data from storage.
+        get_all_forge_accounts().unwrap_or_default()
     })?;
 
     Some(ForgeRepoInfo {
@@ -61,6 +63,29 @@ pub fn derive_forge_repo_info(url: &str) -> Option<ForgeRepoInfo> {
         repo: provider_info.repo().to_string(),
         protocol: protocol.to_string(),
     })
+}
+
+/// Resolve the forge type for a repository `host`, in priority order:
+///
+/// 1. keywords in the host itself (`github.com`, `gitlab.*`, ...),
+/// 2. a configured account whose custom host matches (fetched lazily via
+///    `accounts`, since that reads from storage),
+/// 3. the project's saved `forge_override`, honored only as a last resort.
+///
+/// Step 3 mirrors the pre-0.20.1 frontend, which applied the override only when
+/// host detection returned "default" (`if forgeType === "default" &&
+/// forgeOverride`). It is what lets a self-hosted forge - e.g. GitLab on a
+/// private host - resolve again before an account has been configured (#14319).
+/// A recognizable host or a matching account always wins over the override, so
+/// a stale preference can never mislabel a repository whose forge is known.
+fn resolve_forge_name(
+    host: &str,
+    override_forge: Option<ForgeName>,
+    accounts: impl FnOnce() -> Vec<ForgeUser>,
+) -> Option<ForgeName> {
+    determine_forge_from_host(host)
+        .or_else(|| match_host_to_accounts_custom_host(host, &accounts()))
+        .or(override_forge)
 }
 
 /// Look for the best matching account by comparing the repository host to the
@@ -153,8 +178,90 @@ pub fn get_all_forge_accounts() -> anyhow::Result<Vec<ForgeUser>> {
 #[cfg(test)]
 mod tests {
     use super::{
-        ForgeName, ForgeUser, match_host_to_accounts_custom_host, normalize_host_for_comparison,
+        ForgeName, ForgeUser, derive_forge_repo_info, match_host_to_accounts_custom_host,
+        normalize_host_for_comparison, resolve_forge_name,
     };
+
+    #[test]
+    fn forge_override_resolves_unrecognized_self_hosted_host() {
+        // The #14319 regression: a self-hosted host matches no built-in forge
+        // and (here) no account, so the project's saved override is the only
+        // thing that can identify it. Without the override this returns `None`
+        // and the UI reports "No forge could be determined".
+        assert_eq!(
+            resolve_forge_name("git.selfhosted.example", Some(ForgeName::GitLab), Vec::new),
+            Some(ForgeName::GitLab)
+        );
+    }
+
+    #[test]
+    fn detected_host_wins_over_override() {
+        // A recognizable host is authoritative - the override must never
+        // override a forge we can already identify from the URL. Here the host
+        // is GitLab and the (contradictory) override is GitHub; GitLab wins.
+        assert_eq!(
+            resolve_forge_name("gitlab.com", Some(ForgeName::GitHub), Vec::new),
+            Some(ForgeName::GitLab)
+        );
+    }
+
+    #[test]
+    fn matching_account_wins_over_override() {
+        // A configured account whose custom host matches is a stronger signal
+        // than a saved preference, so it takes precedence over the override.
+        let accounts = vec![ForgeUser::GitLab(
+            but_gitlab::GitlabAccountIdentifier::selfhosted("bob", "gl.example.com"),
+        )];
+        assert_eq!(
+            resolve_forge_name("gl.example.com", Some(ForgeName::GitHub), || accounts
+                .clone()),
+            Some(ForgeName::GitLab)
+        );
+    }
+
+    #[test]
+    fn no_override_and_unknown_host_resolves_to_none() {
+        assert_eq!(
+            resolve_forge_name("git.selfhosted.example", None, Vec::new),
+            None
+        );
+    }
+
+    #[test]
+    fn derive_repo_info_uses_override_for_self_hosted_url() {
+        // End-to-end for #14319, exercising the real parse -> provider_info ->
+        // resolve path (not just the host->forge helper): a self-hosted URL that
+        // host detection can't classify still yields a `ForgeRepoInfo` via the
+        // override, with owner/repo parsed from the URL. Guards the ordering trap
+        // that the override is only consulted *after* `provider_info()` succeeds -
+        // if `GenericProvider` rejected this URL shape the fix would silently
+        // no-op. (The account lookup finds nothing for this synthetic host, so
+        // the result is deterministic regardless of locally-configured accounts.)
+        let info = derive_forge_repo_info(
+            "https://git.selfhosted.example/group/repo.git",
+            Some(ForgeName::GitLab),
+        )
+        .expect("override should resolve the forge for an otherwise-unknown host");
+        assert_eq!(info.forge, ForgeName::GitLab);
+        assert_eq!(info.owner, "group");
+        assert_eq!(info.repo, "repo");
+        assert_eq!(info.protocol, "https");
+    }
+
+    #[test]
+    fn from_override_str_is_case_and_whitespace_insensitive() {
+        assert_eq!(
+            ForgeName::from_override_str("gitlab"),
+            Some(ForgeName::GitLab)
+        );
+        assert_eq!(
+            ForgeName::from_override_str("  GitLab "),
+            Some(ForgeName::GitLab)
+        );
+        // "default" (the unset sentinel) and anything unrecognized are no-override.
+        assert_eq!(ForgeName::from_override_str("default"), None);
+        assert_eq!(ForgeName::from_override_str("subversion"), None);
+    }
 
     #[test]
     fn matches_github_enterprise_custom_host() {

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -364,7 +364,13 @@ async fn ensure_forge_authentication(ctx: &mut Context) -> Result<(), anyhow::Er
             ctx,
             ctx.shared_worktree_access().read_permission(),
         )?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+        let forge_repo_info = but_forge::derive_forge_repo_info(
+            &base_branch.remote_url,
+            ctx.legacy_project
+                .forge_override
+                .as_deref()
+                .and_then(but_forge::ForgeName::from_override_str),
+        );
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
             forge_repo_info,


### PR DESCRIPTION
Fixes #14319. Opening as a **draft** for review — the direction was confirmed by the maintainer investigation in the issue and by the reporter, so I'd welcome a self-hosted test and any steer on the shape before marking it ready.

## Bug
0.20.1 regressed self-hosted GitLab: a project with `forge_override = gitlab` shows "No forge could be determined" and the GitLab settings section disappears.

## Cause
547b873 moved forge resolution into Rust, but `but_forge::derive_forge_repo_info(url)` never consumed the project's `forge_override`. For a self-hosted host that isn't a recognized keyword (`gitlab.com`/`gitlab.*`) and before an account is configured, it returns `None` — so `forge_info()` returns `None` and `ForgeForm.svelte` hides the GitLab config (gated on `forgeInfo?.name === "gitlab"`).

## Fix
Resolve the forge type in one place, `resolve_forge_name`, in priority order:
1. the URL host (`github.com`, `gitlab.*`, …),
2. a configured account whose custom host matches,
3. the project's saved `forge_override` — **last resort**, mirroring pre-0.20.1's `if forgeType === "default" && forgeOverride`.

A recognized host or a matching account always wins, so a stale override can't mislabel a repo whose forge is already known. Owner/repo still come from the URL's `GenericProvider` regardless of how the type is resolved, so the override path produces the same `ForgeRepoInfo` the account path would.

The override (`legacy_project.forge_override`) is threaded through `forge_info`, `compare_branch_url`, and the forge API paths in but-api and the CLI auth path. The pure-URL identity comparison (`remote_urls_match`) passes `None`.

## Tests
- `resolve_forge_name` precedence — the override resolves a self-hosted host; a recognized host and a matching account each win over the override; none → `None`
- end-to-end `derive_forge_repo_info` on a self-hosted URL (owner/repo parsed correctly)
- `build_base_url` builds the self-hosted web URL from the override-derived info
- `from_override_str` is case/whitespace-insensitive

`cargo check --workspace` and clippy are clean.

## Notes / open questions
- Host detection is substring-based, so a self-hosted host embedding another forge's domain (e.g. `git.azure.company.com`) is still detected as that forge and the override won't correct it — a pre-existing limitation, left out of scope here.
- Account-vs-override ordering: a configured account (which carries credentials) is treated as authoritative over the saved preference. This doesn't affect the reported case (no account configured).
- I threaded an `Option<ForgeName>` parameter through `derive_forge_repo_info` and its callers; happy to switch to a centralized `ctx`-level helper if that's preferred.

The reporter offered to test a build on their self-hosted instance — that would be the strongest confirmation.