### PR TITLE
Recompute the merge base when needed

### DIFF
--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -36,9 +36,10 @@ pub fn get_workspace(
 ///
 /// This acquires exclusive worktree access from `ctx` before updating project metadata.
 /// See [`but_workspace::init::set_target_ref_and_init_project()`] for details; notably the
-/// target commit id is only computed when it wasn't set before, and an omitted
-/// `push_remote` keeps the currently configured one. It deliberately records no oplog
-/// snapshot - only project metadata changes, no repository state.
+/// target commit id is recomputed when the target ref changes and preserved when the same
+/// ref is set again. An omitted `push_remote` keeps the currently configured one. It
+/// deliberately records no oplog snapshot - only project metadata changes, no repository
+/// state.
 #[cfg(feature = "legacy")]
 #[but_api(napi)]
 #[instrument(err(Debug))]

--- a/crates/but-workspace/src/init.rs
+++ b/crates/but-workspace/src/init.rs
@@ -21,8 +21,10 @@ use but_core::{
 ///   back-fills the legacy metadata in `meta`,
 /// * set `log.excludeDecoration = refs/gitbutler` in the repository-local Git config.
 ///
-/// The target commit id is only computed - as the merge-base between `HEAD` and
-/// `target_ref` - if it isn't already set; an existing value is never overwritten.
+/// The target commit id is computed as the merge-base between `HEAD` and `target_ref`
+/// when it isn't already set or when the target ref changes. An existing value is
+/// preserved when setting the same target ref again, keeping the workspace frame stable
+/// if that ref has advanced.
 /// `push_remote`, if `Some`, is validated and stored; if `None`, an existing push remote
 /// is kept as is.
 ///
@@ -83,9 +85,13 @@ pub fn set_target_ref_and_init_project(
         .url(gix::remote::Direction::Fetch)
         .with_context(|| format!("failed to get remote url for '{remote_name}'"))?;
 
+    let target_ref_changed = project_meta
+        .as_ref()
+        .and_then(|meta| meta.target_ref.as_ref())
+        .is_none_or(|existing| existing.as_ref() != target_ref);
     let sha = match project_meta.as_ref().and_then(|meta| meta.target_commit_id) {
-        Some(existing) => existing,
-        None => {
+        Some(existing) if !target_ref_changed => existing,
+        _ => {
             let head_commit = repo
                 .head()
                 .context("Failed to get HEAD reference")?

--- a/crates/but-workspace/tests/workspace/init.rs
+++ b/crates/but-workspace/tests/workspace/init.rs
@@ -133,12 +133,12 @@ fn resetting_the_same_ref_keeps_the_target_commit_id() {
     assert_eq!(
         stored_meta(&repo, &meta).target_commit_id,
         Some(initial_target_id),
-        "an existing target commit id is never overwritten"
+        "the target commit stays stable when its ref advances"
     );
 }
 
 #[test]
-fn changing_the_target_ref_preserves_the_target_commit_id() {
+fn changing_the_target_ref_recomputes_the_target_commit_id() {
     let (repo, mut meta, _tmp) = scenario();
     set_target_ref(&repo, &mut meta, "refs/remotes/origin/main", None).unwrap();
     let initial_target_id = stored_meta(&repo, &meta).target_commit_id.unwrap();
@@ -165,8 +165,13 @@ fn changing_the_target_ref_preserves_the_target_commit_id() {
     );
     assert_eq!(
         project_meta.target_commit_id,
+        Some(new_commit),
+        "a different target ref gets its own merge-base"
+    );
+    assert_ne!(
+        project_meta.target_commit_id,
         Some(initial_target_id),
-        "the stored id is kept verbatim even for a different target branch"
+        "switching targets must not retain the old frame of reference"
     );
 }
 

--- a/crates/but/tests/but/command/config.rs
+++ b/crates/but/tests/but/command/config.rs
@@ -8,6 +8,15 @@ fn target_configures_distinct_push_remote_for_fork() {
     env.but("setup").assert().success();
     env.invoke_git("remote add upstream .");
     env.invoke_git("update-ref refs/remotes/upstream/main refs/remotes/origin/main");
+    let expected_target_commit_id = env.invoke_git("merge-base HEAD refs/remotes/upstream/main");
+    let stale_target_commit_id = env.invoke_git("commit-tree HEAD^{tree} -p HEAD -m stale-target");
+    assert_ne!(
+        stale_target_commit_id, expected_target_commit_id,
+        "the seeded target commit must expose accidental preservation"
+    );
+    env.invoke_git(&format!(
+        "config --local gitbutler.project.targetCommitId {stale_target_commit_id}"
+    ));
 
     env.but("config target upstream/main --push-remote origin")
         .assert()
@@ -20,6 +29,11 @@ fn target_configures_distinct_push_remote_for_fork() {
     assert_eq!(
         env.invoke_git("config --local --get gitbutler.project.pushRemote"),
         "origin"
+    );
+    assert_eq!(
+        env.invoke_git("config --local --get gitbutler.project.targetCommitId"),
+        expected_target_commit_id,
+        "switching target refs recomputes the merge-base"
     );
 }
 

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -493,9 +493,10 @@ export declare function setReviewTemplate(projectId: string, templatePath: strin
  *
  * This acquires exclusive worktree access from `ctx` before updating project metadata.
  * See [`but_workspace::init::set_target_ref_and_init_project()`] for details; notably the
- * target commit id is only computed when it wasn't set before, and an omitted
- * `push_remote` keeps the currently configured one. It deliberately records no oplog
- * snapshot - only project metadata changes, no repository state.
+ * target commit id is recomputed when the target ref changes and preserved when the same
+ * ref is set again. An omitted `push_remote` keeps the currently configured one. It
+ * deliberately records no oplog snapshot - only project metadata changes, no repository
+ * state.
  */
 export declare function setTargetRefAndInitProject(projectId: string, targetRef: string, pushRemote: string | null): Promise<void>
 

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -493,9 +493,10 @@ export declare function setReviewTemplate(projectId: string, templatePath: strin
  *
  * This acquires exclusive worktree access from `ctx` before updating project metadata.
  * See [`but_workspace::init::set_target_ref_and_init_project()`] for details; notably the
- * target commit id is only computed when it wasn't set before, and an omitted
- * `push_remote` keeps the currently configured one. It deliberately records no oplog
- * snapshot - only project metadata changes, no repository state.
+ * target commit id is recomputed when the target ref changes and preserved when the same
+ * ref is set again. An omitted `push_remote` keeps the currently configured one. It
+ * deliberately records no oplog snapshot - only project metadata changes, no repository
+ * state.
  */
 export declare function setTargetRefAndInitProject(projectId: string, targetRef: string, pushRemote: string | null): Promise<void>
 


### PR DESCRIPTION
## Changes

- Recompute `targetCommitId` when `but config target` switches to a different target ref, while preserving it when the same ref advances.
- Add workspace-level and CLI end-to-end regression coverage for target base recomputation.

## Motivation

- Prevent target and status calculations from using the previous branch's merge-base after changing targets.

## Validation

- Ran focused workspace and CLI tests, `cargo fmt`, targeted `cargo check`, and Clippy with warnings denied.
