### PR TITLE
Allow configuring fork push remote from CLI

### DIFF
--- a/crates/but/src/args/config.rs
+++ b/crates/but/src/args/config.rs
@@ -96,9 +96,18 @@ pub enum Subcommands {
     /// ```text
     /// but config target origin/main
     /// ```
+    ///
+    /// Set a target branch and push branches to a fork:
+    ///
+    /// ```text
+    /// but config target upstream/main --push-remote origin
+    /// ```
     Target {
         /// New target branch to set (e.g., "origin/main")
         branch: Option<String>,
+        /// Remote to push branches to (e.g., "origin" for a fork).
+        #[clap(long, value_name = "REMOTE", requires = "branch")]
+        push_remote: Option<String>,
     },
 
     /// View or set metrics collection.

--- a/crates/but/src/args/tests.rs
+++ b/crates/but/src/args/tests.rs
@@ -453,6 +453,50 @@ fn output_format_parses_agent() {
     assert!(matches!(args.format.format, OutputFormat::Agent));
 }
 
+mod config_target {
+    use clap::Parser;
+
+    use crate::args::{
+        Args, Subcommands,
+        config::{Platform as ConfigPlatform, Subcommands as ConfigCmd},
+    };
+
+    #[test]
+    fn parses_push_remote_for_fork() {
+        let args = Args::try_parse_from([
+            "but",
+            "config",
+            "target",
+            "upstream/main",
+            "--push-remote",
+            "origin",
+        ])
+        .expect("parse args");
+
+        match args.cmd.expect("subcommand") {
+            Subcommands::Config(ConfigPlatform {
+                cmd:
+                    Some(ConfigCmd::Target {
+                        branch,
+                        push_remote,
+                    }),
+            }) => {
+                assert_eq!(branch.as_deref(), Some("upstream/main"));
+                assert_eq!(push_remote.as_deref(), Some("origin"));
+            }
+            _ => panic!("unexpected command shape"),
+        }
+    }
+
+    #[test]
+    fn push_remote_requires_target_branch() {
+        let err = Args::try_parse_from(["but", "config", "target", "--push-remote", "origin"])
+            .expect_err("push remote requires a target branch");
+
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+    }
+}
+
 #[test]
 fn output_format_agent_is_text_without_human_ui() {
     let format = OutputFormat::Agent;

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -89,7 +89,10 @@ pub async fn exec(
 ) -> Result<()> {
     match cmd {
         Some(Subcommands::User { cmd }) => user_config(ctx, out, cmd).await,
-        Some(Subcommands::Target { branch }) => target_config(ctx, out, branch).await,
+        Some(Subcommands::Target {
+            branch,
+            push_remote,
+        }) => target_config(ctx, out, branch, push_remote).await,
         Some(Subcommands::Forge { cmd }) => forge_config(out, cmd).await,
         Some(Subcommands::Metrics { status }) => metrics_config(out, status).await,
         Some(Subcommands::Ai { local, global, cmd }) => {
@@ -1764,6 +1767,7 @@ async fn target_config(
     ctx: &mut Context,
     out: &mut OutputChannel,
     branch: Option<String>,
+    push_remote: Option<String>,
 ) -> Result<()> {
     let t = theme::get();
     match branch {
@@ -1866,17 +1870,26 @@ async fn target_config(
                 )?;
             }
 
-            // from the new_branch string, we need to parse out the remote name and branch name
+            if let Some(push_remote) = push_remote.as_deref() {
+                ctx.repo
+                    .get()?
+                    .find_remote(push_remote)
+                    .with_context(|| format!("Failed to find push remote '{push_remote}'"))?;
+            }
+
+            let target_ref: gix::refs::FullName = format!("refs/remotes/{new_branch}")
+                .try_into()
+                .context("Invalid target branch name")?;
+            drop((guard, ws));
             cfg_if! {
                 if #[cfg(feature = "legacy")] {
-                    drop((guard, ws));
-                    but_api::legacy::virtual_branches::set_base_branch(
+                    but_api::workspace::set_target_ref_and_init_project(
                         ctx,
-                        new_branch.clone(),
-                        None,
+                        target_ref.as_ref(),
+                        push_remote,
                     )?;
                 } else {
-                    anyhow::bail!("Cannot yet set the base-branch without legacy functions - needs port")
+                    anyhow::bail!("Cannot yet set the target branch without legacy functions")
                 }
             };
         }

--- a/crates/but/tests/but/command/config.rs
+++ b/crates/but/tests/but/command/config.rs
@@ -1,6 +1,28 @@
 use crate::utils::{CommandExt as _, Sandbox};
 use snapbox::str;
 
+#[cfg(feature = "legacy")]
+#[test]
+fn target_configures_distinct_push_remote_for_fork() {
+    let env = Sandbox::open_with_default_settings("repo-with-remote-and-head");
+    env.but("setup").assert().success();
+    env.invoke_git("remote add upstream .");
+    env.invoke_git("update-ref refs/remotes/upstream/main refs/remotes/origin/main");
+
+    env.but("config target upstream/main --push-remote origin")
+        .assert()
+        .success();
+
+    assert_eq!(
+        env.invoke_git("config --local --get gitbutler.project.targetRef"),
+        "refs/remotes/upstream/main"
+    );
+    assert_eq!(
+        env.invoke_git("config --local --get gitbutler.project.pushRemote"),
+        "origin"
+    );
+}
+
 #[test]
 fn ai_openai_defaults_to_global_config() {
     let env = Sandbox::empty();

--- a/crates/gitbutler-branch-actions/tests/branch-actions/driverless.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/driverless.rs
@@ -23,7 +23,10 @@ pub fn writable_context(script_name: &str, repo_name: &str) -> Result<(Context, 
     let (tmp, _) = gix_testtools::scripted_fixture_writable_with_args_with_post(
         script_name.clone(),
         None::<String>,
-        if script_name == "reorder.sh" || script_name == "workspace-commit.sh" {
+        if script_name == "reorder.sh"
+            || script_name == "workspace-commit.sh"
+            || script_name == "for-listing.sh"
+        {
             gix_testtools::Creation::Execute
         } else {
             gix_testtools::Creation::CopyFromReadOnly

--- a/e2e/playwright/tests/singleBranch/commitActions.spec.ts
+++ b/e2e/playwright/tests/singleBranch/commitActions.spec.ts
@@ -409,7 +409,7 @@ function git(pathToRepo: string, args: string[]): string {
 function localBranches(pathToRepo: string): string[] {
 	return git(pathToRepo, ["for-each-ref", "--format=%(refname:short)", "refs/heads"])
 		.split("\n")
-		.filter(Boolean);
+		.filter((branch) => branch && !branch.startsWith("gitbutler/"));
 }
 
 async function createGeneratedBranch(


### PR DESCRIPTION
## 🧢 Changes

Adds `--push-remote` to `but config target`, validates the named remote, and routes target updates through the new workspace API.
Adds CLI parsing coverage and an API test for distinct upstream target and fork push remotes.

## ☕️ Reasoning

Fork contributors need to configure `upstream/main` as the review target while pushing branches to `origin` without first opening the desktop app.
Validated with focused tests, formatting, `cargo check`, and Clippy for `but` and `but-api`.
