### PR TITLE
Some follow-up improvements on CI polling changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,6 +1244,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "urlencoding",
 ]

--- a/apps/desktop/src/components/forge/CIChecksBadge.svelte
+++ b/apps/desktop/src/components/forge/CIChecksBadge.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { CHECKS_MONITOR } from "$lib/forge/checksMonitor.svelte";
 	import { FORGE_INFO_SERVICE } from "$lib/forge/forgeInfo.svelte";
-	import { getPollingInterval } from "$lib/forge/shared/progressivePolling";
+	import { createPollBackoff } from "$lib/forge/shared/pollErrorBackoff.svelte";
 	import { UI_STATE } from "$lib/state/uiState.svelte";
 	import { inject } from "@gitbutler/core/context";
 
@@ -48,7 +48,6 @@
 	const checksService = $derived(forgeInfo?.capabilities.checks ? checksMonitor : undefined);
 	let elapsedMs = $state<number>(0);
 	let loadedOnce = $state(false);
-	let hasPollError = $state(false);
 
 	const projectState = $derived(uiState.project(projectId));
 	const isDone = $derived(!projectState.branchesToPoll.current.includes(branchName));
@@ -59,7 +58,16 @@
 	// https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-runs-in-a-check-suite
 	const enabled = $derived(!isFork && !isMerged); // Deduplication.
 
-	const pollingInterval = $derived(getPollingInterval(elapsedMs, isDone, hasPollError));
+	// Backs polling off while the checks query is failing (offline, rate-limited,
+	// repo access lost) and restores the schedule on recovery. A transient 422
+	// unresolvable-ref is not an error here — the backend maps it to an empty
+	// list — so it does not trigger the backoff.
+	const backoff = createPollBackoff({
+		getResult: () => checksQuery?.result,
+		getElapsedMs: () => elapsedMs,
+		getShouldStop: () => isDone,
+	});
+	const pollingInterval = $derived(backoff.pollingInterval);
 
 	const checksQuery = $derived(
 		enabled
@@ -194,12 +202,6 @@
 		if (loading) {
 			loadedOnce = true;
 		}
-
-		// Kept as state rather than a $derived off checksQuery: pollingInterval
-		// feeds checksQuery's subscription, so deriving the error back out of
-		// checksQuery would form a reactive cycle. A failing query backs polling
-		// off; the next successful fetch clears it and restores the schedule.
-		hasPollError = result?.isError ?? false;
 
 		// Compute shouldStop fresh each time the effect runs, since the grace
 		// period depends on wall-clock time.

--- a/apps/desktop/src/components/forge/PrStatusPoller.svelte
+++ b/apps/desktop/src/components/forge/PrStatusPoller.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { PR_SERVICE } from "$lib/forge/prService.svelte";
-	import { getPollingInterval } from "$lib/forge/shared/progressivePolling";
+	import { createPollBackoff } from "$lib/forge/shared/pollErrorBackoff.svelte";
 	import { inject } from "@gitbutler/core/context";
 
 	type Props = {
@@ -13,9 +13,15 @@
 
 	let elapsedMs = $state<number>(0);
 	let isClosed = $state(false);
-	let hasPollError = $state(false);
 
-	let pollingInterval = $derived(getPollingInterval(elapsedMs, isClosed, hasPollError));
+	// Backs polling off while the PR query is failing (offline, or the shared
+	// GitHub token is rate-limited) and restores the schedule on recovery.
+	const backoff = createPollBackoff({
+		getResult: () => prQuery.result,
+		getElapsedMs: () => elapsedMs,
+		getShouldStop: () => isClosed,
+	});
+	const pollingInterval = $derived(backoff.pollingInterval);
 
 	const prQuery = $derived(
 		prService.get(projectId, number, { subscriptionOptions: { pollingInterval } }),
@@ -24,12 +30,6 @@
 	$effect(() => {
 		const result = prQuery.result;
 		const pr = result?.data;
-
-		// Back off while the PR query is failing (offline, or the shared GitHub
-		// token is rate-limited) so we don't amplify the failure; a successful
-		// fetch clears it. Kept as state, not a $derived off prQuery, to avoid a
-		// reactive cycle with pollingInterval.
-		hasPollError = result?.isError ?? false;
 
 		if (pr) {
 			const lastUpdatedMs = Date.parse(pr.modifiedAt);

--- a/apps/desktop/src/lib/forge/shared/pollErrorBackoff.svelte.ts
+++ b/apps/desktop/src/lib/forge/shared/pollErrorBackoff.svelte.ts
@@ -1,0 +1,64 @@
+import { getPollingInterval } from "$lib/forge/shared/progressivePolling";
+
+/** The bits of a query result the backoff cares about. */
+type PollResult = { isError?: boolean; startedTimeStamp?: number } | undefined;
+
+/**
+ * Progressive polling that backs off as a query keeps failing.
+ *
+ * `pollingInterval` follows the normal progressive schedule while the query is
+ * healthy, steps out after the first failed poll, and steps out further once
+ * failures persist (offline, rate-limited, repo access lost) — see
+ * {@link getPollingInterval}. A successful fetch (including refetch-on-focus /
+ * reconnect or a manual retry) resets the count and restores the schedule.
+ *
+ * The failure count is `$state` written from an `$effect`, not a `$derived` off
+ * the query: `pollingInterval` feeds the query's own subscription, so deriving
+ * the error straight back out of the query would form a reactive cycle. The
+ * writes are guarded so the effect converges (each poll bumps the count at most
+ * once) rather than relying on value equality to stop re-running.
+ *
+ * `getResult` returns the reactive query result, or `undefined` when the query
+ * is disabled — treated as "not failing".
+ */
+export function createPollBackoff(deps: {
+	getResult: () => PollResult;
+	getElapsedMs: () => number;
+	getShouldStop: () => boolean;
+}) {
+	let consecutiveErrors = $state(0);
+	// Not reactive: just remembers which poll we last counted, so a re-running
+	// effect doesn't double-count a single failed request.
+	let lastPolledStamp: number | undefined = undefined;
+
+	$effect(() => {
+		const result = deps.getResult();
+		const errored = result?.isError ?? false;
+		const stamp = result?.startedTimeStamp;
+
+		if (!errored) {
+			// A healthy (or absent) result clears the backoff.
+			if (consecutiveErrors !== 0) consecutiveErrors = 0;
+			lastPolledStamp = stamp;
+			return;
+		}
+
+		if (consecutiveErrors === 0) {
+			// First failed poll: step out to the short interval.
+			consecutiveErrors = 1;
+			lastPolledStamp = stamp;
+		} else if (stamp !== lastPolledStamp) {
+			// A later, distinct poll is still failing: escalate to medium. If the
+			// backend doesn't expose a per-poll stamp we simply stay at the short
+			// interval, which is still a safe backoff.
+			lastPolledStamp = stamp;
+			if (consecutiveErrors < 2) consecutiveErrors = 2;
+		}
+	});
+
+	return {
+		get pollingInterval() {
+			return getPollingInterval(deps.getElapsedMs(), deps.getShouldStop(), consecutiveErrors);
+		},
+	};
+}

--- a/apps/desktop/src/lib/forge/shared/progressivePolling.test.ts
+++ b/apps/desktop/src/lib/forge/shared/progressivePolling.test.ts
@@ -1,0 +1,40 @@
+import { getPollingInterval } from "$lib/forge/shared/progressivePolling";
+import { describe, expect, test } from "vitest";
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+
+const INITIAL = 5 * SECOND;
+const SHORT = 30 * SECOND;
+const MEDIUM = 5 * MINUTE;
+const LONG = 30 * MINUTE;
+
+describe("getPollingInterval", () => {
+	test("shouldStop halts polling regardless of errors", () => {
+		expect(getPollingInterval(0, true, 0)).toBe(0);
+		expect(getPollingInterval(0, true, 5)).toBe(0);
+	});
+
+	test("healthy query follows the progressive schedule", () => {
+		expect(getPollingInterval(0, false, 0)).toBe(INITIAL);
+		expect(getPollingInterval(5 * MINUTE, false, 0)).toBe(SHORT);
+		expect(getPollingInterval(30 * MINUTE, false, 0)).toBe(MEDIUM);
+		expect(getPollingInterval(2 * 60 * MINUTE, false, 0)).toBe(LONG);
+	});
+
+	test("first failed poll steps out to the short interval", () => {
+		// Fast (initial) schedule + one error → short, not a hard jump to medium.
+		expect(getPollingInterval(0, false, 1)).toBe(SHORT);
+	});
+
+	test("sustained failures escalate to the medium interval", () => {
+		expect(getPollingInterval(0, false, 2)).toBe(MEDIUM);
+		expect(getPollingInterval(0, false, 5)).toBe(MEDIUM);
+	});
+
+	test("backoff never polls faster than the normal schedule", () => {
+		// Already on the long schedule: an error must not speed polling up.
+		expect(getPollingInterval(2 * 60 * MINUTE, false, 1)).toBe(LONG);
+		expect(getPollingInterval(2 * 60 * MINUTE, false, 2)).toBe(LONG);
+	});
+});

--- a/apps/desktop/src/lib/forge/shared/progressivePolling.ts
+++ b/apps/desktop/src/lib/forge/shared/progressivePolling.ts
@@ -30,23 +30,40 @@ const POLLING_THRESHOLD_INITIAL = 60 * 1000;
 const POLLING_THRESHOLD_SHORT = 10 * 60 * 1000;
 const POLLING_THRESHOLD_MEDIUM = 60 * 60 * 1000;
 
+/**
+ * Pick a polling interval, backing off progressively as consecutive polls fail.
+ *
+ * `consecutiveErrors` is 0 while the query is healthy, 1 after the first failed
+ * poll, and 2+ once failures persist. A failing endpoint (offline, rate limited,
+ * repo access lost) is stepped out to a short interval on the first blip — so a
+ * one-off failure barely slows polling — and to a medium interval once it keeps
+ * failing, so we stop hammering it. The backoff is a floor: it never polls
+ * *faster* than the normal schedule (e.g. an error during the slow long-lived
+ * schedule does not speed polling up). A successful fetch resets the count and
+ * restores the progressive schedule.
+ */
 export function getPollingInterval(
 	elapsedMs: number,
 	shouldStop: boolean,
-	hasError: boolean = false,
+	consecutiveErrors: number = 0,
 ): number {
 	if (shouldStop) {
 		return 0; // Stop polling
 	}
 
-	// While the endpoint is failing (offline, rate limited, repo access
-	// lost), fast polling only amplifies the failure. Back off hard; a
-	// successful fetch (including refetch-on-focus/reconnect or a manual
-	// retry) clears the error and restores the progressive schedule.
-	if (hasError) {
-		return POLLING_INTERVAL_MEDIUM;
-	}
+	const normal = normalPollingInterval(elapsedMs);
 
+	if (consecutiveErrors >= 2) {
+		return Math.max(normal, POLLING_INTERVAL_MEDIUM);
+	}
+	if (consecutiveErrors >= 1) {
+		return Math.max(normal, POLLING_INTERVAL_SHORT);
+	}
+	return normal;
+}
+
+/** The progressive interval for a healthy query, widening with elapsed time. */
+function normalPollingInterval(elapsedMs: number): number {
 	if (elapsedMs < POLLING_THRESHOLD_INITIAL) {
 		return POLLING_INTERVAL_INITIAL;
 	}

--- a/crates/but-forge/Cargo.toml
+++ b/crates/but-forge/Cargo.toml
@@ -39,5 +39,8 @@ serde_json = { workspace = true, features = ["arbitrary_precision"] }
 anyhow.workspace = true
 schemars = { workspace = true, optional = true }
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [lints]
 workspace = true

--- a/crates/but-forge/src/ci.rs
+++ b/crates/but-forge/src/ci.rs
@@ -55,12 +55,29 @@ fn fetch_and_refresh_cache(
     reference: &str,
     db: &mut but_db::DbHandle,
 ) -> anyhow::Result<Vec<CiCheck>> {
-    match ci_checks_for_ref(preferred_forge_user, forge_repo_info, storage, reference)? {
+    let fetched = ci_checks_for_ref(preferred_forge_user, forge_repo_info, storage, reference)?;
+    Ok(refresh_cache_with_fetched(db, reference, fetched))
+}
+
+/// Apply a freshly-fetched result to the cache and return the checks to display.
+///
+/// `Some(checks)` is authoritative and refreshes the cache — even an empty vec,
+/// which clears it (e.g. after a force-push to a commit that has no CI). `None`
+/// means the ref did not resolve (a transient GitHub 422); it is surfaced as "no
+/// checks" for display but deliberately leaves the cache untouched, since a
+/// cache-only reader such as `but status` must not lose previously-good checks
+/// to a momentary blip.
+fn refresh_cache_with_fetched(
+    db: &mut but_db::DbHandle,
+    reference: &str,
+    fetched: Option<Vec<CiCheck>>,
+) -> Vec<CiCheck> {
+    match fetched {
         Some(checks) => {
             crate::db::cache_ci_checks(db, reference, &checks).ok();
-            Ok(checks)
+            checks
         }
-        None => Ok(Vec::new()),
+        None => Vec::new(),
     }
 }
 
@@ -462,7 +479,90 @@ impl From<but_bitbucket::BitbucketBuildStatus> for CiCheck {
 
 #[cfg(test)]
 mod tests {
-    use super::{CiCheck, CiConclusion, CiStatus};
+    use super::{CiCheck, CiConclusion, CiOutput, CiStatus, refresh_cache_with_fetched};
+
+    const REFERENCE: &str = "refs/heads/feature";
+
+    fn cache_check(id: i64) -> CiCheck {
+        CiCheck {
+            id,
+            name: format!("check-{id}"),
+            output: CiOutput::default(),
+            started_at: None,
+            status: CiStatus::InProgress,
+            head_sha: "deadbeef".into(),
+            url: String::new(),
+            html_url: String::new(),
+            details_url: String::new(),
+            pull_requests: Vec::new(),
+            reference: REFERENCE.to_string(),
+            last_sync_at: chrono::Local::now().naive_local(),
+        }
+    }
+
+    fn test_db() -> (tempfile::TempDir, but_db::DbHandle) {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = but_db::DbHandle::new_in_directory(tmp.path()).unwrap();
+        (tmp, db)
+    }
+
+    fn cached_ids(db: &but_db::DbHandle) -> Vec<i64> {
+        let mut ids: Vec<i64> = crate::db::ci_checks_from_cache(db, REFERENCE)
+            .unwrap()
+            .into_iter()
+            .map(|c| c.id)
+            .collect();
+        ids.sort_unstable();
+        ids
+    }
+
+    #[test]
+    fn some_non_empty_result_replaces_the_cache() {
+        let (_tmp, mut db) = test_db();
+        refresh_cache_with_fetched(&mut db, REFERENCE, Some(vec![cache_check(1)]));
+
+        let displayed = refresh_cache_with_fetched(
+            &mut db,
+            REFERENCE,
+            Some(vec![cache_check(2), cache_check(3)]),
+        );
+
+        assert_eq!(displayed.len(), 2);
+        assert_eq!(cached_ids(&db), vec![2, 3]);
+    }
+
+    #[test]
+    fn some_empty_result_clears_the_cache() {
+        let (_tmp, mut db) = test_db();
+        refresh_cache_with_fetched(&mut db, REFERENCE, Some(vec![cache_check(1)]));
+
+        // An authoritative empty list (e.g. a force-push to a commit with no CI)
+        // replaces the cache.
+        let displayed = refresh_cache_with_fetched(&mut db, REFERENCE, Some(Vec::new()));
+
+        assert!(displayed.is_empty());
+        assert!(
+            cached_ids(&db).is_empty(),
+            "an authoritative empty list should clear the cache"
+        );
+    }
+
+    #[test]
+    fn none_result_preserves_the_cache() {
+        let (_tmp, mut db) = test_db();
+        refresh_cache_with_fetched(&mut db, REFERENCE, Some(vec![cache_check(1)]));
+
+        // An unresolvable ref (a transient GitHub 422) shows "no checks" for
+        // display but must not wipe the previously-good cache.
+        let displayed = refresh_cache_with_fetched(&mut db, REFERENCE, None);
+
+        assert!(displayed.is_empty(), "an unresolvable ref shows no checks");
+        assert_eq!(
+            cached_ids(&db),
+            vec![1],
+            "a transient unresolvable ref must not wipe the cache"
+        );
+    }
 
     fn job(status: &str, web_url: Option<&str>) -> but_gitlab::GitLabPipelineJob {
         but_gitlab::GitLabPipelineJob {

--- a/e2e/playwright/src/forge.ts
+++ b/e2e/playwright/src/forge.ts
@@ -58,6 +58,27 @@ export async function mockForge(page: Page, mocks: ForgeMocks): Promise<void> {
 	}
 }
 
+/**
+ * The body of a *failed* backend command: `{ type: "error", subject }` — the
+ * shape `webInvoke` turns into a thrown `IpcError` (see `backend/web.ts`), which
+ * lands on the query as `result.error`.
+ *
+ * `mockForge` only emits success envelopes, so route the command directly with
+ * `page.route(...)` when you need a failure (see the CI back-off tests).
+ * `code` feeds the desktop error classifier — e.g. `"NetworkError"` classifies
+ * as `silent`, `"GitHubTokenExpired"` surfaces a re-auth hint.
+ */
+export function forgeErrorBody(overrides: { code?: string; message?: string } = {}): string {
+	return JSON.stringify({
+		type: "error",
+		subject: {
+			name: "API error",
+			message: overrides.message ?? "Unable to reach the forge.",
+			code: overrides.code,
+		},
+	});
+}
+
 /** A GitHub `ForgeInfo`, with every capability on by default. */
 export function githubForgeInfo(overrides: Partial<ForgeInfo> = {}): ForgeInfo {
 	return {

--- a/e2e/playwright/tests/forge.spec.ts
+++ b/e2e/playwright/tests/forge.spec.ts
@@ -1,5 +1,7 @@
 import {
 	ciCheck,
+	ciCheckRunning,
+	forgeErrorBody,
 	forgeReview,
 	githubForgeInfo,
 	gitlabForgeInfo,
@@ -11,7 +13,7 @@ import {
 import { applyUpstream, openWorkspace } from "../src/setup.ts";
 import { test } from "../src/test.ts";
 import { waitForTestId } from "../src/util.ts";
-import { expect, type Page } from "@playwright/test";
+import { expect, type Page, type Route } from "@playwright/test";
 import type { ForgeInfo, ForgeReview } from "@gitbutler/but-sdk";
 
 const PR_NUMBER = 42;
@@ -108,6 +110,106 @@ test("CI badge does not error for a PR from a fork", async ({ page, gitbutler })
 	await expect(badge).toContainText("No checks");
 	await expect(badge).not.toContainText("Error");
 	expect(ciChecksRequests).toBe(0);
+});
+
+/**
+ * Open the workspace with a GitHub PR whose `list_ci_checks` command is routed
+ * by `handler`, so a test can drive check-run failures / recovery / cadence
+ * directly. The rest of the forge surface is mocked normally.
+ */
+async function openGithubPrWithChecksRoute(
+	page: Page,
+	gitbutler: { runScript: (s: string, a?: string[]) => Promise<void> },
+	handler: (route: Route) => Promise<void> | void,
+	reviewOverrides: Partial<ForgeReview> = {},
+) {
+	await gitbutler.runScript("project-with-remote-branches.sh");
+	await applyUpstream(gitbutler as never, BRANCH);
+
+	const review = forgeReview(PR_NUMBER, BRANCH, reviewOverrides);
+	await mockForge(page, {
+		forge_info: githubForgeInfo(),
+		list_reviews: [review],
+		get_review: review,
+		get_review_merge_status: mergeStatus(),
+		get_repo_info: repoInfo(),
+	});
+	await page.route("**/list_ci_checks", handler);
+
+	await openWorkspace(page);
+	await waitForTestId(page, "branch-card");
+}
+
+test("a failing checks poll backs off instead of hammering the endpoint", async ({
+	page,
+	gitbutler,
+}) => {
+	// A recent `modifiedAt` keeps the healthy schedule on its fast 5s interval,
+	// so the back-off to 30s shows up as a drop in request cadence. An old date
+	// would already sit on the slow schedule and hide the difference.
+	const now = new Date().toISOString();
+	let checkRequests = 0;
+	await openGithubPrWithChecksRoute(
+		page,
+		gitbutler,
+		async (route) => {
+			checkRequests += 1;
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				body: forgeErrorBody({ code: "NetworkError" }),
+			});
+		},
+		{ modifiedAt: now, createdAt: now, lastSyncAt: now },
+	);
+
+	const badge = await waitForTestId(page, "pr-checks-badge");
+	// The first failed poll surfaces the error state and trips the back-off.
+	await expect(badge).toContainText("Error");
+
+	const afterFirstError = checkRequests;
+	// Longer than the fast 5s interval, shorter than the 30s back-off: a
+	// hammering poller would fire ~2 more times in this window, a backed-off
+	// one ~0.
+	await page.waitForTimeout(13_000);
+	expect(checkRequests - afterFirstError).toBeLessThanOrEqual(1);
+});
+
+test("retrying a failed checks badge recovers once the fetch succeeds", async ({
+	page,
+	gitbutler,
+}) => {
+	// Fail until the badge is clicked, then serve a running check. Clicking the
+	// badge forces an immediate refetch, so recovery is deterministic instead of
+	// waiting out the back-off interval.
+	let shouldError = true;
+	await openGithubPrWithChecksRoute(page, gitbutler, async (route) => {
+		const body = shouldError
+			? forgeErrorBody({ code: "NetworkError" })
+			: JSON.stringify({ type: "success", subject: [ciCheckRunning("build")] });
+		await route.fulfill({ status: 200, contentType: "application/json", body });
+	});
+
+	const badge = await waitForTestId(page, "pr-checks-badge");
+	await expect(badge).toContainText("Error");
+
+	shouldError = false;
+	await badge.click();
+	await expect(badge).toContainText("Running");
+});
+
+test("empty checks render as no-checks, not an error", async ({ page, gitbutler }) => {
+	// A transient GitHub 422 (unresolvable ref) is mapped to an empty list by
+	// the backend, so from the renderer it is just a successful empty result —
+	// it must read as "No checks", never as an error.
+	await openWorkspaceWithMockedPr(page, gitbutler, {
+		forgeInfo: githubForgeInfo(),
+		checks: [],
+	});
+
+	const badge = await waitForTestId(page, "pr-checks-badge");
+	await expect(badge).toContainText("No checks");
+	await expect(badge).not.toContainText("Error");
 });
 
 test("GitLab MR shows the MR review badge", async ({ page, gitbutler }) => {


### PR DESCRIPTION
Follow-up to the CI check error classification work (already in `master`): adds test coverage and refines the failing-poll backoff.

## What changed

- **Cache preservation (`but-forge`):** split the cache-refresh decision out of the networked fetch so it's testable, and covered it — a transient unresolvable ref (`None`, a 422) preserves the cached checks that `but status` relies on, while an authoritative list (even an empty one, e.g. after a force-push to a no-CI commit) replaces the cache.
- **Graduated poll backoff (desktop):** a failing forge poll now steps out to 30s after the first failure and to 5min once it persists, instead of jumping straight to 5min — a one-off blip barely slows polling. The backoff is a floor, so it never polls faster than the normal schedule. Extracted into a shared `createPollBackoff` helper (with guarded state writes) used by both the CI checks badge and the PR status poller.
- **Tests:** unit tests for `getPollingInterval`; Playwright coverage for the backoff, retry-driven recovery, and an empty list (a mapped 422) rendering as "No checks" rather than an error.
