### PR TITLE
feat(but): add help topics via `but help <topic>`

### DIFF
--- a/crates/but-clap/src/generator.rs
+++ b/crates/but-clap/src/generator.rs
@@ -95,6 +95,26 @@ pub fn generate_command_mdx(cmd: &Command) -> String {
     replace_rustdoc_hyperlinks(&output)
 }
 
+pub fn generate_topic_mdx(cmd: &Command, path: &[&str]) -> String {
+    let mut output = String::new();
+    let command_path = path.join(" ");
+    let title = format!("`but {command_path}`");
+    let (description, remaining_body) = get_description_and_body(cmd);
+
+    output.push_str("---\n");
+    output.push_str(&format!("title: \"{title}\"\n"));
+    output.push_str(&format!("description: \"{description}\"\n"));
+    output.push_str("---\n\n");
+
+    if let Some(body) = remaining_body {
+        output.push_str(&format!("{body}\n\n"));
+    }
+
+    output.push_str(&format!("**Usage:** `but {command_path}`\n\n"));
+
+    replace_rustdoc_hyperlinks(&output)
+}
+
 fn replace_rustdoc_hyperlinks(input: &str) -> String {
     let mut output = String::with_capacity(input.len());
     let mut remaining = input;

--- a/crates/but-clap/src/main.rs
+++ b/crates/but-clap/src/main.rs
@@ -29,6 +29,28 @@ fn main() -> Result<()> {
         println!("Generated: {file_path:?}");
     }
 
+    // Generate documentation for each help topic.
+    if let Some(help_command) = app
+        .get_subcommands()
+        .find(|subcommand| subcommand.get_name() == "help")
+    {
+        for topic_command in help_command.get_subcommands() {
+            if topic_command.is_hide_set() {
+                continue;
+            }
+
+            let topic_name = topic_command.get_name();
+            let file_path = docs_dir.join(format!("but-help-{topic_name}.mdx"));
+            let mdx_content = generator::generate_topic_mdx(
+                topic_command,
+                &[help_command.get_name(), topic_command.get_name()],
+            );
+            fs::write(&file_path, mdx_content)
+                .with_context(|| format!("Failed to write topic documentation to {file_path:?}"))?;
+            println!("Generated: {file_path:?}");
+        }
+    }
+
     println!("\nDocumentation generation complete!");
     Ok(())
 }

--- a/crates/but-clap/tests/mdx_generation.rs
+++ b/crates/but-clap/tests/mdx_generation.rs
@@ -326,3 +326,50 @@ fn test_replaces_rustdoc_hyperlink_in_long_about_with_mdx_compatible_link() {
         "Rustdoc (raw markdown) hyperlink replaced with MDX compatible link"
     );
 }
+
+#[test]
+fn test_help_topic_mdx_generation() {
+    use clap::CommandFactory;
+
+    let cmd = but::args::Args::command();
+    let help = cmd
+        .get_subcommands()
+        .find(|subcommand| subcommand.get_name() == "help")
+        .expect("help command exists");
+    let topic = help
+        .get_subcommands()
+        .find(|subcommand| subcommand.get_name() == "cli-ids")
+        .expect("CLI IDs topic command exists");
+    let mdx = but_clap::generator::generate_topic_mdx(topic, &[help.get_name(), topic.get_name()]);
+
+    assert!(mdx.contains("title: \"`but help cli-ids`\""));
+    assert!(mdx.contains("description: \"Smart IDs to reference commits, branches and more"));
+    assert!(mdx.contains("Most but not all commands accept CLI IDs"));
+    assert!(mdx.contains("**Usage:** `but help cli-ids`"));
+}
+
+#[test]
+fn test_help_topic_doc_filenames_are_unique() {
+    use std::collections::HashSet;
+
+    use clap::CommandFactory;
+
+    let cmd = but::args::Args::command();
+    let help = cmd
+        .get_subcommands()
+        .find(|subcommand| subcommand.get_name() == "help")
+        .expect("help command exists");
+
+    let mut filenames = HashSet::new();
+    for topic in help.get_subcommands() {
+        let filename = format!("but-help-{}.mdx", topic.get_name());
+        assert!(
+            !filename.is_empty(),
+            "topic doc filename should not be empty"
+        );
+        assert!(
+            filenames.insert(filename),
+            "topic doc filenames should be unique"
+        );
+    }
+}

--- a/crates/but/src/args/commit2.rs
+++ b/crates/but/src/args/commit2.rs
@@ -39,6 +39,8 @@ pub struct Platform {
     /// If `BRANCH` is omitted, an unstacked branch with a generated name is created.
     ///
     /// Attempting to place a commit on a branch that exists but is not applied is an error.
+    ///
+    /// Takes a CLI ID, see `but help cli-ids` for details.
     #[clap(short, long, value_name = "BRANCH", group = "targeting")]
     pub branch: Option<Option<CliIdArg>>,
 
@@ -49,6 +51,8 @@ pub struct Platform {
     ///
     /// If `BRANCH_OR_COMMIT` is a branch, the new commit is placed on a new branch above the
     /// targeted branch.
+    ///
+    /// Takes a CLI ID, see `but help cli-ids` for details.
     #[clap(
         short = 'A',
         long,
@@ -65,6 +69,8 @@ pub struct Platform {
     /// If `BRANCH_OR_COMMIT` is a branch, the new commit is placed on a new branch below the
     /// targeted branch. Branches are treated as buckets, meaning that "below a branch" is treated
     /// as below the oldest ancestor on that branch.
+    ///
+    /// Takes a CLI ID, see `but help cli-ids` for details.
     #[clap(
         short = 'B',
         long,
@@ -84,6 +90,8 @@ pub struct Platform {
     /// One or more changes to commit.
     ///
     /// A change can either be a file or a hunk.
+    ///
+    /// Takes CLI IDs, see `but help cli-ids` for details.
     #[clap(group = "changes_to_commit")]
     pub changes: Vec<CliIdArg>,
 }

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -112,6 +112,52 @@ impl OutputFormat {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::Subcommand)]
+pub enum HelpTopic {
+    /// Smart IDs to reference commits, branches and more in `but`.
+    ///
+    /// CLI IDs are used by `but` to reference things such as commits, branches and files. While
+    /// obvious identifiers like full commit hashes and entire branch names are viable CLI IDs,
+    /// there are also various shorter identifiers that can be used in place of the full names.
+    ///
+    /// In general, `but status` will show all currently available CLI IDs in front of the "thing".
+    ///
+    /// Typical CLI IDs include:
+    ///
+    /// * **Commit:** The first few characters of the commit hash
+    /// * **Branch:** A couple of characters from the branch name
+    /// * **Uncommitted file:** A path-derived ID that's typically 2-3 characters
+    /// * **Uncommitted hunk:** `<uncommitted_file_cli_id>:<hunk_cli_id>`
+    ///     - Run `but diff` to show all current uncommitted hunks and their IDs
+    /// * **Uncommitted area:** Always `zz`
+    /// * **Committed file:** `<commit_cli_id>:<file_cli_id>`
+    ///     - Run `but status -f` to show committed files
+    ///
+    /// CLI IDs depend on the context and may change if the context changes, such as when new data
+    /// is written to files, commits are made or rearranged and branches are created or deleted.
+    ///
+    /// Most but not all commands accept CLI IDs to perform various actions. See the documentation
+    /// for the individual command (`but <command> --help`) for details on how to use CLI IDs for
+    /// that command in particular.
+    #[clap(name = "cli-ids")]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
+    CliIds,
+}
+
+impl HelpTopic {
+    pub fn name(self) -> &'static str {
+        match self {
+            HelpTopic::CliIds => "cli-ids",
+        }
+    }
+
+    pub fn title(self) -> &'static str {
+        match self {
+            HelpTopic::CliIds => "CLI IDs",
+        }
+    }
+}
+
 #[derive(
     Debug, clap::Subcommand, strum::VariantNames, strum::AsRefStr, strum::EnumDiscriminants,
 )]
@@ -1346,15 +1392,19 @@ pub enum Subcommands {
         cmd: but_agentlog::Command,
     },
 
-    /// Show help information grouped by category.
+    /// Show help information.
     ///
-    /// Displays all available commands organized into functional categories
+    /// Without a topic, displays all available commands organized into functional categories
     /// such as Inspection, Branching and Committing, Server Interactions, etc.
     ///
-    /// This is equivalent to running `but -h` to see the command overview.
+    /// With a topic, displays help for that topic, such as `but help cli-ids`.
     #[clap(hide = true)]
     #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
-    Help,
+    Help {
+        /// Help topic to show.
+        #[clap(subcommand)]
+        topic: Option<HelpTopic>,
+    },
 
     /// INTERNAL: First-run onboarding that shows metrics info and marks onboarding complete.
     ///

--- a/crates/but/src/args/move2.rs
+++ b/crates/but/src/args/move2.rs
@@ -41,6 +41,8 @@ pub struct Platform {
     /// If `BRANCH` is provided, `<SOURCES>` must be either commits or committed files.
     ///
     /// Attempting to place `<SOURCES>` on a branch that exists but is not applied is an error.
+    ///
+    /// Takes a CLI ID, see `but help cli-ids` for details.
     #[clap(short, long, value_name = "BRANCH")]
     pub branch: Option<Option<CliIdArg>>,
     /// Place `<SOURCES>` above `BRANCH_OR_COMMIT`, which must be an applied branch or commit.
@@ -52,6 +54,8 @@ pub struct Platform {
     /// branch.
     ///
     /// This target is applicable for all kinds of `<SOURCES>`.
+    ///
+    /// Takes a CLI ID, see `but help cli-ids` for details.
     #[clap(short = 'A', long, value_name = "BRANCH_OR_COMMIT")]
     pub above: Option<CliIdArg>,
     /// Place `<SOURCES>` below `BRANCH_OR_COMMIT`, which must be an applied branch or commit.
@@ -64,6 +68,8 @@ pub struct Platform {
     /// the oldest ancestor on that branch.
     ///
     /// This target is only applicable for `<SOURCES>` that are commits or committed files.
+    ///
+    /// Takes a CLI ID, see `but help cli-ids` for details.
     #[clap(short = 'B', long, value_name = "BRANCH_OR_COMMIT")]
     pub below: Option<CliIdArg>,
     /// Unstack `<SOURCES>` from their current stacks.
@@ -88,6 +94,8 @@ pub struct Platform {
     ///
     /// Providing any of the sources as an argument for a target such as `--above` or `--below` is
     /// an error.
+    ///
+    /// Takes CLI IDs, see `but help cli-ids` for details.
     #[clap(required = true)]
     pub sources: Vec<CliIdArg>,
 }

--- a/crates/but/src/args/squash2.rs
+++ b/crates/but/src/args/squash2.rs
@@ -59,6 +59,8 @@ pub struct Platform {
     /// If `TARGET` is a branch the sources will be added to the first commit on the branch.
     ///
     /// If `TARGET` is the uncommitted area (`zz`) the sources will be uncommitted.
+    ///
+    /// Takes a CLI ID, see `but help cli-ids` for details.
     #[clap(long, short)]
     pub target: Option<CliIdArg>,
 
@@ -84,6 +86,8 @@ pub struct Platform {
     ///
     /// It is not possible to mix sources of different types, i.e., all sources must either be
     /// commits, branches, uncommitted files, `zz`, or committed files.
+    ///
+    /// Takes CLI IDs, see `but help cli-ids` for details.
     #[clap(required = true)]
     pub sources: Vec<CliIdArg>,
 }

--- a/crates/but/src/args/tests.rs
+++ b/crates/but/src/args/tests.rs
@@ -332,6 +332,41 @@ fn clap() {
     Args::command().debug_assert();
 }
 
+#[test]
+fn help_parses_without_topic() {
+    use clap::Parser;
+
+    let args = Args::try_parse_from(["but", "help"]).expect("parse help args");
+
+    match args.cmd.expect("subcommand") {
+        Subcommands::Help { topic } => assert_eq!(topic, None),
+        _ => panic!("unexpected command shape"),
+    }
+}
+
+#[test]
+fn help_parses_cli_ids_topic() {
+    use clap::Parser;
+
+    let args = Args::try_parse_from(["but", "help", "cli-ids"]).expect("parse help topic args");
+
+    match args.cmd.expect("subcommand") {
+        Subcommands::Help { topic } => assert_eq!(topic, Some(HelpTopic::CliIds)),
+        _ => panic!("unexpected command shape"),
+    }
+}
+
+#[test]
+fn help_rejects_unknown_topic() {
+    use clap::Parser;
+
+    let err = Args::try_parse_from(["but", "help", "unknown-topic"]).expect_err("reject topic");
+    assert!(
+        err.to_string().contains("unknown-topic"),
+        "rejected topic should appear in clap error"
+    );
+}
+
 #[cfg(feature = "legacy")]
 #[test]
 fn status_short_is_hidden_noop_compatibility_flag() {

--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -1,7 +1,7 @@
 use indexmap::IndexMap;
 use strum::IntoEnumIterator as _;
 
-use crate::args::{Args, SubcommandDiscriminant};
+use crate::args::{Args, HelpTopic, SubcommandDiscriminant};
 use crate::theme::{self, Paint};
 use crate::tui::text::{terminal_width, truncate_text};
 use crate::utils::{OutputChannel, envs};
@@ -29,9 +29,46 @@ impl std::fmt::Display for Group {
     }
 }
 
+pub fn print(out: &mut OutputChannel, topic: Option<HelpTopic>) -> std::fmt::Result {
+    match topic {
+        Some(topic) => print_topic(out, topic),
+        None => print_grouped(out),
+    }
+}
+
 pub fn print_grouped(out: &mut OutputChannel) -> std::fmt::Result {
     let allow_truncation = out.format().allows_truncation();
     print_grouped_with_truncation(out, allow_truncation)
+}
+
+fn print_topic(out: &mut OutputChannel, topic: HelpTopic) -> std::fmt::Result {
+    use clap::CommandFactory;
+    use std::fmt::Write;
+
+    let mut cmd = Args::command();
+    let topic_command = cmd
+        .find_subcommand_mut("help")
+        .and_then(|help| help.find_subcommand_mut(topic.name()))
+        .expect("all help topics have clap command metadata");
+
+    let t = theme::get();
+    writeln!(out, "{}", t.important.paint(topic.title()))?;
+    writeln!(out)?;
+
+    // We can't easily hook into Clap's colorize choice. It's only implemented in
+    // `Command::print_long_help()` and that forces use of `std::io::Stdout`, side-stepping our
+    // OutputChannel implementation.
+    //
+    // A full implementation here would entail using `anstream::AutoStream` along with
+    // `Command::get_color()` and map that to `anstream::ColorChoice`. But just checking if the
+    // output is a terminal is generally sufficient as all modern terminals support ANSI escape
+    // codes, so we'll stay with this simple solution for now.
+    let long_help = topic_command.render_long_help();
+    if out.is_terminal() {
+        writeln!(out, "{}", long_help.ansi())
+    } else {
+        writeln!(out, "{long_help}")
+    }
 }
 
 fn print_grouped_with_truncation(
@@ -239,6 +276,33 @@ fn print_grouped_with_truncation(
         writeln!(out)?;
     }
 
+    if let Some(help_command) = clap_subcommands
+        .iter()
+        .find(|subcommand| subcommand.get_name() == "help")
+    {
+        writeln!(
+            out,
+            "{} (view with {}):",
+            t.important.paint("Help Topics"),
+            t.important.paint("but help <topic>")
+        )?;
+        for topic_command in help_command.get_subcommands() {
+            if topic_command.is_hide_set() {
+                continue;
+            }
+            let about = topic_command.get_about().unwrap_or_default().to_string();
+            let available_width = terminal_width.saturating_sub(LONGEST_COMMAND_LEN_AND_ELLIPSIS);
+            let truncated_about = truncate_text(&about, available_width);
+            writeln!(
+                out,
+                "  {:<LONGEST_COMMAND_LEN$}{}",
+                t.success.paint(topic_command.get_name()),
+                truncated_about,
+            )?;
+        }
+        writeln!(out)?;
+    }
+
     // Add command completion instructions
     writeln!(
         out,
@@ -361,6 +425,9 @@ Other Commands:
   agent        Set up GitButler for AI coding agents
   completions  Generate but shell completions
 
+Help Topics (view with but help <topic>):
+  cli-ids      Smart IDs to reference commits, branches and more in but
+
 To add command completion, add this to your shell rc: (for example ~/.zshrc)
   eval "$(but completions zsh)"
 
@@ -433,6 +500,9 @@ Other Commands:
   skill        Manage AI agent skills for GitButler
   agent        Set up GitButler for AI coding agents
   completions  Generate but shell completions
+
+Help Topics (view with but help <topic>):
+  cli-ids      Smart IDs to reference commits, branches and more in but
 
 To add command completion, add this to your shell rc: (for example ~/.zshrc)
   eval "$(but completions zsh)"

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -157,9 +157,11 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
         return Ok(());
     }
 
-    // Handle `but help -h` and `but help --help` to show the grouped help output
-    if args_vec.iter().any(|arg| arg == "help")
-        && args_vec.iter().any(|arg| arg == "--help" || arg == "-h")
+    // Handle bare `but help -h` and `but help --help` to show the grouped help output.
+    // Topic help flags, like `but help cli-ids --help`, are left to clap.
+    if args_vec.len() == 3
+        && args_vec[1] == "help"
+        && matches!(args_vec[2].as_str(), "--help" | "-h")
     {
         let mut out = OutputChannel::new(early_help_format(&args));
         command::help::print_grouped(&mut out)?;
@@ -412,8 +414,8 @@ async fn match_subcommand(
                 .emit_metrics(metrics_ctx)
                 .map_err(CliError::from)
         }
-        Subcommands::Help => {
-            command::help::print_grouped(out)?;
+        Subcommands::Help { topic } => {
+            command::help::print(out, topic)?;
             Ok(())
         }
         Subcommands::Onboarding => command::onboarding::handle(out).map_err(CliError::from),

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -181,7 +181,7 @@ impl Subcommands {
                 _ => Unknown,
             },
             Subcommands::Completions { .. } => Completions,
-            Subcommands::Help => Unknown,
+            Subcommands::Help { .. } => Unknown,
             Subcommands::Alias(alias_args::Platform { cmd }) => match cmd {
                 None | Some(alias_args::Subcommands::List) => AliasCheck,
                 Some(alias_args::Subcommands::Add { .. }) => AliasAdd,

--- a/crates/but/src/utils/output_channel.rs
+++ b/crates/but/src/utils/output_channel.rs
@@ -200,7 +200,12 @@ impl OutputChannel {
     ///
     /// Note that this is implied to be true if [Self::prepare_for_terminal_input()] returns `Some()`.
     pub fn can_prompt(&self) -> bool {
-        self.format.allows_human_ui() && std::io::stdin().is_terminal() && self.stdout.is_terminal()
+        self.format.allows_human_ui() && std::io::stdin().is_terminal() && self.is_terminal()
+    }
+
+    /// Return `true` if this channel is connected to a terminal.
+    pub fn is_terminal(&self) -> bool {
+        self.stdout.is_terminal()
     }
 
     /// Before performing further output, obtain an input channel which always bypasses the pager when writing,


### PR DESCRIPTION
Adds in help topics via `but help <topic>`. This way, we can refer to `but help <topic>` instead of describing it at length in every single command.