### PR TITLE
Move all metadata associated with a reference

### DIFF
--- a/crates/but-agentlog/src/environment.rs
+++ b/crates/but-agentlog/src/environment.rs
@@ -734,6 +734,14 @@ impl RefMetadata for EmptyRefMetadata {
     fn remove(&mut self, _ref_name: &gix::refs::FullNameRef) -> anyhow::Result<bool> {
         Ok(false)
     }
+
+    fn rename(
+        &mut self,
+        _old_ref_name: &gix::refs::FullNameRef,
+        _new_ref_name: &gix::refs::FullNameRef,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/but-core/src/lib.rs
+++ b/crates/but-core/src/lib.rs
@@ -288,6 +288,23 @@ pub trait RefMetadata {
     ///
     /// It is OK to delete something that doesn't exist.
     fn remove(&mut self, ref_name: &gix::refs::FullNameRef) -> anyhow::Result<bool>;
+
+    /// Move all metadata associated with `old_ref_name` over to `new_ref_name`.
+    ///
+    /// This carries over any per-branch metadata blob and renames the persisted branch-stack-order
+    /// entry (see [`rename_branch_stack_order_reference`](Self::rename_branch_stack_order_reference)).
+    ///
+    /// It is OK to rename a `ref_name` that has no metadata, and renaming onto itself is a no-op.
+    ///
+    /// There is deliberately no default implementation: a generic one built from `branch` +
+    /// `set_branch` + `remove` would copy per-branch metadata into a *new* standalone stack and tear
+    /// the branch out of its existing one, fragmenting managed stacks. Each backend must move its
+    /// metadata in place instead.
+    fn rename(
+        &mut self,
+        old_ref_name: &gix::refs::FullNameRef,
+        new_ref_name: &gix::refs::FullNameRef,
+    ) -> anyhow::Result<()>;
 }
 
 /// A decoded commit object with easy access to additional GitButler information.

--- a/crates/but-debug/src/metadata.rs
+++ b/crates/but-debug/src/metadata.rs
@@ -87,4 +87,12 @@ impl RefMetadata for EmptyRefMetadata {
     fn remove(&mut self, _ref_name: &gix::refs::FullNameRef) -> anyhow::Result<bool> {
         Ok(false)
     }
+
+    fn rename(
+        &mut self,
+        _old_ref_name: &gix::refs::FullNameRef,
+        _new_ref_name: &gix::refs::FullNameRef,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
 }

--- a/crates/but-meta/src/legacy/mod.rs
+++ b/crates/but-meta/src/legacy/mod.rs
@@ -969,6 +969,65 @@ impl RefMetadata for VirtualBranchesTomlMetadata {
             Ok(self.remove_branch(ref_name)?.is_some())
         }
     }
+
+    fn rename(
+        &mut self,
+        old_ref_name: &FullNameRef,
+        new_ref_name: &FullNameRef,
+    ) -> anyhow::Result<()> {
+        if old_ref_name == new_ref_name {
+            return Ok(());
+        }
+        // Rename the branch in place within its stack, preserving its position and all its other
+        // metadata (pr number, archived, review id). This avoids the generic trait default, which
+        // would copy the branch into a brand-new standalone stack and tear it out of this one.
+        let Some((stack_id, branch_idx)) = self
+            .data()
+            .branches
+            .values()
+            .sorted_by(order_then_name)
+            .find_map(|stack| {
+                stack
+                    .heads
+                    .iter()
+                    .enumerate()
+                    .find_map(|(branch_idx, branch)| {
+                        full_branch_name(branch.name.as_str()).and_then(|full_name| {
+                            (full_name.as_ref() == old_ref_name).then_some((stack.id, branch_idx))
+                        })
+                    })
+            })
+        else {
+            // No managed metadata for this ref (e.g. an ad-hoc branch); nothing to rename here.
+            return Ok(());
+        };
+
+        // Refuse to rename onto a name that already exists in managed metadata: it would create
+        // duplicate `refs/heads/<name>` heads, which the rest of the code treats as an invariant
+        // violation (see the "There shouldn't be duplication" note in `branch()`).
+        let new_exists = self.data().branches.values().any(|stack| {
+            stack.heads.iter().any(|branch| {
+                full_branch_name(branch.name.as_str())
+                    .is_some_and(|full_name| full_name.as_ref() == new_ref_name)
+            })
+        });
+        if new_exists {
+            bail!(
+                "Cannot rename to '{}': a branch with that name already exists",
+                new_ref_name.shorten()
+            );
+        }
+
+        let new_short_name = new_ref_name.shorten().to_string();
+        let stack = self
+            .data_mut()
+            .branches
+            .get_mut(&stack_id)
+            .expect("stack was just found");
+        stack.heads[branch_idx].name = new_short_name;
+        self.snapshot.set_changed_to_necessitate_write();
+        Ok(())
+    }
 }
 
 /// Ref metadata backed by legacy TOML for historical workspace metadata and by
@@ -1117,6 +1176,51 @@ impl RefMetadata for BranchOrderMetadata {
                 .remove_reference(ref_name.as_bstr().to_str()?)?;
         }
         Ok(self.legacy.remove(ref_name)? || removed_branch_order)
+    }
+
+    fn rename(
+        &mut self,
+        old_ref_name: &FullNameRef,
+        new_ref_name: &FullNameRef,
+    ) -> anyhow::Result<()> {
+        if old_ref_name == new_ref_name {
+            return Ok(());
+        }
+        // Rename the managed (TOML) branch metadata in place, then move the ad-hoc branch-order
+        // entry. Both are no-ops when the respective metadata isn't present for this ref.
+        //
+        // Reject a destination that already exists in *either* layer up front, before mutating
+        // *either* of them. Each layer's own rename guards against a conflict on its own, but doing
+        // the checks first is what keeps the two writes from diverging: without the DB pre-check
+        // here, a name that exists only in the branch-order DB would let `legacy.rename` mutate the
+        // TOML before `rename_reference` failed, leaving the two layers half-renamed.
+        //
+        // This makes the rename conflict-atomic, not fully atomic: if the branch-order DB write
+        // still fails for an unrelated reason (I/O, a lock) after the in-memory TOML rename applied,
+        // the layers can diverge. Closing that window would require a single cross-layer transaction.
+        if !self.read_only
+            && let Some(db) = self.db.as_ref()
+            && db
+                .branch_order()
+                .order_for_reference(new_ref_name.as_bstr().to_str()?)?
+                .is_some()
+        {
+            bail!(
+                "Cannot rename to '{}': a branch with that name already exists",
+                new_ref_name.shorten()
+            );
+        }
+
+        self.legacy.rename(old_ref_name, new_ref_name)?;
+        if !self.read_only
+            && let Some(db) = self.db.as_mut()
+        {
+            db.branch_order_mut()?.rename_reference(
+                old_ref_name.as_bstr().to_str()?,
+                new_ref_name.as_bstr().to_str()?,
+            )?;
+        }
+        Ok(())
     }
 }
 

--- a/crates/but-meta/tests/meta/ref_metadata_legacy.rs
+++ b/crates/but-meta/tests/meta/ref_metadata_legacy.rs
@@ -1630,6 +1630,41 @@ fn vb_store_rw(name: &str) -> anyhow::Result<(VirtualBranchesTomlMetadata, TempD
     Ok((store, tmp))
 }
 
+#[test]
+fn rename_onto_an_existing_branch_is_rejected() -> anyhow::Result<()> {
+    let (mut store, _tmp) = empty_vb_store_rw()?;
+
+    let a: gix::refs::FullName = "refs/heads/a".try_into()?;
+    let b: gix::refs::FullName = "refs/heads/b".try_into()?;
+
+    // Persist two distinct branches (each ends up in its own stack).
+    for name in [&a, &b] {
+        let mut branch = store.branch(name.as_ref())?;
+        branch.review.pull_request = Some(1);
+        store.set_branch(&branch)?;
+    }
+
+    // Renaming `a` onto the existing `b` must be rejected rather than creating a duplicate head.
+    let err = store
+        .rename(a.as_ref(), b.as_ref())
+        .expect_err("cannot rename onto an existing branch");
+    assert!(err.to_string().contains("already exists"), "{err}");
+    assert!(store.branch_opt(a.as_ref())?.is_some());
+    assert!(store.branch_opt(b.as_ref())?.is_some());
+
+    // Renaming onto a fresh name works and moves the metadata in place.
+    let c: gix::refs::FullName = "refs/heads/c".try_into()?;
+    store.rename(a.as_ref(), c.as_ref())?;
+    assert!(store.branch_opt(a.as_ref())?.is_none());
+    assert!(store.branch_opt(c.as_ref())?.is_some());
+
+    // Renaming a branch onto its own name is a no-op, not a self-conflict.
+    store.rename(c.as_ref(), c.as_ref())?;
+    assert!(store.branch_opt(c.as_ref())?.is_some());
+
+    Ok(())
+}
+
 fn empty_vb_store_rw() -> anyhow::Result<(VirtualBranchesTomlMetadata, TempDir)> {
     let tmp = tempdir()?;
     let mut store = VirtualBranchesTomlMetadata::from_path(tmp.path().join("vb.toml"))?;

--- a/crates/but-testsupport/src/in_memory_meta.rs
+++ b/crates/but-testsupport/src/in_memory_meta.rs
@@ -156,6 +156,45 @@ impl but_core::RefMetadata for InMemoryRefMetadata {
         };
         Ok(res)
     }
+
+    fn rename(
+        &mut self,
+        old_ref_name: &gix::refs::FullNameRef,
+        new_ref_name: &gix::refs::FullNameRef,
+    ) -> anyhow::Result<()> {
+        if old_ref_name == new_ref_name {
+            return Ok(());
+        }
+        // Refuse to rename onto an existing key rather than creating a duplicate entry: readers
+        // match the first entry, so a duplicate would make later reads/updates/removals act on the
+        // wrong one.
+        let new_exists = self
+            .branches
+            .iter()
+            .any(|(rn, _)| rn.as_ref() == new_ref_name)
+            || self
+                .workspaces
+                .iter()
+                .any(|(rn, _)| rn.as_ref() == new_ref_name);
+        if new_exists {
+            anyhow::bail!(
+                "Cannot rename to '{}': metadata for that ref already exists",
+                new_ref_name.shorten()
+            );
+        }
+        // Rename in place, keeping each entry's value and position.
+        for (rn, _v) in self.branches.iter_mut() {
+            if rn.as_ref() == old_ref_name {
+                *rn = new_ref_name.to_owned();
+            }
+        }
+        for (rn, _v) in self.workspaces.iter_mut() {
+            if rn.as_ref() == old_ref_name {
+                *rn = new_ref_name.to_owned();
+            }
+        }
+        Ok(())
+    }
 }
 
 /// A more descriptive way of showing if the stack is included in the workspace or not.

--- a/crates/but-transaction/src/lib.rs
+++ b/crates/but-transaction/src/lib.rs
@@ -925,6 +925,16 @@ impl RefMetadata for RecordingMetadata {
     fn remove(&mut self, _ref_name: &FullNameRef) -> anyhow::Result<bool> {
         Ok(false)
     }
+
+    fn rename(
+        &mut self,
+        _old_ref_name: &FullNameRef,
+        _new_ref_name: &FullNameRef,
+    ) -> anyhow::Result<()> {
+        // Renames aren't part of the recorded transaction surface (like `remove`, which is handled
+        // out-of-band via `Transaction::remove_reference`); nothing to record here.
+        Ok(())
+    }
 }
 
 #[derive(Debug, Default)]

--- a/crates/but-workspace/tests/workspace/branch_details.rs
+++ b/crates/but-workspace/tests/workspace/branch_details.rs
@@ -388,5 +388,13 @@ mod with_workspace {
         fn remove(&mut self, _ref_name: &FullNameRef) -> anyhow::Result<bool> {
             unreachable!()
         }
+
+        fn rename(
+            &mut self,
+            _old_ref_name: &FullNameRef,
+            _new_ref_name: &FullNameRef,
+        ) -> anyhow::Result<()> {
+            unreachable!()
+        }
     }
 }


### PR DESCRIPTION
Add a metadata rename handler that correctly updates all metadata
associated with a reference name, to another.

### Why
We need this to be able to handle in one place the renaming of a branch in SBM
