### PR TITLE
Support reordering empty branches in single-branch mode

### DIFF
--- a/apps/desktop/src/lib/dragging/dropHandlers/branchDropHandler.ts
+++ b/apps/desktop/src/lib/dragging/dropHandlers/branchDropHandler.ts
@@ -42,12 +42,17 @@ export class MoveBranchDzHandler implements DropzoneHandler {
 	}
 
 	accepts(data: unknown): boolean {
-		return (
-			data instanceof BranchDropData &&
-			data.stackId !== this.stackId &&
-			!data.hasConflicts &&
-			data.numberOfCommits > 0 // TODO: If trying to move an empty branch, we should just delete the reference and recreate it.
-		);
+		if (!(data instanceof BranchDropData) || data.hasConflicts) {
+			return false;
+		}
+		// Dropping a (non-empty) branch onto a different stack merges it into that stack.
+		if (data.stackId !== this.stackId) {
+			return data.numberOfCommits > 0;
+		}
+		// Reordering within the same stack is a pure metadata operation only for empty branches
+		// (e.g. single-branch mode, where all branches share one stack). Don't accept a drop onto
+		// the branch's own position, which would be a no-op self-move.
+		return data.numberOfCommits === 0 && data.branchName !== this.branchName;
 	}
 	async ondrop(data: BranchDropData): Promise<DropResult | void> {
 		const sourceStackDeleted = data.numberOfBranchesInStack === 1;

--- a/apps/desktop/src/lib/dragging/dropHandlers/branchDropHandler.ts
+++ b/apps/desktop/src/lib/dragging/dropHandlers/branchDropHandler.ts
@@ -64,7 +64,9 @@ export class MoveBranchDzHandler implements DropzoneHandler {
 		});
 
 		if (this.prService && this.baseBranchName) {
-			if (!sourceStackDeleted) {
+			// For a same-stack reorder the source and target stacks are identical, so the refresh
+			// below already covers it - only refresh the source stack when it's a different stack.
+			if (!sourceStackDeleted && data.stackId !== this.stackId) {
 				const branchDetails = await this.stackService.fetchBranches(this.projectId, data.stackId);
 				await updateStackPrs(
 					this.prService,

--- a/apps/desktop/src/lib/stacks/stackEndpoints.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.ts
@@ -789,6 +789,10 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 				invalidatesList(ReduxTag.HeadSha),
 				invalidatesList(ReduxTag.WorktreeChanges), // Moving commits can cause conflicts
 				invalidatesList(ReduxTag.BranchChanges),
+				// Reordering empty branches in single-branch mode is metadata-only and doesn't move
+				// HEAD, so the stack/branch list must be invalidated explicitly to reflect the new order.
+				invalidatesList(ReduxTag.Stacks),
+				invalidatesList(ReduxTag.StackDetails),
 			],
 		}),
 		tearOffBranch: build.mutation<

--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -1297,7 +1297,7 @@ pub fn move_branch_with_perm(
     dry_run: DryRun,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<MoveBranchResult> {
-    branch_mutation_with_snapshot(
+    let (result, new_tip) = branch_mutation_with_snapshot(
         ctx,
         perm,
         OperationKind::MoveBranch,
@@ -1306,14 +1306,33 @@ pub fn move_branch_with_perm(
             let mut meta = ctx.meta()?;
             let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
             let editor = Editor::create(&mut ws, &mut meta, &repo)?;
-            let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-                but_workspace::branch::move_branch(editor, subject_branch, target_branch)?;
+            let but_workspace::branch::move_branch::Outcome {
+                rebase,
+                ws_meta,
+                new_tip,
+            } = but_workspace::branch::move_branch(editor, subject_branch, target_branch)?;
 
-            Ok(MoveBranchResult {
+            let result = MoveBranchResult {
                 workspace: branch_workspace_from_rebase(rebase, ws_meta, &repo, dry_run)?,
-            })
+            };
+            Ok((result, new_tip))
         },
-    )
+    )?;
+
+    // In single-branch (ad-hoc) mode a move can place the subject above the checked-out tip. The
+    // operation doesn't move `HEAD`, so check out the new tip here to keep the moved branch part of
+    // the projected workspace (mirroring `create_reference`). Skipped on dry runs.
+    let is_dry_run: bool = dry_run.into();
+    if let Some(new_tip) = new_tip
+        && !is_dry_run
+    {
+        let checkout = branch_checkout_with_perm(ctx, new_tip, perm)?;
+        return Ok(MoveBranchResult {
+            workspace: checkout.workspace,
+        });
+    }
+
+    Ok(result)
 }
 
 /// Tears off a branch using the behavior described by [`tear_off_branch_with_perm()`].
@@ -1358,8 +1377,9 @@ pub fn tear_off_branch_with_perm(
             let mut meta = ctx.meta()?;
             let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
             let editor = Editor::create(&mut ws, &mut meta, &repo)?;
-            let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-                but_workspace::branch::tear_off_branch(editor, subject_branch, None)?;
+            let but_workspace::branch::move_branch::Outcome {
+                rebase, ws_meta, ..
+            } = but_workspace::branch::tear_off_branch(editor, subject_branch, None)?;
 
             Ok(MoveBranchResult {
                 workspace: branch_workspace_from_rebase(rebase, ws_meta, &repo, dry_run)?,

--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -1307,10 +1307,19 @@ pub fn move_branch_with_perm(
             let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
             let editor = Editor::create(&mut ws, &mut meta, &repo)?;
             let but_workspace::branch::move_branch::Outcome {
-                rebase,
+                mut rebase,
                 ws_meta,
                 new_tip,
+                branch_stack_order,
             } = but_workspace::branch::move_branch(editor, subject_branch, target_branch)?;
+
+            // In single-branch mode the reorder is returned rather than persisted. Only write it for
+            // real runs so a dry-run preview never mutates the user's branch-order metadata.
+            let is_dry_run: bool = dry_run.into();
+            if let Some(order) = branch_stack_order.filter(|_| !is_dry_run) {
+                let (_repo, meta) = rebase.repo_and_meta_mut();
+                meta.set_branch_stack_order(&order)?;
+            }
 
             let result = MoveBranchResult {
                 workspace: branch_workspace_from_rebase(rebase, ws_meta, &repo, dry_run)?,

--- a/crates/but-transaction/src/lib.rs
+++ b/crates/but-transaction/src/lib.rs
@@ -320,15 +320,32 @@ where
         Ok(())
     }
 
+    /// Restack `source_branch` on top of `target_branch` within the transaction's workspace.
+    ///
+    /// Transactions operate on managed workspaces only. The ad-hoc (single-branch) move path is the
+    /// one that populates [`Outcome::new_tip`] and [`Outcome::branch_stack_order`] for the caller to
+    /// apply, and `RecordingMetadata` can't persist branch stack order anyway, so we bail if either
+    /// field is ever set rather than silently dropping a metadata reorder or a required checkout.
+    ///
+    /// [`Outcome::new_tip`]: but_workspace::branch::move_branch::Outcome::new_tip
+    /// [`Outcome::branch_stack_order`]: but_workspace::branch::move_branch::Outcome::branch_stack_order
     pub fn stack_branch_on(
         &mut self,
         source_branch: &FullNameRef,
         target_branch: &FullNameRef,
     ) -> anyhow::Result<()> {
-        let ws_meta = self.rebase(|editor, _, _| {
+        let (ws_meta, new_tip, branch_stack_order) = self.rebase(|editor, _, _| {
             let outcome = but_workspace::branch::move_branch(editor, source_branch, target_branch)?;
-            Ok((outcome.ws_meta, outcome.rebase))
+            Ok((
+                (outcome.ws_meta, outcome.new_tip, outcome.branch_stack_order),
+                outcome.rebase,
+            ))
         })?;
+
+        anyhow::ensure!(
+            new_tip.is_none() && branch_stack_order.is_none(),
+            "Ad-hoc (single-branch) branch moves are not supported inside transactions"
+        );
 
         self.record_workspace_metadata_update(ws_meta)?;
 

--- a/crates/but-workspace/src/branch/move_branch.rs
+++ b/crates/but-workspace/src/branch/move_branch.rs
@@ -17,6 +17,11 @@ pub struct Outcome<'ws, 'meta, M: RefMetadata> {
     /// the projected workspace (mirroring [`create_reference`](crate::branch::create_reference())).
     /// `None` when the tip is unchanged.
     pub new_tip: Option<gix::refs::FullName>,
+    /// In single-branch (ad-hoc) mode, the reordered tip-to-base branch chain that the caller should
+    /// persist with [`RefMetadata::set_branch_stack_order`].
+    /// It is returned rather than written here so callers can apply it only for real runs and skip
+    /// persistence for dry-run previews. `None` outside single-branch mode.
+    pub branch_stack_order: Option<Vec<gix::refs::FullName>>,
 }
 
 pub(super) mod function {
@@ -90,6 +95,7 @@ pub(super) mod function {
                 rebase: editor.rebase()?,
                 ws_meta,
                 new_tip: None,
+                branch_stack_order: None,
             });
         }
 
@@ -151,6 +157,7 @@ pub(super) mod function {
             rebase: editor.rebase()?,
             ws_meta,
             new_tip: None,
+            branch_stack_order: None,
         })
     }
 
@@ -191,7 +198,6 @@ pub(super) mod function {
                 successful_rebase,
                 workspace.ref_name().map(ToOwned::to_owned),
                 source,
-                destination,
                 subject_branch_name,
                 target_branch_name,
             ),
@@ -214,22 +220,23 @@ pub(super) mod function {
     /// In single-branch (ad-hoc) mode there is no workspace commit, and the tip-to-base order of
     /// same-commit empty branches lives in the `branch_order` metadata table rather than in the
     /// workspace metadata. Reordering two empty branches is therefore a pure metadata operation
-    /// with no graph rewrite - mirror `create_reference`'s ad-hoc handling and persist the new
-    /// order directly.
+    /// with no graph rewrite - mirror `create_reference`'s ad-hoc handling. The reordered chain is
+    /// returned in [`Outcome::branch_stack_order`] for the caller to persist (via
+    /// [`RefMetadata::set_branch_stack_order`]) rather than being written here, so callers can skip
+    /// persistence for dry-run previews.
     fn move_branch_in_single_branch_mode<'ws, 'meta, M: RefMetadata>(
         mut successful_rebase: SuccessfulRebase<'ws, 'meta, M>,
         entrypoint: Option<gix::refs::FullName>,
         source: WorkspaceSegmentContext,
-        destination: WorkspaceSegmentContext,
         subject_branch_name: &FullNameRef,
         target_branch_name: &FullNameRef,
     ) -> anyhow::Result<Outcome<'ws, 'meta, M>> {
         let (_, subject_segment) = &source;
-        let (_, target_segment) = &destination;
-        // The base-most segment of a single-branch stack owns the commits, so a non-empty segment
-        // means the move would change commit ownership and needs a real rebase.
-        if !(subject_segment.commits.is_empty() && target_segment.commits.is_empty()) {
-            bail!("Moving non-empty branches in single-branch mode is not yet supported");
+        // Only the *subject* needs to be empty: a branch that owns no commits can be reordered by
+        // metadata alone, regardless of whether the target owns commits (e.g. the base branch). A
+        // non-empty subject would change commit ownership and needs a real rebase.
+        if !subject_segment.commits.is_empty() {
+            bail!("Moving a non-empty branch in single-branch mode is not yet supported");
         }
         let (_repo, meta) = successful_rebase.repo_and_meta_mut();
         if !meta.can_persist_branch_stack_order() {
@@ -237,18 +244,28 @@ pub(super) mod function {
                 "Cannot reorder '{subject_branch_name}' in single-branch mode without branch order metadata"
             );
         }
+        // Reorder against the existing chain. A movable subject is always part of `branch_order`
+        // (that's what makes it a projected segment), so the first lookup normally succeeds. The
+        // target and entrypoint lookups are defensive fallbacks so that, should the projection ever
+        // surface a segment that isn't tracked yet, we extend the real chain instead of clobbering
+        // it down to just the moved refs.
         let existing_order = match meta.branch_stack_order(subject_branch_name)? {
             Some(order) => order,
-            None => meta
-                .branch_stack_order(target_branch_name)?
-                .unwrap_or_default(),
+            None => match meta.branch_stack_order(target_branch_name)? {
+                Some(order) => order,
+                None => entrypoint
+                    .as_ref()
+                    .map(|entrypoint| meta.branch_stack_order(entrypoint.as_ref()))
+                    .transpose()?
+                    .flatten()
+                    .unwrap_or_default(),
+            },
         };
         let new_order = reorder_empty_branch_in_stack_order(
             existing_order,
             target_branch_name,
             subject_branch_name,
         );
-        meta.set_branch_stack_order(&new_order)?;
 
         // Moving the subject on top of the checked-out branch makes it the new tip. The workspace
         // only projects the entrypoint and the segments below it, so unless `HEAD` moves the subject
@@ -261,6 +278,7 @@ pub(super) mod function {
             rebase: successful_rebase,
             ws_meta: None,
             new_tip,
+            branch_stack_order: Some(new_order),
         })
     }
 
@@ -295,6 +313,7 @@ pub(super) mod function {
                 rebase: successful_rebase,
                 ws_meta,
                 new_tip: None,
+                branch_stack_order: None,
             });
         }
 
@@ -335,6 +354,7 @@ pub(super) mod function {
             rebase: editor.rebase()?,
             ws_meta,
             new_tip: None,
+            branch_stack_order: None,
         })
     }
 

--- a/crates/but-workspace/src/branch/move_branch.rs
+++ b/crates/but-workspace/src/branch/move_branch.rs
@@ -11,6 +11,12 @@ pub struct Outcome<'ws, 'meta, M: RefMetadata> {
     /// The updated workspace metadata that accompanies the move operation.
     /// It should replace the actual workspace metadata to configure moved 'virtual' branches segments, if `Some()`.
     pub ws_meta: Option<but_core::ref_metadata::Workspace>,
+    /// In single-branch (ad-hoc) mode, set to the reference that became the new tip when the move
+    /// placed the subject above the currently checked-out branch. `HEAD` is *not* moved by the
+    /// operation; the caller is responsible for checking this out so the moved branch stays part of
+    /// the projected workspace (mirroring [`create_reference`](crate::branch::create_reference)).
+    /// `None` when the tip is unchanged.
+    pub new_tip: Option<gix::refs::FullName>,
 }
 
 pub(super) mod function {
@@ -83,6 +89,7 @@ pub(super) mod function {
             return Ok(Outcome {
                 rebase: editor.rebase()?,
                 ws_meta,
+                new_tip: None,
             });
         }
 
@@ -143,6 +150,7 @@ pub(super) mod function {
         Ok(Outcome {
             rebase: editor.rebase()?,
             ws_meta,
+            new_tip: None,
         })
     }
 
@@ -181,6 +189,7 @@ pub(super) mod function {
         match &workspace.kind {
             WorkspaceKind::AdHoc => move_branch_in_single_branch_mode(
                 successful_rebase,
+                workspace.ref_name().map(ToOwned::to_owned),
                 source,
                 destination,
                 subject_branch_name,
@@ -209,6 +218,7 @@ pub(super) mod function {
     /// order directly.
     fn move_branch_in_single_branch_mode<'ws, 'meta, M: RefMetadata>(
         mut successful_rebase: SuccessfulRebase<'ws, 'meta, M>,
+        entrypoint: Option<gix::refs::FullName>,
         source: WorkspaceSegmentContext,
         destination: WorkspaceSegmentContext,
         subject_branch_name: &FullNameRef,
@@ -239,9 +249,18 @@ pub(super) mod function {
             subject_branch_name,
         );
         meta.set_branch_stack_order(&new_order)?;
+
+        // Moving the subject on top of the checked-out branch makes it the new tip. The workspace
+        // only projects the entrypoint and the segments below it, so unless `HEAD` moves the subject
+        // would sit above the entrypoint and drop out of the projection. Report it as the new tip so
+        // the caller can check it out (mirroring `create_reference`); we don't move `HEAD` here.
+        let new_tip = (entrypoint.as_ref().map(|name| name.as_ref()) == Some(target_branch_name))
+            .then(|| subject_branch_name.to_owned());
+
         Ok(Outcome {
             rebase: successful_rebase,
             ws_meta: None,
+            new_tip,
         })
     }
 
@@ -275,6 +294,7 @@ pub(super) mod function {
             return Ok(Outcome {
                 rebase: successful_rebase,
                 ws_meta,
+                new_tip: None,
             });
         }
 
@@ -314,6 +334,7 @@ pub(super) mod function {
         Ok(Outcome {
             rebase: editor.rebase()?,
             ws_meta,
+            new_tip: None,
         })
     }
 

--- a/crates/but-workspace/src/branch/move_branch.rs
+++ b/crates/but-workspace/src/branch/move_branch.rs
@@ -27,6 +27,7 @@ pub(super) mod function {
     use anyhow::bail;
     use but_graph::workspace::WorkspaceKind;
     use but_rebase::graph_rebase::Editor;
+    use but_rebase::graph_rebase::SuccessfulRebase;
     use gix::refs::FullNameRef;
 
     /// Remove a branch out of a stack, creating a new stack out of it, in memory.
@@ -174,21 +175,87 @@ pub(super) mod function {
         let (source, destination) =
             retrieve_branches_and_containers(&workspace, subject_branch_name, target_branch_name)?;
 
-        let Some(workspace_head) = workspace.tip_commit().map(|commit| commit.id) else {
-            bail!("Couldn't find workspace head.")
-        };
-
-        // We're currently stopping the move branch operations imperatively at this stage, in order to
-        // reduce the scope of this first iteration of moving the branches.
+        // Each kind of workspace has a very different notion of what "moving a branch" means, so we
+        // dispatch into a dedicated handler for each one.
         // TODO: Enable and test that we can move branches in any kind of workspace.
         match &workspace.kind {
-            WorkspaceKind::Managed { .. } => {}
+            WorkspaceKind::AdHoc => move_branch_in_single_branch_mode(
+                successful_rebase,
+                source,
+                destination,
+                subject_branch_name,
+                target_branch_name,
+            ),
             WorkspaceKind::ManagedMissingWorkspaceCommit { .. } => {
                 bail!("Moving branches currently need a workspace commit")
             }
-            WorkspaceKind::AdHoc => {
-                bail!("Moving branches in non-managed workspaces is not supported");
-            }
+            WorkspaceKind::Managed { .. } => move_branch_in_managed_workspace(
+                successful_rebase,
+                workspace,
+                source,
+                destination,
+                subject_branch_name,
+                target_branch_name,
+            ),
+        }
+    }
+
+    /// Move a branch in a single-branch (ad-hoc) workspace, where `HEAD` is on a plain local branch.
+    ///
+    /// In single-branch (ad-hoc) mode there is no workspace commit, and the tip-to-base order of
+    /// same-commit empty branches lives in the `branch_order` metadata table rather than in the
+    /// workspace metadata. Reordering two empty branches is therefore a pure metadata operation
+    /// with no graph rewrite - mirror `create_reference`'s ad-hoc handling and persist the new
+    /// order directly.
+    fn move_branch_in_single_branch_mode<'ws, 'meta, M: RefMetadata>(
+        mut successful_rebase: SuccessfulRebase<'ws, 'meta, M>,
+        source: WorkspaceSegmentContext,
+        destination: WorkspaceSegmentContext,
+        subject_branch_name: &FullNameRef,
+        target_branch_name: &FullNameRef,
+    ) -> anyhow::Result<Outcome<'ws, 'meta, M>> {
+        let (_, subject_segment) = &source;
+        let (_, target_segment) = &destination;
+        // The base-most segment of a single-branch stack owns the commits, so a non-empty segment
+        // means the move would change commit ownership and needs a real rebase.
+        if !(subject_segment.commits.is_empty() && target_segment.commits.is_empty()) {
+            bail!("Moving non-empty branches in single-branch mode is not yet supported");
+        }
+        let (_repo, meta) = successful_rebase.repo_and_meta_mut();
+        if !meta.can_persist_branch_stack_order() {
+            bail!(
+                "Cannot reorder '{subject_branch_name}' in single-branch mode without branch order metadata"
+            );
+        }
+        let existing_order = match meta.branch_stack_order(subject_branch_name)? {
+            Some(order) => order,
+            None => meta
+                .branch_stack_order(target_branch_name)?
+                .unwrap_or_default(),
+        };
+        let new_order = reorder_empty_branch_in_stack_order(
+            existing_order,
+            target_branch_name,
+            subject_branch_name,
+        );
+        meta.set_branch_stack_order(&new_order)?;
+        Ok(Outcome {
+            rebase: successful_rebase,
+            ws_meta: None,
+        })
+    }
+
+    /// Move a branch within a managed workspace (one backed by a workspace commit).
+    fn move_branch_in_managed_workspace<'ws, 'meta, M: RefMetadata>(
+        successful_rebase: SuccessfulRebase<'ws, 'meta, M>,
+        workspace: but_graph::Workspace,
+        source: WorkspaceSegmentContext,
+        destination: WorkspaceSegmentContext,
+        subject_branch_name: &FullNameRef,
+        target_branch_name: &FullNameRef,
+    ) -> anyhow::Result<Outcome<'ws, 'meta, M>> {
+        let Some(workspace_head) = workspace.tip_commit().map(|commit| commit.id) else {
+            bail!("Couldn't find workspace head.")
         };
 
         let mut ws_meta = workspace.metadata.clone();
@@ -307,6 +374,26 @@ pub(super) mod function {
             );
         };
         Ok((own_context(source), own_context(destination)))
+    }
+
+    /// Reorder `subject` to sit directly on top of `target` in the tip-to-base ad-hoc `order`.
+    ///
+    /// Mirrors the [`Position::Above`](crate::branch::create_reference::Position) case of
+    /// `create_reference`'s `insert_into_branch_stack_order`: `subject` is removed and re-inserted
+    /// at `target`'s slot, pushing `target` (and everything below it) down. If `target` isn't in the
+    /// order (stale metadata), `subject` becomes the new tip.
+    fn reorder_empty_branch_in_stack_order(
+        mut order: Vec<gix::refs::FullName>,
+        target_branch_name: &FullNameRef,
+        subject_branch_name: &FullNameRef,
+    ) -> Vec<gix::refs::FullName> {
+        order.retain(|branch| branch.as_ref() != subject_branch_name);
+        let insert_idx = order
+            .iter()
+            .position(|branch| branch.as_ref() == target_branch_name)
+            .unwrap_or(0);
+        order.insert(insert_idx, subject_branch_name.to_owned());
+        order
     }
 
     fn move_branch_in_metadata(

--- a/crates/but-workspace/src/branch/move_branch.rs
+++ b/crates/but-workspace/src/branch/move_branch.rs
@@ -380,19 +380,28 @@ pub(super) mod function {
     ///
     /// Mirrors the [`Position::Above`](crate::branch::create_reference::Position) case of
     /// `create_reference`'s `insert_into_branch_stack_order`: `subject` is removed and re-inserted
-    /// at `target`'s slot, pushing `target` (and everything below it) down. If `target` isn't in the
-    /// order (stale metadata), `subject` becomes the new tip.
+    /// at `target`'s slot, pushing `target` (and everything below it) down.
+    ///
+    /// If `target` isn't tracked yet (stale or empty metadata) it is appended first, so that a move
+    /// where *both* branches are missing adds them both - `subject` on top of `target` - instead of
+    /// silently clobbering the rest of the ordering down to just `subject`.
     fn reorder_empty_branch_in_stack_order(
         mut order: Vec<gix::refs::FullName>,
         target_branch_name: &FullNameRef,
         subject_branch_name: &FullNameRef,
     ) -> Vec<gix::refs::FullName> {
         order.retain(|branch| branch.as_ref() != subject_branch_name);
-        let insert_idx = order
+        let target_idx = match order
             .iter()
             .position(|branch| branch.as_ref() == target_branch_name)
-            .unwrap_or(0);
-        order.insert(insert_idx, subject_branch_name.to_owned());
+        {
+            Some(idx) => idx,
+            None => {
+                order.push(target_branch_name.to_owned());
+                order.len() - 1
+            }
+        };
+        order.insert(target_idx, subject_branch_name.to_owned());
         order
     }
 
@@ -414,6 +423,71 @@ pub(super) mod function {
                 but_core::ref_metadata::WorkspaceCommitRelation::Merged,
                 |_| StackId::generate(),
             );
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::reorder_empty_branch_in_stack_order;
+
+        fn r(name: &str) -> gix::refs::FullName {
+            gix::refs::FullName::try_from(name).expect("valid ref name")
+        }
+
+        fn names(order: &[gix::refs::FullName]) -> Vec<String> {
+            order.iter().map(|n| n.to_string()).collect()
+        }
+
+        #[test]
+        fn moves_subject_on_top_of_target_when_both_present() {
+            let order = vec![r("refs/heads/main"), r("refs/heads/a"), r("refs/heads/b")];
+            let new = reorder_empty_branch_in_stack_order(
+                order,
+                r("refs/heads/main").as_ref(),
+                r("refs/heads/b").as_ref(),
+            );
+            // `b` moves directly above `main`, `a` shifts down.
+            assert_eq!(
+                names(&new),
+                ["refs/heads/b", "refs/heads/main", "refs/heads/a"]
+            );
+        }
+
+        #[test]
+        fn adds_subject_above_target_when_only_target_is_present() {
+            let order = vec![r("refs/heads/main")];
+            let new = reorder_empty_branch_in_stack_order(
+                order,
+                r("refs/heads/main").as_ref(),
+                r("refs/heads/new").as_ref(),
+            );
+            assert_eq!(names(&new), ["refs/heads/new", "refs/heads/main"]);
+        }
+
+        #[test]
+        fn adds_both_in_order_when_neither_is_present() {
+            // Stale/empty metadata: neither branch is tracked yet. Both are added, subject on top of
+            // target, without dropping any pre-existing ordering.
+            let order = vec![r("refs/heads/main")];
+            let new = reorder_empty_branch_in_stack_order(
+                order,
+                r("refs/heads/target").as_ref(),
+                r("refs/heads/subject").as_ref(),
+            );
+            assert_eq!(
+                names(&new),
+                ["refs/heads/main", "refs/heads/subject", "refs/heads/target"]
+            );
+        }
+
+        #[test]
+        fn adds_both_in_order_from_empty_metadata() {
+            let new = reorder_empty_branch_in_stack_order(
+                Vec::new(),
+                r("refs/heads/target").as_ref(),
+                r("refs/heads/subject").as_ref(),
+            );
+            assert_eq!(names(&new), ["refs/heads/subject", "refs/heads/target"]);
         }
     }
 }

--- a/crates/but-workspace/src/branch/move_branch.rs
+++ b/crates/but-workspace/src/branch/move_branch.rs
@@ -14,7 +14,7 @@ pub struct Outcome<'ws, 'meta, M: RefMetadata> {
     /// In single-branch (ad-hoc) mode, set to the reference that became the new tip when the move
     /// placed the subject above the currently checked-out branch. `HEAD` is *not* moved by the
     /// operation; the caller is responsible for checking this out so the moved branch stays part of
-    /// the projected workspace (mirroring [`create_reference`](crate::branch::create_reference)).
+    /// the projected workspace (mirroring [`create_reference`](crate::branch::create_reference())).
     /// `None` when the tip is unchanged.
     pub new_tip: Option<gix::refs::FullName>,
 }

--- a/crates/but-workspace/tests/workspace/branch/move_branch.rs
+++ b/crates/but-workspace/tests/workspace/branch/move_branch.rs
@@ -1267,3 +1267,186 @@ fn set_workspace_metadata(
     }
     Ok(())
 }
+
+/// Tests for `move_branch` in single-branch (ad-hoc) mode, where `HEAD` is on a plain local branch
+/// (no `gitbutler/workspace` commit) and the tip-to-base order of same-commit empty branches lives
+/// in the `branch_order` metadata table rather than in `Workspace` metadata.
+mod single_branch_mode {
+    use but_core::RefMetadata;
+    use but_core::ref_metadata::StackId;
+    use but_graph::init::Options;
+    use but_meta::BranchOrderMetadata;
+    use but_rebase::graph_rebase::Editor;
+    use but_testsupport::graph_workspace;
+    use but_workspace::branch::create_reference::{Anchor, Position};
+
+    use crate::ref_info::with_workspace_commit::utils::named_writable_scenario;
+    use crate::utils::r;
+
+    fn stack_id_for_name(rn: &gix::refs::FullNameRef) -> StackId {
+        use bstr::ByteSlice;
+        StackId::from_number_for_testing(rn.shorten().chars().map(|c| c as u128).sum())
+    }
+
+    fn branch_order_meta(repo: &gix::Repository) -> anyhow::Result<BranchOrderMetadata> {
+        BranchOrderMetadata::from_paths(repo.path().join("virtual-branches.toml"), repo.path())
+    }
+
+    /// Build a single-branch (ad-hoc) workspace on `main` (3 commits) with two empty dependent
+    /// branches `empty-top` and `empty-bottom` stacked above the commit-owning base branch.
+    ///
+    /// The tip-to-base branch order ends up as `[main, empty-top, empty-bottom, base]`, so both
+    /// `empty-top` and `empty-bottom` are empty segments that can be reordered by metadata alone.
+    fn ad_hoc_workspace_with_two_empty_branches() -> anyhow::Result<(
+        tempfile::TempDir,
+        gix::Repository,
+        BranchOrderMetadata,
+        but_core::ref_metadata::ProjectMeta,
+    )> {
+        let (tmp, repo, legacy_meta) = named_writable_scenario("single-branch-with-3-commits")?;
+        let project_meta = legacy_meta
+            .workspace(but_core::WORKSPACE_REF_NAME.try_into()?)
+            .map(|w| w.project_meta())
+            .unwrap_or_default();
+        let mut meta = branch_order_meta(&repo)?;
+
+        let main_ref = r("refs/heads/main");
+        let mut ws =
+            but_graph::Graph::from_head(&repo, &meta, project_meta.clone(), Options::limited())?
+                .into_workspace()?;
+
+        // Each branch is inserted directly below `main`, so creating them in this order yields the
+        // chain [main, empty-top, empty-bottom, base] (tip to base).
+        for name in [
+            "refs/heads/base",
+            "refs/heads/empty-bottom",
+            "refs/heads/empty-top",
+        ] {
+            ws = but_workspace::branch::create_reference(
+                r(name),
+                Anchor::at_reference(main_ref, Position::Below),
+                &repo,
+                &ws,
+                &mut meta,
+                stack_id_for_name,
+                None,
+            )?
+            .into_owned();
+        }
+
+        Ok((tmp, repo, meta, project_meta))
+    }
+
+    /// `move_branch` reorders two empty branches in single-branch (ad-hoc) mode by rewriting the
+    /// `branch_order` metadata, without any graph rewrite.
+    #[test]
+    fn reorder_empty_branches_updates_branch_order() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, project_meta) = ad_hoc_workspace_with_two_empty_branches()?;
+        let main_ref = r("refs/heads/main");
+
+        let mut ws =
+            but_graph::Graph::from_head(&repo, &meta, project_meta.clone(), Options::limited())?
+                .into_workspace()?;
+        // Single-branch (ad-hoc) workspace: `HEAD` is on `main` directly, no `gitbutler/workspace`
+        // commit. `empty-top`/`empty-bottom` are empty segments; `base` owns the commits.
+        insta::assert_snapshot!(graph_workspace(&ws), @"
+        ⌂:1:main[🌳] <> ✓! on 281da94
+        └── ≡:1:main[🌳] {1}
+            ├── :1:main[🌳]
+            ├── 📙:2:empty-top
+            ├── 📙:3:empty-bottom
+            └── 📙:0:base
+                ├── ·281da94
+                ├── ·12995d7
+                └── ·3d57fc1
+        ");
+        assert_eq!(
+            meta.branch_stack_order(main_ref)?,
+            Some(vec![
+                r("refs/heads/main").to_owned(),
+                r("refs/heads/empty-top").to_owned(),
+                r("refs/heads/empty-bottom").to_owned(),
+                r("refs/heads/base").to_owned(),
+            ]),
+        );
+
+        // Move `empty-bottom` on top of `empty-top` (both empty) - a pure metadata reorder.
+        let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+        let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
+            but_workspace::branch::move_branch(
+                editor,
+                r("refs/heads/empty-bottom"),
+                r("refs/heads/empty-top"),
+            )?;
+        assert!(
+            ws_meta.is_none(),
+            "ad-hoc reorder lives in branch_order, not workspace metadata"
+        );
+        rebase.materialize()?;
+
+        // The ad-hoc order is updated: `empty-bottom` now sits above `empty-top`.
+        assert_eq!(
+            meta.branch_stack_order(main_ref)?,
+            Some(vec![
+                r("refs/heads/main").to_owned(),
+                r("refs/heads/empty-bottom").to_owned(),
+                r("refs/heads/empty-top").to_owned(),
+                r("refs/heads/base").to_owned(),
+            ]),
+        );
+
+        // Re-projecting from the reloaded metadata reflects the new order, and no commit was moved.
+        let ws = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?
+            .into_workspace()?;
+        insta::assert_snapshot!(graph_workspace(&ws), @"
+        ⌂:1:main[🌳] <> ✓! on 281da94
+        └── ≡:1:main[🌳] {1}
+            ├── :1:main[🌳]
+            ├── 📙:2:empty-bottom
+            ├── 📙:3:empty-top
+            └── 📙:0:base
+                ├── ·281da94
+                ├── ·12995d7
+                └── ·3d57fc1
+        ");
+
+        Ok(())
+    }
+
+    /// Moving a *non-empty* branch in single-branch mode is not supported yet: the base-most branch
+    /// of a single-branch stack owns the commits, so moving it would change commit ownership and
+    /// needs a real rebase rather than a pure metadata reorder.
+    #[test]
+    fn moving_non_empty_branch_is_unsupported() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, project_meta) = ad_hoc_workspace_with_two_empty_branches()?;
+        let main_ref = r("refs/heads/main");
+        let order_before = meta.branch_stack_order(main_ref)?;
+
+        let mut ws = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?
+            .into_workspace()?;
+
+        // `base` owns the stack's commits, so trying to move it must be rejected.
+        let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+        let err = match but_workspace::branch::move_branch(
+            editor,
+            r("refs/heads/base"),
+            r("refs/heads/empty-top"),
+        ) {
+            // `Outcome` holds the metadata backend (not `Debug`), so unwrap the error by hand.
+            Ok(_) => panic!("moving a non-empty branch in single-branch mode should be rejected"),
+            Err(err) => err,
+        };
+
+        assert_eq!(
+            err.to_string(),
+            "Moving non-empty branches in single-branch mode is not yet supported"
+        );
+        assert_eq!(
+            meta.branch_stack_order(main_ref)?,
+            order_before,
+            "the ad-hoc branch order must be untouched after the rejected move"
+        );
+
+        Ok(())
+    }
+}

--- a/crates/but-workspace/tests/workspace/branch/move_branch.rs
+++ b/crates/but-workspace/tests/workspace/branch/move_branch.rs
@@ -1306,6 +1306,18 @@ mod single_branch_mode {
         BranchOrderMetadata::from_paths(repo.path().join("virtual-branches.toml"), repo.path())
     }
 
+    /// `move_branch` returns the reordered chain instead of persisting it (so callers can skip
+    /// persistence for dry runs); persist it here to mimic a real, non-dry-run caller.
+    fn persist_order(
+        meta: &mut BranchOrderMetadata,
+        order: &Option<Vec<gix::refs::FullName>>,
+    ) -> anyhow::Result<()> {
+        if let Some(order) = order {
+            meta.set_branch_stack_order(order)?;
+        }
+        Ok(())
+    }
+
     /// Build a single-branch (ad-hoc) workspace on `main` (3 commits) with two empty dependent
     /// branches `empty-top` and `empty-bottom` stacked above the commit-owning base branch.
     ///
@@ -1366,7 +1378,10 @@ mod single_branch_mode {
         // Move empty `empty-bottom` on top of the checked-out `main`, which makes it the new tip.
         let editor = Editor::create(&mut ws, &mut meta, &repo)?;
         let but_workspace::branch::move_branch::Outcome {
-            rebase, new_tip, ..
+            rebase,
+            new_tip,
+            branch_stack_order,
+            ..
         } = but_workspace::branch::move_branch(editor, r("refs/heads/empty-bottom"), main_ref)?;
         rebase.materialize()?;
 
@@ -1375,8 +1390,9 @@ mod single_branch_mode {
             new_tip.as_ref().map(|n| n.as_ref()),
             Some(r("refs/heads/empty-bottom"))
         );
+        // The reordered chain is returned (for the caller to persist), placing the subject on top.
         assert_eq!(
-            meta.branch_stack_order(main_ref)?,
+            branch_stack_order,
             Some(vec![
                 r("refs/heads/empty-bottom").to_owned(),
                 r("refs/heads/main").to_owned(),
@@ -1397,7 +1413,10 @@ mod single_branch_mode {
 
         let editor = Editor::create(&mut ws, &mut meta, &repo)?;
         let but_workspace::branch::move_branch::Outcome {
-            rebase, new_tip, ..
+            rebase,
+            new_tip,
+            branch_stack_order,
+            ..
         } = but_workspace::branch::move_branch(
             editor,
             r("refs/heads/empty-bottom"),
@@ -1408,6 +1427,10 @@ mod single_branch_mode {
         assert_eq!(
             new_tip, None,
             "target isn't the tip, so the tip is unchanged"
+        );
+        assert!(
+            branch_stack_order.is_some(),
+            "the reorder is still computed and returned"
         );
         Ok(())
     }
@@ -1452,7 +1475,10 @@ mod single_branch_mode {
         // Move `empty-bottom` on top of `empty-top` (both empty) - a pure metadata reorder.
         let editor = Editor::create(&mut ws, &mut meta, &repo)?;
         let but_workspace::branch::move_branch::Outcome {
-            rebase, ws_meta, ..
+            rebase,
+            ws_meta,
+            branch_stack_order,
+            ..
         } = but_workspace::branch::move_branch(
             editor,
             r("refs/heads/empty-bottom"),
@@ -1463,6 +1489,8 @@ mod single_branch_mode {
             "ad-hoc reorder lives in branch_order, not workspace metadata"
         );
         rebase.materialize()?;
+        // A real (non-dry-run) caller persists the returned order.
+        persist_order(&mut meta, &branch_stack_order)?;
 
         // The ad-hoc order is updated: `empty-bottom` now sits above `empty-top`.
         assert_eq!(
@@ -1523,7 +1551,7 @@ mod single_branch_mode {
 
         assert_eq!(
             err.to_string(),
-            "Moving non-empty branches in single-branch mode is not yet supported"
+            "Moving a non-empty branch in single-branch mode is not yet supported"
         );
         assert_eq!(
             meta.branch_stack_order(main_ref)?,
@@ -1531,6 +1559,136 @@ mod single_branch_mode {
             "the ad-hoc branch order must be untouched after the rejected move"
         );
 
+        Ok(())
+    }
+
+    /// Moving an *empty* branch onto the commit-owning base is a metadata-only reorder and must be
+    /// allowed - only a non-empty *subject* needs a real rebase, so a non-empty *target* is fine.
+    #[test]
+    fn reorder_empty_branch_onto_commit_owning_base() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, project_meta) = ad_hoc_workspace_with_two_empty_branches()?;
+
+        let mut ws = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?
+            .into_workspace()?;
+
+        // `base` owns the stack's commits; moving the empty `empty-top` on top of it is still just a
+        // metadata reorder and must succeed (previously rejected because the target owns commits).
+        let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+        let but_workspace::branch::move_branch::Outcome {
+            rebase,
+            new_tip,
+            branch_stack_order,
+            ..
+        } = but_workspace::branch::move_branch(
+            editor,
+            r("refs/heads/empty-top"),
+            r("refs/heads/base"),
+        )?;
+        rebase.materialize()?;
+
+        assert_eq!(new_tip, None, "base isn't the checked-out tip");
+        // `empty-top` is placed directly above `base`; the rest of the order is preserved.
+        assert_eq!(
+            branch_stack_order,
+            Some(vec![
+                r("refs/heads/main").to_owned(),
+                r("refs/heads/empty-bottom").to_owned(),
+                r("refs/heads/empty-top").to_owned(),
+                r("refs/heads/base").to_owned(),
+            ]),
+        );
+        Ok(())
+    }
+
+    /// Regression for the "clobbering" concern (#4): a branch is only projected as a *movable*
+    /// segment in ad-hoc mode when it's already part of `branch_order`. Refs that aren't tracked
+    /// there (e.g. stale/partial metadata, or refs created outside GitButler) are not projected as
+    /// segments, so `move_branch` fails to find them *before* reaching the reorder - it can never
+    /// overwrite the persisted order down to just untracked refs. This documents why the
+    /// "neither ref is tracked" path is unreachable in practice.
+    #[test]
+    fn untracked_refs_are_not_movable_and_never_clobber_order() -> anyhow::Result<()> {
+        use gix::refs::transaction::PreviousValue;
+
+        let (_tmp, repo, mut meta, project_meta) = ad_hoc_workspace_with_two_empty_branches()?;
+        let main_ref = r("refs/heads/main");
+        let order_before = meta.branch_stack_order(main_ref)?;
+        let tip = repo.find_reference(main_ref)?.peel_to_id()?.detach();
+
+        // Two refs at the tip that were never added to `branch_order`. They show up only as commit
+        // decorations, not as ordered stack segments.
+        repo.reference(r("refs/heads/x"), tip, PreviousValue::Any, "test")?;
+        repo.reference(r("refs/heads/y"), tip, PreviousValue::Any, "test")?;
+
+        let mut ws = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?
+            .into_workspace()?;
+        snapbox::assert_data_eq!(
+            graph_workspace(&ws).to_string(),
+            snapbox::str![[r#"
+⌂:1:main[🌳] <> ✓! on 281da94
+└── ≡:1:main[🌳] {1}
+    ├── :1:main[🌳]
+    ├── 📙:2:empty-top
+    ├── 📙:3:empty-bottom
+    └── 📙:0:base
+        ├── ·281da94 ►x, ►y
+        ├── ·12995d7
+        └── ·3d57fc1
+
+"#]]
+        );
+
+        let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+        let err = match but_workspace::branch::move_branch(
+            editor,
+            r("refs/heads/x"),
+            r("refs/heads/y"),
+        ) {
+            Ok(_) => panic!("untracked refs must not be movable in single-branch mode"),
+            Err(err) => err,
+        };
+        assert_eq!(
+            err.to_string(),
+            "Couldn't find branch to move in workspace with reference name: refs/heads/x"
+        );
+        assert_eq!(
+            meta.branch_stack_order(main_ref)?,
+            order_before,
+            "the branch order must be untouched"
+        );
+        Ok(())
+    }
+
+    /// `move_branch` computes the reorder but must not persist it on its own: the caller applies it,
+    /// which is what lets the API skip persistence for dry-run previews without corrupting metadata.
+    #[test]
+    fn move_branch_does_not_persist_branch_order() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, project_meta) = ad_hoc_workspace_with_two_empty_branches()?;
+        let main_ref = r("refs/heads/main");
+        let order_before = meta.branch_stack_order(main_ref)?;
+
+        let mut ws = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?
+            .into_workspace()?;
+        let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+        let but_workspace::branch::move_branch::Outcome {
+            rebase,
+            branch_stack_order,
+            ..
+        } = but_workspace::branch::move_branch(
+            editor,
+            r("refs/heads/empty-bottom"),
+            r("refs/heads/empty-top"),
+        )?;
+        rebase.materialize()?;
+
+        // A reorder is computed and returned...
+        assert!(branch_stack_order.is_some());
+        // ...but nothing is written to metadata until the caller persists it.
+        assert_eq!(
+            meta.branch_stack_order(main_ref)?,
+            order_before,
+            "move_branch must not persist branch order on its own"
+        );
         Ok(())
     }
 }

--- a/crates/but-workspace/tests/workspace/branch/move_branch.rs
+++ b/crates/but-workspace/tests/workspace/branch/move_branch.rs
@@ -1424,17 +1424,21 @@ mod single_branch_mode {
                 .into_workspace()?;
         // Single-branch (ad-hoc) workspace: `HEAD` is on `main` directly, no `gitbutler/workspace`
         // commit. `empty-top`/`empty-bottom` are empty segments; `base` owns the commits.
-        insta::assert_snapshot!(graph_workspace(&ws), @"
-        ⌂:1:main[🌳] <> ✓! on 281da94
-        └── ≡:1:main[🌳] {1}
-            ├── :1:main[🌳]
-            ├── 📙:2:empty-top
-            ├── 📙:3:empty-bottom
-            └── 📙:0:base
-                ├── ·281da94
-                ├── ·12995d7
-                └── ·3d57fc1
-        ");
+        snapbox::assert_data_eq!(
+            graph_workspace(&ws).to_string(),
+            snapbox::str![[r#"
+⌂:1:main[🌳] <> ✓! on 281da94
+└── ≡:1:main[🌳] {1}
+    ├── :1:main[🌳]
+    ├── 📙:2:empty-top
+    ├── 📙:3:empty-bottom
+    └── 📙:0:base
+        ├── ·281da94
+        ├── ·12995d7
+        └── ·3d57fc1
+
+"#]]
+        );
         assert_eq!(
             meta.branch_stack_order(main_ref)?,
             Some(vec![
@@ -1474,17 +1478,21 @@ mod single_branch_mode {
         // Re-projecting from the reloaded metadata reflects the new order, and no commit was moved.
         let ws = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?
             .into_workspace()?;
-        insta::assert_snapshot!(graph_workspace(&ws), @"
-        ⌂:1:main[🌳] <> ✓! on 281da94
-        └── ≡:1:main[🌳] {1}
-            ├── :1:main[🌳]
-            ├── 📙:2:empty-bottom
-            ├── 📙:3:empty-top
-            └── 📙:0:base
-                ├── ·281da94
-                ├── ·12995d7
-                └── ·3d57fc1
-        ");
+        snapbox::assert_data_eq!(
+            graph_workspace(&ws).to_string(),
+            snapbox::str![[r#"
+⌂:1:main[🌳] <> ✓! on 281da94
+└── ≡:1:main[🌳] {1}
+    ├── :1:main[🌳]
+    ├── 📙:2:empty-bottom
+    ├── 📙:3:empty-top
+    └── 📙:0:base
+        ├── ·281da94
+        ├── ·12995d7
+        └── ·3d57fc1
+
+"#]]
+        );
 
         Ok(())
     }

--- a/crates/but-workspace/tests/workspace/branch/move_branch.rs
+++ b/crates/but-workspace/tests/workspace/branch/move_branch.rs
@@ -54,12 +54,13 @@ fn move_top_branch_to_top_of_another_stack() -> anyhow::Result<()> {
 
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Put C on top of A
-    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-        but_workspace::branch::move_branch(
-            editor,
-            "refs/heads/C".try_into()?,
-            "refs/heads/A".try_into()?,
-        )?;
+    let but_workspace::branch::move_branch::Outcome {
+        rebase, ws_meta, ..
+    } = but_workspace::branch::move_branch(
+        editor,
+        "refs/heads/C".try_into()?,
+        "refs/heads/A".try_into()?,
+    )?;
 
     // Materialize the operation
     rebase.materialize()?;
@@ -179,12 +180,13 @@ fn move_bottom_branch_to_top_of_another_stack() -> anyhow::Result<()> {
     );
 
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
-    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-        but_workspace::branch::move_branch(
-            editor,
-            "refs/heads/B".try_into()?,
-            "refs/heads/A".try_into()?,
-        )?;
+    let but_workspace::branch::move_branch::Outcome {
+        rebase, ws_meta, ..
+    } = but_workspace::branch::move_branch(
+        editor,
+        "refs/heads/B".try_into()?,
+        "refs/heads/A".try_into()?,
+    )?;
 
     // Materialize the operation
     rebase.materialize()?;
@@ -270,12 +272,13 @@ fn move_single_branch_to_top_of_another_stack() -> anyhow::Result<()> {
 
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Put A on top of C
-    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-        but_workspace::branch::move_branch(
-            editor,
-            "refs/heads/A".try_into()?,
-            "refs/heads/C".try_into()?,
-        )?;
+    let but_workspace::branch::move_branch::Outcome {
+        rebase, ws_meta, ..
+    } = but_workspace::branch::move_branch(
+        editor,
+        "refs/heads/A".try_into()?,
+        "refs/heads/C".try_into()?,
+    )?;
 
     // Materialize the operation
     rebase.materialize()?;
@@ -357,12 +360,13 @@ fn reorder_branch_in_stack() -> anyhow::Result<()> {
 
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Put B on top of C
-    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-        but_workspace::branch::move_branch(
-            editor,
-            "refs/heads/B".try_into()?,
-            "refs/heads/C".try_into()?,
-        )?;
+    let but_workspace::branch::move_branch::Outcome {
+        rebase, ws_meta, ..
+    } = but_workspace::branch::move_branch(
+        editor,
+        "refs/heads/B".try_into()?,
+        "refs/heads/C".try_into()?,
+    )?;
 
     // Materialize the operation
     rebase.materialize()?;
@@ -448,12 +452,13 @@ fn insert_branch_in_the_middle_of_a_stack() -> anyhow::Result<()> {
 
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Put A on top of B, and below C
-    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-        but_workspace::branch::move_branch(
-            editor,
-            "refs/heads/A".try_into()?,
-            "refs/heads/B".try_into()?,
-        )?;
+    let but_workspace::branch::move_branch::Outcome {
+        rebase, ws_meta, ..
+    } = but_workspace::branch::move_branch(
+        editor,
+        "refs/heads/A".try_into()?,
+        "refs/heads/B".try_into()?,
+    )?;
 
     // Materialize the operation
     rebase.materialize()?;
@@ -527,12 +532,13 @@ fn move_empty_branch() -> anyhow::Result<()> {
 
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Put B on top of A
-    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-        but_workspace::branch::move_branch(
-            editor,
-            "refs/heads/B".try_into()?,
-            "refs/heads/A".try_into()?,
-        )?;
+    let but_workspace::branch::move_branch::Outcome {
+        rebase, ws_meta, ..
+    } = but_workspace::branch::move_branch(
+        editor,
+        "refs/heads/B".try_into()?,
+        "refs/heads/A".try_into()?,
+    )?;
 
     // Materialize the operation
     rebase.materialize()?;
@@ -600,12 +606,13 @@ fn move_branch_on_top_of_empty_branch() -> anyhow::Result<()> {
 
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Put A on top of B
-    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-        but_workspace::branch::move_branch(
-            editor,
-            "refs/heads/A".try_into()?,
-            "refs/heads/B".try_into()?,
-        )?;
+    let but_workspace::branch::move_branch::Outcome {
+        rebase, ws_meta, ..
+    } = but_workspace::branch::move_branch(
+        editor,
+        "refs/heads/A".try_into()?,
+        "refs/heads/B".try_into()?,
+    )?;
 
     // Materialize the operation
     rebase.materialize()?;
@@ -676,12 +683,13 @@ fn move_empty_branch_on_top_of_empty_branch_in_same_stack() -> anyhow::Result<()
     );
 
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
-    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-        but_workspace::branch::move_branch(
-            editor,
-            "refs/heads/A".try_into()?,
-            "refs/heads/B".try_into()?,
-        )?;
+    let but_workspace::branch::move_branch::Outcome {
+        rebase, ws_meta, ..
+    } = but_workspace::branch::move_branch(
+        editor,
+        "refs/heads/A".try_into()?,
+        "refs/heads/B".try_into()?,
+    )?;
 
     rebase.materialize()?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
@@ -743,12 +751,13 @@ fn move_empty_branch_on_top_of_empty_branch_across_stacks() -> anyhow::Result<()
     );
 
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
-    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-        but_workspace::branch::move_branch(
-            editor,
-            "refs/heads/A".try_into()?,
-            "refs/heads/B".try_into()?,
-        )?;
+    let but_workspace::branch::move_branch::Outcome {
+        rebase, ws_meta, ..
+    } = but_workspace::branch::move_branch(
+        editor,
+        "refs/heads/A".try_into()?,
+        "refs/heads/B".try_into()?,
+    )?;
 
     rebase.materialize()?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
@@ -821,12 +830,13 @@ fn non_empty_move_updates_metadata_and_keeps_display_order_aligned() -> anyhow::
     // Move non-empty C on top of non-empty A.
     // This rewrites metadata and keeps display + metadata aligned.
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
-    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-        but_workspace::branch::move_branch(
-            editor,
-            "refs/heads/C".try_into()?,
-            "refs/heads/A".try_into()?,
-        )?;
+    let but_workspace::branch::move_branch::Outcome {
+        rebase, ws_meta, ..
+    } = but_workspace::branch::move_branch(
+        editor,
+        "refs/heads/C".try_into()?,
+        "refs/heads/A".try_into()?,
+    )?;
 
     let updated_metadata_order = ws_meta
         .as_ref()
@@ -932,12 +942,13 @@ fn empty_move_keeps_display_order_aligned_with_metadata() -> anyhow::Result<()> 
     // Move empty B on top of non-empty A.
     // This path rewrites metadata and keeps display + metadata aligned.
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
-    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-        but_workspace::branch::move_branch(
-            editor,
-            "refs/heads/B".try_into()?,
-            "refs/heads/A".try_into()?,
-        )?;
+    let but_workspace::branch::move_branch::Outcome {
+        rebase, ws_meta, ..
+    } = but_workspace::branch::move_branch(
+        editor,
+        "refs/heads/B".try_into()?,
+        "refs/heads/A".try_into()?,
+    )?;
 
     let updated_metadata_order = ws_meta
         .as_ref()
@@ -1023,12 +1034,13 @@ fn move_branch_when_base_segment_has_no_ref_name() -> anyhow::Result<()> {
 
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Move B on top of A — the base segment at the old fork point has no ref name.
-    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-        but_workspace::branch::move_branch(
-            editor,
-            "refs/heads/B".try_into()?,
-            "refs/heads/A".try_into()?,
-        )?;
+    let but_workspace::branch::move_branch::Outcome {
+        rebase, ws_meta, ..
+    } = but_workspace::branch::move_branch(
+        editor,
+        "refs/heads/B".try_into()?,
+        "refs/heads/A".try_into()?,
+    )?;
 
     rebase.materialize()?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
@@ -1109,12 +1121,13 @@ fn move_empty_branch_onto_non_empty_branch_with_advanced_target() -> anyhow::Res
 
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Put empty B on top of non-empty A.
-    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-        but_workspace::branch::move_branch(
-            editor,
-            "refs/heads/B".try_into()?,
-            "refs/heads/A".try_into()?,
-        )?;
+    let but_workspace::branch::move_branch::Outcome {
+        rebase, ws_meta, ..
+    } = but_workspace::branch::move_branch(
+        editor,
+        "refs/heads/B".try_into()?,
+        "refs/heads/A".try_into()?,
+    )?;
 
     rebase.materialize()?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
@@ -1190,12 +1203,13 @@ fn move_non_empty_branch_onto_empty_branch_with_advanced_target() -> anyhow::Res
 
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Put non-empty A on top of empty B.
-    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-        but_workspace::branch::move_branch(
-            editor,
-            "refs/heads/A".try_into()?,
-            "refs/heads/B".try_into()?,
-        )?;
+    let but_workspace::branch::move_branch::Outcome {
+        rebase, ws_meta, ..
+    } = but_workspace::branch::move_branch(
+        editor,
+        "refs/heads/A".try_into()?,
+        "refs/heads/B".try_into()?,
+    )?;
 
     rebase.materialize()?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
@@ -1337,6 +1351,67 @@ mod single_branch_mode {
         Ok((tmp, repo, meta, project_meta))
     }
 
+    /// Moving a branch on top of the checked-out tip reports it as `new_tip` so the caller can check
+    /// it out; the operation itself does not move `HEAD`.
+    #[test]
+    fn reorder_above_checked_out_tip_returns_new_tip() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, project_meta) = ad_hoc_workspace_with_two_empty_branches()?;
+        let main_ref = r("refs/heads/main");
+
+        let mut ws = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?
+            .into_workspace()?;
+        // `main` is the checked-out entrypoint (the projected tip).
+        assert_eq!(ws.ref_name(), Some(main_ref));
+
+        // Move empty `empty-bottom` on top of the checked-out `main`, which makes it the new tip.
+        let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+        let but_workspace::branch::move_branch::Outcome {
+            rebase, new_tip, ..
+        } = but_workspace::branch::move_branch(editor, r("refs/heads/empty-bottom"), main_ref)?;
+        rebase.materialize()?;
+
+        // The subject is reported as the new tip so the caller can check it out.
+        assert_eq!(
+            new_tip.as_ref().map(|n| n.as_ref()),
+            Some(r("refs/heads/empty-bottom"))
+        );
+        assert_eq!(
+            meta.branch_stack_order(main_ref)?,
+            Some(vec![
+                r("refs/heads/empty-bottom").to_owned(),
+                r("refs/heads/main").to_owned(),
+                r("refs/heads/empty-top").to_owned(),
+                r("refs/heads/base").to_owned(),
+            ]),
+        );
+        Ok(())
+    }
+
+    /// A reorder that does not touch the tip leaves `new_tip` unset.
+    #[test]
+    fn reorder_below_tip_has_no_new_tip() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, project_meta) = ad_hoc_workspace_with_two_empty_branches()?;
+
+        let mut ws = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?
+            .into_workspace()?;
+
+        let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+        let but_workspace::branch::move_branch::Outcome {
+            rebase, new_tip, ..
+        } = but_workspace::branch::move_branch(
+            editor,
+            r("refs/heads/empty-bottom"),
+            r("refs/heads/empty-top"),
+        )?;
+        rebase.materialize()?;
+
+        assert_eq!(
+            new_tip, None,
+            "target isn't the tip, so the tip is unchanged"
+        );
+        Ok(())
+    }
+
     /// `move_branch` reorders two empty branches in single-branch (ad-hoc) mode by rewriting the
     /// `branch_order` metadata, without any graph rewrite.
     #[test]
@@ -1372,12 +1447,13 @@ mod single_branch_mode {
 
         // Move `empty-bottom` on top of `empty-top` (both empty) - a pure metadata reorder.
         let editor = Editor::create(&mut ws, &mut meta, &repo)?;
-        let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-            but_workspace::branch::move_branch(
-                editor,
-                r("refs/heads/empty-bottom"),
-                r("refs/heads/empty-top"),
-            )?;
+        let but_workspace::branch::move_branch::Outcome {
+            rebase, ws_meta, ..
+        } = but_workspace::branch::move_branch(
+            editor,
+            r("refs/heads/empty-bottom"),
+            r("refs/heads/empty-top"),
+        )?;
         assert!(
             ws_meta.is_none(),
             "ad-hoc reorder lives in branch_order, not workspace metadata"

--- a/crates/but-workspace/tests/workspace/branch/tear_off_branch.rs
+++ b/crates/but-workspace/tests/workspace/branch/tear_off_branch.rs
@@ -51,12 +51,13 @@ fn tear_off_top_most_branch() -> anyhow::Result<()> {
 
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Tear off C from the stack.
-    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-        but_workspace::branch::tear_off_branch(
-            editor,
-            "refs/heads/C".try_into()?,
-            Some(StackId::from_number_for_testing(3)),
-        )?;
+    let but_workspace::branch::move_branch::Outcome {
+        rebase, ws_meta, ..
+    } = but_workspace::branch::tear_off_branch(
+        editor,
+        "refs/heads/C".try_into()?,
+        Some(StackId::from_number_for_testing(3)),
+    )?;
 
     // Materialize the operation
     rebase.materialize()?;
@@ -144,12 +145,13 @@ fn tear_off_bottom_most_branch() -> anyhow::Result<()> {
 
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Tear off B from the stack.
-    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-        but_workspace::branch::tear_off_branch(
-            editor,
-            "refs/heads/B".try_into()?,
-            Some(StackId::from_number_for_testing(3)),
-        )?;
+    let but_workspace::branch::move_branch::Outcome {
+        rebase, ws_meta, ..
+    } = but_workspace::branch::tear_off_branch(
+        editor,
+        "refs/heads/B".try_into()?,
+        Some(StackId::from_number_for_testing(3)),
+    )?;
 
     // Materialize the operation
     rebase.materialize()?;
@@ -237,12 +239,13 @@ fn tear_off_only_branch_in_stack() -> anyhow::Result<()> {
 
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Tear off A from the stack. Should be a no-op.
-    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-        but_workspace::branch::tear_off_branch(
-            editor,
-            "refs/heads/A".try_into()?,
-            Some(StackId::from_number_for_testing(3)),
-        )?;
+    let but_workspace::branch::move_branch::Outcome {
+        rebase, ws_meta, ..
+    } = but_workspace::branch::tear_off_branch(
+        editor,
+        "refs/heads/A".try_into()?,
+        Some(StackId::from_number_for_testing(3)),
+    )?;
 
     // Materialize the operation
     rebase.materialize()?;
@@ -318,12 +321,13 @@ fn tear_off_from_single_stack_in_ws_top() -> anyhow::Result<()> {
 
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Tear off B from the stack.
-    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-        but_workspace::branch::tear_off_branch(
-            editor,
-            "refs/heads/B".try_into()?,
-            Some(StackId::from_number_for_testing(3)),
-        )?;
+    let but_workspace::branch::move_branch::Outcome {
+        rebase, ws_meta, ..
+    } = but_workspace::branch::tear_off_branch(
+        editor,
+        "refs/heads/B".try_into()?,
+        Some(StackId::from_number_for_testing(3)),
+    )?;
 
     // Materialize the operation
     rebase.materialize()?;
@@ -396,12 +400,13 @@ fn tear_off_from_single_stack_in_ws_bottom() -> anyhow::Result<()> {
 
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Tear off A from the stack.
-    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-        but_workspace::branch::tear_off_branch(
-            editor,
-            "refs/heads/A".try_into()?,
-            Some(StackId::from_number_for_testing(3)),
-        )?;
+    let but_workspace::branch::move_branch::Outcome {
+        rebase, ws_meta, ..
+    } = but_workspace::branch::tear_off_branch(
+        editor,
+        "refs/heads/A".try_into()?,
+        Some(StackId::from_number_for_testing(3)),
+    )?;
 
     // Materialize the operation
     rebase.materialize()?;
@@ -474,12 +479,13 @@ fn tear_off_empty_branch() -> anyhow::Result<()> {
 
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Tear off B from the stack.
-    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-        but_workspace::branch::tear_off_branch(
-            editor,
-            "refs/heads/B".try_into()?,
-            Some(StackId::from_number_for_testing(3)),
-        )?;
+    let but_workspace::branch::move_branch::Outcome {
+        rebase, ws_meta, ..
+    } = but_workspace::branch::tear_off_branch(
+        editor,
+        "refs/heads/B".try_into()?,
+        Some(StackId::from_number_for_testing(3)),
+    )?;
 
     // Materialize the operation
     rebase.materialize()?;
@@ -550,12 +556,13 @@ fn tear_off_non_empty_branch() -> anyhow::Result<()> {
 
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Tear off A from the stack.
-    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-        but_workspace::branch::tear_off_branch(
-            editor,
-            "refs/heads/A".try_into()?,
-            Some(StackId::from_number_for_testing(3)),
-        )?;
+    let but_workspace::branch::move_branch::Outcome {
+        rebase, ws_meta, ..
+    } = but_workspace::branch::tear_off_branch(
+        editor,
+        "refs/heads/A".try_into()?,
+        Some(StackId::from_number_for_testing(3)),
+    )?;
 
     // Materialize the operation
     rebase.materialize()?;

--- a/e2e/playwright/tests/singleBranch/moveBranch.spec.ts
+++ b/e2e/playwright/tests/singleBranch/moveBranch.spec.ts
@@ -53,6 +53,36 @@ test("can reorder empty branches by dragging within the single-branch stack", as
 	await assertBranch("empty-top", localClone);
 });
 
+test("moving an empty branch above the checked-out branch checks out the new tip", async ({
+	page,
+	gitbutler,
+}) => {
+	const localClone = await setupSingleBranchProject(gitbutler, page);
+
+	// `empty-b` is created last, so it's the checked-out tip, with `empty-a` below it.
+	await createDependentBranch(page, "empty-a");
+	await createDependentBranch(page, "empty-b");
+
+	await expect(getByTestId(page, "branch-card")).toHaveCount(3);
+	await expectBranchHeaderOrder(page, ["empty-b", "empty-a", SINGLE_BRANCH_NAME]);
+	await expectCurrentBranchChip(page, "empty-b");
+	await assertBranch("empty-b", localClone);
+
+	// Drag `empty-a` onto the dropzone above the checked-out tip `empty-b` (the top dropzone renders
+	// while the drag is active). This places `empty-a` above the entrypoint, so it becomes the new
+	// tip. Because the move can't leave the new tip above `HEAD` unprojected, the backend reports it
+	// as the new tip and the app checks it out.
+	await dragAndDropByLocator(page, branchHeader(page, "empty-a"), branchHeader(page, "empty-b"), {
+		force: true,
+		position: { x: 120, y: -10 },
+	});
+
+	// `empty-a` is now the tip and is checked out; the whole stack stays projected.
+	await expectBranchHeaderOrder(page, ["empty-a", "empty-b", SINGLE_BRANCH_NAME]);
+	await expectCurrentBranchChip(page, "empty-a");
+	await assertBranch("empty-a", localClone);
+});
+
 async function expectBranchHeaderOrder(page: Page, expectedBranchNames: string[]): Promise<void> {
 	await expect
 		.poll(

--- a/e2e/playwright/tests/singleBranch/moveBranch.spec.ts
+++ b/e2e/playwright/tests/singleBranch/moveBranch.spec.ts
@@ -1,0 +1,71 @@
+import {
+	branchHeader,
+	createDependentBranch,
+	expectCurrentBranchChip,
+	setupSingleBranchProject,
+	SINGLE_BRANCH_NAME,
+} from "./helpers.ts";
+import { assertBranch } from "../../src/branch.ts";
+import { test } from "../../src/test.ts";
+import { dragAndDropByLocator, getByTestId } from "../../src/util.ts";
+import { expect, type Page } from "@playwright/test";
+
+test.use({
+	gitbutlerOptions: {
+		config: {
+			onboardingComplete: true,
+			featureFlags: { singleBranch: true },
+		},
+	},
+});
+
+test("can reorder empty branches by dragging within the single-branch stack", async ({
+	page,
+	gitbutler,
+}) => {
+	const localClone = await setupSingleBranchProject(gitbutler, page);
+
+	// Build a stack of empty branches. Each `createDependentBranch` is created above the current tip
+	// and checked out, so `empty-top` ends up as the checked-out entrypoint with two empty branches
+	// (`empty-mid`, `empty-low`) below it, sitting on the commit-owning `single-branch-fixture` base.
+	await createDependentBranch(page, "empty-low");
+	await createDependentBranch(page, "empty-mid");
+	await createDependentBranch(page, "empty-top");
+
+	await expect(getByTestId(page, "branch-card")).toHaveCount(4);
+	await expectCurrentBranchChip(page, "empty-top");
+	await expectBranchHeaderOrder(page, ["empty-top", "empty-mid", "empty-low", SINGLE_BRANCH_NAME]);
+
+	// Drag `empty-low` onto the insertion dropzone above `empty-mid` to put it on top of `empty-mid`.
+	// Both branches are empty and below the entrypoint, so the whole stack stays projected and the
+	// move is a pure `branch_order` metadata reorder.
+	//
+	await dragAndDropByLocator(
+		page,
+		branchHeader(page, "empty-low"),
+		branchHeader(page, "empty-mid"),
+		{ force: true, position: { x: 120, y: 0 } },
+	);
+
+	// `empty-low` now sits above `empty-mid`; the entrypoint and base are unchanged.
+	await expectBranchHeaderOrder(page, ["empty-top", "empty-low", "empty-mid", SINGLE_BRANCH_NAME]);
+	await expectCurrentBranchChip(page, "empty-top");
+	await assertBranch("empty-top", localClone);
+});
+
+async function expectBranchHeaderOrder(page: Page, expectedBranchNames: string[]): Promise<void> {
+	await expect
+		.poll(
+			async () =>
+				await page
+					.locator('[data-testid="branch-header"]')
+					.evaluateAll((headers) =>
+						headers.map((header) => header.getAttribute("data-testid-branch-header")),
+					),
+			{
+				message: `Expected branch header order ${JSON.stringify(expectedBranchNames)}`,
+				intervals: [100, 200, 500, 1000],
+			},
+		)
+		.toEqual(expectedBranchNames);
+}


### PR DESCRIPTION
## 🧢 Changes

`move_branch` now handles ad-hoc (single-branch) workspaces instead of bailing: it reorders two empty branches by rewriting the `branch_order` metadata (mirroring `create_reference`'s ad-hoc handling), and its body is split into a `match` on the workspace kind that dispatches to dedicated single-branch and managed-workspace handlers. Non-empty branches in single-branch mode are still rejected, since moving the commit-owning branch needs a real rebase. Adds positive and negative tests for the single-branch path.

## ☕️ Reasoning

Reordering empty branches in single-branch mode was untested and, it turned out, unsupported — `move_branch` rejected all non-managed workspaces before ever touching branch-order metadata. This wires up the pure-metadata reorder path so single-branch users get the same reordering behavior as managed workspaces.