### PR TITLE
fix(but-api): raise the open-file limit at startup to avoid EMFILE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,6 +1003,7 @@ dependencies = [
  "objc2-app-kit",
  "objc2-foundation",
  "open",
+ "rlimit",
  "schemars 1.2.1",
  "serde",
  "serde-error",
@@ -8608,6 +8609,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rlimit"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -165,5 +165,9 @@ snapbox.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["full"] }
 
+[target.'cfg(unix)'.dev-dependencies]
+# Used by tests/fd_limit.rs to read RLIMIT_NOFILE and assert the never-lowers invariant.
+rlimit = "0.10.2"
+
 [lints]
 workspace = true

--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -153,6 +153,10 @@ but-schemars.workspace = true
 objc2-app-kit = { version = "0.3.2", default-features = false, features = ["std", "NSWorkspace"] }
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "NSString", "NSURL"] }
 
+[target.'cfg(unix)'.dependencies]
+# Raise the open-file soft limit at startup so large rebases don't hit EMFILE (#14260).
+rlimit = "0.10.2"
+
 [dev-dependencies]
 but-api = { path = ".", features = ["legacy"] }
 but-testsupport.workspace = true

--- a/crates/but-api/src/fd_limit.rs
+++ b/crates/but-api/src/fd_limit.rs
@@ -28,38 +28,3 @@ pub fn raise_soft_limit() {
         Err(err) => tracing::warn!("could not raise the open-file soft limit: {err}"),
     }
 }
-
-#[cfg(all(test, unix))]
-mod tests {
-    use rlimit::Resource;
-
-    // We assert only the safety invariant (never lowers), not that the target
-    // is reached: the OS-permitted maximum is platform-specific and, on macOS,
-    // is `kern.maxfilesperproc` - which is well below `RLIM_INFINITY`, so the
-    // achieved soft limit can legitimately be below `TARGET_NOFILE` even when
-    // the reported hard limit is unlimited.
-    #[test]
-    fn raise_soft_limit_runs_and_never_lowers() {
-        let (soft_before, _hard) = Resource::NOFILE.get().expect("read NOFILE limit");
-
-        // The public helper is best-effort and must not panic.
-        super::raise_soft_limit();
-
-        let (soft_after, _hard) = Resource::NOFILE.get().expect("read NOFILE limit");
-        assert!(
-            soft_after >= soft_before,
-            "raise_soft_limit must never lower the limit: {soft_after} < {soft_before}"
-        );
-
-        // Asking for less than the current soft limit is a no-op - we only ever
-        // grow the descriptor table, never shrink it.
-        if soft_before > 1 {
-            let requested_lower =
-                rlimit::increase_nofile_limit(soft_before - 1).expect("increase_nofile_limit");
-            assert!(
-                requested_lower >= soft_before,
-                "requesting a lower target must not shrink the limit: {requested_lower} < {soft_before}"
-            );
-        }
-    }
-}

--- a/crates/but-api/src/fd_limit.rs
+++ b/crates/but-api/src/fd_limit.rs
@@ -1,0 +1,65 @@
+//! Raise the process's open-file-descriptor soft limit at startup.
+//!
+//! macOS ships a default `RLIMIT_NOFILE` soft limit of 256, which a large
+//! rebase across many stacks can exhaust with `EMFILE` ("too many open
+//! files"): each `gix`/`git2` repository memory-maps a potentially large
+//! number of pack files on first object access, and several repositories can
+//! be open at once. Hitting that limit mid-rebase can leave the workspace in
+//! an inconsistent state, so raise the soft limit toward the hard limit up
+//! front to avoid the crash entirely (#14260).
+
+/// The soft `RLIMIT_NOFILE` we try to raise to. Capped rather than unbounded so
+/// we don't request an enormous descriptor table on hosts with a very high
+/// hard limit; this matches the `ulimit -n 65536` workaround that resolves the
+/// issue in practice.
+#[cfg(unix)]
+const TARGET_NOFILE: u64 = 65536;
+
+/// Raise the open-file soft limit toward the hard limit (up to `TARGET_NOFILE`).
+///
+/// Best-effort and safe to call once at startup: it never *lowers* the limit,
+/// treats any failure as non-fatal (the process simply keeps the OS default),
+/// and is a no-op on non-Unix platforms (Windows has no comparably low
+/// default).
+pub fn raise_soft_limit() {
+    #[cfg(unix)]
+    match rlimit::increase_nofile_limit(TARGET_NOFILE) {
+        Ok(limit) => tracing::debug!("raised open-file soft limit to {limit}"),
+        Err(err) => tracing::warn!("could not raise the open-file soft limit: {err}"),
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use rlimit::Resource;
+
+    // We assert only the safety invariant (never lowers), not that the target
+    // is reached: the OS-permitted maximum is platform-specific and, on macOS,
+    // is `kern.maxfilesperproc` - which is well below `RLIM_INFINITY`, so the
+    // achieved soft limit can legitimately be below `TARGET_NOFILE` even when
+    // the reported hard limit is unlimited.
+    #[test]
+    fn raise_soft_limit_runs_and_never_lowers() {
+        let (soft_before, _hard) = Resource::NOFILE.get().expect("read NOFILE limit");
+
+        // The public helper is best-effort and must not panic.
+        super::raise_soft_limit();
+
+        let (soft_after, _hard) = Resource::NOFILE.get().expect("read NOFILE limit");
+        assert!(
+            soft_after >= soft_before,
+            "raise_soft_limit must never lower the limit: {soft_after} < {soft_before}"
+        );
+
+        // Asking for less than the current soft limit is a no-op - we only ever
+        // grow the descriptor table, never shrink it.
+        if soft_before > 1 {
+            let requested_lower =
+                rlimit::increase_nofile_limit(soft_before - 1).expect("increase_nofile_limit");
+            assert!(
+                requested_lower >= soft_before,
+                "requesting a lower target must not shrink the limit: {requested_lower} < {soft_before}"
+            );
+        }
+    }
+}

--- a/crates/but-api/src/lib.rs
+++ b/crates/but-api/src/lib.rs
@@ -59,6 +59,8 @@ pub mod open;
 
 pub mod panic_capture;
 
+pub mod fd_limit;
+
 /// The types for watcher events
 #[cfg(feature = "export-schema")]
 pub mod watcher;

--- a/crates/but-api/tests/fd_limit.rs
+++ b/crates/but-api/tests/fd_limit.rs
@@ -1,0 +1,33 @@
+//! Integration test for the public `but_api::fd_limit` API.
+//!
+//! Unix-only: the helper is a no-op elsewhere and `rlimit` is a Unix-only dev
+//! dependency, so the whole file compiles away on other platforms.
+#![cfg(unix)]
+
+use rlimit::Resource;
+
+/// `raise_soft_limit` is best-effort. We assert only its safety contract - it
+/// must not panic and must never *lower* the open-file soft limit - not that a
+/// specific target is reached: the OS-permitted maximum is platform-specific
+/// (on macOS `kern.maxfilesperproc`, well below `RLIM_INFINITY`), so the
+/// achieved limit can legitimately fall short of the target.
+#[test]
+fn raise_soft_limit_never_lowers_and_is_repeatable() {
+    let (soft_before, _hard) = Resource::NOFILE.get().expect("read NOFILE limit");
+
+    but_api::fd_limit::raise_soft_limit();
+    let (soft_after, _hard) = Resource::NOFILE.get().expect("read NOFILE limit");
+    assert!(
+        soft_after >= soft_before,
+        "raise_soft_limit must never lower the limit: {soft_after} < {soft_before}"
+    );
+
+    // Called once at startup in production, but it must stay safe to call again:
+    // a second invocation must likewise never lower the limit.
+    but_api::fd_limit::raise_soft_limit();
+    let (soft_again, _hard) = Resource::NOFILE.get().expect("read NOFILE limit");
+    assert!(
+        soft_again >= soft_after,
+        "a repeated raise_soft_limit call must not lower the limit: {soft_again} < {soft_after}"
+    );
+}

--- a/crates/but-server/src/main.rs
+++ b/crates/but-server/src/main.rs
@@ -20,6 +20,8 @@ struct Args {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     trace::init()?;
+    // Raise the open-file soft limit so large operations don't hit EMFILE (#14260).
+    but_api::fd_limit::raise_soft_limit();
     // In debug builds, prefer git-credential-backed secret storage when platform keychains are
     // either noisy (macOS rebuild prompts) or unavailable (headless e2e Linux containers).
     // Release builds keep using the platform keychain.

--- a/crates/but/src/main.rs
+++ b/crates/but/src/main.rs
@@ -1,6 +1,5 @@
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    but_api::fd_limit::raise_soft_limit();
     but_askpass::disable();
     but::handle_args(std::env::args_os()).await
 }

--- a/crates/but/src/main.rs
+++ b/crates/but/src/main.rs
@@ -1,5 +1,6 @@
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    but_api::fd_limit::raise_soft_limit();
     but_askpass::disable();
     but::handle_args(std::env::args_os()).await
 }

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -51,6 +51,7 @@ fn effective_irc(
 
 fn main() -> anyhow::Result<()> {
     but_api::panic_capture::install_panic_hook();
+    but_api::fd_limit::raise_soft_limit();
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?;


### PR DESCRIPTION
Addresses the EMFILE trigger in #14260.

## Bug
On a large repo with many stacks, `UpdateWorkspaceBase` (updating trunk) can fail partway with **EMFILE ("too many open files")**: the app inherits macOS's default `RLIMIT_NOFILE` soft limit of **256**, and each `gix`/`git2` repository memory-maps a potentially large number of pack files on first object access (with several repositories open at once). When the rebase fails mid-operation, the workspace is left in an inconsistent, hard-to-recover state.

## Fix
Raise the soft open-file limit toward the hard limit once at startup, from the desktop app, the CLI, and the local API server. The value is capped at 65536 — the `ulimit -n 65536` that resolves the issue in practice. It's best-effort (never lowers the limit, treats a failure as non-fatal) and a no-op on Windows (which has no comparably low default).

- `but_api::fd_limit::raise_soft_limit()` wraps `rlimit::increase_nofile_limit`, which handles the macOS quirk where `rlim_max` is `RLIM_INFINITY` but the real ceiling is `kern.maxfilesperproc`.
- Called at the top of the `gitbutler-tauri`, `but`, and `but-server` mains — before anything opens a repository.

## Scope
This removes the EMFILE **trigger**. The separate, primary issue in #14260 — non-atomic failure handling (a rebase failure of any cause leaving the database and refs desynced) — is out of scope here, so this intentionally doesn't close the issue.

## Verification
- `cargo doc` (`-D warnings`), `cargo clippy`, and `cargo test -p but-api` are clean; `but`, `gitbutler-tauri`, and `but-server` compile.
- The raise is exercised under a lowered limit: from `ulimit -n 400`, the helper raised the soft limit to 61440 (the macOS `kern.maxfilesperproc` ceiling — well above the 256 that triggers the crash).
- A full EMFILE-cascade repro isn't practical (it needs a very large many-pack repository), so this prevents the trigger rather than reproducing the end-to-end failure.

Note: `but-napi` (the Electron/node host) has no Rust entrypoint to hook, so raising its limit would need to be done by the node host.