### PR TITLE
fix(but): render anonymous workspace segments instead of wedging status

### DIFF
--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -1233,33 +1233,53 @@ fn print_group(
                 .unwrap_or_default();
 
             let branch = segment.branch_name().unwrap_or(BStr::new("")).to_string();
-            let branch_cli_id = lookup_cli_id_for_short_id(
-                &status_ctx.id_map,
-                &repo,
-                &segment.short_id,
-                |id| matches!(id, CliId::Branch { .. }),
-                "branch",
-            )?;
+            // The branch CliId is its name, so a nameless segment gets no short
+            // id assigned (see `populate_branch_short_ids`) and isn't in the
+            // IdMap. Such an anonymous segment - e.g. a `gitbutler/workspace`
+            // merge-commit parent whose branch was deleted or unapplied - must be
+            // tolerated here instead of throwing "Could not find branch CLI id ''
+            // in IdMap", which used to wedge `status` and every workspace
+            // mutation that enumerates it first (#14497).
+            let is_anonymous = segment.branch_name().is_none();
+            let branch_cli_id = if is_anonymous {
+                None
+            } else {
+                Some(lookup_cli_id_for_short_id(
+                    &status_ctx.id_map,
+                    &repo,
+                    &segment.short_id,
+                    |id| matches!(id, CliId::Branch { .. }),
+                    "branch",
+                )?)
+            };
             let mut branch_suffix = Vec::new();
             branch_suffix.extend(ci_spans);
             if let Some(branch_status) = branch_status {
                 branch_suffix.push(branch_status);
             }
             branch_suffix.extend(review_spans);
+            if is_anonymous {
+                branch_suffix.push(Span::styled(
+                    " (unnamed - run `git branch <name> <commit>` to recover)",
+                    t.hint,
+                ));
+            }
             if !no_commits.is_empty() {
                 branch_suffix.push(Span::raw(" "));
                 branch_suffix.push(Span::styled(no_commits, t.hint));
             }
 
+            let branch_name = if is_anonymous {
+                Vec::from([Span::styled("unnamed segment", t.hint)])
+            } else {
+                Vec::from([Span::styled(branch, t.local_branch), Span::raw(workspace)])
+            };
             output.branch(
                 Vec::from([Span::raw(format!("┊{notch}┄"))]),
                 BranchLineContent {
                     id: Vec::from([Span::styled(segment.short_id.clone(), t.cli_id)]),
                     decoration_start: Vec::from([Span::raw(" [")]),
-                    branch_name: Vec::from([
-                        Span::styled(branch, t.local_branch),
-                        Span::raw(workspace),
-                    ]),
+                    branch_name,
                     decoration_end: Vec::from([Span::raw("]")]),
                     suffix: branch_suffix,
                 },

--- a/crates/but/src/command/legacy/status/output.rs
+++ b/crates/but/src/command/legacy/status/output.rs
@@ -133,14 +133,14 @@ impl StatusOutput<'_> {
         &mut self,
         connector: Vec<Span<'static>>,
         line: BranchLineContent,
-        id: CliId,
+        id: Option<CliId>,
         is_merged_upstream: bool,
     ) -> anyhow::Result<()> {
         self.push_line(
             Some(connector),
             StatusOutputContent::Branch(line),
             StatusOutputLineData::Branch {
-                cli_id: Arc::new(id),
+                cli_id: id.map(Arc::new),
                 is_merged_upstream,
             },
         )
@@ -395,7 +395,9 @@ pub(super) enum StatusOutputLineData {
         cli_id: Arc<CliId>,
     },
     Branch {
-        cli_id: Arc<CliId>,
+        /// `None` for an anonymous segment - a `gitbutler/workspace` merge-commit
+        /// parent that no stack head claims, so it has no CLI id (#14497).
+        cli_id: Option<Arc<CliId>>,
         is_merged_upstream: bool,
     },
     Commit {
@@ -418,9 +420,10 @@ pub(super) enum StatusOutputLineData {
 impl StatusOutputLineData {
     pub(super) fn cli_id(&self) -> Option<&Arc<CliId>> {
         match self {
+            // An anonymous segment carries no CLI id (#14497).
+            StatusOutputLineData::Branch { cli_id, .. } => cli_id.as_ref(),
             StatusOutputLineData::UncommittedChanges { cli_id }
             | StatusOutputLineData::UncommittedFile { cli_id }
-            | StatusOutputLineData::Branch { cli_id, .. }
             | StatusOutputLineData::StagedChanges { cli_id }
             | StatusOutputLineData::StagedFile { cli_id }
             | StatusOutputLineData::Commit { cli_id, .. }

--- a/crates/but/src/command/legacy/status/tui/app/commit_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/commit_mode.rs
@@ -262,6 +262,10 @@ impl App {
                 }
             }
             StatusOutputLineData::Branch { cli_id, .. } => {
+                // An anonymous segment has no CLI id and isn't a commit target (#14497).
+                let Some(cli_id) = cli_id else {
+                    return Ok(());
+                };
                 let CliId::Branch { stack_id, .. } = &**cli_id else {
                     return Ok(());
                 };

--- a/crates/but/src/command/legacy/status/tui/app/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/app/mod.rs
@@ -900,6 +900,10 @@ impl App {
 
         match &selection.data {
             StatusOutputLineData::Branch { cli_id, .. } => {
+                // An anonymous segment has no CLI id, so there's nothing to act on (#14497).
+                let Some(cli_id) = cli_id else {
+                    return Ok(());
+                };
                 let CliId::Branch { name, .. } = &**cli_id else {
                     return Ok(());
                 };
@@ -955,6 +959,10 @@ impl App {
 
         let new_name = match &selection.data {
             StatusOutputLineData::Branch { cli_id, .. } => {
+                // An anonymous segment has no CLI id, so there's nothing to act on (#14497).
+                let Some(cli_id) = cli_id else {
+                    return Ok(());
+                };
                 let CliId::Branch { name, .. } = &**cli_id else {
                     return Ok(());
                 };

--- a/crates/but/src/command/legacy/status/tui/app/move_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/move_mode.rs
@@ -186,7 +186,10 @@ impl App {
             }
         } else {
             match &selection.data {
-                StatusOutputLineData::Branch { cli_id, .. }
+                StatusOutputLineData::Branch {
+                    cli_id: Some(cli_id),
+                    ..
+                }
                 | StatusOutputLineData::Commit { cli_id, .. } => {
                     let Ok(source) = MoveSource::try_from(Arc::unwrap_or_clone(Arc::clone(cli_id)))
                     else {
@@ -211,6 +214,8 @@ impl App {
                 | StatusOutputLineData::UpstreamChanges
                 | StatusOutputLineData::Warning
                 | StatusOutputLineData::Hint
+                // An anonymous segment (no CLI id) is not a move source (#14497).
+                | StatusOutputLineData::Branch { cli_id: None, .. }
                 | StatusOutputLineData::NoAssignmentsUnstaged => return,
             }
         };
@@ -262,6 +267,10 @@ impl App {
 
         let target = match &selection.data {
             StatusOutputLineData::Branch { cli_id, .. } => {
+                // An anonymous segment (no CLI id) is not a move target (#14497).
+                let Some(cli_id) = cli_id else {
+                    return Ok(());
+                };
                 if let CliId::Branch { name, .. } = &**cli_id {
                     MoveTarget::Branch { name }
                 } else {

--- a/crates/but/src/command/legacy/status/tui/app/stack_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/stack_mode.rs
@@ -192,6 +192,7 @@ pub fn stack_ids_in_display_order(status_lines: &[StatusOutputLine]) -> Vec<Stac
     let mut stack_ids = Vec::new();
     for line in status_lines {
         if let StatusOutputLineData::Branch { cli_id, .. } = &line.data
+            && let Some(cli_id) = cli_id
             && let CliId::Branch {
                 stack_id: Some(stack_id),
                 ..
@@ -209,7 +210,10 @@ fn stack_id_for_line(
     status_lines: &[StatusOutputLine],
 ) -> Option<StackId> {
     match &line.data {
-        StatusOutputLineData::Branch { cli_id, .. }
+        StatusOutputLineData::Branch {
+            cli_id: Some(cli_id),
+            ..
+        }
         | StatusOutputLineData::StagedChanges { cli_id }
         | StatusOutputLineData::StagedFile { cli_id }
         | StatusOutputLineData::UncommittedFile { cli_id }
@@ -225,6 +229,8 @@ fn stack_id_for_line(
         | StatusOutputLineData::UpstreamChanges
         | StatusOutputLineData::Warning
         | StatusOutputLineData::Hint
+        // An anonymous segment has no CLI id, so no stack (#14497).
+        | StatusOutputLineData::Branch { cli_id: None, .. }
         | StatusOutputLineData::NoAssignmentsUnstaged => None,
     }
 }

--- a/crates/but/src/command/legacy/status/tui/cursor/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/mod.rs
@@ -248,7 +248,11 @@ impl Cursor {
         }
 
         for line in lines.iter().take(self.0 + 1).rev() {
-            if let StatusOutputLineData::Branch { cli_id, .. } = &line.data {
+            if let StatusOutputLineData::Branch {
+                cli_id: Some(cli_id),
+                ..
+            } = &line.data
+            {
                 return Some(SelectAfterReload::CliId(Box::new((**cli_id).clone())));
             }
 

--- a/crates/but/src/command/legacy/status/tui/render.rs
+++ b/crates/but/src/command/legacy/status/tui/render.rs
@@ -379,7 +379,7 @@ fn row_stack_ids(lines: &[StatusOutputLine]) -> Vec<Option<StackId>> {
         .iter()
         .map(|line| match &line.data {
             StatusOutputLineData::Branch { cli_id, .. } => {
-                let stack_id = stack_id_from_cli_id(cli_id.as_ref());
+                let stack_id = cli_id.as_ref().and_then(|c| stack_id_from_cli_id(c));
                 current_stack_id = stack_id;
                 stack_id
             }
@@ -793,7 +793,10 @@ fn selected_operation_extension<'a>(
                     mode,
                     direction: mode.insert_side.into(),
                 })
-            } else if let StatusOutputLineData::Branch { cli_id: target, .. } = data
+            } else if let StatusOutputLineData::Branch {
+                cli_id: Some(target),
+                ..
+            } = data
                 && !mode.source.contains(target)
             {
                 let source_is_commit = match &*mode.source {
@@ -1114,17 +1117,21 @@ pub fn commit_operation_display(
     } = mode;
 
     match data {
-        StatusOutputLineData::Branch { cli_id, .. } => {
-            if let Some(stack_scope) = scope_to_stack
-                && let Some(stack_id) = cli_id.stack_id()
-                && *stack_scope != stack_id
-            {
-                // don't allow selecting branches outside the scoped stack
-                None
-            } else {
-                Some("commit to branch")
+        StatusOutputLineData::Branch { cli_id, .. } => match cli_id {
+            // An anonymous segment (no CLI id) is not a commit target (#14497).
+            None => None,
+            Some(cli_id) => {
+                if let Some(stack_scope) = scope_to_stack
+                    && let Some(stack_id) = cli_id.stack_id()
+                    && *stack_scope != stack_id
+                {
+                    // don't allow selecting branches outside the scoped stack
+                    None
+                } else {
+                    Some("commit to branch")
+                }
             }
-        }
+        },
         StatusOutputLineData::Commit { stack_id, .. } => {
             if let Some(stack_scope) = scope_to_stack
                 && Some(*stack_scope) != *stack_id
@@ -1271,6 +1278,9 @@ pub fn stack_operation_display(
     let StackMode { stack_heads } = mode;
     match data {
         StatusOutputLineData::Branch { cli_id, .. } => {
+            let Some(cli_id) = cli_id else {
+                return None;
+            };
             let CliId::Branch { name, .. } = &**cli_id else {
                 return None;
             };

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -1159,3 +1159,51 @@ fn status_in_edit_mode_delegates_to_resolve_status() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn status_renders_anonymous_segment_after_branch_ref_deleted() {
+    // Regression for #14497: deleting an applied branch's git ref out from under
+    // GitButler leaves the `gitbutler/workspace` merge commit with a parent that
+    // no stack head claims - an anonymous segment with no name and no CLI id.
+    // `but status` used to abort with "Could not find branch CLI id '' in IdMap",
+    // wedging the project (and every mutation that enumerates the workspace)
+    // with no in-product recovery. It must now render the unnamed segment.
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    // Sanity: status works while the branch is named.
+    env.but("status").assert().success();
+
+    // Delete branch A's ref directly, as `git branch -D` would; the workspace
+    // merge commit still references A's tip as a now-orphaned parent.
+    let a_tip = env.invoke_git("rev-parse A");
+    env.invoke_git("branch -D A");
+
+    // Human status must render the unnamed segment, not throw the IdMap error.
+    let assert = env.but("status").assert().success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(
+        stdout.contains("unnamed segment"),
+        "status should render the anonymous segment, got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("IdMap"),
+        "status must not throw the IdMap error, got:\n{stdout}"
+    );
+
+    // The JSON path builds cli ids from `short_id` directly (never the IdMap
+    // lookup), so it never threw - but smoke-test that it still renders the
+    // anonymous segment (with an empty cli id/name) without erroring.
+    env.but("status --format json").assert().success();
+
+    // The recovery the hint advertises works: re-creating a branch at the
+    // orphan's tip re-binds the segment so it is named again (Byron's recovery,
+    // `git branch foo @~1`).
+    env.invoke_git(&format!("branch A {}", a_tip.trim()));
+    let recovered = env.but("status").assert().success();
+    let recovered = String::from_utf8_lossy(&recovered.get_output().stdout);
+    assert!(
+        !recovered.contains("unnamed segment"),
+        "re-creating the branch should re-bind the segment, got:\n{recovered}"
+    );
+}


### PR DESCRIPTION
Fixes #14497.

## Bug
When the `gitbutler/workspace` merge commit has a parent that no stack head claims — an **anonymous segment** — `but status` aborts with `Could not find branch CLI id '' in IdMap`. Because the same enumeration backs every workspace mutation, the whole project is wedged with no in-product recovery. A minimal reproduction is in the issue thread: `git branch -d <applied-branch>` deletes the ref, and the next `but status` throws.

## Cause
An anonymous segment has no name, so `populate_branch_short_ids` assigns it no CLI id and it isn't in the `IdMap`. `but status` looked its empty id up in the `IdMap`, found nothing, and the error propagated out — aborting `status` and every mutation that enumerates the workspace first.

## Fix
Tolerate the anonymous segment at render:
- `StatusOutputLineData::Branch.cli_id` becomes `Option<Arc<CliId>>` (`None` = anonymous); the status enumeration detects a nameless segment via `branch_name().is_none()` and skips the `IdMap` lookup.
- It renders as `[unnamed segment]` with a hint to recover by naming its tip (`git branch <name> <commit>`) — the recovery described in the issue thread.
- Every interactive TUI consumer (commit/move/stack modes, cursor selection) treats a `None` id as a non-target — you can't commit to, move, or stack an unnamed segment.

## Tests
Adds a regression test that deletes an applied branch's ref, asserts `status` renders the unnamed segment rather than erroring, and that re-creating the branch re-binds it. It also smoke-tests `--format json`, which builds ids from `short_id` directly and so never threw.

`cargo test -p but` (468 tests) and clippy are clean.

## Scope
This fixes the `status` wedge (the anonymous-segment `IdMap` throw). Preventing the orphan parent from being retained in the first place — rebuilding the workspace merge commit on unapply, as the issue also suggests — is a separate, complementary change in `but-workspace`, out of scope here.