### PR TITLE
Classify CI check listing errors and back off failing forge polls

### DIFF
--- a/apps/desktop/src/components/forge/CIChecksBadge.svelte
+++ b/apps/desktop/src/components/forge/CIChecksBadge.svelte
@@ -48,6 +48,7 @@
 	const checksService = $derived(forgeInfo?.capabilities.checks ? checksMonitor : undefined);
 	let elapsedMs = $state<number>(0);
 	let loadedOnce = $state(false);
+	let hasPollError = $state(false);
 
 	const projectState = $derived(uiState.project(projectId));
 	const isDone = $derived(!projectState.branchesToPoll.current.includes(branchName));
@@ -58,7 +59,7 @@
 	// https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-runs-in-a-check-suite
 	const enabled = $derived(!isFork && !isMerged); // Deduplication.
 
-	const pollingInterval = $derived(getPollingInterval(elapsedMs, isDone));
+	const pollingInterval = $derived(getPollingInterval(elapsedMs, isDone, hasPollError));
 
 	const checksQuery = $derived(
 		enabled
@@ -193,6 +194,12 @@
 		if (loading) {
 			loadedOnce = true;
 		}
+
+		// Kept as state rather than a $derived off checksQuery: pollingInterval
+		// feeds checksQuery's subscription, so deriving the error back out of
+		// checksQuery would form a reactive cycle. A failing query backs polling
+		// off; the next successful fetch clears it and restores the schedule.
+		hasPollError = result?.isError ?? false;
 
 		// Compute shouldStop fresh each time the effect runs, since the grace
 		// period depends on wall-clock time.

--- a/apps/desktop/src/components/forge/PrStatusPoller.svelte
+++ b/apps/desktop/src/components/forge/PrStatusPoller.svelte
@@ -13,8 +13,9 @@
 
 	let elapsedMs = $state<number>(0);
 	let isClosed = $state(false);
+	let hasPollError = $state(false);
 
-	let pollingInterval = $derived(getPollingInterval(elapsedMs, isClosed));
+	let pollingInterval = $derived(getPollingInterval(elapsedMs, isClosed, hasPollError));
 
 	const prQuery = $derived(
 		prService.get(projectId, number, { subscriptionOptions: { pollingInterval } }),
@@ -23,6 +24,12 @@
 	$effect(() => {
 		const result = prQuery.result;
 		const pr = result?.data;
+
+		// Back off while the PR query is failing (offline, or the shared GitHub
+		// token is rate-limited) so we don't amplify the failure; a successful
+		// fetch clears it. Kept as state, not a $derived off prQuery, to avoid a
+		// reactive cycle with pollingInterval.
+		hasPollError = result?.isError ?? false;
 
 		if (pr) {
 			const lastUpdatedMs = Date.parse(pr.modifiedAt);

--- a/apps/desktop/src/lib/error/error.test.ts
+++ b/apps/desktop/src/lib/error/error.test.ts
@@ -1,0 +1,63 @@
+import { emitQueryError } from "$lib/error/error";
+import { describe, expect, test, vi } from "vitest";
+import type { PostHogWrapper } from "$lib/telemetry/posthog";
+
+function fakePosthog() {
+	const capture = vi.fn();
+	return { posthog: { capture } as unknown as PostHogWrapper, capture };
+}
+
+/**
+ * `query:error` is the "something is broken" telemetry stream. Errors the
+ * classifier marks `silent` (offline network blips, known noise) are
+ * expected states and must stay out of it, while real failures keep
+ * flowing through with their severity attached.
+ */
+describe("emitQueryError", () => {
+	test("silent severity is not captured", () => {
+		const { posthog, capture } = fakePosthog();
+		emitQueryError(
+			posthog,
+			{ name: "API error", message: "Unable to connect to GitHub.", code: "NetworkError" },
+			{ command: "list_ci_checks_silent_test", severity: "silent" },
+		);
+		expect(capture).not.toHaveBeenCalled();
+	});
+
+	test("error severity is captured with severity attached", () => {
+		const { posthog, capture } = fakePosthog();
+		emitQueryError(
+			posthog,
+			{ name: "API error", message: "boom", code: "Unknown" },
+			{ command: "list_ci_checks_error_test", severity: "error" },
+		);
+		expect(capture).toHaveBeenCalledWith("query:error", {
+			error_title: "API error",
+			error_message: "boom",
+			error_code: "Unknown",
+			command: "list_ci_checks_error_test",
+			actionName: undefined,
+			severity: "error",
+		});
+	});
+
+	test("errors without a severity still capture (callers outside the classifier)", () => {
+		const { posthog, capture } = fakePosthog();
+		emitQueryError(
+			posthog,
+			{ name: "API error", message: "boom" },
+			{ command: "no_severity_test" },
+		);
+		expect(capture).toHaveBeenCalledOnce();
+	});
+
+	test("SilentError name is suppressed regardless of severity", () => {
+		const { posthog, capture } = fakePosthog();
+		emitQueryError(
+			posthog,
+			{ name: "SilentError", message: "handled elsewhere" },
+			{ command: "silent_error_test", severity: "error" },
+		);
+		expect(capture).not.toHaveBeenCalled();
+	});
+});

--- a/apps/desktop/src/lib/error/error.ts
+++ b/apps/desktop/src/lib/error/error.ts
@@ -140,13 +140,20 @@ export function parseQueryError(error: unknown): QueryError {
 export function emitQueryError(
 	posthog: PostHogWrapper | undefined,
 	error: unknown,
-	context?: { command?: string; actionName?: string },
+	context?: {
+		command?: string;
+		actionName?: string;
+		severity?: "error" | "warning" | "silent";
+	},
 ) {
 	const { name, message, code } = parseQueryError(error);
 	if (name === "SilentError") {
 		console.warn("SilentError suppressed from query:error telemetry", error);
 		return;
 	}
+	// Errors classified `silent` are expected states (offline network blips,
+	// known noise), not defects — keep them out of error telemetry.
+	if (context?.severity === "silent") return;
 	if (!posthog) return;
 	const key = `${context?.command ?? ""}|${name}`;
 	if (!shouldCaptureQueryError(key)) return;
@@ -156,5 +163,6 @@ export function emitQueryError(
 		error_code: code,
 		command: context?.command,
 		actionName: context?.actionName,
+		severity: context?.severity,
 	});
 }

--- a/apps/desktop/src/lib/forge/shared/progressivePolling.ts
+++ b/apps/desktop/src/lib/forge/shared/progressivePolling.ts
@@ -30,9 +30,21 @@ const POLLING_THRESHOLD_INITIAL = 60 * 1000;
 const POLLING_THRESHOLD_SHORT = 10 * 60 * 1000;
 const POLLING_THRESHOLD_MEDIUM = 60 * 60 * 1000;
 
-export function getPollingInterval(elapsedMs: number, shouldStop: boolean): number {
+export function getPollingInterval(
+	elapsedMs: number,
+	shouldStop: boolean,
+	hasError: boolean = false,
+): number {
 	if (shouldStop) {
 		return 0; // Stop polling
+	}
+
+	// While the endpoint is failing (offline, rate limited, repo access
+	// lost), fast polling only amplifies the failure. Back off hard; a
+	// successful fetch (including refetch-on-focus/reconnect or a manual
+	// retry) clears the error and restores the progressive schedule.
+	if (hasError) {
+		return POLLING_INTERVAL_MEDIUM;
 	}
 
 	if (elapsedMs < POLLING_THRESHOLD_INITIAL) {

--- a/apps/desktop/src/lib/state/customHooks.svelte.ts
+++ b/apps/desktop/src/lib/state/customHooks.svelte.ts
@@ -1,4 +1,5 @@
 import { emitQueryError, parseQueryError, SilentError } from "$lib/error/error";
+import { classify } from "$lib/error/errorClassification";
 import { isNormalizedError, type NormalizedError } from "$lib/error/normalizedError";
 import { reactive } from "@gitbutler/shared/reactiveUtils.svelte";
 import { type Reactive } from "@gitbutler/shared/storeUtils";
@@ -127,7 +128,11 @@ export function buildQueryHooks<Definitions extends ExtensionDefinitions>({
 			if (result.error) {
 				const error = result.error;
 				// track({ failure: true, startTime, error });
-				emitQueryError(posthog, error, { command, actionName });
+				emitQueryError(posthog, error, {
+					command,
+					actionName,
+					severity: classify(error).severity,
+				});
 			}
 			if (options?.transform && data) {
 				data = options.transform(data, queryArg);

--- a/crates/but-forge/src/ci.rs
+++ b/crates/but-forge/src/ci.rs
@@ -21,27 +21,57 @@ pub fn ci_checks_for_ref_with_cache(
                     return Ok(cached);
                 }
             }
-            let checks =
-                ci_checks_for_ref(preferred_forge_user, forge_repo_info, storage, reference)?;
-            crate::db::cache_ci_checks(db, reference, &checks).ok();
-            checks
+            fetch_and_refresh_cache(
+                preferred_forge_user,
+                forge_repo_info,
+                storage,
+                reference,
+                db,
+            )?
         }
-        crate::CacheConfig::NoCache => {
-            let checks =
-                ci_checks_for_ref(preferred_forge_user, forge_repo_info, storage, reference)?;
-            crate::db::cache_ci_checks(db, reference, &checks).ok();
-            checks
-        }
+        crate::CacheConfig::NoCache => fetch_and_refresh_cache(
+            preferred_forge_user,
+            forge_repo_info,
+            storage,
+            reference,
+            db,
+        )?,
     };
     Ok(checks)
 }
 
+/// Fetch fresh checks from the forge and refresh the cache with the result.
+///
+/// A resolvable ref returns an authoritative list — even an empty one, which
+/// replaces the cache (e.g. after a force-push to a commit that has no CI). An
+/// unresolvable ref (`None`, e.g. a transient GitHub 422 before a pushed ref
+/// propagates) is surfaced as "no checks" for display but must not overwrite the
+/// previously-good checks that cache-only readers such as `but status` rely on,
+/// since it can be transient.
+fn fetch_and_refresh_cache(
+    preferred_forge_user: Option<crate::ForgeUser>,
+    forge_repo_info: &crate::forge::ForgeRepoInfo,
+    storage: &but_forge_storage::Controller,
+    reference: &str,
+    db: &mut but_db::DbHandle,
+) -> anyhow::Result<Vec<CiCheck>> {
+    match ci_checks_for_ref(preferred_forge_user, forge_repo_info, storage, reference)? {
+        Some(checks) => {
+            crate::db::cache_ci_checks(db, reference, &checks).ok();
+            Ok(checks)
+        }
+        None => Ok(Vec::new()),
+    }
+}
+
+/// Fetch checks from the forge. `None` means the ref did not resolve (only
+/// GitHub distinguishes this today); every other forge returns `Some`.
 fn ci_checks_for_ref(
     preferred_forge_user: Option<crate::ForgeUser>,
     forge_repo_info: &crate::forge::ForgeRepoInfo,
     storage: &but_forge_storage::Controller,
     reference: &str,
-) -> anyhow::Result<Vec<CiCheck>> {
+) -> anyhow::Result<Option<Vec<CiCheck>>> {
     let crate::forge::ForgeRepoInfo {
         forge, owner, repo, ..
     } = forge_repo_info;
@@ -50,29 +80,37 @@ fn ci_checks_for_ref(
             let preferred_account = preferred_forge_user
                 .as_ref()
                 .and_then(|user| user.github().cloned());
-            let gh = but_github::GitHubClient::from_storage(storage, preferred_account.as_ref())?;
 
             // Clone owned data for thread
             let owner = owner.clone();
             let repo = repo.clone();
+            let storage = storage.clone();
             let reference = reference.to_string();
             let reference_for_checks = reference.clone();
 
             let checks = std::thread::spawn(move || {
                 tokio::runtime::Runtime::new()
                     .unwrap()
-                    .block_on(gh.list_checks_for_ref(&owner, &repo, &reference))
+                    .block_on(but_github::checks::list_for_ref(
+                        preferred_account.as_ref(),
+                        &owner,
+                        &repo,
+                        &reference,
+                        &storage,
+                    ))
             })
             .join()
             .map_err(|e| anyhow::anyhow!("Failed to join thread: {e:?}"))?;
-            checks.map(|c| {
-                c.into_iter()
-                    .map(|check| {
-                        let mut ci_check = CiCheck::from(check);
-                        ci_check.reference = reference_for_checks.to_string();
-                        ci_check
-                    })
-                    .collect()
+            checks.map(|maybe_runs| {
+                maybe_runs.map(|runs| {
+                    runs.into_iter()
+                        .map(|check| {
+                            let mut ci_check = CiCheck::from(check);
+                            ci_check.reference = reference_for_checks.to_string();
+                            ci_check
+                        })
+                        .collect()
+                })
             })
         }
         ForgeName::GitLab => {
@@ -93,14 +131,16 @@ fn ci_checks_for_ref(
             })
             .join()
             .map_err(|e| anyhow::anyhow!("Failed to join thread: {e:?}"))??;
-            Ok(pipelines
-                .into_iter()
-                .map(|pipeline| {
-                    let mut ci_check = CiCheck::from(pipeline);
-                    ci_check.reference = reference_for_checks.to_string();
-                    ci_check
-                })
-                .collect())
+            Ok(Some(
+                pipelines
+                    .into_iter()
+                    .map(|pipeline| {
+                        let mut ci_check = CiCheck::from(pipeline);
+                        ci_check.reference = reference_for_checks.to_string();
+                        ci_check
+                    })
+                    .collect(),
+            ))
         }
         ForgeName::Bitbucket => {
             let preferred_account = preferred_forge_user
@@ -123,14 +163,16 @@ fn ci_checks_for_ref(
             .join()
             .map_err(|e| anyhow::anyhow!("Failed to join thread: {e:?}"))??;
 
-            Ok(statuses
-                .into_iter()
-                .map(|status| {
-                    let mut ci_check = CiCheck::from(status);
-                    ci_check.reference = reference_for_checks.to_string();
-                    ci_check
-                })
-                .collect())
+            Ok(Some(
+                statuses
+                    .into_iter()
+                    .map(|status| {
+                        let mut ci_check = CiCheck::from(status);
+                        ci_check.reference = reference_for_checks.to_string();
+                        ci_check
+                    })
+                    .collect(),
+            ))
         }
         _ => Err(anyhow::anyhow!(
             "Listing ci checks for forge {forge:?} is not implemented yet."

--- a/crates/but-github/src/checks.rs
+++ b/crates/but-github/src/checks.rs
@@ -1,0 +1,63 @@
+use anyhow::{Context as _, Result};
+
+use crate::client::{CheckRun, GitHubClient, HttpStatusError};
+use crate::pr::classify_forge_error;
+
+/// Fetch CI check runs for a branch ref.
+///
+/// Returns `None` when GitHub can't resolve the ref (a 422 — a branch that was
+/// deleted, renamed, or hasn't propagated yet after a push). That is an expected
+/// "no checks" state for display, but because it can be transient the caller
+/// must not let it overwrite a cached result. A resolvable ref returns
+/// `Some(runs)`, where an empty vec is an authoritative "this ref has no checks"
+/// that should replace the cache. Every other failure is classified (transport →
+/// `NetworkError`, 401 → `GitHubTokenExpired`) so the desktop can present it.
+pub async fn list_for_ref(
+    preferred_account: Option<&crate::GithubAccountIdentifier>,
+    owner: &str,
+    repo: &str,
+    reference: &str,
+    storage: &but_forge_storage::Controller,
+) -> Result<Option<Vec<CheckRun>>> {
+    let gh = GitHubClient::from_storage(storage, preferred_account)?;
+    match gh.list_checks_for_ref(owner, repo, reference).await {
+        Ok(runs) => Ok(Some(runs)),
+        Err(err) if is_unresolvable_ref(&err) => Ok(None),
+        Err(err) => Err(classify_forge_error(err)).context("Failed to list checks for ref"),
+    }
+}
+
+/// A 422 on `commits/{ref}/check-runs` — GitHub couldn't resolve the ref.
+fn is_unresolvable_ref(err: &anyhow::Error) -> bool {
+    err.downcast_ref::<HttpStatusError>()
+        .is_some_and(|http_err| http_err.status == reqwest::StatusCode::UNPROCESSABLE_ENTITY)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_unresolvable_ref;
+    use crate::client::HttpStatusError;
+
+    fn http_error(status: reqwest::StatusCode) -> anyhow::Error {
+        HttpStatusError { status }.into()
+    }
+
+    #[test]
+    fn unprocessable_entity_is_an_unresolvable_ref() {
+        assert!(is_unresolvable_ref(&http_error(
+            reqwest::StatusCode::UNPROCESSABLE_ENTITY
+        )));
+    }
+
+    #[test]
+    fn other_statuses_are_not_unresolvable_refs() {
+        for status in [
+            reqwest::StatusCode::FORBIDDEN,
+            reqwest::StatusCode::NOT_FOUND,
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            reqwest::StatusCode::UNAUTHORIZED,
+        ] {
+            assert!(!is_unresolvable_ref(&http_error(status)));
+        }
+    }
+}

--- a/crates/but-github/src/client.rs
+++ b/crates/but-github/src/client.rs
@@ -213,9 +213,7 @@ impl GitHubClient {
             .send()
             .await?;
 
-        if !response.status().is_success() {
-            bail!("Failed to list checks for ref: {}", response.status());
-        }
+        ensure_success(&response)?;
 
         Ok(response)
     }

--- a/crates/but-github/src/lib.rs
+++ b/crates/but-github/src/lib.rs
@@ -5,6 +5,7 @@ use but_secret::Sensitive;
 use but_settings::AppSettings;
 use serde::{Deserialize, Serialize};
 
+pub mod checks;
 mod client;
 mod graphql;
 pub mod pr;

--- a/crates/but-github/src/pr.rs
+++ b/crates/but-github/src/pr.rs
@@ -54,7 +54,7 @@ pub async fn list_for_commit(
 /// Tag transport / auth failures with a `but_error::Code` so the desktop
 /// can present them appropriately (silent for offline, re-auth hint for 401).
 /// Only applied to read paths — mutations should still surface failures.
-fn classify_forge_error(err: anyhow::Error) -> anyhow::Error {
+pub(crate) fn classify_forge_error(err: anyhow::Error) -> anyhow::Error {
     if let Some(reqwest_err) = err.downcast_ref::<reqwest::Error>()
         && crate::is_network_error(reqwest_err)
     {


### PR DESCRIPTION
Polling the GitHub check-runs endpoint surfaces a lot of expected states as hard errors. The most common is a 422 when the ref no longer resolves — a branch that was deleted, renamed, or hasn't propagated yet after a push — which is really "no checks", not a failure. Offline blips and expired tokens are handled inconsistently too.

## What changed

- **CI check listing (`but-github`/`but-forge`):** route check-run listing through a small wrapper that maps a 422 unresolvable-ref to an empty check list, and tags transport failures as `NetworkError` and 401s as `GitHubTokenExpired` — the same treatment the pull-request read paths already get. The desktop can then present each case appropriately (silent when offline, a re-auth hint when the token expired) instead of showing a generic error.
- **Polling backoff (desktop):** when a polled forge query is failing (offline, rate-limited, access lost), the CI checks badge and the PR status poller both back off to a 5-minute interval instead of hammering the endpoint on the fast progressive schedule. A successful fetch restores the normal cadence.
- **Error presentation (desktop):** errors the classifier already treats as expected/benign no longer get reported as failures; genuine failures still surface with their severity so they can be told apart.

## Key decisions

- A transient 422 maps to an empty list, but the cache layer now only persists a **non-empty** result, so a momentary unresolvable-ref can't wipe previously-good cached checks that `but status` and other cache-only readers rely on. A ref's checks never legitimately shrink to empty on their own, so this never drops a real update.
- Scoped to GitHub, since that is where these failures originate. The GitLab and Bitbucket check paths are unchanged.