### PR TITLE
Guide unskilled agents through GitButler skill installation

### DIFF
--- a/crates/but-path/src/lib.rs
+++ b/crates/but-path/src/lib.rs
@@ -10,6 +10,7 @@
 //! - logs: `<E2E_TEST_APP_DATA_DIR>/logs`
 //! - config: `<E2E_TEST_APP_DATA_DIR>/gitbutler`
 //! - cache: `<E2E_TEST_APP_DATA_DIR>/cache`
+//! - home: `<E2E_TEST_APP_DATA_DIR>/home`
 //!
 //! This override intentionally ignores the compile-time or explicit [`AppChannel`]. Even
 //! `*_for_channel(...)` helpers return the same E2E path for all channels so tests do not
@@ -28,6 +29,18 @@ use anyhow::Context;
 /// `<E2E_TEST_APP_DATA_DIR>/com.gitbutler.app` for every channel.
 pub fn app_data_dir() -> anyhow::Result<PathBuf> {
     app_data_dir_for_channel(AppChannel::new())
+}
+
+/// The user's home directory, for code that reads or writes user-level files
+/// (like agent skill installations).
+///
+/// When `E2E_TEST_APP_DATA_DIR` is set, returns `<E2E_TEST_APP_DATA_DIR>/home`
+/// so tests never touch the real home directory.
+pub fn home_dir() -> Option<PathBuf> {
+    if let Some(test_dir) = std::env::var_os("E2E_TEST_APP_DATA_DIR") {
+        return Some(PathBuf::from(test_dir).join("home"));
+    }
+    dirs::home_dir()
 }
 
 /// Like [`app_data_dir()`], but explicitly for `channel`.

--- a/crates/but/src/args/skill.rs
+++ b/crates/but/src/args/skill.rs
@@ -21,7 +21,8 @@ pub enum Subcommands {
     /// Use --global to install the skill in a global location instead of the
     /// current repository.
     ///
-    /// In non-interactive mode, specify --path or --detect.
+    /// In non-interactive mode, a detected agent uses its global skill directory;
+    /// otherwise specify --path or --detect.
     ///
     /// ## Examples
     ///

--- a/crates/but/src/command/agent/mod.rs
+++ b/crates/but/src/command/agent/mod.rs
@@ -313,7 +313,7 @@ fn prompt_agents(
     // the CLI (if any), plus any whose config we can find on this machine or in
     // this repository.
     let running = detect_agent::detect().and_then(AgentTarget::from_detected);
-    let home = dirs::home_dir();
+    let home = but_path::home_dir();
     let preselect =
         |agent: AgentTarget| Some(agent) == running || agent.in_use(home.as_deref(), repo);
 
@@ -674,7 +674,7 @@ fn write_review(writer: &mut impl fmt::Write, plan: &Plan) -> fmt::Result {
 /// leading `.` component so review paths read cleanly (`AGENTS.md`,
 /// `~/.codex/...`).
 fn display_path(path: &Path) -> String {
-    if let Some(home) = dirs::home_dir()
+    if let Some(home) = but_path::home_dir()
         && let Ok(rest) = path.strip_prefix(&home)
     {
         return if rest.as_os_str().is_empty() {

--- a/crates/but/src/command/agent/plan.rs
+++ b/crates/but/src/command/agent/plan.rs
@@ -37,7 +37,7 @@ impl AgentTarget {
             Self::ClaudeCode => "Claude Code",
             Self::Cursor => "Cursor",
             Self::GitHubCopilot => "GitHub Copilot",
-            Self::Windsurf => "Windsurf / Devin",
+            Self::Windsurf => "Windsurf",
             Self::OpenCode => "OpenCode",
             Self::AgentSkills => "Agent Skills",
         }
@@ -70,8 +70,7 @@ impl AgentTarget {
             detect_agent::Agent::Cursor | detect_agent::Agent::CursorCli => Some(Self::Cursor),
             detect_agent::Agent::GitHubCopilot => Some(Self::GitHubCopilot),
             detect_agent::Agent::OpenCode => Some(Self::OpenCode),
-            detect_agent::Agent::Devin => Some(Self::Windsurf),
-            detect_agent::Agent::Pi => Some(Self::AgentSkills),
+            detect_agent::Agent::Devin => Some(Self::AgentSkills),
             detect_agent::Agent::GeminiCli
             | detect_agent::Agent::Augment
             | detect_agent::Agent::Antigravity
@@ -85,6 +84,7 @@ impl AgentTarget {
             | detect_agent::Agent::RooCode
             | detect_agent::Agent::Trae
             | detect_agent::Agent::TabnineCli
+            | detect_agent::Agent::Pi
             | detect_agent::Agent::Unknown => None,
         }
     }
@@ -151,7 +151,7 @@ impl AgentTarget {
 
     /// This agent's `SKILL_FORMATS` display name. The install paths themselves
     /// are the single source of truth in `crate::command::skill`.
-    fn skill_format_name(self) -> &'static str {
+    pub(super) fn skill_format_name(self) -> &'static str {
         match self {
             Self::Codex => "Codex",
             Self::ClaudeCode => "Claude Code",
@@ -241,7 +241,7 @@ pub(super) fn collect_skill_installs(
     // base directory once, expanding `Both` into global + repository.
     let mut locations: Vec<(Scope, PathBuf)> = Vec::new();
     if matches!(scope, Scope::Global | Scope::Both) {
-        let home = dirs::home_dir()
+        let home = but_path::home_dir()
             .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
         locations.push((Scope::Global, home));
     }
@@ -278,7 +278,7 @@ pub(super) fn collect_instruction_writes(
     let mut by_path: BTreeMap<PathBuf, Vec<AgentTarget>> = BTreeMap::new();
     let mut print_only_notes = Vec::new();
     let home = if matches!(scope, Scope::Global | Scope::Both) {
-        Some(dirs::home_dir().context("Could not determine home directory")?)
+        Some(but_path::home_dir().context("Could not determine home directory")?)
     } else {
         None
     };

--- a/crates/but/src/command/agent/tests.rs
+++ b/crates/but/src/command/agent/tests.rs
@@ -7,6 +7,14 @@ use super::{
 };
 
 #[test]
+fn devin_uses_shared_agent_skills_target() {
+    assert_eq!(
+        AgentTarget::from_detected(detect_agent::Agent::Devin),
+        Some(AgentTarget::AgentSkills)
+    );
+}
+
+#[test]
 fn generated_default_policy_includes_baseline_and_default_preferences() {
     let policy = render_managed_policy_block(&WizardAnswers::default());
 
@@ -87,7 +95,7 @@ fn display_path_strips_leading_dot_component() {
 #[test]
 fn display_path_collapses_home_to_tilde() {
     use std::path::MAIN_SEPARATOR as SEP;
-    let home = dirs::home_dir().expect("home dir");
+    let home = but_path::home_dir().expect("home dir");
     let inside = home.join(".codex").join("AGENTS.md");
     assert_eq!(display_path(&inside), format!("~{SEP}.codex{SEP}AGENTS.md"));
 }
@@ -123,11 +131,12 @@ fn agent_in_use_detects_repo_marker_but_ignores_shared_agents_md() {
 #[test]
 fn agent_in_use_detects_existing_skill_install() {
     let home = tempfile::tempdir().expect("home");
-    // A skill a prior run installed for OpenCode (`~/.opencode/skills/gitbutler`)
+    // A skill a prior run installed for OpenCode
     // should mark it in use even without other config present.
     std::fs::create_dir_all(
         home.path()
-            .join(".opencode")
+            .join(".config")
+            .join("opencode")
             .join("skills")
             .join("gitbutler"),
     )
@@ -571,18 +580,15 @@ fn skill_installs_global_only_uses_home_paths() {
             .iter()
             .any(|i| i.path.ends_with(".copilot/skills/gitbutler"))
     );
-    // Paths match `but skill`'s SKILL_FORMATS so installs stay discoverable —
-    // OpenCode is `.opencode` (not `.config/opencode`) and Windsurf is
-    // `.windsurf` (not `.codeium/windsurf`).
     assert!(
         installs
             .iter()
-            .any(|i| { i.path.ends_with(".opencode/skills/gitbutler") })
+            .any(|i| { i.path.ends_with(".config/opencode/skills/gitbutler") })
     );
     assert!(
         installs
             .iter()
-            .any(|i| { i.path.ends_with(".windsurf/skills/gitbutler") })
+            .any(|i| { i.path.ends_with(".codeium/windsurf/skills/gitbutler") })
     );
 }
 

--- a/crates/but/src/command/skill/freshness.rs
+++ b/crates/but/src/command/skill/freshness.rs
@@ -1,0 +1,238 @@
+//! The agent-facing skill freshness subsystem: detect whether the driving
+//! agent can load a GitButler skill, nudge it to install one,
+//! and keep existing installs current.
+
+use std::path::PathBuf;
+
+use super::{
+    find_format_installations, home_dir, is_current_skill_installation, skill_format_for_agent,
+    skill_format_for_name, write_skill_files,
+};
+use crate::{
+    theme,
+    utils::detect_agent::{self, Agent},
+};
+
+pub(crate) enum AgentSkillNotice {
+    Hint(String),
+    Updated(String),
+    UpdateFailed(String),
+}
+
+impl AgentSkillNotice {
+    pub(crate) fn text(&self) -> &str {
+        match self {
+            Self::Hint(text) | Self::Updated(text) | Self::UpdateFailed(text) => text,
+        }
+    }
+
+    fn into_text(self) -> String {
+        match self {
+            Self::Hint(text) | Self::Updated(text) | Self::UpdateFailed(text) => text,
+        }
+    }
+
+    pub(crate) fn is_hint(&self) -> bool {
+        matches!(self, Self::Hint(_))
+    }
+}
+
+pub(crate) fn agent_skill_notice(current_dir: &std::path::Path) -> Option<AgentSkillNotice> {
+    let update = agent_skill_freshness_check();
+    let hint = agent_skill_install_hint(current_dir);
+    match update {
+        Some(failed @ AgentSkillNotice::UpdateFailed(_)) => Some(failed),
+        update => hint.or(update),
+    }
+}
+
+pub(crate) fn agent_skill_update_notice() -> Option<String> {
+    agent_skill_freshness_check().map(AgentSkillNotice::into_text)
+}
+
+/// Skill upkeep for agent commands. Returns `None` when no agent is detected.
+///
+/// Scans skill installations and updates the detected agent's stale global copy.
+///
+/// Best-effort by construction: every failure in skill detection or file
+/// updates is logged or turned into an agent-facing line.
+/// Nothing propagates to the command that triggered the check.
+fn agent_skill_freshness_check() -> Option<AgentSkillNotice> {
+    let agent = detect_agent::detect()?;
+    let version = option_env!("VERSION").unwrap_or("dev");
+    let outdated: Vec<_> = agent_skill_installations(agent, None)?
+        .into_iter()
+        .filter(|path| !is_current_skill_installation(path, version))
+        .collect();
+    if outdated.is_empty() {
+        return None;
+    }
+    for path in outdated {
+        if let Err(err) = write_skill_files(&path) {
+            tracing::debug!(?err, "failed to update the agent skill");
+            return Some(AgentSkillNotice::UpdateFailed(
+                agent_skill_update_failed_notice(&err),
+            ));
+        }
+    }
+    Some(AgentSkillNotice::Updated(agent_skill_updated_message(
+        version,
+    )))
+}
+
+/// Report a missing skill before normal agent-driven commands.
+fn agent_skill_install_hint(current_dir: &std::path::Path) -> Option<AgentSkillNotice> {
+    let agent = detect_agent::detect()?;
+    let workdir = gix::discover(current_dir)
+        .ok()
+        .and_then(|repo| repo.workdir().map(std::path::Path::to_path_buf));
+    let installations = agent_skill_installations(agent, workdir.as_deref())?;
+    let version = option_env!("VERSION").unwrap_or("dev");
+    if installations.is_empty() {
+        Some(AgentSkillNotice::Hint(agent_skill_not_installed_notice()))
+    } else if installations
+        .iter()
+        .all(|path| is_current_skill_installation(path, version))
+    {
+        None
+    } else {
+        Some(AgentSkillNotice::Hint(agent_skill_outdated_notice()))
+    }
+}
+
+fn agent_skill_installations(
+    agent: Agent,
+    workdir: Option<&std::path::Path>,
+) -> Option<Vec<PathBuf>> {
+    let global = skill_format_for_agent(agent, true)?;
+    let mut installations = home_dir()
+        .map(|home| find_format_installations(global, &home))
+        .unwrap_or_default();
+    if let Some(workdir) = workdir {
+        if let Some(format) = skill_format_for_agent(agent, false) {
+            installations.extend(find_format_installations(format, workdir));
+        }
+        if matches!(agent, Agent::OpenCode | Agent::Devin)
+            && let Some(format) = skill_format_for_name("Agent Skills", false)
+        {
+            installations.extend(find_format_installations(format, workdir));
+        }
+    }
+    Some(installations)
+}
+
+fn agent_skill_not_installed_notice() -> String {
+    let t = theme::get();
+    format!(
+        "{} AGENT ACTION REQUIRED: Install the GitButler skill before continuing.\n\
+         Run now: but skill install\n\
+         Then read the installed SKILL.md path printed by that command and continue.\n\
+         Do not merely tell the user to run it.\n\
+         This notice repeats until the skill is installed. If it still appears \
+         after installing, report it instead of retrying.",
+        t.sym().warning,
+    )
+}
+
+fn agent_skill_outdated_notice() -> String {
+    let t = theme::get();
+    format!(
+        "{} AGENT ACTION REQUIRED: The GitButler skill is out of date or incomplete.\n\
+         Run once: but skill check --update\n\
+         Then reload/use the updated skill.",
+        t.sym().warning,
+    )
+}
+
+/// The default install location for a bare `but skill install` when a detected
+/// agent runs it without a terminal to answer the wizard: the agent's own
+/// global skill directory, the same location the freshness check considers
+/// loadable. The caller decides whether this is an agent-driven invocation.
+pub(super) fn agent_default_install_path(agent: Agent) -> Option<PathBuf> {
+    Some(skill_format_for_agent(agent, true)?.get_install_path(&home_dir()?))
+}
+
+fn agent_skill_updated_message(version: &str) -> String {
+    let t = theme::get();
+    format!(
+        "{} The GitButler skill was out of date and was updated to {version}. \
+         Reload/use the GitButler skill to pick up the changes.",
+        t.sym().success,
+    )
+}
+
+fn agent_skill_update_failed_notice(err: &anyhow::Error) -> String {
+    let t = theme::get();
+    format!(
+        "{} AGENT ACTION REQUIRED: The GitButler skill is out of date and auto-update failed: {err:#}.\n\
+         Run once: but skill check --update\n\
+         Then reload/use the updated skill.\n\
+         If this warning repeats, report it instead of retrying.",
+        t.sym().warning,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Full notice/hint wording is pinned by the status snapshot test.
+    #[test]
+    fn not_installed_notice_explains_the_action() {
+        let notice = agent_skill_not_installed_notice();
+        assert!(
+            notice.contains("repeats until the skill is installed"),
+            "repetition is expected behavior, so the notice must say so instead \
+             of letting the agent read a repeat as a malfunction"
+        );
+        assert!(notice.contains("Run now: but skill install"));
+        assert!(!notice.contains("but agent setup"));
+    }
+
+    #[test]
+    fn update_failure_notice_surfaces_the_error() {
+        let failed = agent_skill_update_failed_notice(&anyhow::anyhow!("denied"));
+        assert!(failed.contains("denied"));
+        assert!(failed.contains("but skill check --update"));
+    }
+
+    #[test]
+    fn agent_global_skill_dirs_match_agent_loaders() {
+        let cases = [
+            (Agent::ClaudeCode, &[".claude", "skills", "gitbutler"][..]),
+            (Agent::GeminiCli, &[".gemini", "skills", "gitbutler"][..]),
+            (
+                Agent::OpenCode,
+                &[".config", "opencode", "skills", "gitbutler"][..],
+            ),
+            (
+                Agent::Devin,
+                &[".config", "devin", "skills", "gitbutler"][..],
+            ),
+            (Agent::Pi, &[".pi", "agent", "skills", "gitbutler"][..]),
+        ];
+        for (agent, expected) in cases {
+            assert_eq!(
+                skill_format_for_agent(agent, true).map(|format| format.path_components),
+                Some(expected),
+                "global skill dir for {agent:?}"
+            );
+        }
+        assert!(skill_format_for_agent(Agent::Unknown, true).is_none());
+    }
+
+    #[test]
+    fn agent_skill_installations_ignore_local_without_workdir() {
+        let dir = tempfile::tempdir().unwrap();
+        let local = skill_format_for_agent(Agent::Codex, false)
+            .unwrap()
+            .get_install_path(dir.path());
+        write_skill_files(&local).unwrap();
+
+        assert!(
+            !agent_skill_installations(Agent::Codex, None)
+                .unwrap()
+                .contains(&local)
+        );
+    }
+}

--- a/crates/but/src/command/skill/mod.rs
+++ b/crates/but/src/command/skill/mod.rs
@@ -2,15 +2,20 @@ use std::{fmt::Write as _, path::PathBuf};
 
 use anyhow::{Context as _, Result};
 use but_ctx::Context;
-use chrono::{DateTime, Duration, Utc};
-use command_group::AsyncCommandGroup;
+// Test-override-aware (`E2E_TEST_APP_DATA_DIR`), so skill discovery and
+// installation never touch the real home directory under test.
+use but_path::home_dir;
 use serde::Serialize;
 
 use crate::{
     args::skill,
     theme::{self, Paint},
-    utils::OutputChannel,
+    utils::{OutputChannel, detect_agent::Agent},
 };
+
+mod freshness;
+use freshness::agent_default_install_path;
+pub(crate) use freshness::{agent_skill_notice, agent_skill_update_notice};
 
 /// Error type for user-initiated cancellation
 #[derive(Debug, Clone, Copy)]
@@ -25,15 +30,10 @@ impl std::fmt::Display for UserCancelled {
 impl std::error::Error for UserCancelled {}
 
 // Embedded skill files
-const SKILL_MD: &[u8] = include_bytes!("../../skill/SKILL.md");
-const CONCEPTS_MD: &[u8] = include_bytes!("../../skill/references/concepts.md");
-const EXAMPLES_MD: &[u8] = include_bytes!("../../skill/references/examples.md");
-const REFERENCE_MD: &[u8] = include_bytes!("../../skill/references/reference.md");
-/// Minimum time between agent-triggered skill freshness checks. Long, because
-/// staleness is auto-repaired rather than waiting on the agent to act; the
-/// debounce only bounds the filesystem-check overhead. The timestamp lives in
-/// the pre-existing `agent-skill-notice` cache table.
-const AGENT_SKILL_CHECK_DEBOUNCE_HOURS: i64 = 12;
+const SKILL_MD: &[u8] = include_bytes!("../../../skill/SKILL.md");
+const CONCEPTS_MD: &[u8] = include_bytes!("../../../skill/references/concepts.md");
+const EXAMPLES_MD: &[u8] = include_bytes!("../../../skill/references/examples.md");
+const REFERENCE_MD: &[u8] = include_bytes!("../../../skill/references/reference.md");
 
 /// Metadata for a skill file to be installed
 struct SkillFile {
@@ -86,6 +86,13 @@ const SKILL_FILES: &[SkillFile] = &[
     },
 ];
 
+fn skill_files_in_write_order() -> impl Iterator<Item = &'static SkillFile> {
+    SKILL_FILES
+        .iter()
+        .filter(|file| !file.is_main_skill_file())
+        .chain(SKILL_FILES.iter().filter(|file| file.is_main_skill_file()))
+}
+
 /// Represents a skill installation location format
 #[derive(Debug, Clone)]
 struct SkillFormat {
@@ -107,6 +114,15 @@ enum SkillFormatAvailability {
 }
 
 impl SkillFormat {
+    const fn global(name: &'static str, path_components: &'static [&'static str]) -> Self {
+        Self {
+            name,
+            description: "Agent-specific global skill format",
+            availability: SkillFormatAvailability::GlobalOnly,
+            path_components,
+        }
+    }
+
     /// Get the actual installation path given a base directory
     fn get_install_path(&self, base_dir: &std::path::Path) -> PathBuf {
         join_relative_path(base_dir, self.path_components)
@@ -137,10 +153,13 @@ impl SkillFormat {
 /// the same locations that `but skill check`/install/update discover, instead of
 /// duplicating (and drifting from) these paths.
 pub(crate) fn path_components_for(name: &str, global: bool) -> Option<&'static [&'static str]> {
+    skill_format_for_name(name, global).map(|format| format.path_components)
+}
+
+fn skill_format_for_name(name: &str, global: bool) -> Option<&'static SkillFormat> {
     SKILL_FORMATS
         .iter()
         .find(|format| format.name == name && format.is_available_for(global))
-        .map(|format| format.path_components)
 }
 
 /// Join a relative path from components using platform-native separators.
@@ -168,10 +187,11 @@ const SKILL_FORMATS: &[SkillFormat] = &[
     },
     SkillFormat {
         name: "OpenCode",
-        description: "OpenCode AI skill format",
-        availability: SkillFormatAvailability::LocalAndGlobal,
+        description: "OpenCode local skill format",
+        availability: SkillFormatAvailability::LocalOnly,
         path_components: &[".opencode", "skills", "gitbutler"],
     },
+    SkillFormat::global("OpenCode", &[".config", "opencode", "skills", "gitbutler"]),
     SkillFormat {
         name: "Codex",
         description: "Codex skill format",
@@ -198,11 +218,53 @@ const SKILL_FORMATS: &[SkillFormat] = &[
     },
     SkillFormat {
         name: "Windsurf",
-        description: "Windsurf skill format",
-        availability: SkillFormatAvailability::LocalAndGlobal,
+        description: "Windsurf local skill format",
+        availability: SkillFormatAvailability::LocalOnly,
         path_components: &[".windsurf", "skills", "gitbutler"],
     },
+    SkillFormat::global("Windsurf", &[".codeium", "windsurf", "skills", "gitbutler"]),
+    SkillFormat::global("Gemini CLI", &[".gemini", "skills", "gitbutler"]),
+    SkillFormat::global("Augment", &[".augment", "skills", "gitbutler"]),
+    SkillFormat::global(
+        "Antigravity",
+        &[".gemini", "antigravity", "skills", "gitbutler"],
+    ),
+    SkillFormat::global(
+        "Universal Agents",
+        &[".config", "agents", "skills", "gitbutler"],
+    ),
+    SkillFormat::global("Crush", &[".config", "crush", "skills", "gitbutler"]),
+    SkillFormat::global("Goose", &[".config", "goose", "skills", "gitbutler"]),
+    SkillFormat::global("Roo Code", &[".roo", "skills", "gitbutler"]),
+    SkillFormat::global("Trae", &[".trae", "skills", "gitbutler"]),
+    SkillFormat::global("Tabnine CLI", &[".tabnine", "agent", "skills", "gitbutler"]),
+    SkillFormat::global("Pi", &[".pi", "agent", "skills", "gitbutler"]),
+    SkillFormat::global("Devin", &[".config", "devin", "skills", "gitbutler"]),
 ];
+
+fn skill_format_for_agent(agent: Agent, global: bool) -> Option<&'static SkillFormat> {
+    let name = match agent {
+        Agent::Codex => "Codex",
+        Agent::ClaudeCode | Agent::ClaudeCodeCowork => "Claude Code",
+        Agent::Cursor | Agent::CursorCli => "Cursor",
+        Agent::GitHubCopilot => "GitHub Copilot",
+        Agent::OpenCode => "OpenCode",
+        Agent::GeminiCli => "Gemini CLI",
+        Agent::Augment => "Augment",
+        Agent::Antigravity => "Antigravity",
+        Agent::Replit | Agent::Amp => "Universal Agents",
+        Agent::Crush => "Crush",
+        Agent::Goose => "Goose",
+        Agent::Cline => "Agent Skills",
+        Agent::RooCode => "Roo Code",
+        Agent::Trae => "Trae",
+        Agent::TabnineCli => "Tabnine CLI",
+        Agent::Pi => "Pi",
+        Agent::Devin => "Devin",
+        Agent::V0 | Agent::PulumiNeo | Agent::Unknown => return None,
+    };
+    skill_format_for_name(name, global)
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum InstallScope {
@@ -299,7 +361,7 @@ pub fn handle(
 /// Expand tilde in path to home directory
 fn expand_tilde(path_str: &str) -> Option<PathBuf> {
     if path_str == "~" || path_str.starts_with("~/") || path_str.starts_with("~\\") {
-        dirs::home_dir().map(|home| {
+        home_dir().map(|home| {
             if path_str == "~" {
                 home
             } else {
@@ -314,7 +376,7 @@ fn expand_tilde(path_str: &str) -> Option<PathBuf> {
 /// Get the base directory for installation (repo root or home directory)
 fn get_base_dir(ctx: Option<&mut Context>, global: bool) -> Result<PathBuf> {
     if global {
-        dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))
+        home_dir().ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))
     } else {
         let ctx = ctx.ok_or_else(|| {
             anyhow::anyhow!(
@@ -460,6 +522,18 @@ fn find_format_installations(format: &SkillFormat, base_dir: &std::path::Path) -
     found
 }
 
+fn is_complete_skill_installation(path: &std::path::Path) -> bool {
+    is_gitbutler_skill(&path.join("SKILL.md"))
+        && SKILL_FILES
+            .iter()
+            .all(|file| file.get_install_path(path).is_file())
+}
+
+fn is_current_skill_installation(path: &std::path::Path, version: &str) -> bool {
+    is_complete_skill_installation(path)
+        && extract_installed_version(&path.join("SKILL.md")).as_deref() == Some(version)
+}
+
 /// Scope labels for a skill installation. Single-sourced here because
 /// [`detect_install_paths`] selects installations by scope.
 const SCOPE_GLOBAL: &str = "global";
@@ -478,7 +552,7 @@ fn find_all_installations(
     // Determine which base directories to check
     let mut base_dirs: Vec<(PathBuf, &str)> = Vec::new();
 
-    if check_global && let Some(home) = dirs::home_dir() {
+    if check_global && let Some(home) = home_dir() {
         base_dirs.push((home, SCOPE_GLOBAL));
     }
 
@@ -525,7 +599,7 @@ pub fn check_skill_status(
         let installed_version =
             extract_installed_version(&skill_md_path).unwrap_or_else(|| "unknown".to_string());
 
-        let up_to_date = installed_version == cli_version;
+        let up_to_date = is_current_skill_installation(&path, &cli_version);
         if !up_to_date {
             outdated_count += 1;
         }
@@ -544,194 +618,6 @@ pub fn check_skill_status(
         skills,
         outdated_count,
     })
-}
-
-/// Periodic agent-facing skill upkeep, run after agent mutation commands.
-///
-/// At most once per [`AGENT_SKILL_CHECK_DEBOUNCE_HOURS`], checks all skill
-/// installations and starts a background update of outdated ones. Skill files
-/// are fully application-managed, so staleness is fixed directly rather than by
-/// asking the agent to act. Returns an agent-facing line when something
-/// happened: an update announcement (the agent should reload the skill), or an
-/// `AGENT ACTION REQUIRED` notice for cases the application cannot resolve
-/// itself (skill not installed, or the update could not start).
-///
-/// Best-effort by construction: every failure - cache access, skill detection,
-/// the update subprocess - is logged or turned into an agent-facing line.
-/// Nothing propagates to the mutation command that triggered the check.
-pub fn agent_skill_freshness_check_for_context(ctx: Option<&mut Context>) -> Option<String> {
-    let now = Utc::now();
-    match ctx {
-        Some(ctx) => {
-            let workdir = ctx
-                .repo
-                .get()
-                .ok()
-                .and_then(|repo| repo.workdir().map(|workdir| workdir.to_path_buf()));
-            {
-                let cache = ctx.app_cache.get_cache().ok()?;
-                if !agent_skill_check_due(cache.agent_skill_notice().get().as_ref(), now) {
-                    return None;
-                }
-            }
-            {
-                let mut cache = ctx.app_cache.get_cache_mut().ok()?;
-                if !record_agent_skill_check(&mut cache, now) {
-                    return None;
-                }
-            }
-            reconcile_agent_skills(check_skill_status(Some(&mut *ctx), true, true), move || {
-                spawn_skill_update(workdir.as_deref())
-            })
-        }
-        None => {
-            let mut cache = Context::app_cache();
-
-            if !agent_skill_check_due(cache.agent_skill_notice().get().as_ref(), now) {
-                return None;
-            }
-            if !record_agent_skill_check(&mut cache, now) {
-                return None;
-            }
-            reconcile_agent_skills(check_skill_status(None, true, true), || {
-                spawn_skill_update(None)
-            })
-        }
-    }
-}
-
-/// Bring skill installations in line with the running CLI and describe the
-/// outcome to the agent, if anything needs saying. `spawn_update` starts the
-/// actual update and is only invoked when something is outdated.
-fn reconcile_agent_skills(
-    result: Result<SkillCheckResult>,
-    spawn_update: impl FnOnce() -> Result<()>,
-) -> Option<String> {
-    let result = match result {
-        Ok(result) => result,
-        Err(err) => {
-            tracing::debug!(?err, "failed to check agent skill freshness");
-            return None;
-        }
-    };
-
-    if result.skills.is_empty() {
-        return Some(agent_skill_not_installed_notice());
-    }
-    if result.outdated_count == 0 {
-        return None;
-    }
-
-    match spawn_update() {
-        Ok(()) => Some(agent_skill_update_started_message(&result.cli_version)),
-        Err(err) => {
-            tracing::debug!(?err, "failed to spawn the agent skill auto-update");
-            Some(agent_skill_update_failed_notice(&err))
-        }
-    }
-}
-
-/// Update outdated skills by spawning `but skill check --update` as a detached
-/// child of the current binary, mirroring how metrics emission and background
-/// sync spawn `but`. Out-of-process so the update cannot disturb the invoking
-/// command and is recorded by command metrics like any other invocation;
-/// detached so it survives the parent. The outcome is not observed - if the
-/// update fails, the next debounced check finds the skill still outdated and
-/// tries again.
-fn spawn_skill_update(workdir: Option<&std::path::Path>) -> Result<()> {
-    let but_path = crate::utils::binary_path::current_exe_for_but_exec()
-        .context("failed to resolve the but binary path")?;
-    let mut cmd = tokio::process::Command::new(but_path);
-    // Anchor local-scope skill detection to the repository the parent runs in.
-    if let Some(workdir) = workdir {
-        cmd.arg("-C").arg(workdir);
-    }
-    cmd.args(["skill", "check", "--update"])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .group()
-        .kill_on_drop(false)
-        .spawn()
-        .context("failed to spawn `but skill check --update`")?;
-    Ok(())
-}
-
-/// Record that the skill check ran, so the next one waits out the debounce.
-///
-/// Returns `false` when another process already recorded a check within the
-/// debounce window (or the cache is locked/unavailable) - the caller should
-/// then skip the check entirely.
-fn record_agent_skill_check(cache: &mut but_db::AppCacheHandle, now: DateTime<Utc>) -> bool {
-    match cache.immediate_transaction_nonblocking() {
-        Ok(Some(mut transaction)) => {
-            let cached = transaction.agent_skill_notice().get();
-
-            if !agent_skill_check_due(cached.as_ref(), now) {
-                false
-            } else {
-                let save_result = transaction.agent_skill_notice_mut().and_then(|handle| {
-                    handle.save(&but_db::cache::AgentSkillNotice { shown_at: now })
-                });
-                match save_result.and_then(|_| transaction.commit()) {
-                    Ok(()) => true,
-                    Err(err) => {
-                        tracing::debug!(?err, "failed to debounce agent skill check");
-                        false
-                    }
-                }
-            }
-        }
-        Ok(None) => {
-            tracing::debug!("agent skill check debounce cache is locked");
-            false
-        }
-        Err(err) => {
-            tracing::debug!(?err, "failed to access agent skill check debounce cache");
-            false
-        }
-    }
-}
-
-fn agent_skill_check_due(
-    cached: Option<&but_db::cache::AgentSkillNotice>,
-    now: DateTime<Utc>,
-) -> bool {
-    let Some(cached) = cached else {
-        return true;
-    };
-
-    now.signed_duration_since(cached.shown_at) >= Duration::hours(AGENT_SKILL_CHECK_DEBOUNCE_HOURS)
-}
-
-fn agent_skill_not_installed_notice() -> String {
-    let t = theme::get();
-    format!(
-        "{} AGENT ACTION REQUIRED: The GitButler skill is not installed.\n\
-         Install it once for this agent, then reload/use the GitButler skill.\n\
-         If this warning repeats, report it instead of retrying.",
-        t.sym().warning,
-    )
-}
-
-fn agent_skill_update_started_message(version: &str) -> String {
-    let t = theme::get();
-    format!(
-        "{} The GitButler skill was out of date; an automatic update to {version} \
-         has started in the background. Reload/use the GitButler skill to pick up \
-         the changes.",
-        t.sym().success,
-    )
-}
-
-fn agent_skill_update_failed_notice(err: &anyhow::Error) -> String {
-    let t = theme::get();
-    format!(
-        "{} AGENT ACTION REQUIRED: The GitButler skill is out of date and auto-update failed: {err:#}.\n\
-         Run once: but skill check --update\n\
-         Then reload/use the updated skill.\n\
-         If this warning repeats, report it instead of retrying.",
-        t.sym().warning,
-    )
 }
 
 /// Check if installed skills are up to date
@@ -952,7 +838,7 @@ fn prompt_for_install_path(
     let t = theme::get();
     if out.for_human().is_none() {
         anyhow::bail!(
-            "In non-interactive mode, you must specify --path or --detect. Use --path <path> to specify where to install the skill, or --detect to update an existing installation."
+            "No supported agent was detected. In non-interactive mode, specify --path or --detect. Use --path <path> to choose an installation directory, or --detect to update an existing installation."
         );
     }
     if !out.can_prompt() {
@@ -1078,7 +964,7 @@ pub(crate) fn write_skill_files(install_path: &std::path::Path) -> Result<&'stat
         )
     })?;
 
-    for file in SKILL_FILES {
+    for file in skill_files_in_write_order() {
         let file_path = file.get_install_path(install_path);
         let content = if file.is_main_skill_file() {
             // Use the version-injected content for SKILL.md
@@ -1113,6 +999,9 @@ fn install_skill(
     detect: bool,
 ) -> Result<()> {
     let t = theme::get();
+    let driving_agent = (!out.can_prompt())
+        .then(crate::utils::detect_agent::detect)
+        .flatten();
     // Validate that embedded files are not empty (catches build issues)
     if SKILL_FILES.iter().any(|f| f.content.is_empty()) {
         anyhow::bail!(
@@ -1168,10 +1057,18 @@ fn install_skill(
 
     // Determine installation path(s). Only --detect can yield more than one, when
     // several GitButler skills share a scope; they are all refreshed together.
+    let agent_default_path = if custom_path.is_none() && !detect {
+        driving_agent.and_then(agent_default_install_path)
+    } else {
+        None
+    };
+    let installed_for_driving_agent = agent_default_path.is_some();
     let install_paths = if let Some(custom) = custom_path {
         vec![resolve_custom_path(&custom, ctx, global)?]
     } else if detect {
         detect_install_paths(ctx, global)?
+    } else if let Some(path) = agent_default_path {
+        vec![path]
     } else {
         vec![prompt_for_install_path(ctx, global, out, &mut progress)?]
     };
@@ -1234,6 +1131,18 @@ fn install_skill(
             writeln!(writer, "    • {}", file.display_path())?;
         }
         writeln!(writer)?;
+        // A skill installed mid-session is only picked up when the agent's
+        // harness next indexes skills, so point the current session at the
+        // file directly. The locations all carry the same content, so reading
+        // the first one is enough.
+        if installed_for_driving_agent && let [first, ..] = install_paths.as_slice() {
+            writeln!(
+                writer,
+                "To use it in this session, read {} now; future sessions load it automatically.",
+                first.join("SKILL.md").display()
+            )?;
+            writeln!(writer)?;
+        }
     }
 
     if let Some(out) = out.for_json() {
@@ -1514,7 +1423,7 @@ mod tests {
     }
 
     // NOTE: detect_install_paths is difficult to test in isolation because it depends on
-    // dirs::home_dir() and git repository context. It's tested indirectly through
+    // the user home directory and git repository context. It's tested indirectly through
     // integration tests and manual testing. The core logic (is_gitbutler_skill validation
     // and per-format discovery) is tested separately.
 
@@ -1640,87 +1549,6 @@ mod tests {
     }
 
     #[test]
-    fn reconcile_handles_current_missing_and_check_errors() {
-        let update_must_not_run =
-            || -> Result<()> { panic!("no update may run unless something is outdated") };
-
-        let current = SkillCheckResult {
-            cli_version: "2.0.0".to_string(),
-            skills: vec![SkillStatus {
-                path: PathBuf::from("/test/path"),
-                format_name: "Codex".to_string(),
-                scope: "global".to_string(),
-                installed_version: "2.0.0".to_string(),
-                up_to_date: true,
-            }],
-            outdated_count: 0,
-        };
-        assert!(
-            reconcile_agent_skills(Ok(current), update_must_not_run).is_none(),
-            "up-to-date skills need neither repair nor notice"
-        );
-
-        let missing = SkillCheckResult {
-            cli_version: "2.0.0".to_string(),
-            skills: vec![],
-            outdated_count: 0,
-        };
-        let missing_notice = reconcile_agent_skills(Ok(missing), update_must_not_run)
-            .expect("a missing installation cannot be auto-repaired, so the agent is told");
-        assert!(missing_notice.contains("AGENT ACTION REQUIRED"));
-        assert!(missing_notice.contains("not installed"));
-        assert!(missing_notice.contains("report it instead of retrying"));
-
-        assert!(
-            reconcile_agent_skills(Err(anyhow::anyhow!("check failed")), update_must_not_run)
-                .is_none(),
-            "check errors are logged, not surfaced to the agent"
-        );
-    }
-
-    fn stale_check_result() -> SkillCheckResult {
-        SkillCheckResult {
-            cli_version: "2.0.0".to_string(),
-            skills: vec![SkillStatus {
-                path: PathBuf::from("/test/path"),
-                format_name: "Claude Code".to_string(),
-                scope: "global".to_string(),
-                installed_version: "1.0.0".to_string(),
-                up_to_date: false,
-            }],
-            outdated_count: 1,
-        }
-    }
-
-    #[test]
-    fn reconcile_spawns_update_for_stale_installations() {
-        let mut update_spawns = 0;
-        let message = reconcile_agent_skills(Ok(stale_check_result()), || {
-            update_spawns += 1;
-            Ok(())
-        })
-        .expect("a started update is announced so the agent reloads the skill");
-        assert_eq!(update_spawns, 1, "one update run repairs all installations");
-        assert!(message.contains("automatic update to 2.0.0"));
-        assert!(
-            !message.contains("AGENT ACTION REQUIRED"),
-            "a started auto-update is informational, not an action request"
-        );
-    }
-
-    #[test]
-    fn reconcile_falls_back_to_agent_notice_when_update_fails() {
-        let notice =
-            reconcile_agent_skills(Ok(stale_check_result()), || Err(anyhow::anyhow!("denied")))
-                .expect("when auto-update fails the agent is asked to run it");
-        assert!(notice.contains("AGENT ACTION REQUIRED"));
-        assert!(notice.contains("auto-update failed"));
-        assert!(notice.contains("denied"), "the update error is surfaced");
-        assert!(notice.contains("but skill check --update"));
-        assert!(notice.contains("report it instead of retrying"));
-    }
-
-    #[test]
     fn write_skill_files_writes_versioned_bundle() {
         let dir = tempfile::tempdir().unwrap();
         let install_path = dir.path().join(".claude").join("skills").join("gitbutler");
@@ -1742,47 +1570,13 @@ mod tests {
     }
 
     #[test]
-    fn agent_skill_check_debounce_is_12_hours() {
-        let now = DateTime::from_timestamp(2_000_000, 0).unwrap();
-        assert!(agent_skill_check_due(None, now));
-
-        let recent = but_db::cache::AgentSkillNotice {
-            shown_at: now - Duration::hours(11),
-        };
-        assert!(!agent_skill_check_due(Some(&recent), now));
-
-        let old = but_db::cache::AgentSkillNotice {
-            shown_at: now - Duration::hours(12),
-        };
-        assert!(agent_skill_check_due(Some(&old), now));
-    }
-
-    #[test]
-    fn agent_skill_check_records_only_when_cache_write_succeeds() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("app-cache.sqlite");
-        let now = DateTime::from_timestamp(2_000_000, 0).unwrap();
-        let mut cache = but_db::AppCacheHandle::new_at_path(&path);
-
-        assert!(record_agent_skill_check(&mut cache, now));
-        assert!(!record_agent_skill_check(
-            &mut cache,
-            now + Duration::hours(11)
-        ));
-        assert!(record_agent_skill_check(
-            &mut cache,
-            now + Duration::hours(12)
-        ));
-
-        let mut locked_cache = but_db::AppCacheHandle::new_at_path(&path);
-        let _lock = cache
-            .immediate_transaction_nonblocking()
-            .unwrap()
-            .expect("write lock should be available");
-        assert!(!record_agent_skill_check(
-            &mut locked_cache,
-            now + Duration::hours(24)
-        ));
+    fn skill_entrypoint_is_written_last() {
+        assert!(
+            skill_files_in_write_order()
+                .last()
+                .is_some_and(SkillFile::is_main_skill_file),
+            "a partial bundle must not look installed"
+        );
     }
 
     #[test]
@@ -1837,7 +1631,7 @@ mod tests {
         fs::create_dir_all(&other_skill_dir).unwrap();
         fs::write(other_skill_dir.join("SKILL.md"), "# Some other skill").unwrap();
 
-        // We can't easily test find_all_installations directly since it uses dirs::home_dir()
+        // We can't easily test find_all_installations directly since it uses the user home.
         // But we can test the components it uses
 
         // Verify is_gitbutler_skill correctly identifies our test files
@@ -1894,6 +1688,15 @@ mod tests {
             find_format_installations(format_without_dir, temp_dir.path()).is_empty(),
             "a missing skills directory yields no installations"
         );
+    }
+
+    #[test]
+    fn skill_installation_requires_every_embedded_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        write_skill_files(temp_dir.path()).unwrap();
+        std::fs::remove_file(temp_dir.path().join("references/concepts.md")).unwrap();
+
+        assert!(!is_complete_skill_installation(temp_dir.path()));
     }
 
     #[test]

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -400,7 +400,32 @@ async fn match_subcommand(
         cmd => cmd,
     };
 
-    let metrics_ctx = cmd.to_metrics_context(&app_settings, &args.current_dir);
+    let show_agent_skill_notice = out.format().is_human_text()
+        && !out.can_prompt()
+        && !matches!(
+            &cmd,
+            Subcommands::Skill(_)
+                | Subcommands::Agent(_)
+                | Subcommands::Help { .. }
+                | Subcommands::Completions { .. }
+                | Subcommands::Metrics { .. }
+        );
+    let agent_skill_notice = show_agent_skill_notice
+        .then(|| command::skill::agent_skill_notice(&args.current_dir))
+        .flatten();
+    if let Some(notice) = agent_skill_notice.as_ref()
+        && let Some(human) = out.for_human()
+    {
+        writeln!(human, "{}", notice.text()).ok();
+        writeln!(human).ok();
+    }
+
+    let mut metrics_ctx = cmd.to_metrics_context(&app_settings, &args.current_dir);
+    if agent_skill_notice.is_some_and(|notice| notice.is_hint())
+        && let Some(metrics_ctx) = metrics_ctx.as_mut()
+    {
+        metrics_ctx.push_extra_prop("agentSkillHintShown", true);
+    }
 
     match cmd {
         Subcommands::Metrics {
@@ -1866,11 +1891,8 @@ async fn maybe_run_status_after<T, E>(
 /// In human mode, prints a blank line then full status.
 /// In JSON mode, combines the mutation's buffered JSON with status JSON into
 /// `{"result": <mutation_output>, "status": <workspace_status>}`.
-/// Periodically reconciles skill installations: stale skills are auto-updated
-/// in the background, and an agent-facing line (update announcement, or an
-/// action notice when the skill is missing or the update could not start) is
-/// included between the mutation output and the status (so output-trimming
-/// pipes like `head` still deliver it), or under `agent_skill_notice` in JSON.
+/// For JSON commands, reconciles stale skill installations and includes an
+/// update announcement or failure notice under `agent_skill_notice`.
 /// This function only runs when the CLI caller was detected as an agent.
 ///
 /// Status errors are handled gracefully: in JSON mode the mutation result is
@@ -1884,13 +1906,11 @@ async fn run_status_after(
 ) {
     use crate::command::legacy::status::StatusFlags;
 
-    // Producing a notice burns its global debounce, so compute it only when the
-    // format can deliver it (human text below, or a field in the JSON object).
-    let agent_skill_notice = if out.format().is_human_text() || out.format().is_json() {
-        command::skill::agent_skill_freshness_check_for_context(Some(&mut *ctx))
-    } else {
-        None
-    };
+    let agent_skill_notice = out
+        .format()
+        .is_json()
+        .then(command::skill::agent_skill_update_notice)
+        .flatten();
 
     if out.is_json() {
         out.start_json_buffering();
@@ -1932,13 +1952,6 @@ async fn run_status_after(
     } else {
         if let Some(human) = out.for_human() {
             writeln!(human).ok();
-            // The notice must precede the status dump: agents routinely pipe
-            // `but` output through `head`/`grep`, which keeps leading lines and
-            // drops trailing ones.
-            if let Some(notice) = agent_skill_notice {
-                writeln!(human, "{notice}").ok();
-                writeln!(human).ok();
-            }
         }
         if let Err(err) = command::legacy::status::worktree(
             ctx,

--- a/crates/but/src/utils/detect_agent.rs
+++ b/crates/but/src/utils/detect_agent.rs
@@ -172,7 +172,27 @@ fn parse_ai_agent_var(lookup: &impl Fn(&str) -> Option<OsString>) -> Option<Agen
     if val.is_empty() {
         return None;
     }
-    Some(match_agent_name(&val).unwrap_or(Agent::Unknown))
+    Some(
+        match_agent_name(&val)
+            .or_else(|| match_agent_name_prefix(&val))
+            .unwrap_or(Agent::Unknown),
+    )
+}
+
+/// Match a normalized `AI_AGENT` value whose leading segments name a known
+/// agent, tolerating trailing decorations that embed a version without the
+/// `@` separator — Claude Code desktop sets e.g. `claude-code_2-1-202_agent`.
+/// Segments are dropped from the end one at a time, so the longest matching
+/// prefix wins (`claude-code-...` resolves before the `claude` alias could).
+fn match_agent_name_prefix(val: &str) -> Option<Agent> {
+    let mut prefix = val;
+    while let Some((rest, _)) = prefix.rsplit_once('-') {
+        if let Some(agent) = match_agent_name(rest) {
+            return Some(agent);
+        }
+        prefix = rest;
+    }
+    None
 }
 
 /// Parse the shorter `AGENT` convention (distinct from `AI_AGENT`), adopted by
@@ -451,6 +471,23 @@ mod tests {
             detect_with(env_from(&[("AI_AGENT", "some-new-agent")])),
             Some(Agent::Unknown),
         );
+    }
+
+    #[test]
+    fn ai_agent_matches_known_prefix_with_trailing_decorations() {
+        // Claude Code desktop embeds its version without the `@` separator.
+        for (value, expected) in [
+            ("claude-code_2-1-202_agent", Agent::ClaudeCode),
+            ("claude-code-2.1.202", Agent::ClaudeCode),
+            ("cursor-cli-extra", Agent::CursorCli),
+        ] {
+            assert_eq!(
+                detect_with(env_from(&[("AI_AGENT", value)])),
+                Some(expected),
+                "AI_AGENT={value} should prefix-match {}",
+                expected.name(),
+            );
+        }
     }
 
     #[test]

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -53,6 +53,10 @@ impl OneshotMetricsContext {
             current_dir,
         }
     }
+
+    pub(crate) fn push_extra_prop<T: Serialize>(&mut self, key: &str, value: T) {
+        push_prop(&mut self.extra_props, key, value);
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, strum::Display)]

--- a/crates/but/tests/but/command/skill.rs
+++ b/crates/but/tests/but/command/skill.rs
@@ -68,9 +68,245 @@ fn skill_install_json_outside_repo_requires_path_instead_of_repo_context() {
         .failure()
         .stdout_eq(str![[]])
         .stderr_eq(str![[r#"
-Error: In non-interactive mode, you must specify --path or --detect. Use --path <path> to specify where to install the skill, or --detect to update an existing installation.
+Error: No supported agent was detected. In non-interactive mode, specify --path or --detect. Use --path <path> to choose an installation directory, or --detect to update an existing installation.
 
 "#]]);
+}
+
+#[test]
+fn skill_install_bare_defaults_to_detected_agents_global_dir() {
+    let env = Sandbox::empty();
+
+    // A detected agent running the bare command without a terminal gets its
+    // own global skill directory instead of the interactive wizard - this is
+    // the command the not-installed status notice suggests.
+    let output = env
+        .but("skill install")
+        .env("AI_AGENT", "codex")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let skill_md = env
+        .home_dir()
+        .join(".codex")
+        .join("skills")
+        .join("gitbutler")
+        .join("SKILL.md");
+    assert!(
+        skill_md.is_file(),
+        "the skill lands in the agent's global directory under the sandboxed home"
+    );
+
+    // A skill installed mid-session is invisible to the agent's harness until
+    // the next session, so the agent is pointed at the file directly.
+    let stdout = String::from_utf8_lossy(&output);
+    assert!(!stdout.contains("AGENT ACTION REQUIRED"));
+    assert!(
+        stdout.contains("To use it in this session, read "),
+        "an agent caller is told to read the skill now, got: {stdout}"
+    );
+}
+
+#[test]
+fn agent_skill_notice_gating() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    // Only human-text output can carry the notice; JSON output skips the check.
+    let json_run = env
+        .but("--format json alias list")
+        .env("AI_AGENT", "codex")
+        .allow_json()
+        .output()
+        .expect("status --format json runs");
+    assert!(json_run.status.success());
+    assert!(
+        !String::from_utf8_lossy(&json_run.stdout).contains("AGENT ACTION REQUIRED"),
+        "JSON status output carries no skill notice"
+    );
+
+    // A human-text agent run delivers the notice, leading the output so
+    // output-trimming pipes like `head` keep it.
+    let stdout_of = || {
+        let out = env
+            .but("alias list")
+            .env("AI_AGENT", "codex")
+            .output()
+            .expect("alias list runs");
+        assert!(out.status.success());
+        String::from_utf8(out.stdout).unwrap()
+    };
+    // Wording is pinned by the status snapshot; this asserts placement only.
+    let stdout = stdout_of();
+    assert!(
+        stdout.starts_with("⚠ AGENT ACTION REQUIRED"),
+        "the notice must lead the output, got: {stdout}"
+    );
+
+    // The not-installed notice is not debounced - every session and every
+    // agent is nudged on each status until the skill is installed, rather
+    // than one delivery silencing all others for hours.
+    assert!(
+        stdout_of().contains("AGENT ACTION REQUIRED"),
+        "the not-installed notice keeps showing until the skill is installed"
+    );
+
+    let failed = env
+        .but("alias add 'bad name' status")
+        .env("AI_AGENT", "codex")
+        .output()
+        .expect("alias add runs");
+    assert!(!failed.status.success());
+    assert!(
+        String::from_utf8_lossy(&failed.stdout).starts_with("⚠ AGENT ACTION REQUIRED"),
+        "failed normal commands receive the same pre-dispatch notice"
+    );
+}
+
+#[test]
+fn agent_skill_notice_is_scoped_to_the_driving_agents_format() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    // A Cursor session installs the skill into its own format directory.
+    env.but("skill install")
+        .env("AI_AGENT", "cursor")
+        .assert()
+        .success();
+    assert!(
+        env.home_dir()
+            .join(".cursor")
+            .join("skills")
+            .join("gitbutler")
+            .join("SKILL.md")
+            .is_file(),
+        "the Cursor install landed in the sandboxed home"
+    );
+
+    // Claude Code cannot read `.cursor/skills`, so it must still be told to
+    // install its own copy - the Cursor install does not count for it.
+    let claude = env
+        .but("alias list")
+        .env("AI_AGENT", "claude-code")
+        .output()
+        .expect("alias list runs");
+    assert!(claude.status.success());
+    let stdout = String::from_utf8_lossy(&claude.stdout);
+    assert!(
+        stdout.contains("AGENT ACTION REQUIRED")
+            && stdout.contains("Install the GitButler skill before continuing"),
+        "another agent's install must not silence Claude Code, got: {stdout}"
+    );
+
+    // The Cursor session, whose format holds the install, is satisfied.
+    let cursor = env
+        .but("alias list")
+        .env("AI_AGENT", "cursor")
+        .output()
+        .expect("alias list runs");
+    assert!(cursor.status.success());
+    assert!(
+        !String::from_utf8_lossy(&cursor.stdout).contains("AGENT ACTION REQUIRED"),
+        "the agent whose format holds the install gets no notice"
+    );
+
+    env.but("skill install --path .claude/skills/gitbutler")
+        .assert()
+        .success();
+    let claude = env
+        .but("alias list")
+        .env("AI_AGENT", "claude-code")
+        .output()
+        .expect("alias list runs");
+    assert!(
+        !String::from_utf8_lossy(&claude.stdout).contains("AGENT ACTION REQUIRED"),
+        "a repository-local install also satisfies its agent"
+    );
+}
+
+#[test]
+fn agent_skill_notice_accepts_compatible_shared_local_install() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+    env.but("skill install --path .agents/skills/gitbutler")
+        .assert()
+        .success();
+
+    for agent in ["opencode", "devin"] {
+        let output = env
+            .but("alias list")
+            .env("AI_AGENT", agent)
+            .output()
+            .expect("alias list runs");
+        assert!(output.status.success());
+        assert!(
+            !String::from_utf8_lossy(&output.stdout).contains("AGENT ACTION REQUIRED"),
+            "{agent} should accept the shared local skill format"
+        );
+    }
+}
+
+#[test]
+fn agent_skill_notice_reports_a_stale_local_skill_despite_a_current_global_copy() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.but("skill install --path .codex/skills/gitbutler")
+        .assert()
+        .success();
+    std::fs::write(
+        env.projects_root().join(".codex/skills/gitbutler/SKILL.md"),
+        "---\nname: but\nversion: old\n---\n",
+    )
+    .unwrap();
+    env.but("skill install")
+        .env("AI_AGENT", "codex")
+        .assert()
+        .success();
+
+    let output = env
+        .but("alias list")
+        .env("AI_AGENT", "codex")
+        .output()
+        .expect("alias list runs");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        stdout.starts_with("⚠ AGENT ACTION REQUIRED")
+            && stdout.contains("but skill check --update"),
+        "the stale local copy must not hide behind the current global copy, got: {stdout}"
+    );
+}
+
+#[test]
+fn agent_skill_notice_repairs_a_stale_global_skill() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+    env.but("skill install")
+        .env("AI_AGENT", "codex")
+        .assert()
+        .success();
+    std::fs::write(
+        env.home_dir().join(".codex/skills/gitbutler/SKILL.md"),
+        "---\nname: but\nversion: old\n---\n",
+    )
+    .unwrap();
+
+    let output = env
+        .but("alias list")
+        .env("AI_AGENT", "codex")
+        .output()
+        .expect("alias list runs");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        stdout.contains("was out of date and was updated")
+            && !stdout.contains("but skill check --update"),
+        "a stale global skill should be repaired before a read-only command, got: {stdout}"
+    );
 }
 
 #[test]
@@ -130,7 +366,7 @@ fn skill_install_absolute_path_outside_repo_does_not_require_global() -> anyhow:
 }
 
 #[test]
-fn skill_install_agent_outputs_success_message() -> anyhow::Result<()> {
+fn skill_install_explicit_path_does_not_claim_the_agent_will_load_it() -> anyhow::Result<()> {
     let env = Sandbox::empty();
     let install_dir = env.projects_root().join("agent-skill-install");
 
@@ -141,6 +377,7 @@ fn skill_install_agent_outputs_success_message() -> anyhow::Result<()> {
         .args(["--format", "agent", "--global"])
         .arg("--path")
         .arg(&install_dir)
+        .env("AI_AGENT", "codex")
         .assert()
         .success()
         .stderr_eq(str![[]])
@@ -156,6 +393,10 @@ fn skill_install_agent_outputs_success_message() -> anyhow::Result<()> {
     assert!(
         stdout.contains("Files installed:"),
         "agent skill install should print installed files, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("To use it in this session"),
+        "the read-it-now hint is for detected agent callers only, got: {stdout}"
     );
 
     Ok(())
@@ -203,6 +444,40 @@ fn skill_check_detects_agent_skills_installation_in_repo() -> anyhow::Result<()>
         "expected Agent Skills installation in .agents/skills/gitbutler, got: {skills:?}"
     );
 
+    Ok(())
+}
+
+#[test]
+fn skill_check_marks_an_incomplete_bundle_outdated() -> anyhow::Result<()> {
+    let env = Sandbox::open_with_default_settings("repo-no-remote");
+    let install_path = relative_agent_skill_path(".agents");
+    env.but("")
+        .arg("skill")
+        .arg("install")
+        .arg("--path")
+        .arg(&install_path)
+        .assert()
+        .success();
+    std::fs::remove_file(
+        env.projects_root()
+            .join(&install_path)
+            .join("references/concepts.md"),
+    )?;
+
+    let output = env
+        .but("skill check --local --format json")
+        .allow_json()
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output)?;
+
+    assert_eq!(
+        json.get("outdated_count").and_then(|value| value.as_u64()),
+        Some(1)
+    );
     Ok(())
 }
 

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -1144,12 +1144,20 @@ Hint: run `but help` for all commands
 
 "#]]);
 
+    // The first agent-detected invocation also delivers the skill-install
+    // notice ahead of the graph (the sandbox home has no skill installed).
     env.but("status")
         .env("AI_AGENT", "codex")
         .assert()
         .success()
         .stderr_eq(snapbox::str![])
         .stdout_eq(snapbox::str![[r#"
+⚠ AGENT ACTION REQUIRED: Install the GitButler skill before continuing.
+Run now: but skill install
+Then read the installed SKILL.md path printed by that command and continue.
+Do not merely tell the user to run it.
+This notice repeats until the skill is installed. If it still appears after installing, report it instead of retrying.
+
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]

--- a/crates/but/tests/but/command/uncommit.rs
+++ b/crates/but/tests/but/command/uncommit.rs
@@ -273,12 +273,12 @@ fn uncommit_same_file_from_different_commits_same_branch() -> anyhow::Result<()>
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
     env.setup_metadata(&["A", "B"]);
 
-    // Three commits on branch A, each overwriting the same file.
+    // Different lengths prevent racy-clean false negatives on coarse-mtime filesystems.
     env.file("f.txt", "v1\n");
     env.but("commit A -m 'write v1'").assert().success();
-    env.file("f.txt", "v2\n");
+    env.file("f.txt", "v22\n");
     env.but("commit A -m 'write v2'").assert().success();
-    env.file("f.txt", "v3\n");
+    env.file("f.txt", "v333\n");
     env.but("commit A -m 'write v3'").assert().success();
 
     env.but("stf")
@@ -289,10 +289,10 @@ fn uncommit_same_file_from_different_commits_same_branch() -> anyhow::Result<()>
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   e128a9a write v3
-┊│     e:s M f.txt
-┊●   4dba526 write v2
+┊●   485d867 write v3
 ┊│     4:s M f.txt
+┊●   adeaad7 write v2
+┊│     a:s M f.txt
 ┊●   825d09f write v1
 ┊│     8:s A f.txt
 ┊●   9477ae7 add A
@@ -313,11 +313,11 @@ Hint: run `but help` for all commands
     // Commit contents before: newest-first is v3, v2, v1.
     assert_eq!(
         commit_file_content(&env, "A:f.txt").as_deref(),
-        Some("v3\n")
+        Some("v333\n")
     );
     assert_eq!(
         commit_file_content(&env, "A~1:f.txt").as_deref(),
-        Some("v2\n")
+        Some("v22\n")
     );
     assert_eq!(
         commit_file_content(&env, "A~2:f.txt").as_deref(),
@@ -375,7 +375,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
     assert_eq!(commit_file_content(&env, "A:f.txt"), None);
     assert_eq!(commit_file_content(&env, "A~1:f.txt"), None);
     assert_eq!(commit_file_content(&env, "A~2:f.txt"), None);
-    assert_eq!(worktree_file_content(&env, "f.txt"), "v3\n");
+    assert_eq!(worktree_file_content(&env, "f.txt"), "v333\n");
 
     Ok(())
 }

--- a/crates/but/tests/but/utils.rs
+++ b/crates/but/tests/but/utils.rs
@@ -136,6 +136,13 @@ impl Sandbox {
             .env("E2E_TEST_APP_DATA_DIR", self.app_data_dir())
             .current_dir(self.projects_root())
     }
+
+    /// The sandboxed home directory `but` resolves under `E2E_TEST_APP_DATA_DIR`
+    /// (see `but_path::home_dir`), for tests that inspect or seed user-level
+    /// files like skill installations.
+    pub fn home_dir(&self) -> PathBuf {
+        self.app_data_dir().join("home")
+    }
 }
 
 pub trait CommandExt {


### PR DESCRIPTION
Agent-driven CLI sessions now receive an actionable installation notice, install into the detected agent loadable skill directory, and read the skill immediately. Existing installations are kept current and hint exposure is recorded so conversion can be measured.

This targets agentic users who invoke but without the skill and otherwise get a worse workflow.