### PR TITLE
fix(desktop): show update banner again on manual check after dismiss (#12898)

### DIFF
--- a/apps/desktop/src/components/shared/AppUpdater.test.ts
+++ b/apps/desktop/src/components/shared/AppUpdater.test.ts
@@ -63,11 +63,34 @@ describe("AppUpdater", () => {
 		expect(button).toBeVisible();
 	});
 
+	test("should display download button again on manual check after dismiss", async () => {
+		vi.spyOn(backend, "checkUpdate").mockReturnValue(
+			mockUpdate({
+				version: "1",
+				body: "release notes",
+			}),
+		);
+
+		render(AppUpdater, { context });
+		await vi.advanceTimersToNextTimerAsync();
+
+		expect(screen.getByTestId("download-update")).toBeVisible();
+
+		updater.dismiss();
+		await vi.advanceTimersToNextTimerAsync();
+		expect(screen.queryByTestId("update-banner")).toBe(null);
+
+		await updater.checkForUpdate(true);
+		await vi.advanceTimersToNextTimerAsync();
+
+		expect(screen.getByTestId("download-update")).toBeVisible();
+	});
+
 	test("should display up-to-date on manual check", async () => {
 		vi.spyOn(backend, "checkUpdate").mockReturnValue(mockUpdate(null));
 		const { getByTestId } = render(AppUpdater, { context });
-		updater.checkForUpdate(true);
 		await vi.advanceTimersToNextTimerAsync();
+		await updater.checkForUpdate(true);
 
 		const button = getByTestId("got-it");
 		expect(button).toBeVisible();

--- a/apps/desktop/src/lib/updater/updater.test.ts
+++ b/apps/desktop/src/lib/updater/updater.test.ts
@@ -73,6 +73,30 @@ describe("Updater", () => {
 		expect(update2).toHaveProperty("releaseNotes", body);
 	});
 
+	test("should prompt again on manual check after dismiss", async () => {
+		const version = "1";
+		const body = "release notes";
+
+		vi.spyOn(backend, "checkUpdate").mockReturnValue(
+			mockUpdate({
+				version,
+				body,
+			}),
+		);
+		await updater.checkForUpdate();
+		expect(get(updater.update)).toHaveProperty("version", version);
+
+		updater.dismiss();
+		expect(get(updater.update)).toMatchObject({});
+
+		await updater.checkForUpdate();
+		expect(get(updater.update)).toMatchObject({});
+
+		await updater.checkForUpdate(true);
+		expect(get(updater.update)).toHaveProperty("version", version);
+		expect(get(updater.update)).toHaveProperty("releaseNotes", body);
+	});
+
 	test("should not prompt download for seen version", async () => {
 		const version = "1";
 		const body = "release notes";

--- a/apps/desktop/src/lib/updater/updater.ts
+++ b/apps/desktop/src/lib/updater/updater.ts
@@ -107,6 +107,7 @@ export class UpdaterService {
 			handleError(err, manual);
 		} finally {
 			this.loading.set(false);
+			this.manualCheck = false;
 		}
 	}
 
@@ -121,8 +122,9 @@ export class UpdaterService {
 			return;
 		}
 
+		const isUnseenVersion = update.version !== this.seenVersion;
 		if (
-			update.version !== this.seenVersion &&
+			(isUnseenVersion || this.manualCheck) &&
 			update.currentVersion !== "0.0.0" // DEV mode.
 		) {
 			this.backendDownload = async (onEvent) => await update.download(onEvent);


### PR DESCRIPTION
## 🧢 Changes

Fix **Check for updates** so the update banner reappears after the user dismissed it.

- Show the banner on manual checks even when `seenVersion` matches (`isUnseenVersion || manualCheck`).
- Reset `manualCheck` in the `finally` block of `checkForUpdate` so it only applies to the current call.

Add unit and component tests for the dismiss → manual-check flow.

Also adjust the existing `should display up-to-date on manual check` test in `AppUpdater.test.ts` (see Reasoning).

## ☕️ Reasoning

Dismissing the banner clears the UI but leaves `seenVersion` set, which correctly suppresses background auto-checks for a version the user already saw. **Check for updates** is explicit though.

Manual checks now bypass the `seenVersion` gate. Auto-check behaviour is unchanged.

**`AppUpdater.test.ts`:** The existing `should display up-to-date on manual check` test is unrelated to the dismiss bug, but it started failing with this PR. On render, `AppUpdater` triggers a background auto-check; the test also fires a manual check. Resetting `manualCheck` in `finally` means a late-finishing mount auto-check can wipe the manual result. The fix is to let the mount auto-check finish first (`advanceTimersToNextTimerAsync`), then run the manual check which is also the same pattern as the other tests in that file.

**Manual testing:** The unit/component tests mock `checkUpdate`, but clicking through in `pnpm dev:desktop` is not possible without workarounds: the real Tauri `checkUpdate` hangs indefinitely in dev. For local click-through I temporarily stubbed `checkUpdate` behind `VITE_STUB_UPDATER=true` so it returned a fake update (`99.99.99-stub`) immediately. Flow tested: banner on startup → dismiss → **File → Check for updates…**. With the fix commented out, the banner stayed hidden (bug). With the fix restored, it reappeared. The stub was removed before this PR.

## 🎫 Affected issues

Fixes: #12898