### PR TITLE
caleb/fix-remote-only-segments-in-workspace

### DIFF
--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -1038,6 +1038,10 @@ impl Graph {
             .and_then(|first_commit| s.ref_info.take().map(|rn| (rn, first_commit)))
         {
             first_commit.refs.push(rn);
+            // The upstream belonged to the ref that now lives on the commit -
+            // a detached HEAD has none.
+            s.remote_tracking_ref_name = None;
+            s.remote_tracking_branch_segment_id = None;
         }
         Ok(())
     }

--- a/crates/but-graph/src/projection/workspace/init.rs
+++ b/crates/but-graph/src/projection/workspace/init.rs
@@ -418,6 +418,7 @@ impl Graph {
         } else {
             let start = &self[frame.ws_tip_segment_id];
             let has_seen_base = RefCell::new(false);
+            let discarded_base_only_stack = RefCell::new(false);
             let maybe_stack = self
                 .collect_stack_segments(
                     start.id,
@@ -443,8 +444,15 @@ impl Graph {
                         }
                     },
                     |_s| !*has_seen_base.borrow(),
-                    // Never discard stacks
-                    |_s| false,
+                    // A detached HEAD parked exactly on the base has no branch container
+                    // to show - don't mint a stack for it, mirroring the managed path's
+                    // base-segment discard.
+                    |s| {
+                        let discard =
+                            Some(s.id) == frame.lower_bound_segment_id && s.ref_info.is_none();
+                        discarded_base_only_stack.replace(discard);
+                        discard
+                    },
                 )?
                 .map(|segments| {
                     Stack::from_base_and_segments(
@@ -455,7 +463,7 @@ impl Graph {
                 });
             if let Some(stack) = maybe_stack {
                 stacks.push(stack);
-            } else {
+            } else if !*discarded_base_only_stack.borrow() {
                 tracing::warn!(
                     "Didn't get a single stack for AdHoc workspace - this is unexpected"
                 );

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -1671,4 +1671,13 @@ EOF
        commit x2
      create_workspace_commit_once X
   )
+
+  # HEAD is detached at the tip of the target's local tracking branch,
+  # like after `git switch main --detach`.
+  git init detached-head-at-target
+  (cd detached-head-at-target
+     commit M1
+     setup_target_to_match_main
+     git checkout --detach main
+  )
 )

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -7700,11 +7700,12 @@ fn remote_ref_as_stack_top() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// `git switch main --detach` with a configured target produces a stack whose single
-/// segment has neither a ref name (`HEAD` is detached so the segment is anonymized)
-/// nor any commits (they are all integrated), while still carrying the remote tracking
-/// branch of the ref it was detached from.
-/// Ideally, such a segment would either be named or have at least one commit.
+/// `git switch main --detach` with a configured target must not produce a stack whose
+/// single segment has neither a ref name (`HEAD` is detached so the segment is anonymized)
+/// nor any commits (the stack is exactly the base), advertising only the upstream of the
+/// ref `HEAD` was detached from.
+/// Instead, the anonymized entrypoint doesn't keep `main`'s upstream, and the projection
+/// declines to mint the base-only stack in the first place.
 #[test]
 fn detached_head_at_target() -> anyhow::Result<()> {
     let (repo, mut meta) = read_only_in_memory_scenario("ws/detached-head-at-target")?;
@@ -7716,29 +7717,17 @@ fn detached_head_at_target() -> anyhow::Result<()> {
     insta::assert_snapshot!(graph_tree(&graph), @"
 
     └── ►:1[0]:origin/main →:0:
-        └── ►:0[1]:anon: <> origin/main →:1:
+        └── ►:0[1]:anon:
             └── 👉🏁·3183e43 (⌂|1) ►main
     ");
 
     let ws = graph.into_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @"
-    ⌂:0:DETACHED <> ✓refs/remotes/origin/main on 3183e43
-    └── ≡:0:anon: <> origin/main →:1: {1}
-        └── :0:anon: <> origin/main →:1:
-    ");
+    insta::assert_snapshot!(graph_workspace(&ws), @"⌂:0:DETACHED <> ✓refs/remotes/origin/main on 3183e43");
 
-    let segment = &ws.stacks[0].segments[0];
-    assert!(
-        segment.ref_name().is_none() && segment.commits.is_empty(),
-        "the current behavior: a segment with neither a name nor commits"
-    );
     assert_eq!(
-        segment
-            .remote_tracking_ref_name
-            .as_ref()
-            .map(|rn| rn.as_bstr()),
-        Some("refs/remotes/origin/main".into()),
-        "but it kept the remote tracking branch of the ref HEAD was detached from"
+        ws.stacks.len(),
+        0,
+        "a detached HEAD parked on the base has no stack to show"
     );
     Ok(())
 }

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -7699,3 +7699,46 @@ fn remote_ref_as_stack_top() -> anyhow::Result<()> {
     ");
     Ok(())
 }
+
+/// `git switch main --detach` with a configured target produces a stack whose single
+/// segment has neither a ref name (`HEAD` is detached so the segment is anonymized)
+/// nor any commits (they are all integrated), while still carrying the remote tracking
+/// branch of the ref it was detached from.
+/// Ideally, such a segment would either be named or have at least one commit.
+#[test]
+fn detached_head_at_target() -> anyhow::Result<()> {
+    let (repo, mut meta) = read_only_in_memory_scenario("ws/detached-head-at-target")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* 3183e43 (HEAD, origin/main, main) M1");
+
+    add_workspace(&mut meta);
+    let graph =
+        Graph::from_head(&repo, &*meta, project_meta(&*meta), standard_options())?.validated()?;
+    insta::assert_snapshot!(graph_tree(&graph), @"
+
+    └── ►:1[0]:origin/main →:0:
+        └── ►:0[1]:anon: <> origin/main →:1:
+            └── 👉🏁·3183e43 (⌂|1) ►main
+    ");
+
+    let ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    ⌂:0:DETACHED <> ✓refs/remotes/origin/main on 3183e43
+    └── ≡:0:anon: <> origin/main →:1: {1}
+        └── :0:anon: <> origin/main →:1:
+    ");
+
+    let segment = &ws.stacks[0].segments[0];
+    assert!(
+        segment.ref_name().is_none() && segment.commits.is_empty(),
+        "the current behavior: a segment with neither a name nor commits"
+    );
+    assert_eq!(
+        segment
+            .remote_tracking_ref_name
+            .as_ref()
+            .map(|rn| rn.as_bstr()),
+        Some("refs/remotes/origin/main".into()),
+        "but it kept the remote tracking branch of the ref HEAD was detached from"
+    );
+    Ok(())
+}

--- a/crates/but-rebase/src/graph_rebase/mod.rs
+++ b/crates/but-rebase/src/graph_rebase/mod.rs
@@ -462,9 +462,9 @@ impl RevisionHistory {
     }
 
     /// The commit mappings starts empty, and gets updated when we perform a cherry pick.
-    /// If there is no entry whose old `to` that cooresponds with the new
+    /// If there is no entry whose old `to` that corresponds with the new
     /// `from`, then we just add a `to <- from` entry.
-    /// If there is an entry whose old `to` that cooresponds with the new
+    /// If there is an entry whose old `to` that corresponds with the new
     /// `from`, then we replace `old_to <- old_from` with `new_to <- old_from`
     pub(crate) fn update_mapping(&mut self, from: gix::ObjectId, to: gix::ObjectId) {
         if let Some(value) = self.commit_mappings.remove(&from) {


### PR DESCRIPTION
The goal of this was to try and avoid showing an "empty" (IE no commits or local ref) `origin/master` segment in the workspace projection. A situation that seems to occur in a detached head scenario.

* Closes GB-1722

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #14674 
- <kbd>&nbsp;1&nbsp;</kbd> #14649 👈 
<!-- GitButler Footer Boundary Bottom -->

