### PR TITLE
Log IPC invocations as network requests in devtools

### DIFF
--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -1,6 +1,12 @@
 import { checkForUpdates, registerUpdater } from "./updater.js";
 import WatcherManager from "./watcher.js";
 import {
+	ipcTraceCompleteChannel,
+	ipcTraceCompletionPath,
+	ipcTraceHost,
+	isIpcTraceCompletion,
+} from "./tracing.js";
+import {
 	liteIpcChannels,
 	type AbsorbParams,
 	type AbsorptionPlanParams,
@@ -347,6 +353,31 @@ const registerIpcHandlers = (): void => {
 
 		ipcMain.handle(channel, senderValidatingListener);
 	};
+
+	if (!app.isPackaged) {
+		senderValidatingHandle(
+			ipcTraceCompleteChannel,
+			async (_event, value: unknown): Promise<boolean> => {
+				if (!isIpcTraceCompletion(value)) return false;
+
+				const devServerUrl = process.env.VITE_DEV_SERVER_URL;
+				if (devServerUrl === undefined) return false;
+
+				const completionUrl = new URL(ipcTraceCompletionPath, devServerUrl);
+				try {
+					const response = await net.fetch(completionUrl.toString(), {
+						method: "POST",
+						headers: { "content-type": "application/json" },
+						body: JSON.stringify(value),
+					});
+					return response.ok;
+				} catch {
+					// Tracing must never affect the real IPC call.
+					return false;
+				}
+			},
+		);
+	}
 
 	senderValidatingHandle(
 		liteIpcChannels.absorptionPlan,
@@ -790,6 +821,8 @@ void app.whenReady().then(async () => {
 		});
 	} else {
 		await installExtension([REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS]);
+		const ipcTraceUrl = new URL(process.env.VITE_DEV_SERVER_URL ?? "http://127.0.0.1:5173");
+		ipcTraceUrl.hostname = ipcTraceHost;
 
 		if (process.platform === "darwin") {
 			const dockIcon = getMacDockIcon();
@@ -806,7 +839,7 @@ void app.whenReady().then(async () => {
 			"style-src 'self' 'unsafe-inline';" +
 			"font-src 'self';" +
 			// ws source for HMR
-			"connect-src 'self' ws://127.0.0.1:5173;" +
+			`connect-src 'self' ws://127.0.0.1:5173 ${ipcTraceUrl.origin};` +
 			"object-src 'none';" +
 			"base-uri 'none';" +
 			"frame-ancestors 'none';" +

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -4,7 +4,11 @@ import {
 	ipcTraceCompleteChannel,
 	ipcTraceCompletionPath,
 	ipcTraceHost,
+	ipcTraceWatcherEventChannel,
+	ipcTraceWatcherEventPath,
+	ipcTraceWatcherHost,
 	isIpcTraceCompletion,
+	isIpcTraceWatcherEvent,
 } from "./tracing.js";
 import {
 	liteIpcChannels,
@@ -355,26 +359,37 @@ const registerIpcHandlers = (): void => {
 	};
 
 	if (!app.isPackaged) {
+		const relayIpcTrace = async (path: string, value: unknown, host?: string): Promise<boolean> => {
+			const devServerUrl = process.env.VITE_DEV_SERVER_URL;
+			if (devServerUrl === undefined) return false;
+
+			try {
+				const relayUrl = new URL(path, devServerUrl);
+				if (host !== undefined) relayUrl.hostname = host;
+				const response = await net.fetch(relayUrl.toString(), {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify(value),
+				});
+				return response.ok;
+			} catch {
+				// Tracing must never affect real IPC calls or watcher events.
+				return false;
+			}
+		};
+
 		senderValidatingHandle(
 			ipcTraceCompleteChannel,
 			async (_event, value: unknown): Promise<boolean> => {
 				if (!isIpcTraceCompletion(value)) return false;
-
-				const devServerUrl = process.env.VITE_DEV_SERVER_URL;
-				if (devServerUrl === undefined) return false;
-
-				const completionUrl = new URL(ipcTraceCompletionPath, devServerUrl);
-				try {
-					const response = await net.fetch(completionUrl.toString(), {
-						method: "POST",
-						headers: { "content-type": "application/json" },
-						body: JSON.stringify(value),
-					});
-					return response.ok;
-				} catch {
-					// Tracing must never affect the real IPC call.
-					return false;
-				}
+				return relayIpcTrace(ipcTraceCompletionPath, value);
+			},
+		);
+		senderValidatingHandle(
+			ipcTraceWatcherEventChannel,
+			async (_event, value: unknown): Promise<boolean> => {
+				if (!isIpcTraceWatcherEvent(value)) return false;
+				return relayIpcTrace(ipcTraceWatcherEventPath, value, ipcTraceWatcherHost);
 			},
 		);
 	}
@@ -823,6 +838,8 @@ void app.whenReady().then(async () => {
 		await installExtension([REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS]);
 		const ipcTraceUrl = new URL(process.env.VITE_DEV_SERVER_URL ?? "http://127.0.0.1:5173");
 		ipcTraceUrl.hostname = ipcTraceHost;
+		const ipcTraceWatcherUrl = new URL(ipcTraceUrl);
+		ipcTraceWatcherUrl.hostname = ipcTraceWatcherHost;
 
 		if (process.platform === "darwin") {
 			const dockIcon = getMacDockIcon();
@@ -839,7 +856,7 @@ void app.whenReady().then(async () => {
 			"style-src 'self' 'unsafe-inline';" +
 			"font-src 'self';" +
 			// ws source for HMR
-			`connect-src 'self' ws://127.0.0.1:5173 ${ipcTraceUrl.origin};` +
+			`connect-src 'self' ws://127.0.0.1:5173 ${ipcTraceUrl.origin} ${ipcTraceWatcherUrl.origin};` +
 			"object-src 'none';" +
 			"base-uri 'none';" +
 			"frame-ancestors 'none';" +

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -4,7 +4,11 @@ import {
 	ipcTraceCompleteChannel,
 	ipcTraceCompletionPath,
 	ipcTraceHost,
+	ipcTraceWatcherEventChannel,
+	ipcTraceWatcherEventPath,
+	ipcTraceWatcherHost,
 	isIpcTraceCompletion,
+	isIpcTraceWatcherEvent,
 } from "./tracing.js";
 import * as sdk from "@gitbutler/but-sdk";
 import { apiParamNames } from "@gitbutler/but-sdk/api-param-names";
@@ -376,19 +380,21 @@ const registerIpcHandlers = (): void => {
 	};
 
 	if (!app.isPackaged) {
-		const relayIpcTrace = async (path: string, value: unknown): Promise<boolean> => {
+		const relayIpcTrace = async (path: string, value: unknown, host?: string): Promise<boolean> => {
 			const devServerUrl = process.env.VITE_DEV_SERVER_URL;
 			if (devServerUrl === undefined) return false;
 
 			try {
-				const response = await net.fetch(new URL(path, devServerUrl).toString(), {
+				const relayUrl = new URL(path, devServerUrl);
+				if (host !== undefined) relayUrl.hostname = host;
+				const response = await net.fetch(relayUrl.toString(), {
 					method: "POST",
 					headers: { "content-type": "application/json" },
 					body: JSON.stringify(value),
 				});
 				return response.ok;
 			} catch {
-				// Tracing must never affect real IPC calls.
+				// Tracing must never affect real IPC calls or watcher events.
 				return false;
 			}
 		};
@@ -398,6 +404,13 @@ const registerIpcHandlers = (): void => {
 			async (_event, value: unknown): Promise<boolean> => {
 				if (!isIpcTraceCompletion(value)) return false;
 				return relayIpcTrace(ipcTraceCompletionPath, value);
+			},
+		);
+		senderValidatingHandle(
+			ipcTraceWatcherEventChannel,
+			async (_event, value: unknown): Promise<boolean> => {
+				if (!isIpcTraceWatcherEvent(value)) return false;
+				return relayIpcTrace(ipcTraceWatcherEventPath, value, ipcTraceWatcherHost);
 			},
 		);
 	}
@@ -523,6 +536,8 @@ void app.whenReady().then(async () => {
 		await installExtension([REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS]);
 		const ipcTraceUrl = new URL(process.env.VITE_DEV_SERVER_URL ?? "http://127.0.0.1:5173");
 		ipcTraceUrl.hostname = ipcTraceHost;
+		const ipcTraceWatcherUrl = new URL(ipcTraceUrl);
+		ipcTraceWatcherUrl.hostname = ipcTraceWatcherHost;
 
 		if (process.platform === "darwin") {
 			const dockIcon = getMacDockIcon();
@@ -539,7 +554,7 @@ void app.whenReady().then(async () => {
 			"style-src 'self' 'unsafe-inline';" +
 			"font-src 'self';" +
 			// ws source for HMR
-			`connect-src 'self' ws://127.0.0.1:5173 ${ipcTraceUrl.origin};` +
+			`connect-src 'self' ws://127.0.0.1:5173 ${ipcTraceUrl.origin} ${ipcTraceWatcherUrl.origin};` +
 			"object-src 'none';" +
 			"base-uri 'none';" +
 			"frame-ancestors 'none';" +

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -1,5 +1,11 @@
 import { checkForUpdates, registerUpdater, setAutoUpdateEnabled } from "./updater.js";
 import WatcherManager from "./watcher.js";
+import {
+	ipcTraceCompleteChannel,
+	ipcTraceCompletionPath,
+	ipcTraceHost,
+	isIpcTraceCompletion,
+} from "./tracing.js";
 import * as sdk from "@gitbutler/but-sdk";
 import { apiParamNames } from "@gitbutler/but-sdk/api-param-names";
 import {
@@ -369,6 +375,33 @@ const registerIpcHandlers = (): void => {
 		ipcMain.handle(channel, senderValidatingListener);
 	};
 
+	if (!app.isPackaged) {
+		const relayIpcTrace = async (path: string, value: unknown): Promise<boolean> => {
+			const devServerUrl = process.env.VITE_DEV_SERVER_URL;
+			if (devServerUrl === undefined) return false;
+
+			try {
+				const response = await net.fetch(new URL(path, devServerUrl).toString(), {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify(value),
+				});
+				return response.ok;
+			} catch {
+				// Tracing must never affect real IPC calls.
+				return false;
+			}
+		};
+
+		senderValidatingHandle(
+			ipcTraceCompleteChannel,
+			async (_event, value: unknown): Promise<boolean> => {
+				if (!isIpcTraceCompletion(value)) return false;
+				return relayIpcTrace(ipcTraceCompletionPath, value);
+			},
+		);
+	}
+
 	for (const key of exposedEndpoints) {
 		if (isOverride(key)) continue;
 		senderValidatingHandle(key, (_e, params: unknown) => derivedHandler(key)(params));
@@ -488,6 +521,8 @@ void app.whenReady().then(async () => {
 		});
 	} else {
 		await installExtension([REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS]);
+		const ipcTraceUrl = new URL(process.env.VITE_DEV_SERVER_URL ?? "http://127.0.0.1:5173");
+		ipcTraceUrl.hostname = ipcTraceHost;
 
 		if (process.platform === "darwin") {
 			const dockIcon = getMacDockIcon();
@@ -504,7 +539,7 @@ void app.whenReady().then(async () => {
 			"style-src 'self' 'unsafe-inline';" +
 			"font-src 'self';" +
 			// ws source for HMR
-			"connect-src 'self' ws://127.0.0.1:5173;" +
+			`connect-src 'self' ws://127.0.0.1:5173 ${ipcTraceUrl.origin};` +
 			"object-src 'none';" +
 			"base-uri 'none';" +
 			"frame-ancestors 'none';" +

--- a/apps/lite/electron/src/preload.cts
+++ b/apps/lite/electron/src/preload.cts
@@ -43,8 +43,12 @@ import type { GUISettings } from "./settings";
 
 // Sandboxed preloads cannot load local modules. Keep these values in sync with tracing.ts.
 const ipcTraceCompleteChannel = "lite:ipc-trace-complete";
+const ipcTraceWatcherEventChannel = "lite:ipc-trace-watcher-event";
+const ipcTraceWatcherHost = "ipc-watcher.localhost";
 const ipcTracePathPrefix = "/__ipc/";
 const ipcTraceAcceptPrefix = "application/json; trace-id=";
+const ipcTraceStreamAcceptPrefix = "text/event-stream; trace-id=";
+const ipcTraceWatcherEventsPath = `${ipcTracePathPrefix}watcher-events`;
 const maxTraceResponseCharacters = 1_000_000;
 const maxTraceArgsCharacters = 4_000;
 const maxTraceGateMs = 60_000;
@@ -54,6 +58,13 @@ const ipcTraceServerUrl = (() => {
 
 	const url = new URL(devServerUrl);
 	url.hostname = "ipc.localhost";
+	return url;
+})();
+const ipcTraceWatcherServerUrl = (() => {
+	if (ipcTraceServerUrl === undefined) return undefined;
+
+	const url = new URL(ipcTraceServerUrl);
+	url.hostname = ipcTraceWatcherHost;
 	return url;
 })();
 
@@ -183,6 +194,80 @@ const invoke = async (channel: string, ...args: Array<unknown>): Promise<unknown
 		await completeIpcTrace(trace, false, error);
 		throw error;
 	}
+};
+
+interface IpcWatcherTraceStream {
+	streamId: string;
+	connected: boolean;
+	active: boolean;
+	stop: () => void;
+}
+
+let watcherTraceStream: IpcWatcherTraceStream | undefined;
+
+const startWatcherTraceStream = (): void => {
+	if (ipcTraceWatcherServerUrl === undefined || watcherTraceStream?.active === true) return;
+
+	const streamId = crypto.randomUUID();
+	const abortController = new AbortController();
+	const stream: IpcWatcherTraceStream = {
+		streamId,
+		connected: false,
+		active: true,
+		stop: () => {
+			stream.active = false;
+			abortController.abort();
+		},
+	};
+	watcherTraceStream = stream;
+
+	const streamUrl = new URL(ipcTraceWatcherEventsPath, ipcTraceWatcherServerUrl);
+	void fetch(streamUrl, {
+		headers: { Accept: `${ipcTraceStreamAcceptPrefix}${streamId}` },
+		signal: abortController.signal,
+	})
+		.then(async (response) => {
+			if (!response.ok || !stream.active) return;
+			stream.connected = true;
+
+			// Drain incrementally: response.text() would retain the stream's entire lifetime in memory.
+			const reader = response.body?.getReader();
+			if (reader === undefined) return;
+			while (!(await reader.read()).done) {
+				// DevTools records the server-sent events; preload only needs to consume the bytes.
+			}
+		})
+		.catch(() => undefined)
+		.finally(() => {
+			stream.connected = false;
+			stream.active = false;
+		});
+};
+
+const stopWatcherTraceStream = (): void => {
+	watcherTraceStream?.stop();
+	watcherTraceStream = undefined;
+};
+
+const traceWatcherEvent = (
+	projectId: string,
+	subscriptionId: string,
+	event: WatcherEvent,
+): void => {
+	const stream = watcherTraceStream;
+	if (stream?.connected !== true) return;
+
+	void ipcRenderer
+		.invoke(ipcTraceWatcherEventChannel, {
+			streamId: stream.streamId,
+			type: event.payload.type,
+			body: stringifyTracePayload({
+				projectId,
+				subscriptionId,
+				payload: event.payload,
+			}),
+		})
+		.catch(() => undefined);
 };
 
 /**
@@ -338,7 +423,9 @@ const api: LiteElectronApi = {
 		const { subscriptionId, eventChannel } = (await invoke("workspace:watcher-subscribe", {
 			projectId,
 		})) as WatcherSubscribeResult;
+		startWatcherTraceStream();
 		const listener = (_event: Electron.IpcRendererEvent, payload: WatcherEvent) => {
+			traceWatcherEvent(projectId, subscriptionId, payload);
 			callback(payload);
 		};
 		watcherListenerBySubscription.set(subscriptionId, { eventChannel, listener });
@@ -357,6 +444,7 @@ const api: LiteElectronApi = {
 		if (registration) {
 			ipcRenderer.removeListener(registration.eventChannel, registration.listener);
 			watcherListenerBySubscription.delete(subscriptionId);
+			if (watcherListenerBySubscription.size === 0) stopWatcherTraceStream();
 		}
 		return invoke("workspace:watcher-unsubscribe", {
 			subscriptionId,
@@ -372,6 +460,7 @@ const api: LiteElectronApi = {
 			ipcRenderer.removeListener(eventChannel, listener);
 
 		watcherListenerBySubscription.clear();
+		stopWatcherTraceStream();
 		return invoke("workspace:watcher-stop-all") as Promise<number>;
 	},
 	readGUISettings: () => invoke("lite:gui-settings:read") as Promise<GUISettings>,

--- a/apps/lite/electron/src/preload.cts
+++ b/apps/lite/electron/src/preload.cts
@@ -41,6 +41,150 @@ import type {
 } from "@gitbutler/but-sdk";
 import type { GUISettings } from "./settings";
 
+// Sandboxed preloads cannot load local modules. Keep these values in sync with tracing.ts.
+const ipcTraceCompleteChannel = "lite:ipc-trace-complete";
+const ipcTracePathPrefix = "/__ipc/";
+const ipcTraceAcceptPrefix = "application/json; trace-id=";
+const maxTraceResponseCharacters = 1_000_000;
+const maxTraceArgsCharacters = 4_000;
+const maxTraceGateMs = 60_000;
+const ipcTraceServerUrl = (() => {
+	const devServerUrl = process.env.VITE_DEV_SERVER_URL;
+	if (devServerUrl === undefined) return undefined;
+
+	const url = new URL(devServerUrl);
+	url.hostname = "ipc.localhost";
+	return url;
+})();
+
+interface IpcTrace {
+	traceId: string;
+	startedAt: number;
+	finished: Promise<void>;
+	stopWaiting: () => void;
+}
+
+const traceSafeArgs = (channel: string, args: Array<unknown>): Array<unknown> => {
+	if (channel === "askpass:submit-prompt-response") {
+		const [params, ...rest] = args;
+		if (typeof params === "object" && params !== null)
+			return [{ ...params, response: "<redacted>" }, ...rest];
+	}
+
+	if (channel === "lite:clipboard-write-text") return ["<redacted>"];
+
+	return args;
+};
+
+// Lite's IPC arguments and results are JSON-compatible. Errors are the one useful exception: their
+// properties are not enumerable, so normalize them before displaying them in DevTools.
+const stringifyTracePayload = (
+	value: unknown,
+	maxCharacters = maxTraceResponseCharacters,
+): string => {
+	let json: string;
+
+	try {
+		json = JSON.stringify(value, (_key, nestedValue: unknown) => {
+			if (nestedValue instanceof Error) {
+				return {
+					name: nestedValue.name,
+					message: nestedValue.message,
+					stack: nestedValue.stack,
+				};
+			}
+			return nestedValue;
+		});
+	} catch (error) {
+		json = JSON.stringify({ serializationError: String(error) });
+	}
+
+	if (json.length <= maxCharacters) return json;
+	return JSON.stringify({
+		truncated: true,
+		originalCharacters: json.length,
+		preview: json.slice(0, maxCharacters),
+	});
+};
+
+const beginIpcTrace = (channel: string, args: Array<unknown>): IpcTrace | undefined => {
+	if (ipcTraceServerUrl === undefined) return undefined;
+
+	const traceId = crypto.randomUUID();
+	const separatorIndex = channel.indexOf(":");
+	const scope = separatorIndex === -1 ? "ipc" : channel.slice(0, separatorIndex);
+	const method = separatorIndex === -1 ? channel : channel.slice(separatorIndex + 1);
+	const traceUrl = new URL(
+		`${ipcTracePathPrefix}${encodeURIComponent(scope)}/${encodeURIComponent(method)}`,
+		ipcTraceServerUrl,
+	);
+	const serializedArgs = stringifyTracePayload(
+		traceSafeArgs(channel, args),
+		maxTraceArgsCharacters,
+	);
+	const abortController = new AbortController();
+	const startedAt = performance.now();
+
+	const response = fetch(traceUrl, {
+		method: "POST",
+		headers: { Accept: `${ipcTraceAcceptPrefix}${traceId}` },
+		body: serializedArgs,
+		signal: abortController.signal,
+	});
+	const timeout = setTimeout(() => abortController.abort(), maxTraceGateMs);
+	const finished = response
+		.then((response) => response.arrayBuffer())
+		.then(() => undefined)
+		.catch(() => undefined)
+		.finally(() => clearTimeout(timeout));
+
+	return {
+		traceId,
+		startedAt,
+		finished,
+		stopWaiting: () => abortController.abort(),
+	};
+};
+
+const completeIpcTrace = async (
+	trace: IpcTrace | undefined,
+	ok: boolean,
+	value: unknown,
+): Promise<void> => {
+	if (trace === undefined) return;
+
+	try {
+		const stored = (await ipcRenderer.invoke(ipcTraceCompleteChannel, {
+			traceId: trace.traceId,
+			ok,
+			body: stringifyTracePayload(value),
+			durationMs: performance.now() - trace.startedAt,
+		})) as unknown;
+		if (stored !== true) {
+			trace.stopWaiting();
+			return;
+		}
+
+		await trace.finished;
+	} catch {
+		trace.stopWaiting();
+		// Tracing must never affect the real IPC call.
+	}
+};
+
+const invoke = async (channel: string, ...args: Array<unknown>): Promise<unknown> => {
+	const trace = beginIpcTrace(channel, args);
+
+	try {
+		const result = (await ipcRenderer.invoke(channel, ...args)) as unknown;
+		await completeIpcTrace(trace, true, result);
+		return result;
+	} catch (error) {
+		await completeIpcTrace(trace, false, error);
+		throw error;
+	}
+};
+
 /**
  * The map of subscription IDs to channels and callbacks.
  *
@@ -57,14 +201,11 @@ const watcherListenerBySubscription = new Map<
 
 const api: LiteElectronApi = {
 	absorptionPlan: (params) =>
-		ipcRenderer.invoke("workspace:absorption-plan", params) as Promise<Array<CommitAbsorption>>,
-	absorb: (params) => ipcRenderer.invoke("workspace:absorb", params) as Promise<number>,
-	apply: (params) => ipcRenderer.invoke("workspace:apply", params) as Promise<ApplyOutcome>,
+		invoke("workspace:absorption-plan", params) as Promise<Array<CommitAbsorption>>,
+	absorb: (params) => invoke("workspace:absorb", params) as Promise<number>,
+	apply: (params) => invoke("workspace:apply", params) as Promise<ApplyOutcome>,
 	applyBranchIntegration: (params) =>
-		ipcRenderer.invoke(
-			"workspace:apply-branch-integration",
-			params,
-		) as Promise<IntegrateBranchResult>,
+		invoke("workspace:apply-branch-integration", params) as Promise<IntegrateBranchResult>,
 	onAskpassPrompt: (callback) => {
 		const listener = (_event: Electron.IpcRendererEvent, payload: AskpassPromptEvent) => {
 			callback(payload);
@@ -73,144 +214,110 @@ const api: LiteElectronApi = {
 		return () => ipcRenderer.removeListener("askpass:prompt", listener);
 	},
 	askpassSubmitPromptResponse: (params) =>
-		ipcRenderer.invoke("askpass:submit-prompt-response", params) as Promise<void>,
-	assignHunk: (params) => ipcRenderer.invoke("workspace:assign-hunk", params) as Promise<void>,
+		invoke("askpass:submit-prompt-response", params) as Promise<void>,
+	assignHunk: (params) => invoke("workspace:assign-hunk", params) as Promise<void>,
 	branchCheckout: (params) =>
-		ipcRenderer.invoke("workspace:branch-checkout", params) as Promise<BranchCheckoutResult>,
+		invoke("workspace:branch-checkout", params) as Promise<BranchCheckoutResult>,
 	branchCheckoutNew: (params) =>
-		ipcRenderer.invoke("workspace:branch-checkout-new", params) as Promise<BranchCheckoutResult>,
+		invoke("workspace:branch-checkout-new", params) as Promise<BranchCheckoutResult>,
 	branchCreate: (params) =>
-		ipcRenderer.invoke("workspace:branch-create", params) as Promise<BranchCreateResult>,
-	branchDetails: (params) =>
-		ipcRenderer.invoke("workspace:branch-details", params) as Promise<BranchDetails>,
-	branchDiff: (params) =>
-		ipcRenderer.invoke("workspace:branch-diff", params) as Promise<TreeChanges>,
+		invoke("workspace:branch-create", params) as Promise<BranchCreateResult>,
+	branchDetails: (params) => invoke("workspace:branch-details", params) as Promise<BranchDetails>,
+	branchDiff: (params) => invoke("workspace:branch-diff", params) as Promise<TreeChanges>,
 	changesInWorktree: (projectId) =>
-		ipcRenderer.invoke("workspace:changes-in-worktree", projectId) as Promise<WorktreeChanges>,
-	clipboardWriteText: (text) =>
-		ipcRenderer.invoke("lite:clipboard-write-text", text) as Promise<void>,
-	commitAmend: (params) =>
-		ipcRenderer.invoke("workspace:commit-amend", params) as Promise<CommitCreateResult>,
+		invoke("workspace:changes-in-worktree", projectId) as Promise<WorktreeChanges>,
+	clipboardWriteText: (text) => invoke("lite:clipboard-write-text", text) as Promise<void>,
+	commitAmend: (params) => invoke("workspace:commit-amend", params) as Promise<CommitCreateResult>,
 	commitCreate: (params) =>
-		ipcRenderer.invoke("workspace:commit-create", params) as Promise<CommitCreateResult>,
+		invoke("workspace:commit-create", params) as Promise<CommitCreateResult>,
 	commitDiscard: (params) =>
-		ipcRenderer.invoke("workspace:commit-discard", params) as Promise<CommitDiscardResult>,
+		invoke("workspace:commit-discard", params) as Promise<CommitDiscardResult>,
 	commitDiscardChanges: (params) =>
-		ipcRenderer.invoke("workspace:commit-discard-changes", params) as Promise<MoveChangesResult>,
+		invoke("workspace:commit-discard-changes", params) as Promise<MoveChangesResult>,
 	commitDetailsWithLineStats: (params) =>
-		ipcRenderer.invoke(
-			"workspace:commit-details-with-line-stats",
-			params,
-		) as Promise<CommitDetails>,
+		invoke("workspace:commit-details-with-line-stats", params) as Promise<CommitDetails>,
 	discardWorktreeChanges: (params) =>
-		ipcRenderer.invoke("workspace:discard-worktree-changes", params) as Promise<Array<DiffSpec>>,
+		invoke("workspace:discard-worktree-changes", params) as Promise<Array<DiffSpec>>,
 	commitInsertBlank: (params) =>
-		ipcRenderer.invoke("workspace:commit-insert-blank", params) as Promise<CommitInsertBlankResult>,
-	commitMove: (params) =>
-		ipcRenderer.invoke("workspace:commit-move", params) as Promise<CommitMoveResult>,
+		invoke("workspace:commit-insert-blank", params) as Promise<CommitInsertBlankResult>,
+	commitMove: (params) => invoke("workspace:commit-move", params) as Promise<CommitMoveResult>,
 	commitSquash: (params) =>
-		ipcRenderer.invoke("workspace:commit-squash", params) as Promise<CommitSquashResult>,
+		invoke("workspace:commit-squash", params) as Promise<CommitSquashResult>,
 	commitReword: (params) =>
-		ipcRenderer.invoke("workspace:commit-reword", params) as Promise<CommitRewordResult>,
+		invoke("workspace:commit-reword", params) as Promise<CommitRewordResult>,
 	commitMoveChangesBetween: (params) =>
-		ipcRenderer.invoke(
-			"workspace:commit-move-changes-between",
-			params,
-		) as Promise<MoveChangesResult>,
+		invoke("workspace:commit-move-changes-between", params) as Promise<MoveChangesResult>,
 	commitUncommit: (params) =>
-		ipcRenderer.invoke("workspace:commit-uncommit", params) as Promise<UncommitResult>,
+		invoke("workspace:commit-uncommit", params) as Promise<UncommitResult>,
 	commitUncommitChanges: (params) =>
-		ipcRenderer.invoke("workspace:commit-uncommit-changes", params) as Promise<MoveChangesResult>,
+		invoke("workspace:commit-uncommit-changes", params) as Promise<MoveChangesResult>,
 	forgeCompareBranchUrl: (params) =>
-		ipcRenderer.invoke("workspace:forge-compare-branch-url", params) as Promise<string | null>,
-	forgeInfo: (projectId) =>
-		ipcRenderer.invoke("workspace:forge-info", projectId) as Promise<ForgeInfo | null>,
+		invoke("workspace:forge-compare-branch-url", params) as Promise<string | null>,
+	forgeInfo: (projectId) => invoke("workspace:forge-info", projectId) as Promise<ForgeInfo | null>,
 	forgeProvider: (projectId) =>
-		ipcRenderer.invoke("workspace:forge-provider", projectId) as Promise<ForgeName | null>,
+		invoke("workspace:forge-provider", projectId) as Promise<ForgeName | null>,
 	getInitialBranchIntegration: (params) =>
-		ipcRenderer.invoke(
-			"workspace:get-initial-branch-integration",
-			params,
-		) as Promise<InitialBranchIntegration>,
-	getRepoInfo: (projectId) =>
-		ipcRenderer.invoke("workspace:get-repo-info", projectId) as Promise<RepoInfo>,
+		invoke("workspace:get-initial-branch-integration", params) as Promise<InitialBranchIntegration>,
+	getRepoInfo: (projectId) => invoke("workspace:get-repo-info", projectId) as Promise<RepoInfo>,
 	getReviewBaseRepoUrl: (params) =>
-		ipcRenderer.invoke("workspace:get-review-base-repo-url", params) as Promise<string | null>,
+		invoke("workspace:get-review-base-repo-url", params) as Promise<string | null>,
 	getReviewMergeStatus: (params) =>
-		ipcRenderer.invoke("workspace:get-review-merge-status", params) as Promise<ReviewMergeStatus>,
-	getVersion: () => ipcRenderer.invoke("lite:get-version") as Promise<string>,
+		invoke("workspace:get-review-merge-status", params) as Promise<ReviewMergeStatus>,
+	getVersion: () => invoke("lite:get-version") as Promise<string>,
 	getRedoTargetSnapshot: (params) =>
-		ipcRenderer.invoke("workspace:get-redo-target-snapshot", params) as Promise<Snapshot | null>,
-	getReview: (params) => ipcRenderer.invoke("workspace:get-review", params) as Promise<ForgeReview>,
+		invoke("workspace:get-redo-target-snapshot", params) as Promise<Snapshot | null>,
+	getReview: (params) => invoke("workspace:get-review", params) as Promise<ForgeReview>,
 	getUndoTargetSnapshot: (params) =>
-		ipcRenderer.invoke("workspace:get-undo-target-snapshot", params) as Promise<Snapshot | null>,
-	headInfo: (projectId) => ipcRenderer.invoke("workspace:head-info", projectId) as Promise<RefInfo>,
+		invoke("workspace:get-undo-target-snapshot", params) as Promise<Snapshot | null>,
+	headInfo: (projectId) => invoke("workspace:head-info", projectId) as Promise<RefInfo>,
 	listBranches: (projectId, filter) =>
-		ipcRenderer.invoke("workspace:list-branches", projectId, filter) as Promise<
-			Array<BranchListing>
-		>,
+		invoke("workspace:list-branches", projectId, filter) as Promise<Array<BranchListing>>,
 	listAvailableReviewTemplates: (projectId) =>
-		ipcRenderer.invoke("workspace:list-available-review-templates", projectId) as Promise<
-			Array<string>
-		>,
-	listCiChecks: (params) =>
-		ipcRenderer.invoke("workspace:list-ci-checks", params) as Promise<Array<CiCheck>>,
-	listEditors: () => ipcRenderer.invoke("workspace:list-editors") as Promise<Array<Editor>>,
+		invoke("workspace:list-available-review-templates", projectId) as Promise<Array<string>>,
+	listCiChecks: (params) => invoke("workspace:list-ci-checks", params) as Promise<Array<CiCheck>>,
+	listEditors: () => invoke("workspace:list-editors") as Promise<Array<Editor>>,
 	listProjectsStateless: () =>
-		ipcRenderer.invoke("projects:list-stateless") as Promise<Array<ProjectForFrontend>>,
-	listReviews: (params) =>
-		ipcRenderer.invoke("workspace:list-reviews", params) as Promise<Array<ForgeReview>>,
+		invoke("projects:list-stateless") as Promise<Array<ProjectForFrontend>>,
+	listReviews: (params) => invoke("workspace:list-reviews", params) as Promise<Array<ForgeReview>>,
 	listReviewsForBranch: (params) =>
-		ipcRenderer.invoke("workspace:list-reviews-for-branch", params) as Promise<Array<ForgeReview>>,
-	mergeReview: (params) => ipcRenderer.invoke("workspace:merge-review", params) as Promise<void>,
-	moveBranch: (params) =>
-		ipcRenderer.invoke("workspace:move-branch", params) as Promise<MoveBranchResult>,
-	openInEditor: (params) => ipcRenderer.invoke("workspace:open-in-editor", params) as Promise<void>,
-	openInWebBrowser: (url) =>
-		ipcRenderer.invoke("workspace:open-in-web-browser", url) as Promise<void>,
-	pathJoin: (path, ...paths) =>
-		ipcRenderer.invoke("lite:path-join", path, ...paths) as Promise<string>,
-	publishReview: (params) =>
-		ipcRenderer.invoke("workspace:publish-review", params) as Promise<ForgeReview>,
+		invoke("workspace:list-reviews-for-branch", params) as Promise<Array<ForgeReview>>,
+	mergeReview: (params) => invoke("workspace:merge-review", params) as Promise<void>,
+	moveBranch: (params) => invoke("workspace:move-branch", params) as Promise<MoveBranchResult>,
+	openInEditor: (params) => invoke("workspace:open-in-editor", params) as Promise<void>,
+	openInWebBrowser: (url) => invoke("workspace:open-in-web-browser", url) as Promise<void>,
+	pathJoin: (path, ...paths) => invoke("lite:path-join", path, ...paths) as Promise<string>,
+	publishReview: (params) => invoke("workspace:publish-review", params) as Promise<ForgeReview>,
 	updateBranchName: (params) =>
-		ipcRenderer.invoke("workspace:update-branch-name", params) as Promise<UpdateBranchNameResult>,
-	updateReview: (params) => ipcRenderer.invoke("workspace:update-review", params) as Promise<void>,
+		invoke("workspace:update-branch-name", params) as Promise<UpdateBranchNameResult>,
+	updateReview: (params) => invoke("workspace:update-review", params) as Promise<void>,
 	tearOffBranch: (params) =>
-		ipcRenderer.invoke("workspace:tear-off-branch", params) as Promise<MoveBranchResult>,
+		invoke("workspace:tear-off-branch", params) as Promise<MoveBranchResult>,
 	peelRestoreSnapshot: (params) =>
-		ipcRenderer.invoke("workspace:peel-restore-snapshot", params) as Promise<Snapshot | null>,
+		invoke("workspace:peel-restore-snapshot", params) as Promise<Snapshot | null>,
 	workspaceBranchAndAncestorsPush: (params) =>
-		ipcRenderer.invoke("workspace:push-stack", params) as Promise<PushResult>,
-	removeBranch: (params) => ipcRenderer.invoke("workspace:remove-branch", params) as Promise<void>,
+		invoke("workspace:push-stack", params) as Promise<PushResult>,
+	removeBranch: (params) => invoke("workspace:remove-branch", params) as Promise<void>,
 	restoreSnapshotWithKind: (params) =>
-		ipcRenderer.invoke("workspace:restore-snapshot-with-kind", params) as Promise<void>,
+		invoke("workspace:restore-snapshot-with-kind", params) as Promise<void>,
 	reviewTemplate: (projectId) =>
-		ipcRenderer.invoke(
-			"workspace:review-template",
-			projectId,
-		) as Promise<ReviewTemplateInfo | null>,
+		invoke("workspace:review-template", projectId) as Promise<ReviewTemplateInfo | null>,
 	setReviewAutoMerge: (params) =>
-		ipcRenderer.invoke("workspace:set-review-auto-merge", params) as Promise<void>,
+		invoke("workspace:set-review-auto-merge", params) as Promise<void>,
 	setReviewDraftiness: (params) =>
-		ipcRenderer.invoke("workspace:set-review-draftiness", params) as Promise<void>,
-	setReviewTemplate: (params) =>
-		ipcRenderer.invoke("workspace:set-review-template", params) as Promise<void>,
+		invoke("workspace:set-review-draftiness", params) as Promise<void>,
+	setReviewTemplate: (params) => invoke("workspace:set-review-template", params) as Promise<void>,
 	setTargetRefAndInitProject: (params) =>
-		ipcRenderer.invoke("workspace:set-target-ref-and-init-project", params) as Promise<void>,
-	showNativeMenu: (params) =>
-		ipcRenderer.invoke("lite:show-native-menu", params) as Promise<string | null>,
+		invoke("workspace:set-target-ref-and-init-project", params) as Promise<void>,
+	showNativeMenu: (params) => invoke("lite:show-native-menu", params) as Promise<string | null>,
 	treeChangeDiffs: (params) =>
-		ipcRenderer.invoke("workspace:tree-change-diffs", params) as Promise<UnifiedPatch | null>,
-	unapplyStack: (params) => ipcRenderer.invoke("workspace:unapply-stack", params) as Promise<void>,
+		invoke("workspace:tree-change-diffs", params) as Promise<UnifiedPatch | null>,
+	unapplyStack: (params) => invoke("workspace:unapply-stack", params) as Promise<void>,
 	workspaceIntegrateUpstream: (params) =>
-		ipcRenderer.invoke(
-			"workspace:integrate-upstream",
-			params,
-		) as Promise<WorkspaceIntegrateUpstreamOutcome>,
+		invoke("workspace:integrate-upstream", params) as Promise<WorkspaceIntegrateUpstreamOutcome>,
 	updateReviewFooters: (params) =>
-		ipcRenderer.invoke("workspace:update-review-footers", params) as Promise<void>,
+		invoke("workspace:update-review-footers", params) as Promise<void>,
 	warmCiChecksCache: (projectId) =>
-		ipcRenderer.invoke("workspace:warm-ci-checks-cache", projectId) as Promise<void>,
+		invoke("workspace:warm-ci-checks-cache", projectId) as Promise<void>,
 	/**
 	 * Subscribe to a project.
 	 *
@@ -228,10 +335,9 @@ const api: LiteElectronApi = {
 	 * @returns A subscription ID.
 	 */
 	watcherSubscribe: async (projectId, callback) => {
-		const { subscriptionId, eventChannel } = (await ipcRenderer.invoke(
-			"workspace:watcher-subscribe",
-			{ projectId },
-		)) as WatcherSubscribeResult;
+		const { subscriptionId, eventChannel } = (await invoke("workspace:watcher-subscribe", {
+			projectId,
+		})) as WatcherSubscribeResult;
 		const listener = (_event: Electron.IpcRendererEvent, payload: WatcherEvent) => {
 			callback(payload);
 		};
@@ -252,7 +358,7 @@ const api: LiteElectronApi = {
 			ipcRenderer.removeListener(registration.eventChannel, registration.listener);
 			watcherListenerBySubscription.delete(subscriptionId);
 		}
-		return ipcRenderer.invoke("workspace:watcher-unsubscribe", {
+		return invoke("workspace:watcher-unsubscribe", {
 			subscriptionId,
 		}) as Promise<boolean>;
 	},
@@ -266,11 +372,11 @@ const api: LiteElectronApi = {
 			ipcRenderer.removeListener(eventChannel, listener);
 
 		watcherListenerBySubscription.clear();
-		return ipcRenderer.invoke("workspace:watcher-stop-all") as Promise<number>;
+		return invoke("workspace:watcher-stop-all") as Promise<number>;
 	},
-	readGUISettings: () => ipcRenderer.invoke("lite:gui-settings:read") as Promise<GUISettings>,
+	readGUISettings: () => invoke("lite:gui-settings:read") as Promise<GUISettings>,
 	writeGUISettings: (settings: GUISettings) =>
-		ipcRenderer.invoke("lite:gui-settings:write", settings) as Promise<void>,
+		invoke("lite:gui-settings:write", settings) as Promise<void>,
 	platform: process.platform,
 };
 

--- a/apps/lite/electron/src/preload.cts
+++ b/apps/lite/electron/src/preload.cts
@@ -5,8 +5,12 @@ import type { AskpassPromptEvent, WatcherEvent } from "@gitbutler/but-sdk";
 
 // Sandboxed preloads cannot load local modules. Keep these values in sync with tracing.ts.
 const ipcTraceCompleteChannel = "lite:ipc-trace-complete";
+const ipcTraceWatcherEventChannel = "lite:ipc-trace-watcher-event";
+const ipcTraceWatcherHost = "ipc-watcher.localhost";
 const ipcTracePathPrefix = "/__ipc/";
 const ipcTraceAcceptPrefix = "application/json; trace-id=";
+const ipcTraceStreamAcceptPrefix = "text/event-stream; trace-id=";
+const ipcTraceWatcherEventsPath = `${ipcTracePathPrefix}watcher-events`;
 const maxTraceResponseCharacters = 1_000_000;
 const maxTraceArgsCharacters = 4_000;
 const maxTraceGateMs = 60_000;
@@ -16,6 +20,13 @@ const ipcTraceServerUrl = (() => {
 
 	const url = new URL(devServerUrl);
 	url.hostname = "ipc.localhost";
+	return url;
+})();
+const ipcTraceWatcherServerUrl = (() => {
+	if (ipcTraceServerUrl === undefined) return undefined;
+
+	const url = new URL(ipcTraceServerUrl);
+	url.hostname = ipcTraceWatcherHost;
 	return url;
 })();
 
@@ -202,6 +213,80 @@ const invoke = async (channel: string, ...args: Array<unknown>): Promise<unknown
 	}
 };
 
+interface IpcWatcherTraceStream {
+	streamId: string;
+	connected: boolean;
+	active: boolean;
+	stop: () => void;
+}
+
+let watcherTraceStream: IpcWatcherTraceStream | undefined;
+
+const startWatcherTraceStream = (): void => {
+	if (ipcTraceWatcherServerUrl === undefined || watcherTraceStream?.active === true) return;
+
+	const streamId = crypto.randomUUID();
+	const abortController = new AbortController();
+	const stream: IpcWatcherTraceStream = {
+		streamId,
+		connected: false,
+		active: true,
+		stop: () => {
+			stream.active = false;
+			abortController.abort();
+		},
+	};
+	watcherTraceStream = stream;
+
+	const streamUrl = new URL(ipcTraceWatcherEventsPath, ipcTraceWatcherServerUrl);
+	void fetch(streamUrl, {
+		headers: { Accept: `${ipcTraceStreamAcceptPrefix}${streamId}` },
+		signal: abortController.signal,
+	})
+		.then(async (response) => {
+			if (!response.ok || !stream.active) return;
+			stream.connected = true;
+
+			// Drain incrementally: response.text() would retain the stream's entire lifetime in memory.
+			const reader = response.body?.getReader();
+			if (reader === undefined) return;
+			while (!(await reader.read()).done) {
+				// DevTools records the server-sent events; preload only needs to consume the bytes.
+			}
+		})
+		.catch(() => undefined)
+		.finally(() => {
+			stream.connected = false;
+			stream.active = false;
+		});
+};
+
+const stopWatcherTraceStream = (): void => {
+	watcherTraceStream?.stop();
+	watcherTraceStream = undefined;
+};
+
+const traceWatcherEvent = (
+	projectId: string,
+	subscriptionId: string,
+	event: WatcherEvent,
+): void => {
+	const stream = watcherTraceStream;
+	if (stream?.connected !== true) return;
+
+	void ipcRenderer
+		.invoke(ipcTraceWatcherEventChannel, {
+			streamId: stream.streamId,
+			type: event.payload.type,
+			body: stringifyTracePayload({
+				projectId,
+				subscriptionId,
+				payload: event.payload,
+			}),
+		})
+		.catch(() => undefined);
+};
+
 /**
  * Every forwarded member hands its arguments to the channel of the same
  * name, so they are generated from the lists rather than written out. The
@@ -250,7 +335,9 @@ const api: LiteElectronApi = {
 		const { subscriptionId, eventChannel } = (await invoke("watcherSubscribe", {
 			projectId,
 		})) as WatcherSubscribeResult;
+		startWatcherTraceStream();
 		const listener = (_event: Electron.IpcRendererEvent, payload: WatcherEvent) => {
+			traceWatcherEvent(projectId, subscriptionId, payload);
 			callback(payload);
 		};
 		watcherListenerBySubscription.set(subscriptionId, { eventChannel, listener });
@@ -269,6 +356,7 @@ const api: LiteElectronApi = {
 		if (registration) {
 			ipcRenderer.removeListener(registration.eventChannel, registration.listener);
 			watcherListenerBySubscription.delete(subscriptionId);
+			if (watcherListenerBySubscription.size === 0) stopWatcherTraceStream();
 		}
 		return invoke("watcherUnsubscribe", { subscriptionId }) as Promise<boolean>;
 	},
@@ -282,6 +370,7 @@ const api: LiteElectronApi = {
 			ipcRenderer.removeListener(eventChannel, listener);
 
 		watcherListenerBySubscription.clear();
+		stopWatcherTraceStream();
 		return invoke("watcherStopAll") as Promise<number>;
 	},
 	platform: process.platform,

--- a/apps/lite/electron/src/preload.cts
+++ b/apps/lite/electron/src/preload.cts
@@ -3,6 +3,137 @@ import { exposedEndpoints, localEndpoints } from "./ipc.js";
 import type { LiteElectronApi, WatcherSubscribeResult } from "./ipc";
 import type { AskpassPromptEvent, WatcherEvent } from "@gitbutler/but-sdk";
 
+// Sandboxed preloads cannot load local modules. Keep these values in sync with tracing.ts.
+const ipcTraceCompleteChannel = "lite:ipc-trace-complete";
+const ipcTracePathPrefix = "/__ipc/";
+const ipcTraceAcceptPrefix = "application/json; trace-id=";
+const maxTraceResponseCharacters = 1_000_000;
+const maxTraceArgsCharacters = 4_000;
+const maxTraceGateMs = 60_000;
+const ipcTraceServerUrl = (() => {
+	const devServerUrl = process.env.VITE_DEV_SERVER_URL;
+	if (devServerUrl === undefined) return undefined;
+
+	const url = new URL(devServerUrl);
+	url.hostname = "ipc.localhost";
+	return url;
+})();
+
+interface IpcTrace {
+	traceId: string;
+	startedAt: number;
+	finished: Promise<void>;
+	stopWaiting: () => void;
+}
+
+const traceSafeArgs = (channel: string, args: Array<unknown>): Array<unknown> => {
+	if (channel === "askpassSubmitPromptResponse") {
+		const [params, ...rest] = args;
+		if (typeof params === "object" && params !== null)
+			return [{ ...params, response: "<redacted>" }, ...rest];
+	}
+
+	if (channel === "clipboardWriteText") return ["<redacted>"];
+
+	return args;
+};
+
+// Lite's IPC arguments and results are JSON-compatible. Errors are the one useful exception: their
+// properties are not enumerable, so normalize them before displaying them in DevTools.
+const stringifyTracePayload = (
+	value: unknown,
+	maxCharacters = maxTraceResponseCharacters,
+): string => {
+	let json: string;
+
+	try {
+		json = JSON.stringify(value, (_key, nestedValue: unknown) => {
+			if (nestedValue instanceof Error) {
+				return {
+					name: nestedValue.name,
+					message: nestedValue.message,
+					stack: nestedValue.stack,
+				};
+			}
+			return nestedValue;
+		});
+	} catch (error) {
+		json = JSON.stringify({ serializationError: String(error) });
+	}
+
+	if (json.length <= maxCharacters) return json;
+	return JSON.stringify({
+		truncated: true,
+		originalCharacters: json.length,
+		preview: json.slice(0, maxCharacters),
+	});
+};
+
+const beginIpcTrace = (channel: string, args: Array<unknown>): IpcTrace | undefined => {
+	if (ipcTraceServerUrl === undefined) return undefined;
+
+	const traceId = crypto.randomUUID();
+	const separatorIndex = channel.indexOf(":");
+	const scope = separatorIndex === -1 ? "ipc" : channel.slice(0, separatorIndex);
+	const method = separatorIndex === -1 ? channel : channel.slice(separatorIndex + 1);
+	const traceUrl = new URL(
+		`${ipcTracePathPrefix}${encodeURIComponent(scope)}/${encodeURIComponent(method)}`,
+		ipcTraceServerUrl,
+	);
+	const serializedArgs = stringifyTracePayload(
+		traceSafeArgs(channel, args),
+		maxTraceArgsCharacters,
+	);
+	const abortController = new AbortController();
+	const startedAt = performance.now();
+
+	const response = fetch(traceUrl, {
+		method: "POST",
+		headers: { Accept: `${ipcTraceAcceptPrefix}${traceId}` },
+		body: serializedArgs,
+		signal: abortController.signal,
+	});
+	const timeout = setTimeout(() => abortController.abort(), maxTraceGateMs);
+	const finished = response
+		.then((response) => response.arrayBuffer())
+		.then(() => undefined)
+		.catch(() => undefined)
+		.finally(() => clearTimeout(timeout));
+
+	return {
+		traceId,
+		startedAt,
+		finished,
+		stopWaiting: () => abortController.abort(),
+	};
+};
+
+const completeIpcTrace = async (
+	trace: IpcTrace | undefined,
+	ok: boolean,
+	value: unknown,
+): Promise<void> => {
+	if (trace === undefined) return;
+
+	try {
+		const stored = (await ipcRenderer.invoke(ipcTraceCompleteChannel, {
+			traceId: trace.traceId,
+			ok,
+			body: stringifyTracePayload(value),
+			durationMs: performance.now() - trace.startedAt,
+		})) as unknown;
+		if (stored !== true) {
+			trace.stopWaiting();
+			return;
+		}
+
+		await trace.finished;
+	} catch {
+		trace.stopWaiting();
+		// Tracing must never affect the real IPC call.
+	}
+};
+
 /**
  * The map of subscription IDs to channels and callbacks.
  *
@@ -58,8 +189,18 @@ const special = new Set<string>(specialNames);
  * every caller. Narrowing it to `unknown` — by annotation, not assertion —
  * makes each wire result something a reader has to pin down.
  */
-const invoke = (channel: string, ...args: Array<unknown>): Promise<unknown> =>
-	ipcRenderer.invoke(channel, ...args);
+const invoke = async (channel: string, ...args: Array<unknown>): Promise<unknown> => {
+	const trace = beginIpcTrace(channel, args);
+
+	try {
+		const result = (await ipcRenderer.invoke(channel, ...args)) as unknown;
+		await completeIpcTrace(trace, true, result);
+		return result;
+	} catch (error) {
+		await completeIpcTrace(trace, false, error);
+		throw error;
+	}
+};
 
 /**
  * Every forwarded member hands its arguments to the channel of the same

--- a/apps/lite/electron/src/tracing.ts
+++ b/apps/lite/electron/src/tracing.ts
@@ -1,0 +1,219 @@
+/**
+ * @file Development-only IPC tracing for Chromium DevTools.
+ *
+ * Electron IPC does not pass through Chromium's renderer network stack, so this mirrors each call
+ * with real development HTTP traffic. A row describes the renderer-to-main boundary only; work
+ * below it may include local reads, retries, or multiple network requests.
+ *
+ * 1. Before invoking IPC, preload POSTs the serialized arguments to
+ *    `http://ipc.localhost:<vite-port>/__ipc/<scope>/<method>`. A media-type parameter on `Accept`
+ *    carries the trace ID without adding noise to the URL or triggering a CORS preflight.
+ * 2. The Vite plugin holds the response open until main receives the IPC result from preload and
+ *    POSTs it to `/__ipc/complete` on the normal Vite origin. Relaying completion through main keeps
+ *    that request out of DevTools and outside renderer network throttling.
+ * 3. Vite responds with the result and IPC duration, and preload consumes the complete body before
+ *    releasing the real IPC result. `Server-Timing` preserves the raw IPC duration separately from
+ *    the Network row's end-to-end duration, which includes any simulated network delay. The JSON
+ *    response and explicit `Content-Length` keep DevTools' Response and Size views populated.
+ *
+ * The dedicated `ipc.localhost` origin is essential even though it reaches the same Vite server.
+ * Held trace responses must not occupy the app origin's connection pool and block navigation. The
+ * completion cache handles the inverse race, where IPC finishes before a queued trace reaches Vite.
+ * Preload aborts its gate after 60 seconds so tracing cannot freeze the app; Vite retains state only
+ * slightly longer to cover timer skew and clean up requests whose connection does not close cleanly.
+ *
+ * Consuming the response makes latency and bandwidth throttling part of the IPC boundary, which can
+ * approximate slow local work. Fetch is required so DevTools retains the response body. Tracing
+ * fails open after a bounded delay. Lite's typed IPC arguments and results are JSON-compatible;
+ * thrown errors are normalized for display, large payloads are truncated, and sensitive
+ * askpass/clipboard arguments are redacted.
+ *
+ * Some preload-side code remains in `preload.cts`: sandboxed Electron preloads use a restricted
+ * CommonJS environment that cannot load arbitrary local modules without introducing a bundling
+ * step. Keep its duplicated trace constants in sync with this module.
+ */
+
+import { Buffer } from "node:buffer";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { Plugin } from "vite";
+
+export const ipcTraceCompleteChannel = "lite:ipc-trace-complete";
+export const ipcTraceHost = "ipc.localhost";
+const ipcTracePathPrefix = "/__ipc/";
+const ipcTraceAcceptPrefix = "application/json; trace-id=";
+export const ipcTraceCompletionPath = `${ipcTracePathPrefix}complete`;
+
+interface IpcTraceCompletion {
+	traceId: string;
+	ok: boolean;
+	body: string;
+	durationMs: number;
+}
+
+export const isIpcTraceCompletion = (value: unknown): value is IpcTraceCompletion =>
+	typeof value === "object" &&
+	value !== null &&
+	"traceId" in value &&
+	typeof value.traceId === "string" &&
+	"ok" in value &&
+	typeof value.ok === "boolean" &&
+	"body" in value &&
+	typeof value.body === "string" &&
+	"durationMs" in value &&
+	typeof value.durationMs === "number" &&
+	Number.isFinite(value.durationMs) &&
+	value.durationMs >= 0;
+
+const ipcTraceIdFromAccept = (accept: string | undefined): string | undefined => {
+	if (accept === undefined || !accept.startsWith(ipcTraceAcceptPrefix)) return undefined;
+
+	const traceId = accept.slice(ipcTraceAcceptPrefix.length);
+	return /^[\da-f]{8}(?:-[\da-f]{4}){3}-[\da-f]{12}$/i.test(traceId) ? traceId : undefined;
+};
+
+const readRequestBody = async (request: IncomingMessage): Promise<string> =>
+	await new Promise((resolve, reject) => {
+		const chunks: Array<Buffer> = [];
+		let byteLength = 0;
+		let tooLarge = false;
+
+		request.on("data", (chunk: Buffer | string) => {
+			const buffer = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+			byteLength += buffer.byteLength;
+			if (byteLength > 5_000_000) tooLarge = true;
+			else chunks.push(buffer);
+		});
+		request.on("end", () => {
+			if (tooLarge) reject(new Error("IPC trace payload is too large"));
+			else resolve(Buffer.concat(chunks).toString("utf8"));
+		});
+		request.on("error", reject);
+	});
+
+/** @internal Only loaded by the development Vite configuration. */
+export const ipcTracePlugin = (): Plugin => {
+	type PendingTrace = {
+		response: ServerResponse;
+		timeout: ReturnType<typeof setTimeout>;
+	};
+
+	// Preload gives up after 60 seconds; retain server state just long enough to cover timer skew.
+	const traceRetentionMs = 65_000;
+	const pendingTraces = new Map<string, PendingTrace>();
+	const storedCompletions = new Map<
+		string,
+		{ completion: IpcTraceCompletion; timeout: ReturnType<typeof setTimeout> }
+	>();
+
+	const respond = (response: ServerResponse, completion: IpcTraceCompletion): void => {
+		response.statusCode = completion.ok ? 200 : 500;
+		response.setHeader("cache-control", "no-store");
+		response.setHeader("content-length", String(Buffer.byteLength(completion.body)));
+		response.setHeader("content-type", "application/json");
+		response.setHeader("access-control-allow-origin", "*");
+		response.setHeader("server-timing", `ipc;dur=${completion.durationMs}`);
+		response.setHeader("timing-allow-origin", "*");
+		response.end(completion.body);
+	};
+
+	return {
+		name: "gitbutler-ipc-trace",
+		apply: "serve",
+		configureServer(server) {
+			// oxlint-disable-next-line typescript/no-misused-promises -- Connect does not model async middleware.
+			server.middlewares.use(async (request, response, next) => {
+				const requestUrl = new URL(request.url ?? "/", "http://127.0.0.1");
+				if (!requestUrl.pathname.startsWith(ipcTracePathPrefix)) {
+					next();
+					return;
+				}
+
+				if (requestUrl.pathname === ipcTraceCompletionPath) {
+					if (request.method !== "POST") {
+						response.statusCode = 405;
+						response.end("Method not allowed");
+						return;
+					}
+
+					let payload: unknown;
+					try {
+						payload = JSON.parse(await readRequestBody(request));
+					} catch {
+						response.statusCode = 400;
+						response.end("Invalid IPC trace payload");
+						return;
+					}
+
+					if (!isIpcTraceCompletion(payload)) {
+						response.statusCode = 400;
+						response.end("Invalid IPC trace completion");
+						return;
+					}
+
+					const pending = pendingTraces.get(payload.traceId);
+					if (pending !== undefined) {
+						clearTimeout(pending.timeout);
+						pendingTraces.delete(payload.traceId);
+						respond(pending.response, payload);
+					} else {
+						const existing = storedCompletions.get(payload.traceId);
+						if (existing !== undefined) clearTimeout(existing.timeout);
+						const timeout = setTimeout(
+							() => storedCompletions.delete(payload.traceId),
+							traceRetentionMs,
+						);
+						storedCompletions.set(payload.traceId, { completion: payload, timeout });
+					}
+
+					response.statusCode = 204;
+					response.end();
+					return;
+				}
+
+				if (request.method !== "POST") {
+					response.statusCode = 405;
+					response.end("Method not allowed");
+					return;
+				}
+
+				try {
+					await readRequestBody(request);
+				} catch {
+					response.statusCode = 400;
+					response.end("Invalid IPC trace request");
+					return;
+				}
+
+				const traceId = ipcTraceIdFromAccept(request.headers.accept);
+				if (traceId === undefined) {
+					response.statusCode = 400;
+					response.end("Missing IPC trace ID");
+					return;
+				}
+
+				const stored = storedCompletions.get(traceId);
+				if (stored !== undefined) {
+					clearTimeout(stored.timeout);
+					storedCompletions.delete(traceId);
+					respond(response, stored.completion);
+					return;
+				}
+
+				const timeout = setTimeout(() => {
+					pendingTraces.delete(traceId);
+					response.statusCode = 504;
+					response.setHeader("timing-allow-origin", "*");
+					response.end("IPC trace timed out");
+				}, traceRetentionMs);
+				pendingTraces.set(traceId, { response, timeout });
+
+				response.on("close", () => {
+					const pending = pendingTraces.get(traceId);
+					if (pending?.response !== response) return;
+					clearTimeout(pending.timeout);
+					pendingTraces.delete(traceId);
+				});
+			});
+		},
+	};
+};

--- a/apps/lite/electron/src/tracing.ts
+++ b/apps/lite/electron/src/tracing.ts
@@ -16,11 +16,20 @@
  *    the Network row's end-to-end duration, which includes any simulated network delay. The JSON
  *    response and explicit `Content-Length` keep DevTools' Response and Size views populated.
  *
+ * Watcher events use one shared streaming fetch per renderer while any watcher subscriptions are
+ * active. Preload copies each event through main to Vite, which writes it as a server-sent event;
+ * Chromium then exposes the copies in the request's EventStream tab. The real watcher callback runs
+ * immediately, so throttling or failure of the diagnostic stream never changes event delivery. A
+ * single stream avoids consuming one HTTP/1.1 connection per subscription, and mirrored events are
+ * dropped while the response is backpressured rather than allowing diagnostics to grow memory.
+ *
  * The dedicated `ipc.localhost` origin is essential even though it reaches the same Vite server.
  * Held trace responses must not occupy the app origin's connection pool and block navigation. The
- * completion cache handles the inverse race, where IPC finishes before a queued trace reaches Vite.
- * Preload aborts its gate after 60 seconds so tracing cannot freeze the app; Vite retains state only
- * slightly longer to cover timer skew and clean up requests whose connection does not close cleanly.
+ * permanent watcher stream and its relay traffic use `ipc-watcher.localhost` as well, so they cannot
+ * reduce the connection budget available to ordinary IPC traces. The completion cache handles the
+ * inverse race, where IPC finishes before a queued trace reaches Vite. Preload aborts its gate after
+ * 60 seconds so tracing cannot freeze the app; Vite retains state only slightly longer to cover
+ * timer skew and clean up requests whose connection does not close cleanly.
  *
  * Consuming the response makes latency and bandwidth throttling part of the IPC boundary, which can
  * approximate slow local work. Fetch is required so DevTools retains the response body. Tracing
@@ -38,10 +47,15 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Plugin } from "vite";
 
 export const ipcTraceCompleteChannel = "lite:ipc-trace-complete";
+export const ipcTraceWatcherEventChannel = "lite:ipc-trace-watcher-event";
 export const ipcTraceHost = "ipc.localhost";
+export const ipcTraceWatcherHost = "ipc-watcher.localhost";
 const ipcTracePathPrefix = "/__ipc/";
 const ipcTraceAcceptPrefix = "application/json; trace-id=";
+const ipcTraceStreamAcceptPrefix = "text/event-stream; trace-id=";
 export const ipcTraceCompletionPath = `${ipcTracePathPrefix}complete`;
+export const ipcTraceWatcherEventPath = `${ipcTracePathPrefix}watcher-event`;
+const ipcTraceWatcherEventsPath = `${ipcTracePathPrefix}watcher-events`;
 
 interface IpcTraceCompletion {
 	traceId: string;
@@ -49,6 +63,15 @@ interface IpcTraceCompletion {
 	body: string;
 	durationMs: number;
 }
+
+interface IpcTraceWatcherEvent {
+	streamId: string;
+	type: string;
+	body: string;
+}
+
+const isIpcTraceId = (value: string): boolean =>
+	/^[\da-f]{8}(?:-[\da-f]{4}){3}-[\da-f]{12}$/i.test(value);
 
 export const isIpcTraceCompletion = (value: unknown): value is IpcTraceCompletion =>
 	typeof value === "object" &&
@@ -64,11 +87,28 @@ export const isIpcTraceCompletion = (value: unknown): value is IpcTraceCompletio
 	Number.isFinite(value.durationMs) &&
 	value.durationMs >= 0;
 
-const ipcTraceIdFromAccept = (accept: string | undefined): string | undefined => {
-	if (accept === undefined || !accept.startsWith(ipcTraceAcceptPrefix)) return undefined;
+export const isIpcTraceWatcherEvent = (value: unknown): value is IpcTraceWatcherEvent =>
+	typeof value === "object" &&
+	value !== null &&
+	"streamId" in value &&
+	typeof value.streamId === "string" &&
+	isIpcTraceId(value.streamId) &&
+	"type" in value &&
+	typeof value.type === "string" &&
+	value.type.length > 0 &&
+	!/[\r\n]/.test(value.type) &&
+	"body" in value &&
+	typeof value.body === "string" &&
+	!/[\r\n]/.test(value.body);
 
-	const traceId = accept.slice(ipcTraceAcceptPrefix.length);
-	return /^[\da-f]{8}(?:-[\da-f]{4}){3}-[\da-f]{12}$/i.test(traceId) ? traceId : undefined;
+const ipcTraceIdFromAccept = (
+	accept: string | undefined,
+	prefix = ipcTraceAcceptPrefix,
+): string | undefined => {
+	if (accept === undefined || !accept.startsWith(prefix)) return undefined;
+
+	const traceId = accept.slice(prefix.length);
+	return isIpcTraceId(traceId) ? traceId : undefined;
 };
 
 const readRequestBody = async (request: IncomingMessage): Promise<string> =>
@@ -96,10 +136,12 @@ export const ipcTracePlugin = (): Plugin => {
 		response: ServerResponse;
 		timeout: ReturnType<typeof setTimeout>;
 	};
+	type WatcherEventStream = { response: ServerResponse };
 
 	// Preload gives up after 60 seconds; retain server state just long enough to cover timer skew.
 	const traceRetentionMs = 65_000;
 	const pendingTraces = new Map<string, PendingTrace>();
+	const watcherEventStreams = new Map<string, WatcherEventStream>();
 	const storedCompletions = new Map<
 		string,
 		{ completion: IpcTraceCompletion; timeout: ReturnType<typeof setTimeout> }
@@ -125,6 +167,76 @@ export const ipcTracePlugin = (): Plugin => {
 				const requestUrl = new URL(request.url ?? "/", "http://127.0.0.1");
 				if (!requestUrl.pathname.startsWith(ipcTracePathPrefix)) {
 					next();
+					return;
+				}
+
+				if (requestUrl.pathname === ipcTraceWatcherEventsPath) {
+					if (request.method !== "GET") {
+						response.statusCode = 405;
+						response.end("Method not allowed");
+						return;
+					}
+
+					const streamId = ipcTraceIdFromAccept(request.headers.accept, ipcTraceStreamAcceptPrefix);
+					if (streamId === undefined) {
+						response.statusCode = 400;
+						response.end("Missing IPC watcher stream ID");
+						return;
+					}
+
+					watcherEventStreams.get(streamId)?.response.end();
+					watcherEventStreams.set(streamId, { response });
+					response.statusCode = 200;
+					response.setHeader("access-control-allow-origin", "*");
+					response.setHeader("cache-control", "no-cache, no-store");
+					response.setHeader("content-type", "text/event-stream");
+					response.flushHeaders();
+
+					response.on("close", () => {
+						if (watcherEventStreams.get(streamId)?.response === response)
+							watcherEventStreams.delete(streamId);
+					});
+					return;
+				}
+
+				if (requestUrl.pathname === ipcTraceWatcherEventPath) {
+					if (request.method !== "POST") {
+						response.statusCode = 405;
+						response.end("Method not allowed");
+						return;
+					}
+
+					let payload: unknown;
+					try {
+						payload = JSON.parse(await readRequestBody(request));
+					} catch {
+						response.statusCode = 400;
+						response.end("Invalid IPC watcher event payload");
+						return;
+					}
+
+					if (!isIpcTraceWatcherEvent(payload)) {
+						response.statusCode = 400;
+						response.end("Invalid IPC watcher event");
+						return;
+					}
+
+					const stream = watcherEventStreams.get(payload.streamId);
+					if (stream === undefined) {
+						response.statusCode = 404;
+						response.end("IPC watcher event stream not found");
+						return;
+					}
+					if (stream.response.writableNeedDrain) {
+						response.statusCode = 429;
+						response.end("IPC watcher event stream is backpressured");
+						return;
+					}
+
+					stream.response.write(`event: ${payload.type}\ndata: ${payload.body}\n\n`);
+
+					response.statusCode = 204;
+					response.end();
 					return;
 				}
 

--- a/apps/lite/ui/vite.config.ts
+++ b/apps/lite/ui/vite.config.ts
@@ -2,6 +2,7 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { ipcTracePlugin } from "../electron/src/tracing.ts";
 
 const currentFilePath = fileURLToPath(import.meta.url);
 const currentDirPath = path.dirname(currentFilePath);
@@ -14,6 +15,7 @@ export default defineConfig(({ command }) => ({
 				plugins: ["babel-plugin-react-compiler"],
 			},
 		}),
+		...(command === "serve" ? [ipcTracePlugin()] : []),
 	],
 	base: "/",
 	build: {

--- a/apps/lite/ui/vite.config.ts
+++ b/apps/lite/ui/vite.config.ts
@@ -2,7 +2,7 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { ipcTraceHost, ipcTracePlugin } from "../electron/src/tracing.js";
+import { ipcTraceHost, ipcTracePlugin, ipcTraceWatcherHost } from "../electron/src/tracing.js";
 
 const currentFilePath = fileURLToPath(import.meta.url);
 const currentDirPath = path.dirname(currentFilePath);
@@ -26,7 +26,7 @@ export default defineConfig(({ command }) => ({
 		format: "es",
 	},
 	server: {
-		allowedHosts: [ipcTraceHost],
+		allowedHosts: [ipcTraceHost, ipcTraceWatcherHost],
 		port: 5173,
 		strictPort: true,
 	},

--- a/apps/lite/ui/vite.config.ts
+++ b/apps/lite/ui/vite.config.ts
@@ -2,6 +2,7 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { ipcTraceHost, ipcTracePlugin } from "../electron/src/tracing.js";
 
 const currentFilePath = fileURLToPath(import.meta.url);
 const currentDirPath = path.dirname(currentFilePath);
@@ -9,6 +10,7 @@ const currentDirPath = path.dirname(currentFilePath);
 export default defineConfig(({ command }) => ({
 	root: currentDirPath,
 	plugins: [
+		ipcTracePlugin(),
 		react({
 			babel: {
 				plugins: ["babel-plugin-react-compiler"],
@@ -24,6 +26,7 @@ export default defineConfig(({ command }) => ({
 		format: "es",
 	},
 	server: {
+		allowedHosts: [ipcTraceHost],
 		port: 5173,
 		strictPort: true,
 	},


### PR DESCRIPTION
See commits. I'll be using this in my megamerge for a few days before potentially merging. Ideally there'd be less code in preload, we could potentially extract some stuff to a package boundary.

In the past this code wouldn't have existed, and if it did it would have been a non-neglible maintenance burden. Neither any longer applies.

Observed bugs:

- [ ] `open-in-web-browser` is logged as cancelled