### PR TITLE
feat: register managed hooks via git config on git 2.54+

### DIFF
--- a/crates/but/src/command/legacy/setup.rs
+++ b/crates/but/src/command/legacy/setup.rs
@@ -21,6 +21,14 @@ struct SetupResult {
     project_status: ProjectStatus,
     /// The target branch configuration
     target: Option<TargetInfo>,
+    /// Hook installation problems; when non-empty, some GitButler hooks are not
+    /// installed and direct commits to the workspace branch may go unblocked.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    hook_warnings: Vec<String>,
+    /// Hook installation was skipped via `gitbutler.installHooks=false`, so
+    /// commits to the workspace branch are not blocked.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    hooks_skipped: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -424,24 +432,53 @@ pub(crate) fn repo(
         but_api::legacy::virtual_branches::switch_back_to_workspace_with_perm(ctx, perm)?;
     }
 
-    // Install managed hooks to prevent accidental git commits
-    if let Ok(repo) = ctx.repo.get()
-        && let Err(e) = gitbutler_repo::managed_hooks::install_managed_hooks(&repo)
-        && let Some(out) = out.for_human()
-    {
-        writeln!(
-            out,
-            "  {}",
-            t.attention.paint(format!(
-                "Warning: Failed to install GitButler managed hooks: {e}"
-            ))
-        )?;
+    // Install managed hooks to prevent accidental git commits. Partial
+    // successes matter as much as hard errors here: they mean some hook could
+    // not be installed or cleaned up, so tell the user instead of dropping
+    // the warnings.
+    let mut hooks_skipped = false;
+    let mut hook_warnings = Vec::new();
+    if let Ok(repo) = ctx.repo.get() {
+        hook_warnings = match gitbutler_repo::managed_hooks::install_managed_hooks(&repo) {
+            Ok(gitbutler_repo::managed_hooks::HookInstallationResult::PartialSuccess {
+                warnings,
+            }) => warnings,
+            Ok(gitbutler_repo::managed_hooks::HookInstallationResult::SkippedByConfig) => {
+                hooks_skipped = true;
+                Vec::new()
+            }
+            Ok(_) => Vec::new(),
+            Err(e) => vec![format!("Failed to install GitButler managed hooks: {e}")],
+        };
+        if let Some(out) = out.for_human() {
+            for problem in &hook_warnings {
+                writeln!(
+                    out,
+                    "  {}",
+                    t.attention.paint(format!("Warning: {problem}"))
+                )?;
+            }
+            if hooks_skipped {
+                writeln!(
+                    out,
+                    "  {}",
+                    t.attention.paint(
+                        "Note: Skipped Git hook installation (gitbutler.installHooks=false). Commits made directly to the workspace branch will not be blocked."
+                    )
+                )?;
+            }
+        }
     }
 
     // if we switched - tell the user what this is all about
     if pre_head_name != "gitbutler/workspace"
         && let Some(out) = out.for_human()
     {
+        let hooks_note = if hooks_skipped {
+            "- Skipping Git hooks (disabled via gitbutler.installHooks)"
+        } else {
+            "- Installing Git hooks to help manage commits on the workspace branch"
+        };
         writeln!(
             out,
             "{}",
@@ -450,7 +487,7 @@ pub(crate) fn repo(
 Setting up your project for GitButler tooling. Some things to note:
 
 - Switching you to a special `gitbutler/workspace` branch to enable parallel branches
-- Installing Git hooks to help manage commits on the workspace branch
+{hooks_note}
 
 To undo these changes and return to normal Git mode, either:
 
@@ -474,6 +511,8 @@ More info: https://docs.gitbutler.com/workspace-branch
             repository_path: path::absolute(repo_path)?.display().to_string(),
             project_status,
             target: target_info,
+            hook_warnings,
+            hooks_skipped,
         };
         json_out.write_value(&result)?;
     }

--- a/crates/but/src/command/legacy/teardown.rs
+++ b/crates/but/src/command/legacy/teardown.rs
@@ -15,6 +15,10 @@ use crate::{
 struct TeardownResult {
     snapshot_id: String,
     checked_out_branch: String,
+    /// Hook cleanup problems; when non-empty, some GitButler hooks are still
+    /// installed and may keep affecting git operations.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    hook_warnings: Vec<String>,
 }
 
 pub(crate) fn teardown(
@@ -156,17 +160,27 @@ pub(crate) fn teardown(
         writeln!(out)?;
     }
 
-    // Uninstall managed hooks before checking out
-    if let Ok(repo) = ctx.repo.get()
-        && let Err(e) = gitbutler_repo::managed_hooks::uninstall_managed_hooks(&repo)
-        && let Some(out) = out.for_human()
-    {
-        writeln!(
-            out,
-            "  {}",
-            t.attention
-                .paint(format!("Warning: Failed to uninstall Git hooks: {e}"))
-        )?;
+    // Uninstall managed hooks before checking out. `uninstall_managed_hooks`
+    // reports removal failures as PartialSuccess warnings rather than Err, so
+    // surface those too -- they mean GitButler hooks are still active.
+    let mut hook_warnings = Vec::new();
+    if let Ok(repo) = ctx.repo.get() {
+        hook_warnings = match gitbutler_repo::managed_hooks::uninstall_managed_hooks(&repo) {
+            Ok(gitbutler_repo::managed_hooks::HookInstallationResult::PartialSuccess {
+                warnings,
+            }) => warnings,
+            Ok(_) => Vec::new(),
+            Err(e) => vec![format!("Failed to uninstall Git hooks: {e}")],
+        };
+        if let Some(out) = out.for_human() {
+            for problem in &hook_warnings {
+                writeln!(
+                    out,
+                    "  {}",
+                    t.attention.paint(format!("Warning: {problem}"))
+                )?;
+            }
+        }
     }
 
     // Check out the target branch using Git directly
@@ -228,11 +242,21 @@ pub(crate) fn teardown(
 
     // Final success message
     if let Some(out) = out.for_human() {
-        writeln!(
-            out,
-            "{}",
-            t.success.paint("✓ Successfully exited GitButler mode!")
-        )?;
+        if hook_warnings.is_empty() {
+            writeln!(
+                out,
+                "{}",
+                t.success.paint("✓ Successfully exited GitButler mode!")
+            )?;
+        } else {
+            writeln!(
+                out,
+                "{}",
+                t.attention.paint(
+                    "⚠ Exited GitButler mode, but some GitButler hooks could not be removed (see warnings above)."
+                )
+            )?;
+        }
         writeln!(out)?;
         writeln!(
             out,
@@ -251,6 +275,7 @@ pub(crate) fn teardown(
         out.write_value(&TeardownResult {
             snapshot_id,
             checked_out_branch: target_branch_name,
+            hook_warnings: hook_warnings.clone(),
         })?;
     }
 

--- a/crates/but/tests/but/command/setup.rs
+++ b/crates/but/tests/but/command/setup.rs
@@ -730,3 +730,119 @@ Learn more at https://docs.gitbutler.com/cli-overview
 
 "#]]);
 }
+
+/// When the user opted out of hooks via `gitbutler.installHooks=false`, setup
+/// must say hook installation was skipped instead of claiming hooks are being
+/// installed while direct commits to the workspace branch go unguarded.
+#[test]
+fn setup_with_hooks_opted_out_says_so() {
+    let env = Sandbox::open_with_default_settings("repo-no-remote");
+    env.invoke_git("config --local gitbutler.installHooks false");
+
+    env.but("setup")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+Setting up GitButler project...
+
+→ Adding repository to GitButler project registry
+  ✓ Repository already in project registry
+
+→ Configuring default target branch
+  No push remote found, creating gb-local remote...
+  ✓ Created gb-local remote tracking main
+  ✓ Set default target to: gb-local/main
+
+GitButler project setup complete!
+Target branch: gb-local/main
+Remote: gb-local
+
+  Note: Skipped Git hook installation (gitbutler.installHooks=false). Commits made directly to the workspace branch will not be blocked.
+
+Setting up your project for GitButler tooling. Some things to note:
+
+- Switching you to a special `gitbutler/workspace` branch to enable parallel branches
+- Skipping Git hooks (disabled via gitbutler.installHooks)
+
+To undo these changes and return to normal Git mode, either:
+
+    - Directly checkout a branch (`git checkout main`)
+    - Run `but teardown`
+
+More info: https://docs.gitbutler.com/workspace-branch
+
+
+
+██▄      ▄██  ▀██▀▀█▄ ▀██▀ ▀██▀ █▀▀██▀▀█
+████▄  ▄████   ██  ██  ██   ██  ▀  ██  ▀
+████████████   ██▀▀█▄  ██   ██     ██
+████▀  ▀████   ██  ██  ██   ██     ██
+██▀      ▀██  ▄██▄▄█▀  ▀█▄▄▄█▀   ▄▄██▄▄
+
+The command-line interface for GitButler ⋈
+
+$ but branch new <name>                       Create a new branch
+$ but status                                  View workspace status
+$ but commit -m <message>                     Commit changes to current branch
+$ but push                                    Push all branches
+$ but teardown                                Return to normal Git mode
+
+Learn more at https://docs.gitbutler.com/cli-overview
+
+
+"#]]);
+}
+
+/// The opt-out note above only reaches humans. A JSON consumer that cannot see
+/// it would proceed as if the workspace were guarded, so the skip has to be
+/// visible in the JSON output too.
+#[test]
+fn json_output_reports_hooks_skipped() {
+    let env = Sandbox::open_with_default_settings("repo-no-remote");
+    env.invoke_git("config --local gitbutler.installHooks false");
+
+    env.but("--json setup")
+        .allow_json()
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+{
+  "repositoryPath": "[..]",
+  "projectStatus": "alreadyexists",
+  "target": {
+    "branchName": "gb-local/main",
+    "remoteName": "gb-local",
+    "newlySet": true
+  },
+  "hooksSkipped": true
+}
+
+"#]]);
+}
+
+/// Hooks install cleanly here, so neither new field should appear -- existing
+/// JSON consumers must see exactly the payload they saw before.
+#[test]
+fn json_output_omits_hook_fields_when_install_succeeds() {
+    let env = Sandbox::open_with_default_settings("repo-no-remote");
+
+    env.but("--json setup")
+        .allow_json()
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+{
+  "repositoryPath": "[..]",
+  "projectStatus": "alreadyexists",
+  "target": {
+    "branchName": "gb-local/main",
+    "remoteName": "gb-local",
+    "newlySet": true
+  }
+}
+
+"#]]);
+}

--- a/crates/but/tests/but/command/setup.rs
+++ b/crates/but/tests/but/command/setup.rs
@@ -731,3 +731,119 @@ Learn more at https://docs.gitbutler.com/cli-overview
 
     Ok(())
 }
+
+/// When the user opted out of hooks via `gitbutler.installHooks=false`, setup
+/// must say hook installation was skipped instead of claiming hooks are being
+/// installed while direct commits to the workspace branch go unguarded.
+#[test]
+fn setup_with_hooks_opted_out_says_so() {
+    let env = Sandbox::open_with_default_settings("repo-no-remote");
+    env.invoke_git("config --local gitbutler.installHooks false");
+
+    env.but("setup")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+Setting up GitButler project...
+
+→ Adding repository to GitButler project registry
+  ✓ Repository already in project registry
+
+→ Configuring default target branch
+  No push remote found, creating gb-local remote...
+  ✓ Created gb-local remote tracking main
+  ✓ Set default target to: gb-local/main
+
+GitButler project setup complete!
+Target branch: gb-local/main
+Remote: gb-local
+
+  Note: Skipped Git hook installation (gitbutler.installHooks=false). Commits made directly to the workspace branch will not be blocked.
+
+Setting up your project for GitButler tooling. Some things to note:
+
+- Switching you to a special `gitbutler/workspace` branch to enable parallel branches
+- Skipping Git hooks (disabled via gitbutler.installHooks)
+
+To undo these changes and return to normal Git mode, either:
+
+    - Directly checkout a branch (`git checkout main`)
+    - Run `but teardown`
+
+More info: https://docs.gitbutler.com/workspace-branch
+
+
+
+██▄      ▄██  ▀██▀▀█▄ ▀██▀ ▀██▀ █▀▀██▀▀█
+████▄  ▄████   ██  ██  ██   ██  ▀  ██  ▀
+████████████   ██▀▀█▄  ██   ██     ██
+████▀  ▀████   ██  ██  ██   ██     ██
+██▀      ▀██  ▄██▄▄█▀  ▀█▄▄▄█▀   ▄▄██▄▄
+
+The command-line interface for GitButler ⋈
+
+$ but branch new <name>                       Create a new branch
+$ but status                                  View workspace status
+$ but commit -m <message>                     Commit changes to current branch
+$ but push                                    Push all branches
+$ but teardown                                Return to normal Git mode
+
+Learn more at https://docs.gitbutler.com/cli-overview
+
+
+"#]]);
+}
+
+/// The opt-out note above only reaches humans. A JSON consumer that cannot see
+/// it would proceed as if the workspace were guarded, so the skip has to be
+/// visible in the JSON output too.
+#[test]
+fn json_output_reports_hooks_skipped() {
+    let env = Sandbox::open_with_default_settings("repo-no-remote");
+    env.invoke_git("config --local gitbutler.installHooks false");
+
+    env.but("--json setup")
+        .allow_json()
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+{
+  "repositoryPath": "[..]",
+  "projectStatus": "alreadyexists",
+  "target": {
+    "branchName": "gb-local/main",
+    "remoteName": "gb-local",
+    "newlySet": true
+  },
+  "hooksSkipped": true
+}
+
+"#]]);
+}
+
+/// Hooks install cleanly here, so neither new field should appear -- existing
+/// JSON consumers must see exactly the payload they saw before.
+#[test]
+fn json_output_omits_hook_fields_when_install_succeeds() {
+    let env = Sandbox::open_with_default_settings("repo-no-remote");
+
+    env.but("--json setup")
+        .allow_json()
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+{
+  "repositoryPath": "[..]",
+  "projectStatus": "alreadyexists",
+  "target": {
+    "branchName": "gb-local/main",
+    "remoteName": "gb-local",
+    "newlySet": true
+  }
+}
+
+"#]]);
+}

--- a/crates/but/tests/but/command/teardown.rs
+++ b/crates/but/tests/but/command/teardown.rs
@@ -406,3 +406,94 @@ Invalid ref for checkout: 'origin/main' is not a local branch
 
 "#]]);
 }
+
+/// When hook cleanup partially fails, teardown must not report unqualified
+/// success: the final human message has to say hooks are left behind.
+#[cfg(unix)]
+#[test]
+fn teardown_with_failing_hook_cleanup_does_not_claim_full_success() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    // Plant GitButler-managed legacy hooks, then make the hooks directory
+    // read-only so their removal fails during teardown.
+    let hooks_dir = env.projects_root().join(".git/hooks");
+    std::fs::create_dir_all(&hooks_dir).unwrap();
+    let managed_hook = "#!/bin/sh\n# GITBUTLER_MANAGED_HOOK_V1\nexit 0\n";
+    std::fs::write(hooks_dir.join("pre-commit"), managed_hook).unwrap();
+    std::fs::write(hooks_dir.join("post-checkout"), managed_hook).unwrap();
+    std::fs::set_permissions(&hooks_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+    // Teardown completes, but instead of the "✓ Successfully exited" line it
+    // prints per-hook warnings and a "⚠ ... some hooks could not be removed"
+    // summary, so the user knows GitButler hooks are still active.
+    env.but("teardown")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+Exiting GitButler mode...
+
+→ Creating snapshot...
+  ✓ Snapshot created: [..]
+
+→ Finding active branch to check out...
+  ✓ Will check out: A
+
+  Warning: Failed to uninstall pre-commit: [..]
+  Warning: Failed to uninstall post-checkout: [..]
+→ Checking out A...
+  ✓ Checked out: A
+
+⚠ Exited GitButler mode, but some GitButler hooks could not be removed (see warnings above).
+
+You are now on branch: A
+
+To return to GitButler mode, run:
+  but setup
+
+
+"#]]);
+
+    // Restore permissions so the sandbox can clean up after itself.
+    std::fs::set_permissions(&hooks_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+/// JSON consumers must be able to detect a partial hook cleanup: the warnings
+/// surface as a dedicated field instead of only being printed for humans.
+#[cfg(unix)]
+#[test]
+fn json_output_reports_partial_hook_cleanup() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    let hooks_dir = env.projects_root().join(".git/hooks");
+    std::fs::create_dir_all(&hooks_dir).unwrap();
+    let managed_hook = "#!/bin/sh\n# GITBUTLER_MANAGED_HOOK_V1\nexit 0\n";
+    std::fs::write(hooks_dir.join("pre-commit"), managed_hook).unwrap();
+    std::fs::write(hooks_dir.join("post-checkout"), managed_hook).unwrap();
+    std::fs::set_permissions(&hooks_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+    env.but("--json teardown")
+        .allow_json()
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+{
+  "snapshotId": "[..]",
+  "checkedOutBranch": "A",
+  "hookWarnings": [
+    "Failed to uninstall pre-commit: [..]",
+    "Failed to uninstall post-checkout: [..]"
+  ]
+}
+
+"#]]);
+
+    std::fs::set_permissions(&hooks_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+}

--- a/crates/but/tests/but/command/teardown.rs
+++ b/crates/but/tests/but/command/teardown.rs
@@ -564,3 +564,94 @@ Invalid ref for checkout: 'origin/main' is not a local branch
 
 "#]]);
 }
+
+/// When hook cleanup partially fails, teardown must not report unqualified
+/// success: the final human message has to say hooks are left behind.
+#[cfg(unix)]
+#[test]
+fn teardown_with_failing_hook_cleanup_does_not_claim_full_success() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    // Plant GitButler-managed legacy hooks, then make the hooks directory
+    // read-only so their removal fails during teardown.
+    let hooks_dir = env.projects_root().join(".git/hooks");
+    std::fs::create_dir_all(&hooks_dir).unwrap();
+    let managed_hook = "#!/bin/sh\n# GITBUTLER_MANAGED_HOOK_V1\nexit 0\n";
+    std::fs::write(hooks_dir.join("pre-commit"), managed_hook).unwrap();
+    std::fs::write(hooks_dir.join("post-checkout"), managed_hook).unwrap();
+    std::fs::set_permissions(&hooks_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+    // Teardown completes, but instead of the "✓ Successfully exited" line it
+    // prints per-hook warnings and a "⚠ ... some hooks could not be removed"
+    // summary, so the user knows GitButler hooks are still active.
+    env.but("teardown")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+Exiting GitButler mode...
+
+→ Creating snapshot...
+  ✓ Snapshot created: [..]
+
+→ Finding active branch to check out...
+  ✓ Will check out: A
+
+  Warning: Failed to uninstall pre-commit: [..]
+  Warning: Failed to uninstall post-checkout: [..]
+→ Checking out A...
+  ✓ Checked out: A
+
+⚠ Exited GitButler mode, but some GitButler hooks could not be removed (see warnings above).
+
+You are now on branch: A
+
+To return to GitButler mode, run:
+  but setup
+
+
+"#]]);
+
+    // Restore permissions so the sandbox can clean up after itself.
+    std::fs::set_permissions(&hooks_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+/// JSON consumers must be able to detect a partial hook cleanup: the warnings
+/// surface as a dedicated field instead of only being printed for humans.
+#[cfg(unix)]
+#[test]
+fn json_output_reports_partial_hook_cleanup() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    let hooks_dir = env.projects_root().join(".git/hooks");
+    std::fs::create_dir_all(&hooks_dir).unwrap();
+    let managed_hook = "#!/bin/sh\n# GITBUTLER_MANAGED_HOOK_V1\nexit 0\n";
+    std::fs::write(hooks_dir.join("pre-commit"), managed_hook).unwrap();
+    std::fs::write(hooks_dir.join("post-checkout"), managed_hook).unwrap();
+    std::fs::set_permissions(&hooks_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+    env.but("--json teardown")
+        .allow_json()
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+{
+  "snapshotId": "[..]",
+  "checkedOutBranch": "A",
+  "hookWarnings": [
+    "Failed to uninstall pre-commit: [..]",
+    "Failed to uninstall post-checkout: [..]"
+  ]
+}
+
+"#]]);
+
+    std::fs::set_permissions(&hooks_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+}

--- a/crates/gitbutler-branch-actions/src/integration.rs
+++ b/crates/gitbutler-branch-actions/src/integration.rs
@@ -189,8 +189,14 @@ pub(crate) fn update_workspace_commit_from_workspace(
     repo.set_head(&GITBUTLER_WORKSPACE_REFERENCE.clone().to_string())?;
 
     // Install managed hooks to prevent accidental git commits on workspace branch
-    if let Err(e) = gitbutler_repo::managed_hooks::install_managed_hooks(&gix_repo) {
-        tracing::warn!("Failed to install managed hooks: {}", e);
+    match gitbutler_repo::managed_hooks::install_managed_hooks(&gix_repo) {
+        Ok(gitbutler_repo::managed_hooks::HookInstallationResult::PartialSuccess { warnings }) => {
+            for warning in warnings {
+                tracing::warn!("Managed hooks installed with warnings: {warning}");
+            }
+        }
+        Ok(_) => {}
+        Err(e) => tracing::warn!("Failed to install managed hooks: {}", e),
     }
 
     let mut index = repo.index()?;

--- a/crates/gitbutler-branch-actions/src/integration.rs
+++ b/crates/gitbutler-branch-actions/src/integration.rs
@@ -194,8 +194,14 @@ pub(crate) fn update_workspace_commit_with_vb_state(
     repo.set_head(&GITBUTLER_WORKSPACE_REFERENCE.clone().to_string())?;
 
     // Install managed hooks to prevent accidental git commits on workspace branch
-    if let Err(e) = gitbutler_repo::managed_hooks::install_managed_hooks(&gix_repo) {
-        tracing::warn!("Failed to install managed hooks: {}", e);
+    match gitbutler_repo::managed_hooks::install_managed_hooks(&gix_repo) {
+        Ok(gitbutler_repo::managed_hooks::HookInstallationResult::PartialSuccess { warnings }) => {
+            for warning in warnings {
+                tracing::warn!("Managed hooks installed with warnings: {warning}");
+            }
+        }
+        Ok(_) => {}
+        Err(e) => tracing::warn!("Failed to install managed hooks: {}", e),
     }
 
     let mut index = repo.index()?;

--- a/crates/gitbutler-repo/src/managed_hooks.rs
+++ b/crates/gitbutler-repo/src/managed_hooks.rs
@@ -262,22 +262,8 @@ if [ "$PREV_BRANCH" = "refs/heads/gitbutler/workspace" ]; then
         # A prior install may have failed to fully clean up a legacy
         # file-based installation while migrating to config-based hooks
         # (e.g. a filesystem error). Sweep any stranded GitButler-signed
-        # hooks left in the hooks directory, respecting core.hooksPath.
-        # --type=path expands ~ against HOME, matching how this crate's own
-        # gix-based lookup (and git itself) interpret core.hooksPath; a bare
-        # `--get` would return the raw, unexpanded string.
-        LEGACY_HOOKS_PATH=$(git config --get --type=path core.hooksPath 2>/dev/null)
-        case "$LEGACY_HOOKS_PATH" in
-            "")
-                LEGACY_HOOKS_DIR=$(git rev-parse --git-dir)/hooks
-                ;;
-            /*)
-                LEGACY_HOOKS_DIR="$LEGACY_HOOKS_PATH"
-                ;;
-            *)
-                LEGACY_HOOKS_DIR="$(git rev-parse --show-toplevel)/$LEGACY_HOOKS_PATH"
-                ;;
-        esac
+        # hooks left in the hooks directory.
+        LEGACY_HOOKS_DIR=$(git rev-parse --path-format=absolute --git-path hooks 2>/dev/null)
 
         # Legacy pre-commit is a different event: safe to remove outright.
         legacy_pre_commit="$LEGACY_HOOKS_DIR/pre-commit"

--- a/crates/gitbutler-repo/src/managed_hooks.rs
+++ b/crates/gitbutler-repo/src/managed_hooks.rs
@@ -142,9 +142,184 @@ pub enum HookInstallationResult {
     Success,
     /// Hook was already in the desired state
     AlreadyConfigured,
+    /// Installation was skipped because the user opted out via `gitbutler.installHooks=false`
+    SkippedByConfig,
     /// Installation partially succeeded with warnings
     PartialSuccess { warnings: Vec<String> },
 }
+
+/// Subdirectory of the common git directory where GitButler stores its hook scripts
+/// when hooks are registered through git config (git 2.54+). Git never reads this
+/// location on its own, so nothing here can shadow or displace user hooks.
+const CONFIG_HOOK_SCRIPTS_SUBDIR: &str = "gitbutler/hooks";
+
+/// Local git config key that lets users opt out of hook installation entirely.
+const INSTALL_HOOKS_CONFIG_KEY: &str = "gitbutler.installHooks";
+
+/// Pre-commit hook script content for config-based hooks.
+///
+/// Much simpler than [`PRE_COMMIT_HOOK_SCRIPT`]: since the script never occupies a
+/// slot in the hooks directory, there is no user hook to back up, chain, or restore.
+const CONFIG_PRE_COMMIT_HOOK_SCRIPT: &str = r#"#!/bin/sh
+# GITBUTLER_MANAGED_HOOK_V1
+# This hook is managed by GitButler and registered via git config (hook.gitbutler-pre-commit).
+# It does not occupy .git/hooks, so your own hooks and hook managers are left untouched.
+
+BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
+
+if [ "$BRANCH" = "gitbutler/workspace" ]; then
+    echo ""
+    echo "GITBUTLER_ERROR: Cannot commit directly to gitbutler/workspace branch."
+    echo ""
+    echo "GitButler manages commits on this branch. Please use GitButler to commit your changes:"
+    echo "  - Use the GitButler app to create commits"
+    echo "  - Or run 'but commit' from the command line"
+    echo ""
+    echo "If you want to exit GitButler mode and use normal git:"
+    echo "  - Run 'but teardown' to switch to a regular branch"
+    echo "  - Or directly checkout another branch: git checkout <branch>"
+    echo ""
+    echo "If you no longer have the GitButler CLI installed, you can remove this hook with:"
+    echo "  git config --remove-section hook.gitbutler-pre-commit"
+    echo ""
+    exit 1
+fi
+
+exit 0
+"#;
+
+/// Post-checkout hook script content for config-based hooks.
+///
+/// Cleans up GitButler's config entries and scripts when the user checks out away
+/// from `gitbutler/workspace`. No user hook restoration is needed because nothing
+/// was displaced in the first place. Also sweeps any legacy file-based GitButler
+/// hooks that a prior migration to config-based hooks failed to clean up, so a
+/// partially-migrated repo still ends up fully torn down.
+const CONFIG_POST_CHECKOUT_HOOK_SCRIPT: &str = r#"#!/bin/sh
+# GITBUTLER_MANAGED_HOOK_V1
+# This hook is managed by GitButler and registered via git config (hook.gitbutler-post-checkout).
+# It auto-removes GitButler's hooks when you checkout away from gitbutler/workspace.
+
+# post-checkout receives: $1 previous HEAD, $2 new HEAD, $3 branch-checkout flag.
+PREV_HEAD=$1
+BRANCH_CHECKOUT=$3
+
+# Only act on branch checkouts (not file checkouts)
+if [ "$BRANCH_CHECKOUT" != "1" ]; then
+    exit 0
+fi
+
+NEW_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
+
+# If we just left gitbutler/workspace (and aren't coming back to it). @{-1}
+# is the branch that was checked out before this checkout, from git's own
+# record (the HEAD reflog, on by default in non-bare repos). Comparing
+# commit ids instead would misfire when another ref happens to point at the
+# same commit, or when a concurrent GitButler process moves the workspace
+# ref between checkout start and hook execution.
+PREV_BRANCH=$(git rev-parse --symbolic-full-name @{-1} 2>/dev/null)
+case "$PREV_BRANCH" in
+    refs/*)
+        # Resolved to a real ref: trust it.
+        ;;
+    *)
+        # @{-1} gave no branch. Without a reflog
+        # (core.logAllRefUpdates=false or logs pruned) rev-parse fails and
+        # echoes the literal "@{-1}"; after a detached checkout it prints
+        # nothing. Fall back to comparing the previous HEAD commit against
+        # the workspace ref. Weaker (a coinciding ref or a concurrent ref
+        # move can confuse it), but far better than never cleaning up.
+        WORKSPACE_HEAD=$(git rev-parse --verify -q refs/heads/gitbutler/workspace 2>/dev/null)
+        if [ -n "$WORKSPACE_HEAD" ] && [ "$WORKSPACE_HEAD" = "$PREV_HEAD" ]; then
+            PREV_BRANCH="refs/heads/gitbutler/workspace"
+        fi
+        ;;
+esac
+if [ "$PREV_BRANCH" = "refs/heads/gitbutler/workspace" ]; then
+    if [ "$NEW_BRANCH" != "gitbutler/workspace" ]; then
+        echo ""
+        echo "NOTE: You have left GitButler's managed workspace branch."
+        echo "Cleaning up GitButler hooks..."
+
+        SCRIPTS_DIR=$(dirname "$0")
+
+        # Only delete a script once its config registration is confirmed
+        # gone: if `--remove-section` fails (lock contention, permissions),
+        # leaving the script in place keeps the hook consistent (still
+        # working) instead of a config entry pointing at a deleted script.
+        git config --remove-section hook.gitbutler-pre-commit 2>/dev/null
+        if ! git config --get hook.gitbutler-pre-commit.command >/dev/null 2>&1; then
+            rm -f "$SCRIPTS_DIR/pre-commit"
+        fi
+
+        git config --remove-section hook.gitbutler-post-checkout 2>/dev/null
+        if ! git config --get hook.gitbutler-post-checkout.command >/dev/null 2>&1; then
+            rm -f "$SCRIPTS_DIR/post-checkout"
+        fi
+
+        rmdir "$SCRIPTS_DIR" 2>/dev/null
+
+        # A prior install may have failed to fully clean up a legacy
+        # file-based installation while migrating to config-based hooks
+        # (e.g. a filesystem error). Sweep any stranded GitButler-signed
+        # hooks left in the hooks directory, respecting core.hooksPath.
+        # --type=path expands ~ against HOME, matching how this crate's own
+        # gix-based lookup (and git itself) interpret core.hooksPath; a bare
+        # `--get` would return the raw, unexpanded string.
+        LEGACY_HOOKS_PATH=$(git config --get --type=path core.hooksPath 2>/dev/null)
+        case "$LEGACY_HOOKS_PATH" in
+            "")
+                LEGACY_HOOKS_DIR=$(git rev-parse --git-dir)/hooks
+                ;;
+            /*)
+                LEGACY_HOOKS_DIR="$LEGACY_HOOKS_PATH"
+                ;;
+            *)
+                LEGACY_HOOKS_DIR="$(git rev-parse --show-toplevel)/$LEGACY_HOOKS_PATH"
+                ;;
+        esac
+
+        # Legacy pre-commit is a different event: safe to remove outright.
+        legacy_pre_commit="$LEGACY_HOOKS_DIR/pre-commit"
+        if [ -f "$legacy_pre_commit" ] && grep -q "GITBUTLER_MANAGED_HOOK_V1" "$legacy_pre_commit" 2>/dev/null; then
+            rm -f "$legacy_pre_commit"
+        fi
+        # Put the user's original back if the old file-based installer left
+        # its backup behind and nothing else took the hook's place.
+        if [ -f "$LEGACY_HOOKS_DIR/pre-commit-user" ] && [ ! -e "$legacy_pre_commit" ]; then
+            mv "$LEGACY_HOOKS_DIR/pre-commit-user" "$legacy_pre_commit"
+        fi
+
+        # Legacy post-checkout is *this same event's* own hooks-directory
+        # hook: git already resolved to run it right after this config hook
+        # returns, so deleting the file out from under that exec would make
+        # git fail with "cannot exec: No such file or directory". Neuter its
+        # content in place instead: the path still exists for git to exec,
+        # it just does nothing now, and it keeps the signature so the next
+        # `but setup` still recognizes and removes it for good.
+        legacy_post_checkout="$LEGACY_HOOKS_DIR/post-checkout"
+        if [ -f "$legacy_post_checkout" ] && grep -q "GITBUTLER_MANAGED_HOOK_V1" "$legacy_post_checkout" 2>/dev/null; then
+            if [ -f "$LEGACY_HOOKS_DIR/post-checkout-user" ]; then
+                # Swap the user's original back in atomically: the path git
+                # resolved for its upcoming hooks-directory exec stays valid,
+                # and the user's own post-checkout runs for this checkout --
+                # just as it would have without GitButler in the way.
+                mv "$LEGACY_HOOKS_DIR/post-checkout-user" "$legacy_post_checkout"
+            else
+                printf '#!/bin/sh\n# GITBUTLER_MANAGED_HOOK_V1\nexit 0\n' > "$legacy_post_checkout"
+            fi
+        elif [ -f "$LEGACY_HOOKS_DIR/post-checkout-user" ] && [ ! -e "$legacy_post_checkout" ]; then
+            mv "$LEGACY_HOOKS_DIR/post-checkout-user" "$legacy_post_checkout"
+        fi
+
+        echo ""
+        echo "To return to GitButler mode, run: but setup"
+        echo ""
+    fi
+fi
+
+exit 0
+"#;
 
 /// Types of hooks we manage
 #[derive(Debug, Clone, Copy)]
@@ -154,10 +329,29 @@ enum ManagedHookType {
 }
 
 impl ManagedHookType {
+    /// Every hook type GitButler manages.
+    const ALL: [ManagedHookType; 2] = [ManagedHookType::PreCommit, ManagedHookType::PostCheckout];
+
     fn hook_name(&self) -> &'static str {
         match self {
             Self::PreCommit => "pre-commit",
             Self::PostCheckout => "post-checkout",
+        }
+    }
+
+    /// Subsection name under which this hook is registered in git config (git 2.54+).
+    fn config_section(&self) -> &'static str {
+        match self {
+            Self::PreCommit => "gitbutler-pre-commit",
+            Self::PostCheckout => "gitbutler-post-checkout",
+        }
+    }
+
+    /// Script content used when this hook is registered through git config.
+    fn config_script_content(&self) -> &'static str {
+        match self {
+            Self::PreCommit => CONFIG_PRE_COMMIT_HOOK_SCRIPT,
+            Self::PostCheckout => CONFIG_POST_CHECKOUT_HOOK_SCRIPT,
         }
     }
 
@@ -201,6 +395,20 @@ pub(crate) fn get_hooks_dir(repo: &gix::Repository) -> PathBuf {
             .ok()
             .flatten(),
     )
+}
+
+/// Directory holding GitButler's config-registered hook scripts.
+fn config_scripts_dir(repo: &gix::Repository) -> PathBuf {
+    repo.common_dir().join(CONFIG_HOOK_SCRIPTS_SUBDIR)
+}
+
+/// Whether two paths refer to the same location, resolving symlinks where
+/// possible and falling back to a literal comparison otherwise.
+fn is_same_path(a: &Path, b: &Path) -> bool {
+    match (a.canonicalize(), b.canonicalize()) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => a == b,
+    }
 }
 
 /// Check if a hook file contains our signature
@@ -284,18 +492,216 @@ fn uninstall_hook(hooks_dir: &Path, hook_type: ManagedHookType) -> Result<HookIn
 
 /// Install all GitButler managed hooks
 ///
-/// Called after switching HEAD to gitbutler/workspace
+/// Called after switching HEAD to gitbutler/workspace.
+///
+/// With git 2.54+ on `PATH`, hooks are registered through git config
+/// (`hook.<name>.event` / `hook.<name>.command`) and their scripts live in a
+/// GitButler-owned directory — the hooks directory and any hooks in it (whether
+/// the user's own or a hook manager's) are never touched. Older gits fall back
+/// to the previous file-based installation.
 pub fn install_managed_hooks(repo: &gix::Repository) -> Result<HookInstallationResult> {
-    let hooks_dir = get_hooks_dir(repo);
-    install_managed_hooks_at(&hooks_dir)
+    install_managed_hooks_with(repo, git_on_path_supports_config_hooks())
+}
+
+/// Like [`install_managed_hooks`], but with explicit control over whether
+/// config-based hooks (git 2.54+) are used instead of the hooks directory.
+pub fn install_managed_hooks_with(
+    repo: &gix::Repository,
+    use_config_hooks: bool,
+) -> Result<HookInstallationResult> {
+    if hooks_opted_out(repo) {
+        // Opting out must actually remove any hooks a previous install left
+        // behind, not just skip installing new ones -- otherwise a user who
+        // opts out after the fact keeps being blocked by stale hooks.
+        return match uninstall_managed_hooks(repo) {
+            partial @ Ok(HookInstallationResult::PartialSuccess { .. }) => partial,
+            Ok(_) => Ok(HookInstallationResult::SkippedByConfig),
+            Err(e) => {
+                Err(e.context("Failed to remove hooks after opting out of hook installation"))
+            }
+        };
+    }
+    if use_config_hooks {
+        install_config_based_hooks(repo)
+    } else {
+        install_file_based_hooks(repo)
+    }
+}
+
+/// Install the hooks into the hooks directory, dropping any config-based
+/// registration a previous install left behind.
+///
+/// Every path that ends up here can be reached on a repository that was
+/// previously installed through config — the git on `PATH` losing 2.54 support
+/// is enough — and leaving the registrations in place would run each hook
+/// twice: once via config, once via the hooks directory.
+fn install_file_based_hooks(repo: &gix::Repository) -> Result<HookInstallationResult> {
+    uninstall_config_based_hooks(repo)?;
+    install_managed_hooks_at(&get_hooks_dir(repo))
+}
+
+/// Register GitButler's hooks through git config (git 2.54+).
+///
+/// Scripts are written to a GitButler-owned directory inside the common git dir
+/// and referenced from local config. The hooks directory is left alone, so user
+/// hooks and hook-manager hooks (prek, pre-commit, husky, ...) keep working —
+/// git runs config-based hooks first and the hooks-directory hook afterwards.
+fn install_config_based_hooks(repo: &gix::Repository) -> Result<HookInstallationResult> {
+    // Registering through config means serializing the script path into
+    // `hook.<section>.command`. On Unix `sh_quote` passes raw bytes through
+    // losslessly, but elsewhere (Windows) a path that isn't valid Unicode has
+    // no lossless byte encoding, so the config value would be corrupted and
+    // the hook would silently never run. Fall back to file-based hooks, which
+    // never embed a path anywhere.
+    #[cfg(not(unix))]
+    if repo.common_dir().to_str().is_none() {
+        return install_file_based_hooks(repo);
+    }
+
+    let scripts_dir = config_scripts_dir(repo);
+    fs::create_dir_all(&scripts_dir)
+        .context("Failed to create GitButler hook scripts directory")?;
+
+    // If `core.hooksPath` points at our scripts directory, writing scripts
+    // there would overwrite the user's hooks in place (without a backup), and
+    // the legacy-hook sweep below would then remove our own signed scripts
+    // again. Fall back to the file-based mechanism, which backs up and
+    // restores whatever lives in the hooks directory.
+    if is_same_path(&get_hooks_dir(repo), &scripts_dir) {
+        return install_file_based_hooks(repo);
+    }
+
+    let mut changed = false;
+    let mut warnings = Vec::new();
+
+    for hook_type in ManagedHookType::ALL {
+        let script_path = scripts_dir.join(hook_type.hook_name());
+        let content = hook_type.config_script_content();
+        if fs::read_to_string(&script_path).ok().as_deref() != Some(content) {
+            fs::write(&script_path, content).context("Failed to write hook script")?;
+            changed = true;
+        }
+        set_hook_executable(&script_path)?;
+    }
+
+    // `edit_repo_config` reads the config file fresh from disk and only writes it
+    // back if the edit changed anything, so this is naturally idempotent.
+    let wrote_config =
+        but_core::git_config::edit_repo_config(repo, gix::config::Source::Local, |config| {
+            for hook_type in ManagedHookType::ALL {
+                let section = hook_type.config_section();
+                let script_path = scripts_dir.join(hook_type.hook_name());
+                config.set_raw_value(
+                    format!("hook.{section}.event").as_str(),
+                    hook_type.hook_name(),
+                )?;
+                let quoted_path = sh_quote(&script_path);
+                config.set_raw_value(
+                    format!("hook.{section}.command").as_str(),
+                    quoted_path.as_slice(),
+                )?;
+            }
+            Ok(())
+        })?;
+    changed |= wrote_config;
+
+    // Clean up hooks that an older GitButler version installed into the hooks
+    // directory, restoring any displaced user hook from its backup.
+    match uninstall_managed_hooks_at(&get_hooks_dir(repo)) {
+        Ok(HookInstallationResult::PartialSuccess { warnings: w }) => warnings.extend(w),
+        Ok(_) => {}
+        Err(e) => warnings.push(format!("Failed to clean up legacy GitButler hooks: {e}")),
+    }
+
+    if !warnings.is_empty() {
+        Ok(HookInstallationResult::PartialSuccess { warnings })
+    } else if changed {
+        Ok(HookInstallationResult::Success)
+    } else {
+        Ok(HookInstallationResult::AlreadyConfigured)
+    }
+}
+
+/// `true` if the user has opted out of hook installation via
+/// `gitbutler.installHooks=false`.
+fn hooks_opted_out(repo: &gix::Repository) -> bool {
+    repo.config_snapshot()
+        .boolean(INSTALL_HOOKS_CONFIG_KEY)
+        .is_some_and(|enabled| !enabled)
+}
+
+/// `true` if the `git` binary on `PATH` supports config-based hooks (git 2.54+).
+///
+/// The version that actually matters is that of whatever `git` binary the user
+/// invokes later -- hooks run under it, not under the gitoxide library
+/// GitButler links. That binary is unknowable at install time, so probing
+/// GitButler's own `PATH` is the best available proxy. The accepted residual
+/// risk: a user whose shell resolves an older `git` than GitButler's will have
+/// config-based hooks registered that their git silently ignores, leaving the
+/// workspace branch unguarded -- the same exposure as opting out of hooks, and
+/// one that disappears as soon as their git reaches 2.54.
+fn git_on_path_supports_config_hooks() -> bool {
+    static SUPPORTED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *SUPPORTED.get_or_init(|| {
+        std::process::Command::new("git")
+            .arg("--version")
+            .output()
+            .ok()
+            .filter(|out| out.status.success())
+            .and_then(|out| parse_git_version(&String::from_utf8_lossy(&out.stdout)))
+            .is_some_and(|version| version >= (2, 54))
+    })
+}
+
+/// Parse output like `git version 2.54.0` or `git version 2.39.5 (Apple Git-154)`
+/// into `(major, minor)`.
+fn parse_git_version(output: &str) -> Option<(u32, u32)> {
+    let rest = output.trim().strip_prefix("git version ")?;
+    let mut numbers = rest.split(|c: char| !c.is_ascii_digit());
+    let major = numbers.next()?.parse().ok()?;
+    let minor = numbers.next()?.parse().ok()?;
+    Some((major, minor))
+}
+
+/// Single-quote a path so git can run it as a shell command from config.
+///
+/// Works at the byte level rather than through `Path::display()`, which
+/// lossily replaces invalid UTF-8 with `U+FFFD` -- that would silently
+/// corrupt the `hook.<section>.command` value for a repository living at a
+/// non-UTF-8 path on Unix.
+fn sh_quote(path: &Path) -> bstr::BString {
+    #[cfg(unix)]
+    let bytes: Vec<u8> = {
+        use std::os::unix::ffi::OsStrExt;
+        path.as_os_str().as_bytes().to_vec()
+    };
+    // Lossy is acceptable here: `install_config_based_hooks` falls back to
+    // file-based hooks for non-Unicode paths on non-Unix, so this branch only
+    // ever sees paths where `to_string_lossy` is in fact lossless.
+    #[cfg(not(unix))]
+    let bytes: Vec<u8> = path.to_string_lossy().into_owned().into_bytes();
+
+    let mut quoted = Vec::with_capacity(bytes.len() + 2);
+    quoted.push(b'\'');
+    for byte in bytes {
+        if byte == b'\'' {
+            quoted.extend_from_slice(b"'\\''");
+        } else {
+            quoted.push(byte);
+        }
+    }
+    quoted.push(b'\'');
+    bstr::BString::from(quoted)
 }
 
 fn install_managed_hooks_at(hooks_dir: &Path) -> Result<HookInstallationResult> {
     let mut warnings = Vec::new();
     let mut already_configured_count = 0;
 
-    for hook_type in [ManagedHookType::PreCommit, ManagedHookType::PostCheckout] {
+    for hook_type in ManagedHookType::ALL {
         match install_hook(hooks_dir, hook_type) {
+            // Never produced by install_hook; needed for exhaustiveness.
+            Ok(HookInstallationResult::SkippedByConfig) => {}
             Ok(HookInstallationResult::Success) => {
                 tracing::debug!("Installed {} hook", hook_type.hook_name());
             }
@@ -317,7 +723,7 @@ fn install_managed_hooks_at(hooks_dir: &Path) -> Result<HookInstallationResult> 
     }
 
     // If all hooks were already configured, return AlreadyConfigured
-    if already_configured_count == 2 && warnings.is_empty() {
+    if already_configured_count == ManagedHookType::ALL.len() && warnings.is_empty() {
         Ok(HookInstallationResult::AlreadyConfigured)
     } else if warnings.is_empty() {
         Ok(HookInstallationResult::Success)
@@ -328,17 +734,62 @@ fn install_managed_hooks_at(hooks_dir: &Path) -> Result<HookInstallationResult> 
 
 /// Uninstall all GitButler managed hooks and restore user's originals
 ///
-/// Called during teardown
+/// Called during teardown. Cleans up both installation mechanisms regardless of
+/// the current git version: config-based registrations (git 2.54+) and hooks in
+/// the hooks directory from older installs.
 pub fn uninstall_managed_hooks(repo: &gix::Repository) -> Result<HookInstallationResult> {
-    let hooks_dir = get_hooks_dir(repo);
-    uninstall_managed_hooks_at(&hooks_dir)
+    let mut warnings = Vec::new();
+
+    if let Err(e) = uninstall_config_based_hooks(repo) {
+        warnings.push(format!("Failed to remove config-based hooks: {e}"));
+    }
+
+    match uninstall_managed_hooks_at(&get_hooks_dir(repo)) {
+        Ok(HookInstallationResult::PartialSuccess { warnings: w }) => warnings.extend(w),
+        Ok(_) => {}
+        Err(e) => warnings.push(format!("Failed to remove hooks from hooks directory: {e}")),
+    }
+
+    if warnings.is_empty() {
+        Ok(HookInstallationResult::Success)
+    } else {
+        Ok(HookInstallationResult::PartialSuccess { warnings })
+    }
+}
+
+/// Remove GitButler's config-based hook registrations and their scripts.
+fn uninstall_config_based_hooks(repo: &gix::Repository) -> Result<()> {
+    // Removing an absent section is a no-op, and the file is only written back
+    // if anything actually changed.
+    but_core::git_config::edit_repo_config(repo, gix::config::Source::Local, |config| {
+        for hook_type in ManagedHookType::ALL {
+            config.remove_section("hook", Some(hook_type.config_section().into()));
+        }
+        Ok(())
+    })?;
+
+    let scripts_dir = config_scripts_dir(repo);
+    for hook_type in ManagedHookType::ALL {
+        let script_path = scripts_dir.join(hook_type.hook_name());
+        // The signature check matters when `core.hooksPath` points at the
+        // scripts directory: a user's own hook may live at this path, and only
+        // GitButler's signed scripts may be deleted.
+        if script_path.exists() && is_gitbutler_managed_hook(&script_path) {
+            fs::remove_file(&script_path).context("Failed to remove hook script")?;
+        }
+    }
+    // Remove the scripts directory if it is now empty; keep it if anything else is inside.
+    let _ = fs::remove_dir(&scripts_dir);
+    Ok(())
 }
 
 fn uninstall_managed_hooks_at(hooks_dir: &Path) -> Result<HookInstallationResult> {
     let mut warnings = Vec::new();
 
-    for hook_type in [ManagedHookType::PreCommit, ManagedHookType::PostCheckout] {
+    for hook_type in ManagedHookType::ALL {
         match uninstall_hook(hooks_dir, hook_type) {
+            // Never produced by uninstall_hook; needed for exhaustiveness.
+            Ok(HookInstallationResult::SkippedByConfig) => {}
             Ok(HookInstallationResult::Success) => {
                 tracing::debug!("Uninstalled {} hook", hook_type.hook_name());
             }
@@ -360,5 +811,64 @@ fn uninstall_managed_hooks_at(hooks_dir: &Path) -> Result<HookInstallationResult
         Ok(HookInstallationResult::Success)
     } else {
         Ok(HookInstallationResult::PartialSuccess { warnings })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_git_version, sh_quote};
+
+    #[test]
+    fn parses_plain_git_version() {
+        assert_eq!(parse_git_version("git version 2.54.0\n"), Some((2, 54)));
+    }
+
+    #[test]
+    fn parses_apple_git_version() {
+        assert_eq!(
+            parse_git_version("git version 2.39.5 (Apple Git-154)\n"),
+            Some((2, 39))
+        );
+    }
+
+    #[test]
+    fn parses_windows_git_version() {
+        assert_eq!(
+            parse_git_version("git version 2.54.0.windows.1\n"),
+            Some((2, 54))
+        );
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert_eq!(parse_git_version("not git"), None);
+        assert_eq!(parse_git_version(""), None);
+        assert_eq!(parse_git_version("git version x.y"), None);
+    }
+
+    /// `Path::display()` (used internally by the old implementation of
+    /// `sh_quote`) lossily replaces invalid UTF-8 bytes with `U+FFFD`. On Unix,
+    /// a repository living at a non-UTF-8 path would therefore get a mangled
+    /// `hook.<section>.command` config value that git can't execute. The
+    /// quoted value must preserve the exact original bytes.
+    #[cfg(unix)]
+    #[test]
+    fn sh_quote_preserves_non_utf8_path_bytes() {
+        use bstr::ByteSlice;
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        // 0xFF is never valid UTF-8 on its own.
+        let raw: &[u8] = b"/tmp/repo-\xFF/gitbutler/hooks/pre-commit";
+        let path = std::path::Path::new(OsStr::from_bytes(raw));
+
+        let quoted = sh_quote(path);
+        assert!(
+            quoted
+                .as_bytes()
+                .windows(raw.len())
+                .any(|window| window == raw),
+            "quoted path should preserve the exact non-UTF-8 byte sequence, got {quoted:?}"
+        );
     }
 }

--- a/crates/gitbutler-repo/tests/repo/managed_hooks_tests.rs
+++ b/crates/gitbutler-repo/tests/repo/managed_hooks_tests.rs
@@ -11,7 +11,8 @@ use std::os::unix::fs::PermissionsExt;
 
 use anyhow::Result;
 use gitbutler_repo::managed_hooks::{
-    HookInstallationResult, install_managed_hooks, uninstall_managed_hooks,
+    HookInstallationResult, install_managed_hooks, install_managed_hooks_with,
+    uninstall_managed_hooks,
 };
 use tempfile::TempDir;
 
@@ -77,7 +78,7 @@ fn test_install_hooks_creates_hooks_directory() -> Result<()> {
         fs::remove_dir_all(&hooks_dir)?;
     }
 
-    install_managed_hooks(&repo)?;
+    install_managed_hooks_with(&repo, false)?;
 
     assert!(hooks_dir.exists(), "Hooks directory should be created");
     Ok(())
@@ -87,7 +88,7 @@ fn test_install_hooks_creates_hooks_directory() -> Result<()> {
 fn test_install_creates_pre_commit_and_post_checkout_hooks() -> Result<()> {
     let (_temp, repo) = create_test_repo()?;
 
-    install_managed_hooks(&repo)?;
+    install_managed_hooks_with(&repo, false)?;
 
     assert!(
         hook_exists(&repo, "pre-commit"),
@@ -104,7 +105,7 @@ fn test_install_creates_pre_commit_and_post_checkout_hooks() -> Result<()> {
 fn test_installed_hooks_have_gitbutler_signature() -> Result<()> {
     let (_temp, repo) = create_test_repo()?;
 
-    install_managed_hooks(&repo)?;
+    install_managed_hooks_with(&repo, false)?;
 
     let pre_commit = read_hook(&repo, "pre-commit")?;
     let post_checkout = read_hook(&repo, "post-checkout")?;
@@ -125,7 +126,7 @@ fn test_installed_hooks_have_gitbutler_signature() -> Result<()> {
 fn test_installed_hooks_are_executable() -> Result<()> {
     let (_temp, repo) = create_test_repo()?;
 
-    install_managed_hooks(&repo)?;
+    install_managed_hooks_with(&repo, false)?;
 
     assert!(
         is_executable(&repo, "pre-commit"),
@@ -143,8 +144,8 @@ fn test_install_is_idempotent() -> Result<()> {
     let (_temp, repo) = create_test_repo()?;
 
     // Install twice
-    let result1 = install_managed_hooks(&repo)?;
-    let result2 = install_managed_hooks(&repo)?;
+    let result1 = install_managed_hooks_with(&repo, false)?;
+    let result2 = install_managed_hooks_with(&repo, false)?;
 
     // First install should succeed
     assert!(matches!(result1, HookInstallationResult::Success));
@@ -166,7 +167,7 @@ fn test_install_backs_up_existing_user_hook() -> Result<()> {
         "#!/bin/sh\n# User's custom pre-commit hook\necho 'Running user hook'\n";
     create_user_hook(&repo, "pre-commit", user_hook_content)?;
 
-    install_managed_hooks(&repo)?;
+    install_managed_hooks_with(&repo, false)?;
 
     // Original hook should be backed up
     assert!(
@@ -202,7 +203,7 @@ fn test_install_does_not_overwrite_existing_backup() -> Result<()> {
     create_user_hook(&repo, "pre-commit", new_hook)?;
 
     // Install GitButler hooks - should NOT overwrite the backup
-    install_managed_hooks(&repo)?;
+    install_managed_hooks_with(&repo, false)?;
 
     // Backup should still have original content
     let backup_content = read_hook(&repo, "pre-commit-user")?;
@@ -217,7 +218,7 @@ fn test_install_does_not_overwrite_existing_backup() -> Result<()> {
 fn test_uninstall_removes_managed_hooks() -> Result<()> {
     let (_temp, repo) = create_test_repo()?;
 
-    install_managed_hooks(&repo)?;
+    install_managed_hooks_with(&repo, false)?;
     assert!(hook_exists(&repo, "pre-commit"));
     assert!(hook_exists(&repo, "post-checkout"));
 
@@ -242,7 +243,7 @@ fn test_uninstall_restores_user_hooks() -> Result<()> {
     create_user_hook(&repo, "pre-commit", user_hook_content)?;
 
     // Install GitButler hooks (backs up user hook)
-    install_managed_hooks(&repo)?;
+    install_managed_hooks_with(&repo, false)?;
     assert!(hook_exists(&repo, "pre-commit-user"));
 
     // Uninstall should restore the backup
@@ -296,7 +297,7 @@ fn test_uninstall_does_not_remove_non_managed_hooks() -> Result<()> {
 fn test_uninstall_is_idempotent() -> Result<()> {
     let (_temp, repo) = create_test_repo()?;
 
-    install_managed_hooks(&repo)?;
+    install_managed_hooks_with(&repo, false)?;
 
     // Uninstall twice
     let result1 = uninstall_managed_hooks(&repo)?;
@@ -323,7 +324,7 @@ fn test_install_uninstall_roundtrip_with_user_hooks() -> Result<()> {
     create_user_hook(&repo, "post-checkout", original_post_checkout)?;
 
     // Install GitButler hooks
-    install_managed_hooks(&repo)?;
+    install_managed_hooks_with(&repo, false)?;
 
     // Verify GitButler hooks are installed
     let installed_pre = read_hook(&repo, "pre-commit")?;
@@ -362,15 +363,15 @@ fn test_multiple_install_uninstall_cycles() -> Result<()> {
     create_user_hook(&repo, "pre-commit", user_hook)?;
 
     // Cycle 1
-    install_managed_hooks(&repo)?;
+    install_managed_hooks_with(&repo, false)?;
     uninstall_managed_hooks(&repo)?;
 
     // Cycle 2
-    install_managed_hooks(&repo)?;
+    install_managed_hooks_with(&repo, false)?;
     uninstall_managed_hooks(&repo)?;
 
     // Cycle 3
-    install_managed_hooks(&repo)?;
+    install_managed_hooks_with(&repo, false)?;
     uninstall_managed_hooks(&repo)?;
 
     // User hook should still be intact
@@ -388,7 +389,7 @@ fn test_hook_manually_modified_after_install() -> Result<()> {
     let (_temp, repo) = create_test_repo()?;
 
     // Install GitButler hooks
-    install_managed_hooks(&repo)?;
+    install_managed_hooks_with(&repo, false)?;
 
     // User manually modifies the hook
     let modified_hook = "#!/bin/sh\n# User modified this\necho 'modified'\n";
@@ -420,7 +421,7 @@ fn test_respects_absolute_core_hooks_path() -> Result<()> {
     )?;
 
     // Install hooks
-    install_managed_hooks(&repo)?;
+    install_managed_hooks_with(&repo, false)?;
 
     // Hooks should be in custom directory, not .git/hooks
     assert!(
@@ -457,7 +458,7 @@ fn test_respects_relative_core_hooks_path() -> Result<()> {
     repo.config_snapshot_mut()
         .set_raw_value("core.hooksPath", relative_hooks.as_str())?;
 
-    install_managed_hooks(&repo)?;
+    install_managed_hooks_with(&repo, false)?;
 
     assert!(
         hook_exists_at(&expected_hooks_dir, "pre-commit"),
@@ -490,7 +491,7 @@ fn test_uninstall_respects_relative_core_hooks_path() -> Result<()> {
 
     repo.config_snapshot_mut()
         .set_raw_value("core.hooksPath", relative_hooks.as_str())?;
-    install_managed_hooks(&repo)?;
+    install_managed_hooks_with(&repo, false)?;
 
     assert!(
         hook_exists_at(&expected_hooks_dir, "pre-commit"),
@@ -523,7 +524,7 @@ fn test_partial_installation_with_one_existing_hook() -> Result<()> {
     create_user_hook(&repo, "pre-commit", user_hook)?;
 
     // Install (should back up pre-commit, create new post-checkout)
-    install_managed_hooks(&repo)?;
+    install_managed_hooks_with(&repo, false)?;
 
     assert!(hook_exists(&repo, "pre-commit"));
     assert!(hook_exists(&repo, "pre-commit-user"));
@@ -563,7 +564,7 @@ fn test_hook_with_shebang_variations() -> Result<()> {
     )?;
     create_user_hook(&repo, "post-checkout", "#!/bin/bash\necho 'bash hook'\n")?;
 
-    install_managed_hooks(&repo)?;
+    install_managed_hooks_with(&repo, false)?;
 
     // Verify backups preserved shebangs
     let pre_backup = read_hook(&repo, "pre-commit-user")?;
@@ -592,7 +593,7 @@ fn test_empty_hooks_directory() -> Result<()> {
     fs::create_dir_all(&hooks_dir)?;
 
     // Should install cleanly
-    let result = install_managed_hooks(&repo)?;
+    let result = install_managed_hooks_with(&repo, false)?;
     assert!(matches!(result, HookInstallationResult::Success));
 
     assert!(hook_exists(&repo, "pre-commit"));
@@ -613,12 +614,1059 @@ fn test_concurrent_installs_with_backup_present() -> Result<()> {
     create_user_hook(&repo, "pre-commit", new_hook)?;
 
     // Install should not overwrite the existing backup
-    install_managed_hooks(&repo)?;
+    install_managed_hooks_with(&repo, false)?;
 
     let backup = read_hook(&repo, "pre-commit-user")?;
     assert_eq!(
         backup, backup_content,
         "Existing backup should not be modified"
     );
+    Ok(())
+}
+
+// ---- Config-based hooks (git 2.54+) ----
+//
+// These tests drive `install_managed_hooks_with(repo, true)` explicitly so they
+// are independent of the git version on `PATH`. The tests that execute real git
+// commands skip themselves when git is older than 2.54.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Run git in `repo_dir` with host configuration masked out.
+fn git_in(repo_dir: &Path, args: &[&str]) -> std::process::Output {
+    Command::new("git")
+        .args(args)
+        .current_dir(repo_dir)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env("GIT_AUTHOR_NAME", "Test")
+        .env("GIT_AUTHOR_EMAIL", "test@example.com")
+        .env("GIT_COMMITTER_NAME", "Test")
+        .env("GIT_COMMITTER_EMAIL", "test@example.com")
+        .output()
+        .expect("failed to run git")
+}
+
+fn git_ok(repo_dir: &Path, args: &[&str]) -> String {
+    let out = git_in(repo_dir, args);
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Read a key from the repo's local git config, if set.
+fn local_config(repo_dir: &Path, key: &str) -> Option<String> {
+    let out = git_in(repo_dir, &["config", "--local", "--get", key]);
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+fn config_scripts_dir(repo: &gix::Repository) -> std::path::PathBuf {
+    repo.common_dir().join("gitbutler/hooks")
+}
+
+fn workdir(repo: &gix::Repository) -> std::path::PathBuf {
+    repo.workdir()
+        .expect("test repos have a worktree")
+        .to_owned()
+}
+
+/// `true` if the `git` on `PATH` runs config-based hooks (2.54+).
+fn real_git_supports_config_hooks() -> bool {
+    let out = Command::new("git")
+        .arg("--version")
+        .output()
+        .expect("git is on PATH");
+    let text = String::from_utf8_lossy(&out.stdout);
+    let Some(rest) = text.trim().strip_prefix("git version ") else {
+        return false;
+    };
+    let mut numbers = rest.split(|c: char| !c.is_ascii_digit());
+    match (
+        numbers.next().and_then(|s| s.parse::<u32>().ok()),
+        numbers.next().and_then(|s| s.parse::<u32>().ok()),
+    ) {
+        (Some(major), Some(minor)) => (major, minor) >= (2, 54),
+        _ => false,
+    }
+}
+
+#[test]
+fn test_config_install_registers_hooks_without_touching_hooks_dir() -> Result<()> {
+    let (_tmp, repo) = create_test_repo()?;
+    let dir = workdir(&repo);
+
+    // A hook-manager-style hook occupies the pre-commit slot.
+    let manager_hook = "#!/bin/sh\n# File generated by prek\nexec prek hook-impl pre-commit\n";
+    create_user_hook(&repo, "pre-commit", manager_hook)?;
+
+    let result = install_managed_hooks_with(&repo, true)?;
+    assert!(matches!(result, HookInstallationResult::Success));
+
+    // Config entries point at GitButler-owned scripts.
+    for (section, event) in [
+        ("gitbutler-pre-commit", "pre-commit"),
+        ("gitbutler-post-checkout", "post-checkout"),
+    ] {
+        assert_eq!(
+            local_config(&dir, &format!("hook.{section}.event")).as_deref(),
+            Some(event),
+            "{section} should be registered for its event"
+        );
+        let command = local_config(&dir, &format!("hook.{section}.command"))
+            .unwrap_or_else(|| panic!("{section} should have a command"));
+        assert!(
+            command.contains("gitbutler/hooks"),
+            "command should point into the GitButler scripts dir: {command}"
+        );
+    }
+
+    // Scripts exist and carry the GitButler signature.
+    for name in ["pre-commit", "post-checkout"] {
+        let script = config_scripts_dir(&repo).join(name);
+        assert!(script.exists(), "{name} script should exist");
+        assert!(fs::read_to_string(&script)?.contains("GITBUTLER_MANAGED_HOOK_V1"));
+    }
+
+    // The hooks directory is untouched: the manager's hook is byte-identical,
+    // no backup was created, and no GitButler hook occupies any slot.
+    assert_eq!(read_hook(&repo, "pre-commit")?, manager_hook);
+    assert!(!hook_exists(&repo, "pre-commit-user"));
+    assert!(!hook_exists(&repo, "post-checkout"));
+
+    Ok(())
+}
+
+/// If another tool (a future prek/husky/etc.) registers its own hook through
+/// git config for the same event, GitButler's install/uninstall must not
+/// touch that tool's section at all. Config-based hooks are keyed by section
+/// name, not a shared slot, so this should hold by construction — this test
+/// exists to document and pin that guarantee.
+#[test]
+fn test_config_install_does_not_touch_other_config_based_hooks() -> Result<()> {
+    let (_tmp, repo) = create_test_repo()?;
+    let dir = workdir(&repo);
+
+    // Simulate a different tool that already registered its own config-based
+    // hook for the same event, under its own section name.
+    let other_command = "/opt/homebrew/bin/some-other-tool hook-impl pre-commit";
+    for (key, value) in [
+        ("hook.some-other-tool.event", "pre-commit"),
+        ("hook.some-other-tool.command", other_command),
+    ] {
+        let out = git_in(&dir, &["config", "--local", key, value]);
+        assert!(out.status.success(), "failed to set {key}: {out:?}");
+    }
+
+    let result = install_managed_hooks_with(&repo, true)?;
+    assert!(matches!(result, HookInstallationResult::Success));
+
+    // GitButler registered its own section...
+    assert_eq!(
+        local_config(&dir, "hook.gitbutler-pre-commit.event").as_deref(),
+        Some("pre-commit"),
+        "GitButler's own hook should still be registered"
+    );
+
+    // ...without touching the other tool's section at all.
+    assert_eq!(
+        local_config(&dir, "hook.some-other-tool.event").as_deref(),
+        Some("pre-commit"),
+        "other tool's hook registration should be left alone"
+    );
+    assert_eq!(
+        local_config(&dir, "hook.some-other-tool.command").as_deref(),
+        Some(other_command),
+        "other tool's hook command should be untouched"
+    );
+
+    // Uninstalling GitButler's hooks must not remove the other tool's entry either.
+    uninstall_managed_hooks(&repo)?;
+    assert_eq!(
+        local_config(&dir, "hook.some-other-tool.event").as_deref(),
+        Some("pre-commit"),
+        "other tool's hook registration should survive GitButler's uninstall"
+    );
+    assert_eq!(
+        local_config(&dir, "hook.gitbutler-pre-commit.event"),
+        None,
+        "GitButler's own hook should be gone after uninstall"
+    );
+
+    Ok(())
+}
+
+/// Config-based hook registration must work correctly even when a hook
+/// manager has redirected `core.hooksPath` elsewhere (e.g. Husky's `.husky`
+/// convention). Registration is independent of `core.hooksPath` -- this test
+/// pins that the redirected directory (and whatever lives in it) is
+/// inspected only for legacy-signature cleanup purposes and otherwise left
+/// completely alone.
+#[test]
+fn test_config_install_coexists_with_custom_core_hooks_path() -> Result<()> {
+    let (_tmp, repo) = create_test_repo()?;
+    let dir = workdir(&repo);
+
+    // Simulate a Husky-style redirect: hooks live in a custom directory, with
+    // a manager-owned hook already installed there.
+    let custom_hooks_dir = dir.join(".husky");
+    fs::create_dir_all(&custom_hooks_dir)?;
+    let manager_hook = "#!/bin/sh\n# husky\nexit 0\n";
+    fs::write(custom_hooks_dir.join("pre-commit"), manager_hook)?;
+    git_in(&dir, &["config", "--local", "core.hooksPath", ".husky"]);
+    let repo = but_testsupport::open_repo(repo.path())?;
+
+    let result = install_managed_hooks_with(&repo, true)?;
+    assert!(matches!(result, HookInstallationResult::Success));
+
+    // GitButler's registration succeeded, independent of core.hooksPath.
+    assert_eq!(
+        local_config(&dir, "hook.gitbutler-pre-commit.event").as_deref(),
+        Some("pre-commit"),
+        "GitButler's own hook should register even with a custom core.hooksPath"
+    );
+
+    // The redirected hooks directory (and the manager's hook in it) is
+    // completely untouched.
+    assert_eq!(
+        fs::read_to_string(custom_hooks_dir.join("pre-commit"))?,
+        manager_hook,
+        "core.hooksPath-redirected hook should be byte-identical, untouched"
+    );
+    assert!(!custom_hooks_dir.join("post-checkout").exists());
+
+    Ok(())
+}
+
+#[test]
+fn test_config_install_is_idempotent() -> Result<()> {
+    let (_tmp, repo) = create_test_repo()?;
+
+    let first = install_managed_hooks_with(&repo, true)?;
+    assert!(matches!(first, HookInstallationResult::Success));
+
+    let second = install_managed_hooks_with(&repo, true)?;
+    assert!(
+        matches!(second, HookInstallationResult::AlreadyConfigured),
+        "second install should change nothing, got {second:?}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_config_install_migrates_legacy_file_hooks() -> Result<()> {
+    let (_tmp, repo) = create_test_repo()?;
+    let dir = workdir(&repo);
+
+    // An older GitButler displaced this user hook into a backup.
+    let user_hook = "#!/bin/sh\necho user hook\n";
+    create_user_hook(&repo, "pre-commit", user_hook)?;
+    install_managed_hooks_with(&repo, false)?;
+    assert!(
+        hook_exists(&repo, "pre-commit-user"),
+        "legacy install backs up"
+    );
+
+    // Installing config-based hooks cleans up the legacy install and restores the user hook.
+    install_managed_hooks_with(&repo, true)?;
+
+    assert_eq!(
+        read_hook(&repo, "pre-commit")?,
+        user_hook,
+        "user hook restored"
+    );
+    assert!(!hook_exists(&repo, "pre-commit-user"), "backup consumed");
+    assert!(
+        !hook_exists(&repo, "post-checkout"),
+        "legacy managed hook removed"
+    );
+    assert!(
+        local_config(&dir, "hook.gitbutler-pre-commit.command").is_some(),
+        "config-based hooks registered"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_uninstall_removes_config_hooks_and_scripts() -> Result<()> {
+    let (_tmp, repo) = create_test_repo()?;
+    let dir = workdir(&repo);
+
+    install_managed_hooks_with(&repo, true)?;
+    let result = uninstall_managed_hooks(&repo)?;
+    assert!(matches!(result, HookInstallationResult::Success));
+
+    for section in ["gitbutler-pre-commit", "gitbutler-post-checkout"] {
+        assert_eq!(
+            local_config(&dir, &format!("hook.{section}.command")),
+            None,
+            "{section} should be unregistered"
+        );
+    }
+    assert!(
+        !config_scripts_dir(&repo).exists(),
+        "scripts directory should be removed when empty"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_opt_out_skips_installation_entirely() -> Result<()> {
+    let (_tmp, repo) = create_test_repo()?;
+    let dir = workdir(&repo);
+
+    git_ok(&dir, &["config", "gitbutler.installHooks", "false"]);
+    // Re-open so the freshly written config is visible to the snapshot.
+    let repo = but_testsupport::open_repo(repo.path())?;
+
+    let result = install_managed_hooks(&repo)?;
+    assert!(
+        matches!(result, HookInstallationResult::SkippedByConfig),
+        "expected SkippedByConfig, got {result:?}"
+    );
+
+    assert!(!config_scripts_dir(&repo).exists());
+    assert_eq!(
+        local_config(&dir, "hook.gitbutler-pre-commit.command"),
+        None
+    );
+    assert!(!hook_exists(&repo, "pre-commit"));
+
+    Ok(())
+}
+
+/// Drive a real `git commit` and verify the config-registered guard blocks it.
+#[cfg(unix)]
+#[test]
+fn test_real_git_commit_blocked_on_workspace_branch() -> Result<()> {
+    if !real_git_supports_config_hooks() {
+        eprintln!("skipping: git on PATH is older than 2.54");
+        return Ok(());
+    }
+
+    let (_tmp, repo) = create_test_repo()?;
+    let dir = workdir(&repo);
+    git_ok(&dir, &["commit", "--allow-empty", "-m", "initial"]);
+    git_ok(&dir, &["checkout", "-b", "gitbutler/workspace"]);
+
+    install_managed_hooks_with(&repo, true)?;
+
+    fs::write(dir.join("file.txt"), "content")?;
+    git_ok(&dir, &["add", "file.txt"]);
+    let out = git_in(&dir, &["commit", "-m", "should be blocked"]);
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !out.status.success(),
+        "commit should be blocked: {combined}"
+    );
+    assert!(
+        combined.contains("GITBUTLER_ERROR"),
+        "guard message should be shown: {combined}"
+    );
+
+    Ok(())
+}
+
+/// Checking out away from the workspace branch removes the config entries and scripts.
+#[cfg(unix)]
+#[test]
+fn test_real_git_checkout_away_cleans_up() -> Result<()> {
+    if !real_git_supports_config_hooks() {
+        eprintln!("skipping: git on PATH is older than 2.54");
+        return Ok(());
+    }
+
+    let (_tmp, repo) = create_test_repo()?;
+    let dir = workdir(&repo);
+    git_ok(&dir, &["commit", "--allow-empty", "-m", "initial"]);
+    let default_branch = git_ok(&dir, &["symbolic-ref", "--short", "HEAD"]);
+    git_ok(&dir, &["checkout", "-b", "gitbutler/workspace"]);
+    // Advance the workspace branch so the previous HEAD resolves to it unambiguously.
+    git_ok(
+        &dir,
+        &[
+            "commit",
+            "--allow-empty",
+            "--no-verify",
+            "-m",
+            "workspace commit",
+        ],
+    );
+
+    install_managed_hooks_with(&repo, true)?;
+
+    git_ok(&dir, &["checkout", &default_branch]);
+
+    assert_eq!(
+        local_config(&dir, "hook.gitbutler-pre-commit.command"),
+        None,
+        "pre-commit registration should be cleaned up"
+    );
+    assert_eq!(
+        local_config(&dir, "hook.gitbutler-post-checkout.command"),
+        None,
+        "post-checkout registration should be cleaned up"
+    );
+    assert!(!config_scripts_dir(&repo).join("pre-commit").exists());
+    assert!(!config_scripts_dir(&repo).join("post-checkout").exists());
+
+    Ok(())
+}
+
+/// If a previous install left legacy file-based GitButler hooks behind (e.g.
+/// because cleanup during migration to config-based hooks failed partway),
+/// the config-based post-checkout hook must tear those down too when the
+/// user leaves the workspace branch -- not just the config-based
+/// registration. `pre-commit` (a different event) is removed outright;
+/// `post-checkout` is this same event's own hooks-directory hook, so it is
+/// neutered in place instead of deleted (deleting it out from under git's
+/// own resolved exec would make the checkout itself fail).
+#[cfg(unix)]
+#[test]
+fn test_real_git_checkout_away_removes_legacy_hooks_from_partial_migration() -> Result<()> {
+    if !real_git_supports_config_hooks() {
+        eprintln!("skipping: git on PATH is older than 2.54");
+        return Ok(());
+    }
+
+    let (_tmp, repo) = create_test_repo()?;
+    let dir = workdir(&repo);
+    git_ok(&dir, &["commit", "--allow-empty", "-m", "initial"]);
+    let default_branch = git_ok(&dir, &["symbolic-ref", "--short", "HEAD"]);
+    git_ok(&dir, &["checkout", "-b", "gitbutler/workspace"]);
+    // Advance the workspace branch so the previous HEAD resolves to it unambiguously.
+    git_ok(
+        &dir,
+        &[
+            "commit",
+            "--allow-empty",
+            "--no-verify",
+            "-m",
+            "workspace commit",
+        ],
+    );
+
+    install_managed_hooks_with(&repo, true)?;
+
+    // Simulate legacy file-based hooks stranded by a partially failed
+    // migration: GitButler-signed files sitting directly in the hooks dir,
+    // even though config-based hooks are the ones actually registered. The
+    // marker lets us tell "still the stale legacy script" apart from "has
+    // been neutered by the fix".
+    let legacy_hooks_dir = hooks_dir(&repo);
+    fs::create_dir_all(&legacy_hooks_dir)?;
+    for name in ["pre-commit", "post-checkout"] {
+        let legacy_path = legacy_hooks_dir.join(name);
+        fs::write(
+            &legacy_path,
+            "#!/bin/sh\n# GITBUTLER_MANAGED_HOOK_V1\n# ACTIVE_LEGACY_HOOK_MARKER\nexit 0\n",
+        )?;
+        fs::set_permissions(&legacy_path, fs::Permissions::from_mode(0o755))?;
+    }
+
+    git_ok(&dir, &["checkout", &default_branch]);
+
+    assert!(
+        !legacy_hooks_dir.join("pre-commit").exists(),
+        "legacy pre-commit hook stranded by a partial migration should be removed outright"
+    );
+
+    let post_checkout_content = fs::read_to_string(legacy_hooks_dir.join("post-checkout"))?;
+    assert!(
+        !post_checkout_content.contains("ACTIVE_LEGACY_HOOK_MARKER"),
+        "legacy post-checkout hook should be neutered, not left running its stale logic: {post_checkout_content}"
+    );
+    assert!(
+        post_checkout_content.contains("GITBUTLER_MANAGED_HOOK_V1"),
+        "neutered post-checkout hook should still carry the signature so a future install recognizes it"
+    );
+
+    Ok(())
+}
+
+/// If another ref happens to coincide on the exact same commit as
+/// `gitbutler/workspace`'s tip (e.g. a branch created but never advanced),
+/// `git name-rev` can report that *other* ref's name for the previous HEAD
+/// instead of "gitbutler/workspace" -- it picks some name for a commit, not
+/// necessarily the ref that was actually checked out. Detecting "was on
+/// workspace" must not depend on that heuristic guess.
+#[cfg(unix)]
+#[test]
+fn test_real_git_checkout_away_cleans_up_even_with_ambiguous_commit() -> Result<()> {
+    if !real_git_supports_config_hooks() {
+        eprintln!("skipping: git on PATH is older than 2.54");
+        return Ok(());
+    }
+
+    let (_tmp, repo) = create_test_repo()?;
+    let dir = workdir(&repo);
+    git_ok(&dir, &["commit", "--allow-empty", "-m", "initial"]);
+    let default_branch = git_ok(&dir, &["symbolic-ref", "--short", "HEAD"]);
+    git_ok(&dir, &["checkout", "-b", "gitbutler/workspace"]);
+
+    // A decoy ref coinciding on the exact same commit as workspace's tip --
+    // name-rev may prefer naming this one instead of "gitbutler/workspace".
+    git_ok(&dir, &["branch", "decoy-branch"]);
+
+    install_managed_hooks_with(&repo, true)?;
+
+    git_ok(&dir, &["checkout", &default_branch]);
+
+    assert_eq!(
+        local_config(&dir, "hook.gitbutler-pre-commit.command"),
+        None,
+        "leaving workspace should clean up hooks even when another ref coincides on the same commit"
+    );
+
+    Ok(())
+}
+
+/// A user's `core.hooksPath` may use `~` (e.g. `~/hooks`), which git expands
+/// against `HOME` -- but a bare `git config --get` returns the raw,
+/// unexpanded string; only `--type=path` applies that expansion. The
+/// legacy-hook sweep must expand it the same way this crate's own gix-based
+/// `get_hooks_dir` already does (via `trusted_path`), or it computes a
+/// nonexistent path and never finds the legacy hooks it's meant to remove.
+#[cfg(unix)]
+#[test]
+fn test_real_git_checkout_away_sweeps_legacy_hooks_under_tilde_hooks_path() -> Result<()> {
+    if !real_git_supports_config_hooks() {
+        eprintln!("skipping: git on PATH is older than 2.54");
+        return Ok(());
+    }
+
+    let tmp = TempDir::new()?;
+    // A fake HOME confined to the tempdir, so `~` expansion never touches
+    // the real user's home directory.
+    let fake_home = tmp.path().join("fake-home");
+    fs::create_dir_all(&fake_home)?;
+    let repo_dir = tmp.path().join("repo");
+    fs::create_dir_all(&repo_dir)?;
+
+    let git = |args: &[&str]| -> std::process::Output {
+        Command::new("git")
+            .args(args)
+            .current_dir(&repo_dir)
+            .env("HOME", &fake_home)
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .env("GIT_AUTHOR_NAME", "Test")
+            .env("GIT_AUTHOR_EMAIL", "test@example.com")
+            .env("GIT_COMMITTER_NAME", "Test")
+            .env("GIT_COMMITTER_EMAIL", "test@example.com")
+            .output()
+            .expect("failed to run git")
+    };
+    let git_ok = |args: &[&str]| -> String {
+        let out = git(args);
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    };
+
+    git(&["init", "-q"]);
+    git_ok(&["commit", "--allow-empty", "-m", "initial"]);
+    let default_branch = git_ok(&["symbolic-ref", "--short", "HEAD"]);
+    git_ok(&["checkout", "-b", "gitbutler/workspace"]);
+    git_ok(&[
+        "commit",
+        "--allow-empty",
+        "--no-verify",
+        "-m",
+        "workspace commit",
+    ]);
+    git_ok(&["config", "--local", "core.hooksPath", "~/legacy-hooks"]);
+
+    let repo = but_testsupport::open_repo(&repo_dir)?;
+    install_managed_hooks_with(&repo, true)?;
+
+    // Plant a legacy GitButler hook under the ~-expanded hooks directory,
+    // simulating a partial migration that left it behind.
+    let legacy_hooks_dir = fake_home.join("legacy-hooks");
+    fs::create_dir_all(&legacy_hooks_dir)?;
+    let legacy_pre_commit = legacy_hooks_dir.join("pre-commit");
+    fs::write(
+        &legacy_pre_commit,
+        "#!/bin/sh\n# GITBUTLER_MANAGED_HOOK_V1\nexit 0\n",
+    )?;
+    fs::set_permissions(&legacy_pre_commit, fs::Permissions::from_mode(0o755))?;
+
+    git_ok(&["checkout", &default_branch]);
+
+    assert!(
+        !legacy_pre_commit.exists(),
+        "legacy hook under a ~-expanded core.hooksPath should be swept, not left running"
+    );
+
+    Ok(())
+}
+
+/// Leaving a branch whose name merely *contains* "gitbutler/workspace" as a
+/// substring (but isn't the managed branch itself) must not trigger cleanup.
+/// The previous-branch check must be an exact match, not a substring search.
+#[cfg(unix)]
+#[test]
+fn test_real_git_checkout_away_from_similarly_named_branch_does_not_clean_up() -> Result<()> {
+    if !real_git_supports_config_hooks() {
+        eprintln!("skipping: git on PATH is older than 2.54");
+        return Ok(());
+    }
+
+    let (_tmp, repo) = create_test_repo()?;
+    let dir = workdir(&repo);
+    git_ok(&dir, &["commit", "--allow-empty", "-m", "initial"]);
+    let default_branch = git_ok(&dir, &["symbolic-ref", "--short", "HEAD"]);
+
+    // A decoy branch containing "gitbutler/workspace" as a substring, but not
+    // equal to it.
+    git_ok(&dir, &["checkout", "-b", "gitbutler/workspace-old"]);
+    git_ok(
+        &dir,
+        &[
+            "commit",
+            "--allow-empty",
+            "--no-verify",
+            "-m",
+            "decoy commit",
+        ],
+    );
+
+    install_managed_hooks_with(&repo, true)?;
+
+    git_ok(&dir, &["checkout", &default_branch]);
+
+    assert!(
+        local_config(&dir, "hook.gitbutler-pre-commit.command").is_some(),
+        "leaving a decoy branch that only contains 'gitbutler/workspace' as a substring must not trigger cleanup"
+    );
+
+    Ok(())
+}
+
+/// Opting out via `gitbutler.installHooks=false` after hooks were already
+/// installed must actually remove them, not just skip future installs.
+#[test]
+fn test_opt_out_after_install_uninstalls_existing_hooks() -> Result<()> {
+    let (_tmp, repo) = create_test_repo()?;
+    let dir = workdir(&repo);
+
+    install_managed_hooks_with(&repo, true)?;
+    assert!(local_config(&dir, "hook.gitbutler-pre-commit.command").is_some());
+
+    git_ok(&dir, &["config", "gitbutler.installHooks", "false"]);
+    // Re-open so the freshly written config is visible to the snapshot.
+    let repo = but_testsupport::open_repo(repo.path())?;
+
+    install_managed_hooks_with(&repo, true)?;
+
+    assert_eq!(
+        local_config(&dir, "hook.gitbutler-pre-commit.command"),
+        None,
+        "opting out after an existing install should remove the previously installed hooks, \
+         not just skip future ones"
+    );
+
+    Ok(())
+}
+
+/// If `git config --remove-section` fails during checkout-away cleanup (e.g.
+/// a permissions error), the config entry and its script must be left in a
+/// *consistent* state -- either both present or both gone -- never a config
+/// entry pointing at a script that was deleted anyway.
+#[cfg(unix)]
+#[test]
+fn test_checkout_away_cleanup_stays_consistent_when_config_removal_fails() -> Result<()> {
+    if !real_git_supports_config_hooks() {
+        eprintln!("skipping: git on PATH is older than 2.54");
+        return Ok(());
+    }
+
+    let (_tmp, repo) = create_test_repo()?;
+    let dir = workdir(&repo);
+    git_ok(&dir, &["commit", "--allow-empty", "-m", "initial"]);
+    let default_branch = git_ok(&dir, &["symbolic-ref", "--short", "HEAD"]);
+    git_ok(&dir, &["checkout", "-b", "gitbutler/workspace"]);
+    git_ok(
+        &dir,
+        &[
+            "commit",
+            "--allow-empty",
+            "--no-verify",
+            "-m",
+            "workspace commit",
+        ],
+    );
+
+    install_managed_hooks_with(&repo, true)?;
+
+    // Force `git config --remove-section` to fail during checkout-away
+    // cleanup: git's config writer needs to create `config.lock` before it
+    // can rewrite the file, so pre-creating that lockfile makes the write
+    // fail with "could not lock config file" without touching directory
+    // permissions (which would also break the checkout's own HEAD/ref
+    // updates and defeat the point of the test).
+    let config_lock_path = repo.git_dir().join("config.lock");
+    fs::write(&config_lock_path, "")?;
+
+    let checkout_result = git_in(&dir, &["checkout", &default_branch]);
+
+    fs::remove_file(&config_lock_path).ok();
+
+    assert!(
+        checkout_result.status.success(),
+        "post-checkout hook failures must not block the checkout itself: {}",
+        String::from_utf8_lossy(&checkout_result.stderr)
+    );
+
+    let command_still_registered =
+        local_config(&dir, "hook.gitbutler-pre-commit.command").is_some();
+    let script_still_exists = config_scripts_dir(&repo).join("pre-commit").exists();
+
+    assert_eq!(
+        command_still_registered, script_still_exists,
+        "config registration and script presence must stay consistent when config removal fails \
+         (command registered: {command_still_registered}, script exists: {script_still_exists})"
+    );
+
+    Ok(())
+}
+
+/// Cleanup keys off which branch the user actually left (git's own `@{-1}`
+/// record), not the workspace ref's current commit -- another GitButler
+/// process may advance `gitbutler/workspace` between checkout start and hook
+/// execution, and that must not suppress cleanup. Simulated by recording a
+/// departure from the workspace branch, advancing the workspace ref, and then
+/// invoking the installed hook script directly with the pre-advance HEAD as
+/// `$1`, exactly as git would have during the racy checkout.
+#[cfg(unix)]
+#[test]
+fn test_checkout_away_cleans_up_even_when_workspace_ref_advances_concurrently() -> Result<()> {
+    if !real_git_supports_config_hooks() {
+        eprintln!("skipping: git on PATH is older than 2.54");
+        return Ok(());
+    }
+
+    let (_tmp, repo) = create_test_repo()?;
+    let dir = workdir(&repo);
+    git_ok(&dir, &["commit", "--allow-empty", "-m", "initial"]);
+    let default_branch = git_ok(&dir, &["symbolic-ref", "--short", "HEAD"]);
+    git_ok(&dir, &["checkout", "-b", "gitbutler/workspace"]);
+    let prev_head = git_ok(&dir, &["rev-parse", "HEAD"]);
+
+    // Leave the workspace branch before hooks are installed: the reflog
+    // records the departure, but no hook runs yet.
+    git_ok(&dir, &["checkout", &default_branch]);
+
+    // The "concurrent" advance: by hook run time the workspace ref no longer
+    // points at the commit that was actually checked out away from.
+    let tree = format!("{prev_head}^{{tree}}");
+    let advanced = git_ok(
+        &dir,
+        &["commit-tree", "-p", &prev_head, "-m", "advanced", &tree],
+    );
+    git_ok(
+        &dir,
+        &["update-ref", "refs/heads/gitbutler/workspace", &advanced],
+    );
+
+    install_managed_hooks_with(&repo, true)?;
+    assert!(local_config(&dir, "hook.gitbutler-pre-commit.command").is_some());
+
+    // Run the hook exactly as git would have at the end of the racy checkout.
+    let script = config_scripts_dir(&repo).join("post-checkout");
+    let new_head = git_ok(&dir, &["rev-parse", "HEAD"]);
+    let out = Command::new("sh")
+        .arg(&script)
+        .args([prev_head.as_str(), new_head.as_str(), "1"])
+        .current_dir(&dir)
+        .output()?;
+    assert!(
+        out.status.success(),
+        "hook failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    assert_eq!(
+        local_config(&dir, "hook.gitbutler-pre-commit.command"),
+        None,
+        "cleanup must not be suppressed by a concurrent workspace ref advance"
+    );
+
+    Ok(())
+}
+
+/// `@{-1}` needs the HEAD reflog; with `core.logAllRefUpdates=false` (and no
+/// pre-existing logs) it yields nothing. Cleanup must then fall back to
+/// comparing the previous HEAD commit against the workspace ref instead of
+/// silently never tearing down.
+#[cfg(unix)]
+#[test]
+fn test_real_git_checkout_away_cleans_up_without_reflog() -> Result<()> {
+    if !real_git_supports_config_hooks() {
+        eprintln!("skipping: git on PATH is older than 2.54");
+        return Ok(());
+    }
+
+    let (_tmp, repo) = create_test_repo()?;
+    let dir = workdir(&repo);
+    git_ok(&dir, &["commit", "--allow-empty", "-m", "initial"]);
+    let default_branch = git_ok(&dir, &["symbolic-ref", "--short", "HEAD"]);
+    git_ok(&dir, &["config", "core.logAllRefUpdates", "false"]);
+    fs::remove_dir_all(repo.git_dir().join("logs")).ok();
+
+    git_ok(&dir, &["checkout", "-b", "gitbutler/workspace"]);
+    git_ok(
+        &dir,
+        &[
+            "commit",
+            "--allow-empty",
+            "--no-verify",
+            "-m",
+            "workspace commit",
+        ],
+    );
+
+    install_managed_hooks_with(&repo, true)?;
+
+    // Sanity: the reflog really is absent, so @{-1} has nothing to answer.
+    let prev = git_in(&dir, &["rev-parse", "--symbolic-full-name", "@{-1}"]);
+    assert!(
+        !prev.status.success() || prev.stdout.iter().all(|b| b.is_ascii_whitespace()),
+        "test setup should leave @{{-1}} unresolvable"
+    );
+
+    git_ok(&dir, &["checkout", &default_branch]);
+
+    assert_eq!(
+        local_config(&dir, "hook.gitbutler-pre-commit.command"),
+        None,
+        "cleanup must still run when the reflog is disabled"
+    );
+    assert!(!config_scripts_dir(&repo).join("pre-commit").exists());
+
+    Ok(())
+}
+
+/// The config-hook scripts live in the common dir, which all linked worktrees
+/// share. A code review flagged that one worktree leaving `gitbutler/workspace`
+/// would remove the shared scripts and unguard a sibling worktree still on that
+/// branch. That sibling state is unreachable: git refuses to check out a branch
+/// that is already checked out in another worktree (without `--force`). This
+/// test pins the refusal, which is what makes the shared location safe.
+#[test]
+fn test_second_worktree_cannot_check_out_workspace_branch() -> Result<()> {
+    let (_tmp, repo) = create_test_repo()?;
+    let dir = workdir(&repo);
+    git_ok(&dir, &["commit", "--allow-empty", "-m", "initial"]);
+    git_ok(&dir, &["checkout", "-b", "gitbutler/workspace"]);
+
+    install_managed_hooks_with(&repo, true)?;
+
+    let sibling = dir.join("sibling-worktree");
+    let output = git_in(
+        &dir,
+        &[
+            "worktree",
+            "add",
+            sibling.to_str().expect("test path is valid UTF-8"),
+            "gitbutler/workspace",
+        ],
+    );
+    assert!(
+        !output.status.success(),
+        "git must refuse a second worktree on the workspace branch, but it succeeded: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    // Nothing was swept: the shared hook installation is still intact.
+    assert!(config_scripts_dir(&repo).join("pre-commit").exists());
+    assert!(config_scripts_dir(&repo).join("post-checkout").exists());
+
+    Ok(())
+}
+
+/// If the user points `core.hooksPath` at GitButler's own config-scripts
+/// directory, config-based installation would overwrite the user's hooks in
+/// place (no backup), and its legacy-hook sweep would then delete the freshly
+/// written scripts again, leaving the config registrations pointing at nothing.
+/// Installation must detect the collision and fall back to the file-based
+/// mechanism, which backs up and restores user hooks.
+#[test]
+fn test_config_install_hooks_path_collision_preserves_user_hook() -> Result<()> {
+    let (_tmp, repo) = create_test_repo()?;
+    let dir = workdir(&repo);
+
+    let scripts_dir = config_scripts_dir(&repo);
+    fs::create_dir_all(&scripts_dir)?;
+    let user_hook = "#!/bin/sh\n# the user's own pre-commit\nexit 0\n";
+    fs::write(scripts_dir.join("pre-commit"), user_hook)?;
+    git_in(
+        &dir,
+        &[
+            "config",
+            "--local",
+            "core.hooksPath",
+            scripts_dir.to_str().expect("test path is valid UTF-8"),
+        ],
+    );
+    let repo = but_testsupport::open_repo(repo.path())?;
+
+    install_managed_hooks_with(&repo, true)?;
+
+    // An active GitButler hook must exist at the effective hooks path...
+    let installed = fs::read_to_string(scripts_dir.join("pre-commit"))?;
+    assert!(
+        installed.contains("GITBUTLER_MANAGED_HOOK_V1"),
+        "a GitButler hook must be in effect at the hooks path, got: {installed}"
+    );
+    // ...the user's hook must survive as a backup...
+    assert_eq!(
+        fs::read_to_string(scripts_dir.join("pre-commit-user"))?,
+        user_hook,
+        "the user's hook must be preserved as a backup"
+    );
+    // ...and no config registration may point into the directory the legacy
+    // sweep cleans, where its script would immediately be removed again.
+    assert_eq!(
+        local_config(&dir, "hook.gitbutler-pre-commit.event"),
+        None,
+        "config-based registration must not be used when core.hooksPath collides with the scripts directory"
+    );
+
+    // Uninstall restores the user's hook.
+    uninstall_managed_hooks(&repo)?;
+    assert_eq!(
+        fs::read_to_string(scripts_dir.join("pre-commit"))?,
+        user_hook,
+        "uninstall must restore the user's original hook"
+    );
+
+    Ok(())
+}
+
+/// A partially failed migration can leave the old file-based installer's
+/// `pre-commit-user` / `post-checkout-user` backups stranded next to the
+/// GitButler-signed hooks. The config-based post-checkout cleanup must put the
+/// user's originals back in place, not just delete or neuter the managed
+/// hooks — otherwise the user's real hooks never run again after leaving the
+/// workspace branch.
+#[cfg(unix)]
+#[test]
+fn test_real_git_checkout_away_restores_user_backups_from_partial_migration() -> Result<()> {
+    if !real_git_supports_config_hooks() {
+        eprintln!("skipping: git on PATH is older than 2.54");
+        return Ok(());
+    }
+
+    let (_tmp, repo) = create_test_repo()?;
+    let dir = workdir(&repo);
+    git_ok(&dir, &["commit", "--allow-empty", "-m", "initial"]);
+    let default_branch = git_ok(&dir, &["symbolic-ref", "--short", "HEAD"]);
+    git_ok(&dir, &["checkout", "-b", "gitbutler/workspace"]);
+    // Advance the workspace branch so the previous HEAD resolves to it unambiguously.
+    git_ok(
+        &dir,
+        &[
+            "commit",
+            "--allow-empty",
+            "--no-verify",
+            "-m",
+            "workspace commit",
+        ],
+    );
+
+    install_managed_hooks_with(&repo, true)?;
+
+    // Strand legacy managed hooks together with the user backups the old
+    // file-based installer created when it displaced the user's hooks.
+    let legacy_hooks_dir = hooks_dir(&repo);
+    fs::create_dir_all(&legacy_hooks_dir)?;
+    let user_pre_commit = "#!/bin/sh\n# the user's own pre-commit\nexit 0\n";
+    let user_post_checkout = "#!/bin/sh\n# the user's own post-checkout\nexit 0\n";
+    for (name, user_content) in [
+        ("pre-commit", user_pre_commit),
+        ("post-checkout", user_post_checkout),
+    ] {
+        let managed_path = legacy_hooks_dir.join(name);
+        fs::write(
+            &managed_path,
+            "#!/bin/sh\n# GITBUTLER_MANAGED_HOOK_V1\nexit 0\n",
+        )?;
+        fs::set_permissions(&managed_path, fs::Permissions::from_mode(0o755))?;
+        let backup_path = legacy_hooks_dir.join(format!("{name}-user"));
+        fs::write(&backup_path, user_content)?;
+        fs::set_permissions(&backup_path, fs::Permissions::from_mode(0o755))?;
+    }
+
+    git_ok(&dir, &["checkout", &default_branch]);
+
+    assert_eq!(
+        fs::read_to_string(legacy_hooks_dir.join("pre-commit"))?,
+        user_pre_commit,
+        "the user's pre-commit must be restored from its backup"
+    );
+    assert_eq!(
+        fs::read_to_string(legacy_hooks_dir.join("post-checkout"))?,
+        user_post_checkout,
+        "the user's post-checkout must be restored from its backup"
+    );
+    assert!(!legacy_hooks_dir.join("pre-commit-user").exists());
+    assert!(!legacy_hooks_dir.join("post-checkout-user").exists());
+
+    Ok(())
+}
+
+/// The git on `PATH` can lose config-hook support after an install -- a PATH
+/// change that puts an older git first is enough. Installing file-based hooks
+/// on top of a config-based installation must drop the config registrations,
+/// or every commit runs GitButler's hook twice: once via config, once via the
+/// hooks directory.
+#[test]
+fn test_file_install_over_config_install_removes_config_registrations() -> Result<()> {
+    let (_tmp, repo) = create_test_repo()?;
+    let dir = workdir(&repo);
+
+    install_managed_hooks_with(&repo, true)?;
+    assert_eq!(
+        local_config(&dir, "hook.gitbutler-pre-commit.event").as_deref(),
+        Some("pre-commit"),
+        "precondition: the config-based install must have registered the hook"
+    );
+
+    // The same repo, now seen by a git that predates config-based hooks.
+    install_managed_hooks_with(&repo, false)?;
+
+    let installed = fs::read_to_string(hooks_dir(&repo).join("pre-commit"))?;
+    assert!(
+        installed.contains("GITBUTLER_MANAGED_HOOK_V1"),
+        "the file-based hook must be installed, got: {installed}"
+    );
+    for section in ["gitbutler-pre-commit", "gitbutler-post-checkout"] {
+        assert_eq!(
+            local_config(&dir, &format!("hook.{section}.event")),
+            None,
+            "{section} must be unregistered, or it runs alongside the hooks-directory hook"
+        );
+    }
+    assert!(
+        !config_scripts_dir(&repo).join("pre-commit").exists(),
+        "the orphaned config script must be removed with its registration"
+    );
+
     Ok(())
 }

--- a/crates/gitbutler-repo/tests/repo/managed_hooks_tests.rs
+++ b/crates/gitbutler-repo/tests/repo/managed_hooks_tests.rs
@@ -1078,6 +1078,16 @@ fn test_real_git_checkout_away_removes_legacy_hooks_from_partial_migration() -> 
 
     git_ok(&dir, &["checkout", &default_branch]);
 
+    for section in ["gitbutler-pre-commit", "gitbutler-post-checkout"] {
+        assert_eq!(
+            local_config(&dir, &format!("hook.{section}.command")),
+            None,
+            "config-based {section} hook should be unregistered"
+        );
+    }
+    assert!(!config_scripts_dir(&repo).join("pre-commit").exists());
+    assert!(!config_scripts_dir(&repo).join("post-checkout").exists());
+
     assert!(
         !legacy_hooks_dir.join("pre-commit").exists(),
         "legacy pre-commit hook stranded by a partial migration should be removed outright"


### PR DESCRIPTION
## 🧢 Changes

On git ≥ 2.54, GitButler registers its workspace-guard hooks through [config-based hooks](https://git-scm.com/docs/githooks#_configuration_based_hooks) instead of writing into `.git/hooks/`:

- Guard scripts live in `<git-common-dir>/gitbutler/hooks/`, registered via `hook.<name>.event` / `hook.<name>.command` in local config.
- `.git/hooks/` is never touched, so prek / pre-commit / husky / lefthook keep working unchanged — git runs config hooks first, then the hooks-directory hook.
- Installing on 2.54+ also cleans up hooks that older GitButler versions wrote into `.git/hooks/` (signature-checked) and restores any displaced user hook from its backup. Installation re-runs on every workspace update, so after a git upgrade this migration happens on the user's next GitButler operation — no manual step. Until then the old file hooks simply keep working.
- `git config gitbutler.installHooks false` opts out on any git version, and `but setup` reports the skip in both its human and JSON output.
- `but setup` and `but teardown` report hooks they couldn't install or remove, in both the human and JSON output, instead of silently claiming success.

For git < 2.54 nothing changes by default: the file-based installation stays exactly as it is today (hooks run under whatever `git` the user invokes, so support is detected via `git --version`, not the library GitButler links). The only version-independent additions are the opt-out and teardown's honest reporting. Checking out away from `gitbutler/workspace` still cleans everything up (`git switch` and `git checkout` both fire the post-checkout hook — verified with both).

About two-thirds of the added lines are tests. They run against real repositories, including end-to-end with a real git ≥ 2.54: an actual `git commit` on the workspace branch is blocked, an actual `git checkout` away removes the config entries and scripts (self-skipping on older CI git).

What I validated personally, with a release build of this branch on macOS:

- [x] Disposable repo with a local bare remote and a `pre-commit` hook installed by an actual `prek install`: `but setup`, inspected the config entries and both hook directories, `git commit` blocked with `GITBUTLER_ERROR` (prek's own hook still ran and passed alongside it), `git checkout main` removed the config entries and scripts — then the same staged change committed successfully through prek. The prek hook's checksum was identical before, during, and after.
- [x] Second repo, exiting via `but branch new` + `but teardown` instead of the checkout: same clean end state, same untouched checksum. (One caveat: `but teardown` straight after `but setup`, with no branch created, stops at "Finding active branch to check out" before reaching the hooks — pre-existing behavior, `--checkout-to` gets past it and hook cleanup is then complete.)
- [x] First validated on git 2.54.0; after Homebrew moved this machine to 2.55.0 I re-ran both scenarios and the automated suite against it — everything still passes
- [x] The pre-2.54 fallback and the upgrade migration, in a Debian container (reproduction script in a comment below): with git 2.53.0 `but setup` installs today's file-based hooks — user hook displaced to `pre-commit-user` but still chained and running, commit blocked; after switching to git 2.55.0 the next install registers the config hooks, sweeps the signed file hooks, and restores the user hook byte-identical; checkout away then removes everything. 18 scripted checks, all green.

The core of the manual run:

```console
$ but setup
$ git config --local --get-regexp '^hook\.'
hook.gitbutler-pre-commit.event pre-commit
hook.gitbutler-pre-commit.command '.../.git/gitbutler/hooks/pre-commit'
...
$ git commit -m test
GITBUTLER_ERROR: Cannot commit directly to gitbutler/workspace branch.
$ git checkout main
NOTE: You have left GitButler's managed workspace branch.
$ git config --local --get-regexp '^hook\.'   # exits 1 — nothing left
```

## ☕️ Reasoning

This is the surgical alternative discussed in #12748 after @Alxandr pointed out git 2.54's config-based hooks. The ownership-model PR (#12980) made *sharing* `.git/hooks/` slots safe; config-based hooks make the slots uncontested by construction, so nearly all of that machinery becomes unnecessary — "nearly", because a small signature-checked remnant survives as the migration sweep that removes hooks older GitButler versions wrote and restores displaced user hooks. None of the rest has to be merged only to be removed as git ≥ 2.54 spreads.

The biggest structural win: the old approach needed adapter code per hook manager — a detection signature, config matching, and integration instructions for prek first, then again for pre-commit, husky, lefthook, hk, and whatever comes next. Here that whole axis disappears. GitButler never inspects or even notices the other tool, so every hook manager — including ones that don't exist yet — is supported with zero code. This honestly is my favorite part of this new PR compared to the old one. A close second favorite is that this PR contains drastically less code and attempts to contribute something that should hold for a long time, very much unlike the first attempt which would have added maintenance burden to the project, no matter how well-meaning.

Git 2.54 shipped in April 2026, so package-manager gits (Homebrew, winget, Arch, Fedora…) are already past it — my machine is on 2.55 — while slower channels (Apple's Command Line Tools, Debian/Ubuntu LTS) will lag for a while. That's fine: users below 2.54 keep today's file-based behavior and lose nothing, and the share on the config-based path only grows from here.

Two review notes:

- This landed bigger than the couple-hundred lines you mused about — a good part of the implementation is the hook scripts themselves. It was bigger still: the CLI exit-code plumbing that came with the reporting is no longer part of this PR.
- The new integration tests keep the `test_` prefix you asked to avoid on #12980: they extend the existing `managed_hooks_tests.rs`, where all 21 existing tests use it, and matching the file seemed better than mixing conventions or renaming untouched tests. Glad to rename if you prefer.

## 🎫 Affected issues

Fixes: #12748

