### PR TITLE
Wire up the new uncommit changes API

### DIFF
--- a/apps/desktop/src/lib/stacks/stackEndpoints.test.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.test.ts
@@ -58,6 +58,52 @@ describe("buildStackEndpoints", () => {
 		});
 	});
 
+	test("maps uncommit changes to the multi-source API", () => {
+		const endpoints = buildStackEndpoints(createEndpointBuilder());
+		const query = endpoints.commitUncommitChangesFromCommits.query;
+
+		expect(endpoints.commitUncommitChangesFromCommits.extraOptions).toEqual({
+			command: "commit_uncommit_changes_from_commits",
+			actionName: "Uncommit Changes",
+		});
+		expect(query).toBeDefined();
+		expect(
+			query?.({
+				projectId: "project-1",
+				sources: [
+					{
+						commitId: "commit-1",
+						changes: [
+							{
+								previousPathBytes: null,
+								pathBytes: [102, 105, 108, 101, 46, 116, 120, 116],
+								hunkHeaders: [],
+							},
+						],
+					},
+				],
+				assignTo: "stack-1",
+				dryRun: false,
+			}),
+		).toEqual({
+			projectId: "project-1",
+			sources: [
+				{
+					commitId: "commit-1",
+					changes: [
+						{
+							previousPathBytes: null,
+							pathBytes: [102, 105, 108, 101, 46, 116, 120, 116],
+							hunkHeaders: [],
+						},
+					],
+				},
+			],
+			assignTo: "stack-1",
+			dryRun: false,
+		});
+	});
+
 	test("uses commit_move for generic commit moves", () => {
 		const endpoints = buildStackEndpoints(createEndpointBuilder());
 		const query = endpoints.commitMove.query;

--- a/apps/desktop/src/lib/stacks/stackEndpoints.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.ts
@@ -59,6 +59,8 @@ import type {
 	BranchCreatePlacement,
 	BranchCreateResult,
 	BranchRemoveResult,
+	UncommitChangesFromCommitsResult,
+	UncommitChangesSource,
 } from "@gitbutler/but-sdk";
 
 export type BranchParams = {
@@ -640,24 +642,22 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 				invalidatesList(ReduxTag.CommitChanges),
 			],
 		}),
-		commitUncommitChanges: build.mutation<
-			MoveChangesResult,
+		commitUncommitChangesFromCommits: build.mutation<
+			UncommitChangesFromCommitsResult,
 			{
 				projectId: string;
-				changes: DiffSpec[];
-				commitId: string;
+				sources: UncommitChangesSource[];
 				assignTo?: string;
 				dryRun: boolean;
 			}
 		>({
 			extraOptions: {
-				command: "commit_uncommit_changes",
+				command: "commit_uncommit_changes_from_commits",
 				actionName: "Uncommit Changes",
 			},
-			query: ({ projectId, changes, commitId, assignTo, dryRun }) => ({
+			query: ({ projectId, sources, assignTo, dryRun }) => ({
 				projectId,
-				changes,
-				commitId,
+				sources,
 				assignTo,
 				dryRun,
 			}),

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -619,10 +619,14 @@ export class StackService {
 		assignTo?: string;
 		dryRun: boolean;
 	}) {
-		const result = await this.backendApi.endpoints.commitUncommitChanges.mutate({
+		const result = await this.backendApi.endpoints.commitUncommitChangesFromCommits.mutate({
 			projectId: args.projectId,
-			changes: args.changes,
-			commitId: args.commitId,
+			sources: [
+				{
+					commitId: args.commitId,
+					changes: args.changes,
+				},
+			],
 			assignTo: args.assignTo,
 			dryRun: args.dryRun,
 		});

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -1186,6 +1186,9 @@ async fn handle_command(
             .and_then(|params| but_api::branch::branch_create_cmd(params).map(|r| json!(r))),
         "branch_remove" => deserialize_json(request.params)
             .and_then(|params| but_api::branch::branch_remove_cmd(params).map(|r| json!(r))),
+        "commit_uncommit_changes_from_commits" => {
+            commit::uncommit::commit_uncommit_changes_from_commits_cmd(request.params)
+        }
         // Async virtual branches commands (not yet migrated due to different pattern)
         "upstream_integration_statuses" => {
             let params = deserialize_json(request.params);

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -1,10 +1,12 @@
+use std::collections::HashMap;
 use std::fmt;
 
 use crate::theme::{self, Paint};
 use anyhow::bail;
 use bstr::BStr;
 use but_api::commit::types::{
-    CommitCreateResult, CommitMoveResult, CommitSquashResult, MoveChangesResult, UncommitResult,
+    CommitCreateResult, CommitMoveResult, CommitSquashResult, MoveChangesResult,
+    UncommitChangesSource, UncommitResult,
 };
 use but_core::{DiffSpec, DryRun, ref_metadata::StackId, sync::RepoExclusive};
 use but_ctx::Context;
@@ -1540,6 +1542,18 @@ pub(crate) fn handle_uncommit(
         return Ok(());
     }
 
+    // When every source is a committed file, uncommit them in a single batched
+    // operation. This lets the backend group the changes by commit and apply them
+    // in child-to-parent order, so callers can pass files from several commits
+    // (and in any order) without hitting stale commit IDs from intermediate
+    // rebases. Whole-commit sources keep the sequential `rub <source> zz` path.
+    if sources
+        .iter()
+        .all(|source| matches!(source, CliId::CommittedFile { .. }))
+    {
+        return uncommit_committed_files(ctx, out, &sources);
+    }
+
     // Call the main rub handler with "zz" as target
     handle(
         ctx,
@@ -1548,6 +1562,104 @@ pub(crate) fn handle_uncommit(
         "zz",
         MessageCombinationStrategy::KeepBoth,
     )
+}
+
+/// Uncommit one or more committed files as a single multi-source operation.
+///
+/// Committed-file ids are grouped by commit so each source commit yields a
+/// single [`UncommitChangesSource`] with all of its changes combined. This
+/// computes the diff specs for a commit in one pass and keeps the payload to one
+/// entry per commit; the backend then applies them child-to-parent in one editor
+/// session. Sources that could not be applied are reported best-effort without
+/// failing the whole operation.
+fn uncommit_committed_files(
+    ctx: &mut Context,
+    out: &mut OutputChannel,
+    sources: &[CliId],
+) -> anyhow::Result<()> {
+    // Group the requested paths by commit, preserving first-seen commit order.
+    let mut commit_order = Vec::new();
+    let mut paths_by_commit: HashMap<gix::ObjectId, Vec<&BStr>> = HashMap::new();
+    for source in sources {
+        let CliId::CommittedFile {
+            commit_id, path, ..
+        } = source
+        else {
+            unreachable!("uncommit_committed_files only handles committed files");
+        };
+        match paths_by_commit.get_mut(commit_id) {
+            Some(paths) => paths.push(path.as_ref()),
+            None => {
+                commit_order.push(*commit_id);
+                paths_by_commit.insert(*commit_id, vec![path.as_ref()]);
+            }
+        }
+    }
+
+    // One source per commit, with the changes for all of its paths combined.
+    let mut uncommit_sources = Vec::with_capacity(commit_order.len());
+    for commit_id in commit_order {
+        let paths = paths_by_commit
+            .remove(&commit_id)
+            .expect("commit id was just inserted");
+        uncommit_sources.push(UncommitChangesSource {
+            commit_id,
+            changes: file_changes_from_commit_paths(ctx, commit_id, &paths)?,
+        });
+    }
+
+    // One source per commit, so this is the number of commits we attempted.
+    let source_count = uncommit_sources.len();
+    let result = but_api::commit::uncommit::commit_uncommit_changes_from_commits(
+        ctx,
+        uncommit_sources,
+        None,
+        DryRun::No,
+    )?;
+
+    // The multi-source API is best-effort and returns `Ok` even when sources
+    // fail. If every commit failed, nothing was uncommitted, so fail the command
+    // (matching the old single-source behavior) rather than reporting success.
+    if result.failures.len() == source_count {
+        let repo = ctx.repo.get()?;
+        let details = result
+            .failures
+            .iter()
+            .map(|failure| {
+                format!(
+                    "{}: {}",
+                    shorten_object_id(&repo, failure.commit_id),
+                    failure.error
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        bail!("Failed to uncommit changes:\n{details}");
+    }
+
+    // Partial success: warn about the sources that could not be applied.
+    if !result.failures.is_empty()
+        && let Some(out) = out.for_human()
+    {
+        let t = theme::get();
+        let repo = ctx.repo.get()?;
+        for failure in &result.failures {
+            writeln!(
+                out,
+                "Warning: could not uncommit changes from {}: {}",
+                t.cli_id.paint(shorten_object_id(&repo, failure.commit_id)),
+                failure.error
+            )?;
+        }
+    }
+
+    if let Some(out) = out.for_human() {
+        writeln!(out, "Uncommitted changes")?;
+    } else if let Some(out) = out.for_json() {
+        out.write_value(serde_json::json!({"ok": true}))?;
+    }
+
+    Ok(())
 }
 
 /// Handler for `but amend <file>... <commit>` - runs `but rub <file> <commit>`
@@ -1998,12 +2110,24 @@ fn changes_for_stack_assignment(
 fn file_changes_from_commit(
     ctx: &Context,
     commit_oid: gix::ObjectId,
-    path: &bstr::BStr,
+    path: &BStr,
+) -> anyhow::Result<Vec<DiffSpec>> {
+    file_changes_from_commit_paths(ctx, commit_oid, std::slice::from_ref(&path))
+}
+
+/// Compute the combined diff specs for several `paths` in a single commit, using
+/// one workspace/db and [`DiffSpecBuilder`] setup for all of them.
+fn file_changes_from_commit_paths(
+    ctx: &Context,
+    commit_oid: gix::ObjectId,
+    paths: &[&BStr],
 ) -> anyhow::Result<Vec<DiffSpec>> {
     let context_lines = ctx.settings.context_lines;
     let (_guard, repo, ws, mut db) = ctx.workspace_and_db_mut()?;
     let mut builder = DiffSpecBuilder::new(&mut db, &repo, &ws, context_lines);
-    builder.push_changes_from_path_in_commit(path, commit_oid, "no parents")?;
+    for path in paths {
+        builder.push_changes_from_path_in_commit(path, commit_oid, "no parents")?;
+    }
     Ok(builder.into_diff_specs())
 }
 

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -58,6 +58,8 @@ mod r#switch;
 #[cfg(feature = "legacy")]
 mod teardown;
 #[cfg(feature = "legacy")]
+mod uncommit;
+#[cfg(feature = "legacy")]
 mod undo;
 #[cfg(feature = "legacy")]
 mod worktree;

--- a/crates/but/tests/but/command/uncommit.rs
+++ b/crates/but/tests/but/command/uncommit.rs
@@ -1,0 +1,483 @@
+//! Integration tests for `but uncommit` with multiple committed-file sources.
+//!
+//! These exercise the multi-source uncommit path, where several committed files
+//! (potentially from different commits and branches, in any order) are handed to
+//! the backend in a single batched operation. Each test asserts the `but status`
+//! tree and the file contents of the affected commits, both before and after the
+//! uncommit.
+
+use snapbox::str;
+
+use crate::{command::util::status_json_with_files as status_json, utils::Sandbox};
+
+/// Return the committed-file CLI id (e.g. `e8:nk`) for `file_path` in the commit
+/// at `commit_index` (newest-first) on `branch_name`.
+fn committed_file_id_in_commit(
+    status: &serde_json::Value,
+    branch_name: &str,
+    commit_index: usize,
+    file_path: &str,
+) -> Option<String> {
+    status["stacks"]
+        .as_array()?
+        .iter()
+        .flat_map(|stack| stack["branches"].as_array().unwrap().iter())
+        .find(|branch| branch["name"].as_str().unwrap() == branch_name)?["commits"]
+        .as_array()?
+        .get(commit_index)?["changes"]
+        .as_array()?
+        .iter()
+        .find_map(|change| {
+            (change["filePath"].as_str().unwrap() == file_path)
+                .then(|| change["cliId"].as_str().unwrap().to_string())
+        })
+}
+
+/// Whether `file_path` currently appears among the uncommitted changes.
+fn uncommitted_contains_file(status: &serde_json::Value, file_path: &str) -> bool {
+    status["uncommittedChanges"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|change| change["filePath"].as_str().unwrap() == file_path)
+}
+
+/// Read the contents of `file_path` as it exists in the commit named by
+/// `revspec` (e.g. `A`, `A~1`). Returns `None` when the file is absent from that
+/// commit's tree.
+fn commit_file_content(env: &Sandbox, revspec: &str) -> Option<String> {
+    let repo = env.open_repo();
+    let object = repo
+        .rev_parse_single(revspec.as_bytes())
+        .ok()?
+        .object()
+        .ok()?;
+    Some(String::from_utf8_lossy(&object.data).into_owned())
+}
+
+/// Read the contents of a file in the working directory.
+fn worktree_file_content(env: &Sandbox, path: &str) -> String {
+    std::fs::read_to_string(env.projects_root().join(path)).expect("worktree file should exist")
+}
+
+#[test]
+fn uncommit_different_files_from_different_commits_same_branch() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
+
+    // Two commits on branch A, each introducing a different file.
+    env.file("c1.txt", "c1 content\n");
+    env.but("commit A -m 'add c1'").assert().success();
+    env.file("c2.txt", "c2 content\n");
+    env.but("commit A -m 'add c2'").assert().success();
+
+    env.but("stf")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   3d21fdd add c2
+┊│     3d:wy A c2.txt
+┊●   28b88fc add c1
+┊│     28:ls A c1.txt
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┊╭┄h0 [B]
+┊●   d3e2ba3 add B
+┊│     d3:pl A B
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    // c2 lives in the newest commit (index 0), c1 in the older one (index 1).
+    let before = status_json(&env)?;
+    let c1_id =
+        committed_file_id_in_commit(&before, "A", 1, "c1.txt").expect("c1.txt committed-file id");
+    let c2_id =
+        committed_file_id_in_commit(&before, "A", 0, "c2.txt").expect("c2.txt committed-file id");
+
+    // Commit contents before uncommitting.
+    assert_eq!(
+        commit_file_content(&env, "A:c2.txt").as_deref(),
+        Some("c2 content\n")
+    );
+    assert_eq!(
+        commit_file_content(&env, "A~1:c1.txt").as_deref(),
+        Some("c1 content\n")
+    );
+
+    // Uncommit both, passing the older (parent) commit's file first to prove the
+    // backend sorts child-to-parent and rebases once, without stale commit IDs.
+    env.but(format!("uncommit {c1_id},{c2_id}"))
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+Uncommitted changes
+
+"#]]);
+
+    env.but("stf")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄zz [uncommitted]
+┊   ls A c1.txt
+┊   wy A c2.txt
+┊
+┊╭┄g0 [A]
+┊●   01fc011 add c2 (no changes)
+┊●   5682e2a add c1 (no changes)
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┊╭┄h0 [B]
+┊●   d3e2ba3 add B
+┊│     d3:pl A B
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
+
+"#]]);
+
+    let after = status_json(&env)?;
+    assert!(uncommitted_contains_file(&after, "c1.txt"));
+    assert!(uncommitted_contains_file(&after, "c2.txt"));
+
+    // Both files were removed from the commit trees but remain in the worktree.
+    assert_eq!(commit_file_content(&env, "A:c2.txt"), None);
+    assert_eq!(commit_file_content(&env, "A~1:c1.txt"), None);
+    assert_eq!(worktree_file_content(&env, "c1.txt"), "c1 content\n");
+    assert_eq!(worktree_file_content(&env, "c2.txt"), "c2 content\n");
+
+    Ok(())
+}
+
+#[test]
+fn uncommit_different_files_from_the_same_commit() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
+
+    // A single commit on branch A introducing two files. The CLI groups both
+    // committed-file ids into one source for that commit.
+    env.file("c1.txt", "c1 content\n");
+    env.file("c2.txt", "c2 content\n");
+    env.but("commit A -m 'add c1 and c2'").assert().success();
+
+    env.but("stf")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   191c6ed add c1 and c2
+┊│     19:ls A c1.txt
+┊│     19:wy A c2.txt
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┊╭┄h0 [B]
+┊●   d3e2ba3 add B
+┊│     d3:pl A B
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    // Both files live in the same (newest) commit.
+    let before = status_json(&env)?;
+    let c1_id =
+        committed_file_id_in_commit(&before, "A", 0, "c1.txt").expect("c1.txt committed-file id");
+    let c2_id =
+        committed_file_id_in_commit(&before, "A", 0, "c2.txt").expect("c2.txt committed-file id");
+
+    assert_eq!(
+        commit_file_content(&env, "A:c1.txt").as_deref(),
+        Some("c1 content\n")
+    );
+    assert_eq!(
+        commit_file_content(&env, "A:c2.txt").as_deref(),
+        Some("c2 content\n")
+    );
+
+    // Uncommit both files from the one commit in a single call.
+    env.but(format!("uncommit {c1_id},{c2_id}"))
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+Uncommitted changes
+
+"#]]);
+
+    env.but("stf")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄zz [uncommitted]
+┊   ls A c1.txt
+┊   wy A c2.txt
+┊
+┊╭┄g0 [A]
+┊●   3d256e6 add c1 and c2 (no changes)
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┊╭┄h0 [B]
+┊●   d3e2ba3 add B
+┊│     d3:pl A B
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
+
+"#]]);
+
+    let after = status_json(&env)?;
+    assert!(uncommitted_contains_file(&after, "c1.txt"));
+    assert!(uncommitted_contains_file(&after, "c2.txt"));
+
+    // Both files were removed from the commit tree but remain in the worktree.
+    assert_eq!(commit_file_content(&env, "A:c1.txt"), None);
+    assert_eq!(commit_file_content(&env, "A:c2.txt"), None);
+    assert_eq!(worktree_file_content(&env, "c1.txt"), "c1 content\n");
+    assert_eq!(worktree_file_content(&env, "c2.txt"), "c2 content\n");
+
+    Ok(())
+}
+
+#[test]
+fn uncommit_same_file_from_different_commits_same_branch() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
+
+    // Three commits on branch A, each overwriting the same file.
+    env.file("f.txt", "v1\n");
+    env.but("commit A -m 'write v1'").assert().success();
+    env.file("f.txt", "v2\n");
+    env.but("commit A -m 'write v2'").assert().success();
+    env.file("f.txt", "v3\n");
+    env.but("commit A -m 'write v3'").assert().success();
+
+    env.but("stf")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   e128a9a write v3
+┊│     e1:sp M f.txt
+┊●   4dba526 write v2
+┊│     4d:sp M f.txt
+┊●   825d09f write v1
+┊│     82:sp A f.txt
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┊╭┄h0 [B]
+┊●   d3e2ba3 add B
+┊│     d3:pl A B
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    // Commit contents before: newest-first is v3, v2, v1.
+    assert_eq!(
+        commit_file_content(&env, "A:f.txt").as_deref(),
+        Some("v3\n")
+    );
+    assert_eq!(
+        commit_file_content(&env, "A~1:f.txt").as_deref(),
+        Some("v2\n")
+    );
+    assert_eq!(
+        commit_file_content(&env, "A~2:f.txt").as_deref(),
+        Some("v1\n")
+    );
+
+    let before = status_json(&env)?;
+    let v1_id = committed_file_id_in_commit(&before, "A", 2, "f.txt").expect("v1 f.txt id");
+    let v2_id = committed_file_id_in_commit(&before, "A", 1, "f.txt").expect("v2 f.txt id");
+    let v3_id = committed_file_id_in_commit(&before, "A", 0, "f.txt").expect("v3 f.txt id");
+
+    // Uncommit the file from all three commits in a deliberately shuffled order
+    // (middle, top, bottom) to prove the input does not need to be sorted.
+    env.but(format!("uncommit {v2_id},{v3_id},{v1_id}"))
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+Uncommitted changes
+
+"#]]);
+
+    env.but("stf")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄zz [uncommitted]
+┊   sp A f.txt
+┊
+┊╭┄g0 [A]
+┊●   ddf33f2 write v3 (no changes)
+┊●   3212a72 write v2 (no changes)
+┊●   637ac90 write v1 (no changes)
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┊╭┄h0 [B]
+┊●   d3e2ba3 add B
+┊│     d3:pl A B
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
+
+"#]]);
+
+    let after = status_json(&env)?;
+    assert!(uncommitted_contains_file(&after, "f.txt"));
+
+    // The file is gone from every commit tree, and the worktree keeps the latest
+    // (v3) content.
+    assert_eq!(commit_file_content(&env, "A:f.txt"), None);
+    assert_eq!(commit_file_content(&env, "A~1:f.txt"), None);
+    assert_eq!(commit_file_content(&env, "A~2:f.txt"), None);
+    assert_eq!(worktree_file_content(&env, "f.txt"), "v3\n");
+
+    Ok(())
+}
+
+#[test]
+fn uncommit_different_files_from_different_commits_different_branches() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
+
+    // One commit on each of the two parallel stacks, each adding its own file.
+    env.file("fa.txt", "a content\n");
+    env.but("commit A -m 'add fa'").assert().success();
+    env.file("fb.txt", "b content\n");
+    env.but("commit B -m 'add fb'").assert().success();
+
+    env.but("stf")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   1675e0b add fa
+┊│     16:sk A fa.txt
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┊╭┄h0 [B]
+┊●   30b330c add fb
+┊│     30:qq A fb.txt
+┊●   d3e2ba3 add B
+┊│     d3:pl A B
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    assert_eq!(
+        commit_file_content(&env, "A:fa.txt").as_deref(),
+        Some("a content\n")
+    );
+    assert_eq!(
+        commit_file_content(&env, "B:fb.txt").as_deref(),
+        Some("b content\n")
+    );
+
+    let before = status_json(&env)?;
+    let fa_id = committed_file_id_in_commit(&before, "A", 0, "fa.txt").expect("fa.txt id");
+    let fb_id = committed_file_id_in_commit(&before, "B", 0, "fb.txt").expect("fb.txt id");
+
+    // Uncommit one file from each branch in a single batched operation.
+    env.but(format!("uncommit {fa_id},{fb_id}"))
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+Uncommitted changes
+
+"#]]);
+
+    env.but("stf")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄zz [uncommitted]
+┊   sk A fa.txt
+┊   qq A fb.txt
+┊
+┊╭┄g0 [A]
+┊●   3bbaec6 add fa (no changes)
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┊╭┄h0 [B]
+┊●   0596eed add fb (no changes)
+┊●   d3e2ba3 add B
+┊│     d3:pl A B
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
+
+"#]]);
+
+    let after = status_json(&env)?;
+    assert!(uncommitted_contains_file(&after, "fa.txt"));
+    assert!(uncommitted_contains_file(&after, "fb.txt"));
+
+    // Both files were removed from their respective branch commits but remain in
+    // the worktree.
+    assert_eq!(commit_file_content(&env, "A:fa.txt"), None);
+    assert_eq!(commit_file_content(&env, "B:fb.txt"), None);
+    assert_eq!(worktree_file_content(&env, "fa.txt"), "a content\n");
+    assert_eq!(worktree_file_content(&env, "fb.txt"), "b content\n");
+
+    Ok(())
+}

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -529,6 +529,7 @@ fn main() -> anyhow::Result<()> {
                 commit::move_changes::tauri_commit_move_changes_between::commit_move_changes_between,
                 commit::squash::tauri_commit_squash::commit_squash,
                 commit::uncommit::tauri_commit_uncommit_changes::commit_uncommit_changes,
+                commit::uncommit::tauri_commit_uncommit_changes_from_commits::commit_uncommit_changes_from_commits,
                 commit::uncommit::tauri_commit_uncommit::commit_uncommit,
                 workspace::tauri_workspace_integrate_upstream::workspace_integrate_upstream,
                 land::tauri_branch_land::branch_land,


### PR DESCRIPTION
## 🧢 Changes

Wires the new multi-source `commit_uncommit_changes_from_commits` API into the `but` CLI and the desktop app: `but uncommit` now batches committed-file sources into a single call, `StackService.uncommitChanges` sends one grouped source, and the command is registered on the server/Tauri bridges.

## ☕️ Reasoning

Routing multiple committed-file sources through the batched API lets the backend group and order them child-to-parent in one rebase, avoiding the stale commit IDs the old per-source path produced. Adds CLI integration tests for uncommitting files from different commits and different branches, asserting `but status` and commit file contents before/after.

---

⚠️ Stacked on top of #14629 — review/merge that first.