### PR TITLE
Tolerate index conflicts from conflicted uncommitted files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4037,7 +4037,6 @@ dependencies = [
  "but-core",
  "but-ctx",
  "but-meta",
- "but-oxidize",
  "but-schemars",
  "but-serde",
  "but-testsupport",

--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -37,7 +37,7 @@ but commit <branch> -c -m "<msg>" --changes <id>,<id>
 
 ## Non-Negotiable Rules
 
-1. Use `but` for all write operations. Never run `git add`, `git commit`, `git push`, `git checkout`, `git merge`, `git rebase`, `git stash`, or `git cherry-pick`. If the user says a `git` write command, translate it to `but` and run that.
+1. Use `but` for all write operations. Never run `git add`, `git commit`, `git push`, `git checkout`, `git merge`, `git rebase`, `git stash`, or `git cherry-pick`. If the user says a `git` write command, translate it to `but` and run that. Sole exception: `git add -- <path>` to mark a conflicted uncommitted file resolved — see "Conflicts in uncommitted files".
 2. After mutations, read the returned output for the updated workspace state — it replaces a follow-up status command.
 3. You may chain `but commit` mutations with `&&` to make several commits from one diff; they stack in the order you write them, so the first `but commit` is the oldest of the new commits and each later one goes on top (newest). File/hunk IDs copied from the original output generally remain usable across commits, and branch IDs are stable. Do NOT chain mutations that consume or rewrite commit IDs (`amend`, `squash`, `move`, `uncommit`); those reassign IDs the next command needs, so run one, read the returned workspace state, and take fresh IDs from it. If a chained command cannot resolve an ID, re-read with `but status`/`but diff` and retry.
 4. Use CLI IDs from `but diff` / `but status` / `but status -fv` / `but show`; never hardcode IDs.
@@ -228,6 +228,14 @@ If `but move` causes conflicts (conflicted commits in status):
 6. Repeat for any remaining conflicted commits.
 
 **Common mistakes:** Do NOT use `but amend` on conflicted commits (it won't work). Do NOT skip step 4 — you must actually edit the files to remove conflict markers before finishing.
+
+### Conflicts in uncommitted files
+
+`but status` lists uncommitted files with unresolved merge conflicts marked
+`{conflicted}`; they are excluded from committable changes. These conflicts are
+outside `but resolve` mode. Choose the desired contents or delete the file, then
+run `git add -- <path>` to mark it resolved. This is the one case where using
+`git add` is permitted.
 
 ## Git-to-But Map
 

--- a/crates/but/src/command/legacy/status/json.rs
+++ b/crates/but/src/command/legacy/status/json.rs
@@ -31,6 +31,9 @@ use super::StatusContext;
 pub(crate) struct WorkspaceStatus {
     /// Represents uncommitted changes that are not assigned to any stack
     uncommitted_changes: Vec<FileChange>,
+    /// Uncommitted files with unresolved merge conflicts in the index; not committable until resolved.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    conflicted_files: Vec<String>,
     /// The stacks that are applied in the current workspace
     stacks: Vec<Stack>,
     /// The most recent common merge base between all applied stacks and the target upstream branch
@@ -57,12 +60,14 @@ pub(crate) struct UpstreamState {
 impl WorkspaceStatus {
     pub fn new(
         uncommitted_changes: Vec<FileChange>,
+        conflicted_files: Vec<String>,
         stacks: Vec<Stack>,
         merge_base: Commit,
         upstream_state: UpstreamState,
     ) -> Self {
         Self {
             uncommitted_changes,
+            conflicted_files,
             stacks,
             merge_base,
             upstream_state,
@@ -709,6 +714,7 @@ pub(super) fn build_workspace_status_json(
 
     Ok(WorkspaceStatus::new(
         json_uncommitted_changes,
+        status_ctx.conflicted_paths.clone(),
         json_stacks,
         merge_base_commit,
         upstream_state_json,

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -5,7 +5,7 @@ use assignment::FileAssignment;
 use bstr::{BStr, BString, ByteSlice};
 use but_api::diff::ComputeLineStats;
 use but_core::{
-    RepositoryExt, TreeStatus,
+    IgnoredWorktreeTreeChangeStatus, RepositoryExt, TreeStatus,
     ref_metadata::StackId,
     sync::{RepoExclusive, RepoExclusiveGuard},
     ui,
@@ -187,6 +187,8 @@ struct StatusContext<'a> {
     flags: StatusFlags,
     stack_details: Vec<StackEntry>,
     worktree_changes: Vec<ui::TreeChange>,
+    /// Uncommitted files with unresolved merge conflicts in the index; not committable until resolved.
+    conflicted_paths: Vec<String>,
     common_merge_base_data: CommonMergeBase,
     target_tip_id: gix::ObjectId,
     upstream_state: Option<UpstreamState>,
@@ -400,6 +402,15 @@ fn build_status_context<'a>(
     let worktree_changes =
         but_api::diff::changes_in_worktree_with_perm(ctx, true, perm.read_permission())?;
 
+    let mut conflicted_paths: Vec<String> = worktree_changes
+        .worktree_changes
+        .ignored_changes
+        .iter()
+        .filter(|change| matches!(change.status, IgnoredWorktreeTreeChangeStatus::Conflict))
+        .map(|change| change.path.to_string())
+        .collect();
+    conflicted_paths.sort();
+
     let id_map = IdMap::new(stacks, worktree_changes.assignments.clone())?;
 
     let stacks = id_map.stacks();
@@ -527,6 +538,7 @@ fn build_status_context<'a>(
     Ok(StatusContext {
         stack_details,
         worktree_changes: worktree_changes.worktree_changes.changes,
+        conflicted_paths,
         common_merge_base_data,
         target_tip_id,
         upstream_state,
@@ -563,6 +575,7 @@ fn build_status_output(
     let has_merged_upstream_branch = print_worktree_status(ctx, status_ctx, output)?;
     print_upstream_state(ctx, status_ctx, output)?;
     print_common_merge_base_summary(status_ctx, output)?;
+    print_conflicted_files_warning(status_ctx, output)?;
     let not_on_workspace = matches!(
         status_ctx.mode,
         gitbutler_operating_modes::OperatingMode::OutsideWorkspace(_)
@@ -597,6 +610,23 @@ fn print_update_notice(
         output.connector(Vec::from([Span::raw("")]))?;
     }
 
+    Ok(())
+}
+
+/// Print a note on how to deal with the uncommitted files marked `{conflicted}` in the
+/// listing above.
+fn print_conflicted_files_warning(
+    status_ctx: &StatusContext<'_>,
+    output: &mut StatusOutput<'_>,
+) -> anyhow::Result<()> {
+    if status_ctx.conflicted_paths.is_empty() {
+        return Ok(());
+    }
+    let t = crate::theme::get();
+    output.warning(Vec::from([Span::styled(
+        "⚠ Uncommitted file conflicts: choose the desired file state, then run `git add -- <path>`.",
+        t.attention,
+    )]))?;
     Ok(())
 }
 
@@ -1351,7 +1381,7 @@ fn print_group(
             decoration_start: Vec::from([Span::raw(" [")]),
             label: Vec::from([Span::styled("uncommitted", t.info)]),
             decoration_end: Vec::from([Span::raw("]")]),
-            suffix: if assignments.is_empty() {
+            suffix: if assignments.is_empty() && status_ctx.conflicted_paths.is_empty() {
                 Vec::from([Span::raw(" "), Span::styled("(no changes)", t.hint)])
             } else {
                 Vec::new()
@@ -1360,6 +1390,17 @@ fn print_group(
         output.unstaged_changes(Vec::from([Span::raw("╭┄")]), line, cli_id.clone())?;
         if !assignments.is_empty() {
             print_assignments(&repo, status_ctx, None, None, assignments, true, output)?;
+        }
+        for path in &status_ctx.conflicted_paths {
+            output.no_assignments_unstaged(
+                Vec::from([Span::raw("┊"), Span::raw(" "), Span::raw("  ")]),
+                Vec::from([
+                    Span::raw(" "),
+                    Span::raw(path.clone()),
+                    Span::raw(" "),
+                    Span::styled("{conflicted}", t.error),
+                ]),
+            )?;
         }
     }
     if !first {

--- a/crates/but/src/command/legacy/status/output.rs
+++ b/crates/but/src/command/legacy/status/output.rs
@@ -220,7 +220,6 @@ impl StatusOutput<'_> {
         )
     }
 
-    #[expect(dead_code)]
     pub(super) fn no_assignments_unstaged(
         &mut self,
         connector: Vec<Span<'static>>,

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -1156,6 +1156,85 @@ Hint: run `but help` for all commands
 }
 
 #[test]
+fn conflicted_uncommitted_file_is_surfaced() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    // Leave behind what a conflicting workspace update produces for an uncommitted
+    // file: conflict markers in the worktree and unmerged entries in the index.
+    env.file(
+        "conflicted.txt",
+        "<<<<<<< ours\nours\n=======\ntheirs\n>>>>>>> theirs\n",
+    );
+    env.invoke_bash(
+        r#"base=$(echo base | git hash-object -w --stdin) &&
+ours=$(echo ours | git hash-object -w --stdin) &&
+theirs=$(echo theirs | git hash-object -w --stdin) &&
+printf '100644 %s 1\tconflicted.txt\n100644 %s 2\tconflicted.txt\n100644 %s 3\tconflicted.txt\n' "$base" "$ours" "$theirs" | git update-index --index-info"#,
+    );
+
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted]
+┊    conflicted.txt {conflicted}
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+⚠ Uncommitted file conflicts: choose the desired file state, then run `git add -- <path>`.
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    assert_eq!(
+        status_json(&env)?["conflictedFiles"],
+        serde_json::json!(["conflicted.txt"]),
+        "JSON status should list uncommitted files with unresolved index conflicts"
+    );
+
+    // Committing composes the oplog snapshot and the pre-commit hook index swap;
+    // both must tolerate the unmerged index, and the conflict must survive.
+    env.file("other.txt", "unrelated\n");
+    env.but("commit A -m unrelated").assert().success();
+    assert_eq!(
+        env.invoke_git("ls-files --unmerged").lines().count(),
+        3,
+        "the index conflict survives the commit, including the hook index swap"
+    );
+    assert_eq!(
+        env.invoke_git("show --name-only --format= A --"),
+        "other.txt",
+        "the commit contains only the unrelated file, not the conflicted one"
+    );
+
+    // Git already owns index conflict resolution; once marked resolved, the file
+    // becomes an ordinary committable change and the warning disappears.
+    env.file("conflicted.txt", "resolved\n");
+    env.invoke_git("add -- conflicted.txt");
+    assert_eq!(
+        status_json(&env)?["conflictedFiles"],
+        serde_json::Value::Null,
+        "the conflict warning is gone after resolving"
+    );
+    assert!(
+        status_json(&env)?["uncommittedChanges"]
+            .as_array()
+            .is_some_and(|changes| changes
+                .iter()
+                .any(|change| change["filePath"] == "conflicted.txt")),
+        "the resolved file becomes an ordinary committable change"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn status_in_edit_mode_delegates_to_resolve_status() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     enter_edit_mode_with_conflicted_commit(&env)?;

--- a/crates/gitbutler-branch-actions/Cargo.toml
+++ b/crates/gitbutler-branch-actions/Cargo.toml
@@ -61,6 +61,7 @@ but-schemars = { workspace = true, optional = true }
 
 [dev-dependencies]
 but-askpass.workspace = true
+git2.workspace = true
 pretty_assertions = "1.4"
 but-graph.workspace = true
 but-testsupport.workspace = true

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/oplog.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/oplog.rs
@@ -5,6 +5,9 @@
 
 use std::{io::Write, path::Path};
 
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt as _;
+
 use bstr::ByteSlice as _;
 use but_core::{GitConfigSettings, RepositoryExt as _};
 use gitbutler_branch::BranchCreateRequest;
@@ -141,6 +144,118 @@ fn restore_snapshot_reverts_the_target() -> anyhow::Result<()> {
         "undoing a base-branch switch reverts the target everywhere, not just in the TOML"
     );
     Ok(())
+}
+
+#[test]
+fn snapshot_creation_works_with_unmerged_index() -> anyhow::Result<()> {
+    let Test { repo, ctx, .. } = &mut Test::default();
+    configure_default_target(ctx)?;
+
+    // Simulate what a workspace update leaves behind when an uncommitted file
+    // conflicts: conflict markers in the worktree and unmerged entries in the index.
+    // `deleted.txt` has no 'ours' stage, as when the local side deleted the file.
+    let (base_blob, ours_blob, theirs_blob) = {
+        let git2_repo = ctx.git2_repo.get()?;
+        let ours_blob = git2_repo.blob(b"ours\n")?;
+        let base_blob = git2_repo.blob(b"base\n")?;
+        let theirs_blob = git2_repo.blob(b"theirs\n")?;
+        let mut index = git2_repo.index()?;
+        for (path, stage, blob) in [
+            ("conflicted.txt", 1, base_blob),
+            ("conflicted.txt", 2, ours_blob),
+            ("conflicted.txt", 3, theirs_blob),
+            ("deleted.txt", 1, base_blob),
+            ("deleted.txt", 3, theirs_blob),
+            ("df", 2, ours_blob),
+            ("df/child", 3, theirs_blob),
+        ] {
+            index.add(&conflict_index_entry(path, stage, blob))?;
+        }
+        #[cfg(unix)]
+        for (stage, blob) in [(1, base_blob), (2, ours_blob), (3, theirs_blob)] {
+            index.add(&conflict_index_entry(b"invalid-\xff.txt", stage, blob))?;
+        }
+        index.write()?;
+        (base_blob, ours_blob, theirs_blob)
+    };
+    fs::write(
+        repo.path().join("conflicted.txt"),
+        "<<<<<<< ours\nours\n||||||| base\nbase\n=======\ntheirs\n>>>>>>> theirs\n",
+    )?;
+
+    let mut guard = ctx.exclusive_worktree_access();
+    let snapshot_id = ctx.create_snapshot(
+        SnapshotDetails::new(OperationKind::OnDemandSnapshot),
+        guard.write_permission(),
+    )?;
+
+    {
+        let git2_repo = ctx.git2_repo.get()?;
+        let mut index = git2_repo.index()?;
+        index.clear()?;
+        index.write()?;
+        assert!(
+            !index.has_conflicts(),
+            "the conflict is cleared before restore"
+        );
+    }
+    ctx.restore_snapshot(
+        snapshot_id,
+        RestoreKind::RestoreFromSnapshotViaUndo,
+        guard.write_permission(),
+    )?;
+
+    let index = ctx.git2_repo.get()?.index()?;
+    for (path, stage, expected) in [
+        ("conflicted.txt", 1, base_blob),
+        ("conflicted.txt", 2, ours_blob),
+        ("conflicted.txt", 3, theirs_blob),
+        ("deleted.txt", 1, base_blob),
+        ("deleted.txt", 3, theirs_blob),
+        ("df", 2, ours_blob),
+        ("df/child", 3, theirs_blob),
+    ] {
+        assert_eq!(
+            index.get_path(Path::new(path), stage).map(|entry| entry.id),
+            Some(expected),
+            "restore preserves stage {stage} for {path}"
+        );
+    }
+    assert!(
+        index.get_path(Path::new("deleted.txt"), 2).is_none(),
+        "restore preserves the missing ours stage for a local deletion"
+    );
+    #[cfg(unix)]
+    {
+        let path = Path::new(std::ffi::OsStr::from_bytes(b"invalid-\xff.txt"));
+        for (stage, expected) in [(1, base_blob), (2, ours_blob), (3, theirs_blob)] {
+            assert_eq!(
+                index.get_path(path, stage).map(|entry| entry.id),
+                Some(expected),
+                "restore preserves non-UTF-8 conflict paths at stage {stage}"
+            );
+        }
+    }
+    Ok(())
+}
+
+fn conflict_index_entry(path: impl AsRef<[u8]>, stage: u16, blob: git2::Oid) -> git2::IndexEntry {
+    let path = path.as_ref();
+    let path_len = path.len().min(0x0fff) as u16;
+    git2::IndexEntry {
+        ctime: git2::IndexTime::new(0, 0),
+        mtime: git2::IndexTime::new(0, 0),
+        dev: 0,
+        ino: 0,
+        mode: 0o100644,
+        uid: 0,
+        gid: 0,
+        file_size: 0,
+        id: blob,
+        flags: stage << 12 | path_len,
+        flags_extended: 0,
+        path: path.into(),
+    }
 }
 
 fn wd_file_count(worktree_dir: &&Path) -> anyhow::Result<usize> {

--- a/crates/gitbutler-oplog/Cargo.toml
+++ b/crates/gitbutler-oplog/Cargo.toml
@@ -16,7 +16,6 @@ export-schema = ["dep:schemars", "dep:but-schemars"]
 but-meta = { workspace = true, features = ["legacy"] }
 but-serde = { workspace = true, features = ["legacy"]}
 but-core.workspace = true
-but-oxidize.workspace = true
 but-utils.workspace = true
 but-ctx = { workspace = true }
 but-schemars = { workspace = true, optional = true }

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, hash_map::Entry},
+    collections::{BTreeSet, HashMap, hash_map::Entry},
     fs,
     str::{FromStr, from_utf8},
 };
@@ -11,14 +11,18 @@ use but_ctx::{
     access::{RepoExclusive, RepoShared},
 };
 use but_meta::virtual_branches_legacy_types::VirtualBranches;
-use but_oxidize::{ObjectIdExt as _, OidExt};
 use gitbutler_cherry_pick::GixRepositoryExt as _;
 use gitbutler_repo::{
     SignaturePurpose, commit_ids_excluding_reachable_from_with_graph, commit_without_signature_gix,
     signature_gix,
 };
 use gix::objs::Write as _;
-use gix::{ObjectId, bstr::ByteSlice, object::tree::EntryKind};
+use gix::{
+    ObjectId,
+    bstr::ByteSlice,
+    index::entry::{Flags, Stage},
+    object::tree::EntryKind,
+};
 use tracing::instrument;
 
 use super::{
@@ -40,6 +44,7 @@ const AUTO_TRACK_LIMIT_BYTES: u64 = 0;
 /// .
 /// ├── conflicts/…
 /// ├── index/
+/// ├── index-conflicts/…
 /// ├── target_tree/…
 /// ├── virtual_branches
 /// │   └── [branch-id]
@@ -318,22 +323,111 @@ fn get_workdir_tree(
     }
 }
 
-fn write_index_tree(ctx: &Context) -> Result<gix::ObjectId> {
-    #[expect(deprecated, reason = "index materialization boundary")]
-    let git2_repo = ctx.git2_repo.get()?;
-    let mut index = git2_repo.index()?;
-    Ok(index.write_tree()?.to_gix())
+struct IndexTrees {
+    index: gix::ObjectId,
+    conflicts: Option<gix::ObjectId>,
 }
 
-fn reset_index_to_tree(ctx: &Context, tree_id: gix::ObjectId) -> Result<()> {
-    #[expect(deprecated, reason = "index materialization boundary")]
-    let git2_repo = ctx.git2_repo.get()?;
-    let tree = git2_repo
-        .find_tree(tree_id.to_git2())
-        .context("failed to convert index tree entry to tree")?;
-    let mut index = git2_repo.index()?;
-    index.read_tree(&tree)?;
-    index.write()?;
+fn write_index_trees(ctx: &Context) -> Result<IndexTrees> {
+    let repo = ctx.repo.get()?;
+    let index = repo.index_or_empty()?;
+    // The detached editor writes trees without checking that each entry's blob exists
+    // locally, which it may not, e.g. for unfetched files in a partial clone with a
+    // sparse checkout.
+    let mut tree = repo.empty_tree().edit()?.detach();
+    let mut conflicts = repo.empty_tree().edit()?.detach();
+    let mut has_conflicts = false;
+    for entry in index.entries() {
+        let stage = entry.stage();
+        let mode = entry.mode.to_tree_entry_mode().with_context(|| {
+            format!(
+                "index entry {} has no tree representation",
+                entry.path(&index)
+            )
+        })?;
+        if stage != Stage::Unconflicted {
+            has_conflicts = true;
+            let mut conflict_path = Vec::with_capacity(entry.path(&index).len() + 2);
+            conflict_path.push(b'0' + stage as u8);
+            conflict_path.push(b'/');
+            conflict_path.extend_from_slice(entry.path(&index));
+            conflicts.upsert(
+                conflict_path.as_bstr().split_str("/"),
+                mode.kind(),
+                entry.id,
+            )?;
+        }
+        // Unmerged entries (e.g. a conflict in an uncommitted file left by a workspace
+        // update) cannot be represented in a tree. Keep the side with the local changes
+        // ('ours', stage 2, absent when locally deleted); the worktree file with conflict
+        // markers is captured in the snapshot's `worktree` tree.
+        if !matches!(stage, Stage::Unconflicted | Stage::Ours) {
+            continue;
+        }
+        tree.upsert(entry.path(&index).split_str("/"), mode.kind(), entry.id)?;
+    }
+    Ok(IndexTrees {
+        index: tree.write(|tree| repo.write_object(tree).map(|id| id.detach()))?,
+        conflicts: has_conflicts
+            .then(|| conflicts.write(|tree| repo.write_object(tree).map(|id| id.detach())))
+            .transpose()?,
+    })
+}
+
+fn reset_index_to_tree(
+    ctx: &Context,
+    tree_id: gix::ObjectId,
+    conflicts_tree_id: Option<gix::ObjectId>,
+) -> Result<()> {
+    let repo = ctx.repo.get()?;
+    let tree = repo.find_tree(tree_id)?;
+    let mut index = repo.index_from_tree(&tree.id())?;
+    if let Some(conflicts_tree_id) = conflicts_tree_id {
+        restore_index_conflicts(&mut index, repo.find_tree(conflicts_tree_id)?.id())?;
+    }
+    index.write(Default::default())?;
+    // Keep the legacy libgit2 handle in sync with the index written through gix.
+    #[expect(deprecated, reason = "index cache compatibility boundary")]
+    ctx.git2_repo.get()?.index()?.read(true)?;
+    Ok(())
+}
+
+#[expect(clippy::indexing_slicing)]
+fn restore_index_conflicts(index: &mut gix::index::State, conflict_tree: gix::Id) -> Result<()> {
+    let conflict_tree = conflict_tree.object()?.try_into_tree()?;
+    let mut recorder = gix::traverse::tree::Recorder::default();
+    conflict_tree.traverse().depthfirst(&mut recorder)?;
+
+    let mut to_remove = BTreeSet::new();
+    for record in &recorder.records {
+        if record.mode.is_tree() {
+            continue;
+        }
+        let path = &record.filepath;
+        let slash = path
+            .find_byte(b'/')
+            .context("BUG: expecting <stage>/<path>")?;
+        let stage = match &path[..slash] {
+            b"1" => Stage::Base,
+            b"2" => Stage::Ours,
+            b"3" => Stage::Theirs,
+            stage => bail!("Invalid conflict stage '{}'", stage.as_bstr()),
+        };
+        let path = path[slash + 1..].as_bstr();
+
+        index.dangerously_push_entry(
+            Default::default(),
+            record.oid,
+            Flags::from_stage(stage),
+            record.mode.into(),
+            path,
+        );
+        to_remove.insert(path);
+    }
+    index.remove_entries(|_idx, path, entry| {
+        entry.flags.stage() == Stage::Unconflicted && to_remove.contains(path)
+    });
+    index.sort_entries();
     Ok(())
 }
 
@@ -467,11 +561,14 @@ fn prepare_snapshot_with_target(
     let mut graph = repo.revision_graph(commit_graph_cache.as_ref());
 
     // write out the index as a tree to store
-    let index_tree_id = write_index_tree(ctx)?;
+    let index_trees = write_index_trees(ctx)?;
 
     // start building our snapshot tree
     let mut snapshot_tree = repo.empty_tree().edit()?;
-    snapshot_tree.upsert("index", EntryKind::Tree, index_tree_id)?;
+    snapshot_tree.upsert("index", EntryKind::Tree, index_trees.index)?;
+    if let Some(conflicts) = index_trees.conflicts {
+        snapshot_tree.upsert("index-conflicts", EntryKind::Tree, conflicts)?;
+    }
     snapshot_tree.upsert("target_tree", EntryKind::Tree, target_tree_id)?;
     snapshot_tree.upsert("conflicts", EntryKind::Tree, conflicts_tree_id)?;
     snapshot_tree.upsert("virtual_branches", EntryKind::Tree, empty_tree_id)?;
@@ -765,8 +862,11 @@ fn restore_snapshot(
     // reset the repo index to our index tree
     let index_tree_entry = snapshot_tree
         .lookup_entry_by_path("index")?
-        .context("failed to get virtual_branches.toml blob")?;
-    reset_index_to_tree(ctx, index_tree_entry.id().detach())?;
+        .context("failed to get index tree")?;
+    let index_conflicts_tree_id = snapshot_tree
+        .lookup_entry_by_path("index-conflicts")?
+        .map(|entry| entry.id().detach());
+    reset_index_to_tree(ctx, index_tree_entry.id().detach(), index_conflicts_tree_id)?;
 
     let restored_operation = snapshot_commit
         .message_raw()?

--- a/crates/gitbutler-repo/src/hooks.rs
+++ b/crates/gitbutler-repo/src/hooks.rs
@@ -4,14 +4,14 @@ use std::{
     process::Stdio,
 };
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use bstr::ByteSlice;
 use but_ctx::Context;
 use but_oxidize::ObjectIdExt;
 use git2_hooks::{self, HookResult as H, HookRunResponse};
 use serde::Serialize;
 
-use crate::{managed_hooks::get_hooks_dir, staging};
+use crate::managed_hooks::get_hooks_dir;
 
 #[derive(Serialize, PartialEq, Debug, Clone)]
 pub struct MessageData {
@@ -84,44 +84,121 @@ pub fn commit_msg(ctx: &Context, mut message: String) -> Result<MessageHookResul
 pub fn pre_commit_with_tree(ctx: &Context, tree_id: gix::ObjectId) -> Result<HookResult> {
     #[expect(deprecated, reason = "libgit2 hook/index adapter boundary")]
     let repo = &*ctx.git2_repo.get()?;
-    let original_tree = repo.index()?.write_tree()?;
+    // Back up the index file byte for byte; a round-trip through a tree would fail
+    // on an index with unmerged entries (a conflict in an uncommitted file) and
+    // could not bring those entries back. A sibling file copy keeps memory flat and
+    // lets the restore be a single atomic rename that also keeps the permissions.
+    let index_path = repo
+        .index()?
+        .path()
+        .context("repository index has no backing file")?
+        .to_owned();
+    let backup_path = index_path.with_extension("gitbutler-hook-backup");
+    let backup_tmp_path = index_path.with_extension("gitbutler-hook-backup.tmp");
+    let mut transaction_lock =
+        but_core::sync::LockFile::open(index_path.with_extension("gitbutler-hook-lock"))
+            .context("failed to open pre-commit index lock")?;
+    if !transaction_lock
+        .try_lock()
+        .context("failed to lock the index for a pre-commit hook")?
+    {
+        anyhow::bail!("another pre-commit hook is already using the repository index");
+    }
+    match std::fs::symlink_metadata(&backup_path) {
+        Ok(_) => anyhow::bail!(
+            "stale pre-commit index backup at '{}'; restore it to '{}' before retrying",
+            backup_path.display(),
+            index_path.display()
+        ),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => return Err(err).context("failed to inspect pre-commit index backup"),
+    }
+    match std::fs::remove_file(&backup_tmp_path) {
+        Ok(()) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => return Err(err).context("failed to remove stale temporary index backup"),
+    }
+    let had_index = match std::fs::copy(&index_path, &backup_tmp_path) {
+        Ok(_) => {
+            std::fs::rename(&backup_tmp_path, &backup_path)
+                .context("failed to finalize pre-commit index backup")?;
+            true
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => false,
+        Err(err) => return Err(err).context("failed to back up index for pre-commit hook"),
+    };
 
-    // Scope guard that resets the index at the end, even under panic.
-    let _guard = scopeguard::guard((), |_| {
-        match staging::reset_index(repo, original_tree) {
-            Ok(()) => (),
-            Err(err) => tracing::error!("Failed to reset index: {}", err),
-        };
+    // Panic fallback; normal restoration below can report failures to the caller.
+    let guard = scopeguard::guard((), |_| {
+        if let Err(err) = restore_index(repo, &index_path, &backup_path, had_index) {
+            tracing::error!("Failed to reset index: {}", err);
+        }
     });
 
-    let mut index = repo.index()?;
-    index.read_tree(&repo.find_tree(tree_id.to_git2())?)?;
-    index.write()?;
+    let hook_result = (|| -> Result<HookResult> {
+        {
+            let mut index = repo.index()?;
+            index.read_tree(&repo.find_tree(tree_id.to_git2())?)?;
+            index.write()?;
+        }
 
-    Ok(
-        match git2_hooks::hooks_pre_commit(repo, husky_search_paths(ctx))? {
-            H::NoHookFound => HookResult::NotConfigured,
-            H::Run(HookRunResponse {
-                stdout,
-                stderr,
-                code,
-                ..
-            }) => {
-                if code == 0 {
-                    HookResult::Success
-                } else {
-                    // If the output contains GITBUTLER_ERROR, it's our managed hook blocking
-                    // commits on gitbutler/workspace - this is expected behavior, not a failure
-                    if stdout.contains("GITBUTLER_ERROR") || stderr.contains("GITBUTLER_ERROR") {
+        Ok(
+            match git2_hooks::hooks_pre_commit(repo, husky_search_paths(ctx))? {
+                H::NoHookFound => HookResult::NotConfigured,
+                H::Run(HookRunResponse {
+                    stdout,
+                    stderr,
+                    code,
+                    ..
+                }) => {
+                    if code == 0 {
                         HookResult::Success
                     } else {
-                        let error = join_output(stdout, stderr, Some(code));
-                        HookResult::Failure(ErrorData { error })
+                        // If the output contains GITBUTLER_ERROR, it's our managed hook blocking
+                        // commits on gitbutler/workspace - this is expected behavior, not a failure
+                        if stdout.contains("GITBUTLER_ERROR") || stderr.contains("GITBUTLER_ERROR")
+                        {
+                            HookResult::Success
+                        } else {
+                            let error = join_output(stdout, stderr, Some(code));
+                            HookResult::Failure(ErrorData { error })
+                        }
                     }
                 }
+            },
+        )
+    })();
+
+    if let Err(err) = restore_index(repo, &index_path, &backup_path, had_index) {
+        drop(guard); // Retry once through the fallback before returning the original error.
+        return Err(err);
+    }
+    scopeguard::ScopeGuard::into_inner(guard);
+    hook_result
+}
+
+fn restore_index(
+    repo: &git2::Repository,
+    index_path: &Path,
+    backup_path: &Path,
+    had_index: bool,
+) -> Result<()> {
+    if had_index {
+        std::fs::rename(backup_path, index_path).context("failed to restore pre-commit index")?;
+        // Refresh the in-memory index from the restored file.
+        repo.index()?
+            .read(true)
+            .context("failed to reload restored pre-commit index")?;
+    } else {
+        match std::fs::remove_file(index_path) {
+            Err(err) if err.kind() != std::io::ErrorKind::NotFound => {
+                return Err(err).context("failed to remove temporary pre-commit index");
             }
-        },
-    )
+            _ => {}
+        }
+        repo.index()?.clear()?;
+    }
+    Ok(())
 }
 
 pub fn post_commit(ctx: &Context) -> Result<HookResult> {

--- a/crates/gitbutler-repo/src/lib.rs
+++ b/crates/gitbutler-repo/src/lib.rs
@@ -16,7 +16,6 @@ pub use repository_ext::{commit_with_signature_gix, commit_without_signature_gix
 pub mod hooks;
 pub mod managed_hooks;
 mod remote;
-pub mod staging;
 
 pub mod commit_message;
 

--- a/crates/gitbutler-repo/src/staging.rs
+++ b/crates/gitbutler-repo/src/staging.rs
@@ -1,9 +1,0 @@
-use anyhow::Result;
-use git2::Repository;
-
-pub fn reset_index(repo: &Repository, tree_id: git2::Oid) -> Result<()> {
-    let mut index = repo.index()?;
-    let tree = repo.find_tree(tree_id)?;
-    index.read_tree(&tree)?;
-    Ok(index.write()?)
-}

--- a/crates/gitbutler-repo/tests/repo/hooks.rs
+++ b/crates/gitbutler-repo/tests/repo/hooks.rs
@@ -1,10 +1,101 @@
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
 
 use crate::support::RepoWithOrigin;
+use but_ctx::{Context, RepoOpenMode};
+use but_settings::AppSettings;
 use but_testsupport::open_repo;
-use gitbutler_repo::hooks::{HookResult, pre_push};
+use gitbutler_repo::hooks::{HookResult, pre_commit_with_tree, pre_push};
+
+fn context_for_repo(workdir: &Path) -> Context {
+    let project = gitbutler_project::Project::new_for_gitbutler_repo(workdir.to_path_buf());
+    Context::new_from_legacy_project_and_settings_with_repo_open_mode(
+        &project,
+        AppSettings::default(),
+        RepoOpenMode::Isolated,
+    )
+    .expect("can create context")
+    .with_memory_app_cache()
+}
+
+#[test]
+fn pre_commit_refuses_to_overwrite_stale_index_backup() -> anyhow::Result<()> {
+    let test_project = RepoWithOrigin::default();
+    let workdir = test_project.local_repo.workdir().expect("non-bare");
+    let ctx = context_for_repo(workdir);
+    let index_path = ctx.gitdir.join("index");
+    let backup_path = index_path.with_extension("gitbutler-hook-backup");
+    let original_index = fs::read(&index_path)?;
+    fs::write(&backup_path, b"stale backup")?;
+    let tree_id = ctx.repo.get()?.head_tree_id_or_empty()?.detach();
+
+    let err = pre_commit_with_tree(&ctx, tree_id).expect_err("stale backup must stop the hook");
+
+    assert!(
+        err.to_string().contains("stale pre-commit index backup"),
+        "unexpected error: {err:#}"
+    );
+    assert_eq!(
+        fs::read(&backup_path)?,
+        b"stale backup",
+        "stale backup must be preserved"
+    );
+    assert_eq!(
+        fs::read(&index_path)?,
+        original_index,
+        "index must remain untouched"
+    );
+    Ok(())
+}
+
+#[test]
+fn pre_commit_refuses_a_concurrent_index_swap() -> anyhow::Result<()> {
+    let test_project = RepoWithOrigin::default();
+    let workdir = test_project.local_repo.workdir().expect("non-bare");
+    let ctx = context_for_repo(workdir);
+    let mut lock = but_core::sync::LockFile::open(
+        ctx.gitdir
+            .join("index")
+            .with_extension("gitbutler-hook-lock"),
+    )?;
+    lock.lock()?;
+    let tree_id = ctx.repo.get()?.head_tree_id_or_empty()?.detach();
+
+    let err = pre_commit_with_tree(&ctx, tree_id).expect_err("concurrent swap must be rejected");
+
+    assert!(
+        err.to_string()
+            .contains("another pre-commit hook is already using the repository index"),
+        "unexpected error: {err:#}"
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn pre_commit_propagates_index_restore_failure() -> anyhow::Result<()> {
+    let test_project = RepoWithOrigin::default();
+    let workdir = test_project.local_repo.workdir().expect("non-bare");
+    let ctx = context_for_repo(workdir);
+    let hook_path = ctx.gitdir.join("hooks/pre-commit");
+    fs::write(
+        &hook_path,
+        "#!/bin/sh\nrm -f \"$(git rev-parse --git-path index).gitbutler-hook-backup\"\n",
+    )?;
+    fs::set_permissions(&hook_path, fs::Permissions::from_mode(0o755))?;
+    let tree_id = ctx.repo.get()?.head_tree_id_or_empty()?.detach();
+
+    let err = pre_commit_with_tree(&ctx, tree_id).expect_err("restore failure must be returned");
+
+    assert!(
+        err.to_string()
+            .contains("failed to restore pre-commit index"),
+        "unexpected error: {err:#}"
+    );
+    Ok(())
+}
 
 #[test]
 fn pre_push_hook_not_configured() -> anyhow::Result<()> {


### PR DESCRIPTION
## Problem

A user reported that entering conflict resolution mode failed with:

```
Failed to prepare snapshot

Caused by:
    1: cannot create a tree from a not fully merged index.; class=Index (10); code=Unmerged (-10)
```

`but teardown` failed the same way, in both the Desktop app and the CLI.

The state behind it: when a workspace update replays uncommitted changes and they conflict, GitButler writes conflict markers into the file and unmerged (stage 1/2/3) entries into `.git/index`. From that moment, one conflicted uncommitted file locks the user out of most of the app:

- Every snapshot-taking operation fails — entering edit/resolve mode, `but undo`, `but teardown`, and the automatic snapshots taken around normal operations. The oplog writes the index as a tree, which libgit2 refuses while entries are unmerged.
- `but commit` fails with the same error, even when no hook script is installed, because the pre-commit hook path also round-trips the index through a tree.
- Nothing explains why: the conflicted file is silently excluded from committable changes, so the only clue is the cryptic libgit2 error above.

The operations a user would reach for to get out of this state are exactly the ones that break.

## Fix

- **oplog**: snapshots now preserve the local side in the index tree and store every unmerged stage separately, so restore recreates the conflict exactly (including local deletions). The worktree file with its markers is captured too. This uses gix's detached tree editor so partial clones with unfetched blobs keep working.
- **pre-commit hooks**: the index is backed up and restored byte-for-byte (atomically, preserving permissions) instead of through a tree. This also preserves the conflict entries exactly across the hook run, which the tree round-trip never could.
- **`but status`** now lists the conflicted files, guides users to edit them and run `git add -- <path>`, and exposes them as `conflictedFiles` in JSON. The bundled agent skill documents this exception outside `but resolve` mode.

With this, a user in the reported state can resolve conflicted commits, commit unrelated work, undo, and tear down — while the conflicted file stays clearly called out until they resolve it.

Surfacing conflicted files in the Desktop UI is a follow-up.

