### PR TITLE
Translate web app (gitbutler.com) to German

### DIFF
--- a/apps/lite/AGENTS.md
+++ b/apps/lite/AGENTS.md
@@ -6,6 +6,8 @@ JavaScript dependencies are sourced from pnpm. Commands are surfaced via pnpm.
 
 In dev the app is accessible for agent automation on port 9222.
 
+bla
+
 # Typechecking
 
 Typechecking is the fastest way to validate that everything is okay. Always run this **exact** command to typecheck:

--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="de">
 	<head>
 		<title>GitButler</title>
 		<meta charset="utf-8" />

--- a/apps/web/src/lib/components/ChatComponent.svelte
+++ b/apps/web/src/lib/components/ChatComponent.svelte
@@ -95,9 +95,9 @@
 {:else}
 	<div class="chat-wrapper" class:tablet-mode={isTabletMode}>
 		<div class="chat-header">
-			<h3 class="text-13 text-bold">Discussion</h3>
+			<h3 class="text-13 text-bold">Diskussion</h3>
 			<div class="chat-header-actions">
-				<Button icon="minus" kind="ghost" tooltip="Hide discussion" onclick={onMinimizeToggle} />
+				<Button icon="minus" kind="ghost" tooltip="Diskussion ausblenden" onclick={onMinimizeToggle} />
 			</div>
 		</div>
 
@@ -122,11 +122,12 @@
 								<div class="blank-state-content">
 									{@html blankChat}
 									<div class="blank-message">
-										<div class="text-18 text-semibold blank-message-title">Give some feedback!</div>
+										<div class="text-18 text-semibold blank-message-title">Gib uns Feedback!</div>
 										<p class="text-12 text-body blank-message-text">
-											If you're here, you must be important. This patch can use your help. Leave a
-											comment or ask a question. Does this look right to you? How can it be
-											improved? Is it perfect? Just let us know!
+											Wenn du hier bist, musst du wichtig sein. Dieser Patch kann deine Hilfe
+											gebrauchen. Hinterlasse einen Kommentar oder stelle eine Frage. Sieht das
+											für dich richtig aus? Wie kann er verbessert werden? Ist er perfekt? Sag es
+											uns einfach!
 										</p>
 									</div>
 								</div>

--- a/apps/web/src/lib/components/CompactFooter.svelte
+++ b/apps/web/src/lib/components/CompactFooter.svelte
@@ -11,11 +11,11 @@
 
 	<div class="footer-links">
 		<a class="footer-link underline" href="https://gitbutler.com/privacy" target="_blank">
-			Privacy Policy
+			Datenschutz
 		</a>
 		<span> | </span>
 		<a class="footer-link underline" href="https://gitbutler.com/terms" target="_blank">
-			Terms of Service
+			Nutzungsbedingungen
 		</a>
 	</div>
 </footer>

--- a/apps/web/src/lib/components/GitbutlerLogoLink.svelte
+++ b/apps/web/src/lib/components/GitbutlerLogoLink.svelte
@@ -30,11 +30,11 @@
 {/snippet}
 
 {#if disabled}
-	<div class="logo" aria-label="main nav">
+	<div class="logo" aria-label="Hauptnavigation">
 		{@render logoContent()}
 	</div>
 {:else}
-	<a href={routes.homePath()} class="logo" aria-label="main nav" title="Go to Home">
+	<a href={routes.homePath()} class="logo" aria-label="Hauptnavigation" title="Zur Startseite">
 		{@render logoContent()}
 	</a>
 {/if}

--- a/apps/web/src/lib/components/HeaderAuthSection.svelte
+++ b/apps/web/src/lib/components/HeaderAuthSection.svelte
@@ -21,8 +21,8 @@
 	<UserAuthAvatar user={$user} />
 {:else if !$user}
 	<div class="login-signup-wrap">
-		<Button kind="outline" onclick={() => goto(routes.signupPath())}>Sign up</Button>
-		<Button style="pop" onclick={() => goto(routes.loginPath())} icon="login">Log in</Button>
+		<Button kind="outline" onclick={() => goto(routes.signupPath())}>Registrieren</Button>
+		<Button style="pop" onclick={() => goto(routes.loginPath())} icon="login">Anmelden</Button>
 	</div>
 {/if}
 

--- a/apps/web/src/lib/components/InviteLink.svelte
+++ b/apps/web/src/lib/components/InviteLink.svelte
@@ -56,7 +56,7 @@
 
 		// Show confirmation dialog
 		const confirmed = confirm(
-			"Are you sure you want to reset the invite code? This will invalidate all existing invite links.",
+			"Möchtest du den Einladungscode wirklich zurücksetzen? Dadurch werden alle bestehenden Einladungslinks ungültig.",
 		);
 
 		if (confirmed) {
@@ -73,7 +73,7 @@
 				updateInviteUrl();
 			} catch (error) {
 				console.error("Failed to reset invite code:", error);
-				alert("Failed to reset invite code. Please try again.");
+				alert("Einladungscode konnte nicht zurückgesetzt werden. Bitte versuche es erneut.");
 			} finally {
 				resetting = false;
 			}
@@ -83,30 +83,31 @@
 
 {#if inviteCode}
 	<div class="invite-link-container">
-		<p>Share this link to invite people to join this organization:</p>
+		<p>Teile diesen Link, um Personen zu dieser Organisation einzuladen:</p>
 
 		<div class="invite-url-container">
 			<Textbox readonly value={inviteCode} />
-			<Button onclick={copyToClipboard} style={copied ? "safe" : "pop"}>copy url</Button>
+			<Button onclick={copyToClipboard} style={copied ? "safe" : "pop"}>URL kopieren</Button>
 		</div>
 
 		<p class="info-text">
-			Anyone with this link can join your organization by accepting the invitation.
+			Jeder mit diesem Link kann deiner Organisation beitreten, indem er die Einladung annimmt.
 		</p>
 
 		<div class="reset-container">
 			<Button onclick={resetInviteCode} style="warning" disabled={resetting || serviceError}>
 				{#if serviceError}
-					Service Unavailable
+					Dienst nicht verfügbar
 				{:else if resetting}
-					Resetting...
+					Wird zurückgesetzt...
 				{:else}
-					Reset Invite Code
+					Einladungscode zurücksetzen
 				{/if}
 			</Button>
 			{#if serviceError}
 				<p class="error-text">
-					Reset functionality is currently unavailable. The organization service could not be found.
+					Die Zurücksetzen-Funktion ist derzeit nicht verfügbar. Der Organisationsdienst konnte nicht
+					gefunden werden.
 				</p>
 			{/if}
 		</div>

--- a/apps/web/src/lib/components/LoginModal.svelte
+++ b/apps/web/src/lib/components/LoginModal.svelte
@@ -28,18 +28,18 @@
 			{@html loginSvg}
 		</div>
 		<div class="login-modal__content">
-			<h2 class="text-18 text-bold login-modal__title">🔒 Log in to continue</h2>
+			<h2 class="text-18 text-bold login-modal__title">🔒 Zum Fortfahren anmelden</h2>
 			<p class="text-13 text-body login-modal__text">
 				{#if children}
 					{@render children()}
 				{:else}
-					You need to be logged in to unlock full access to all features.
+					Du musst angemeldet sein, um vollen Zugriff auf alle Funktionen zu erhalten.
 				{/if}
 			</p>
 
 			<div class="login-modal__actions">
-				<Button style="pop" onclick={login}>Log in</Button>
-				<Button kind="outline" onclick={login}>Sign up</Button>
+				<Button style="pop" onclick={login}>Anmelden</Button>
+				<Button kind="outline" onclick={login}>Registrieren</Button>
 			</div>
 		</div>
 	</div>

--- a/apps/web/src/lib/components/OrganizationEditModal.svelte
+++ b/apps/web/src/lib/components/OrganizationEditModal.svelte
@@ -47,7 +47,7 @@
 			}
 		} catch (error) {
 			chipToasts.error(
-				`Failed to fetch organization details: ${error instanceof Error ? error.message : "Unknown error"}`,
+				`Organisationsdetails konnten nicht abgerufen werden: ${error instanceof Error ? error.message : "Unbekannter Fehler"}`,
 			);
 		} finally {
 			isLoading = false;
@@ -71,7 +71,7 @@
 				description,
 			});
 
-			chipToasts.success("Organization updated successfully");
+			chipToasts.success("Organisation erfolgreich aktualisiert");
 
 			// Notify parent component about the update
 			onUpdate(sluggifiedSlug);
@@ -85,7 +85,7 @@
 			}
 		} catch (error) {
 			chipToasts.error(
-				`Failed to update organization: ${error instanceof Error ? error.message : "Unknown error"}`,
+				`Organisation konnte nicht aktualisiert werden: ${error instanceof Error ? error.message : "Unbekannter Fehler"}`,
 			);
 		} finally {
 			isLoading = false;
@@ -104,21 +104,21 @@
 	}
 </script>
 
-<Modal bind:this={modal} title="Edit Organization" onClose={onModalClose} width="medium">
+<Modal bind:this={modal} title="Organisation bearbeiten" onClose={onModalClose} width="medium">
 	<div class="form-container">
 		<Textbox bind:value={name} label="Name" required={submitAttempted} disabled={isLoading} />
 
 		<Textbox bind:value={slug} label="Slug" required={submitAttempted} disabled={isLoading} />
 
 		{#if slug !== sluggifiedSlug}
-			<p class="slug-note">Slug will be saved as: {sluggifiedSlug}</p>
+			<p class="slug-note">Slug wird gespeichert als: {sluggifiedSlug}</p>
 		{/if}
 
-		<Textarea bind:value={description} label="Description" disabled={isLoading} />
+		<Textarea bind:value={description} label="Beschreibung" disabled={isLoading} />
 	</div>
 
 	{#snippet controls(close)}
-		<Button kind="outline" onclick={close} disabled={isLoading}>Cancel</Button>
+		<Button kind="outline" onclick={close} disabled={isLoading}>Abbrechen</Button>
 
 		<Button
 			style="pop"
@@ -126,7 +126,7 @@
 			loading={isLoading}
 			onclick={() => updateOrganization(close)}
 		>
-			Save Changes
+			Änderungen speichern
 		</Button>
 	{/snippet}
 </Modal>

--- a/apps/web/src/lib/components/OrganizationProfile.svelte
+++ b/apps/web/src/lib/components/OrganizationProfile.svelte
@@ -175,7 +175,7 @@
 			{#if localOrganization.avatarUrl}
 				<img
 					src={localOrganization.avatarUrl}
-					alt="{localOrganization.name}'s logo"
+					alt="Logo von {localOrganization.name}"
 					class="avatar"
 				/>
 			{/if}
@@ -189,7 +189,7 @@
 			{#if currentUserIsAdmin()}
 				<div class="org-actions">
 					<Button style="pop" onclick={() => organizationEditModal?.show()}>
-						Edit Organization
+						Organisation bearbeiten
 					</Button>
 				</div>
 			{/if}
@@ -210,7 +210,7 @@
 		<div class="side-column">
 			{#if localOrganization.inviteCode}
 				<div class="section-card invite-code-section">
-					<h2 class="section-title">Invite Code</h2>
+					<h2 class="section-title">Einladungscode</h2>
 					<div class="invite-link-wrapper">
 						<InviteLink organizationSlug={ownerSlug} inviteCode={localOrganization.inviteCode} />
 					</div>
@@ -219,14 +219,14 @@
 
 			{#if localOrganization.members && localOrganization.members.length > 0}
 				<div class="section-card members-section">
-					<h2 class="section-title">Members</h2>
+					<h2 class="section-title">Mitglieder</h2>
 					<div class="members-list">
 						{#each localOrganization.members as member}
 							<div class="member-card">
 								<a href="/{member.login}" class="member-link">
 									<img
 										src={member.avatar_url || "/images/default-avatar.png"}
-										alt="{member.login}'s avatar"
+										alt="Avatar von {member.login}"
 										class="member-avatar"
 									/>
 									<div class="member-info">
@@ -234,7 +234,7 @@
 										<span class="member-role">
 											{member.name}
 											{#if isOwner(member)}
-												<span class="badge owner-badge">Owner</span>
+												<span class="badge owner-badge">Eigentümer</span>
 											{/if}
 										</span>
 									</div>
@@ -247,7 +247,7 @@
 											style="gray"
 											onclick={() => confirmMakeOwnerDialog(member.login)}
 										>
-											Make Owner
+											Zum Eigentümer machen
 										</Button>
 									{/if}
 
@@ -257,7 +257,7 @@
 											style="danger"
 											onclick={() => confirmRemoveUserDialog(member.login)}
 										>
-											Remove
+											Entfernen
 										</Button>
 									{/if}
 								</div>
@@ -272,23 +272,23 @@
 
 <!-- Remove User Confirmation Modal -->
 <Modal bind:this={confirmRemoveUserModal} width="small" onSubmit={removeUser}>
-	<p>Are you sure you want to remove this user from the organization?</p>
+	<p>Möchtest du diesen Benutzer wirklich aus der Organisation entfernen?</p>
 	{#snippet controls(close)}
-		<Button kind="outline" onclick={close}>Cancel</Button>
-		<Button style="danger" type="submit" loading={isRemoving}>Remove</Button>
+		<Button kind="outline" onclick={close}>Abbrechen</Button>
+		<Button style="danger" type="submit" loading={isRemoving}>Entfernen</Button>
 	{/snippet}
 </Modal>
 
 <!-- Make Owner Confirmation Modal -->
 <Modal bind:this={confirmMakeOwnerModal} width="small" onSubmit={makeUserOwner}>
-	<p>Are you sure you want to make this user an owner?</p>
+	<p>Möchtest du diesen Benutzer wirklich zum Eigentümer machen?</p>
 	<p class="modal-note">
-		Owners have full administrative access to the organization, including managing members,
-		projects, and settings.
+		Eigentümer haben vollen administrativen Zugriff auf die Organisation, einschließlich der
+		Verwaltung von Mitgliedern, Projekten und Einstellungen.
 	</p>
 	{#snippet controls(close)}
-		<Button kind="outline" onclick={close}>Cancel</Button>
-		<Button style="pop" type="submit" loading={isPromoting}>Make Owner</Button>
+		<Button kind="outline" onclick={close}>Abbrechen</Button>
+		<Button style="pop" type="submit" loading={isPromoting}>Zum Eigentümer machen</Button>
 	{/snippet}
 </Modal>
 

--- a/apps/web/src/lib/components/ProjectConnectModal.svelte
+++ b/apps/web/src/lib/components/ProjectConnectModal.svelte
@@ -66,7 +66,7 @@
 			}
 		} catch (error) {
 			console.error("Failed to fetch organization projects:", error);
-			chipToasts.error("Failed to fetch organization projects");
+			chipToasts.error("Projekte der Organisation konnten nicht abgerufen werden");
 			organizationProjects = [];
 		} finally {
 			isLoadingProjects = false;
@@ -99,7 +99,7 @@
 		const projectSlug = isCreatingNew ? newProjectSlug : selectedProjectSlug;
 
 		if (!projectSlug) {
-			chipToasts.error("Please select or create a project first");
+			chipToasts.error("Bitte wähle zuerst ein Projekt aus oder erstelle eines");
 			return;
 		}
 
@@ -109,18 +109,18 @@
 				organizationSlug,
 				projectSlug,
 			);
-			chipToasts.success("Project connected to organization");
+			chipToasts.success("Projekt mit Organisation verbunden");
 			modal?.close();
 		} catch (error) {
 			chipToasts.error(
-				`Failed to connect project: ${error instanceof Error ? error.message : "Unknown error"}`,
+				`Projekt konnte nicht verbunden werden: ${error instanceof Error ? error.message : "Unbekannter Fehler"}`,
 			);
 		}
 	}
 
 	const title = $derived.by(() => {
-		if (project?.status !== "found") return "Connect Project";
-		return `Connect ${project.value.name} to an Organization`;
+		if (project?.status !== "found") return "Projekt verbinden";
+		return `${project.value.name} mit einer Organisation verbinden`;
 	});
 
 	let modal = $state<ReturnType<typeof Modal>>();
@@ -159,7 +159,7 @@
 									{/if}
 								</div>
 								<Button style="pop" onclick={() => selectOrganization(organization.slug)}>
-									Select
+									Auswählen
 								</Button>
 							</CardGroup.Item>
 						{/snippet}
@@ -168,20 +168,20 @@
 			</CardGroup>
 		{:else}
 			<div class="empty-state">
-				<p>You don't belong to any organizations yet.</p>
-				<p>Create or join an organization to connect this project.</p>
+				<p>Du gehörst noch keiner Organisation an.</p>
+				<p>Erstelle eine Organisation oder tritt einer bei, um dieses Projekt zu verbinden.</p>
 			</div>
 		{/if}
 	{:else}
 		<!-- Project Selection Step -->
 		<div class="selection-header">
-			<h4>Select a project in {selectedOrgSlug}</h4>
-			<Button style="gray" onclick={() => (selectedOrgSlug = null)}>Back to Organizations</Button>
+			<h4>Wähle ein Projekt in {selectedOrgSlug}</h4>
+			<Button style="gray" onclick={() => (selectedOrgSlug = null)}>Zurück zu Organisationen</Button>
 		</div>
 
 		{#if isLoadingProjects}
 			<div class="loading-container">
-				<p>Loading projects...</p>
+				<p>Projekte werden geladen...</p>
 			</div>
 		{:else}
 			<CardGroup>
@@ -213,20 +213,20 @@
 				<div class={isCreatingNew ? "selected create-new" : "create-new"}>
 					<CardGroup.Item onclick={toggleCreateNew}>
 						<div class="project-info">
-							<h5 class="text-15 text-bold">Create New Project</h5>
+							<h5 class="text-15 text-bold">Neues Projekt erstellen</h5>
 							{#if isCreatingNew}
 								<div class="new-project-form">
-									<label for="newProjectSlug">Project Slug:</label>
+									<label for="newProjectSlug">Projekt-Slug:</label>
 									<input
 										type="text"
 										id="newProjectSlug"
 										bind:value={newProjectSlug}
-										placeholder="Enter project slug"
+										placeholder="Projekt-Slug eingeben"
 										class="form-input"
 									/>
 								</div>
 							{:else}
-								<p class="description">Create a new project with this repository</p>
+								<p class="description">Ein neues Projekt mit diesem Repository erstellen</p>
 							{/if}
 						</div>
 						<div class="radio-option">
@@ -243,7 +243,7 @@
 
 			<div class="action-buttons">
 				<Button style="pop" onclick={() => connectToOrganization(selectedOrgSlug || "")}>
-					Connect
+					Verbinden
 				</Button>
 			</div>
 		{/if}

--- a/apps/web/src/lib/components/ProjectsSection.svelte
+++ b/apps/web/src/lib/components/ProjectsSection.svelte
@@ -15,14 +15,14 @@
 		loading?: boolean;
 	}
 
-	let { projects, ownerSlug, sectionTitle = "Projects", loading = false }: Props = $props();
+	let { projects, ownerSlug, sectionTitle = "Projekte", loading = false }: Props = $props();
 </script>
 
 <div class="section-card projects-section">
 	<h2 class="section-title">{sectionTitle}</h2>
 	{#if loading}
 		<div class="loading-state">
-			<p>Loading projects...</p>
+			<p>Projekte werden geladen...</p>
 		</div>
 	{:else if projects.length > 0}
 		<div class="projects-grid">
@@ -33,7 +33,7 @@
 							<a href="/{ownerSlug}/{project.slug}">{project.name || project.slug}</a>
 						</h3>
 						{#if project.updated_at}
-							<span class="updated-at">Updated {getRelativeTime(project.updated_at)}</span>
+							<span class="updated-at">Aktualisiert {getRelativeTime(project.updated_at)}</span>
 						{/if}
 					</div>
 					{#if project.description}
@@ -44,7 +44,7 @@
 		</div>
 	{:else}
 		<div class="empty-state">
-			<p>No projects found.</p>
+			<p>Keine Projekte gefunden.</p>
 		</div>
 	{/if}
 </div>

--- a/apps/web/src/lib/components/ReviewsSection.svelte
+++ b/apps/web/src/lib/components/ReviewsSection.svelte
@@ -44,7 +44,7 @@
 	let {
 		reviews,
 		status = "found",
-		sectionTitle = "Recent Reviews",
+		sectionTitle = "Aktuelle Prüfungen",
 		allReviewsUrl = undefined,
 		reviewsCount = 0,
 	}: Props = $props();
@@ -55,7 +55,7 @@
 			? review.title
 			: "title" in review && review.title !== undefined
 				? String(review.title)
-				: "Untitled Review";
+				: "Unbenannte Prüfung";
 	}
 
 	function getReviewUrl(review: Review): string {
@@ -68,7 +68,7 @@
 	function getContributorAvatars(contributors: Contributor[]) {
 		return contributors.map((contributor) => ({
 			srcUrl: contributor.user?.avatarUrl || "/images/default-avatar.png",
-			username: contributor.user?.name || "User",
+			username: contributor.user?.name || "Benutzer",
 		}));
 	}
 </script>
@@ -77,7 +77,7 @@
 	<div class="section-header">
 		<h2 class="section-title">{sectionTitle}</h2>
 		{#if allReviewsUrl && reviewsCount > 0}
-			<Button onclick={() => goto(allReviewsUrl)} style="pop">All Reviews</Button>
+			<Button onclick={() => goto(allReviewsUrl)} style="pop">Alle Prüfungen</Button>
 		{/if}
 	</div>
 
@@ -86,12 +86,12 @@
 			<thead>
 				<tr>
 					<th>Status</th>
-					<th>Project</th>
+					<th>Projekt</th>
 					<th>Name</th>
 					<th>Commits</th>
-					<th>Update</th>
-					<th>Authors</th>
-					<th title="Commit version">Ver.</th>
+					<th>Aktualisierung</th>
+					<th>Autoren</th>
+					<th title="Commit-Version">Ver.</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -125,12 +125,12 @@
 	{:else if status === "loading"}
 		<div class="loading-state">
 			<div class="loading-spinner"></div>
-			<p>Loading reviews...</p>
+			<p>Prüfungen werden geladen...</p>
 		</div>
 	{:else}
 		<div class="empty-state">
-			<p>No recent reviews</p>
-			<p class="empty-state-subtitle">Reviews will appear here once they are created.</p>
+			<p>Keine aktuellen Prüfungen</p>
+			<p class="empty-state-subtitle">Prüfungen erscheinen hier, sobald sie erstellt wurden.</p>
 		</div>
 	{/if}
 </div>

--- a/apps/web/src/lib/components/ShowChatButton.svelte
+++ b/apps/web/src/lib/components/ShowChatButton.svelte
@@ -54,7 +54,7 @@
 		</div>
 	</div>
 	<div class="show-chat__content">
-		<span class="text-12 text-semibold">Show discussion</span>
+		<span class="text-12 text-semibold">Diskussion anzeigen</span>
 		<div class="show-chat__icon"><Icon name="chat" /></div>
 	</div>
 </button>

--- a/apps/web/src/lib/components/SideNavigation.svelte
+++ b/apps/web/src/lib/components/SideNavigation.svelte
@@ -19,7 +19,7 @@
 
 <div class="navigation">
 	<div class="domains">
-		<a href="/" class="main-nav" aria-label="main nav" title="Home">
+		<a href="/" class="main-nav" aria-label="Hauptnavigation" title="Startseite">
 			<svg
 				xmlns="http://www.w3.org/2000/svg"
 				width="23"
@@ -32,7 +32,7 @@
 		</a>
 
 		{#if $user}
-			<a class="nav-link nav-button" href="/organizations" aria-label="organizations">
+			<a class="nav-link nav-button" href="/organizations" aria-label="Organisationen">
 				<svg
 					xmlns="http://www.w3.org/2000/svg"
 					width="16"
@@ -59,8 +59,8 @@
 			<a
 				class="nav-link nav-button"
 				href={routes.projectsPath()}
-				aria-label="projects"
-				title="Projects"
+				aria-label="Projekte"
+				title="Projekte"
 			>
 				<svg
 					xmlns="http://www.w3.org/2000/svg"
@@ -141,7 +141,7 @@
 				</svg>
 			{/if}
 		</button>
-		<a class="nav-link nav-button" href="/downloads" aria-label="downloads" title="Downloads">
+		<a class="nav-link nav-button" href="/downloads" aria-label="Downloads" title="Downloads">
 			<svg
 				xmlns="http://www.w3.org/2000/svg"
 				width="16"
@@ -162,8 +162,8 @@
 		<a
 			class="nav-link email"
 			href="mailto:hello@gitbutler.com"
-			aria-label="contact us"
-			title="Contact Us"
+			aria-label="Kontakt"
+			title="Kontakt"
 		>
 			<svg
 				xmlns="http://www.w3.org/2000/svg"

--- a/apps/web/src/lib/components/UserAuthAvatar.svelte
+++ b/apps/web/src/lib/components/UserAuthAvatar.svelte
@@ -13,7 +13,7 @@
 	const routes = inject(WEB_ROUTES_SERVICE);
 </script>
 
-<Tooltip text="Profile & Settings">
+<Tooltip text="Profil & Einstellungen">
 	<button
 		type="button"
 		class="user-btn"

--- a/apps/web/src/lib/components/UserProfile.svelte
+++ b/apps/web/src/lib/components/UserProfile.svelte
@@ -49,10 +49,10 @@
 			};
 
 			editingReadme = false;
-			chipToasts.success("README updated successfully");
+			chipToasts.success("README erfolgreich aktualisiert");
 		} catch (error) {
 			chipToasts.error(
-				`Failed to update README: ${error instanceof Error ? error.message : "Unknown error"}`,
+				`README konnte nicht aktualisiert werden: ${error instanceof Error ? error.message : "Unbekannter Fehler"}`,
 			);
 		} finally {
 			isSavingReadme = false;
@@ -112,7 +112,7 @@
 						<div class="readme-actions">
 							{#if editingReadme}
 								<AsyncButton style="pop" action={saveReadme} disabled={isSavingReadme}>
-									Save
+									Speichern
 								</AsyncButton>
 								<Button
 									type="button"
@@ -120,11 +120,11 @@
 									onclick={cancelEditingReadme}
 									disabled={isSavingReadme}
 								>
-									Cancel
+									Abbrechen
 								</Button>
 							{:else}
 								<Button type="button" style="gray" onclick={() => startEditingReadme(user.readme)}>
-									Edit README
+									README bearbeiten
 								</Button>
 							{/if}
 						</div>
@@ -136,11 +136,11 @@
 							bind:value={readmeContent}
 							class="readme-editor"
 							rows="15"
-							placeholder="Enter markdown content for your README..."
+							placeholder="Markdown-Inhalt für dein README eingeben..."
 							disabled={isSavingReadme}
 						></textarea>
 						<div class="readme-preview">
-							<h3 class="preview-title">Preview</h3>
+							<h3 class="preview-title">Vorschau</h3>
 							<Markdown content={readmeContent} />
 						</div>
 					{:else if readme}
@@ -148,9 +148,9 @@
 					{:else}
 						<div class="no-readme">
 							{#if isCurrentUser}
-								<p>No README available for your profile. Click "Edit README" to create one.</p>
+								<p>Für dein Profil ist kein README verfügbar. Klicke auf „README bearbeiten“, um eines zu erstellen.</p>
 							{:else}
-								<p>No README available for this profile.</p>
+								<p>Für dieses Profil ist kein README verfügbar.</p>
 							{/if}
 						</div>
 					{/if}
@@ -168,7 +168,7 @@
 			<!-- User Profile Card - New section with avatar and name -->
 			<div class="section-card profile-card">
 				{#if user.avatarUrl}
-					<img src={user.avatarUrl} alt="{user.name}'s avatar" class="sidebar-avatar" />
+					<img src={user.avatarUrl} alt="Avatar von {user.name}" class="sidebar-avatar" />
 				{/if}
 				<h2 class="sidebar-name">{user.name}</h2>
 				<p class="sidebar-username">@{user.login}</p>
@@ -177,7 +177,7 @@
 			<!-- Contact & Info Section -->
 			{#if hasContactInfo(user)}
 				<div class="section-card contact-info-section">
-					<h2 class="section-title">Contact & Info</h2>
+					<h2 class="section-title">Kontakt & Info</h2>
 					<div class="contact-info-list">
 						{#if user.email}
 							<div class="info-item">
@@ -235,7 +235,7 @@
 			<!-- Organizations Section -->
 			{#if user?.organizations && user.organizations.length > 0}
 				<div class="section-card organizations-section">
-					<h2 class="section-title">Organizations</h2>
+					<h2 class="section-title">Organisationen</h2>
 					<div class="organizations-list">
 						{#each user?.organizations as org}
 							<div class="org-card">

--- a/apps/web/src/lib/components/auth/OAuthButtons.svelte
+++ b/apps/web/src/lib/components/auth/OAuthButtons.svelte
@@ -8,19 +8,19 @@
 
 	let { mode = "signin" }: Props = $props();
 
-	const actionText = untrack(() => mode) === "signup" ? "Sign up" : "Sign in";
+	const actionText = untrack(() => mode) === "signup" ? "Registrieren" : "Anmelden";
 </script>
 
 <div class="auth-form__social">
 	<div class="auth-form__social-title">
-		<span class="text-12"> {mode === "signup" ? "Or sign up with" : "Or sign in with"} </span>
+		<span class="text-12"> {mode === "signup" ? "Oder registrieren mit" : "Oder anmelden mit"} </span>
 	</div>
 	<div class="oauth-buttons">
 		{#snippet oauthButton(provider: "github" | "google")}
 			{@const config = {
 				github: {
 					endpoint: "auth/github",
-					title: `${actionText} with GitHub`,
+					title: `${actionText} mit GitHub`,
 					label: "GitHub",
 					svg: `<svg class="oauth-logo" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
 					<path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="currentColor"/>
@@ -28,7 +28,7 @@
 				},
 				google: {
 					endpoint: "auth/google_oauth2",
-					title: `${actionText} with Google`,
+					title: `${actionText} mit Google`,
 					label: "Google",
 					svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="oauth-logo">
 					<path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285f4"></path>

--- a/apps/web/src/lib/components/auth/PasswordConfirmation.svelte
+++ b/apps/web/src/lib/components/auth/PasswordConfirmation.svelte
@@ -27,22 +27,22 @@
 
 		// Length check (minimum 8 characters)
 		if (pwd.length < 8) {
-			errors.push("at least 8 characters");
+			errors.push("mindestens 8 Zeichen");
 		}
 
 		// Must contain at least one lowercase letter
 		if (!/[a-z]/.test(pwd)) {
-			errors.push("one lowercase letter");
+			errors.push("einen Kleinbuchstaben");
 		}
 
 		// Must contain at least one uppercase letter
 		if (!/[A-Z]/.test(pwd)) {
-			errors.push("one uppercase letter");
+			errors.push("einen Großbuchstaben");
 		}
 
 		// Must contain at least one number
 		if (!/\d/.test(pwd)) {
-			errors.push("one number");
+			errors.push("eine Zahl");
 		}
 
 		return { isValid: errors.length === 0, errors };
@@ -53,21 +53,21 @@
 
 	const passwordError = $derived(
 		showValidation && passwordTouched && password && !isPasswordValid
-			? `Password must contain: ${passwordValidation.errors.join(", ")}`
+			? `Das Passwort muss enthalten: ${passwordValidation.errors.join(", ")}`
 			: undefined,
 	);
 
 	const passwordHelperText = $derived(
 		showValidation && password && isPasswordValid
-			? "Strong password! ✅"
+			? "Starkes Passwort! ✅"
 			: showValidation
-				? "8+ characters with uppercase, lowercase, and number"
+				? "Mindestens 8 Zeichen mit Groß-, Kleinbuchstaben und einer Zahl"
 				: undefined,
 	);
 
 	const passwordConfirmationError = $derived(
 		passwordConfirmationTouched && passwordConfirmation && !passwordsMatch
-			? "Passwords do not match"
+			? "Passwörter stimmen nicht überein"
 			: undefined,
 	);
 
@@ -82,7 +82,7 @@
 <div class="password-confirmation">
 	<Textbox
 		bind:value={password}
-		label="Password"
+		label="Passwort"
 		type="password"
 		{autocomplete}
 		error={passwordError}
@@ -93,7 +93,7 @@
 	/>
 	<Textbox
 		bind:value={passwordConfirmation}
-		label="Confirm password"
+		label="Passwort bestätigen"
 		type="password-non-visible"
 		{autocomplete}
 		error={passwordConfirmationError}

--- a/apps/web/src/lib/components/auth/UsernameTextbox.svelte
+++ b/apps/web/src/lib/components/auth/UsernameTextbox.svelte
@@ -14,11 +14,11 @@
 	}
 
 	let {
-		customValidationMessage = "Please enter a valid username.",
+		customValidationMessage = "Bitte gib einen gültigen Benutzernamen ein.",
 		minLength = 3,
 		maxLength = 30,
 		value = $bindable(),
-		label = "Username",
+		label = "Benutzername",
 		...restProps
 	}: Props = $props();
 
@@ -32,14 +32,14 @@
 		if (val.length < minLength) {
 			return {
 				isValid: false,
-				message: `Username must be at least ${minLength} characters long.`,
+				message: `Der Benutzername muss mindestens ${minLength} Zeichen lang sein.`,
 			};
 		}
 
 		if (val.length > maxLength) {
 			return {
 				isValid: false,
-				message: `Username must be no more than ${maxLength} characters long.`,
+				message: `Der Benutzername darf höchstens ${maxLength} Zeichen lang sein.`,
 			};
 		}
 
@@ -49,7 +49,7 @@
 			return {
 				isValid: false,
 				message:
-					"Username must start with a letter or number and can only contain letters, numbers, underscores, and hyphens.",
+					"Der Benutzername muss mit einem Buchstaben oder einer Zahl beginnen und darf nur Buchstaben, Zahlen, Unterstriche und Bindestriche enthalten.",
 			};
 		}
 
@@ -57,7 +57,7 @@
 		if (/[-_]$/.test(val)) {
 			return {
 				isValid: false,
-				message: "Username cannot end with a hyphen or underscore.",
+				message: "Der Benutzername darf nicht mit einem Bindestrich oder Unterstrich enden.",
 			};
 		}
 
@@ -65,7 +65,7 @@
 		if (/[-_]{2,}/.test(val)) {
 			return {
 				isValid: false,
-				message: "Username cannot contain consecutive hyphens or underscores.",
+				message: "Der Benutzername darf keine aufeinanderfolgenden Bindestriche oder Unterstriche enthalten.",
 			};
 		}
 

--- a/apps/web/src/lib/components/changes/BranchCommitsRow.svelte
+++ b/apps/web/src/lib/components/changes/BranchCommitsRow.svelte
@@ -69,7 +69,7 @@
 			columns={[
 				{ key: "position", value: `${currentPosition}/${branch.patches?.length ?? 1}` },
 				{ key: "status", value: getPatchStatus(patch) },
-				{ key: "version", value: `v${patch.version}`, tooltip: "Patch Version" },
+				{ key: "version", value: `v${patch.version}`, tooltip: "Patch-Version" },
 				{ key: "title", value: patch.title, tooltip: patch.title },
 				{
 					key: "changes",
@@ -81,7 +81,7 @@
 				{ key: "date", value: patch.updatedAt, tooltip: patch.updatedAt },
 				{ key: "avatars", value: contributors },
 				{ key: "reviewers", value: { approvers, rejectors } },
-				{ key: "comments", value: patch.commentCount, tooltip: "Comments" },
+				{ key: "comments", value: patch.commentCount, tooltip: "Kommentare" },
 			]}
 			isTopEntry={currentPosition === branch.patches?.length}
 			separatedBottom={currentPosition === 1}

--- a/apps/web/src/lib/components/changes/BranchCommitsTable.svelte
+++ b/apps/web/src/lib/components/changes/BranchCommitsTable.svelte
@@ -19,10 +19,10 @@
 			{ key: "status", value: "Status" },
 			{ key: "version", value: "Ver." },
 			{ key: "string", value: "Name" },
-			{ key: "changes", value: "Changes" },
-			{ key: "date", value: "Updated" },
-			{ key: "avatars", value: "Authors" },
-			{ key: "reviewers", value: "Reviewers" },
+			{ key: "changes", value: "Änderungen" },
+			{ key: "date", value: "Aktualisiert" },
+			{ key: "avatars", value: "Autoren" },
+			{ key: "reviewers", value: "Prüfer" },
 			{ key: "comments", value: "" },
 		]}
 	>

--- a/apps/web/src/lib/components/chat/Breadcrumbs.svelte
+++ b/apps/web/src/lib/components/chat/Breadcrumbs.svelte
@@ -12,14 +12,14 @@
 
 	function getRootLabel() {
 		if ($user?.login === routes.isProjectReviewBranchPageSubset?.ownerSlug) {
-			return "My Projects";
+			return "Meine Projekte";
 		} else {
-			return "My Reviews";
+			return "Meine Reviews";
 		}
 	}
 </script>
 
-{#snippet backButton({ href, label = "Back" }: { href: string; label: string })}
+{#snippet backButton({ href, label = "Zurück" }: { href: string; label: string })}
 	<a {href} class="breadcrumbs__back-btn">
 		<div class="breadcrumbs__back-btn__icon">
 			<Icon name="chevron-left" />
@@ -35,7 +35,7 @@
 		{#if !routes.isProjectReviewBranchPageSubset}
 			<span class="text-15 text-bold">Dashboard </span>
 		{:else}
-			<Button kind="ghost" onclick={() => goto(routes.projectsPath())} tooltip="Go to Dashboard">
+			<Button kind="ghost" onclick={() => goto(routes.projectsPath())} tooltip="Zum Dashboard">
 				<span class="text-15 text-bold truncate breadcrumbs__path-label">
 					{getRootLabel()} <span>/</span>
 					{routes.isProjectReviewPageSubset?.ownerSlug}</span
@@ -46,12 +46,12 @@
 
 	{#if routes.isProjectReviewBranchCommitPageSubset}
 		{@render backButton({
-			label: "Back",
+			label: "Zurück",
 			href: routes.projectReviewBranchPath(routes.isProjectReviewBranchCommitPageSubset),
 		})}
 	{:else if routes.isProjectReviewBranchPageSubset}
 		{@render backButton({
-			label: "Back",
+			label: "Zurück",
 			href: `${routes.projectPath(routes.isProjectReviewBranchPageSubset)}/reviews`,
 		})}
 	{/if}

--- a/apps/web/src/lib/components/chat/ChatInReplyTo.svelte
+++ b/apps/web/src/lib/components/chat/ChatInReplyTo.svelte
@@ -10,7 +10,7 @@
 	import { Button } from "@gitbutler/ui";
 	import type { UserSimple } from "@gitbutler/shared/users/types";
 
-	const UNKNOWN_AUTHOR = "Unknown author";
+	const UNKNOWN_AUTHOR = "Unbekannter Autor";
 
 	type Props = {
 		message: ReplyToMessage;

--- a/apps/web/src/lib/components/chat/ChatInput.svelte
+++ b/apps/web/src/lib/components/chat/ChatInput.svelte
@@ -136,9 +136,9 @@
 	}
 
 	const actionLabels = {
-		approve: "Approve commit",
-		openIssue: "Open issue",
-		requestChanges: "Request changes",
+		approve: "Commit genehmigen",
+		openIssue: "Issue öffnen",
+		requestChanges: "Änderungen anfordern",
 	} as const;
 
 	type Action = keyof typeof actionLabels;
@@ -183,7 +183,7 @@
 	}
 
 	const actionButtonLabel = $derived.by(() => {
-		const suffix = messageHandler.message ? " & Comment" : "";
+		const suffix = messageHandler.message ? " & Kommentieren" : "";
 		return actionLabels[action] + suffix;
 	});
 
@@ -245,7 +245,7 @@
 
 			<RichTextEditor
 				styleContext="chat-input"
-				placeholder="Write your message"
+				placeholder="Schreibe deine Nachricht"
 				bind:this={richText.richTextEditor}
 				namespace="ChatInput"
 				onError={console.error}
@@ -275,7 +275,7 @@
 							shrinkable
 							width="100%"
 						>
-							<span style="opacity: 0.4">Paste or drop to add files</span>
+							<span style="opacity: 0.4">Einfügen oder ablegen, um Dateien hinzuzufügen</span>
 						</Button>
 					</div>
 				</div>
@@ -321,7 +321,7 @@
 						style="pop"
 						loading={isSendingMessage || isExecuting}
 						disabled={!messageHandler.message}
-						onclick={handleClickSend}>Comment</Button
+						onclick={handleClickSend}>Kommentieren</Button
 					>
 				</div>
 			</div>
@@ -329,8 +329,8 @@
 	</div>
 {:else}
 	<div class="chat-input-notlooged">
-		<p class="text-12">🔒 You must be logged in to join the conversation</p>
-		<Button style="pop" onclick={login}>Log in to comment</Button>
+		<p class="text-12">🔒 Du musst angemeldet sein, um an der Unterhaltung teilzunehmen</p>
+		<Button style="pop" onclick={login}>Zum Kommentieren anmelden</Button>
 	</div>
 {/if}
 

--- a/apps/web/src/lib/components/chat/IssueUpdate.svelte
+++ b/apps/web/src/lib/components/chat/IssueUpdate.svelte
@@ -4,7 +4,7 @@
 	import { Icon } from "@gitbutler/ui";
 	import type { IssueUpdateEvent } from "@gitbutler/shared/patchEvents/types";
 
-	const UNKNOWN_AUTHOR = "Unknown author";
+	const UNKNOWN_AUTHOR = "Unbekannter Autor";
 
 	interface Props {
 		event: IssueUpdateEvent;
@@ -33,7 +33,7 @@
 				<Icon name="tick" />
 			</div>
 
-			<p class="text-12 issue-update__status">resolved</p>
+			<p class="text-12 issue-update__status">gelöst</p>
 		{/if}
 
 		<div class="text-12 issue-update__timestamp" title={event.createdAt}>{timestamp}</div>

--- a/apps/web/src/lib/components/chat/MentionSuggestions.svelte
+++ b/apps/web/src/lib/components/chat/MentionSuggestions.svelte
@@ -84,7 +84,7 @@
 						<li>
 							<div class="suggestion-item">
 								<p class="suggestion-item__no-match text-13 text-tertiary name truncate">
-									No matches found ¯\_(ツ)_/¯
+									Keine Treffer gefunden ¯\_(ツ)_/¯
 								</p>
 							</div>
 						</li>
@@ -92,7 +92,7 @@
 						<li>
 							<div class="suggestion-item">
 								<p class="suggestion-item__no-match text-13 text-tertiary name truncate">
-									Loading...
+									Wird geladen …
 								</p>
 							</div>
 						</li>

--- a/apps/web/src/lib/components/chat/Message.svelte
+++ b/apps/web/src/lib/components/chat/Message.svelte
@@ -45,7 +45,7 @@
 	import { SvelteSet } from "svelte/reactivity";
 	import type { ChatEvent } from "@gitbutler/shared/patchEvents/types";
 	import type { UserSimple } from "@gitbutler/shared/users/types";
-	const UNKNOWN_AUTHOR = "Unknown author";
+	const UNKNOWN_AUTHOR = "Unbekannter Autor";
 
 	const {
 		event,
@@ -140,13 +140,13 @@
 	function getReactionTooltip(users: UserSimple[]) {
 		const thisUsername = $user?.login;
 		if (users.length === 0) return "";
-		const formatted = users.map((user) => (user.login === thisUsername ? "You" : user.login));
+		const formatted = users.map((user) => (user.login === thisUsername ? "Du" : user.login));
 		if (formatted.length < 4) return formatted.map((user) => user).join(", ");
 		return (
 			formatted
 				.slice(0, 3)
 				.map((user) => user)
-				.join(", ") + ` and ${formatted.length - 3} more`
+				.join(", ") + ` und ${formatted.length - 3} weitere`
 		);
 	}
 
@@ -185,7 +185,7 @@
 
 			{#if message.issue}
 				{#if message.resolved}
-					<Badge style="safe">Issue resolved</Badge>
+					<Badge style="safe">Issue gelöst</Badge>
 				{:else}
 					<Badge style="warning">Issue</Badge>
 				{/if}
@@ -266,7 +266,7 @@
 				bind:el={emojiPickerTrigger}
 				activated={isOpenedByEmojiPicker}
 				icon="smile"
-				tooltip="Give me more emojis"
+				tooltip="Mehr Emojis anzeigen"
 				thin
 				overrideYScroll={0}
 				onclick={() => {
@@ -277,7 +277,7 @@
 			<!-- Reply -->
 			<PopoverActionsItem
 				icon="arrow-corner-up-right"
-				tooltip="Reply"
+				tooltip="Antworten"
 				thin
 				onclick={() => onReply()}
 				overrideYScroll={0}
@@ -288,7 +288,7 @@
 				bind:el={kebabMenuTrigger}
 				activated={isOpenedByKebabButton}
 				icon="kebab"
-				tooltip="More options"
+				tooltip="Weitere Optionen"
 				thin
 				onclick={() => {
 					contextMenuOpen = !contextMenuOpen;

--- a/apps/web/src/lib/components/chat/MessageActions.svelte
+++ b/apps/web/src/lib/components/chat/MessageActions.svelte
@@ -36,7 +36,7 @@
 {#if message.issue && !message.resolved}
 	<div class="chat-message-actions">
 		<Button style="gray" kind="outline" icon="tick" loading={isResolving} onclick={resolveIssue}
-			>Resolve issue</Button
+			>Issue lösen</Button
 		>
 	</div>
 {/if}

--- a/apps/web/src/lib/components/chat/MessageContextMenu.svelte
+++ b/apps/web/src/lib/components/chat/MessageContextMenu.svelte
@@ -34,10 +34,10 @@
 {#if open}
 	<ContextMenu {leftClickTrigger} target={leftClickTrigger} {onclose} {onopen}>
 		<ContextMenuSection>
-			<ContextMenuItem label="Copy link" onclick={copyLink} />
+			<ContextMenuItem label="Link kopieren" onclick={copyLink} />
 		</ContextMenuSection>
 		<ContextMenuSection>
-			<ContextMenuItem label="Create a rule" onclick={openRulesModal} />
+			<ContextMenuItem label="Regel erstellen" onclick={openRulesModal} />
 		</ContextMenuSection>
 	</ContextMenu>
 {/if}

--- a/apps/web/src/lib/components/chat/PatchStatus.svelte
+++ b/apps/web/src/lib/components/chat/PatchStatus.svelte
@@ -4,7 +4,7 @@
 	import { Icon } from "@gitbutler/ui";
 	import type { PatchStatusEvent } from "@gitbutler/shared/patchEvents/types";
 
-	const UNKNOWN_USER = "Unknown User";
+	const UNKNOWN_USER = "Unbekannter Benutzer";
 
 	interface Props {
 		event: PatchStatusEvent;
@@ -15,7 +15,11 @@
 	const userName = $derived(
 		event.user?.login ?? event.user?.name ?? event.user?.email ?? UNKNOWN_USER,
 	);
-	const statusAction = $derived(event.data.status ? "approved" : "requested changes on");
+	const statusAction = $derived(
+		event.data.status
+			? "hat diesen Commit genehmigt"
+			: "hat Änderungen an diesem Commit angefordert",
+	);
 	const timestamp = $derived(eventTimeStamp(event));
 </script>
 
@@ -30,7 +34,7 @@
 				<img class="patch-status__avatar" src={event.user.avatarUrl} alt={userName} />
 			{/if}
 			<p class="text-13 text-bold patch-status__name">{userName}</p>
-			<p class="text-12 patch-status__message">{statusAction} this commit</p>
+			<p class="text-12 patch-status__message">{statusAction}</p>
 			<div class="text-12 patch-status__timestamp" title={event.createdAt}>{timestamp}</div>
 		</div>
 

--- a/apps/web/src/lib/components/chat/PatchVersion.svelte
+++ b/apps/web/src/lib/components/chat/PatchVersion.svelte
@@ -50,9 +50,9 @@
 
 		<!-- svelte-ignore a11y_click_events_have_key_events -->
 		<p class="text-12 patch-verssion__message" onclick={viewInterdiff}>
-			published a new <span class="interdiff-version text-bold"
-				>commit version #{patch.version}</span
-			>
+			hat eine neue <span class="interdiff-version text-bold"
+				>Commit-Version #{patch.version}</span
+			> veröffentlicht
 		</p>
 
 		<div class="text-12 patch-version__timestamp" title={event.createdAt}>{timestamp}</div>

--- a/apps/web/src/lib/components/dashboard/DashboardSidebar.svelte
+++ b/apps/web/src/lib/components/dashboard/DashboardSidebar.svelte
@@ -11,8 +11,8 @@
 	const currentTab = $derived(webState.dashboardSidebar.currentTab);
 
 	const tabs = [
-		{ label: "My projects", key: "projects" as SidebarTab },
-		{ label: "My reviews", key: "reviews" as SidebarTab },
+		{ label: "Meine Projekte", key: "projects" as SidebarTab },
+		{ label: "Meine Reviews", key: "reviews" as SidebarTab },
 	];
 </script>
 

--- a/apps/web/src/lib/components/dashboard/DashboardSidebarProjects.svelte
+++ b/apps/web/src/lib/components/dashboard/DashboardSidebarProjects.svelte
@@ -32,7 +32,7 @@
 
 {#if recentProjects.current.length > 0}
 	<div class="group">
-		<p class="text-13 text-bold title">Recent projects</p>
+		<p class="text-13 text-bold title">Letzte Projekte</p>
 		{#each latestRecentProjects as project}
 			<DashboardSidebarProject repositoryId={project.id} showOwner />
 		{/each}

--- a/apps/web/src/lib/components/errors/PrivateProjectError.svelte
+++ b/apps/web/src/lib/components/errors/PrivateProjectError.svelte
@@ -16,13 +16,13 @@
 		<div class="icon-container">
 			<Icon name="lock" size={48} />
 		</div>
-		<h2 class="title text-15 text-body text-bold">Private Project</h2>
+		<h2 class="title text-15 text-body text-bold">Privates Projekt</h2>
 		<p class="error-message text-13 text-body">
-			You don't have permission to view this project. The project may be private or you may need to
-			request access from the owner.
+			Du hast keine Berechtigung, dieses Projekt anzusehen. Das Projekt ist möglicherweise privat
+			oder du musst den Zugriff beim Eigentümer anfragen.
 		</p>
 		<div class="actions">
-			<Button kind="outline" icon="home" onclick={goToHome}>Go to home</Button>
+			<Button kind="outline" icon="home" onclick={goToHome}>Zur Startseite</Button>
 		</div>
 	</div>
 </div>

--- a/apps/web/src/lib/components/marketing/Footer.svelte
+++ b/apps/web/src/lib/components/marketing/Footer.svelte
@@ -15,7 +15,7 @@
 		{#if showDownloadLinks}
 			<div class="banner-content-downloads">
 				<div class="stack-v">
-					<h2 class="banner-title">Download <i>the</i> app</h2>
+					<h2 class="banner-title">Lade <i>die</i> App</h2>
 
 					<div class="download-links">
 						<div class="download-category">
@@ -67,22 +67,23 @@
 
 				<div class="stack-v gap-8">
 					<p class="banner-nightly-text">
-						<span class="op-50">Not your system? See more</span>
-						<a href="/downloads" class="nightly-link"> download options </a>
+						<span class="op-50">Nicht dein System? Sieh dir weitere</span>
+						<a href="/downloads" class="nightly-link"> Download-Optionen </a>
+						an
 					</p>
 
 					<p class="banner-nightly-text">
-						<span class="op-50">Experience GitButler's newest features before anyone else.</span>
-						<a href="/nightly" class="nightly-link"> Get Nightly </a>
+						<span class="op-50">Erlebe die neuesten Funktionen von GitButler noch vor allen anderen.</span>
+						<a href="/nightly" class="nightly-link"> Nightly holen </a>
 					</p>
 				</div>
 			</div>
 		{:else}
 			<div class="banner-content-downloads">
 				<h2 class="banner-title">
-					<i>Version</i> Control
+					<i>Versions</i>verwaltung
 					<br />
-					With <i>Attitude</i> ⧓
+					mit <i>Attitüde</i> ⧓
 				</h2>
 			</div>
 		{/if}
@@ -121,7 +122,7 @@
 		<div class="stack-v gap-20">
 			<div class="meta-links">
 				<span class="meta-links__copyright"
-					>©{new Date().getFullYear()} GitButler. All rights reserved.</span
+					>©{new Date().getFullYear()} GitButler. Alle Rechte vorbehalten.</span
 				>
 				<span class="meta-links__legal">
 					<a href={jsonLinks.legal.privacyPolicy.url} target="_blank">

--- a/apps/web/src/lib/components/marketing/Header.svelte
+++ b/apps/web/src/lib/components/marketing/Header.svelte
@@ -39,7 +39,7 @@
 			})}
 			{@render link({
 				href: jsonLinks.resources.source.url,
-				label: "Source",
+				label: "Quellcode",
 				icon: "github",
 			})}
 			{@render link({

--- a/apps/web/src/lib/components/marketing/ReleaseCard.svelte
+++ b/apps/web/src/lib/components/marketing/ReleaseCard.svelte
@@ -19,7 +19,7 @@
 	<div class="release-header">
 		<h3 class="release-version">{release.version}</h3>
 		<span class="release-date">
-			{new Date(release.released_at).toLocaleDateString("en-GB", {
+			{new Date(release.released_at).toLocaleDateString("de-DE", {
 				day: "numeric",
 				month: "short",
 				year: "numeric",
@@ -41,7 +41,7 @@
 					class="download-links-toggle"
 					onclick={() => (downloadLinksVisible = true)}
 				>
-					<span>Show download options</span>
+					<span>Download-Optionen anzeigen</span>
 					<span>⭳</span>
 				</button>
 			{/if}

--- a/apps/web/src/lib/components/marketing/ThemeSwitcher.svelte
+++ b/apps/web/src/lib/components/marketing/ThemeSwitcher.svelte
@@ -12,7 +12,7 @@
 		class="theme-switcher__button"
 		class:active={currentTheme === "light"}
 		onclick={() => setTheme("light")}
-		aria-label="Light theme"
+		aria-label="Helles Design"
 	>
 		<Icon name="theme-light" />
 	</button>
@@ -21,7 +21,7 @@
 		class="theme-switcher__button"
 		class:active={currentTheme === "system"}
 		onclick={() => setTheme("system")}
-		aria-label="System theme"
+		aria-label="System-Design"
 	>
 		<Icon name="theme-system" />
 	</button>
@@ -30,7 +30,7 @@
 		class="theme-switcher__button"
 		class:active={currentTheme === "dark"}
 		onclick={() => setTheme("dark")}
-		aria-label="Dark theme"
+		aria-label="Dunkles Design"
 	>
 		<Icon name="theme-dark" />
 	</button>

--- a/apps/web/src/lib/components/review/ChangeActionButton.svelte
+++ b/apps/web/src/lib/components/review/ChangeActionButton.svelte
@@ -18,8 +18,8 @@
 	}
 
 	const actionLabels = {
-		approve: "Approve commit",
-		requestChanges: "Request changes",
+		approve: "Commit genehmigen",
+		requestChanges: "Änderungen anfordern",
 	} as const;
 
 	type Action = keyof typeof actionLabels;
@@ -99,8 +99,8 @@
 	function confirmStatusChange(action: Action): boolean {
 		const message =
 			action === "requestChanges"
-				? "You have already approved this commit. Do you want to request changes instead?"
-				: "You have already requested changes for this commit. Do you want to approve it instead?";
+				? "Du hast diesen Commit bereits genehmigt. Möchtest du stattdessen Änderungen anfordern?"
+				: "Du hast für diesen Commit bereits Änderungen angefordert. Möchtest du ihn stattdessen genehmigen?";
 
 		return confirm(message);
 	}
@@ -118,10 +118,10 @@
 		<div class="text-12 my-status-text">
 			{#if userAction === "approved"}
 				<CommitStatusBadge status="approved" kind="icon" />
-				<span>You approved this</span>
+				<span>Du hast dies genehmigt</span>
 			{:else}
 				<CommitStatusBadge status="changes-requested" kind="icon" />
-				<span>You requested changes</span>
+				<span>Du hast Änderungen angefordert</span>
 			{/if}
 		</div>
 
@@ -130,7 +130,7 @@
 			type="button"
 			onclick={() => handleChangeStatus(userAction === "approved" ? "requestChanges" : "approve")}
 		>
-			Change status
+			Status ändern
 		</button>
 	</div>
 {:else}
@@ -165,7 +165,7 @@
 {/if}
 
 <LoginModal bind:this={loginModal}>
-	To approve this commit or request changes, you need to be logged in.
+	Um diesen Commit zu genehmigen oder Änderungen anzufordern, musst du angemeldet sein.
 </LoginModal>
 
 <style lang="postcss">

--- a/apps/web/src/lib/components/review/DiffSection.svelte
+++ b/apps/web/src/lib/components/review/DiffSection.svelte
@@ -88,9 +88,9 @@
 	<div class="diff-section__content">
 		{#if lockFile && !displayLockHunks}
 			<div class="lock-files-hidden-by-default">
-				<p class="text-12 hidden-lock-file-message">Lock files are hidden by default</p>
+				<p class="text-12 hidden-lock-file-message">Lock-Dateien werden standardmäßig ausgeblendet</p>
 				<Button kind="outline" icon="eye" onclick={() => (displayLockHunks = true)}
-					>Show diff</Button
+					>Diff anzeigen</Button
 				>
 			</div>
 		{:else}

--- a/apps/web/src/lib/components/review/ReviewInfo.svelte
+++ b/apps/web/src/lib/components/review/ReviewInfo.svelte
@@ -17,9 +17,9 @@
 	import { copyToClipboard } from "@gitbutler/ui/utils/clipboard";
 	import { untrack } from "svelte";
 
-	const NO_REVIEWERS = "Not reviewed yet";
-	const NO_CONTRIBUTORS = "No contributors";
-	const NO_COMMENTS = "No comments yet";
+	const NO_REVIEWERS = "Noch nicht geprüft";
+	const NO_CONTRIBUTORS = "Keine Mitwirkenden";
+	const NO_COMMENTS = "Noch keine Kommentare";
 
 	interface Props {
 		projectId: string;
@@ -50,7 +50,7 @@
 	<Factoid label="Status">
 		<ChangeStatus {patchCommit} />
 	</Factoid>
-	<Factoid label="Reviewed by" placeholderText={NO_REVIEWERS}>
+	<Factoid label="Geprüft von" placeholderText={NO_REVIEWERS}>
 		{#await Promise.all([approvers, rejectors]) then [approvers, rejectors]}
 			{#if approvers.length > 0 || rejectors.length > 0}
 				<AvatarGroup avatars={rejectors} maxAvatars={2} icon="refresh" iconColor="warning" />
@@ -58,14 +58,14 @@
 			{/if}
 		{/await}
 	</Factoid>
-	<Factoid label="Commented by" placeholderText={NO_COMMENTS}>
+	<Factoid label="Kommentiert von" placeholderText={NO_COMMENTS}>
 		{#await commenters then commentors}
 			{#if commentors.length > 0}
 				<AvatarGroup avatars={commentors} />
 			{/if}
 		{/await}
 	</Factoid>
-	<Factoid label="Authors" placeholderText={NO_CONTRIBUTORS}>
+	<Factoid label="Autoren" placeholderText={NO_CONTRIBUTORS}>
 		{#await contributors then contributors}
 			{#if contributors.length > 0}
 				<AvatarGroup avatars={contributors} />
@@ -75,7 +75,7 @@
 	<Factoid label="Version">
 		v{patchCommit.version}
 	</Factoid>
-	<Factoid label="Commit SHA">
+	<Factoid label="Commit-SHA">
 		<button type="button" class="commit-sha" onclick={() => copyToClipboard(patchCommit.commitSha)}>
 			<span>
 				{commitShortSha}

--- a/apps/web/src/lib/components/review/ReviewSections.svelte
+++ b/apps/web/src/lib/components/review/ReviewSections.svelte
@@ -31,7 +31,7 @@
 	let afterSelectorOpen = $state(false);
 
 	const allOptions: readonly SelectItemType<string>[] = $derived.by(() => {
-		const out = [{ value: "-1", label: "Base" }];
+		const out = [{ value: "-1", label: "Basis" }];
 
 		if (!isDefined(patchCommit.version)) return out;
 
@@ -40,7 +40,7 @@
 
 			out.push({
 				value: i.toString(),
-				label: `v${i}${last ? " (latest)" : ""}`,
+				label: `v${i}${last ? " (aktuell)" : ""}`,
 			});
 		}
 
@@ -82,12 +82,12 @@
 		<div class="review-sections-statistics">
 			<div class="review-sections-statistics__metadata">
 				<p class="text-12 text-bold statistic-files">
-					{patchCommit.statistics.fileCount} files changed
+					{patchCommit.statistics.fileCount} Dateien geändert
 				</p>
 				<p class="text-12 statistic-added">
-					{patchCommit.statistics.lines - patchCommit.statistics.deletions} additions
+					{patchCommit.statistics.lines - patchCommit.statistics.deletions} Ergänzungen
 				</p>
-				<p class="text-12 statistic-deleted">{patchCommit.statistics.deletions} deletions</p>
+				<p class="text-12 statistic-deleted">{patchCommit.statistics.deletions} Löschungen</p>
 			</div>
 			<div class="review-sections-statistics__actions">
 				<div class="review-sections-statistics__actions__interdiff">
@@ -95,7 +95,7 @@
 						<div class="review-sections-statistics__actions__interdiff-changed"></div>
 					{/if}
 					<Button
-						tooltip="Show interdiff"
+						tooltip="Interdiff anzeigen"
 						kind="ghost"
 						icon="interdiff"
 						onclick={() => (isInterdiffBarVisible = !isInterdiffBarVisible)}
@@ -107,7 +107,7 @@
 
 	{#if isInterdiffBarVisible}
 		<div class="interdiff-bar">
-			<p class="text-12 text-bold">Compare versions:</p>
+			<p class="text-12 text-bold">Versionen vergleichen:</p>
 
 			<div class="interdiff-bar__selects">
 				<Select
@@ -174,13 +174,13 @@
 						kind="ghost"
 						icon="undo"
 						size="tag"
-						tooltip="Reset to initial selection"
+						tooltip="Auf ursprüngliche Auswahl zurücksetzen"
 						onclick={async () => {
 							await setBeforeVersion(-1);
 							await setAfterVersion(patchCommit.version, patchCommit.version);
 						}}
 					>
-						Reset
+						Zurücksetzen
 					</Button>
 				{/if}
 			</div>

--- a/apps/web/src/lib/components/review/TextSection.svelte
+++ b/apps/web/src/lib/components/review/TextSection.svelte
@@ -29,18 +29,18 @@
 </script>
 
 <div class="right">
-	<button type="button" class="action" onclick={() => addSection(section.position)}>add</button>
+	<button type="button" class="action" onclick={() => addSection(section.position)}>hinzufügen</button>
 	[
-	<button type="button" class="action" onclick={() => editSection(section.code)}>edit</button>] [
-	<button type="button" class="action" onclick={() => deleteSection(section.code)}>del</button>] [
-	<button type="button" class="action" onclick={() => moveSection(section.position, -1)}>up</button>
-	<button type="button" class="action" onclick={() => moveSection(section.position, 1)}>down</button
+	<button type="button" class="action" onclick={() => editSection(section.code)}>bearbeiten</button>] [
+	<button type="button" class="action" onclick={() => deleteSection(section.code)}>löschen</button>] [
+	<button type="button" class="action" onclick={() => moveSection(section.position, -1)}>hoch</button>
+	<button type="button" class="action" onclick={() => moveSection(section.position, 1)}>runter</button
 	>
 	]
 </div>
 <div class="editor edit-{section.code}">
 	<textarea class="editing">{section.data}</textarea>
-	<button type="button" onclick={() => saveSection(section.code)}>Save</button>
+	<button type="button" onclick={() => saveSection(section.code)}>Speichern</button>
 </div>
 <div class="markdown display-{section.code}">{section.data}</div>
 

--- a/apps/web/src/lib/components/rules/RulesModal.svelte
+++ b/apps/web/src/lib/components/rules/RulesModal.svelte
@@ -212,7 +212,7 @@
 		<Textarea
 			value={ruleTitle}
 			unstyled
-			placeholder="Rule title"
+			placeholder="Regeltitel"
 			fontSize={13}
 			fontWeight="semibold"
 			padding={{ top: 0, right: 0, bottom: 0, left: 0 }}
@@ -234,7 +234,7 @@
 		<Textarea
 			value={ruleDescription}
 			unstyled
-			placeholder="Rule description"
+			placeholder="Regelbeschreibung"
 			fontSize={13}
 			padding={{ top: 0, right: 0, bottom: 0, left: 0 }}
 			disabled={isGenerating}
@@ -251,7 +251,7 @@
 {/snippet}
 
 {#snippet negativeExampleInput()}
-	<p>Don't do this</p>
+	<p>So nicht</p>
 	<div class="rules-modal__input text-input" class:disabled={isGenerating}>
 		<Textarea
 			value={effectiveNegativeExample}
@@ -272,7 +272,7 @@
 {/snippet}
 
 {#snippet positiveExampleInput()}
-	<p>Do this</p>
+	<p>So machen</p>
 	<div class="rules-modal__input text-input" class:disabled={isGenerating}>
 		<Textarea
 			value={effectivePositiveExample}
@@ -292,15 +292,15 @@
 	</div>
 {/snippet}
 
-<Modal bind:this={modal} title="Create a rule" onSubmit={createRule}>
+<Modal bind:this={modal} title="Regel erstellen" onSubmit={createRule}>
 	<div class="rules-modal-wrapper">
 		<ScrollableContainer whenToShow="hover">
 			<div class="rules-modal">
-				<p class="text-16">Enter the information about the rule that should be created</p>
+				<p class="text-16">Gib die Informationen zur Regel ein, die erstellt werden soll</p>
 				{@render titleInput()}
 				{@render descriptionInput()}
 				{#if shouldShowExample}
-					<p class="text-14">Examples</p>
+					<p class="text-14">Beispiele</p>
 					{@render negativeExampleInput()}
 					{@render positiveExampleInput()}
 				{/if}
@@ -308,8 +308,8 @@
 		</ScrollableContainer>
 	</div>
 	{#snippet controls(close)}
-		<Button kind="outline" type="reset" onclick={close}>Cancel</Button>
-		<Button style="pop" type="submit" loading={isGenerating}>Create rule</Button>
+		<Button kind="outline" type="reset" onclick={close}>Abbrechen</Button>
+		<Button style="pop" type="submit" loading={isGenerating}>Regel erstellen</Button>
 	{/snippet}
 </Modal>
 

--- a/apps/web/src/lib/components/service/FullscreenUtilityCard.svelte
+++ b/apps/web/src/lib/components/service/FullscreenUtilityCard.svelte
@@ -23,13 +23,13 @@
 		<div class="text-12 service-form__footer">
 			<p>
 				{#if backlink}
-					← Back to
+					← Zurück zu
 					<a href={backlink.href}>{backlink.label}</a>
 				{/if}
 			</p>
 
 			<p>
-				Need help?
+				Brauchst du Hilfe?
 				<a href={linksJson.other.support.url} target="_blank" rel="noopener noreferrer">
 					{linksJson.other.support.label}
 				</a>

--- a/apps/web/src/lib/components/table/TableRow.svelte
+++ b/apps/web/src/lib/components/table/TableRow.svelte
@@ -103,7 +103,7 @@
 									iconColor="warning"
 								/>
 							{:else}
-								<span class="dynclmn-placeholder">No reviews</span>
+								<span class="dynclmn-placeholder">Keine Reviews</span>
 							{/if}
 						</div>
 					{:else if key === "date"}
@@ -152,7 +152,7 @@
 
 				<InfoFlexRow>
 					{#if columns.find((col) => col.key === "changes")}
-						<Factoid label="Changes">
+						<Factoid label="Änderungen">
 							<div class="dynclmn-changes">
 								<span class="dynclmn-changes_additions">
 									+{(columns.find((col) => col.key === "changes")?.value as ChangesType).additions}
@@ -165,13 +165,13 @@
 					{/if}
 
 					{#if columns.find((col) => col.key === "comments")}
-						<Factoid label="Comments" placeholderText="No comments">
+						<Factoid label="Kommentare" placeholderText="Keine Kommentare">
 							{columns.find((col) => col.key === "comments")?.value}
 						</Factoid>
 					{/if}
 
 					{#if columns.find((col) => col.key === "reviewers")}
-						<Factoid label="Reviewers" placeholderText="No reviews">
+						<Factoid label="Reviewer" placeholderText="Keine Reviews">
 							{@const reviewers = columns.find((col) => col.key === "reviewers")?.value as {
 								approvers: AvatarsType[];
 								rejectors: AvatarsType[];
@@ -196,13 +196,13 @@
 					{/if}
 
 					{#if columns.find((col) => col.key === "date")}
-						<Factoid label="Date">
+						<Factoid label="Datum">
 							{dayjs(columns.find((col) => col.key === "date")?.value as Date).fromNow()}
 						</Factoid>
 					{/if}
 
 					{#if columns.find((col) => col.key === "number")}
-						<Factoid label="Number">
+						<Factoid label="Nummer">
 							{columns.find((col) => col.key === "number")?.value}
 						</Factoid>
 					{/if}
@@ -225,7 +225,7 @@
 					{/if}
 
 					{#if columns.find((col) => col.key === "avatars")}
-						<Factoid label="Authors">
+						<Factoid label="Autoren">
 							<AvatarGroup
 								avatars={columns.find((col) => col.key === "avatars")?.value as AvatarsType[]}
 							/>

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -159,7 +159,7 @@
 		if (!hasNavigation) return [];
 
 		if (page.route.id === "/(app)/profile") {
-			return [{ label: "Profile", href: "/profile" }];
+			return [{ label: "Profil", href: "/profile" }];
 		}
 		return [];
 	}

--- a/apps/web/src/routes/(app)/+page.svelte
+++ b/apps/web/src/routes/(app)/+page.svelte
@@ -10,7 +10,7 @@
 </script>
 
 {#if !loggedIn}
-	<p>Loading...</p>
+	<p>Wird geladen…</p>
 {:else}
 	<!-- For now, just redirect the user back to the  -->
 	<RedirectToProfileIfLoggedIn />

--- a/apps/web/src/routes/(app)/[ownerSlug]/+page.svelte
+++ b/apps/web/src/routes/(app)/[ownerSlug]/+page.svelte
@@ -36,11 +36,11 @@
 
 {#if loading}
 	<div class="loading">
-		<p>Loading owner information...</p>
+		<p>Inhaberinformationen werden geladen…</p>
 	</div>
 {:else if error}
 	<div class="error">
-		<p>Error: {error}</p>
+		<p>Fehler: {error}</p>
 	</div>
 {:else if ownerData}
 	{#if ownerData.type === "user"}
@@ -49,8 +49,8 @@
 		<OrganizationProfile organization={ownerData.data} ownerSlug={data.ownerSlug} />
 	{:else if ownerData.type === "not_found"}
 		<div class="not-found">
-			<h2>Not Found</h2>
-			<p>The owner "{data.ownerSlug}" could not be found.</p>
+			<h2>Nicht gefunden</h2>
+			<p>Der Inhaber „{data.ownerSlug}“ konnte nicht gefunden werden.</p>
 		</div>
 	{/if}
 {:else}

--- a/apps/web/src/routes/(app)/[ownerSlug]/[projectSlug]/+page.svelte
+++ b/apps/web/src/routes/(app)/[ownerSlug]/[projectSlug]/+page.svelte
@@ -75,10 +75,10 @@
 			};
 
 			editingReadme = false;
-			chipToasts.success("README updated successfully");
+			chipToasts.success("README erfolgreich aktualisiert");
 		} catch (error) {
 			chipToasts.error(
-				`Failed to update README: ${error instanceof Error ? error.message : "Unknown error"}`,
+				`README konnte nicht aktualisiert werden: ${error instanceof Error ? error.message : "Unbekannter Fehler"}`,
 			);
 		} finally {
 			isSavingReadme = false;
@@ -125,7 +125,7 @@
 			};
 
 			editProjectModal?.close();
-			chipToasts.success("Project updated successfully");
+			chipToasts.success("Projekt erfolgreich aktualisiert");
 
 			// If the slug changed, redirect to the new URL
 			if (editedSlug !== data.projectSlug) {
@@ -137,7 +137,7 @@
 				);
 			}
 		} catch (error) {
-			chipToasts.error(`Failed to update project`);
+			chipToasts.error(`Projekt konnte nicht aktualisiert werden`);
 			console.error(
 				`Failed to update project: ${error instanceof Error ? error.message : "Unknown error"}`,
 			);
@@ -147,7 +147,7 @@
 	}
 
 	async function deleteProject(repositoryId: string) {
-		if (!confirm("Are you sure you want to delete this project?")) {
+		if (!confirm("Möchten Sie dieses Projekt wirklich löschen?")) {
 			return;
 		}
 
@@ -156,7 +156,7 @@
 	}
 
 	async function handleDisconnectFromParent() {
-		if (!confirm("Are you sure you want to disconnect this project from its parent?")) {
+		if (!confirm("Möchten Sie dieses Projekt wirklich von seinem übergeordneten Projekt trennen?")) {
 			return;
 		}
 
@@ -167,9 +167,9 @@
 				parentProject: undefined,
 				parentProjectRepositoryId: undefined,
 			};
-			chipToasts.success("Project unlinked from parent");
+			chipToasts.success("Projekt vom übergeordneten Projekt getrennt");
 		} catch (error) {
-			chipToasts.error(`Failed to unlink project`);
+			chipToasts.error(`Projekt konnte nicht getrennt werden`);
 			console.error(
 				`Failed to unlink project: ${error instanceof Error ? error.message : "Unknown error"}`,
 			);
@@ -181,7 +181,7 @@
 
 {#await projectPromise}
 	<div class="loading-container">
-		<p>Loading project...</p>
+		<p>Projekt wird geladen…</p>
 	</div>
 {:then _projectData}
 	{#if _projectData}
@@ -196,7 +196,7 @@
 				</div>
 				{#if projectData.parentProject}
 					<div class="parent-project-info">
-						<span class="label">Parent Project:</span>
+						<span class="label">Übergeordnetes Projekt:</span>
 						<a
 							href={routes.projectPath({
 								ownerSlug: projectData.parentProject.owner,
@@ -213,19 +213,19 @@
 				<div class="main-content">
 					<!-- Reviews section using the ReviewsSection component -->
 					{#await patchStacksPromise}
-						<ReviewsSection reviews={[]} status="loading" sectionTitle="Active Reviews" />
+						<ReviewsSection reviews={[]} status="loading" sectionTitle="Aktive Reviews" />
 					{:then _}
 						<ReviewsSection
 							reviews={patchStacksData || []}
 							status={patchStacksData && patchStacksData.length > 0 ? "found" : "not-found"}
-							sectionTitle="Active Reviews"
+							sectionTitle="Aktive Reviews"
 							allReviewsUrl={routes.projectReviewPath(data)}
 							reviewsCount={projectData.activeReviewsCount || 0}
 						/>
 					{:catch error}
-						<ReviewsSection reviews={[]} status="error" sectionTitle="Active Reviews" />
+						<ReviewsSection reviews={[]} status="error" sectionTitle="Aktive Reviews" />
 						<div class="error-text">
-							Error loading reviews: {error.message || "Unknown error"}
+							Fehler beim Laden der Reviews: {error.message || "Unbekannter Fehler"}
 						</div>
 					{/await}
 
@@ -240,7 +240,7 @@
 											action={() => saveReadme(projectData.repositoryId)}
 											disabled={isSavingReadme}
 										>
-											Save
+											Speichern
 										</AsyncButton>
 										<Button
 											type="button"
@@ -248,7 +248,7 @@
 											onclick={cancelEditingReadme}
 											disabled={isSavingReadme}
 										>
-											Cancel
+											Abbrechen
 										</Button>
 									{:else}
 										<Button
@@ -256,7 +256,7 @@
 											style="gray"
 											onclick={() => startEditingReadme((projectData as any).readme)}
 										>
-											Edit README
+											README bearbeiten
 										</Button>
 									{/if}
 								</div>
@@ -268,11 +268,11 @@
 									bind:value={readmeContent}
 									class="readme-editor"
 									rows="15"
-									placeholder="Enter markdown content for the README..."
+									placeholder="Markdown-Inhalt für die README eingeben…"
 									disabled={isSavingReadme}
 								></textarea>
 								<div class="readme-preview">
-									<h3 class="preview-title">Preview</h3>
+									<h3 class="preview-title">Vorschau</h3>
 									<Markdown content={readmeContent} />
 								</div>
 							{:else if (projectData as any).readme}
@@ -280,9 +280,9 @@
 							{:else}
 								<div class="no-readme">
 									{#if projectData.permissions?.canWrite}
-										<p>No README available for this project. Click "Edit README" to create one.</p>
+										<p>Für dieses Projekt ist keine README verfügbar. Klicken Sie auf „README bearbeiten“, um eine zu erstellen.</p>
 									{:else}
-										<p>No README available for this project.</p>
+										<p>Für dieses Projekt ist keine README verfügbar.</p>
 									{/if}
 								</div>
 							{/if}
@@ -293,7 +293,7 @@
 				<div class="sidebar">
 					<section class="card">
 						<div class="card-header">
-							<h2 class="card-title">Project Details</h2>
+							<h2 class="card-title">Projektdetails</h2>
 							{#if projectData.permissions?.canWrite}
 								<Button
 									type="button"
@@ -301,7 +301,7 @@
 									onclick={openEditProjectModal}
 									class="edit-project-btn"
 								>
-									Edit Project
+									Projekt bearbeiten
 								</Button>
 							{/if}
 						</div>
@@ -313,19 +313,19 @@
 								</p>
 							{/if}
 							{#if projectData.description}
-								<h3 class="sidebar-section-title">Description</h3>
+								<h3 class="sidebar-section-title">Beschreibung</h3>
 								<p class="description">
 									{projectData.description}
 								</p>
 							{/if}
 
-							<h3 class="sidebar-section-title">Last Updated</h3>
+							<h3 class="sidebar-section-title">Zuletzt aktualisiert</h3>
 							<p class="description">{getTimeSince(projectData.updatedAt)}</p>
 
 							{#if projectData.lastPushedAt}
 								<div class="meta-info">
 									<div class="meta-item clone-url-container">
-										<h3 class="sidebar-section-title">Clone URL</h3>
+										<h3 class="sidebar-section-title">Klon-URL</h3>
 										<div class="clone-url">
 											<code>{projectData.codeGitUrl}</code>
 											<Button
@@ -333,10 +333,10 @@
 												style="pop"
 												onclick={() => {
 													navigator.clipboard.writeText(projectData.codeGitUrl);
-													chipToasts.success("copied to clipboard");
+													chipToasts.success("in die Zwischenablage kopiert");
 												}}
 											>
-												Copy
+												Kopieren
 											</Button>
 										</div>
 									</div>
@@ -347,11 +347,11 @@
 
 					{#if projectData.parentProject}
 						<section class="card">
-							<h2 class="card-title">Parent Project</h2>
+							<h2 class="card-title">Übergeordnetes Projekt</h2>
 							<div class="card-content">
 								<div class="parent-project-info-card">
 									<p>
-										This project is linked to a parent project:
+										Dieses Projekt ist mit einem übergeordneten Projekt verknüpft:
 										<a
 											href={routes.projectPath({
 												ownerSlug: projectData.parentProject?.owner || data.ownerSlug,
@@ -365,7 +365,7 @@
 
 									{#if projectData.permissions?.canWrite}
 										<Button style="danger" onclick={handleDisconnectFromParent}>
-											Disconnect from Parent
+											Vom übergeordneten Projekt trennen
 										</Button>
 									{/if}
 								</div>
@@ -373,12 +373,12 @@
 						</section>
 					{:else if projectData.ownerType === "user" && projectData.permissions?.canWrite}
 						<section class="card">
-							<h2 class="card-title">Connect to Organization</h2>
+							<h2 class="card-title">Mit Organisation verbinden</h2>
 							<div class="card-content">
 								<div class="connect-org-card">
-									<p>Connect this project to an organization to enable team collaboration.</p>
+									<p>Verbinden Sie dieses Projekt mit einer Organisation, um die Zusammenarbeit im Team zu ermöglichen.</p>
 									<Button style="pop" onclick={() => connectModal?.show()}>
-										Connect to Organization
+										Mit Organisation verbinden
 									</Button>
 								</div>
 							</div>
@@ -392,21 +392,21 @@
 
 					{#if projectData.permissions?.canWrite}
 						<section class="card">
-							<h2 class="card-title">Permissions</h2>
+							<h2 class="card-title">Berechtigungen</h2>
 							<div class="card-content gap-2">
-								<p>This project is <b>{projectData.permissions.shareLevel}</b></p>
+								<p>Dieses Projekt ist <b>{projectData.permissions.shareLevel}</b></p>
 								<PermissionsSelector repositoryId={projectData.repositoryId} />
 							</div>
 						</section>
 
 						<section class="card danger-zone">
-							<h2 class="card-title danger-title">Danger Zone</h2>
+							<h2 class="card-title danger-title">Gefahrenzone</h2>
 							<div class="card-content">
 								<AsyncButton
 									style="danger"
 									action={async () => await deleteProject(projectData.repositoryId)}
 								>
-									Delete Project
+									Projekt löschen
 								</AsyncButton>
 							</div>
 						</section>
@@ -418,26 +418,26 @@
 		<!-- Edit Project Modal -->
 		<Modal
 			bind:this={editProjectModal}
-			title="Edit Project"
+			title="Projekt bearbeiten"
 			onClose={() => {
 				isUpdatingProject = false;
 			}}
 		>
 			<form class="edit-project-form">
 				<div class="form-group">
-					<label for="project-name">Project Name</label>
+					<label for="project-name">Projektname</label>
 					<input
 						id="project-name"
 						type="text"
 						bind:value={editedName}
-						placeholder="Project name"
+						placeholder="Projektname"
 						required
 						disabled={isUpdatingProject}
 					/>
 				</div>
 
 				<div class="form-group">
-					<label for="project-slug">Project Slug</label>
+					<label for="project-slug">Projekt-Slug</label>
 					<input
 						id="project-slug"
 						type="text"
@@ -446,17 +446,17 @@
 						required
 						disabled={isUpdatingProject}
 						pattern="[a-z0-9-]+"
-						title="Lowercase letters, numbers, and hyphens only"
+						title="Nur Kleinbuchstaben, Zahlen und Bindestriche"
 					/>
-					<small>Only lowercase letters, numbers, and hyphens are allowed</small>
+					<small>Es sind nur Kleinbuchstaben, Zahlen und Bindestriche erlaubt</small>
 				</div>
 
 				<div class="form-group">
-					<label for="project-description">Description</label>
+					<label for="project-description">Beschreibung</label>
 					<textarea
 						id="project-description"
 						bind:value={editedDescription}
-						placeholder="Project description"
+						placeholder="Projektbeschreibung"
 						rows="4"
 						disabled={isUpdatingProject}
 					></textarea>
@@ -469,30 +469,30 @@
 						onclick={() => editProjectModal?.close()}
 						disabled={isUpdatingProject}
 					>
-						Cancel
+						Abbrechen
 					</Button>
 					<AsyncButton
 						style="pop"
 						action={() => saveProjectEdits(projectData.repositoryId)}
 						disabled={isUpdatingProject}
 					>
-						Save Changes
+						Änderungen speichern
 					</AsyncButton>
 				</div>
 			</form>
 		</Modal>
 	{:else}
 		<div class="error-message">
-			<h2>Project Not Found</h2>
-			<p>The project you requested could not be found. Please check the URL and try again.</p>
-			<Button onclick={() => goto(routes.projectsPath())}>Return to Projects</Button>
+			<h2>Projekt nicht gefunden</h2>
+			<p>Das angeforderte Projekt konnte nicht gefunden werden. Bitte überprüfen Sie die URL und versuchen Sie es erneut.</p>
+			<Button onclick={() => goto(routes.projectsPath())}>Zurück zu den Projekten</Button>
 		</div>
 	{/if}
 {:catch error}
 	<div class="error-message">
-		<h2>Error Loading Project</h2>
-		<p>There was a problem loading the project: {error.message || "Unknown error"}</p>
-		<Button onclick={() => goto(routes.projectsPath())}>Return to Projects</Button>
+		<h2>Fehler beim Laden des Projekts</h2>
+		<p>Beim Laden des Projekts ist ein Problem aufgetreten: {error.message || "Unbekannter Fehler"}</p>
+		<Button onclick={() => goto(routes.projectsPath())}>Zurück zu den Projekten</Button>
 	</div>
 {/await}
 

--- a/apps/web/src/routes/(app)/[ownerSlug]/[projectSlug]/reviews/+page.svelte
+++ b/apps/web/src/routes/(app)/[ownerSlug]/[projectSlug]/reviews/+page.svelte
@@ -33,10 +33,10 @@
 
 	let filterStatus = $state<BranchStatus>(BranchStatus.All);
 	const selectableStatuses = [
-		{ value: BranchStatus.All, label: "All branches" },
-		{ value: BranchStatus.Closed, label: "Closed" },
-		{ value: BranchStatus.Active, label: "Active" },
-		{ value: BranchStatus.Inactive, label: "Inactive" },
+		{ value: BranchStatus.All, label: "Alle Branches" },
+		{ value: BranchStatus.Closed, label: "Geschlossen" },
+		{ value: BranchStatus.Active, label: "Aktiv" },
+		{ value: BranchStatus.Inactive, label: "Inaktiv" },
 	];
 
 	const brancheses = $derived(
@@ -86,8 +86,8 @@
 
 			{#if brancheses.length === 0}
 				<div class="empty-state">
-					<h3>No branches found</h3>
-					<p>There are no branches matching your current filter.</p>
+					<h3>Keine Branches gefunden</h3>
+					<p>Es gibt keine Branches, die Ihrem aktuellen Filter entsprechen.</p>
 				</div>
 			{:else}
 				<Table
@@ -110,16 +110,16 @@
 						},
 						{
 							key: "date",
-							value: "Update",
+							value: "Aktualisiert",
 						},
 						{
 							key: "avatars",
-							value: "Authors",
+							value: "Autoren",
 						},
 						{
 							key: "number",
 							value: "Ver.",
-							tooltip: "Commit version",
+							tooltip: "Commit-Version",
 						},
 					]}
 				>

--- a/apps/web/src/routes/(app)/[ownerSlug]/[projectSlug]/reviews/[branchId]/+page.svelte
+++ b/apps/web/src/routes/(app)/[ownerSlug]/[projectSlug]/reviews/[branchId]/+page.svelte
@@ -132,7 +132,7 @@
 	}
 
 	function abortEditingSummary() {
-		if (!confirm("Canceling will lose any changes made")) {
+		if (!confirm("Beim Abbrechen gehen alle vorgenommenen Änderungen verloren")) {
 			return;
 		}
 
@@ -147,7 +147,7 @@
 				title: title,
 				description: summary,
 			});
-			chipToasts.success("Updated review status");
+			chipToasts.success("Review-Status aktualisiert");
 		} finally {
 			editingSummary = false;
 		}
@@ -159,7 +159,7 @@
 		await branchService.updateBranch(branch.current.value.uuid, {
 			status,
 		});
-		chipToasts.success("Saved review summary");
+		chipToasts.success("Review-Zusammenfassung gespeichert");
 	}
 
 	function copyLocation() {
@@ -193,7 +193,7 @@
 
 {#snippet startReview(branch: Branch)}
 	{#if (branch.stackSize || 0) > 0 && isBranchAuthor === false}
-		<Button style="pop" icon="play" onclick={() => visitFirstCommit(branch)}>Start review</Button>
+		<Button style="pop" icon="play" onclick={() => visitFirstCommit(branch)}>Review starten</Button>
 	{/if}
 {/snippet}
 
@@ -201,11 +201,11 @@
 	{#if isFound(branch?.current)}
 		<title>{branch.current.value?.title}</title>
 		<meta property="og:title" content="GitButler Review: {branch.current.value?.title}" />
-		<meta property="og:description" content="GitButler code review" />
+		<meta property="og:description" content="GitButler Code-Review" />
 	{:else}
 		<title>{data.ownerSlug}/{data.projectSlug}</title>
 		<meta property="og:title" content="GitButler Review: {data.ownerSlug}/{data.projectSlug}" />
-		<meta property="og:description" content="GitButler code review" />
+		<meta property="og:description" content="GitButler Code-Review" />
 	{/if}
 </svelte:head>
 
@@ -216,7 +216,7 @@
 		<PrivateProjectError />
 	{:else if isError(combinedLoadable)}
 		<div class="error-container">
-			<h2 class="text-15 text-body text-bold">Error loading project data</h2>
+			<h2 class="text-15 text-body text-bold">Fehler beim Laden der Projektdaten</h2>
 			<p class="text-13 text-body">{combinedLoadable.error.message}</p>
 		</div>
 	{/if}
@@ -232,17 +232,17 @@
 							<p class="text-15 text-bold">{branch.title}</p>
 						{/if}
 						<div class="actions">
-							<Button icon="copy" kind="outline" onclick={copyLocation}>Share link</Button>
+							<Button icon="copy" kind="outline" onclick={copyLocation}>Link teilen</Button>
 							{@render startReview(branch)}
 							{#if branch.status === BranchStatus.Closed}
 								<AsyncButton action={async () => updateStatus(BranchStatus.Active)} kind="outline"
-									>Re-open review</AsyncButton
+									>Review wieder öffnen</AsyncButton
 								>
 							{:else}
 								<AsyncButton
 									style="danger"
 									kind="outline"
-									action={async () => updateStatus(BranchStatus.Closed)}>Close review</AsyncButton
+									action={async () => updateStatus(BranchStatus.Closed)}>Review schließen</AsyncButton
 								>
 							{/if}
 						</div>
@@ -266,12 +266,12 @@
 								></Factoid
 							>
 						{/if}
-						<Factoid label="Authors">
+						<Factoid label="Autoren">
 							{#await contributors then contributors}
 								<AvatarGroup avatars={contributors}></AvatarGroup>
 							{/await}
 						</Factoid>
-						<Factoid label="Updated">
+						<Factoid label="Aktualisiert">
 							{dayjs(branch.updatedAt).fromNow()}
 						</Factoid>
 						<Factoid label="Version">
@@ -295,8 +295,8 @@
 							</div>
 
 							<div class="summary-actions">
-								<Button kind="outline" onclick={abortEditingSummary}>Cancel</Button>
-								<AsyncButton style="pop" action={saveSummary}>Save</AsyncButton>
+								<Button kind="outline" onclick={abortEditingSummary}>Abbrechen</Button>
+								<AsyncButton style="pop" action={saveSummary}>Speichern</AsyncButton>
 							</div>
 						{:else if branch.description}
 							<div class="text-13 summary-text">
@@ -304,20 +304,20 @@
 							</div>
 							{#if branch.permissions.canWrite}
 								<div>
-									<Button kind="outline" onclick={editSummary}>Change details</Button>
+									<Button kind="outline" onclick={editSummary}>Details ändern</Button>
 								</div>
 							{/if}
 						{:else}
 							<div class="summary-placeholder">
-								<p class="text-13 clr-text-2">No summary provided.</p>
+								<p class="text-13 clr-text-2">Keine Zusammenfassung vorhanden.</p>
 								{#if branch.permissions.canWrite}
 									<p class="text-12 text-body clr-text-2">
 										<em>
-											Summaries provide context on the branch's purpose and helps team members
-											understand it's changes.
+											Zusammenfassungen bieten Kontext zum Zweck des Branches und helfen
+											Teammitgliedern, dessen Änderungen zu verstehen.
 										</em>
 									</p>
-									<Button icon="plus" kind="outline" onclick={editSummary}>Add summary</Button>
+									<Button icon="plus" kind="outline" onclick={editSummary}>Zusammenfassung hinzufügen</Button>
 								{/if}
 							</div>
 						{/if}

--- a/apps/web/src/routes/(app)/[ownerSlug]/[projectSlug]/reviews/[branchId]/commit/[changeId]/+page.svelte
+++ b/apps/web/src/routes/(app)/[ownerSlug]/[projectSlug]/reviews/[branchId]/commit/[changeId]/+page.svelte
@@ -26,7 +26,7 @@
 	} from "@gitbutler/shared/routing/webRoutes.svelte";
 	import { Button, Markdown } from "@gitbutler/ui";
 
-	const DESCRIPTION_PLACE_HOLDER = "No commit message description provided";
+	const DESCRIPTION_PLACE_HOLDER = "Keine Beschreibung zur Commit-Nachricht vorhanden";
 
 	interface Props {
 		data: ProjectReviewCommitParameters;
@@ -183,7 +183,7 @@
 	{:else}
 		<title>GitButler Review</title>
 		<meta property="og:title" content="Butler Review: {data.ownerSlug}/{data.projectSlug}" />
-		<meta property="og:description" content="GitButler code review" />
+		<meta property="og:description" content="GitButler Code-Review" />
 	{/if}
 </svelte:head>
 
@@ -196,7 +196,7 @@
 		<PrivateProjectError />
 	{:else if isError(combinedLoadable)}
 		<div class="error-container">
-			<h2 class="text-15 text-body text-bold">Error loading project data</h2>
+			<h2 class="text-15 text-body text-bold">Fehler beim Laden der Projektdaten</h2>
 			<p class="text-13 text-body">{combinedLoadable.error.message}</p>
 		</div>
 	{/if}
@@ -264,7 +264,7 @@
 					<div class="review-main__meta">
 						<ReviewInfo projectId={repositoryId} {patchCommit} />
 						<div class="review-main-description">
-							<span class="text-12 review-main-description__caption">Commit message:</span>
+							<span class="text-12 review-main-description__caption">Commit-Nachricht:</span>
 							<p class="review-main-description__markdown">
 								{#if patchCommit.description?.trim()}
 									<Markdown content={patchCommit.description} />

--- a/apps/web/src/routes/(app)/[ownerSlug]/rules/+page.svelte
+++ b/apps/web/src/routes/(app)/[ownerSlug]/rules/+page.svelte
@@ -33,7 +33,7 @@
 </script>
 
 <svelte:head>
-	<title>Rules</title>
+	<title>Regeln</title>
 </svelte:head>
 
 <Loading loadable={rulesList.current}>
@@ -43,13 +43,13 @@
 				<thead class="rules-table__head">
 					<tr>
 						<th>
-							<div class="text-12 rule-title">Title</div>
+							<div class="text-12 rule-title">Titel</div>
 						</th>
 						<th>
-							<div class="text-12 rule-title">Project</div>
+							<div class="text-12 rule-title">Projekt</div>
 						</th>
 						<th>
-							<div class="text-12 rule-title">Created At</div>
+							<div class="text-12 rule-title">Erstellt am</div>
 						</th>
 					</tr>
 				</thead>
@@ -72,7 +72,7 @@
 				</tbody>
 			</table>
 		{:else}
-			<p>No rules found.</p>
+			<p>Keine Regeln gefunden.</p>
 		{/if}
 	{/snippet}
 </Loading>

--- a/apps/web/src/routes/(app)/loggedin/+page.svelte
+++ b/apps/web/src/routes/(app)/loggedin/+page.svelte
@@ -18,7 +18,7 @@
 		if (response.type === "success" && response.data) {
 			copyToClipboard(response.data);
 		} else {
-			chipToasts.error("Failed to get token");
+			chipToasts.error("Token konnte nicht abgerufen werden");
 		}
 	}
 
@@ -35,13 +35,13 @@
 
 	async function followDeeplink() {
 		if (!buildType) {
-			chipToasts.error("Unknown built type");
+			chipToasts.error("Unbekannter Build-Typ");
 			return;
 		}
 
 		const response = await loginService.token();
 		if (response.type !== "success" || !response.data) {
-			chipToasts.error("Failed to get token");
+			chipToasts.error("Token konnte nicht abgerufen werden");
 		} else {
 			const accessToken = response.data;
 			const deeplink = `${buildType}://login?access_token=${accessToken}&t=${Date.now()}`;
@@ -51,34 +51,34 @@
 </script>
 
 <svelte:head>
-	<title>GitButler | Logged in</title>
+	<title>GitButler | Angemeldet</title>
 </svelte:head>
 
 <FullscreenUtilityCard
-	title="Signed in successfully 🎯"
+	title="Erfolgreich angemeldet 🎯"
 	backlink={{
-		label: "Main",
+		label: "Startseite",
 		href: "/",
 	}}
 >
 	<div class="loggedin__success-card-content">
 		{#if buildType !== null}
-			<p class="text-13">Click below to open your client and complete sign-in.</p>
+			<p class="text-13">Klicke unten, um deinen Client zu öffnen und die Anmeldung abzuschließen.</p>
 		{:else}
-			<p class="text-13">Copy the access token and paste it in your client.</p>
+			<p class="text-13">Kopiere das Zugriffstoken und füge es in deinen Client ein.</p>
 		{/if}
 		<div class="flex gap-8 m-t-8">
 			{#if buildType !== null}
 				<AsyncButton style="gray" kind="outline" icon="open-in-ide" action={followDeeplink}
-					>Open client</AsyncButton
+					>Client öffnen</AsyncButton
 				>
 			{:else}
 				<AsyncButton style="gray" kind="outline" icon="copy" action={copyAccessToken}
-					>Copy Access Token</AsyncButton
+					>Zugriffstoken kopieren</AsyncButton
 				>
 			{/if}
 			<Button style="gray" kind="ghost" onclick={() => goto("/profile")} icon="user"
-				>Profile page</Button
+				>Profilseite</Button
 			>
 		</div>
 	</div>

--- a/apps/web/src/routes/(app)/login/+page.svelte
+++ b/apps/web/src/routes/(app)/login/+page.svelte
@@ -73,7 +73,7 @@
 
 	async function resendConfirmationEmail() {
 		if (!email) {
-			error = "Please enter your email to resend the confirmation email.";
+			error = "Bitte gib deine E-Mail-Adresse ein, um die Bestätigungs-E-Mail erneut zu senden.";
 			return;
 		}
 
@@ -99,39 +99,39 @@
 </script>
 
 <svelte:head>
-	<title>GitButler | Login</title>
+	<title>GitButler | Anmelden</title>
 </svelte:head>
 
 <RedirectIfLoggedIn />
 
 <FullscreenIllustrationCard>
 	{#snippet title()}
-		<i>Login</i>
-		to GitButler
+		<i>Anmelden</i>
+		bei GitButler
 	{/snippet}
 
 	<div id="login-form" class="stack-v">
 		<div class="auth-form__inputs">
 			<EmailTextbox
 				bind:this={emailTextbox}
-				label="Email"
+				label="E-Mail"
 				placeholder=" "
 				bind:value={email}
 				autocomplete={false}
 				autocorrect={false}
 				spellcheck
 			/>
-			<Textbox bind:value={password} label="Password" type="password" />
+			<Textbox bind:value={password} label="Passwort" type="password" />
 
 			<div class="text-12 password-reset">
-				<a href={routesService.resetPasswordPath()}>Forgot password?</a>
+				<a href={routesService.resetPasswordPath()}>Passwort vergessen?</a>
 			</div>
 		</div>
 
 		{#if confirmationSent}
 			<InfoMessage filled outlined={false} style="success" class="m-b-16">
 				{#snippet content()}
-					<p>Confirmation email sent! Please check your inbox.</p>
+					<p>Bestätigungs-E-Mail gesendet! Bitte überprüfe deinen Posteingang.</p>
 				{/snippet}
 			</InfoMessage>
 		{:else if error}
@@ -141,19 +141,19 @@
 						{#if errorCode === "email_not_verified"}
 							{#if !resendDisabled}
 								<p>
-									Verify your email before logging in. Check your inbox or <button
+									Bestätige deine E-Mail-Adresse, bevor du dich anmeldest. Überprüfe deinen Posteingang oder <button
 										type="button"
 										class="resend-btn"
 										onclick={resendConfirmationEmail}
 										disabled={!email || resendDisabled}
 									>
-										resend the confirmation email</button
+										sende die Bestätigungs-E-Mail erneut</button
 									>.
 								</p>
 							{:else}
 								<p>
-									Verify your email before logging in. You can resend the confirmation email in {resendCountdown}
-									seconds.
+									Bestätige deine E-Mail-Adresse, bevor du dich anmeldest. Du kannst die Bestätigungs-E-Mail in {resendCountdown}
+									Sekunden erneut senden.
 								</p>
 							{/if}
 						{:else}
@@ -164,7 +164,7 @@
 			</div>
 		{/if}
 
-		<Button style="pop" disabled={!isFormValid} onclick={handleSubmit}>Log in</Button>
+		<Button style="pop" disabled={!isFormValid} onclick={handleSubmit}>Anmelden</Button>
 
 		<OAuthButtons mode="signup" />
 	</div>
@@ -172,7 +172,7 @@
 	{#snippet footer()}
 		<div class="auth-form__footer">
 			<p>
-				Don't have an account? <a href={routesService.signupPath()}>Sign Up</a>
+				Noch kein Konto? <a href={routesService.signupPath()}>Registrieren</a>
 			</p>
 		</div>
 	{/snippet}

--- a/apps/web/src/routes/(app)/login/confirm-password/+page.svelte
+++ b/apps/web/src/routes/(app)/login/confirm-password/+page.svelte
@@ -22,18 +22,18 @@
 		const token = page.url.searchParams.get("t");
 
 		if (!token) {
-			error = "Invalid or missing token";
+			error = "Ungültiges oder fehlendes Token";
 			// TODO: Probably redirect to the login page or show a more user-friendly error
 			return;
 		}
 
 		if (!passwordComponent?.isValid()) {
-			error = "Please check your password and confirmation";
+			error = "Bitte überprüfe dein Passwort und die Bestätigung";
 			return;
 		}
 
 		if (!password || !passwordConfirmation) {
-			error = "Password are required";
+			error = "Passwort ist erforderlich";
 			return;
 		}
 
@@ -55,14 +55,14 @@
 </script>
 
 <svelte:head>
-	<title>GitButler | Confirm Password</title>
+	<title>GitButler | Passwort bestätigen</title>
 </svelte:head>
 
 <RedirectIfLoggedIn />
 
 <FullscreenUtilityCard
-	title="Confirm new password"
-	backlink={{ label: "Login", href: routesService.loginPath() }}
+	title="Neues Passwort bestätigen"
+	backlink={{ label: "Anmelden", href: routesService.loginPath() }}
 >
 	<div class="form-content">
 		<PasswordConfirmation
@@ -88,7 +88,7 @@
 			</InfoMessage>
 		{/if}
 
-		<Button style="pop" onclick={handleSubmit}>Confirm Password</Button>
+		<Button style="pop" onclick={handleSubmit}>Passwort bestätigen</Button>
 	</div>
 </FullscreenUtilityCard>
 

--- a/apps/web/src/routes/(app)/login/forgot-password/+page.svelte
+++ b/apps/web/src/routes/(app)/login/forgot-password/+page.svelte
@@ -19,7 +19,7 @@
 
 	async function handleSubmit() {
 		if (!email) {
-			error = "Email is required";
+			error = "E-Mail-Adresse ist erforderlich";
 			return;
 		}
 
@@ -36,24 +36,24 @@
 </script>
 
 <svelte:head>
-	<title>GitButler | Forgot Password</title>
+	<title>GitButler | Passwort vergessen</title>
 </svelte:head>
 
 <RedirectIfLoggedIn />
 
 <FullscreenUtilityCard
-	title={isLinkSent ? "Link sent!" : "Forgot password?"}
-	backlink={{ label: "Login", href: routesService.loginPath() }}
+	title={isLinkSent ? "Link gesendet!" : "Passwort vergessen?"}
+	backlink={{ label: "Anmelden", href: routesService.loginPath() }}
 >
 	{#if isLinkSent}
 		<p class="text-13 text-body">
-			We've sent a password reset link to: <i class="clr-text-2">{sentToEmail}</i>
+			Wir haben einen Link zum Zurücksetzen des Passworts gesendet an: <i class="clr-text-2">{sentToEmail}</i>
 			<br />
-			Click the link in your email to reset your password.
+			Klicke auf den Link in deiner E-Mail, um dein Passwort zurückzusetzen.
 		</p>
 	{:else}
 		<div class="service-form__inputs">
-			<EmailTextbox bind:this={emailTextbox} bind:value={email} label="Email" />
+			<EmailTextbox bind:this={emailTextbox} bind:value={email} label="E-Mail" />
 
 			{#if error}
 				<InfoMessage filled outlined={false} style="danger">
@@ -63,7 +63,7 @@
 				</InfoMessage>
 			{/if}
 
-			<Button style="pop" disabled={!canSubmit} onclick={handleSubmit}>Send a reset link</Button>
+			<Button style="pop" disabled={!canSubmit} onclick={handleSubmit}>Link zum Zurücksetzen senden</Button>
 		</div>
 	{/if}
 </FullscreenUtilityCard>

--- a/apps/web/src/routes/(app)/organizations/+page.svelte
+++ b/apps/web/src/routes/(app)/organizations/+page.svelte
@@ -45,18 +45,18 @@
 	<header class="page-header">
 		<div class="page-title">
 			<Icon name="settings" />
-			<h1>Organizations</h1>
+			<h1>Organisationen</h1>
 		</div>
-		<p class="page-description">Manage your organizations and team collaboration settings</p>
+		<p class="page-description">Verwalten Sie Ihre Organisationen und Einstellungen zur Zusammenarbeit im Team</p>
 	</header>
 
 	<div class="content-wrapper">
 		<div class="main-content">
 			{#if organizations.length > 0}
 				<div class="organizations-header">
-					<h2>Your Organizations</h2>
+					<h2>Ihre Organisationen</h2>
 					<Button style="pop" onclick={() => createOrganizationModal?.show()}
-						>Create an Organization</Button
+						>Organisation erstellen</Button
 					>
 				</div>
 
@@ -85,11 +85,11 @@
 											<div class="organization-stats">
 												<div class="stat">
 													<Icon name="user" />
-													<span>{getOrganizationMembersCount(organization)} members</span>
+													<span>{getOrganizationMembersCount(organization)} Mitglieder</span>
 												</div>
 												<div class="stat">
 													<Icon name="search" />
-													<span>{getOrganizationProjectsCount(organization)} projects</span>
+													<span>{getOrganizationProjectsCount(organization)} Projekte</span>
 												</div>
 											</div>
 										</div>
@@ -101,7 +101,7 @@
 												kind="outline"
 												onclick={() => navigateToOrganization(organization.slug)}
 											>
-												View
+												Anzeigen
 											</Button>
 										</div>
 									{/snippet}
@@ -114,15 +114,15 @@
 				<div class="empty-state-wrapper">
 					<EmptyStatePlaceholder>
 						{#snippet title()}
-							No Organizations Yet
+							Noch keine Organisationen
 						{/snippet}
 						{#snippet caption()}
-							Create your first organization to collaborate with your team
+							Erstellen Sie Ihre erste Organisation, um mit Ihrem Team zusammenzuarbeiten
 						{/snippet}
 					</EmptyStatePlaceholder>
 					<div class="empty-state-action">
 						<Button style="pop" onclick={() => createOrganizationModal?.show()}
-							>Create an Organization</Button
+							>Organisation erstellen</Button
 						>
 					</div>
 				</div>
@@ -133,9 +133,9 @@
 	<!-- Mobile Join Organization section -->
 	<div class="join-section">
 		<div class="join-card">
-			<h3 class="join-title">Join an Organization</h3>
-			<p class="join-description">Have an invitation code? Join an existing organization.</p>
-			<Button style="pop" onclick={() => joinOrganizationModal?.show()}>Join Organization</Button>
+			<h3 class="join-title">Einer Organisation beitreten</h3>
+			<p class="join-description">Haben Sie einen Einladungscode? Treten Sie einer bestehenden Organisation bei.</p>
+			<Button style="pop" onclick={() => joinOrganizationModal?.show()}>Organisation beitreten</Button>
 		</div>
 	</div>
 </div>

--- a/apps/web/src/routes/(app)/organizations/invite/[slug]/[code]/+page.svelte
+++ b/apps/web/src/routes/(app)/organizations/invite/[slug]/[code]/+page.svelte
@@ -49,7 +49,7 @@
 			}, 1500);
 		} catch (error: any) {
 			// Try to extract error message from JSON response if available
-			let errorMessage = "Failed to join organization";
+			let errorMessage = "Beitritt zur Organisation fehlgeschlagen";
 			try {
 				// Check if error has a response with JSON data
 				if (error.response && error.response.data) {
@@ -98,32 +98,32 @@
 
 <div class="invite-container">
 	<div class="invite-card">
-		<h1>Organization Invitation</h1>
+		<h1>Einladung zur Organisation</h1>
 
 		{#if !isLoggedIn}
-			<p>You've been invited to join <strong>{slug}</strong>.</p>
-			<p>Please log in to continue.</p>
-			<Button onclick={goToLogin} style="pop">Log In</Button>
+			<p>Sie wurden eingeladen, <strong>{slug}</strong> beizutreten.</p>
+			<p>Bitte melden Sie sich an, um fortzufahren.</p>
+			<Button onclick={goToLogin} style="pop">Anmelden</Button>
 		{:else if isJoining}
 			<div class="loading-container">
-				<p>Joining organization...</p>
+				<p>Organisation wird beigetreten…</p>
 			</div>
 		{:else if joinError}
 			<p>{joinError}</p>
 			<div class="button-container">
-				<Button onclick={handleRetry} style="pop">Try Again</Button>
+				<Button onclick={handleRetry} style="pop">Erneut versuchen</Button>
 			</div>
 		{:else if joinSuccess}
-			<p>You have successfully joined the organization.</p>
-			<p>Redirecting to the organization page...</p>
+			<p>Sie sind der Organisation erfolgreich beigetreten.</p>
+			<p>Sie werden zur Organisationsseite weitergeleitet…</p>
 		{:else if showConfirmation}
-			<p>You've been invited to join <strong>{slug}</strong>.</p>
-			<p>Would you like to accept this invitation?</p>
+			<p>Sie wurden eingeladen, <strong>{slug}</strong> beizutreten.</p>
+			<p>Möchten Sie diese Einladung annehmen?</p>
 			<div class="button-container">
-				<Button onclick={handleConfirm} style="pop">Join Organization</Button>
+				<Button onclick={handleConfirm} style="pop">Organisation beitreten</Button>
 			</div>
 		{:else}
-			<p>Processing your invitation...</p>
+			<p>Ihre Einladung wird verarbeitet…</p>
 		{/if}
 	</div>
 </div>

--- a/apps/web/src/routes/(app)/profile/+page.svelte
+++ b/apps/web/src/routes/(app)/profile/+page.svelte
@@ -35,7 +35,7 @@
 		return os === "unknown" ? "macOS" : os;
 	});
 
-	const downloadButtonText = $derived(`Download GitButler for ${detectedOS}`);
+	const downloadButtonText = $derived(`GitButler für ${detectedOS} herunterladen`);
 
 	const downloadLink = $derived.by(() => {
 		switch (detectedOS) {
@@ -51,7 +51,7 @@
 
 	async function refreshAccessToken() {
 		await userService.refreshAccessToken();
-		chipToasts.success("Access token refreshed successfully");
+		chipToasts.success("Zugriffstoken erfolgreich aktualisiert");
 	}
 
 	function logout() {
@@ -74,20 +74,20 @@
 		if (response.type === "success" && response.data) {
 			copyToClipboard(response.data);
 		} else {
-			chipToasts.error("Failed to get token");
+			chipToasts.error("Token konnte nicht abgerufen werden");
 		}
 	}
 </script>
 
 <svelte:head>
-	<title>GitButler | User</title>
+	<title>GitButler | Benutzer</title>
 </svelte:head>
 
 {#if !$user?.id}
 	<div class="not-logged-in">
-		<h3 class="text-18 text-bold">It looks like you're not logged in</h3>
+		<h3 class="text-18 text-bold">Es sieht so aus, als wärst du nicht angemeldet</h3>
 		<p class="text-14 text-body clr-text-2">
-			Please <a class="underline" href="/login">log in</a> to access your profile
+			Bitte <a class="underline" href="/login">melde dich an</a>, um auf dein Profil zuzugreifen
 		</p>
 	</div>
 {:else}
@@ -110,44 +110,44 @@
 			{#if $user}
 				<CardGroup.Item standalone>
 					{#snippet title()}
-						Signing out
+						Abmelden
 					{/snippet}
 					{#snippet caption()}
-						Ready to take a break? Click here to log out and unwind.
+						Bereit für eine Pause? Klicke hier, um dich abzumelden und zu entspannen.
 					{/snippet}
 					{#snippet actions()}
-						<Button kind="outline" icon="logout" onclick={logout}>Log out</Button>
+						<Button kind="outline" icon="logout" onclick={logout}>Abmelden</Button>
 					{/snippet}
 				</CardGroup.Item>
 
 				<CardGroup>
 					<CardGroup.Item>
 						{#snippet title()}
-							Access token
+							Zugriffstoken
 						{/snippet}
 						{#snippet caption()}
-							Your access token is used to authenticate the GitButler clients with our API.
+							Dein Zugriffstoken wird verwendet, um die GitButler-Clients bei unserer API zu authentifizieren.
 							<br />
-							Keep it secure and refresh it periodically for enhanced security.
+							Bewahre es sicher auf und aktualisiere es regelmäßig für mehr Sicherheit.
 						{/snippet}
 					</CardGroup.Item>
 					<CardGroup.Item alignment="center">
 						{#snippet caption()}
-							Copy your token to use with the desktop app or CLI.
+							Kopiere dein Token zur Verwendung mit der Desktop-App oder der CLI.
 						{/snippet}
 						{#snippet actions()}
-							<Button kind="outline" icon="copy" onclick={copyAccessToken}>Copy token</Button>
+							<Button kind="outline" icon="copy" onclick={copyAccessToken}>Token kopieren</Button>
 						{/snippet}
 					</CardGroup.Item>
 					<CardGroup.Item>
 						{#snippet caption()}
-							Refresh your token if you notice unusual activity.
+							Aktualisiere dein Token, wenn du ungewöhnliche Aktivitäten bemerkst.
 							<br />
-							This logs you out everywhere, including the desktop app.
+							Dadurch wirst du überall abgemeldet, einschließlich der Desktop-App.
 						{/snippet}
 						{#snippet actions()}
 							<Button kind="outline" icon="refresh" onclick={refreshAccessToken}
-								>Refresh token</Button
+								>Token aktualisieren</Button
 							>
 						{/snippet}
 					</CardGroup.Item>
@@ -158,17 +158,17 @@
 				<CardGroup>
 					<CardGroup.Item>
 						{#snippet title()}
-							Danger zone
+							Gefahrenzone
 						{/snippet}
 					</CardGroup.Item>
 					<CardGroup.Item>
 						{#snippet caption()}
-							Permanently delete your account and all data.
+							Lösche dein Konto und alle Daten dauerhaft.
 							<br />
-							This action cannot be undone.
+							Diese Aktion kann nicht rückgängig gemacht werden.
 						{/snippet}
 						{#snippet actions()}
-							<Button style="danger" onclick={initiateDeleteAccount}>Delete my account…</Button>
+							<Button style="danger" onclick={initiateDeleteAccount}>Mein Konto löschen…</Button>
 						{/snippet}
 					</CardGroup.Item>
 				</CardGroup>
@@ -186,7 +186,7 @@
 						<img class="download-card__icon" src="/images/app-icon.svg" alt="" />
 
 						<p class="text-12 text-body clr-text-2 text-balance">
-							Get the desktop app for Mac, Windows, and Linux.
+							Hol dir die Desktop-App für Mac, Windows und Linux.
 						</p>
 					</div>
 
@@ -197,9 +197,9 @@
 					<hr class="download-card__divider" />
 
 					<p class="download-card__other-text text-12">
-						Get the app for
+						Hol dir die App für
 						<a href={linksJson.resources.downloads.url} target="_self" rel="noopener noreferrer">
-							other platforms
+							andere Plattformen
 						</a>
 						↗
 					</p>
@@ -219,10 +219,10 @@
 				>
 					<div class="tip-link__title">
 						<Icon name="docs" color="var(--text-2)" />
-						<h3 class="text-14 text-semibold">Get Started</h3>
+						<h3 class="text-14 text-semibold">Erste Schritte</h3>
 					</div>
 					<p class="text-12 text-body clr-text-2">
-						Explore comprehensive guides and best practices.
+						Entdecke umfassende Anleitungen und bewährte Vorgehensweisen.
 					</p>
 
 					<span class="tip-link__arrow-icon">↗</span>
@@ -235,19 +235,19 @@
 				>
 					<div class="tip-link__title">
 						<Icon name="discord" color="var(--text-2)" />
-						<h3 class="text-14 text-semibold">Join the Community</h3>
+						<h3 class="text-14 text-semibold">Werde Teil der Community</h3>
 					</div>
-					<p class="text-12 text-body clr-text-2">Join our Discord for help and discussion.</p>
+					<p class="text-12 text-body clr-text-2">Tritt unserem Discord bei für Hilfe und Austausch.</p>
 
 					<span class="tip-link__arrow-icon">↗</span>
 				</a>
 				<a class="tip-link" href={linksJson.other.support.url}>
 					<div class="tip-link__title">
 						<Icon name="chat" color="var(--text-2)" />
-						<h3 class="text-14 text-semibold">Need Help?</h3>
+						<h3 class="text-14 text-semibold">Brauchst du Hilfe?</h3>
 					</div>
 					<p class="text-12 text-body clr-text-2">
-						Create an issue on GitHub. We're here to assist!
+						Erstelle ein Issue auf GitHub. Wir helfen dir gerne!
 					</p>
 
 					<span class="tip-link__arrow-icon">↗</span>
@@ -257,17 +257,17 @@
 	</div>
 {/if}
 
-<Modal bind:this={deleteAccountConfirmationModal} title="Confirm account deletion" width="small">
+<Modal bind:this={deleteAccountConfirmationModal} title="Kontolöschung bestätigen" width="small">
 	<p class="text-13 text-body">
-		Are you sure you want to delete your account?
+		Bist du sicher, dass du dein Konto löschen möchtest?
 		<br />
-		This action is <b>irreversible</b> and will permanently remove all your data from our servers.
+		Diese Aktion ist <b>unumkehrbar</b> und entfernt alle deine Daten dauerhaft von unseren Servern.
 	</p>
 	{#snippet controls(close)}
 		<div class="flex flex-row gap-8 justify-end">
-			<Button style="pop" onclick={close}>Cancel</Button>
+			<Button style="pop" onclick={close}>Abbrechen</Button>
 			<Button style="danger" icon="bin" kind="outline" onclick={deleteAccount}
-				>Delete permanently</Button
+				>Endgültig löschen</Button
 			>
 		</div>
 	{/snippet}

--- a/apps/web/src/routes/(app)/profile/components/ExperimentalSettings.svelte
+++ b/apps/web/src/routes/(app)/profile/components/ExperimentalSettings.svelte
@@ -6,19 +6,19 @@
 <Spacer />
 
 <div class="stack-v gap-8">
-	<h2 class="text-15 text-bold">Experimental</h2>
+	<h2 class="text-15 text-bold">Experimentell</h2>
 	<p class="text-12 text-body clr-text-2">
-		These settings enable experimental features that are still in development.
+		Diese Einstellungen aktivieren experimentelle Funktionen, die sich noch in der Entwicklung befinden.
 		<br />
-		They may be unstable or incomplete. Use them at your own risk.
+		Sie können instabil oder unvollständig sein. Die Nutzung erfolgt auf eigenes Risiko.
 	</p>
 </div>
 
 <CardGroup>
 	<CardGroup.Item labelFor="showOrganizations">
-		{#snippet title()}Organizations{/snippet}
+		{#snippet title()}Organisationen{/snippet}
 		{#snippet caption()}
-			Organizations are a way of linking together projects.
+			Organisationen sind eine Möglichkeit, Projekte miteinander zu verknüpfen.
 		{/snippet}
 		{#snippet actions()}
 			<Toggle
@@ -30,9 +30,9 @@
 	</CardGroup.Item>
 
 	<CardGroup.Item labelFor="showProjectPage">
-		{#snippet title()}User / Organization / Project Pages{/snippet}
+		{#snippet title()}Benutzer- / Organisations- / Projektseiten{/snippet}
 		{#snippet caption()}
-			This will show the stub landing pages for orgs, users and projects.
+			Dies zeigt die vorläufigen Landingpages für Organisationen, Benutzer und Projekte an.
 		{/snippet}
 		{#snippet actions()}
 			<Toggle

--- a/apps/web/src/routes/(app)/profile/components/NotificationSettings.svelte
+++ b/apps/web/src/routes/(app)/profile/components/NotificationSettings.svelte
@@ -69,19 +69,19 @@
 <Spacer />
 
 <div class="stack-v gap-8">
-	<h2 class="text-15 text-bold">Notification settings</h2>
+	<h2 class="text-15 text-bold">Benachrichtigungseinstellungen</h2>
 	<p class="text-12 text-body clr-text-2">
-		Manage your email notification preferences for various activities within GitButler.
+		Verwalte deine E-Mail-Benachrichtigungseinstellungen für verschiedene Aktivitäten in GitButler.
 	</p>
 </div>
 
 <CardGroup>
 	<CardGroup.Item labelFor="receive-chat-mention-emails">
 		{#snippet title()}
-			Chat message mention emails
+			E-Mails bei Erwähnungen in Chat-Nachrichten
 		{/snippet}
 		{#snippet caption()}
-			Emails when you are mentioned in a message.
+			E-Mails, wenn du in einer Nachricht erwähnt wirst.
 		{/snippet}
 		{#snippet actions()}
 			<Toggle
@@ -96,10 +96,10 @@
 
 	<CardGroup.Item labelFor="receive-chat-reply-emails">
 		{#snippet title()}
-			Chat message reply emails
+			E-Mails bei Antworten auf Chat-Nachrichten
 		{/snippet}
 		{#snippet caption()}
-			Emails when you receive a reply to a chat message.
+			E-Mails, wenn du eine Antwort auf eine Chat-Nachricht erhältst.
 		{/snippet}
 		{#snippet actions()}
 			<Toggle
@@ -113,10 +113,10 @@
 
 	<CardGroup.Item labelFor="receive-issue-creation-emails">
 		{#snippet title()}
-			Issue creation emails
+			E-Mails bei Erstellung von Issues
 		{/snippet}
 		{#snippet caption()}
-			Emails for new issues created in changes you are involved in.
+			E-Mails für neue Issues, die in Änderungen erstellt werden, an denen du beteiligt bist.
 		{/snippet}
 		{#snippet actions()}
 			<Toggle
@@ -131,10 +131,10 @@
 
 	<CardGroup.Item labelFor="receive-issue-resolution-emails">
 		{#snippet title()}
-			Issue status emails
+			E-Mails zum Status von Issues
 		{/snippet}
 		{#snippet caption()}
-			Emails for status updates of issues in changes you are involved in.
+			E-Mails für Statusaktualisierungen von Issues in Änderungen, an denen du beteiligt bist.
 		{/snippet}
 		{#snippet actions()}
 			<Toggle
@@ -149,10 +149,10 @@
 
 	<CardGroup.Item labelFor="receive-review-branch-emails">
 		{#snippet title()}
-			Branch version update emails
+			E-Mails bei neuen Branch-Versionen
 		{/snippet}
 		{#snippet caption()}
-			Emails when a new review branch version is created.
+			E-Mails, wenn eine neue Version eines Review-Branches erstellt wird.
 		{/snippet}
 		{#snippet actions()}
 			<Toggle
@@ -167,10 +167,10 @@
 
 	<CardGroup.Item labelFor="receive-sign-off-emails">
 		{#snippet title()}
-			Change status update emails
+			E-Mails zum Status von Änderungen
 		{/snippet}
 		{#snippet caption()}
-			Emails for updates on the review status of changes you are involved in.
+			E-Mails für Aktualisierungen zum Review-Status von Änderungen, an denen du beteiligt bist.
 		{/snippet}
 		{#snippet actions()}
 			<Toggle

--- a/apps/web/src/routes/(app)/profile/components/ProfileHeader.svelte
+++ b/apps/web/src/routes/(app)/profile/components/ProfileHeader.svelte
@@ -78,14 +78,14 @@
 				<div class="contact-info__fields">
 					<Textbox
 						id="full-name"
-						label="Full name"
+						label="Vollständiger Name"
 						type="text"
 						bind:value={nameValue}
 						readonly={updatingName}
 						onblur={updateName}
 						onkeydown={(e) => e.key === "Enter" && updateName()}
 					/>
-					<Textbox id="email" label="Email" type="text" bind:value={emailValue} readonly={true} />
+					<Textbox id="email" label="E-Mail" type="text" bind:value={emailValue} readonly={true} />
 				</div>
 			</div>
 		</CardGroup.Item>
@@ -121,9 +121,9 @@
 
 				<Textbox
 					id="location"
-					label="Location"
+					label="Standort"
 					type="text"
-					placeholder="City, Country"
+					placeholder="Stadt, Land"
 					bind:value={locationValue}
 					readonly={updatingAdditionalInfo}
 				/>
@@ -132,8 +132,8 @@
 
 				<label class="checkbox-section" for="email-share">
 					<div class="checkbox-section__label">
-						<h3 class="text-15 text-bold">Share my email</h3>
-						<p class="text-12 text-body clr-text-2">Allow other users to see your email address.</p>
+						<h3 class="text-15 text-bold">Meine E-Mail-Adresse teilen</h3>
+						<p class="text-12 text-body clr-text-2">Anderen Benutzern erlauben, deine E-Mail-Adresse zu sehen.</p>
 					</div>
 					<Toggle
 						id="email-share"
@@ -153,7 +153,7 @@
 					loading={updatingAdditionalInfo}
 					disabled={updatingAdditionalInfo}
 				>
-					{updatingAdditionalInfo ? "Saving..." : "Update profile"}
+					{updatingAdditionalInfo ? "Wird gespeichert..." : "Profil aktualisieren"}
 				</Button>
 			</div>
 		</CardGroup.Item>

--- a/apps/web/src/routes/(app)/profile/components/SupporterCard.svelte
+++ b/apps/web/src/routes/(app)/profile/components/SupporterCard.svelte
@@ -4,15 +4,15 @@
 </script>
 
 <div class="supporter-card">
-	<h3 class="text-15 text-bold">🎉 Thank you for being a supporter!</h3>
+	<h3 class="text-15 text-bold">🎉 Danke, dass du uns unterstützt!</h3>
 	<p class="text-12 text-body clr-text-2">
-		Your support helps us build a better GitButler.<br />We appreciate your contribution.
+		Deine Unterstützung hilft uns, GitButler noch besser zu machen.<br />Wir schätzen deinen Beitrag.
 	</p>
 	<Button
 		style="pop"
 		onclick={() => (window.location.href = `${env.PUBLIC_APP_HOST}supporter/portal`)}
 	>
-		Manage your subscription
+		Abonnement verwalten
 	</Button>
 </div>
 

--- a/apps/web/src/routes/(app)/profile/finalize/+page.svelte
+++ b/apps/web/src/routes/(app)/profile/finalize/+page.svelte
@@ -41,17 +41,17 @@
 
 		if (!$user) {
 			// should not happen
-			error = "You must be logged in to finalize your account.";
+			error = "Du musst angemeldet sein, um dein Konto abzuschließen.";
 			return;
 		}
 
 		if (!effectiveEmail) {
-			error = "Email is required.";
+			error = "E-Mail-Adresse ist erforderlich.";
 			return;
 		}
 
 		if (!effectiveUsername) {
-			error = "Username is required.";
+			error = "Benutzername ist erforderlich.";
 			return;
 		}
 
@@ -79,23 +79,23 @@
 </script>
 
 <svelte:head>
-	<title>GitButler | Finalize Account</title>
+	<title>GitButler | Konto abschließen</title>
 </svelte:head>
 
 <FullscreenIllustrationCard illustration={newProjectSvg}>
 	{#snippet title()}
-		Almost <i>done</i>!
+		Fast <i>geschafft</i>!
 	{/snippet}
 
 	<form class="finalize-form__content" onsubmit={handleSubmit}>
 		<p class="text-12 text-base finalize-form__caption">
-			We need these details to set up your account properly.
+			Wir benötigen diese Angaben, um dein Konto korrekt einzurichten.
 		</p>
 		{#if !userLogin}
 			<UsernameTextbox bind:this={usernameTextbox} bind:value={username} />
 		{/if}
 		{#if !userEmail}
-			<EmailTextbox bind:this={emailTextbox} bind:value={email} label="Email" />
+			<EmailTextbox bind:this={emailTextbox} bind:value={email} label="E-Mail" />
 		{/if}
 
 		{#if error}
@@ -114,7 +114,7 @@
 			</InfoMessage>
 		{/if}
 
-		<Button style="pop" type="submit" disabled={!canSubmit}>Finalize Account</Button>
+		<Button style="pop" type="submit" disabled={!canSubmit}>Konto abschließen</Button>
 	</form>
 </FullscreenIllustrationCard>
 

--- a/apps/web/src/routes/(app)/signup/+page.svelte
+++ b/apps/web/src/routes/(app)/signup/+page.svelte
@@ -35,17 +35,17 @@
 	async function handleSubmit(event: Event) {
 		event.preventDefault();
 		if (!username || !email || !password || !passwordConfirmation) {
-			error = "Username, email and password are required";
+			error = "Benutzername, E-Mail-Adresse und Passwort sind erforderlich";
 			return;
 		}
 
 		if (!passwordComponent?.isValid()) {
-			error = "Please check your password and confirmation";
+			error = "Bitte überprüfe dein Passwort und die Bestätigung";
 			return;
 		}
 
 		if (!usernameTextbox?.isValid()) {
-			error = "Please check your username";
+			error = "Bitte überprüfe deinen Benutzernamen";
 			return;
 		}
 
@@ -67,7 +67,7 @@
 </script>
 
 <svelte:head>
-	<title>GitButler | Sign Up</title>
+	<title>GitButler | Registrieren</title>
 </svelte:head>
 
 <RedirectIfLoggedIn />
@@ -75,10 +75,10 @@
 <FullscreenIllustrationCard illustration={successMessage ? newProjectSvg : undefined}>
 	{#snippet title()}
 		{#if !successMessage}
-			<i>Sign Up</i>
-			for GitButler
+			<i>Registrieren</i>
+			für GitButler
 		{:else}
-			🚀 Check <i>your email</i> for confirmation instructions
+			🚀 Überprüfe <i>deine E-Mails</i> für Anweisungen zur Bestätigung
 		{/if}
 	{/snippet}
 
@@ -88,7 +88,7 @@
 				<UsernameTextbox bind:this={usernameTextbox} bind:value={username} />
 				<EmailTextbox
 					bind:this={emailTextbox}
-					label="Email"
+					label="E-Mail"
 					placeholder=" "
 					bind:value={email}
 					autocomplete={false}
@@ -110,7 +110,7 @@
 				</InfoMessage>
 			{/if}
 
-			<Button type="submit" style="pop" disabled={!isFormValid}>Create account</Button>
+			<Button type="submit" style="pop" disabled={!isFormValid}>Konto erstellen</Button>
 
 			<OAuthButtons mode="signup" />
 		</form>
@@ -120,22 +120,22 @@
 		<div class="auth-form__footer">
 			{#if !successMessage}
 				<p>
-					*By signing up, you agree to our
-					<a href="https://gitbutler.com/terms">Terms</a>
-					and
-					<a href="https://gitbutler.com/privacy">Privacy Policy</a>
+					*Mit der Registrierung stimmst du unseren
+					<a href="https://gitbutler.com/terms">Nutzungsbedingungen</a>
+					und der
+					<a href="https://gitbutler.com/privacy">Datenschutzerklärung</a> zu
 				</p>
 				<p>
-					Already have an account? <a href={routesService.loginPath()}>Log in now</a>
+					Du hast bereits ein Konto? <a href={routesService.loginPath()}>Jetzt anmelden</a>
 				</p>
 			{:else}
 				<p>
-					Need help? <a
+					Brauchst du Hilfe? <a
 						href="https://github.com/gitbutlerapp/gitbutler/issues/new?template=BLANK_ISSUE"
 						target="_blank"
 						rel="noopener noreferrer"
 					>
-						Open a support request
+						Support-Anfrage stellen
 					</a>
 				</p>
 			{/if}

--- a/apps/web/src/routes/(app)/signup/resend-confirmation/+page.svelte
+++ b/apps/web/src/routes/(app)/signup/resend-confirmation/+page.svelte
@@ -18,7 +18,7 @@
 	const messageCode = $derived(page.url.searchParams.get("message_code"));
 	const banner = $derived(
 		messageCode === "invalid_or_expired_token"
-			? "It seems that your confirmation token is invalid or has expired. Please try resending the confirmation email."
+			? "Es scheint, dass dein Bestätigungstoken ungültig ist oder abgelaufen ist. Bitte versuche, die Bestätigungs-E-Mail erneut zu senden."
 			: undefined,
 	);
 
@@ -30,7 +30,7 @@
 
 	async function resendConfirmationEmail() {
 		if (!emailToSendTo) {
-			error = "Please enter your email to resend the confirmation email.";
+			error = "Bitte gib deine E-Mail-Adresse ein, um die Bestätigungs-E-Mail erneut zu senden.";
 			return;
 		}
 		const response = await loginService.resendConfirmationEmail(emailToSendTo);
@@ -38,26 +38,26 @@
 			error = response.errorMessage;
 			console.error("Failed to resend confirmation email:", response.raw ?? response.errorMessage);
 		} else {
-			message = "Confirmation email resent. Please check your inbox.";
+			message = "Bestätigungs-E-Mail erneut gesendet. Bitte überprüfe deinen Posteingang.";
 		}
 	}
 </script>
 
 <svelte:head>
-	<title>GitButler | Resend Confirmation</title>
+	<title>GitButler | Bestätigung erneut senden</title>
 </svelte:head>
 
 <FullscreenUtilityCard
-	title="Resend Confirmation"
-	backlink={{ label: "Login", href: routesService.loginPath() }}
+	title="Bestätigung erneut senden"
+	backlink={{ label: "Anmelden", href: routesService.loginPath() }}
 >
 	{#if email}
 		<p class="text-13 text-body">
-			We send a confirmation email to <i class="clr-text-2">{email}</i>.
+			Wir senden eine Bestätigungs-E-Mail an <i class="clr-text-2">{email}</i>.
 		</p>
 	{:else}
 		<div class="stack-v gap-16">
-			<EmailTextbox bind:this={emailTextbox} bind:value={inputEmail} label="Email" />
+			<EmailTextbox bind:this={emailTextbox} bind:value={inputEmail} label="E-Mail" />
 
 			{#if error}
 				<InfoMessage filled outlined={false} style="danger">
@@ -84,7 +84,7 @@
 			{/if}
 
 			<Button style="pop" disabled={!canSubmit} onclick={resendConfirmationEmail}
-				>Resend Confirmation Email</Button
+				>Bestätigungs-E-Mail erneut senden</Button
 			>
 		</div>
 	{/if}

--- a/apps/web/src/routes/(home)/HomePage.svelte
+++ b/apps/web/src/routes/(home)/HomePage.svelte
@@ -17,8 +17,8 @@
 
 <Hero>
 	{#snippet descriptionContent()}
-		GitButler is the Git-backed change management tool for modern, AI&nbsp;coding workflows.
-		Parallel and stacked branches, unlimited undo, agent integrations, and more. It's Git, refined.
+		GitButler ist das Git-basierte Änderungsmanagement-Tool für moderne KI&nbsp;Coding-Workflows.
+		Parallele und gestapelte Branches, unbegrenztes Rückgängigmachen, Agent-Integrationen und mehr. Das ist Git, verfeinert.
 	{/snippet}
 </Hero>
 <MainFeatures />

--- a/apps/web/src/routes/(home)/components/CtaButton.svelte
+++ b/apps/web/src/routes/(home)/components/CtaButton.svelte
@@ -86,7 +86,7 @@
 		: '0'}) scale({isHovering ? 1.02 : 1})"
 >
 	<div class="download-btn__title">
-		<span class="download-btn__title">DOWNLOAD for {detectedOS}</span>
+		<span class="download-btn__title">DOWNLOAD für {detectedOS}</span>
 
 		<svg
 			class="download-btn-icon"
@@ -107,7 +107,7 @@
 <!-- MOBILE -->
 <a class="download-btn mobile" href={jsonLinks.resources.downloads.url}>
 	<div class="download-btn__title">
-		<span class="download-btn__title">DOWNLOAD <i>the</i> app</span>
+		<span class="download-btn__title">DOWNLOAD <i>die</i> App</span>
 	</div>
 	<span class="download-btn__version">Open Beta {$latestClientVersion}</span>
 

--- a/apps/web/src/routes/(home)/components/Features.svelte
+++ b/apps/web/src/routes/(home)/components/Features.svelte
@@ -32,7 +32,7 @@
 			<a class="feature-item" href={item.link} target="_blank" rel="noopener noreferrer">
 				<div class="features__link-indicator">
 					<div class="features__link-indicator-brakets">[</div>
-					<div class="features__link-indicator-text">Learn More</div>
+					<div class="features__link-indicator-text">Mehr erfahren</div>
 					<div class="features__link-indicator-arrow">&#8599;</div>
 					<div class="features__link-indicator-brakets">]</div>
 				</div>

--- a/apps/web/src/routes/(home)/components/MobileMenu.svelte
+++ b/apps/web/src/routes/(home)/components/MobileMenu.svelte
@@ -28,7 +28,7 @@
 	class="mobile-menu-button"
 	class:is-open={isMenuOpen}
 	onclick={toggleMenu}
-	aria-label={isMenuOpen ? "Close menu" : "Open menu"}
+	aria-label={isMenuOpen ? "Menü schließen" : "Menü öffnen"}
 	aria-expanded={isMenuOpen}
 ></button>
 

--- a/apps/web/src/routes/(home)/components/VideoOverlay.svelte
+++ b/apps/web/src/routes/(home)/components/VideoOverlay.svelte
@@ -69,7 +69,7 @@
 	<div class="video-container">
 		<iframe
 			src={embedUrl}
-			title="Demo video"
+			title="Demo-Video"
 			frameborder="0"
 			allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
 			allowfullscreen

--- a/apps/web/src/routes/(home)/sections/AiFeatures.svelte
+++ b/apps/web/src/routes/(home)/sections/AiFeatures.svelte
@@ -21,7 +21,7 @@
 
 <section class="ai-features">
 	<SectionHeader>
-		<i>Orchestrate</i> your AI Tools ✨
+		<i>Orchestriere</i> deine KI-Tools ✨
 	</SectionHeader>
 	<div class="ai-features__video">
 		{#if isPlaying}
@@ -29,7 +29,7 @@
 				width="100%"
 				height="100%"
 				src={`${contentJSON["ai-fetures-demo"]}&autoplay=1`}
-				title="YouTube video player"
+				title="YouTube-Videoplayer"
 				frameborder="0"
 				allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
 				referrerpolicy="strict-origin-when-cross-origin"
@@ -43,7 +43,7 @@
 				onclick={playVideo}
 				onkeydown={handleKeydown}
 			>
-				<img src="images/ai-demo.png" alt="AI Features Demo" loading="lazy" />
+				<img src="images/ai-demo.png" alt="KI-Features-Demo" loading="lazy" />
 				<div class="play-button">
 					<svg
 						width="70"

--- a/apps/web/src/routes/(home)/sections/BlogHighlights.svelte
+++ b/apps/web/src/routes/(home)/sections/BlogHighlights.svelte
@@ -68,11 +68,11 @@
 
 <section class="blog-highlights">
 	<SectionHeader
-		>From <i>the</i> Blog
+		>Aus <i>dem</i> Blog
 
 		{#snippet buttons()}
 			<ArrowButton
-				label="Read more"
+				label="Mehr lesen"
 				onclick={() => window.open("https://blog.gitbutler.com", "_blank")}
 			/>
 		{/snippet}
@@ -89,7 +89,7 @@
 						{posts?.[0]?.title}
 					</h3>
 					<span class="blog-post__meta">
-						{formatDate(posts?.[0]?.published_at ?? "")} by {posts?.[0]?.primary_author?.name}
+						{formatDate(posts?.[0]?.published_at ?? "")} von {posts?.[0]?.primary_author?.name}
 					</span>
 				</div>
 				<div class="blog-post__body">
@@ -109,7 +109,7 @@
 							{posts?.[1]?.title}
 						</h3>
 						<span class="blog-post__meta">
-							{formatDate(posts?.[1]?.published_at ?? "")} by {posts?.[1]?.primary_author?.name}
+							{formatDate(posts?.[1]?.published_at ?? "")} von {posts?.[1]?.primary_author?.name}
 						</span>
 					</div>
 					<div class="blog-post__body">
@@ -127,7 +127,7 @@
 							{posts?.[2]?.title}
 						</h3>
 						<span class="blog-post__meta">
-							{formatDate(posts?.[2]?.published_at ?? "")} by {posts?.[2]?.primary_author?.name}
+							{formatDate(posts?.[2]?.published_at ?? "")} von {posts?.[2]?.primary_author?.name}
 						</span>
 					</div>
 					<div class="blog-post__body">

--- a/apps/web/src/routes/(home)/sections/Changelog.svelte
+++ b/apps/web/src/routes/(home)/sections/Changelog.svelte
@@ -26,7 +26,7 @@
 		Changelog
 
 		{#snippet buttons()}
-			<ArrowButton label="All updates" onclick={goToFullChangelog} />
+			<ArrowButton label="Alle Updates" onclick={goToFullChangelog} />
 		{/snippet}
 	</SectionHeader>
 
@@ -40,17 +40,17 @@
 
 			{#if visibleCount < 10 && releases.length > visibleCount}
 				<div class="show-more-container">
-					<button type="button" class="show-more-button" onclick={showMore}> Show more </button>
+					<button type="button" class="show-more-button" onclick={showMore}> Mehr anzeigen </button>
 				</div>
 			{:else if visibleCount >= 10 || releases.length <= visibleCount}
 				<div class="show-more-container">
 					<button type="button" class="show-more-button full-changelog" onclick={goToFullChangelog}>
-						See complete changelog
+						Vollständiges Changelog ansehen
 					</button>
 				</div>
 			{/if}
 		{:else}
-			<div class="loading">Loading releases...</div>
+			<div class="loading">Releases werden geladen …</div>
 		{/if}
 	</div>
 </section>

--- a/apps/web/src/routes/(home)/sections/DevelopersReview.svelte
+++ b/apps/web/src/routes/(home)/sections/DevelopersReview.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <section class="reviews-wrapper" id="developers-preview">
-	<h2 class="title">What <i>developers<br />say</i> about us</h2>
+	<h2 class="title">Was <i>Entwickler<br />über uns</i> sagen</h2>
 	<section class="reviews">
 		<!-- <div class="reviews-column">
 			<TwitterCard

--- a/apps/web/src/routes/(home)/sections/FeatureUpdates.svelte
+++ b/apps/web/src/routes/(home)/sections/FeatureUpdates.svelte
@@ -144,12 +144,12 @@
 		try {
 			const playlistId = extractPlaylistId(PLAYLIST_URL);
 			if (!playlistId) {
-				throw new Error("Invalid playlist URL");
+				throw new Error("Ungültige Playlist-URL");
 			}
 
 			playlist = await fetchPlaylistVideos(playlistId);
 		} catch (err) {
-			error = err instanceof Error ? err.message : "Failed to load videos";
+			error = err instanceof Error ? err.message : "Videos konnten nicht geladen werden";
 			console.error("Error loading playlist:", err);
 		} finally {
 			isLoading = false;
@@ -159,11 +159,11 @@
 
 <section class="feature-updates">
 	<SectionHeader>
-		<i>Feature</i> updates
+		<i>Feature</i>-Updates
 
 		{#snippet buttons()}
 			<div class="feature-updates__all-demos">
-				<ArrowButton showArrow={false} label="All demos" onclick={openPlaylist} />
+				<ArrowButton showArrow={false} label="Alle Demos" onclick={openPlaylist} />
 			</div>
 			<ArrowButton onclick={() => scroll("left")} reverseDirection disabled={!canScrollLeft} />
 			<ArrowButton onclick={() => scroll("right")} disabled={!canScrollRight} />
@@ -172,15 +172,15 @@
 
 	{#if isLoading}
 		<div class="loading-state">
-			<p>Loading videos...</p>
+			<p>Videos werden geladen …</p>
 		</div>
 	{:else if error}
 		<div class="loading-state">
 			<h3>¯\_(ツ)_/¯</h3>
-			<p>Unable to load videos: {error}</p>
+			<p>Videos konnten nicht geladen werden: {error}</p>
 			<p>
-				Please check our <a href={PLAYLIST_URL} target="_blank" rel="noopener">YouTube playlist</a>
-				directly.
+				Bitte sieh dir direkt unsere <a href={PLAYLIST_URL} target="_blank" rel="noopener">YouTube-Playlist</a>
+				an.
 			</p>
 		</div>
 	{:else if playlist && playlist.videos.length > 0}
@@ -188,7 +188,7 @@
 			<div class="video-carousel__container">
 				<div
 					role="region"
-					aria-label="Video carousel"
+					aria-label="Video-Karussell"
 					class="video-carousel__scroll"
 					bind:this={carousel}
 					ontouchstart={handleTouchStart}

--- a/apps/web/src/routes/(home)/sections/Hero.svelte
+++ b/apps/web/src/routes/(home)/sections/Hero.svelte
@@ -38,7 +38,7 @@
 				type="button"
 				class="video-preview"
 				onclick={openVideoOverlay}
-				aria-label="Watch demo video"
+				aria-label="Demo-Video ansehen"
 				onmouseenter={(e) => e.currentTarget.querySelector("video")?.play()}
 				onmouseleave={(e) => {
 					const video = e.currentTarget.querySelector("video");

--- a/apps/web/src/routes/(home)/sections/HeroHeader.svelte
+++ b/apps/web/src/routes/(home)/sections/HeroHeader.svelte
@@ -68,7 +68,7 @@
 </h1>
 
 <div class="description-wrapper">
-	<div class="toggle-switch" role="group" aria-label="View mode selection">
+	<div class="toggle-switch" role="group" aria-label="Ansichtsmodus-Auswahl">
 		<button
 			bind:this={clientButton}
 			type="button"

--- a/apps/web/src/routes/(home)/sections/SocialQuotes.svelte
+++ b/apps/web/src/routes/(home)/sections/SocialQuotes.svelte
@@ -166,7 +166,7 @@
 
 <section class="social-quotes">
 	<SectionHeader>
-		<i>Community</i> voices
+		<i>Community</i>-Stimmen
 
 		{#snippet buttons()}
 			<ArrowButton reverseDirection onclick={prevSlide} />
@@ -188,7 +188,7 @@
 							<p class="text-15 text-body quote__text">
 								{quote.quote}
 								<a
-									title="View post on {quote.social}"
+									title="Beitrag auf {quote.social} ansehen"
 									class="quote__source"
 									href={quote.source}
 									target="_blank"
@@ -199,7 +199,7 @@
 								<img
 									class="quote__author-avatar"
 									src={quote.avatar}
-									alt="image of {quote.author}"
+									alt="Bild von {quote.author}"
 								/>
 								<div class="stack-v gap-4">
 									<p class="text-15 text-bold quote__author">{quote.author}</p>
@@ -219,7 +219,7 @@
 					<p class="text-15 text-body quote__text">
 						{quote.quote}
 						<a
-							title="View post on {quote.social}"
+							title="Beitrag auf {quote.social} ansehen"
 							class="quote__source"
 							href={quote.source}
 							target="_blank"
@@ -227,7 +227,7 @@
 						>
 					</p>
 					<div class="quote__author-info">
-						<img class="quote__author-avatar" src={quote.avatar} alt="image of {quote.author}" />
+						<img class="quote__author-avatar" src={quote.avatar} alt="Bild von {quote.author}" />
 						<div class="stack-v gap-4">
 							<p class="text-15 text-bold quote__author">{quote.author}</p>
 							<p class="text-13 quote__job-title">{quote.occupation}</p>

--- a/apps/web/src/routes/+error.svelte
+++ b/apps/web/src/routes/+error.svelte
@@ -7,7 +7,7 @@
 	<div class="title">
 		{page.status}
 	</div>
-	<div class="subtitle">Error</div>
+	<div class="subtitle">Fehler</div>
 </section>
 
 <Footer />

--- a/apps/web/src/routes/cli/+page.svelte
+++ b/apps/web/src/routes/cli/+page.svelte
@@ -13,11 +13,11 @@
 
 <Hero currentPage="cli">
 	{#snippet descriptionContent()}
-		A more intuitive Git terminal experience. Stacked branches, unlimited undo, and parallel
-		branches work exactly how you'd expect. Perfect for teams, solo developers or AI-assisted
-		coding.
+		Ein intuitiveres Git-Terminal-Erlebnis. Gestapelte Branches, unbegrenztes Rückgängigmachen und
+		parallele Branches funktionieren genau so, wie du es erwartest. Perfekt für Teams, einzelne
+		Entwickler oder KI-gestütztes Coding.
 		<br /><br />
-		Works with any Git repo. Seamlessly fits your workflow.
+		Funktioniert mit jedem Git-Repo. Fügt sich nahtlos in deinen Workflow ein.
 	{/snippet}
 </Hero>
 <Features />

--- a/apps/web/src/routes/cli/components/CtaButtons.svelte
+++ b/apps/web/src/routes/cli/components/CtaButtons.svelte
@@ -39,7 +39,7 @@
 
 <section class="cta-wrap" class:dark-mode={darkMode}>
 	<button type="button" class="copy-button" class:copied onclick={handleCopy}>
-		<h3>Get the But CLI</h3>
+		<h3>Hol dir die But CLI</h3>
 
 		{#if isLinux && cliBinaryUrl}
 			<code class="subtitle-text">curl -fsSL https://gitbutler.com/install.sh | sh</code>
@@ -48,7 +48,7 @@
 					class="subtitle-link"
 					href={cliBinaryUrl}
 					onclick={(e) => e.stopPropagation()}
-					onmousedown={(e) => e.stopPropagation()}>Download the binary</a
+					onmousedown={(e) => e.stopPropagation()}>Lade die Binärdatei herunter</a
 				>
 				<svg
 					class="subtitle-icon"
@@ -126,7 +126,7 @@
 		</svg>
 
 		<div class="flex items-center gap-16 justify-between">
-			<span>View docs</span>
+			<span>Docs ansehen</span>
 			<svg
 				class="docs-button__arrow"
 				width="22"

--- a/apps/web/src/routes/cli/sections/ComparisonTable.svelte
+++ b/apps/web/src/routes/cli/sections/ComparisonTable.svelte
@@ -2,25 +2,25 @@
 	import SectionHeader from "$home/components/SectionHeader.svelte";
 
 	const features = [
-		{ name: "Stacked branch workflows", git: false, gitbutler: true },
-		{ name: "Work on multiple branches simultaneously", git: false, gitbutler: true },
-		{ name: "Unlimited undo/redo", git: false, gitbutler: true },
-		{ name: "Simple, predictable rebasing", git: false, gitbutler: true },
-		{ name: "Fast worktree management", git: false, gitbutler: true },
-		{ name: "AI agent-friendly commands", git: false, gitbutler: true },
-		{ name: "Make commits", git: true, gitbutler: true },
-		{ name: "Works with Git repositories", git: true, gitbutler: true },
+		{ name: "Gestapelte Branch-Workflows", git: false, gitbutler: true },
+		{ name: "Gleichzeitig an mehreren Branches arbeiten", git: false, gitbutler: true },
+		{ name: "Unbegrenztes Rückgängig/Wiederholen", git: false, gitbutler: true },
+		{ name: "Einfaches, vorhersehbares Rebasing", git: false, gitbutler: true },
+		{ name: "Schnelle Worktree-Verwaltung", git: false, gitbutler: true },
+		{ name: "KI-Agent-freundliche Befehle", git: false, gitbutler: true },
+		{ name: "Commits erstellen", git: true, gitbutler: true },
+		{ name: "Funktioniert mit Git-Repositories", git: true, gitbutler: true },
 	];
 </script>
 
 <section class="comparison-wrapper">
 	<SectionHeader>
-		What <i>But gives you</i> over Git
+		Was <i>But dir bietet</i> gegenüber Git
 	</SectionHeader>
 
 	<div class="comparison-table">
 		<div class="text-16 text-bold table-header">
-			<div class="header-cell feature-header">Feature</div>
+			<div class="header-cell feature-header">Funktion</div>
 			<div class="header-cell">Git</div>
 			<div class="header-cell">GitButler</div>
 		</div>
@@ -96,10 +96,10 @@
 
 	<div class="comparison-description">
 		<p class="text-15 text-body text-center text-balance">
-			GitButler works with your existing Git repositories and remotes.
+			GitButler funktioniert mit deinen bestehenden Git-Repositories und Remotes.
 		</p>
 		<p class="text-15 text-body text-center text-balance">
-			Zero configuration required. It simply layers onto your current workflow.
+			Keine Konfiguration erforderlich. Es legt sich einfach über deinen aktuellen Workflow.
 		</p>
 		<svg
 			class="description-underline"

--- a/apps/web/src/routes/cli/sections/CtaSection.svelte
+++ b/apps/web/src/routes/cli/sections/CtaSection.svelte
@@ -4,12 +4,12 @@
 
 <section class="cta-section">
 	<div class="cta-section__content">
-		<div class="chip-free-opensource text-15 text-semibold">>_ Free and Open Source</div>
-		<h2 class="cta-section__header">Ready to <i>Level Up Your</i> Workflow?</h2>
+		<div class="chip-free-opensource text-15 text-semibold">>_ Kostenlos und Open Source</div>
+		<h2 class="cta-section__header">Bereit, <i>deinen Workflow</i> zu verbessern?</h2>
 		<p class="cta-section__description text-16 text-body">
-			Join thousands of developers who've already made the switch.
+			Schließe dich Tausenden von Entwicklern an, die bereits gewechselt haben.
 			<br />
-			GitButler is compatible with your existing Git repositories.
+			GitButler ist mit deinen bestehenden Git-Repositories kompatibel.
 		</p>
 
 		<CtaButtons darkMode />

--- a/apps/web/src/routes/cli/sections/Features.svelte
+++ b/apps/web/src/routes/cli/sections/Features.svelte
@@ -6,7 +6,7 @@
 
 <section class="cli-features">
 	<SectionHeader>
-		Everything <i>You Wished</i> Git Had
+		Alles, <i>was du dir</i> von Git gewünscht hast
 	</SectionHeader>
 	<Features items={featuresJson} noMargin />
 </section>

--- a/apps/web/src/routes/cli/sections/OptimizedForAgents.svelte
+++ b/apps/web/src/routes/cli/sections/OptimizedForAgents.svelte
@@ -47,12 +47,12 @@
 
 <section class="for-agents">
 	<SectionHeader>
-		Optimized <i>for</i> Coding Agents
+		Optimiert <i>für</i> Coding-Agenten
 	</SectionHeader>
 	<p class="text-16 text-body for-agents__description">
-		GitButler was designed from the ground up to work seamlessly with AI coding agents.
+		GitButler wurde von Grund auf entwickelt, um nahtlos mit KI-Coding-Agenten zu funktionieren.
 		<br />
-		Predictable commands, structured output, and automation-friendly workflows.
+		Vorhersehbare Befehle, strukturierte Ausgabe und automatisierungsfreundliche Workflows.
 	</p>
 	<Features items={AiFeaturesJson} noMargin />
 	<div class="for-agents__terminal">

--- a/apps/web/src/routes/cli/sections/TerminalMockup.svelte
+++ b/apps/web/src/routes/cli/sections/TerminalMockup.svelte
@@ -215,18 +215,18 @@
 	<div class="terminal-mockup__header">
 		{#if os === "macOS"}
 			<div class="terminal-mockup__window-controls">
-				<img src="/images/cli/mac-window-controls.svg" alt="Window controls" />
+				<img src="/images/cli/mac-window-controls.svg" alt="Fenstersteuerung" />
 			</div>
 			<div class="terminal-mockup__title">GitButler CLI</div>
 		{:else if os === "Windows"}
 			<div class="terminal-mockup__title">GitButler CLI</div>
 			<div class="terminal-mockup__window-controls">
-				<img src="/images/cli/windows-window-controls.svg" alt="Window controls" />
+				<img src="/images/cli/windows-window-controls.svg" alt="Fenstersteuerung" />
 			</div>
 		{:else if os === "Linux"}
 			<div class="terminal-mockup__title">GitButler CLI</div>
 			<div class="terminal-mockup__window-controls">
-				<img src="/images/cli/linux-window-controls.svg" alt="Window controls" />
+				<img src="/images/cli/linux-window-controls.svg" alt="Fenstersteuerung" />
 			</div>
 		{/if}
 	</div>

--- a/apps/web/src/routes/downloads/+page.svelte
+++ b/apps/web/src/routes/downloads/+page.svelte
@@ -37,13 +37,13 @@
 			<div class="latest-release__header-labels">
 				<h1>
 					<!-- {latestRelease.version} -->
-					DOWNLOAD <i>the</i> app
+					LADE <i>die</i> App
 				</h1>
 				<div class="latest-release__header-subtitle">
-					<span>{latestRelease.version} Latest release</span>
+					<span>{latestRelease.version} Neueste Version</span>
 					<span> • </span>
 					<span
-						>{new Date(latestRelease.released_at).toLocaleDateString("en-GB", {
+						>{new Date(latestRelease.released_at).toLocaleDateString("de-DE", {
 							day: "numeric",
 							month: "long",
 							year: "numeric",
@@ -77,8 +77,8 @@
 						href={latestReleaseBuilds.darwin_aarch64?.url ?? ""}>Apple Silicon</a
 					>
 					<span class="download-card-subtile"
-						>or <a class="download-card-link" href={latestReleaseBuilds.darwin_x86_64?.url ?? ""}
-							>intel-based</a
+						>oder <a class="download-card-link" href={latestReleaseBuilds.darwin_x86_64?.url ?? ""}
+							>Intel-basiert</a
 						></span
 					>
 				</div>
@@ -121,10 +121,10 @@
 					</div>
 
 					<span class="download-card-small-subtile"
-						>Not working? Have a look at <a
+						>Funktioniert nicht? Wirf einen Blick in <a
 							class="download-card-link"
 							href="https://github.com/gitbutlerapp/gitbutler/blob/master/LINUX.md"
-							target="_blank"><i>our docs</i></a
+							target="_blank"><i>unsere Doku</i></a
 						></span
 					>
 
@@ -140,7 +140,7 @@
 							<a
 								href={linuxArch === "x86-64"
 									? (latestReleaseBuilds.linux_cli_x86_64?.url ?? "")
-									: (latestReleaseBuilds.linux_cli_aarch64?.url ?? "")}>Download CLI binary</a
+									: (latestReleaseBuilds.linux_cli_aarch64?.url ?? "")}>CLI-Binary herunterladen</a
 							>
 						</div>
 					{/if}
@@ -178,8 +178,8 @@
 
 		<div class="nightly-info">
 			<p class="text-14 text-body clr-text-2">
-				Experience GitButler’s newest features before anyone else. ⋆˚₊
-				<a href="/nightly" class="nightly-info__download-link"> Get Nightly </a>
+				Erlebe die neuesten Funktionen von GitButler noch vor allen anderen. ⋆˚₊
+				<a href="/nightly" class="nightly-info__download-link"> Nightly holen </a>
 				☽˚.⋆
 			</p>
 		</div>
@@ -188,7 +188,7 @@
 
 <section class="releases">
 	<h2>
-		Other <i>releases:</i>
+		Weitere <i>Versionen:</i>
 	</h2>
 
 	{#each data.releases.filter((release) => release.version !== latestRelease.version) as release (release.version)}

--- a/apps/web/src/routes/nightly/+page.svelte
+++ b/apps/web/src/routes/nightly/+page.svelte
@@ -28,7 +28,7 @@
 </script>
 
 <svelte:head>
-	<title>GitButler | Nightly Builds</title>
+	<title>GitButler | Nightly-Builds</title>
 </svelte:head>
 
 <section class="latest-nightly-wrapper">
@@ -41,14 +41,14 @@
 				<div class="nightly-hero__header-labels">
 					<h1>{latestNightly.version}</h1>
 					<div class="nightly-hero__header-details">
-						<span>Latest release</span>
+						<span>Neueste Version</span>
 						<span> • </span>
 						<span
-							>{new Date(latestNightly.released_at).toLocaleDateString("en-GB", {
+							>{new Date(latestNightly.released_at).toLocaleDateString("de-DE", {
 								day: "numeric",
 								month: "long",
 								year: "numeric",
-							})} at {new Date(latestNightly.released_at).toLocaleTimeString("en-GB", {
+							})} um {new Date(latestNightly.released_at).toLocaleTimeString("de-DE", {
 								hour: "2-digit",
 								minute: "2-digit",
 								hour12: false,
@@ -65,9 +65,9 @@
 						</a>
 					</div>
 					<p class="nightly-hero__description">
-						Experience GitButler's newest features before anyone else. Nightly builds are
-						automatically generated from the latest development code and may contain experimental
-						features and bugs.
+						Erlebe die neuesten Funktionen von GitButler noch vor allen anderen. Nightly-Builds
+						werden automatisch aus dem aktuellsten Entwicklungscode erzeugt und können
+						experimentelle Funktionen und Fehler enthalten.
 					</p>
 				</div>
 			</div>
@@ -96,8 +96,8 @@
 							href={latestNightlyBuilds.darwin_aarch64?.url ?? ""}>Apple Silicon</a
 						>
 						<span class="download-card-subtile"
-							>or <a class="download-card-link" href={latestNightlyBuilds.darwin_x86_64?.url ?? ""}
-								>intel-based</a
+							>oder <a class="download-card-link" href={latestNightlyBuilds.darwin_x86_64?.url ?? ""}
+								>Intel-basiert</a
 							></span
 						>
 					</div>
@@ -140,10 +140,10 @@
 						</div>
 
 						<span class="download-card-small-subtile"
-							>Not working? Have a look at <a
+							>Funktioniert nicht? Wirf einen Blick in <a
 								class="download-card-link"
 								href="https://github.com/gitbutlerapp/gitbutler/blob/master/LINUX.md"
-								target="_blank"><i>our docs</i></a
+								target="_blank"><i>unsere Doku</i></a
 							></span
 						>
 
@@ -159,7 +159,7 @@
 								<a
 									href={linuxArch === "x86-64"
 										? (latestNightlyBuilds.linux_cli_x86_64?.url ?? "")
-										: (latestNightlyBuilds.linux_cli_aarch64?.url ?? "")}>Download CLI binary</a
+										: (latestNightlyBuilds.linux_cli_aarch64?.url ?? "")}>CLI-Binary herunterladen</a
 								>
 							</div>
 						{/if}
@@ -190,15 +190,15 @@
 			</div>
 
 			<p class="nightly-warning">
-				⚠️ Nightly builds are experimental and may be unstable. Use at your own risk.
+				⚠️ Nightly-Builds sind experimentell und können instabil sein. Nutzung auf eigenes Risiko.
 				<br />
-				For production use, please use the
-				<a href="/downloads">stable release</a>.
+				Für den produktiven Einsatz verwende bitte die
+				<a href="/downloads">stabile Version</a>.
 			</p>
 		</div>
 	{:else}
 		<div class="no-nightly">
-			<p class="text-16 clr-text-2">No nightly builds are currently available.</p>
+			<p class="text-16 clr-text-2">Derzeit sind keine Nightly-Builds verfügbar.</p>
 		</div>
 	{/if}
 </section>
@@ -206,7 +206,7 @@
 {#if otherNightlies.length > 0}
 	<section class="releases">
 		<h2>
-			Other <i>nightly</i> builds:
+			Weitere <i>Nightly</i>-Builds:
 		</h2>
 
 		{#each otherNightlies as release, index (`${release.version}-${release.sha}-${index}`)}
@@ -224,12 +224,12 @@
 						<span class="release-row__version">{release.version}</span>
 						<div class="release-row__info">
 							<span class="release-row__date">
-								{new Date(release.released_at).toLocaleDateString("en-GB", {
+								{new Date(release.released_at).toLocaleDateString("de-DE", {
 									day: "numeric",
 									month: "short",
 									year: "numeric",
 								})},
-								{new Date(release.released_at).toLocaleTimeString("en-GB", {
+								{new Date(release.released_at).toLocaleTimeString("de-DE", {
 									hour: "2-digit",
 									minute: "2-digit",
 									hour12: false,
@@ -241,7 +241,7 @@
 									href="https://github.com/gitbutlerapp/gitbutler/commit/{release.sha}"
 									target="_blank"
 									rel="noopener noreferrer"
-									title="View Commit on GitHub"
+									title="Commit auf GitHub ansehen"
 									class="sha-link"
 									onclick={(e) => e.stopPropagation()}
 								>


### PR DESCRIPTION
## 🧢 Changes

Localises the `apps/web` website to German across all user-facing surfaces (91 files):

- Sets the document language to `de` (`app.html`).
- Translates every hardcoded user-facing string to German — home/marketing, CLI, downloads & nightly, auth/login/signup, profile & settings, dashboard, reviews, rules, and chat.
- Switches date/time formatting from the `en-GB` locale to `de-DE` (6 call sites).
- Leaves code identifiers, URLs, brand names (GitButler, GitHub, etc.), terminal commands, and real-person testimonial quotes untouched.
- Also includes a pre-existing one-line edit to `apps/lite/AGENTS.md` that was already present in the workspace.

## ☕️ Reasoning

Requested change to serve the site in German. Done as an in-place literal translation of the existing hardcoded strings (the app has no i18n framework), so the site is now German-only. `pnpm run check` (svelte-check) passes with 0 errors/0 warnings.