### PR TITLE
but-api: add opt-in flag for changes_in_worktree deps/assignments

### DIFF
--- a/apps/desktop/src/lib/worktree/worktreeEndpoints.ts
+++ b/apps/desktop/src/lib/worktree/worktreeEndpoints.ts
@@ -31,7 +31,7 @@ export function buildWorktreeEndpoints(build: BackendEndpointBuilder) {
 			{ projectId: string }
 		>({
 			extraOptions: { command: "changes_in_worktree" },
-			query: (args) => args,
+			query: (args) => ({ ...args, computeDepsAndAssignments: true }),
 			providesTags: [providesList(ReduxTag.WorktreeChanges)],
 			async onCacheEntryAdded(arg, lifecycleApi) {
 				if (!hasBackendExtra(lifecycleApi.extra)) {

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -394,7 +394,7 @@ const registerIpcHandlers = (): void => {
 		(_e, { projectId, branch }: BranchDiffParams) => branchDiff(projectId, branch),
 	);
 	senderValidatingHandle(liteIpcChannels.changesInWorktree, (_e, projectId: string) =>
-		changesInWorktree(projectId),
+		changesInWorktree(projectId, true),
 	);
 	senderValidatingHandle(liteIpcChannels.clipboardWriteText, (_e, text: string) => {
 		clipboard.writeText(text, "clipboard");

--- a/crates/but-api/src/diff.rs
+++ b/crates/but-api/src/diff.rs
@@ -106,9 +106,12 @@ pub fn tree_change_diffs(
 /// See [`changes_in_worktree_with_perm()`].
 #[but_api(napi)]
 #[instrument(err(Debug))]
-pub fn changes_in_worktree(ctx: &Context) -> anyhow::Result<WorktreeChanges> {
+pub fn changes_in_worktree(
+    ctx: &Context,
+    compute_deps_and_assignments: bool,
+) -> anyhow::Result<WorktreeChanges> {
     let guard = ctx.shared_worktree_access();
-    changes_in_worktree_with_perm(ctx, guard.read_permission())
+    changes_in_worktree_with_perm(ctx, compute_deps_and_assignments, guard.read_permission())
 }
 
 /// This UI-version of [`but_core::diff::worktree_changes()`] simplifies the `git status` information for display in
@@ -121,6 +124,9 @@ pub fn changes_in_worktree(ctx: &Context) -> anyhow::Result<WorktreeChanges> {
 ///
 /// All ignored status changes are also provided so they can be displayed separately.
 ///
+/// When dependency and assignment computation is turned off, hunk assignments and dependencies
+/// are not computed at all: `assignments` is empty and there are no `dependencies`.
+///
 /// For lower-level implementation details, see
 /// [`but_core::diff::worktree_changes()`],
 /// [`but_hunk_assignment::assignments_with_fallback()`], and
@@ -129,9 +135,15 @@ pub fn changes_in_worktree(ctx: &Context) -> anyhow::Result<WorktreeChanges> {
 #[instrument(skip_all, err(Debug))]
 pub fn changes_in_worktree_with_perm(
     ctx: &Context,
+    compute_deps_and_assignments: bool,
     perm: &RepoShared,
 ) -> anyhow::Result<WorktreeChanges> {
     let context_lines = ctx.settings.context_lines;
+
+    if !compute_deps_and_assignments {
+        let repo = ctx.repo.get()?;
+        return Ok(but_core::diff::worktree_changes(&repo)?.into());
+    }
 
     let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(perm)?;
 

--- a/crates/but-api/src/legacy/absorb.rs
+++ b/crates/but-api/src/legacy/absorb.rs
@@ -124,7 +124,7 @@ pub fn absorption_plan_with_perm(
             // TODO: Ideally, there's a simpler way of getting the worktree changes without passing the context to it.
             // At this time, the context is passed pretty deep into the function.
             let worktree_changes =
-                crate::diff::changes_in_worktree_with_perm(ctx, perm.read_permission())?;
+                crate::diff::changes_in_worktree_with_perm(ctx, true, perm.read_permission())?;
             let all_assignments = worktree_changes.assignments;
             let dependencies = worktree_changes.dependencies;
 
@@ -162,7 +162,7 @@ pub fn absorption_plan_with_perm(
         } => {
             // Get all worktree changes, assignments, and dependencies
             let worktree_changes =
-                crate::diff::changes_in_worktree_with_perm(ctx, perm.read_permission())?;
+                crate::diff::changes_in_worktree_with_perm(ctx, true, perm.read_permission())?;
             let all_assignments = worktree_changes.assignments;
             let dependencies = worktree_changes.dependencies;
 
@@ -196,7 +196,7 @@ pub fn absorption_plan_with_perm(
             // TODO: Ideally, there's a simpler way of getting the worktree changes without passing the context to it.
             // At this time, the context is passed pretty deep into the function.
             let worktree_changes =
-                crate::diff::changes_in_worktree_with_perm(ctx, perm.read_permission())?;
+                crate::diff::changes_in_worktree_with_perm(ctx, true, perm.read_permission())?;
             (worktree_changes.assignments, worktree_changes.dependencies)
         }
     };

--- a/crates/but-server/src/irc.rs
+++ b/crates/but-server/src/irc.rs
@@ -256,7 +256,7 @@ pub async fn irc_start_working_files_broadcast(
 
     // Seed initial file list from the current worktree state.
     let initial_files = match but_ctx::Context::try_from(project_id.clone()) {
-        Ok(ctx) => match but_api::diff::changes_in_worktree(&ctx) {
+        Ok(ctx) => match but_api::diff::changes_in_worktree(&ctx, false) {
             Ok(changes) => changes
                 .worktree_changes
                 .changes

--- a/crates/but/src/command/legacy/branch/show.rs
+++ b/crates/but/src/command/legacy/branch/show.rs
@@ -325,7 +325,7 @@ fn get_uncommitted_files(ctx: &mut Context, branch_arg: &BranchArg) -> anyhow::R
         && let Some(stack_id) = stack.id
     {
         // Get worktree changes and assignments
-        let worktree_changes = but_api::diff::changes_in_worktree(ctx)?;
+        let worktree_changes = but_api::diff::changes_in_worktree(ctx, true)?;
 
         let mut by_file: BTreeMap<BString, Vec<HunkAssignment>> = BTreeMap::new();
         for assignment in worktree_changes.assignments {

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -539,7 +539,7 @@ pub(crate) fn commit(
         resolve_insert_position(ctx, &id_map, target_branch, before, after)?;
 
     // Get changes and assignments using but-api
-    let worktree_changes = diff::changes_in_worktree_with_perm(ctx, guard.read_permission())?;
+    let worktree_changes = diff::changes_in_worktree_with_perm(ctx, true, guard.read_permission())?;
     let changes = worktree_changes.worktree_changes.changes;
 
     // Get files to commit - either specific files by ID or all eligible files

--- a/crates/but/src/command/legacy/diff/mod.rs
+++ b/crates/but/src/command/legacy/diff/mod.rs
@@ -12,7 +12,7 @@ mod show;
 pub fn handle_tui(ctx: &mut Context, target_str: Option<&str>) -> anyhow::Result<()> {
     use crate::tui::diff_viewer::{DiffFileEntry, WorktreeFilter};
 
-    let wt_changes = but_api::diff::changes_in_worktree(ctx)?;
+    let wt_changes = but_api::diff::changes_in_worktree(ctx, true)?;
     let id_map = IdMap::legacy_new_from_context(ctx, Some(wt_changes.assignments.clone()))?;
 
     let files = if let Some(entity) = target_str {
@@ -58,7 +58,7 @@ pub fn handle(
     out: &mut OutputChannel,
     target_str: Option<&str>,
 ) -> anyhow::Result<()> {
-    let wt_changes = but_api::diff::changes_in_worktree(ctx)?;
+    let wt_changes = but_api::diff::changes_in_worktree(ctx, true)?;
     let id_map = IdMap::legacy_new_from_context(ctx, Some(wt_changes.assignments.clone()))?;
 
     if let Some(entity) = target_str {

--- a/crates/but/src/command/legacy/discard.rs
+++ b/crates/but/src/command/legacy/discard.rs
@@ -36,7 +36,7 @@ pub fn handle(ctx: &mut Context, out: &mut OutputChannel, id: &str) -> Result<()
     }
 
     // Get worktree changes once for the Uncommitted case.
-    let worktree_changes = diff::changes_in_worktree_with_perm(ctx, guard.read_permission())?;
+    let worktree_changes = diff::changes_in_worktree_with_perm(ctx, true, guard.read_permission())?;
 
     // Extract DiffSpecs from all resolved entities.
     let diff_specs = {

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -2076,7 +2076,7 @@ fn reassign_all_from_stack_to_stack(
     source_stack_id: Option<StackId>,
     target_stack_id: Option<StackId>,
 ) -> anyhow::Result<()> {
-    let requests = but_api::diff::changes_in_worktree(ctx)?
+    let requests = but_api::diff::changes_in_worktree(ctx, true)?
         .assignments
         .into_iter()
         .filter(|assignment| assignment.stack_id == source_stack_id)
@@ -2095,7 +2095,7 @@ fn changes_for_stack_assignment(
     ctx: &mut Context,
     stack_id: Option<StackId>,
 ) -> anyhow::Result<Vec<DiffSpec>> {
-    let assignments = but_api::diff::changes_in_worktree(ctx)?
+    let assignments = but_api::diff::changes_in_worktree(ctx, true)?
         .assignments
         .into_iter()
         .filter(|assignment| assignment.stack_id == stack_id);

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -398,7 +398,7 @@ fn build_status_context<'a>(
     let review_map = review::get_review_map(ctx, Some(cache_config.clone()))?;
 
     let worktree_changes =
-        but_api::diff::changes_in_worktree_with_perm(ctx, perm.read_permission())?;
+        but_api::diff::changes_in_worktree_with_perm(ctx, true, perm.read_permission())?;
 
     let id_map = IdMap::new(stacks, worktree_changes.assignments.clone())?;
 

--- a/crates/but/src/command/legacy/status/tui/copy_selection_picker.rs
+++ b/crates/but/src/command/legacy/status/tui/copy_selection_picker.rs
@@ -244,7 +244,7 @@ fn uncommitted_hunk_or_file_to_diff(
     uncommitted: &UncommittedHunkOrFile,
 ) -> anyhow::Result<String> {
     let repo = ctx.repo.get()?;
-    let worktree_changes = but_api::diff::changes_in_worktree(ctx)?;
+    let worktree_changes = but_api::diff::changes_in_worktree(ctx, true)?;
     let assignments: Vec<_> = worktree_changes
         .assignments
         .into_iter()

--- a/crates/but/src/command/legacy/status/tui/file_browser.rs
+++ b/crates/but/src/command/legacy/status/tui/file_browser.rs
@@ -53,7 +53,7 @@ impl FileBrowser {
         self.tree.0.clear();
 
         let paths = match selection {
-            CliId::Uncommitted { .. } => but_api::diff::changes_in_worktree(ctx)?
+            CliId::Uncommitted { .. } => but_api::diff::changes_in_worktree(ctx, false)?
                 .worktree_changes
                 .changes
                 .into_iter()

--- a/crates/but/src/utils/diff_rendering.rs
+++ b/crates/but/src/utils/diff_rendering.rs
@@ -538,7 +538,7 @@ pub fn render_uncommitted(
 ) -> anyhow::Result<()> {
     let mut id_gen = id_gen.scoped("uncommitted");
 
-    let wt_changes = but_api::diff::changes_in_worktree(ctx)?;
+    let wt_changes = but_api::diff::changes_in_worktree(ctx, true)?;
     let id_map = IdMap::legacy_new_from_context(ctx, Some(wt_changes.assignments))?;
     let uncommitted_hunks = filter_uncommitted_hunks(ctx, &id_map, |hunk_assignment| {
         hunk_assignment.stack_id.is_none()
@@ -587,7 +587,7 @@ pub fn render_uncommitted_hunk(
     let mut id_gen = id_gen.scoped("hunk");
     let mut id_gen = id_gen.scoped(&hunk.id);
 
-    let wt_changes = but_api::diff::changes_in_worktree(ctx)?;
+    let wt_changes = but_api::diff::changes_in_worktree(ctx, true)?;
     let id_map = IdMap::legacy_new_from_context(ctx, Some(wt_changes.assignments))?;
     let uncommitted_hunks = filter_uncommitted_hunks(ctx, &id_map, |hunk_assignment| {
         uncommitted_hunk_matches_selection(hunk_assignment, &hunk)

--- a/crates/gitbutler-tauri/src/irc.rs
+++ b/crates/gitbutler-tauri/src/irc.rs
@@ -374,7 +374,7 @@ pub async fn irc_start_working_files_broadcast(
 
     // Seed initial file list from the current worktree state.
     let initial_files = match but_ctx::Context::try_from(project_id.clone()) {
-        Ok(ctx) => match but_api::diff::changes_in_worktree(&ctx) {
+        Ok(ctx) => match but_api::diff::changes_in_worktree(&ctx, false) {
             Ok(changes) => changes
                 .worktree_changes
                 .changes

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -120,7 +120,7 @@ export declare function branchLand(projectId: string, branch: string, noFf: bool
 export declare function branchRemove(projectId: string, refName: FullNameBytes): Promise<BranchRemoveResult>
 
 /** See [`changes_in_worktree_with_perm()`]. */
-export declare function changesInWorktree(projectId: string): Promise<WorktreeChanges>
+export declare function changesInWorktree(projectId: string, computeDepsAndAssignments: boolean): Promise<WorktreeChanges>
 
 /**
  * This UI-version of [`but_core::diff::worktree_changes()`] simplifies the `git status` information for display in
@@ -133,12 +133,15 @@ export declare function changesInWorktree(projectId: string): Promise<WorktreeCh
  *
  * All ignored status changes are also provided so they can be displayed separately.
  *
+ * When dependency and assignment computation is turned off, hunk assignments and dependencies
+ * are not computed at all: `assignments` is empty and there are no `dependencies`.
+ *
  * For lower-level implementation details, see
  * [`but_core::diff::worktree_changes()`],
  * [`but_hunk_assignment::assignments_with_fallback()`], and
  * [`but_hunk_dependency::ui::hunk_dependencies_for_workspace_changes_by_worktree_dir()`].
  */
-export declare function changesInWorktreeWithPerm(projectId: string): Promise<WorktreeChanges>
+export declare function changesInWorktreeWithPerm(projectId: string, computeDepsAndAssignments: boolean): Promise<WorktreeChanges>
 
 /**
  * Amend the commit at `commit_id` with `changes` and record an oplog snapshot on success.

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -120,7 +120,7 @@ export declare function branchLand(projectId: string, branch: string, noFf: bool
 export declare function branchRemove(projectId: string, refName: FullNameBytes): Promise<BranchRemoveResult>
 
 /** See [`changes_in_worktree_with_perm()`]. */
-export declare function changesInWorktree(projectId: string): Promise<WorktreeChanges>
+export declare function changesInWorktree(projectId: string, computeDepsAndAssignments: boolean): Promise<WorktreeChanges>
 
 /**
  * This UI-version of [`but_core::diff::worktree_changes()`] simplifies the `git status` information for display in
@@ -133,12 +133,15 @@ export declare function changesInWorktree(projectId: string): Promise<WorktreeCh
  *
  * All ignored status changes are also provided so they can be displayed separately.
  *
+ * When dependency and assignment computation is turned off, hunk assignments and dependencies
+ * are not computed at all: `assignments` is empty and there are no `dependencies`.
+ *
  * For lower-level implementation details, see
  * [`but_core::diff::worktree_changes()`],
  * [`but_hunk_assignment::assignments_with_fallback()`], and
  * [`but_hunk_dependency::ui::hunk_dependencies_for_workspace_changes_by_worktree_dir()`].
  */
-export declare function changesInWorktreeWithPerm(projectId: string): Promise<WorktreeChanges>
+export declare function changesInWorktreeWithPerm(projectId: string, computeDepsAndAssignments: boolean): Promise<WorktreeChanges>
 
 /**
  * Amend the commit at `commit_id` with `changes` and record an oplog snapshot on success.


### PR DESCRIPTION
Adds a `compute_deps_and_assignments` flag to `changes_in_worktree` and
`changes_in_worktree_with_perm`. When false, the endpoint skips computing
hunk assignments and dependencies entirely and returns an empty
assignments list with no dependencies.

Callers that consume assignments or dependencies (commit, discard, rub,
absorb, status, the desktop app) request the computation. Callers that
only need the changed paths — the IRC working-files seed and the status
TUI file browser — opt out to skip the extra work. The lite app requests
the computation for now so its dependency indicator keeps working; it can
opt out in a follow-up once that UI is reworked.