### PR TITLE
fix(but): assign short IDs to anonymous segments

### DIFF
--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -1251,16 +1251,22 @@ fn print_group(
                 branch_suffix.push(Span::styled(no_commits, t.hint));
             }
 
+            let (decoration_start, decoration_end) = if branch.is_empty() {
+                ("", "")
+            } else {
+                (" [", "]")
+            };
+
             output.branch(
                 Vec::from([Span::raw(format!("┊{notch}┄"))]),
                 BranchLineContent {
                     id: Vec::from([Span::styled(segment.short_id.clone(), t.cli_id)]),
-                    decoration_start: Vec::from([Span::raw(" [")]),
+                    decoration_start: Vec::from([Span::raw(decoration_start)]),
                     branch_name: Vec::from([
                         Span::styled(branch, t.local_branch),
                         Span::raw(workspace),
                     ]),
-                    decoration_end: Vec::from([Span::raw("]")]),
+                    decoration_end: Vec::from([Span::raw(decoration_end)]),
                     suffix: branch_suffix,
                 },
                 branch_cli_id,

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -779,6 +779,10 @@ impl IdMap {
     }
 
     fn parse_element<'a>(&'a self, element: &str) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>> {
+        if element.is_empty() {
+            return Ok(vec![]);
+        }
+
         // Parse known suffixes.
         if let Some(prefix) = element.strip_suffix("@{stack}") {
             let mut matches = Vec::<Box<dyn Node<'a> + 'a>>::new();

--- a/crates/but/src/id/stacks_info.rs
+++ b/crates/but/src/id/stacks_info.rs
@@ -88,24 +88,25 @@ fn populate_branch_short_ids(
         .iter_mut()
         .flat_map(|stack| stack.segments.iter_mut())
     {
-        let Some(branch_name) = segment.branch_name() else {
-            // The branch CliId is its name, so if this segment doesn't have a
-            // name, it doesn't need an ID.
-            continue;
-        };
-        segment.short_id = 'short_id: {
-            // Find first non-conflicting pair or triple (i.e. used in
-            // exactly one branch) and use it.
-            for candidate in branch_name.windows(2).chain(branch_name.windows(3)) {
-                if let Ok(short_id) = str::from_utf8(candidate)
-                    && let Some(true) = maybe_mark_used(candidate, id_usage)
-                {
-                    break 'short_id short_id.to_owned();
+        if let Some(branch_name) = segment.branch_name() {
+            segment.short_id = 'short_id: {
+                // Find first non-conflicting pair or triple (i.e. used in
+                // exactly one branch) and use it.
+                for candidate in branch_name.windows(2).chain(branch_name.windows(3)) {
+                    if let Ok(short_id) = str::from_utf8(candidate)
+                        && let Some(true) = maybe_mark_used(candidate, id_usage)
+                    {
+                        break 'short_id short_id.to_owned();
+                    }
                 }
-            }
-            // If none available, use next available ID.
-            id_usage.next_available()?.to_short_id()
-        };
+                // If none available, use next available ID.
+                id_usage.next_available()?.to_short_id()
+            };
+        } else {
+            // This sgement is anonymous, so we have no name to base the ID on. We just assign it a
+            // generic ID, which allows some rudimentary stuff to work (e.g. `but status`).
+            segment.short_id = id_usage.next_available()?.to_short_id();
+        }
     }
 
     Ok(())

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -47,6 +47,33 @@ fn worktrees() {
 }
 
 #[test]
+fn anonymous_segment() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-anonymous-segment");
+    env.setup_metadata(&["A"]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0
+┊●   b36b65c anonymous (no changes)
+┊│
+┊├┄h0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
 fn unborn() {
     let env = Sandbox::open_scenario_with_target_and_default_settings("unborn");
     snapbox::assert_data_eq!(env.git_log(), snapbox::str![""]);

--- a/crates/but/tests/fixtures/scenario/one-stack-anonymous-segment.sh
+++ b/crates/but/tests/fixtures/scenario/one-stack-anonymous-segment.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A workspace with one named branch and an unreferenced commit above it, projected as an
+# anonymous stack segment.
+git-init-frozen
+commit-file M
+setup_target_to_match_main
+
+git checkout -b A
+  commit-file A
+
+git checkout --detach
+  commit anonymous
+git branch -f A HEAD^
+
+# HEAD remains on the anonymous commit, so the workspace commit is created above it.
+create_workspace_commit_once


### PR DESCRIPTION
This in effect adds partial support for anonymous segments in `but`.

I accidentally added rudimentary support for anonymous segments with 80d25cd766 as it completely removed the length check for CLI IDs. So anonymous segments would be rendered without any form of identifier. It's of course rather strange to allow a 0-length short ID to match anything, so this commit also removes that behavior and requires a CLI ID to be non-empty.

The short ID on anonymous segments currently cannot be used for much as we in general try to resolve segments to branches. That is a bit unfortunate but this is at least better than what we had before with outright crashes.