### PR TITLE
Render image diffs in the but tui details pane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,6 +869,7 @@ dependencies = [
  "gitbutler-repo",
  "gitbutler-watcher",
  "gix",
+ "image",
  "indexmap 2.14.0",
  "insta",
  "itertools",
@@ -869,6 +880,7 @@ dependencies = [
  "quote",
  "rand 0.9.4",
  "ratatui",
+ "ratatui-image",
  "ratatui-textarea",
  "rmcp",
  "schemars 1.2.1",
@@ -1822,6 +1834,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "byteorder"
@@ -2137,6 +2163,12 @@ dependencies = [
  "core-graphics-types",
  "objc",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
@@ -3762,6 +3794,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -5772,6 +5814,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "icy_sixel"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85518b9086bf01117761b90e7691c0ef3236fa8adfb1fb44dd248fe5f87215d5"
+dependencies = [
+ "quantette",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5822,10 +5874,25 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
  "moxcms",
  "num-traits",
  "png 0.18.1",
  "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
@@ -7081,6 +7148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -7490,6 +7558,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7550,6 +7627,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7566,6 +7649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
 dependencies = [
  "approx",
+ "bytemuck",
  "fast-srgb8",
  "libm",
  "palette_derive",
@@ -8146,6 +8230,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
+name = "quantette"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c98fecda8b16396ff9adac67644a523dd1778c42b58606a29df5c31ca925d174"
+dependencies = [
+ "bitvec",
+ "bytemuck",
+ "image",
+ "libm",
+ "num-traits",
+ "ordered-float 5.3.0",
+ "palette",
+ "rand 0.9.4",
+ "rand_xoshiro",
+ "rayon",
+ "ref-cast",
+ "wide",
+]
+
+[[package]]
 name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8312,6 +8416,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "ratatui"
 version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8362,6 +8475,23 @@ dependencies = [
  "crossterm 0.29.0",
  "instability",
  "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-image"
+version = "11.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000b7a22eae639460bc6ec8bb1cc689ecae5b0ed21935cd7d7dd52d38270c86"
+dependencies = [
+ "base64-simd",
+ "icy_sixel",
+ "image",
+ "rand 0.8.6",
+ "ratatui",
+ "rustix 0.38.44",
+ "self_cell",
+ "thiserror 1.0.69",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -8443,6 +8573,26 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -8892,6 +9042,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629516c85c29fe757770fa03f2074cf1eac43d44c02a3de9fc2ef7b0e207dfdd"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -10531,7 +10690,7 @@ dependencies = [
  "nix 0.29.0",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 4.6.0",
  "pest",
  "pest_derive",
  "phf 0.11.3",
@@ -11389,6 +11548,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
 name = "vswhom"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11684,8 +11849,8 @@ dependencies = [
  "webview2-com-sys",
  "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
@@ -11760,7 +11925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
- "ordered-float",
+ "ordered-float 4.6.0",
  "strsim",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
@@ -11797,6 +11962,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "wide"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ca908d26e4786149c48efcf6c0ea09ab0e06d1fe3c17dc1b4b0f1ca4a7e788"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]
@@ -11847,6 +12022,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -11890,12 +12075,25 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -11907,8 +12105,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -11938,9 +12136,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12014,6 +12234,15 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
@@ -12028,6 +12257,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -380,6 +380,20 @@ serde_json = { opt-level = 3 }
 # This one is special as we can run into debug assertions otherwise.
 # They have a time, but let's chose the time instead of always being hit by it.
 gix-merge = { opt-level = 3, debug-assertions = false }
+# Image decoding and resizing for the TUI's image diffs is far too slow unoptimized.
+image = { opt-level = 3 }
+png = { opt-level = 3 }
+fdeflate = { opt-level = 3 }
+miniz_oxide = { opt-level = 3 }
+flate2 = { opt-level = 3 }
+zune-jpeg = { opt-level = 3 }
+zune-core = { opt-level = 3 }
+image-webp = { opt-level = 3 }
+gif = { opt-level = 3 }
+tiff = { opt-level = 3 }
+weezl = { opt-level = 3 }
+color_quant = { opt-level = 3 }
+byteorder-lite = { opt-level = 3 }
 
 [profile.release.package.but-installer]
 opt-level = "z" # Optimize for size instead of speed

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -148,6 +148,18 @@ itertools.workspace = true
 self_cell.workspace = true
 rand.workspace = true
 ratatui-textarea = "0.8.0"
+ratatui-image = { version = "11", default-features = false, features = [
+    "crossterm",
+] }
+image = { version = "0.25.10", default-features = false, features = [
+    "png",
+    "jpeg",
+    "gif",
+    "webp",
+    "bmp",
+    "ico",
+    "tiff",
+] }
 arboard = { version = "3.6.1", default-features = false }
 textwrap = "0.16.2"
 syntect = { version = "5.3.0", default-features = false, features = [

--- a/crates/but/src/command/legacy/diff2.rs
+++ b/crates/but/src/command/legacy/diff2.rs
@@ -151,6 +151,11 @@ impl DiffLineWriter for DiffWriter<'_> {
                 }
                 writeln!(self.out)?;
             }
+            DetailsLine::Image(_) => {
+                // This writer never reports image support, so image lines are not produced
+                // for it; keep the placeholder in case that ever changes.
+                writeln!(self.out, "Binary file - no diff available")?;
+            }
             DetailsLine::SectionSeparator => {
                 writeln!(self.out)?;
             }

--- a/crates/but/src/command/legacy/status/tui/details.rs
+++ b/crates/but/src/command/legacy/status/tui/details.rs
@@ -1,5 +1,6 @@
 use std::{
     cell::{Cell, RefCell},
+    collections::HashMap,
     fmt::Display,
     sync::{
         Arc,
@@ -15,10 +16,15 @@ use itertools::{Itertools as _, Position};
 use nonempty::NonEmpty;
 use ratatui::{
     Frame,
-    layout::Rect,
-    style::{Color, Stylize as _},
+    layout::{Rect, Size},
+    style::{Color, Style, Stylize as _},
     text::{Line, Span},
     widgets::{Scrollbar, ScrollbarOrientation, ScrollbarState},
+};
+use ratatui_image::{
+    FilterType, Resize,
+    picker::Picker,
+    sliced::{SignedPosition, SlicedImage, SlicedProtocol},
 };
 use syntect::{easy::HighlightLines, highlighting, parsing::SyntaxSet};
 
@@ -35,9 +41,12 @@ use crate::{
         render::available_lines_in_area,
     },
     theme::Theme,
+    tui::image_diff::{DecodedImage, human_bytes},
     utils::{
         DebugAsType,
-        diff_rendering::{self, CodeLineKind, DetailsLine, DiffLineWriter, IdGen, SectionId},
+        diff_rendering::{
+            self, CodeLineKind, DetailsImageLine, DetailsLine, DiffLineWriter, IdGen, SectionId,
+        },
         diff_specs::DiffSpecBuilder,
         string_interning::Strings,
     },
@@ -46,6 +55,15 @@ use crate::{
 mod worker;
 
 const CHANNEL_SIZE: usize = 1024;
+
+/// Cached terminal image encodings are cheap to keep but hold decoded pixels alive;
+/// evict everything when this many distinct images have been rendered.
+const MAX_IMAGE_PROTOCOLS: usize = 16;
+
+/// Encoding an image for the terminal blocks the UI thread, so it only happens once the
+/// selection has rested this long — flying through commits stays smooth, and images pop
+/// in right after the selection settles. Already-encoded images render regardless.
+const IMAGE_ENCODE_DEBOUNCE: Duration = Duration::from_millis(150);
 
 #[derive(Debug)]
 pub enum DetailsMessage {
@@ -81,6 +99,15 @@ pub struct Details {
     highlights: Highlights<SectionId>,
     worker: Worker,
     to_be_discarded: Vec<SectionId>,
+    /// Terminal graphics capabilities; `None` disables image rendering entirely.
+    picker: Option<Picker>,
+    /// Terminal render state per image, keyed by content fingerprint and target size so
+    /// it survives selection changes; encoding an image for the terminal is expensive.
+    /// Sliced protocols render any visible band of the image without re-encoding, so
+    /// scrolling never invalidates an entry.
+    image_protocols: DebugAsType<RefCell<HashMap<(u64, u16, u16), SlicedProtocol>>>,
+    /// When the selection last changed, for debouncing image encodes while scrolling.
+    selection_changed_at: Option<Instant>,
 }
 
 #[derive(Debug, Default)]
@@ -123,7 +150,18 @@ impl Details {
             highlights: Default::default(),
             worker: Worker::new(),
             to_be_discarded: Default::default(),
+            picker: None,
+            image_protocols: RefCell::new(HashMap::new()).into(),
+            selection_changed_at: None,
         }
+    }
+
+    /// Enable image rendering with the terminal graphics capabilities in `picker`.
+    ///
+    /// The picker must be created before the terminal enters raw mode and the alternate
+    /// screen, as querying capabilities reads responses from stdin.
+    pub fn set_graphics_picker(&mut self, picker: Option<Picker>) {
+        self.picker = picker;
     }
 
     pub fn is_polling_thread(&self) -> bool {
@@ -223,6 +261,10 @@ impl Details {
                 }
             }
         };
+
+        if selection_did_change {
+            self.selection_changed_at = Some(Instant::now());
+        }
 
         match selection {
             CliId::Commit {
@@ -423,7 +465,10 @@ impl Details {
                     start: Instant::now(),
                     cache_key,
                 };
-                let mut line_writer = ChannelLineWriter { tx };
+                let mut line_writer = ChannelLineWriter {
+                    tx,
+                    images_enabled: self.picker.is_some(),
+                };
                 let strings = self.strings.clone();
                 let theme = self.theme;
                 let ctx = ctx.to_sync();
@@ -557,8 +602,15 @@ impl Details {
 
         let section_selected_bg = self.theme.selection_highlight.bg.unwrap();
 
+        let image_layout = ImageLayout {
+            font_size: self.picker.as_ref().map_or((10, 20), |picker| {
+                let font_size = picker.font_size();
+                (font_size.width, font_size.height)
+            }),
+            viewport_height: area.height,
+        };
         let mut layout_cache = self.layout_cache.borrow_mut();
-        layout_cache.update(area.width, &self.lines);
+        layout_cache.update(area.width, image_layout, &self.lines);
 
         let viewport_height = area.height as usize;
         let total_display_lines = layout_cache.total_display_lines();
@@ -595,9 +647,12 @@ impl Details {
 
         let mut areas = available_lines_in_area(area);
         while let Some(line) = self.lines.get(line_index) {
+            let line_display_height = self.layout_cache.borrow().line_display_height(line_index);
             let rendered = self.render_details_line(
                 line,
                 line_offset,
+                line_display_height,
+                image_layout,
                 &mut areas,
                 area.width,
                 tui_has_focus,
@@ -733,6 +788,8 @@ impl Details {
         &self,
         line: &DetailsLine,
         skip_display_lines: usize,
+        line_display_height: usize,
+        image_layout: ImageLayout,
         areas: &mut impl Iterator<Item = Rect>,
         width: u16,
         tui_has_focus: bool,
@@ -846,6 +903,37 @@ impl Details {
                     }
                 }
             }
+            DetailsLine::Image(image_line) => {
+                *highlight_lines = None;
+
+                // Images need one contiguous rectangle, so pull all remaining visible
+                // rows of this line from the iterator and join them.
+                let total_rows = line_display_height;
+                let mut joined: Option<Rect> = None;
+                let mut rows_taken = 0;
+                for _ in skip_display_lines..total_rows {
+                    let Some(row) = areas.next() else { break };
+                    joined = Some(joined.map_or(row, |acc| acc.union(row)));
+                    rows_taken += 1;
+                }
+                let Some(joined) = joined else {
+                    return RenderedLine::viewport_filled();
+                };
+
+                self.render_image_line(
+                    image_line,
+                    joined,
+                    skip_display_lines,
+                    image_layout,
+                    tui_has_focus,
+                    section_selected_bg,
+                    frame,
+                );
+
+                if rows_taken < total_rows - skip_display_lines {
+                    return RenderedLine::viewport_filled();
+                }
+            }
             DetailsLine::SectionSeparator => {
                 *highlight_lines = None;
 
@@ -860,6 +948,114 @@ impl Details {
         }
 
         RenderedLine::line_finished()
+    }
+
+    /// Draw the images of `line` stacked vertically into `area` — old first, then new —
+    /// each below a caption of its dimensions and byte size. `skip_rows` scrolls into the
+    /// stack from the top.
+    #[expect(clippy::too_many_arguments)]
+    fn render_image_line(
+        &self,
+        line: &DetailsImageLine,
+        area: Rect,
+        mut skip_rows: usize,
+        image_layout: ImageLayout,
+        tui_has_focus: bool,
+        section_selected_bg: Color,
+        frame: &mut Frame,
+    ) {
+        let Some(picker) = &self.picker else { return };
+
+        let mut sides: Vec<(&str, Style, &DecodedImage)> = Vec::new();
+        if let Some(old) = &line.image.old {
+            sides.push(("old", self.theme.deletion, old));
+        }
+        if let Some(new) = &line.image.new {
+            sides.push(("new", self.theme.addition, new));
+        }
+
+        let sides_count = sides.len();
+        let selection_settled = self
+            .selection_changed_at
+            .is_none_or(|at| at.elapsed() >= IMAGE_ENCODE_DEBOUNCE);
+        let mut y = area.y;
+        let bottom = area.bottom();
+        let mut protocols = self.image_protocols.borrow_mut();
+        for (label, label_style, side) in sides {
+            if y >= bottom {
+                return;
+            }
+
+            if skip_rows == 0 {
+                let mut caption = Line::from_iter([
+                    Span::styled(format!(" {label}"), label_style),
+                    Span::styled(
+                        format!(
+                            "  {}×{} · {}",
+                            side.width,
+                            side.height,
+                            human_bytes(side.byte_size)
+                        ),
+                        self.theme.hint,
+                    ),
+                ]);
+                if self.section_is_highlighted(line.id) {
+                    caption = caption.style(highlight::style());
+                } else if self.section_is_selected(line.id, tui_has_focus) {
+                    caption = caption.bg(section_selected_bg);
+                }
+                frame.render_widget(caption, Rect::new(area.x, y, area.width, 1));
+                y += 1;
+            } else {
+                skip_rows -= 1;
+            }
+
+            let rows = image_display_rows(side, area.width, image_layout, sides_count);
+            let top_skip = skip_rows.min(rows);
+            let visible = rows - top_skip;
+            skip_rows = skip_rows.saturating_sub(rows);
+            if visible == 0 {
+                continue;
+            }
+            let height = (visible as u16).min(bottom - y);
+            if height == 0 {
+                return;
+            }
+
+            let visible_area = Rect::new(area.x, y, area.width, height);
+            y += height;
+
+            // The image is encoded once at its full size; a partially visible image is
+            // clipped like in a browser by rendering only the visible rows, offset by
+            // what is scrolled past — scrolling never re-encodes.
+            let cache_key = (side.fingerprint, area.width, rows as u16);
+            if !protocols.contains_key(&cache_key) {
+                if !selection_settled {
+                    continue;
+                }
+                if protocols.len() >= MAX_IMAGE_PROTOCOLS {
+                    protocols.clear();
+                }
+                // Bilinear filtering; the default nearest-neighbour looks jagged when
+                // downscaling screenshots.
+                let Ok(protocol) = SlicedProtocol::new_with_resize(
+                    picker,
+                    side.image.clone(),
+                    Size::new(area.width, rows as u16),
+                    Resize::Fit(Some(FilterType::Triangle)),
+                ) else {
+                    continue;
+                };
+                protocols.insert(cache_key, protocol);
+            }
+            let protocol = protocols
+                .get(&cache_key)
+                .expect("just inserted or found above");
+            frame.render_widget(
+                SlicedImage::new(protocol, SignedPosition::from((0, -(top_skip as i16)))),
+                visible_area,
+            );
+        }
     }
 
     fn reset_scroll(&self) {
@@ -1140,9 +1336,14 @@ fn apply_pending_section_selection(
 
 struct ChannelLineWriter {
     tx: std::sync::mpsc::SyncSender<RenderThreadMessage>,
+    images_enabled: bool,
 }
 
 impl DiffLineWriter for ChannelLineWriter {
+    fn supports_images(&self) -> bool {
+        self.images_enabled
+    }
+
     fn write(&mut self, line: DetailsLine) -> anyhow::Result<()> {
         let result = self.tx.send(RenderThreadMessage::Line(line));
         if result.is_ok() {
@@ -1196,6 +1397,7 @@ fn extend_section_list(sections: &mut Vec<Section>, line_index: usize, line: &De
         }
         DetailsLine::Code(line) => (line.id, line.cli_id.clone()),
         DetailsLine::TextToWrap { id, .. } => (*id, None),
+        DetailsLine::Image(line) => (line.id, line.cli_id.clone()),
         DetailsLine::SectionSeparator => return false,
     };
 
@@ -1303,16 +1505,20 @@ enum PendingSectionSelection {
 #[derive(Debug, Default)]
 struct LayoutCache {
     width: u16,
+    image_layout: ImageLayout,
     line_count: usize,
     heights: Vec<usize>,
     prefix_sum: Vec<usize>,
 }
 
 impl LayoutCache {
-    fn update(&mut self, width: u16, lines: &[DetailsLine]) {
+    fn update(&mut self, width: u16, image_layout: ImageLayout, lines: &[DetailsLine]) {
         count_allocations("update_cache", || {
-            if self.width != width || self.line_count > lines.len() {
-                self.rebuild(width, lines);
+            if self.width != width
+                || self.image_layout != image_layout
+                || self.line_count > lines.len()
+            {
+                self.rebuild(width, image_layout, lines);
                 return;
             }
 
@@ -1325,7 +1531,7 @@ impl LayoutCache {
             }
 
             for line in &lines[self.line_count..] {
-                let height = display_height(line, width);
+                let height = display_height(line, width, image_layout);
                 self.heights.push(height);
                 let next = self.prefix_sum.last().copied().unwrap_or_default() + height;
                 self.prefix_sum.push(next);
@@ -1334,12 +1540,17 @@ impl LayoutCache {
         });
     }
 
-    fn rebuild(&mut self, width: u16, lines: &[DetailsLine]) {
+    fn rebuild(&mut self, width: u16, image_layout: ImageLayout, lines: &[DetailsLine]) {
         self.width = width;
+        self.image_layout = image_layout;
         self.line_count = 0;
         self.heights.clear();
         self.prefix_sum.clear();
-        self.update(width, lines);
+        self.update(width, image_layout, lines);
+    }
+
+    fn line_display_height(&self, line_index: usize) -> usize {
+        self.heights.get(line_index).copied().unwrap_or(1)
     }
 
     fn total_display_lines(&self) -> usize {
@@ -1408,11 +1619,62 @@ fn section_display_range(section: &Section, layout_cache: &LayoutCache) -> (usiz
     )
 }
 
-fn display_height(line: &DetailsLine, width: u16) -> usize {
+fn display_height(line: &DetailsLine, width: u16, image_layout: ImageLayout) -> usize {
     match line {
         DetailsLine::Text { .. } | DetailsLine::Code(_) | DetailsLine::SectionSeparator => 1,
         DetailsLine::TextToWrap { text, .. } => wrapped_text_lines(text, width).count(),
+        DetailsLine::Image(image_line) => {
+            let sides: Vec<&DecodedImage> = image_line
+                .image
+                .old
+                .iter()
+                .chain(image_line.image.new.iter())
+                .collect();
+            sides
+                .iter()
+                .map(|side| 1 + image_display_rows(side, width, image_layout, sides.len()))
+                .sum::<usize>()
+                .max(1)
+        }
     }
+}
+
+/// Sizing inputs for image lines: the terminal cell size in pixels and the pane height
+/// that caps how tall an image may grow.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+struct ImageLayout {
+    font_size: (u16, u16),
+    viewport_height: u16,
+}
+
+/// Terminal rows for one image: enough to show it at its native size scaled down to fit
+/// the pane width, capped to an equal share of the viewport per image so a before/after
+/// pair is fully visible together and renders at the same scale.
+fn image_display_rows(
+    side: &DecodedImage,
+    width: u16,
+    image_layout: ImageLayout,
+    sides_count: usize,
+) -> usize {
+    let (font_width, font_height) = image_layout.font_size;
+    if font_height == 0 {
+        return 1;
+    }
+    let width_px = u64::from(width) * u64::from(font_width);
+    let (image_width, image_height) = (u64::from(side.width.max(1)), u64::from(side.height));
+    let shown_width = width_px.min(image_width);
+    let shown_height = image_height * shown_width / image_width;
+
+    let sides_count = sides_count.max(1) as u64;
+    // Reserve rows for the captions plus the stats line, path header and padding around
+    // the images, so the whole before/after block tends to fit the viewport in one screen.
+    let reserved_rows = sides_count + 6;
+    let rows_per_side = (u64::from(image_layout.viewport_height).saturating_sub(reserved_rows)
+        / sides_count)
+        .max(1);
+    shown_height
+        .div_ceil(u64::from(font_height))
+        .clamp(1, rows_per_side) as usize
 }
 
 fn wrapped_text_lines(text: &str, width: u16) -> impl Iterator<Item = std::borrow::Cow<'_, str>> {
@@ -1553,6 +1815,26 @@ fn format_lines_in_section(lines: &[DetailsLine]) -> String {
                     text.push_str(line_text);
                 });
                 text.push('\n');
+            }
+            DetailsLine::Image(image_line) => {
+                let describe = |side: Option<&DecodedImage>| {
+                    side.map_or_else(
+                        || "(none)".to_string(),
+                        |side| {
+                            format!(
+                                "{}×{} ({})",
+                                side.width,
+                                side.height,
+                                human_bytes(side.byte_size)
+                            )
+                        },
+                    )
+                };
+                text.push_str(&format!(
+                    "image: {} → {}\n",
+                    describe(image_line.image.old.as_ref()),
+                    describe(image_line.image.new.as_ref()),
+                ));
             }
             DetailsLine::SectionSeparator => {}
         }

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -132,6 +132,8 @@ pub fn render_tui(
         let (_watcher_handle, received_watcher_event) =
             start_watcher(ctx).context("failed to start filesystem watcher")?;
 
+        app.details.set_graphics_picker(query_graphics_picker());
+
         let mut terminal_guard = CrosstermTerminalGuard::alt_screen(true)?;
         let mut event_polling = CrosstermEventPolling::default();
 
@@ -149,6 +151,44 @@ pub fn render_tui(
     };
 
     Ok((app.status_lines, outcome))
+}
+
+/// Detect the terminal's image graphics protocol for the details pane, or `None` when the
+/// terminal gives no sign of supporting one.
+///
+/// Detection queries the terminal over stdio, so it must run before raw mode and the
+/// alternate screen are entered. The query is only sent when environment variables suggest
+/// a graphics-capable terminal: those terminals reliably answer it, while querying an
+/// arbitrary terminal risks its unanswered-query reader thread swallowing the first
+/// keystroke and breaking raw mode (see `query_with_timeout` in `ratatui_image`).
+fn query_graphics_picker() -> Option<ratatui_image::picker::Picker> {
+    let env_is_set = |name: &str| std::env::var(name).is_ok_and(|value| !value.is_empty());
+    let term = std::env::var("TERM").unwrap_or_default();
+    let term_program = std::env::var("TERM_PROGRAM").unwrap_or_default();
+
+    let likely_supported = env_is_set("KITTY_WINDOW_ID")
+        || env_is_set("GHOSTTY_RESOURCES_DIR")
+        || env_is_set("WEZTERM_EXECUTABLE")
+        || env_is_set("KONSOLE_VERSION")
+        || env_is_set("XTERM_VERSION")
+        || term.contains("kitty")
+        || term.contains("ghostty")
+        || term.starts_with("foot")
+        || matches!(
+            term_program.as_str(),
+            "ghostty" | "WezTerm" | "iTerm.app" | "WarpTerminal" | "rio"
+        );
+    if !likely_supported {
+        return None;
+    }
+
+    ratatui_image::picker::Picker::from_query_stdio_with_options(
+        ratatui_image::picker::cap_parser::QueryStdioOptions {
+            timeout: std::time::Duration::from_millis(500),
+            ..Default::default()
+        },
+    )
+    .ok()
 }
 
 fn render_loop<T, E>(
@@ -374,10 +414,16 @@ where
 {
     if std::mem::take(&mut app.should_render) {
         let _span = tracing::trace_span!("render").entered();
-        terminal_guard.terminal_mut().draw(|frame| {
-            app.renders += 1;
-            count_allocations("render", || render_app(app, frame))
-        })?;
+        terminal_guard.begin_synchronized_update();
+        let drawn = terminal_guard
+            .terminal_mut()
+            .draw(|frame| {
+                app.renders += 1;
+                count_allocations("render", || render_app(app, frame))
+            })
+            .map(|_| ());
+        terminal_guard.end_synchronized_update();
+        drawn?;
     }
 
     Ok(())

--- a/crates/but/src/tui/image_diff.rs
+++ b/crates/but/src/tui/image_diff.rs
@@ -1,0 +1,216 @@
+//! Loading and decoding of changed image files so TUIs can render them as pictures
+//! instead of a "binary file" placeholder.
+
+use std::{
+    hash::{DefaultHasher, Hash as _, Hasher as _},
+    sync::{Arc, Mutex},
+};
+
+use bstr::{BStr, ByteSlice};
+use but_core::ui::{ChangeState, TreeChange, TreeStatus};
+use gix::object::tree::EntryKind;
+use image::DynamicImage;
+
+/// Images larger than this are not decoded to keep memory use and render latency in check.
+const MAX_IMAGE_BYTES: usize = 20 * 1024 * 1024;
+
+/// Decoded images larger than this on either axis are downscaled once at decode time,
+/// off the UI thread, so per-frame resizing and terminal encoding work on fewer pixels.
+const MAX_DECODED_EDGE: u32 = 1600;
+
+/// How many decoded image diffs to keep, so scrolling through commits never decodes the
+/// same image twice.
+const DECODE_CACHE_SIZE: usize = 16;
+
+/// Identity of one side of an image change for the decode cache.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SideId {
+    Absent,
+    Blob(gix::ObjectId),
+    /// A worktree file, identified by its stat data so edits invalidate the entry.
+    Worktree {
+        path: bstr::BString,
+        len: u64,
+        modified: std::time::SystemTime,
+    },
+}
+
+/// Cache key for one decoded image diff.
+type DecodeCacheKey = (SideId, SideId);
+
+/// Decoded image diffs, oldest first.
+static DECODE_CACHE: Mutex<Vec<(DecodeCacheKey, Arc<ImageDiffData>)>> = Mutex::new(Vec::new());
+
+/// Both sides of an image change, decoded and ready to render.
+#[derive(Debug, Clone)]
+pub(crate) struct ImageDiffData {
+    /// The previous image, absent for additions.
+    pub old: Option<DecodedImage>,
+    /// The current image, absent for deletions.
+    pub new: Option<DecodedImage>,
+}
+
+/// One decoded image plus the metadata shown in its caption.
+#[derive(Debug, Clone)]
+pub(crate) struct DecodedImage {
+    /// Possibly downscaled from the file's native size for cheaper rendering.
+    pub image: DynamicImage,
+    /// Native width of the image file, for captions and layout.
+    pub width: u32,
+    /// Native height of the image file, for captions and layout.
+    pub height: u32,
+    pub byte_size: usize,
+    /// Identifies the image content across renders, to cache terminal render state.
+    pub fingerprint: u64,
+}
+
+/// Return `true` if `path` has an extension of an image format we can decode.
+pub(crate) fn is_image_path(path: &[u8]) -> bool {
+    let Some((_, ext)) = path.rsplit_once_str(b".") else {
+        return false;
+    };
+    matches!(
+        ext.to_ascii_lowercase().as_slice(),
+        b"png" | b"jpg" | b"jpeg" | b"gif" | b"webp" | b"bmp" | b"ico" | b"tif" | b"tiff"
+    )
+}
+
+/// Decode the old and new images of `change`, or `None` if no side could be decoded.
+pub(crate) fn from_change(
+    repo: &gix::Repository,
+    change: &TreeChange,
+) -> Option<Arc<ImageDiffData>> {
+    let cache_key = decode_cache_key(repo, change);
+    if let Some(key) = &cache_key
+        && let Ok(cache) = DECODE_CACHE.lock()
+        && let Some((_, data)) = cache.iter().find(|(cached_key, _)| cached_key == key)
+    {
+        return Some(Arc::clone(data));
+    }
+
+    let path = change.path_bytes.as_bstr();
+    let (old, new) = match &change.status {
+        TreeStatus::Addition { state, .. } => (None, load_side(repo, state, path)),
+        TreeStatus::Deletion { previous_state } => (load_side(repo, previous_state, path), None),
+        TreeStatus::Modification {
+            previous_state,
+            state,
+            ..
+        } => (
+            load_side(repo, previous_state, path),
+            load_side(repo, state, path),
+        ),
+        TreeStatus::Rename {
+            previous_path_bytes,
+            previous_state,
+            state,
+            ..
+        } => (
+            load_side(repo, previous_state, previous_path_bytes.as_bstr()),
+            load_side(repo, state, path),
+        ),
+    };
+    let data = (old.is_some() || new.is_some()).then(|| Arc::new(ImageDiffData { old, new }))?;
+
+    if let Some(key) = cache_key
+        && let Ok(mut cache) = DECODE_CACHE.lock()
+    {
+        if cache.len() >= DECODE_CACHE_SIZE {
+            cache.remove(0);
+        }
+        cache.push((key, Arc::clone(&data)));
+    }
+    Some(data)
+}
+
+/// The decode-cache key for `change`, or `None` when a side cannot be identified.
+/// Blob sides are identified by their id; worktree sides (null id) by the file's stat
+/// data, so editing the file invalidates the cached decode.
+fn decode_cache_key(repo: &gix::Repository, change: &TreeChange) -> Option<DecodeCacheKey> {
+    let path = change.path_bytes.as_bstr();
+    match &change.status {
+        TreeStatus::Addition { state, .. } => Some((SideId::Absent, side_id(repo, state, path)?)),
+        TreeStatus::Deletion { previous_state } => {
+            Some((side_id(repo, previous_state, path)?, SideId::Absent))
+        }
+        TreeStatus::Modification {
+            previous_state,
+            state,
+            ..
+        } => Some((
+            side_id(repo, previous_state, path)?,
+            side_id(repo, state, path)?,
+        )),
+        TreeStatus::Rename {
+            previous_path_bytes,
+            previous_state,
+            state,
+            ..
+        } => Some((
+            side_id(repo, previous_state, previous_path_bytes.as_bstr())?,
+            side_id(repo, state, path)?,
+        )),
+    }
+}
+
+fn side_id(repo: &gix::Repository, state: &ChangeState, path: &BStr) -> Option<SideId> {
+    if !state.id.is_null() {
+        return Some(SideId::Blob(state.id));
+    }
+    let metadata = std::fs::metadata(repo.workdir()?.join(gix::path::from_bstr(path))).ok()?;
+    Some(SideId::Worktree {
+        path: path.to_owned(),
+        len: metadata.len(),
+        modified: metadata.modified().ok()?,
+    })
+}
+
+fn load_side(repo: &gix::Repository, state: &ChangeState, path: &BStr) -> Option<DecodedImage> {
+    if !matches!(state.kind, EntryKind::Blob | EntryKind::BlobExecutable) {
+        return None;
+    }
+    let bytes = if state.id.is_null() {
+        let workdir = repo.workdir()?;
+        std::fs::read(workdir.join(gix::path::from_bstr(path))).ok()?
+    } else {
+        repo.find_blob(state.id).ok()?.detach().data
+    };
+    if bytes.len() > MAX_IMAGE_BYTES {
+        return None;
+    }
+    let image = image::load_from_memory(&bytes).ok()?;
+    let (width, height) = (image.width(), image.height());
+    let image = if width > MAX_DECODED_EDGE || height > MAX_DECODED_EDGE {
+        image.resize(
+            MAX_DECODED_EDGE,
+            MAX_DECODED_EDGE,
+            image::imageops::FilterType::Triangle,
+        )
+    } else {
+        image
+    };
+    let fingerprint = {
+        let mut hasher = DefaultHasher::new();
+        bytes.hash(&mut hasher);
+        hasher.finish()
+    };
+    Some(DecodedImage {
+        image,
+        width,
+        height,
+        byte_size: bytes.len(),
+        fingerprint,
+    })
+}
+
+/// Format a byte count for image captions, e.g. `12.3 KiB`.
+pub(crate) fn human_bytes(bytes: usize) -> String {
+    let bytes = bytes as f64;
+    if bytes < 1024.0 {
+        format!("{bytes} B")
+    } else if bytes < 1024.0 * 1024.0 {
+        format!("{:.1} KiB", bytes / 1024.0)
+    } else {
+        format!("{:.1} MiB", bytes / (1024.0 * 1024.0))
+    }
+}

--- a/crates/but/src/tui/mod.rs
+++ b/crates/but/src/tui/mod.rs
@@ -11,6 +11,7 @@ pub mod get_text;
 
 pub(crate) mod diff_viewer;
 pub mod editor;
+pub(crate) mod image_diff;
 pub(crate) mod stage_viewer;
 
 mod picker;
@@ -222,6 +223,15 @@ pub(crate) trait TerminalGuard {
 
     /// Get a mutable reference to the guard's terminal.
     fn terminal_mut(&mut self) -> &mut Terminal<Self::Backend>;
+
+    /// Mark the start of a frame so the terminal presents it atomically, avoiding
+    /// tearing and flicker, notably with inline graphics. Terminals without support
+    /// ignore it. No-op unless the guard targets a real terminal.
+    fn begin_synchronized_update(&mut self) {}
+
+    /// Mark the end of a frame started with
+    /// [`begin_synchronized_update`](Self::begin_synchronized_update).
+    fn end_synchronized_update(&mut self) {}
 }
 
 impl TerminalGuard for CrosstermTerminalGuard {
@@ -238,6 +248,20 @@ impl TerminalGuard for CrosstermTerminalGuard {
 
     fn terminal_mut(&mut self) -> &mut Terminal<CrosstermBackend<io::Stdout>> {
         &mut self.terminal
+    }
+
+    fn begin_synchronized_update(&mut self) {
+        let _ = crossterm::execute!(
+            self.terminal.backend_mut(),
+            crossterm::terminal::BeginSynchronizedUpdate
+        );
+    }
+
+    fn end_synchronized_update(&mut self) {
+        let _ = crossterm::execute!(
+            self.terminal.backend_mut(),
+            crossterm::terminal::EndSynchronizedUpdate
+        );
     }
 }
 

--- a/crates/but/src/utils/diff_rendering.rs
+++ b/crates/but/src/utils/diff_rendering.rs
@@ -32,6 +32,7 @@ use crate::{
     CliId, IdMap,
     id::{ShortId, UncommittedHunk, UncommittedHunkOrFile},
     theme::Theme,
+    tui::image_diff::{self, ImageDiffData},
     utils::string_interning::{SharedStrings, Strings},
 };
 
@@ -76,6 +77,21 @@ impl IdGen<'_> {
 
 pub trait DiffLineWriter {
     fn write(&mut self, line: DetailsLine) -> anyhow::Result<()>;
+
+    /// Whether this writer can display [`DetailsLine::Image`] lines. When `false`, image
+    /// changes are not decoded and render as the usual binary-file placeholder text.
+    fn supports_images(&self) -> bool {
+        false
+    }
+
+    fn write_image(
+        &mut self,
+        id: SectionId,
+        cli_id: Option<Arc<CliId>>,
+        image: Arc<ImageDiffData>,
+    ) -> anyhow::Result<()> {
+        self.write(DetailsLine::Image(DetailsImageLine { id, cli_id, image }))
+    }
 
     fn write_selectable_text(
         &mut self,
@@ -186,6 +202,10 @@ impl<T> DiffLineWriter for WithSyntaxHighlighting<'_, T>
 where
     T: DiffLineWriter,
 {
+    fn supports_images(&self) -> bool {
+        self.inner.supports_images()
+    }
+
     fn write(&mut self, line: DetailsLine) -> anyhow::Result<()> {
         match line {
             DetailsLine::Code(code_line) => {
@@ -233,7 +253,17 @@ pub enum DetailsLine {
         text: String,
     },
     Code(DetailsCodeLine),
+    /// An image change, rendered as pictures by writers that support it.
+    Image(DetailsImageLine),
     SectionSeparator,
+}
+
+#[derive(Debug, Clone)]
+pub struct DetailsImageLine {
+    pub id: SectionId,
+    pub cli_id: Option<Arc<CliId>>,
+    /// Shared so cloning lines into the details cache stays cheap.
+    pub image: Arc<ImageDiffData>,
 }
 
 #[derive(Debug, Clone)]
@@ -497,7 +527,7 @@ pub fn render_commit(
         out.write_section_separator()?;
     }
 
-    render_tree_changes(tree_changes, theme, &mut id_gen, out)?;
+    render_tree_changes(tree_changes, ctx, theme, &mut id_gen, out)?;
 
     Ok(())
 }
@@ -527,7 +557,7 @@ pub fn render_branch(
         out.write_section_separator()?;
     }
 
-    render_tree_changes(tree_changes, theme, &mut id_gen, out)?;
+    render_tree_changes(tree_changes, ctx, theme, &mut id_gen, out)?;
 
     Ok(())
 }
@@ -542,6 +572,7 @@ pub fn render_uncommitted(
     let mut id_gen = id_gen.scoped("uncommitted");
 
     let wt_changes = but_api::diff::changes_in_worktree(ctx)?;
+    let worktree_changes = wt_changes.worktree_changes.changes;
     let id_map = IdMap::legacy_new_from_context(ctx, Some(wt_changes.assignments))?;
     let uncommitted_hunks = filter_uncommitted_hunks(ctx, &id_map, |hunk_assignment| {
         hunk_assignment.stack_id.is_none()
@@ -569,7 +600,20 @@ pub fn render_uncommitted(
             theme,
         )?;
 
-        render_hunk_assignment(id, Some(Arc::clone(&cli_id)), hunk_assignment, theme, out)?;
+        let image = (out.supports_images() && hunk_assignment.diff.is_none())
+            .then(|| {
+                image_for_worktree_path(
+                    ctx,
+                    &worktree_changes,
+                    hunk_assignment.path_bytes.as_bstr(),
+                )
+            })
+            .flatten();
+        if let Some(image) = image {
+            out.write_image(id, Some(Arc::clone(&cli_id)), image)?;
+        } else {
+            render_hunk_assignment(id, Some(Arc::clone(&cli_id)), hunk_assignment, theme, out)?;
+        }
 
         if pos.needs_padding_below() {
             out.write_section_separator()?;
@@ -591,6 +635,7 @@ pub fn render_uncommitted_hunk(
     let mut id_gen = id_gen.scoped(&hunk.id);
 
     let wt_changes = but_api::diff::changes_in_worktree(ctx)?;
+    let worktree_changes = wt_changes.worktree_changes.changes;
     let id_map = IdMap::legacy_new_from_context(ctx, Some(wt_changes.assignments))?;
     let uncommitted_hunks = filter_uncommitted_hunks(ctx, &id_map, |hunk_assignment| {
         uncommitted_hunk_matches_selection(hunk_assignment, &hunk)
@@ -618,7 +663,20 @@ pub fn render_uncommitted_hunk(
             theme,
         )?;
 
-        render_hunk_assignment(id, Some(Arc::clone(&cli_id)), hunk_assignment, theme, out)?;
+        let image = (out.supports_images() && hunk_assignment.diff.is_none())
+            .then(|| {
+                image_for_worktree_path(
+                    ctx,
+                    &worktree_changes,
+                    hunk_assignment.path_bytes.as_bstr(),
+                )
+            })
+            .flatten();
+        if let Some(image) = image {
+            out.write_image(id, Some(Arc::clone(&cli_id)), image)?;
+        } else {
+            render_hunk_assignment(id, Some(Arc::clone(&cli_id)), hunk_assignment, theme, out)?;
+        }
 
         if pos.needs_padding_below() {
             out.write_section_separator()?;
@@ -665,7 +723,7 @@ pub fn render_committed_file(
         out.write_section_separator()?;
     }
 
-    render_tree_changes(tree_changes, theme, &mut id_gen, out)?;
+    render_tree_changes(tree_changes, ctx, theme, &mut id_gen, out)?;
 
     Ok(())
 }
@@ -733,6 +791,25 @@ fn render_hunk_assignment(
     Ok(())
 }
 
+/// Decode both sides of `change` when its path looks like a renderable image.
+fn image_for_tree_change(ctx: &Context, change: &TreeChange) -> Option<Arc<ImageDiffData>> {
+    if !image_diff::is_image_path(&change.path_bytes) {
+        return None;
+    }
+    let repo = ctx.repo.get().ok()?;
+    image_diff::from_change(&repo, change)
+}
+
+/// Find the worktree change for `path` and decode it when it is an image.
+fn image_for_worktree_path(
+    ctx: &Context,
+    changes: &[TreeChange],
+    path: &BStr,
+) -> Option<Arc<ImageDiffData>> {
+    let change = changes.iter().find(|c| c.path_bytes.as_bstr() == path)?;
+    image_for_tree_change(ctx, change)
+}
+
 fn compute_line_stats_from_tree_changes(
     tree_changes: &[(TreeChange, UnifiedPatch)],
     line_stats: &mut LineStats,
@@ -756,6 +833,7 @@ fn compute_line_stats_from_tree_changes(
 
 fn render_tree_changes(
     tree_changes: Vec<(TreeChange, UnifiedPatch)>,
+    ctx: &Context,
     theme: &'static Theme,
     id_gen: &mut IdGen<'_>,
     out: &mut dyn DiffLineWriter,
@@ -817,11 +895,19 @@ fn render_tree_changes(
                     theme,
                 )?;
 
-                out.write_selectable_text(
-                    patch_id,
-                    None,
-                    "Binary file - no diff available".into(),
-                )?;
+                if let Some(image) = out
+                    .supports_images()
+                    .then(|| image_for_tree_change(ctx, &tree_change))
+                    .flatten()
+                {
+                    out.write_image(patch_id, None, image)?;
+                } else {
+                    out.write_selectable_text(
+                        patch_id,
+                        None,
+                        "Binary file - no diff available".into(),
+                    )?;
+                }
 
                 if tree_change_pos.needs_padding_below() {
                     out.write_section_separator()?;


### PR DESCRIPTION
Changed images previously showed only a "no diff available" placeholder in the details pane. They now render as pictures: before on top, after below, at equal scale, each with a caption of its dimensions and file size. Works for uncommitted changes, commits, committed files, and branch diffs.

Rendering uses ratatui-image's graphics support — kitty, iTerm2, or sixel where the terminal supports one. The capability query must run before entering the alternate screen and is only sent when environment variables suggest a graphics-capable terminal, because ratatui-image's query thread swallows a keystroke and breaks raw mode when the query goes unanswered. Terminals without graphics keep the placeholder text, as does the but-2 ANSI renderer, which shares the diff-rendering engine but never requests image decoding.

Notable decisions:

- Images are encoded for the terminal once at full display size via SlicedProtocol; scrolling renders only the visible rows with an offset (browser-style clipping), so scrolling never re-encodes or re-uploads and does not flicker.
- Decoded images are cached by blob ids — worktree files by path/size/mtime so edits invalidate naturally — and pre-scaled off the UI thread; terminal encodes are cached by content fingerprint and debounced until the selection rests, keeping commit-to-commit navigation smooth.
- Frames are bracketed in synchronized-update escapes (mode 2026) so terminals present them atomically; unsupported terminals ignore this.
- The image decoding crates are added to the dev-profile opt-level overrides, following the existing gix precedent — unoptimized PNG decoding made debug builds unusably slow.