### PR TITLE
Don't error when setting PR metadata in single branch mode

### DIFF
--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -2,7 +2,7 @@ use anyhow::{Context as _, Result};
 use but_core::{RepositoryExt, extract_remote_name_and_short_name, ref_metadata::StackId};
 use but_ctx::{Context, access::RepoShared};
 use gitbutler_git::{GitContextExt as _, PushResult};
-use gitbutler_operating_modes::ensure_open_workspace_mode;
+use gitbutler_operating_modes::{ensure_open_workspace_mode, in_open_workspace_mode};
 use gitbutler_oplog::{
     OplogExt, SnapshotExt,
     entry::{OperationKind, SnapshotDetails},
@@ -128,14 +128,18 @@ pub fn update_branch_pr_number(
     pr_number: Option<usize>,
 ) -> Result<()> {
     let mut guard = ctx.exclusive_worktree_access();
+    // In single branch mode there's no open workspace, so there's no stack
+    // metadata to update — just no-op instead of erroring out.
+    if !in_open_workspace_mode(ctx, guard.read_permission())? {
+        // TODO: Write the metadata somewhere else.
+        return Ok(());
+    }
     // Pure metadata write — skip verify so background syncs aren't
     // blocked when HEAD is off the workspace ref (e.g. edit mode).
     let _ = ctx.create_snapshot(
         SnapshotDetails::new(OperationKind::UpdateDependentBranchPrNumber),
         guard.write_permission(),
     );
-    ensure_open_workspace_mode(ctx, guard.read_permission())
-        .context("Requires an open workspace mode")?;
     let mut stack = ctx.virtual_branches().get_stack(stack_id)?;
     stack.set_pr_number(ctx, &branch_name, pr_number)
 }


### PR DESCRIPTION
## 🧢 Changes

`update_branch_pr_number` previously asserted open-workspace mode via `ensure_open_workspace_mode`, which errored out in single branch mode. It now checks `in_open_workspace_mode` and no-ops (returns `Ok(())`) when there's no open workspace instead of failing.

## ☕️ Reasoning

In single branch mode (PGM) there is no stack metadata to update, so the operation should silently succeed rather than surface an error to the user.

## 🎫 Affected issues

