### PR TITLE
Lite: keep move/cut hotkeys enabled in non-default outline mode

### DIFF
--- a/apps/lite/ui/src/selection-scopes.ts
+++ b/apps/lite/ui/src/selection-scopes.ts
@@ -305,11 +305,7 @@ export const useNavigationIndexHotkeys = <T>({
 		},
 	]);
 
-	const outlineMode = useAppSelector((state) =>
-		projectSlice.selectors.selectOutlineModeState(state, projectId),
-	);
-
-	const operationEnabled = outlineMode._tag === "Default" && selection !== null;
+	const operationEnabled = selection !== null;
 
 	const enterTransferModeForSelection = (operationType: OperationType) => {
 		if (selection === null) return;

--- a/apps/lite/ui/src/selection-scopes.ts
+++ b/apps/lite/ui/src/selection-scopes.ts
@@ -305,8 +305,6 @@ export const useNavigationIndexHotkeys = <T>({
 		},
 	]);
 
-	const operationEnabled = selection !== null;
-
 	const enterTransferModeForSelection = (operationType: OperationType) => {
 		if (selection === null) return;
 
@@ -328,7 +326,7 @@ export const useNavigationIndexHotkeys = <T>({
 			callback: () => enterTransferModeForSelection("above"),
 			options: {
 				conflictBehavior: "allow",
-				enabled: operationEnabled,
+				enabled: selection !== null,
 				target: ref,
 				meta: { group, name: "Move" },
 			},
@@ -338,7 +336,7 @@ export const useNavigationIndexHotkeys = <T>({
 			callback: () => enterTransferModeForSelection("into"),
 			options: {
 				conflictBehavior: "allow",
-				enabled: operationEnabled,
+				enabled: selection !== null,
 				target: ref,
 				ignoreInputs: true,
 				meta: { group, name: "Cut" },


### PR DESCRIPTION
@samhh Fixes the bug you noticed