### PR TITLE
Allow single-branch stack reordering

### DIFF
--- a/apps/desktop/src/lib/dragging/dropHandlers/branchDropHandler.test.ts
+++ b/apps/desktop/src/lib/dragging/dropHandlers/branchDropHandler.test.ts
@@ -9,23 +9,21 @@ function branchDropData(branchName: string, numberOfCommits: number): BranchDrop
 }
 
 describe("acceptsSameStackBranchDrop", () => {
-	test("accepts empty branch reorders in managed and single-branch mode", () => {
+	test("accepts empty branch reorders", () => {
 		const data = branchDropData("source", 0);
 
-		expect(acceptsSameStackBranchDrop(data, "target", false)).toBe(true);
-		expect(acceptsSameStackBranchDrop(data, "target", true)).toBe(true);
+		expect(acceptsSameStackBranchDrop(data, "target")).toBe(true);
 	});
 
-	test("accepts non-empty branch reorders only in single-branch mode", () => {
+	test("accepts non-empty branch reorders", () => {
 		const data = branchDropData("source", 1);
 
-		expect(acceptsSameStackBranchDrop(data, "target", false)).toBe(false);
-		expect(acceptsSameStackBranchDrop(data, "target", true)).toBe(true);
+		expect(acceptsSameStackBranchDrop(data, "target")).toBe(true);
 	});
 
 	test("rejects self moves", () => {
 		const data = branchDropData("source", 1);
 
-		expect(acceptsSameStackBranchDrop(data, "source", true)).toBe(false);
+		expect(acceptsSameStackBranchDrop(data, "source")).toBe(false);
 	});
 });

--- a/apps/desktop/src/lib/dragging/dropHandlers/branchDropHandler.test.ts
+++ b/apps/desktop/src/lib/dragging/dropHandlers/branchDropHandler.test.ts
@@ -1,0 +1,31 @@
+import {
+	acceptsSameStackBranchDrop,
+	BranchDropData,
+} from "$lib/dragging/dropHandlers/branchDropHandler";
+import { describe, expect, test } from "vitest";
+
+function branchDropData(branchName: string, numberOfCommits: number): BranchDropData {
+	return new BranchDropData("stack-1", branchName, false, 2, numberOfCommits, undefined, []);
+}
+
+describe("acceptsSameStackBranchDrop", () => {
+	test("accepts empty branch reorders in managed and single-branch mode", () => {
+		const data = branchDropData("source", 0);
+
+		expect(acceptsSameStackBranchDrop(data, "target", false)).toBe(true);
+		expect(acceptsSameStackBranchDrop(data, "target", true)).toBe(true);
+	});
+
+	test("accepts non-empty branch reorders only in single-branch mode", () => {
+		const data = branchDropData("source", 1);
+
+		expect(acceptsSameStackBranchDrop(data, "target", false)).toBe(false);
+		expect(acceptsSameStackBranchDrop(data, "target", true)).toBe(true);
+	});
+
+	test("rejects self moves", () => {
+		const data = branchDropData("source", 1);
+
+		expect(acceptsSameStackBranchDrop(data, "source", true)).toBe(false);
+	});
+});

--- a/apps/desktop/src/lib/dragging/dropHandlers/branchDropHandler.ts
+++ b/apps/desktop/src/lib/dragging/dropHandlers/branchDropHandler.ts
@@ -1,10 +1,12 @@
 import { FileChangeDropData, FolderChangeDropData, HunkDropDataV3 } from "$lib/dragging/draggables";
 import { updateStackPrs } from "$lib/forge/shared/prFooter";
 import { UNCOMMITTED_SERVICE } from "$lib/selection/uncommittedService.svelte";
+import { SETTINGS_SERVICE } from "$lib/settings/appSettings";
 import { normalizeReferenceSubject } from "$lib/stacks/commitMovePlacement";
 import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 import { UI_STATE } from "$lib/state/uiState.svelte";
 import { inject } from "@gitbutler/core/context";
+import { get } from "svelte/store";
 import type { DropResult } from "$lib/dragging/dropResult";
 import type { DropzoneHandler } from "$lib/dragging/handler";
 import type { PrService } from "$lib/forge/prService.svelte";
@@ -25,8 +27,17 @@ export class BranchDropData {
 	}
 }
 
+export function acceptsSameStackBranchDrop(
+	data: BranchDropData,
+	targetBranchName: string,
+	singleBranchMode: boolean,
+): boolean {
+	return data.branchName !== targetBranchName && (data.numberOfCommits === 0 || singleBranchMode);
+}
+
 export class MoveBranchDzHandler implements DropzoneHandler {
 	private readonly stackService = inject(STACK_SERVICE);
+	private readonly settingsService = inject(SETTINGS_SERVICE);
 
 	constructor(
 		private readonly prService: PrService | undefined,
@@ -49,10 +60,13 @@ export class MoveBranchDzHandler implements DropzoneHandler {
 		if (data.stackId !== this.stackId) {
 			return data.numberOfCommits > 0;
 		}
-		// Reordering within the same stack is a pure metadata operation only for empty branches
-		// (e.g. single-branch mode, where all branches share one stack). Don't accept a drop onto
-		// the branch's own position, which would be a no-op self-move.
-		return data.numberOfCommits === 0 && data.branchName !== this.branchName;
+		// In managed workspaces keep the existing empty-branch same-stack restriction; single-branch
+		// mode also allows branches that own commits.
+		return acceptsSameStackBranchDrop(
+			data,
+			this.branchName,
+			get(this.settingsService.appSettings)?.featureFlags.singleBranch === true,
+		);
 	}
 	async ondrop(data: BranchDropData): Promise<DropResult | void> {
 		const sourceStackDeleted = data.numberOfBranchesInStack === 1;

--- a/apps/desktop/src/lib/dragging/dropHandlers/branchDropHandler.ts
+++ b/apps/desktop/src/lib/dragging/dropHandlers/branchDropHandler.ts
@@ -1,12 +1,10 @@
 import { FileChangeDropData, FolderChangeDropData, HunkDropDataV3 } from "$lib/dragging/draggables";
 import { updateStackPrs } from "$lib/forge/shared/prFooter";
 import { UNCOMMITTED_SERVICE } from "$lib/selection/uncommittedService.svelte";
-import { SETTINGS_SERVICE } from "$lib/settings/appSettings";
 import { normalizeReferenceSubject } from "$lib/stacks/commitMovePlacement";
 import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 import { UI_STATE } from "$lib/state/uiState.svelte";
 import { inject } from "@gitbutler/core/context";
-import { get } from "svelte/store";
 import type { DropResult } from "$lib/dragging/dropResult";
 import type { DropzoneHandler } from "$lib/dragging/handler";
 import type { PrService } from "$lib/forge/prService.svelte";
@@ -30,14 +28,12 @@ export class BranchDropData {
 export function acceptsSameStackBranchDrop(
 	data: BranchDropData,
 	targetBranchName: string,
-	singleBranchMode: boolean,
 ): boolean {
-	return data.branchName !== targetBranchName && (data.numberOfCommits === 0 || singleBranchMode);
+	return data.branchName !== targetBranchName;
 }
 
 export class MoveBranchDzHandler implements DropzoneHandler {
 	private readonly stackService = inject(STACK_SERVICE);
-	private readonly settingsService = inject(SETTINGS_SERVICE);
 
 	constructor(
 		private readonly prService: PrService | undefined,
@@ -60,13 +56,7 @@ export class MoveBranchDzHandler implements DropzoneHandler {
 		if (data.stackId !== this.stackId) {
 			return data.numberOfCommits > 0;
 		}
-		// In managed workspaces keep the existing empty-branch same-stack restriction; single-branch
-		// mode also allows branches that own commits.
-		return acceptsSameStackBranchDrop(
-			data,
-			this.branchName,
-			get(this.settingsService.appSettings)?.featureFlags.singleBranch === true,
-		);
+		return acceptsSameStackBranchDrop(data, this.branchName);
 	}
 	async ondrop(data: BranchDropData): Promise<DropResult | void> {
 		const sourceStackDeleted = data.numberOfBranchesInStack === 1;

--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -1572,19 +1572,11 @@ pub fn move_branch_with_perm(
             let (repo, mut ws, db) = ctx.workspace_mut_and_db_with_perm(perm)?;
             let editor = Editor::create(&mut ws, &mut meta, &repo)?;
             let but_workspace::branch::move_branch::Outcome {
-                mut rebase,
+                rebase,
                 ws_meta,
                 new_tip,
                 branch_stack_order,
             } = but_workspace::branch::move_branch(editor, subject_branch, target_branch)?;
-
-            // In single-branch mode the reorder is returned rather than persisted. Only write it for
-            // real runs so a dry-run preview never mutates the user's branch-order metadata.
-            let is_dry_run: bool = dry_run.into();
-            if let Some(order) = branch_stack_order.as_deref().filter(|_| !is_dry_run) {
-                let (_repo, meta) = rebase.repo_and_meta_mut();
-                meta.set_branch_stack_order(order)?;
-            }
 
             let result = MoveBranchResult {
                 workspace: branch_workspace_from_rebase(
@@ -1729,6 +1721,13 @@ fn branch_workspace_from_rebase<M: but_core::RefMetadata>(
     }
 
     let materialized = rebase.materialize()?;
+    if let Some(order) = branch_stack_order {
+        materialized.meta.set_branch_stack_order(order)?;
+        let project_meta = materialized.workspace.graph.project_meta.clone();
+        materialized
+            .workspace
+            .refresh_from_head(repo, &*materialized.meta, project_meta)?;
+    }
     if let Some((ws_meta, ref_name)) = ws_meta.zip(materialized.workspace.ref_name()) {
         let mut md = materialized.meta.workspace(ref_name)?;
         *md = ws_meta;

--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -1581,13 +1581,21 @@ pub fn move_branch_with_perm(
             // In single-branch mode the reorder is returned rather than persisted. Only write it for
             // real runs so a dry-run preview never mutates the user's branch-order metadata.
             let is_dry_run: bool = dry_run.into();
-            if let Some(order) = branch_stack_order.filter(|_| !is_dry_run) {
+            if let Some(order) = branch_stack_order.as_deref().filter(|_| !is_dry_run) {
                 let (_repo, meta) = rebase.repo_and_meta_mut();
-                meta.set_branch_stack_order(&order)?;
+                meta.set_branch_stack_order(order)?;
             }
 
             let result = MoveBranchResult {
-                workspace: branch_workspace_from_rebase(rebase, ws_meta, &repo, dry_run, &db)?,
+                workspace: branch_workspace_from_rebase(
+                    rebase,
+                    ws_meta,
+                    new_tip.as_ref(),
+                    branch_stack_order.as_deref(),
+                    &repo,
+                    dry_run,
+                    &db,
+                )?,
             };
             Ok((result, new_tip))
         },
@@ -1656,7 +1664,9 @@ pub fn tear_off_branch_with_perm(
             } = but_workspace::branch::tear_off_branch(editor, subject_branch, None)?;
 
             Ok(MoveBranchResult {
-                workspace: branch_workspace_from_rebase(rebase, ws_meta, &repo, dry_run, &db)?,
+                workspace: branch_workspace_from_rebase(
+                    rebase, ws_meta, None, None, &repo, dry_run, &db,
+                )?,
             })
         },
     )
@@ -1690,14 +1700,32 @@ where
 }
 
 fn branch_workspace_from_rebase<M: but_core::RefMetadata>(
-    rebase: SuccessfulRebase<'_, '_, M>,
+    mut rebase: SuccessfulRebase<'_, '_, M>,
     ws_meta: Option<but_core::ref_metadata::Workspace>,
+    new_tip: Option<&gix::refs::FullName>,
+    branch_stack_order: Option<&[gix::refs::FullName]>,
     repo: &gix::Repository,
     dry_run: DryRun,
     db: &but_db::DbHandle,
 ) -> anyhow::Result<WorkspaceState> {
     if dry_run.into() {
-        return WorkspaceState::from_successful_rebase_with_db(rebase, repo, dry_run, db);
+        let entrypoint = new_tip
+            .map(|new_tip| -> anyhow::Result<_> {
+                Ok((rebase.reference_target(new_tip.as_ref())?, new_tip.clone()))
+            })
+            .transpose()?;
+        let replaced_commits = rebase.history.commit_mappings();
+        let workspace = rebase
+            .overlayed_graph_with_workspace_overrides(entrypoint, branch_stack_order)?
+            .into_workspace()?;
+        let (repo, meta) = rebase.repo_and_meta_mut();
+        return WorkspaceState::from_workspace_with_db(
+            &workspace,
+            meta,
+            repo,
+            replaced_commits,
+            db,
+        );
     }
 
     let materialized = rebase.materialize()?;

--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -1601,9 +1601,9 @@ pub fn move_branch_with_perm(
         },
     )?;
 
-    // In single-branch (ad-hoc) mode a move can place the subject above the checked-out tip. The
-    // operation doesn't move `HEAD`, so check out the new tip here to keep the moved branch part of
-    // the projected workspace (mirroring `create_reference`). Skipped on dry runs.
+    // In single-branch (ad-hoc) mode a reorder can change which branch is at the top of the visible
+    // stack. The operation doesn't move `HEAD`, so check out that tip here to keep the whole stack
+    // projected (mirroring `create_reference`). Skipped on dry runs.
     let is_dry_run: bool = dry_run.into();
     if let Some(new_tip) = new_tip
         && !is_dry_run

--- a/crates/but-api/tests/api/branch_move.rs
+++ b/crates/but-api/tests/api/branch_move.rs
@@ -147,6 +147,71 @@ fn move_checked_out_top_branch_down_checks_out_new_top() -> anyhow::Result<()> {
 }
 
 #[test]
+fn move_checked_out_top_branch_down_dry_run_does_not_persist_order() -> anyhow::Result<()> {
+    let (mut ctx, _tmp) = context_with_three_branch_stack()?;
+    let subject: gix::refs::FullName = "refs/heads/C".try_into()?;
+    let target: gix::refs::FullName = "refs/heads/A".try_into()?;
+    let order_before = ctx
+        .meta()?
+        .branch_stack_order(subject.as_ref())?
+        .expect("branch order is configured");
+
+    let result =
+        but_api::branch::move_branch(&mut ctx, subject.as_ref(), target.as_ref(), DryRun::Yes)?;
+
+    assert_workspace_ref(&result.workspace, "refs/heads/B");
+    #[cfg(not(feature = "graph-workspace"))]
+    assert_eq!(
+        workspace_branch_names(&result.workspace),
+        ["B", "C", "A"],
+        "dry-run should preview the reordered stack"
+    );
+    assert_eq!(
+        ctx.repo.get()?.head_name()?.as_ref(),
+        Some(&subject),
+        "dry-run should leave HEAD on the original stack tip"
+    );
+    assert_eq!(
+        ctx.meta()?.branch_stack_order(subject.as_ref())?,
+        Some(order_before),
+        "dry-run should not persist the proposed order"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn successful_branch_move_returns_and_persists_reordered_stack() -> anyhow::Result<()> {
+    let (mut ctx, _tmp) = context_with_three_branch_stack()?;
+    let subject: gix::refs::FullName = "refs/heads/A".try_into()?;
+    let target: gix::refs::FullName = "refs/heads/B".try_into()?;
+    let tip: gix::refs::FullName = "refs/heads/C".try_into()?;
+
+    let result =
+        but_api::branch::move_branch(&mut ctx, subject.as_ref(), target.as_ref(), DryRun::No)?;
+
+    assert_workspace_ref(&result.workspace, "refs/heads/C");
+    #[cfg(not(feature = "graph-workspace"))]
+    assert_eq!(
+        workspace_branch_names(&result.workspace),
+        ["C", "A", "B"],
+        "the returned workspace should use the persisted order"
+    );
+    assert_eq!(
+        ctx.repo.get()?.head_name()?.as_ref(),
+        Some(&tip),
+        "a lower-branch reorder should leave HEAD on the stack tip"
+    );
+    assert_eq!(
+        ctx.meta()?.branch_stack_order(tip.as_ref())?,
+        Some(vec![tip, subject, target]),
+        "the successful materialization should persist the new order"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn move_empty_branch_dry_run_previews_new_order_without_persisting_it() -> anyhow::Result<()> {
     let (repo, _tmp) = repo_with_feature_branch()?;
     let mut ctx = but_ctx::Context::from_repo_for_testing(repo)?.with_memory_app_cache();

--- a/crates/but-api/tests/api/branch_move.rs
+++ b/crates/but-api/tests/api/branch_move.rs
@@ -1,0 +1,153 @@
+use but_core::{DryRun, RefMetadata, ref_metadata::ProjectMeta};
+use but_testsupport::{CommandExt, git_at_dir, open_repo};
+
+use crate::support::{
+    assert_workspace_ref, create_empty_branch_above, repo_with_feature_branch, write_file,
+};
+
+fn context_with_three_branch_stack() -> anyhow::Result<(but_ctx::Context, tempfile::TempDir)> {
+    let tmp = tempfile::tempdir()?;
+    git_at_dir(tmp.path()).args(["init", "-b", "main"]).run();
+    git_at_dir(tmp.path())
+        .args(["config", "user.name", "GitButler"])
+        .run();
+    git_at_dir(tmp.path())
+        .args(["config", "user.email", "gitbutler@example.com"])
+        .run();
+    write_file(tmp.path(), "base.txt", "base\n")?;
+    git_at_dir(tmp.path()).args(["add", "base.txt"]).run();
+    git_at_dir(tmp.path()).args(["commit", "-m", "base"]).run();
+    git_at_dir(tmp.path())
+        .args(["config", "remote.origin.url", "../origin"])
+        .run();
+    git_at_dir(tmp.path())
+        .args(["update-ref", "refs/remotes/origin/main", "HEAD"])
+        .run();
+
+    for branch in ["A", "B", "C"] {
+        git_at_dir(tmp.path())
+            .args(["checkout", "-b", branch])
+            .run();
+        let file_name = format!("{branch}.txt");
+        write_file(tmp.path(), &file_name, &format!("{branch}\n"))?;
+        git_at_dir(tmp.path()).args(["add", &file_name]).run();
+        git_at_dir(tmp.path()).args(["commit", "-m", branch]).run();
+    }
+
+    let repo = open_repo(tmp.path())?;
+    let target_commit_id = repo.rev_parse_single("refs/remotes/origin/main")?.detach();
+    ProjectMeta {
+        target_ref: Some("refs/remotes/origin/main".try_into()?),
+        target_commit_id: Some(target_commit_id),
+        push_remote: Some("origin".into()),
+    }
+    .persist_to_local_config(&repo)?;
+
+    let ctx = but_ctx::Context::from_repo_for_testing(repo)?.with_memory_app_cache();
+    let mut meta = ctx.meta()?;
+    meta.set_branch_stack_order(&[
+        "refs/heads/C".try_into()?,
+        "refs/heads/B".try_into()?,
+        "refs/heads/A".try_into()?,
+    ])?;
+    drop(meta);
+    Ok((ctx, tmp))
+}
+
+#[cfg(not(feature = "graph-workspace"))]
+fn workspace_branch_names(workspace: &but_api::WorkspaceState) -> Vec<String> {
+    workspace
+        .head_info
+        .stacks
+        .iter()
+        .flat_map(|stack| &stack.segments)
+        .filter_map(|segment| {
+            segment
+                .ref_info
+                .as_ref()
+                .map(|reference| reference.ref_name.shorten().to_string())
+        })
+        .collect()
+}
+
+#[test]
+fn move_non_empty_branch_dry_run_previews_new_tip_without_mutating_repository() -> anyhow::Result<()>
+{
+    let (mut ctx, _tmp) = context_with_three_branch_stack()?;
+    let subject: gix::refs::FullName = "refs/heads/B".try_into()?;
+    let target: gix::refs::FullName = "refs/heads/C".try_into()?;
+    let (head_before, subject_tip_before, target_tip_before) = {
+        let repo = ctx.repo.get()?;
+        (
+            repo.head_name()?.expect("HEAD is symbolic").to_owned(),
+            repo.rev_parse_single(subject.as_ref())?.detach(),
+            repo.rev_parse_single(target.as_ref())?.detach(),
+        )
+    };
+    let order_before = ctx
+        .meta()?
+        .branch_stack_order(target.as_ref())?
+        .expect("branch order is configured");
+
+    let result =
+        but_api::branch::move_branch(&mut ctx, subject.as_ref(), target.as_ref(), DryRun::Yes)?;
+
+    assert_workspace_ref(&result.workspace, "refs/heads/B");
+    #[cfg(not(feature = "graph-workspace"))]
+    assert_eq!(workspace_branch_names(&result.workspace), ["B", "C", "A"]);
+
+    let repo = ctx.repo.get()?;
+    assert_eq!(repo.head_name()?.as_ref(), Some(&head_before));
+    assert_eq!(
+        repo.rev_parse_single(subject.as_ref())?.detach(),
+        subject_tip_before
+    );
+    assert_eq!(
+        repo.rev_parse_single(target.as_ref())?.detach(),
+        target_tip_before
+    );
+    drop(repo);
+    assert_eq!(
+        ctx.meta()?.branch_stack_order(target.as_ref())?,
+        Some(order_before)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn move_empty_branch_dry_run_previews_new_order_without_persisting_it() -> anyhow::Result<()> {
+    let (repo, _tmp) = repo_with_feature_branch()?;
+    let mut ctx = but_ctx::Context::from_repo_for_testing(repo)?.with_memory_app_cache();
+    let main: gix::refs::FullName = "refs/heads/main".try_into()?;
+    let middle: gix::refs::FullName = "refs/heads/middle".try_into()?;
+    let tip: gix::refs::FullName = "refs/heads/tip".try_into()?;
+    create_empty_branch_above(&mut ctx, &middle, &main)?;
+    create_empty_branch_above(&mut ctx, &tip, &middle)?;
+    let order_before = ctx
+        .meta()?
+        .branch_stack_order(tip.as_ref())?
+        .expect("branch order is configured");
+
+    let result =
+        but_api::branch::move_branch(&mut ctx, middle.as_ref(), tip.as_ref(), DryRun::Yes)?;
+
+    assert_workspace_ref(&result.workspace, "refs/heads/middle");
+    #[cfg(not(feature = "graph-workspace"))]
+    assert_eq!(
+        workspace_branch_names(&result.workspace),
+        ["middle", "tip", "main", "feature"]
+    );
+    assert_eq!(
+        ctx.repo.get()?.head_name()?.as_ref(),
+        Some(&tip),
+        "dry-run leaves HEAD on the original tip"
+    );
+    assert_eq!(
+        ctx.meta()?.branch_stack_order(tip.as_ref())?,
+        Some(order_before),
+        "dry-run leaves the persisted order unchanged"
+    );
+
+    Ok(())
+}

--- a/crates/but-api/tests/api/branch_move.rs
+++ b/crates/but-api/tests/api/branch_move.rs
@@ -116,6 +116,37 @@ fn move_non_empty_branch_dry_run_previews_new_tip_without_mutating_repository() 
 }
 
 #[test]
+fn move_checked_out_top_branch_down_checks_out_new_top() -> anyhow::Result<()> {
+    let (mut ctx, _tmp) = context_with_three_branch_stack()?;
+    let subject: gix::refs::FullName = "refs/heads/C".try_into()?;
+    let target: gix::refs::FullName = "refs/heads/A".try_into()?;
+    let new_tip: gix::refs::FullName = "refs/heads/B".try_into()?;
+
+    let result =
+        but_api::branch::move_branch(&mut ctx, subject.as_ref(), target.as_ref(), DryRun::No)?;
+
+    assert_workspace_ref(&result.workspace, "refs/heads/B");
+    #[cfg(not(feature = "graph-workspace"))]
+    assert_eq!(
+        workspace_branch_names(&result.workspace),
+        ["B", "C", "A"],
+        "the whole reordered stack should remain projected"
+    );
+    assert_eq!(
+        ctx.repo.get()?.head_name()?.as_ref(),
+        Some(&new_tip),
+        "HEAD should follow the new top of the reordered stack"
+    );
+    assert_eq!(
+        ctx.meta()?.branch_stack_order(new_tip.as_ref())?,
+        Some(vec![new_tip, subject, target]),
+        "the persisted branch order should match the graph rewrite"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn move_empty_branch_dry_run_previews_new_order_without_persisting_it() -> anyhow::Result<()> {
     let (repo, _tmp) = repo_with_feature_branch()?;
     let mut ctx = but_ctx::Context::from_repo_for_testing(repo)?.with_memory_app_cache();

--- a/crates/but-api/tests/api/main.rs
+++ b/crates/but-api/tests/api/main.rs
@@ -1,6 +1,7 @@
 mod branch_apply;
 mod branch_checkout;
 mod branch_create;
+mod branch_move;
 mod branch_remove;
 mod branch_rename;
 #[cfg(all(feature = "legacy", not(feature = "graph-workspace")))]

--- a/crates/but-rebase/src/graph_rebase/mod.rs
+++ b/crates/but-rebase/src/graph_rebase/mod.rs
@@ -313,6 +313,28 @@ impl<'ws, 'meta, M: RefMetadata> SuccessfulRebase<'ws, 'meta, M> {
         (&self.repo, self.meta)
     }
 
+    /// Return the commit targeted by `ref_name` in the post-rebase step graph.
+    pub fn reference_target(&self, ref_name: &gix::refs::FullNameRef) -> Result<gix::ObjectId> {
+        let reference = self
+            .graph
+            .node_indices()
+            .find(|node| {
+                matches!(
+                    &self.graph[*node],
+                    Step::Reference { refname, .. } if refname.as_ref() == ref_name
+                )
+            })
+            .with_context(|| format!("Could not find reference '{ref_name}' in rebase result"))?;
+        let parent = collect_ordered_parents(&self.graph, reference)
+            .into_iter()
+            .next()
+            .context("Reference has no target commit in rebase result")?;
+        match self.graph[parent] {
+            Step::Pick(Pick { id, .. }) => Ok(id),
+            _ => bail!("Reference target in rebase result is not a commit"),
+        }
+    }
+
     /// Returns a preview of what the but-graph will look like after
     /// materialization.
     ///
@@ -320,6 +342,20 @@ impl<'ws, 'meta, M: RefMetadata> SuccessfulRebase<'ws, 'meta, M> {
     /// in-memory repository owned by this [`SuccessfulRebase`] (`self.repo`),
     /// since they might exist only in memory.
     pub fn overlayed_graph(&self) -> Result<but_graph::Graph> {
+        self.overlayed_graph_with_workspace_overrides(None, None)
+    }
+
+    /// Return the post-rebase graph with optional ad-hoc workspace projection overrides.
+    ///
+    /// This is useful for dry-run operations whose graph rewrite is accompanied by metadata or
+    /// checkout changes that are deliberately not persisted. The override entrypoint must name the
+    /// commit and local reference that would be checked out, while `branch_stack_order` supplies the
+    /// tip-to-base order that would be written to ref metadata.
+    pub fn overlayed_graph_with_workspace_overrides(
+        &self,
+        entrypoint: Option<(gix::ObjectId, gix::refs::FullName)>,
+        branch_stack_order: Option<&[gix::refs::FullName]>,
+    ) -> Result<but_graph::Graph> {
         let dropped_refs = self.ref_edits.iter().filter_map(|edit| match &edit.change {
             gix::refs::transaction::Change::Delete { .. } => Some(edit.name.clone()),
             _ => None,
@@ -364,10 +400,17 @@ impl<'ws, 'meta, M: RefMetadata> SuccessfulRebase<'ws, 'meta, M> {
             bail!("BUG: Tried to construct rebase engine graph overlay with no entrypoints");
         };
 
-        let overlay = Overlay::default()
+        let (entrypoint_id, entrypoint_refname) = entrypoint
+            .map_or((entrypoint_id, entrypoint_refname), |(id, ref_name)| {
+                (id, Some(ref_name))
+            });
+        let mut overlay = Overlay::default()
             .with_references(updated_refs)
             .with_dropped_references(dropped_refs)
             .with_entrypoint(entrypoint_id, entrypoint_refname);
+        if let Some(branch_stack_order) = branch_stack_order {
+            overlay = overlay.with_branch_stack_order_override(branch_stack_order.iter().cloned());
+        }
         self.workspace
             .graph
             .redo_traversal_with_overlay(&self.repo, self.meta, overlay)

--- a/crates/but-workspace/src/branch/move_branch.rs
+++ b/crates/but-workspace/src/branch/move_branch.rs
@@ -192,12 +192,12 @@ pub(super) mod function {
 
         // Each kind of workspace has a very different notion of what "moving a branch" means, so we
         // dispatch into a dedicated handler for each one.
-        // TODO: Enable and test that we can move branches in any kind of workspace.
         match &workspace.kind {
             WorkspaceKind::AdHoc => move_branch_in_single_branch_mode(
                 successful_rebase,
-                workspace.ref_name().map(ToOwned::to_owned),
+                workspace,
                 source,
+                destination,
                 subject_branch_name,
                 target_branch_name,
             ),
@@ -226,40 +226,45 @@ pub(super) mod function {
     /// persistence for dry-run previews.
     fn move_branch_in_single_branch_mode<'ws, 'meta, M: RefMetadata>(
         mut successful_rebase: SuccessfulRebase<'ws, 'meta, M>,
-        entrypoint: Option<gix::refs::FullName>,
+        workspace: but_graph::Workspace,
         source: WorkspaceSegmentContext,
+        destination: WorkspaceSegmentContext,
         subject_branch_name: &FullNameRef,
         target_branch_name: &FullNameRef,
     ) -> anyhow::Result<Outcome<'ws, 'meta, M>> {
-        let (_, subject_segment) = &source;
-        // Only the *subject* needs to be empty: a branch that owns no commits can be reordered by
-        // metadata alone, regardless of whether the target owns commits (e.g. the base branch). A
-        // non-empty subject would change commit ownership and needs a real rebase.
-        if !subject_segment.commits.is_empty() {
+        let (source_stack, subject_segment) = &source;
+        let (destination_stack, _) = &destination;
+        let entrypoint = workspace.ref_name().map(ToOwned::to_owned);
+        // A branch that owns commits can only be reordered within its current stack in
+        // single-branch mode. Moving it across stacks would change commit ownership and needs a
+        // real rebase.
+        if !subject_segment.commits.is_empty() && !same_stack(source_stack, destination_stack) {
             bail!("Moving a non-empty branch in single-branch mode is not yet supported");
         }
-        let (_repo, meta) = successful_rebase.repo_and_meta_mut();
-        if !meta.can_persist_branch_stack_order() {
-            bail!(
-                "Cannot reorder '{subject_branch_name}' in single-branch mode without branch order metadata"
-            );
-        }
-        // Reorder against the existing chain. A movable subject is always part of `branch_order`
-        // (that's what makes it a projected segment), so the first lookup normally succeeds. The
-        // target and entrypoint lookups are defensive fallbacks so that, should the projection ever
-        // surface a segment that isn't tracked yet, we extend the real chain instead of clobbering
-        // it down to just the moved refs.
-        let existing_order = match meta.branch_stack_order(subject_branch_name)? {
-            Some(order) => order,
-            None => match meta.branch_stack_order(target_branch_name)? {
+        let existing_order = {
+            let (_repo, meta) = successful_rebase.repo_and_meta_mut();
+            if !meta.can_persist_branch_stack_order() {
+                bail!(
+                    "Cannot reorder '{subject_branch_name}' in single-branch mode without branch order metadata"
+                );
+            }
+            // Reorder against the existing chain. A movable subject is always part of `branch_order`
+            // (that's what makes it a projected segment), so the first lookup normally succeeds. The
+            // target and entrypoint lookups are defensive fallbacks so that, should the projection ever
+            // surface a segment that isn't tracked yet, we extend the real chain instead of clobbering
+            // it down to just the moved refs.
+            match meta.branch_stack_order(subject_branch_name)? {
                 Some(order) => order,
-                None => entrypoint
-                    .as_ref()
-                    .map(|entrypoint| meta.branch_stack_order(entrypoint.as_ref()))
-                    .transpose()?
-                    .flatten()
-                    .unwrap_or_default(),
-            },
+                None => match meta.branch_stack_order(target_branch_name)? {
+                    Some(order) => order,
+                    None => entrypoint
+                        .as_ref()
+                        .map(|entrypoint| meta.branch_stack_order(entrypoint.as_ref()))
+                        .transpose()?
+                        .flatten()
+                        .unwrap_or_else(|| stack_branch_order(source_stack)),
+                },
+            }
         };
         let new_order = reorder_empty_branch_in_stack_order(
             existing_order,
@@ -273,6 +278,46 @@ pub(super) mod function {
         // the caller can check it out (mirroring `create_reference`); we don't move `HEAD` here.
         let new_tip = (entrypoint.as_ref().map(|name| name.as_ref()) == Some(target_branch_name))
             .then(|| subject_branch_name.to_owned());
+
+        if !subject_segment.commits.is_empty() {
+            let workspace_head = workspace
+                .tip_commit()
+                .map(|commit| commit.id)
+                .context("Couldn't find workspace head.")?;
+            let (_, target_segment) = destination;
+            let target_segment_ref_name = target_segment
+                .ref_name()
+                .context("Target segment doesn't have a ref")?;
+            let mut editor = successful_rebase.into_editor();
+            let target_selector = editor
+                .select_reference(target_segment_ref_name)
+                .context("Failed to find target reference in graph.")?;
+
+            let DisconnectParameters {
+                delimiter: subject_delimiter,
+                children_to_disconnect,
+                parents_to_disconnect,
+            } = get_disconnect_parameters(&editor, source_stack, subject_segment, workspace_head)?;
+
+            editor.disconnect_segment_from(
+                subject_delimiter.clone(),
+                children_to_disconnect,
+                parents_to_disconnect,
+                false,
+            )?;
+            editor.insert_segment(
+                target_selector,
+                subject_delimiter,
+                but_rebase::graph_rebase::mutate::InsertSide::Above,
+            )?;
+
+            return Ok(Outcome {
+                rebase: editor.rebase()?,
+                ws_meta: None,
+                new_tip,
+                branch_stack_order: Some(new_order),
+            });
+        }
 
         Ok(Outcome {
             rebase: successful_rebase,
@@ -371,6 +416,23 @@ pub(super) mod function {
 
     fn own_context<'a>(ctx: WorkspaceSegmentContextRef<'a>) -> WorkspaceSegmentContext {
         (ctx.0.to_owned(), ctx.1.to_owned())
+    }
+
+    fn same_stack(left: &but_graph::workspace::Stack, right: &but_graph::workspace::Stack) -> bool {
+        left.segments.len() == right.segments.len()
+            && left
+                .segments
+                .iter()
+                .zip(&right.segments)
+                .all(|(left, right)| left.id == right.id)
+    }
+
+    fn stack_branch_order(stack: &but_graph::workspace::Stack) -> Vec<gix::refs::FullName> {
+        stack
+            .segments
+            .iter()
+            .filter_map(|segment| segment.ref_name().map(ToOwned::to_owned))
+            .collect()
     }
 
     /// Determine the surrounding context of the subject and target branches.

--- a/crates/but-workspace/src/branch/move_branch.rs
+++ b/crates/but-workspace/src/branch/move_branch.rs
@@ -11,11 +11,11 @@ pub struct Outcome<'ws, 'meta, M: RefMetadata> {
     /// The updated workspace metadata that accompanies the move operation.
     /// It should replace the actual workspace metadata to configure moved 'virtual' branches segments, if `Some()`.
     pub ws_meta: Option<but_core::ref_metadata::Workspace>,
-    /// In single-branch (ad-hoc) mode, set to the reference that became the new tip when the move
-    /// placed the subject above the currently checked-out branch. `HEAD` is *not* moved by the
-    /// operation; the caller is responsible for checking this out so the moved branch stays part of
-    /// the projected workspace (mirroring [`create_reference`](crate::branch::create_reference())).
-    /// `None` when the tip is unchanged.
+    /// In single-branch (ad-hoc) mode, set to the reference that should become the new tip after the
+    /// reorder. This can be the subject when it moves above the current tip, or the branch now above
+    /// it when the checked-out tip moves down. `HEAD` is *not* moved by the operation; the caller is
+    /// responsible for checking this out so the whole reordered stack stays projected (mirroring
+    /// [`create_reference`](crate::branch::create_reference())). `None` when the tip is unchanged.
     pub new_tip: Option<gix::refs::FullName>,
     /// In single-branch (ad-hoc) mode, the reordered tip-to-base branch chain that the caller should
     /// persist with [`RefMetadata::set_branch_stack_order`].
@@ -122,7 +122,12 @@ pub(super) mod function {
             delimiter: subject_delimiter,
             children_to_disconnect,
             parents_to_disconnect,
-        } = get_disconnect_parameters(&editor, source_stack, subject_segment, workspace_head)?;
+        } = get_disconnect_parameters(
+            &editor,
+            source_stack,
+            subject_segment,
+            Some(workspace_head),
+        )?;
 
         editor.disconnect_segment_from(
             subject_delimiter.clone(),
@@ -218,12 +223,11 @@ pub(super) mod function {
     /// Move a branch in a single-branch (ad-hoc) workspace, where `HEAD` is on a plain local branch.
     ///
     /// In single-branch (ad-hoc) mode there is no workspace commit, and the tip-to-base order of
-    /// same-commit empty branches lives in the `branch_order` metadata table rather than in the
-    /// workspace metadata. Reordering two empty branches is therefore a pure metadata operation
-    /// with no graph rewrite - mirror `create_reference`'s ad-hoc handling. The reordered chain is
-    /// returned in [`Outcome::branch_stack_order`] for the caller to persist (via
-    /// [`RefMetadata::set_branch_stack_order`]) rather than being written here, so callers can skip
-    /// persistence for dry-run previews.
+    /// branches lives in the `branch_order` metadata table rather than in workspace metadata. Empty
+    /// branches can therefore move through metadata alone, while branches with commits also require
+    /// a graph rewrite. The reordered chain is returned in [`Outcome::branch_stack_order`] for the
+    /// caller to persist (via [`RefMetadata::set_branch_stack_order`]) rather than being written
+    /// here, so callers can skip persistence for dry-run previews.
     fn move_branch_in_single_branch_mode<'ws, 'meta, M: RefMetadata>(
         mut successful_rebase: SuccessfulRebase<'ws, 'meta, M>,
         workspace: but_graph::Workspace,
@@ -266,24 +270,29 @@ pub(super) mod function {
                 },
             }
         };
-        let new_order = reorder_empty_branch_in_stack_order(
-            existing_order,
-            target_branch_name,
-            subject_branch_name,
+        let previous_order = existing_order.clone();
+        let new_order =
+            reorder_branch_in_stack_order(existing_order, target_branch_name, subject_branch_name);
+
+        // Keep HEAD at the top of the reordered portion of the stack. This is the subject when it
+        // moves above the current entrypoint, or the branch that moves above the subject when the
+        // checked-out top branch moves down.
+        let new_tip = reordered_entrypoint(
+            entrypoint.as_ref().map(|name| name.as_ref()),
+            source_stack,
+            &new_order,
         );
 
-        // Moving the subject on top of the checked-out branch makes it the new tip. The workspace
-        // only projects the entrypoint and the segments below it, so unless `HEAD` moves the subject
-        // would sit above the entrypoint and drop out of the projection. Report it as the new tip so
-        // the caller can check it out (mirroring `create_reference`); we don't move `HEAD` here.
-        let new_tip = (entrypoint.as_ref().map(|name| name.as_ref()) == Some(target_branch_name))
-            .then(|| subject_branch_name.to_owned());
+        if new_order == previous_order {
+            return Ok(Outcome {
+                rebase: successful_rebase,
+                ws_meta: None,
+                new_tip,
+                branch_stack_order: Some(new_order),
+            });
+        }
 
         if !subject_segment.commits.is_empty() {
-            let workspace_head = workspace
-                .tip_commit()
-                .map(|commit| commit.id)
-                .context("Couldn't find workspace head.")?;
             let (_, target_segment) = destination;
             let target_segment_ref_name = target_segment
                 .ref_name()
@@ -297,7 +306,7 @@ pub(super) mod function {
                 delimiter: subject_delimiter,
                 children_to_disconnect,
                 parents_to_disconnect,
-            } = get_disconnect_parameters(&editor, source_stack, subject_segment, workspace_head)?;
+            } = get_disconnect_parameters(&editor, source_stack, subject_segment, None)?;
 
             editor.disconnect_segment_from(
                 subject_delimiter.clone(),
@@ -374,7 +383,12 @@ pub(super) mod function {
             delimiter: subject_delimiter,
             children_to_disconnect,
             parents_to_disconnect,
-        } = get_disconnect_parameters(&editor, &source_stack, &subject_segment, workspace_head)?;
+        } = get_disconnect_parameters(
+            &editor,
+            &source_stack,
+            &subject_segment,
+            Some(workspace_head),
+        )?;
 
         let skip_reconnect_step = source_stack.segments.len() == 1;
         editor.disconnect_segment_from(
@@ -435,6 +449,21 @@ pub(super) mod function {
             .collect()
     }
 
+    fn reordered_entrypoint(
+        entrypoint: Option<&FullNameRef>,
+        stack: &but_graph::workspace::Stack,
+        new_order: &[gix::refs::FullName],
+    ) -> Option<gix::refs::FullName> {
+        let entrypoint = entrypoint?;
+        let new_entrypoint = new_order.iter().find(|candidate| {
+            stack
+                .segments
+                .iter()
+                .any(|segment| segment.ref_name() == Some(candidate.as_ref()))
+        })?;
+        (new_entrypoint.as_ref() != entrypoint).then(|| new_entrypoint.clone())
+    }
+
     /// Determine the surrounding context of the subject and target branches.
     ///
     /// Currently, this looks into the workspace projection in order to determine **where to take the branch from and to**.
@@ -488,7 +517,7 @@ pub(super) mod function {
     /// If `target` isn't tracked yet (stale or empty metadata) it is appended first, so that a move
     /// where *both* branches are missing adds them both - `subject` on top of `target` - instead of
     /// silently clobbering the rest of the ordering down to just `subject`.
-    fn reorder_empty_branch_in_stack_order(
+    fn reorder_branch_in_stack_order(
         mut order: Vec<gix::refs::FullName>,
         target_branch_name: &FullNameRef,
         subject_branch_name: &FullNameRef,
@@ -531,7 +560,7 @@ pub(super) mod function {
 
     #[cfg(test)]
     mod tests {
-        use super::reorder_empty_branch_in_stack_order;
+        use super::reorder_branch_in_stack_order;
 
         fn r(name: &str) -> gix::refs::FullName {
             gix::refs::FullName::try_from(name).expect("valid ref name")
@@ -544,7 +573,7 @@ pub(super) mod function {
         #[test]
         fn moves_subject_on_top_of_target_when_both_present() {
             let order = vec![r("refs/heads/main"), r("refs/heads/a"), r("refs/heads/b")];
-            let new = reorder_empty_branch_in_stack_order(
+            let new = reorder_branch_in_stack_order(
                 order,
                 r("refs/heads/main").as_ref(),
                 r("refs/heads/b").as_ref(),
@@ -559,7 +588,7 @@ pub(super) mod function {
         #[test]
         fn adds_subject_above_target_when_only_target_is_present() {
             let order = vec![r("refs/heads/main")];
-            let new = reorder_empty_branch_in_stack_order(
+            let new = reorder_branch_in_stack_order(
                 order,
                 r("refs/heads/main").as_ref(),
                 r("refs/heads/new").as_ref(),
@@ -572,7 +601,7 @@ pub(super) mod function {
             // Stale/empty metadata: neither branch is tracked yet. Both are added, subject on top of
             // target, without dropping any pre-existing ordering.
             let order = vec![r("refs/heads/main")];
-            let new = reorder_empty_branch_in_stack_order(
+            let new = reorder_branch_in_stack_order(
                 order,
                 r("refs/heads/target").as_ref(),
                 r("refs/heads/subject").as_ref(),
@@ -585,7 +614,7 @@ pub(super) mod function {
 
         #[test]
         fn adds_both_in_order_from_empty_metadata() {
-            let new = reorder_empty_branch_in_stack_order(
+            let new = reorder_branch_in_stack_order(
                 Vec::new(),
                 r("refs/heads/target").as_ref(),
                 r("refs/heads/subject").as_ref(),

--- a/crates/but-workspace/src/graph_manipulation.rs
+++ b/crates/but-workspace/src/graph_manipulation.rs
@@ -27,7 +27,7 @@ pub fn get_disconnect_parameters<'ws, 'meta, M: RefMetadata>(
     editor: &Editor<'ws, 'meta, M>,
     source_stack: &Stack,
     subject_segment: &StackSegment,
-    workspace_head: gix::ObjectId,
+    workspace_head: Option<gix::ObjectId>,
 ) -> anyhow::Result<DisconnectParameters> {
     let index_of_segment = source_stack
         .segments
@@ -77,12 +77,19 @@ pub fn get_disconnect_parameters<'ws, 'meta, M: RefMetadata>(
     };
 
     if index_of_segment == 0 {
-        // This is the top-most segment in the stack, so the parent is the workspace commit.
-        let workspace_head_selector = editor
-            .select_commit(workspace_head)
-            .context("Failed to find workspace head in graph.")?;
-        let selectors = SomeSelectors::new(vec![workspace_head_selector])?;
-        let children_to_disconnect = SelectorSet::Some(selectors);
+        // Managed workspaces have a workspace commit above the top-most segment. Ad-hoc
+        // workspaces do not have such a child, so there is no child edge to disconnect there.
+        let children_to_disconnect = workspace_head
+            .map(|workspace_head| -> anyhow::Result<SelectorSet> {
+                let workspace_head_selector = editor
+                    .select_commit(workspace_head)
+                    .context("Failed to find workspace head in graph.")?;
+                Ok(SelectorSet::Some(SomeSelectors::new(vec![
+                    workspace_head_selector,
+                ])?))
+            })
+            .transpose()?
+            .unwrap_or(SelectorSet::None);
 
         return Ok(DisconnectParameters {
             delimiter,

--- a/crates/but-workspace/tests/fixtures/scenario/single-branch-three-branch-stack.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/single-branch-three-branch-stack.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+### Description
+# A single-branch repository with three stacked non-empty branches:
+# main <- A <- B <- C, with HEAD on C.
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git init
+commit-file main main
+
+git checkout -b A
+commit-file a a
+
+git checkout -b B
+commit-file b b
+
+git checkout -b C
+commit-file c c

--- a/crates/but-workspace/tests/workspace/branch/move_branch.rs
+++ b/crates/but-workspace/tests/workspace/branch/move_branch.rs
@@ -1286,12 +1286,14 @@ fn set_workspace_metadata(
 /// (no `gitbutler/workspace` commit) and the tip-to-base order of same-commit empty branches lives
 /// in the `branch_order` metadata table rather than in `Workspace` metadata.
 mod single_branch_mode {
+    use std::collections::HashMap;
+
     use but_core::RefMetadata;
     use but_core::ref_metadata::StackId;
     use but_graph::init::Options;
     use but_meta::BranchOrderMetadata;
     use but_rebase::graph_rebase::Editor;
-    use but_testsupport::graph_workspace;
+    use but_testsupport::{graph_workspace, invoke_bash};
     use but_workspace::branch::create_reference::{Anchor, Position};
 
     use crate::ref_info::with_workspace_commit::utils::named_writable_scenario;
@@ -1306,6 +1308,38 @@ mod single_branch_mode {
         BranchOrderMetadata::from_paths(repo.path().join("virtual-branches.toml"), repo.path())
     }
 
+    fn project_meta(meta: &impl RefMetadata) -> but_core::ref_metadata::ProjectMeta {
+        meta.workspace(
+            but_core::WORKSPACE_REF_NAME
+                .try_into()
+                .expect("valid workspace ref"),
+        )
+        .map(|workspace| workspace.project_meta())
+        .unwrap_or_default()
+    }
+
+    fn ad_hoc_workspace_with_three_non_empty_branches(
+        head: &str,
+    ) -> anyhow::Result<(
+        tempfile::TempDir,
+        gix::Repository,
+        BranchOrderMetadata,
+        but_core::ref_metadata::ProjectMeta,
+    )> {
+        let (tmp, repo, legacy_meta) = named_writable_scenario("single-branch-three-branch-stack")?;
+        if head != "C" {
+            invoke_bash(&format!("git checkout {head}\n"), &repo);
+        }
+        let mut meta = branch_order_meta(&repo)?;
+        meta.set_branch_stack_order(&[
+            r("refs/heads/C").to_owned(),
+            r("refs/heads/B").to_owned(),
+            r("refs/heads/A").to_owned(),
+            r("refs/heads/main").to_owned(),
+        ])?;
+        Ok((tmp, repo, meta, project_meta(&legacy_meta)))
+    }
+
     /// `move_branch` returns the reordered chain instead of persisting it (so callers can skip
     /// persistence for dry runs); persist it here to mimic a real, non-dry-run caller.
     fn persist_order(
@@ -1316,6 +1350,92 @@ mod single_branch_mode {
             meta.set_branch_stack_order(order)?;
         }
         Ok(())
+    }
+
+    fn move_branch_and_apply(
+        repo: &gix::Repository,
+        meta: &mut BranchOrderMetadata,
+        project_meta: but_core::ref_metadata::ProjectMeta,
+        subject: &gix::refs::FullNameRef,
+        target: &gix::refs::FullNameRef,
+    ) -> anyhow::Result<Option<Vec<gix::refs::FullName>>> {
+        let mut ws = but_graph::Graph::from_head(repo, meta, project_meta, Options::limited())?
+            .into_workspace()?;
+        let editor = Editor::create(&mut ws, meta, repo)?;
+        let but_workspace::branch::move_branch::Outcome {
+            rebase,
+            ws_meta,
+            new_tip,
+            branch_stack_order,
+            ..
+        } = but_workspace::branch::move_branch(editor, subject, target)?;
+        assert!(
+            ws_meta.is_none(),
+            "ad-hoc reorder lives in branch_order, not workspace metadata"
+        );
+        rebase.materialize()?;
+        persist_order(meta, &branch_stack_order)?;
+        if let Some(new_tip) = new_tip {
+            invoke_bash(&format!("git checkout {}\n", new_tip.shorten()), repo);
+        }
+        Ok(branch_stack_order)
+    }
+
+    fn assert_head(repo: &gix::Repository, branch_name: &str) {
+        let actual = repo
+            .head_name()
+            .expect("HEAD can be read")
+            .expect("HEAD points to a branch")
+            .to_string();
+        assert_eq!(actual, format!("refs/heads/{branch_name}"));
+    }
+
+    fn branch_tip(repo: &gix::Repository, branch_name: &str) -> gix::ObjectId {
+        repo.rev_parse_single(branch_name)
+            .expect("branch exists")
+            .detach()
+    }
+
+    fn normalized_graph_snapshot(repo: &gix::Repository) -> anyhow::Result<String> {
+        let rendered = but_testsupport::visualize_commit_graph_all(repo)?;
+        let mut labels = HashMap::new();
+        Ok(normalize_graph(&rendered, &mut labels)
+            .lines()
+            .map(str::trim_end)
+            .collect::<Vec<_>>()
+            .join("\n"))
+    }
+
+    fn normalize_graph(graph: &str, labels: &mut HashMap<String, String>) -> String {
+        let mut out = String::new();
+        let mut token = String::new();
+        for ch in graph.chars() {
+            if ch.is_ascii_hexdigit() {
+                token.push(ch);
+            } else {
+                push_normalized_token(&mut out, &mut token, labels);
+                out.push(ch);
+            }
+        }
+        push_normalized_token(&mut out, &mut token, labels);
+        out
+    }
+
+    fn push_normalized_token(
+        out: &mut String,
+        token: &mut String,
+        labels: &mut HashMap<String, String>,
+    ) {
+        if (7..=40).contains(&token.len()) && token.chars().all(|ch| ch.is_ascii_hexdigit()) {
+            let next = labels.len() + 1;
+            let label = labels
+                .entry(std::mem::take(token))
+                .or_insert_with(|| format!("[C{next}]"));
+            out.push_str(label);
+        } else {
+            out.push_str(token);
+            token.clear();
+        }
     }
 
     /// Build a single-branch (ad-hoc) workspace on `main` (3 commits) with two empty dependent
@@ -1525,38 +1645,146 @@ mod single_branch_mode {
         Ok(())
     }
 
-    /// Moving a *non-empty* branch in single-branch mode is not supported yet: the base-most branch
-    /// of a single-branch stack owns the commits, so moving it would change commit ownership and
-    /// needs a real rebase rather than a pure metadata reorder.
     #[test]
-    fn moving_non_empty_branch_is_unsupported() -> anyhow::Result<()> {
-        let (_tmp, repo, mut meta, project_meta) = ad_hoc_workspace_with_two_empty_branches()?;
-        let main_ref = r("refs/heads/main");
-        let order_before = meta.branch_stack_order(main_ref)?;
+    fn move_middle_non_empty_branch_to_top_checks_out_subject() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, project_meta) =
+            ad_hoc_workspace_with_three_non_empty_branches("C")?;
 
-        let mut ws = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?
-            .into_workspace()?;
+        snapbox::assert_data_eq!(
+            normalized_graph_snapshot(&repo)?,
+            snapbox::str![[r#"
+* [C1] (HEAD -> C) add c
+* [C2] (B) add b
+* [C3] (A) add a
+* [C4] (main) add main"#]]
+        );
 
-        // `base` owns the stack's commits, so trying to move it must be rejected.
-        let editor = Editor::create(&mut ws, &mut meta, &repo)?;
-        let err = match but_workspace::branch::move_branch(
-            editor,
-            r("refs/heads/base"),
-            r("refs/heads/empty-top"),
-        ) {
-            // `Outcome` holds the metadata backend (not `Debug`), so unwrap the error by hand.
-            Ok(_) => panic!("moving a non-empty branch in single-branch mode should be rejected"),
-            Err(err) => err,
-        };
+        let branch_stack_order = move_branch_and_apply(
+            &repo,
+            &mut meta,
+            project_meta,
+            r("refs/heads/B"),
+            r("refs/heads/C"),
+        )?;
 
+        assert_head(&repo, "B");
         assert_eq!(
-            err.to_string(),
-            "Moving a non-empty branch in single-branch mode is not yet supported"
+            branch_stack_order,
+            Some(vec![
+                r("refs/heads/B").to_owned(),
+                r("refs/heads/C").to_owned(),
+                r("refs/heads/A").to_owned(),
+                r("refs/heads/main").to_owned(),
+            ])
+        );
+        snapbox::assert_data_eq!(
+            normalized_graph_snapshot(&repo)?,
+            snapbox::str![[r#"
+* [C1] (HEAD -> B) add b
+* [C2] (C) add c
+* [C3] (A) add a
+* [C4] (main) add main
+"#]]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn move_bottom_non_empty_branch_to_top_checks_out_subject() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, project_meta) =
+            ad_hoc_workspace_with_three_non_empty_branches("C")?;
+
+        snapbox::assert_data_eq!(
+            normalized_graph_snapshot(&repo)?,
+            snapbox::str![[r#"
+* [C1] (HEAD -> C) add c
+* [C2] (B) add b
+* [C3] (A) add a
+* [C4] (main) add main"#]]
+        );
+
+        let branch_stack_order = move_branch_and_apply(
+            &repo,
+            &mut meta,
+            project_meta,
+            r("refs/heads/A"),
+            r("refs/heads/C"),
+        )?;
+
+        assert_head(&repo, "A");
+        assert_eq!(
+            branch_stack_order,
+            Some(vec![
+                r("refs/heads/A").to_owned(),
+                r("refs/heads/C").to_owned(),
+                r("refs/heads/B").to_owned(),
+                r("refs/heads/main").to_owned(),
+            ])
+        );
+        snapbox::assert_data_eq!(
+            normalized_graph_snapshot(&repo)?,
+            snapbox::str![[r#"
+* [C1] (HEAD -> A) add a
+* [C2] (C) add c
+* [C3] (B) add b
+* [C4] (main) add main
+"#]]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn move_bottom_branch_above_checked_out_middle_leaves_top_branch_untouched()
+    -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, project_meta) =
+            ad_hoc_workspace_with_three_non_empty_branches("B")?;
+        let c_tip_before = branch_tip(&repo, "C");
+
+        snapbox::assert_data_eq!(
+            normalized_graph_snapshot(&repo)?,
+            snapbox::str![[r#"
+* [C1] (C) add c
+* [C2] (HEAD -> B) add b
+* [C3] (A) add a
+* [C4] (main) add main"#]]
+        );
+
+        let branch_stack_order = move_branch_and_apply(
+            &repo,
+            &mut meta,
+            project_meta,
+            r("refs/heads/A"),
+            r("refs/heads/B"),
+        )?;
+
+        assert_head(&repo, "A");
+        assert_eq!(
+            branch_tip(&repo, "C"),
+            c_tip_before,
+            "C should stay untouched when it is above the checked-out entrypoint"
         );
         assert_eq!(
-            meta.branch_stack_order(main_ref)?,
-            order_before,
-            "the ad-hoc branch order must be untouched after the rejected move"
+            branch_stack_order,
+            Some(vec![
+                r("refs/heads/C").to_owned(),
+                r("refs/heads/A").to_owned(),
+                r("refs/heads/B").to_owned(),
+                r("refs/heads/main").to_owned(),
+            ])
+        );
+        snapbox::assert_data_eq!(
+            normalized_graph_snapshot(&repo)?,
+            snapbox::str![[r#"
+* [C1] (HEAD -> A) add a
+* [C2] (B) add b
+| * [C3] (C) add c
+| * [C4] add b
+| * [C5] add a
+|/
+* [C6] (main) add main
+"#]]
         );
 
         Ok(())

--- a/crates/but-workspace/tests/workspace/branch/move_branch.rs
+++ b/crates/but-workspace/tests/workspace/branch/move_branch.rs
@@ -1736,6 +1736,78 @@ mod single_branch_mode {
     }
 
     #[test]
+    fn move_top_non_empty_branch_down_checks_out_new_top() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, project_meta) =
+            ad_hoc_workspace_with_three_non_empty_branches("C")?;
+
+        let branch_stack_order = move_branch_and_apply(
+            &repo,
+            &mut meta,
+            project_meta,
+            r("refs/heads/C"),
+            r("refs/heads/A"),
+        )?;
+
+        assert_head(&repo, "B");
+        assert_eq!(
+            branch_stack_order,
+            Some(vec![
+                r("refs/heads/B").to_owned(),
+                r("refs/heads/C").to_owned(),
+                r("refs/heads/A").to_owned(),
+                r("refs/heads/main").to_owned(),
+            ]),
+            "moving the checked-out tip down should make the branch above it the new tip"
+        );
+        // The same commits are reordered to match the branch order, with the new tip checked out.
+        snapbox::assert_data_eq!(
+            normalized_graph_snapshot(&repo)?,
+            snapbox::str![[r#"
+* [C1] (HEAD -> B) add b
+* [C2] (C) add c
+* [C3] (A) add a
+* [C4] (main) add main
+"#]]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn move_top_non_empty_branch_above_current_parent_is_a_noop() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, project_meta) =
+            ad_hoc_workspace_with_three_non_empty_branches("C")?;
+        let tips_before = ["A", "B", "C"].map(|branch| branch_tip(&repo, branch));
+
+        let branch_stack_order = move_branch_and_apply(
+            &repo,
+            &mut meta,
+            project_meta,
+            r("refs/heads/C"),
+            r("refs/heads/B"),
+        )?;
+
+        assert_head(&repo, "C");
+        assert_eq!(
+            branch_stack_order,
+            Some(vec![
+                r("refs/heads/C").to_owned(),
+                r("refs/heads/B").to_owned(),
+                r("refs/heads/A").to_owned(),
+                r("refs/heads/main").to_owned(),
+            ]),
+            "placing the tip above its current parent should preserve branch order"
+        );
+        assert_eq!(
+            ["A", "B", "C"].map(|branch| branch_tip(&repo, branch)),
+            tips_before,
+            "a no-op move should not rewrite commits"
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn move_bottom_branch_above_checked_out_middle_leaves_top_branch_untouched()
     -> anyhow::Result<()> {
         let (_tmp, repo, mut meta, project_meta) =

--- a/e2e/playwright/scripts/project-in-single-branch-three-branch-stack.sh
+++ b/e2e/playwright/scripts/project-in-single-branch-three-branch-stack.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "GIT CONFIG $GIT_CONFIG_GLOBAL"
+echo "DATA DIR $E2E_TEST_APP_DATA_DIR"
+echo "BUT $BUT"
+
+head_branch="${1:-C}"
+
+# Setup a remote project. GitButler currently requires projects to have a remote.
+mkdir remote-project
+pushd remote-project
+git init -b master --object-format=sha1
+echo "base" > base.txt
+git add base.txt
+git commit -m "base: initial commit"
+popd
+
+# Clone the remote, register the project with GitButler, configure the target,
+# then create a local non-empty stack: master <- A <- B <- C.
+git clone remote-project local-clone
+pushd local-clone
+git checkout master
+target_branch="$(git rev-parse --symbolic-full-name @{u})"
+target_branch="${target_branch#refs/remotes/}"
+"$BUT" setup
+"$BUT" config target "$target_branch"
+
+git checkout -b A master
+echo "A" > A.txt
+git add A.txt
+git commit -m "A: first commit"
+
+git checkout -b B
+echo "B" > B.txt
+git add B.txt
+git commit -m "B: first commit"
+
+git checkout -b C
+echo "C" > C.txt
+git add C.txt
+git commit -m "C: first commit"
+
+sqlite3 .git/gitbutler/but.sqlite <<SQL
+CREATE TABLE IF NOT EXISTS branch_order(
+  branch_ref_name TEXT NOT NULL PRIMARY KEY,
+  parent_ref_name TEXT UNIQUE,
+  CHECK (parent_ref_name IS NULL OR branch_ref_name != parent_ref_name)
+);
+CREATE INDEX IF NOT EXISTS idx_branch_order_parent_ref_name ON branch_order(parent_ref_name);
+DELETE FROM branch_order WHERE branch_ref_name IN ('refs/heads/C', 'refs/heads/B', 'refs/heads/A');
+INSERT INTO branch_order (branch_ref_name, parent_ref_name) VALUES
+  ('refs/heads/C', 'refs/heads/B'),
+  ('refs/heads/B', 'refs/heads/A'),
+  ('refs/heads/A', NULL);
+SQL
+
+git checkout "$head_branch"
+popd

--- a/e2e/playwright/scripts/project-in-single-branch-three-branch-stack.sh
+++ b/e2e/playwright/scripts/project-in-single-branch-three-branch-stack.sh
@@ -42,19 +42,29 @@ echo "C" > C.txt
 git add C.txt
 git commit -m "C: first commit"
 
-sqlite3 .git/gitbutler/but.sqlite <<SQL
-CREATE TABLE IF NOT EXISTS branch_order(
-  branch_ref_name TEXT NOT NULL PRIMARY KEY,
-  parent_ref_name TEXT UNIQUE,
-  CHECK (parent_ref_name IS NULL OR branch_ref_name != parent_ref_name)
-);
-CREATE INDEX IF NOT EXISTS idx_branch_order_parent_ref_name ON branch_order(parent_ref_name);
-DELETE FROM branch_order WHERE branch_ref_name IN ('refs/heads/C', 'refs/heads/B', 'refs/heads/A');
-INSERT INTO branch_order (branch_ref_name, parent_ref_name) VALUES
-  ('refs/heads/C', 'refs/heads/B'),
-  ('refs/heads/B', 'refs/heads/A'),
-  ('refs/heads/A', NULL);
-SQL
+python3 - .git/gitbutler/but.sqlite <<'PYTHON'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as database:
+    database.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS branch_order(
+          branch_ref_name TEXT NOT NULL PRIMARY KEY,
+          parent_ref_name TEXT UNIQUE,
+          CHECK (parent_ref_name IS NULL OR branch_ref_name != parent_ref_name)
+        );
+        CREATE INDEX IF NOT EXISTS idx_branch_order_parent_ref_name
+          ON branch_order(parent_ref_name);
+        DELETE FROM branch_order
+          WHERE branch_ref_name IN ('refs/heads/C', 'refs/heads/B', 'refs/heads/A');
+        INSERT INTO branch_order (branch_ref_name, parent_ref_name) VALUES
+          ('refs/heads/C', 'refs/heads/B'),
+          ('refs/heads/B', 'refs/heads/A'),
+          ('refs/heads/A', NULL);
+        """
+    )
+PYTHON
 
 git checkout "$head_branch"
 popd

--- a/e2e/playwright/src/branch.ts
+++ b/e2e/playwright/src/branch.ts
@@ -139,6 +139,10 @@ export function commitSubjects(pathToRepo: string, count: number): string[] {
 		.filter(Boolean);
 }
 
+export function branchTip(branchName: string, pathToRepo: string): string {
+	return git(pathToRepo, ["rev-parse", branchName]);
+}
+
 function git(pathToRepo: string, args: string[]): string {
 	return execFileSync("git", args, {
 		cwd: pathToRepo,

--- a/e2e/playwright/tests/singleBranch/moveBranch.spec.ts
+++ b/e2e/playwright/tests/singleBranch/moveBranch.spec.ts
@@ -121,6 +121,21 @@ test("can move a bottom non-empty branch above the checked-out branch", async ({
 	await assertCommitSubjects(["A: first commit", "C: first commit", "B: first commit"], localClone);
 });
 
+test("can move the checked-out top branch down within its stack", async ({ page, gitbutler }) => {
+	const localClone = await setupThreeBranchStackProject(gitbutler, page);
+
+	await expect(getByTestId(page, "branch-card")).toHaveCount(3);
+	await expectCurrentBranchChip(page, "C");
+	await expectBranchHeaderOrder(page, ["C", "B", "A"]);
+
+	await dragBranchToInsertionDropzone(page, "C", 1);
+
+	await expectBranchHeaderOrder(page, ["B", "C", "A"]);
+	await expectCurrentBranchChip(page, "B");
+	await assertBranch("B", localClone);
+	await assertCommitSubjects(["B: first commit", "C: first commit", "A: first commit"], localClone);
+});
+
 test("can move a bottom non-empty branch above the checked-out middle branch", async ({
 	page,
 	gitbutler,

--- a/e2e/playwright/tests/singleBranch/moveBranch.spec.ts
+++ b/e2e/playwright/tests/singleBranch/moveBranch.spec.ts
@@ -164,11 +164,15 @@ async function dragBranchToInsertionDropzone(
 
 	await page.mouse.down();
 	await page.mouse.move(box.x + 16, box.y + 16);
-	await page.evaluate(async () => await new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
+	await page.evaluate(
+		async () => await new Promise<void>((resolve) => requestAnimationFrame(() => resolve())),
+	);
 
 	const target = page.getByTestId("BranchListInsertionDropzone").nth(dropzoneIndex);
 	await target.hover({ force: true, position: { x: 120, y: 6 } });
-	await page.evaluate(async () => await new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
+	await page.evaluate(
+		async () => await new Promise<void>((resolve) => requestAnimationFrame(() => resolve())),
+	);
 	await page.mouse.up();
 }
 

--- a/e2e/playwright/tests/singleBranch/moveBranch.spec.ts
+++ b/e2e/playwright/tests/singleBranch/moveBranch.spec.ts
@@ -2,13 +2,15 @@ import {
 	branchHeader,
 	createDependentBranch,
 	expectCurrentBranchChip,
+	openSingleBranchWorkspace,
 	setupSingleBranchProject,
 	SINGLE_BRANCH_NAME,
 } from "./helpers.ts";
-import { assertBranch } from "../../src/branch.ts";
+import { assertBranch, assertCommitSubjects, branchTip } from "../../src/branch.ts";
 import { test } from "../../src/test.ts";
 import { dragAndDropByLocator, getByTestId } from "../../src/util.ts";
 import { expect, type Page } from "@playwright/test";
+import type { GitButler } from "../../src/setup.ts";
 
 test.use({
 	gitbutlerOptions: {
@@ -82,6 +84,93 @@ test("moving an empty branch above the checked-out branch checks out the new tip
 	await expectCurrentBranchChip(page, "empty-a");
 	await assertBranch("empty-a", localClone);
 });
+
+test("can move a middle non-empty branch above the checked-out branch", async ({
+	page,
+	gitbutler,
+}) => {
+	const localClone = await setupThreeBranchStackProject(gitbutler, page);
+
+	await expect(getByTestId(page, "branch-card")).toHaveCount(3);
+	await expectCurrentBranchChip(page, "C");
+	await expectBranchHeaderOrder(page, ["C", "B", "A"]);
+
+	await dragBranchToInsertionDropzone(page, "B", 0);
+
+	await expectBranchHeaderOrder(page, ["B", "C", "A"]);
+	await expectCurrentBranchChip(page, "B");
+	await assertBranch("B", localClone);
+	await assertCommitSubjects(["B: first commit", "C: first commit", "A: first commit"], localClone);
+});
+
+test("can move a bottom non-empty branch above the checked-out branch", async ({
+	page,
+	gitbutler,
+}) => {
+	const localClone = await setupThreeBranchStackProject(gitbutler, page);
+
+	await expect(getByTestId(page, "branch-card")).toHaveCount(3);
+	await expectCurrentBranchChip(page, "C");
+	await expectBranchHeaderOrder(page, ["C", "B", "A"]);
+
+	await dragBranchToInsertionDropzone(page, "A", 0);
+
+	await expectBranchHeaderOrder(page, ["A", "C", "B"]);
+	await expectCurrentBranchChip(page, "A");
+	await assertBranch("A", localClone);
+	await assertCommitSubjects(["A: first commit", "C: first commit", "B: first commit"], localClone);
+});
+
+test("can move a bottom non-empty branch above the checked-out middle branch", async ({
+	page,
+	gitbutler,
+}) => {
+	const localClone = await setupThreeBranchStackProject(gitbutler, page, "B");
+	const cTipBefore = branchTip("C", localClone);
+
+	await expect(getByTestId(page, "branch-card")).toHaveCount(2);
+	await expectCurrentBranchChip(page, "B");
+	await expectBranchHeaderOrder(page, ["B", "A"]);
+
+	await dragBranchToInsertionDropzone(page, "A", 0);
+
+	await expectBranchHeaderOrder(page, ["A", "B"]);
+	await expectCurrentBranchChip(page, "A");
+	await assertBranch("A", localClone);
+	expect(branchTip("C", localClone)).toBe(cTipBefore);
+	await assertCommitSubjects(["A: first commit", "B: first commit"], localClone);
+});
+
+async function setupThreeBranchStackProject(
+	gitbutler: GitButler,
+	page: Page,
+	headBranch = "C",
+): Promise<string> {
+	await gitbutler.runScript("project-in-single-branch-three-branch-stack.sh", [headBranch]);
+	const localClone = gitbutler.pathInWorkdir("local-clone");
+	await openSingleBranchWorkspace(page);
+	return localClone;
+}
+
+async function dragBranchToInsertionDropzone(
+	page: Page,
+	branchName: string,
+	dropzoneIndex: number,
+): Promise<void> {
+	const source = branchHeader(page, branchName);
+	await source.hover();
+	const box = await source.boundingBox();
+	if (!box) throw new Error(`Branch header ${branchName} has no bounding box`);
+
+	await page.mouse.down();
+	await page.mouse.move(box.x + 16, box.y + 16);
+	await page.evaluate(async () => await new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
+
+	const target = page.getByTestId("BranchListInsertionDropzone").nth(dropzoneIndex);
+	await target.hover({ force: true, position: { x: 120, y: 6 } });
+	await page.evaluate(async () => await new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
+	await page.mouse.up();
+}
 
 async function expectBranchHeaderOrder(page: Page, expectedBranchNames: string[]): Promise<void> {
 	await expect


### PR DESCRIPTION
## Why?
It's cool to reorder branches in single branch mode.
While we're here: It's also cool to reorder branches inside a stack.

## 🧢 Changes

- Enables same-stack branch reordering for commit-owning branches in both managed and single-branch/ad-hoc workspaces.
- Adds Rust coverage with normalized graph snapshots and Playwright coverage for non-empty single-branch reorder flows.
- Adds a small desktop drop-handler unit test and shared e2e Git helpers/fixtures for the new drag-and-drop scenarios.

## ☕️ Reasoning

- Reordering a commit-owning branch within its existing stack can be handled by the graph editor plus persisted branch-order metadata in both managed and ad-hoc workspaces.
- Cross-stack non-empty moves remain unsupported in single-branch mode to avoid changing commit ownership outside the scoped behavior.
- Validated with Rust move-branch tests, but-workspace check/clippy, desktop unit tests, the single-branch Playwright move spec, and `pnpm begood`.
