### PR TITLE
checkout: remove extraneous code

### DIFF
--- a/crates/but-core/src/worktree/checkout/function.rs
+++ b/crates/but-core/src/worktree/checkout/function.rs
@@ -149,7 +149,7 @@ pub fn safe_checkout_from_head(
 
         git2_repo.checkout_tree(
             &destination_tree,
-            Some(opts.update_index(true).force().disable_pathspec_match(true)),
+            Some(opts.force().disable_pathspec_match(true)),
         )?;
 
         if num_deleted_files > 0


### PR DESCRIPTION
This extra code confuses both humans and Copilot.
