### PR TITLE
Replacement tracking happens on `replace` call

### DIFF
--- a/crates/but-rebase/src/graph_rebase/commit.rs
+++ b/crates/but-rebase/src/graph_rebase/commit.rs
@@ -77,9 +77,12 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
         Ok((self.new_selector(*first_parent), self.find_commit(pick.id)?))
     }
 
-    /// Writes a commit with correct signing to the in memory repository,
-    /// without updating the history log.
-    pub fn new_commit_untracked(
+    /// Writes a commit with correct signing to the in memory repository.
+    ///
+    /// This does not update the commit mappings; a rewrite is only recorded
+    /// once the commit is installed into the graph via [`Editor::replace`] or
+    /// a rebase.
+    pub fn new_commit(
         &self,
         commit: but_core::CommitOwned,
         date_mode: DateMode,
@@ -90,18 +93,6 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
             date_mode,
             SignCommit::IfSignCommitsEnabled,
         )
-    }
-
-    /// Writes a commit with correct signing to the in memory repository.
-    pub fn new_commit(
-        &mut self,
-        commit: but_core::CommitOwned,
-        date_mode: DateMode,
-    ) -> Result<gix::ObjectId> {
-        let commit_id = commit.id;
-        let new_id = self.new_commit_untracked(commit, date_mode)?;
-        self.history.update_mapping(commit_id, new_id);
-        Ok(new_id)
     }
 
     /// Creates a commit with only the signature, author, and headers set correctly.

--- a/crates/but-rebase/src/graph_rebase/mutate.rs
+++ b/crates/but-rebase/src/graph_rebase/mutate.rs
@@ -335,9 +335,19 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
 
     /// Replaces the node that the function was pointing to.
     ///
+    /// If a commit step has been replaced with another commit step, the commit
+    /// mappings will get updated to include an entry going from the old to the
+    /// new object id.
+    ///
     /// Returns the replaced step.
     pub fn replace(&mut self, target: impl ToSelector, mut step: Step) -> Result<Step> {
         let target = self.history.normalize_selector(target.to_selector(self)?)?;
+        if let (Step::Pick(from), Step::Pick(to)) = (&self.graph[target.id], &step)
+            && !from.exclude_from_tracking
+            && !to.exclude_from_tracking
+        {
+            self.history.update_mapping(from.id, to.id);
+        };
         std::mem::swap(&mut self.graph[target.id], &mut step);
         Ok(step)
     }

--- a/crates/but-rebase/tests/rebase/graph_rebase/merge_commit_changes.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/merge_commit_changes.rs
@@ -517,8 +517,7 @@ fn uses_editor_visible_commits_not_only_original_workspace_graph() -> Result<()>
     let head = repo.rev_parse_single("HEAD")?.detach();
     let mut head_commit = editor.find_commit(head)?;
     head_commit.inner.message = "HEAD rewritten inside editor".into();
-    let rewritten_head =
-        editor.new_commit_untracked(head_commit, DateMode::CommitterUpdateAuthorKeep)?;
+    let rewritten_head = editor.new_commit(head_commit, DateMode::CommitterUpdateAuthorKeep)?;
 
     let head_selector = editor.select_commit(head)?;
     editor.replace(head_selector, Step::new_pick(rewritten_head))?;
@@ -647,8 +646,7 @@ fn planning_works_after_normalizing_chained_editor_mutations() -> Result<()> {
     let head_parent = repo.rev_parse_single("HEAD~1")?.detach();
     let mut rewritten_head = editor.find_commit(head)?;
     rewritten_head.inner.message = "HEAD rewritten inside editor".into();
-    let rewritten_head =
-        editor.new_commit_untracked(rewritten_head, DateMode::CommitterUpdateAuthorKeep)?;
+    let rewritten_head = editor.new_commit(rewritten_head, DateMode::CommitterUpdateAuthorKeep)?;
 
     let head_selector = editor.select_commit(head)?;
     editor.replace(head_selector, Step::new_pick(rewritten_head))?;

--- a/crates/but-rebase/tests/rebase/graph_rebase/replace.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/replace.rs
@@ -84,6 +84,7 @@ fn reword_a_commit() -> Result<()> {
     insta::assert_debug_snapshot!(outcome.history.commit_mappings(), @"
     {
         Sha1(2fc288c36c8bb710c78203f78ea9883724ce142b): Sha1(53af95adeaf78258ee71c74fe4daa6628d750ff1),
+        Sha1(add59d26b2ffd7468fcb44c2db48111dd8f481e5): Sha1(6de6b92e431243cc4676179bd5ef17d95642d250),
         Sha1(e8ee978dac10e6a85006543ef08be07c5824b4f7): Sha1(78aaae2b4d822ed0cc7e0e83767b5dec2c88791b),
     }
     ");
@@ -183,6 +184,7 @@ fn amend_a_commit() -> Result<()> {
     insta::assert_debug_snapshot!(outcome.history.commit_mappings(), @"
     {
         Sha1(2fc288c36c8bb710c78203f78ea9883724ce142b): Sha1(810119232dd43ad1edc6b3d1a9cc2cd507d92a4e),
+        Sha1(add59d26b2ffd7468fcb44c2db48111dd8f481e5): Sha1(f1905a822d4cad49595b47f24d40702dc41a0b57),
         Sha1(e8ee978dac10e6a85006543ef08be07c5824b4f7): Sha1(e7221b5ace99ba38e222e19e5da9c6966955e37b),
     }
     ");

--- a/crates/but-rebase/tests/rebase/graph_rebase/sha256.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/sha256.rs
@@ -40,7 +40,7 @@ fn inserting_a_step_rewrites_sha256_commits() -> Result<()> {
     let (selector, mut merge_obj) = editor.find_selectable_commit(merge_id)?;
     merge_obj.message = "Commit below the merge commit in SHA-256".into();
     merge_obj.parents = vec![].into();
-    let new_commit = editor.new_commit_untracked(merge_obj, DateMode::CommitterKeepAuthorKeep)?;
+    let new_commit = editor.new_commit(merge_obj, DateMode::CommitterKeepAuthorKeep)?;
 
     editor.insert(selector, Step::new_pick(new_commit), InsertSide::Below)?;
 
@@ -115,7 +115,7 @@ fn replacing_a_step_rewrites_sha256_descendants() -> Result<()> {
         .find_selectable_commit(a)
         .context("failed to select branch A commit")?;
     a_obj.message = "A: SHA-256 reworded".into();
-    let a_new = editor.new_commit_untracked(a_obj, DateMode::CommitterKeepAuthorKeep)?;
+    let a_new = editor.new_commit(a_obj, DateMode::CommitterKeepAuthorKeep)?;
 
     editor.replace(a_selector, Step::new_pick(a_new))?;
 
@@ -151,6 +151,7 @@ fn replacing_a_step_rewrites_sha256_descendants() -> Result<()> {
     insta::assert_debug_snapshot!(outcome.history.commit_mappings(), @"
     {
         Sha256(0f01c778cee8081dcfd51d010dfcf6dca150fad6cd58bc269b9aed22587b97fb): Sha256(f6f0125b1f12060e754ba973e8e630cdb51622c06fa9ebdc76afa5510817e2d3),
+        Sha256(2ff29ffab0c95397a8da853ee4ee8bdad788b23a55a1071edf3f218a13c3e10e): Sha256(b5c16abf204e78c0c7cf47a75e5532e31ae40129cdb181739f3742ab31e09f44),
         Sha256(8ab779b6d7ff461b6a09a86724e26c18a4d9d66f733a1cf3c927dc98e6eecbec): Sha256(fccb3fdbafb315097348b7c66fa86a745d923f0f59574cc31650b52f5f1390a2),
     }
     ");

--- a/crates/but-workspace/src/branch/integrate_branch_upstream/plan.rs
+++ b/crates/but-workspace/src/branch/integrate_branch_upstream/plan.rs
@@ -299,7 +299,7 @@ fn prepare_squash_step_for_editor<M: RefMetadata>(
         commit_message,
     )?;
 
-    editor.new_commit_untracked(squashed_commit, DateMode::CommitterUpdateAuthorKeep)
+    editor.new_commit(squashed_commit, DateMode::CommitterUpdateAuthorKeep)
 }
 
 fn apply_merge_commit_changes_outcome(
@@ -395,7 +395,7 @@ fn integration_steps_to_segment_steps_for_editor<M: RefMetadata>(
             PreparedIntegrationStep::Merge { commit_id } => {
                 let mut merge_commit = editor.empty_commit()?;
                 merge_commit.message = format!("Merge {commit_id} into previous commit").into();
-                let merge_commit = editor.new_commit_untracked(
+                let merge_commit = editor.new_commit(
                     merge_commit,
                     but_rebase::commit::DateMode::CommitterKeepAuthorKeep,
                 )?;

--- a/crates/but-workspace/src/commit/insert_blank_commit.rs
+++ b/crates/but-workspace/src/commit/insert_blank_commit.rs
@@ -14,7 +14,7 @@ pub fn insert_blank_commit<'ws, 'meta, M: RefMetadata>(
     relative_to: impl ToSelector,
 ) -> Result<(SuccessfulRebase<'ws, 'meta, M>, Selector)> {
     let commit = editor.empty_commit()?;
-    let new_id = editor.new_commit_untracked(commit, DateMode::CommitterUpdateAuthorUpdate)?;
+    let new_id = editor.new_commit(commit, DateMode::CommitterUpdateAuthorUpdate)?;
 
     let blank_commit_selector =
         editor.insert(relative_to, Step::new_untracked_pick(new_id), side)?;

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -389,7 +389,7 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
             let mut merge_commit = editor.empty_commit()?;
             merge_commit.message = format!("Merge {} into merge", target_ref.ref_name).into();
             let merge_commit =
-                editor.new_commit_untracked(merge_commit, DateMode::CommitterKeepAuthorKeep)?;
+                editor.new_commit(merge_commit, DateMode::CommitterKeepAuthorKeep)?;
             let merge_commit = editor.insert(
                 *head,
                 Step::Pick(Pick::new_untracked_pick(merge_commit)),


### PR DESCRIPTION
This seems to be a nicer system and captures the `commit_amend` situation nicely

* Closes GB-1570