### PR TITLE
breaking(but): remove ability to match branches by substrings

### DIFF
--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -824,18 +824,6 @@ impl IdMap {
             return Ok(Vec::new());
         }
 
-        // Partial branch name match.
-        for stack_with_id in self.indexed_stacks.borrow_owner().iter() {
-            for segment_with_id in stack_with_id.segments.iter() {
-                if segment_with_id
-                    .branch_name()
-                    .is_some_and(|branch_name| branch_name.contains_str(element))
-                {
-                    matches.push(Box::new(segment_with_id));
-                }
-            }
-        }
-
         // Only try SHA matching if the input looks like a hex string
         if element
             .chars()
@@ -881,7 +869,7 @@ impl IdMap {
         // Then try CliId matching
         for stack_with_id in self.indexed_stacks.borrow_owner().iter() {
             for segment_with_id in stack_with_id.segments.iter() {
-                if segment_with_id.is_auto_id && segment_with_id.short_id == element {
+                if segment_with_id.short_id == element {
                     matches.push(Box::new(segment_with_id));
                 }
             }
@@ -910,11 +898,15 @@ impl IdMap {
             matches.push(Box::new(Unstaged {}));
         }
 
-        // To avoid false positives, only check uncommitted files if nothing
-        // else matches. See the uncommitted_files_disambiguate_with_branch()
-        // test for an example of the desired behavior (an uncommitted file
-        // is assigned the ID "kpr" to avoid ambiguity with a branch with the
-        // substring "kp"), so it should not match with "kp".
+        // We only match against uncommitted files if there are no other matches. The reason for
+        // this is that we want prefix matching for uncommitted files to make the IDs "stable under
+        // shortening". However, as the reverse hex IDs of uncommitted files may collide with branch
+        // names and/or branch short IDs, we only match against uncommitted files if there are no
+        // other matches. This allows branch name short IDs to be prefixes of uncommitted file short
+        // IDs.
+        //
+        // We should consider namespacing the branch short IDs as this problem will only grow with
+        // the introduction of change IDs for commits.
         if matches.is_empty() {
             let element_bstring = BString::from(element);
             for (reverse_hex, uncommitted_file) in self

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -347,9 +347,6 @@ impl<'a> Node<'a> for &'a RemoteCommitWithId {
 pub struct SegmentWithId {
     /// The short ID.
     pub short_id: ShortId,
-    /// True iff `short_id` was generated from scratch (and not from a substring
-    /// of the branch name).
-    pub is_auto_id: bool,
     /// The original segment except that `commits` and `commits_on_remote` are
     /// blank to save memory.
     pub inner: StackSegment,

--- a/crates/but/src/id/stacks_info.rs
+++ b/crates/but/src/id/stacks_info.rs
@@ -36,7 +36,6 @@ fn stacks_info_without_short_ids(stacks: Vec<Stack>) -> StacksInfo {
                 .collect::<Vec<_>>();
             stack_with_id.segments.push(SegmentWithId {
                 short_id: ShortId::default(),
-                is_auto_id: false,
                 inner: segment,
                 workspace_commits,
                 remote_commits,
@@ -102,18 +101,18 @@ fn populate_branch_short_ids(
             // name, it doesn't need an ID.
             continue;
         };
-        (segment.short_id, segment.is_auto_id) = 'short_id: {
+        segment.short_id = 'short_id: {
             // Find first non-conflicting pair or triple (i.e. used in
             // exactly one branch) and use it.
             for candidate in branch_name.windows(2).chain(branch_name.windows(3)) {
                 if let Ok(short_id) = str::from_utf8(candidate)
                     && let Some(1) = short_ids_to_count.get(short_id)
                 {
-                    break 'short_id (short_id.to_owned(), false);
+                    break 'short_id short_id.to_owned();
                 }
             }
             // If none available, use next available ID.
-            (id_usage.next_available()?.to_short_id(), true)
+            id_usage.next_available()?.to_short_id()
         };
     }
 

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -183,57 +183,6 @@ fn branches_work_with_single_character() -> anyhow::Result<()> {
 }
 
 #[test]
-fn branches_match_by_substring() -> anyhow::Result<()> {
-    let stacks = vec![stack([
-        segment("foo-bar", [id(1)], None, []),
-        segment("bar", [id(2)], None, []),
-        segment("foo", [id(3)], None, []),
-        segment("baz", [id(4)], None, []),
-    ])];
-
-    let id_map = IdMap::new(stacks, Vec::new())?;
-    let changed_paths_fn = |commit_id: gix::ObjectId,
-                            parent_id: Option<gix::ObjectId>|
-     -> anyhow::Result<Vec<but_core::TreeChange>> {
-        bail!("unexpected IDs {commit_id} {parent_id:?}");
-    };
-    insta::assert_debug_snapshot!(id_map.debug_state(), @"
-    workspace_and_remote_commits_count: 4
-    branches: [ az, g0, h0, i0 ]
-    ");
-
-    let expected = [
-        CliId::Branch {
-            name: "foo-bar".into(),
-            id: "g0".into(),
-            stack_id: None,
-        },
-        CliId::Branch {
-            name: "foo".into(),
-            id: "i0".into(),
-            stack_id: None,
-        },
-    ];
-    assert_eq!(
-        id_map.parse("fo", Box::new(changed_paths_fn))?,
-        expected,
-        "substring searches can yield multiple items"
-    );
-
-    let expected = [CliId::Branch {
-        name: "baz".into(),
-        id: "az".into(),
-        stack_id: None,
-    }];
-    assert_eq!(
-        id_map.parse("az", Box::new(changed_paths_fn))?,
-        expected,
-        "We see the ID was generated from a substring directly"
-    );
-    Ok(())
-}
-
-#[test]
 fn branches_avoid_uncommitted_area_id() -> anyhow::Result<()> {
     let stacks = vec![stack([segment("zza", [id(1)], None, [])])];
     let id_map = IdMap::new(stacks, Vec::new())?;
@@ -283,7 +232,7 @@ fn branches_avoid_invalid_ids() -> anyhow::Result<()> {
         stack_id: None,
     }];
     assert_eq!(
-        id_map.parse("x-yz", Box::new(changed_paths_fn))?,
+        id_map.parse("yz", Box::new(changed_paths_fn))?,
         expected,
         "avoids non-alphanumeric, taking first alphanumeric pair"
     );
@@ -293,7 +242,7 @@ fn branches_avoid_invalid_ids() -> anyhow::Result<()> {
         stack_id: None,
     }];
     assert_eq!(
-        id_map.parse("0ax", Box::new(changed_paths_fn))?,
+        id_map.parse("ax", Box::new(changed_paths_fn))?,
         expected,
         "avoids hexdigit pair which can be confused with a commit ID"
     );
@@ -752,10 +701,18 @@ fn uncommitted_files_disambiguate_between_themselves() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Branch names and short IDs can be prefixes of the reverse hex IDs of file paths for uncommitted
+/// files.
+///
+/// The current solution to this is to only match against uncommitted file short IDs if there are no
+/// other matches. So even on overlapping prefixes, we can still match out a branch short ID.
+///
+/// This needs to be extended further or reconsidered once commits can be matched via change ID, as
+/// change IDs do not provide the convenience of being hexadecimal.
 #[test]
 fn uncommitted_files_disambiguate_with_branch() -> anyhow::Result<()> {
-    let stacks = vec![stack([segment("fookpfoo", [id(1)], None, [])])];
-    let hunk_assignments = vec![hunk_assignment("foo23", None)];
+    let stacks = vec![stack([segment("qsy", [id(1)], None, [])])];
+    let hunk_assignments = vec![hunk_assignment("file", None)];
     let id_map = IdMap::new(stacks, hunk_assignments)?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -767,29 +724,40 @@ fn uncommitted_files_disambiguate_with_branch() -> anyhow::Result<()> {
         })
     };
 
-    // Only the branch is returned
-    insta::assert_debug_snapshot!(id_map.parse("kp", Box::new(changed_paths_fn))?, @r#"
+    // Only the branch is returned when querying by short ID
+    insta::assert_debug_snapshot!(id_map.parse("qs", Box::new(changed_paths_fn))?, @r#"
     [
         Branch {
-            name: "fookpfoo",
-            id: "ok",
+            name: "qsy",
+            id: "qs",
+            stack_id: None,
+        },
+    ]
+    "#);
+
+    // Still only the branch when querying by full name
+    insta::assert_debug_snapshot!(id_map.parse("qsy", Box::new(changed_paths_fn))?, @r#"
+    [
+        Branch {
+            name: "qsy",
+            id: "qs",
             stack_id: None,
         },
     ]
     "#);
 
     // More characters must be specified to get the file
-    insta::assert_debug_snapshot!(id_map.parse("kpr", Box::new(changed_paths_fn))?, @r#"
+    insta::assert_debug_snapshot!(id_map.parse("qsyn", Box::new(changed_paths_fn))?, @r#"
     [
         UncommittedHunkOrFile(
             UncommittedHunkOrFile {
-                id: "kpr",
+                id: "qsyn",
                 hunk_assignments: NonEmpty {
                     head: HunkAssignment {
                         id: None,
                         hunk_header: None,
                         path: "",
-                        path_bytes: "foo23",
+                        path_bytes: "file",
                         stack_id: None,
                         branch_ref_bytes: None,
                         line_nums_added: None,


### PR DESCRIPTION
We only match exact short ID now to reduce collisions with commit IDs.