### PR TITLE
forge cache: grace period for open PRs

### DIFF
--- a/crates/but-db/src/table/forge_reviews.rs
+++ b/crates/but-db/src/table/forge_reviews.rs
@@ -175,51 +175,101 @@ impl ForgeReviewsHandleMut<'_> {
         Ok(())
     }
 
-    /// Reconciles a fresh forge-list response with retained review rows.
+    /// Fold a fresh forge "list reviews" response into the cache.
     ///
-    /// Listed reviews are inserted or updated, cached open reviews that no
-    /// longer appear in the latest list are deleted, and merged reviews at or
-    /// before `merged_cutoff` are pruned. Closed or recently merged reviews
-    /// that are absent from the list are retained so direct review lookups can
-    /// continue to serve integration hints.
+    /// The list is the source of truth for which reviews are currently *open*,
+    /// with two deliberate exceptions that keep the cache useful — and
+    /// non-flickery — between syncs. The three steps run in a single savepoint,
+    /// so a partial reconcile is never observable.
+    ///
+    /// 1. **Upsert everything listed.** Each listed review is inserted or
+    ///    refreshed, which also bumps its `last_sync_at`.
+    /// 2. **Delete open reviews the forge no longer lists — but only stale ones**
+    ///    (see [`delete_open_reviews_absent_from_list`]). A freshly-written
+    ///    optimistic insert is spared via `absent_open_cutoff` so it doesn't
+    ///    flicker off before the forge's eventually-consistent list catches up.
+    /// 3. **Prune old merged reviews** past `merged_cutoff` (see
+    ///    [`prune_merged_before`]). Closed (non-merged) reviews are always kept,
+    ///    so direct lookups such as upstream-integration hints keep working.
+    ///
+    /// [`delete_open_reviews_absent_from_list`]: Self::delete_open_reviews_absent_from_list
+    /// [`prune_merged_before`]: Self::prune_merged_before
     pub fn reconcile_listed(
         self,
         reviews: Vec<ForgeReview>,
         merged_cutoff: chrono::NaiveDateTime,
+        absent_open_cutoff: chrono::NaiveDateTime,
     ) -> rusqlite::Result<()> {
         let listed_numbers = reviews
             .iter()
             .map(|review| review.number)
             .collect::<Vec<_>>();
+
         for review in reviews {
             self.upsert_without_commit(review)?;
         }
-
-        if listed_numbers.is_empty() {
-            self.sp.execute(
-                "DELETE FROM forge_reviews WHERE merged_at IS NULL AND closed_at IS NULL",
-                [],
-            )?;
-        } else {
-            let placeholders = std::iter::repeat_n("?", listed_numbers.len())
-                .collect::<Vec<_>>()
-                .join(", ");
-            self.sp.execute(
-                &format!(
-                    "DELETE FROM forge_reviews \
-                     WHERE merged_at IS NULL AND closed_at IS NULL \
-                     AND number NOT IN ({placeholders})"
-                ),
-                rusqlite::params_from_iter(listed_numbers),
-            )?;
-        }
-
-        self.sp.execute(
-            "DELETE FROM forge_reviews WHERE merged_at IS NOT NULL AND merged_at <= ?1",
-            [merged_cutoff],
-        )?;
+        self.delete_open_reviews_absent_from_list(&listed_numbers, absent_open_cutoff)?;
+        self.prune_merged_before(merged_cutoff)?;
 
         self.sp.commit()?;
+        Ok(())
+    }
+
+    /// Delete cached *open* reviews (neither merged nor closed) that are absent
+    /// from the latest list, restricted to rows last synced at or before
+    /// `absent_open_cutoff`.
+    ///
+    /// The cutoff is what spares a freshly-written optimistic insert (e.g. a PR
+    /// just created locally) from being reconciled away before the forge's
+    /// eventually-consistent list reflects it: callers pass `now - grace`, so any
+    /// row whose `last_sync_at` is newer than the cutoff is retained. An empty
+    /// `listed_numbers` means the forge reports no open reviews at all, so every
+    /// open review older than the cutoff is eligible for deletion.
+    fn delete_open_reviews_absent_from_list(
+        &self,
+        listed_numbers: &[i64],
+        absent_open_cutoff: chrono::NaiveDateTime,
+    ) -> rusqlite::Result<()> {
+        if listed_numbers.is_empty() {
+            self.sp.execute(
+                "DELETE FROM forge_reviews \
+                 WHERE merged_at IS NULL AND closed_at IS NULL \
+                 AND last_sync_at <= ?1",
+                [absent_open_cutoff],
+            )?;
+            return Ok(());
+        }
+
+        let placeholders = (1..=listed_numbers.len())
+            .map(|index| format!("?{index}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let cutoff_parameter = listed_numbers.len() + 1;
+        let mut params: Vec<&dyn rusqlite::ToSql> = Vec::with_capacity(listed_numbers.len() + 1);
+        for number in listed_numbers {
+            params.push(number);
+        }
+        params.push(&absent_open_cutoff);
+
+        self.sp.execute(
+            &format!(
+                "DELETE FROM forge_reviews \
+                 WHERE merged_at IS NULL AND closed_at IS NULL \
+                 AND number NOT IN ({placeholders}) \
+                 AND last_sync_at <= ?{cutoff_parameter}"
+            ),
+            params.as_slice(),
+        )?;
+        Ok(())
+    }
+
+    /// Delete merged reviews whose `merged_at` is at or before `cutoff`. Does not
+    /// commit; the caller owns the surrounding savepoint.
+    fn prune_merged_before(&self, cutoff: chrono::NaiveDateTime) -> rusqlite::Result<()> {
+        self.sp.execute(
+            "DELETE FROM forge_reviews WHERE merged_at IS NOT NULL AND merged_at <= ?1",
+            [cutoff],
+        )?;
         Ok(())
     }
 
@@ -284,11 +334,7 @@ impl ForgeReviewsHandleMut<'_> {
 
     /// Deletes reviews with a merge timestamp at or before `cutoff`.
     pub fn delete_merged_before(self, cutoff: chrono::NaiveDateTime) -> rusqlite::Result<()> {
-        self.sp.execute(
-            "DELETE FROM forge_reviews WHERE merged_at IS NOT NULL AND merged_at <= ?1",
-            [cutoff],
-        )?;
-
+        self.prune_merged_before(cutoff)?;
         self.sp.commit()?;
         Ok(())
     }

--- a/crates/but-db/tests/db/table/forge_review.rs
+++ b/crates/but-db/tests/db/table/forge_review.rs
@@ -242,8 +242,10 @@ fn reconcile_listed_prunes_stale_rows() -> anyhow::Result<()> {
     ])?;
 
     listed_open.title = "Fresh listed open PR".to_string();
+    // All rows were synced at t=1_000_000, well before `cutoff`, so none fall
+    // inside the optimistic-insert grace window here.
     db.forge_reviews_mut()?
-        .reconcile_listed(vec![listed_open.clone()], cutoff)?;
+        .reconcile_listed(vec![listed_open.clone()], cutoff, cutoff)?;
 
     let reviews = db.forge_reviews().list_all()?;
     assert_eq!(
@@ -262,6 +264,84 @@ fn reconcile_listed_prunes_stale_rows() -> anyhow::Result<()> {
     assert!(
         reviews.contains(&recent_merged),
         "recent merged review should be retained for integration hints"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn reconcile_listed_spares_recent_optimistic_inserts() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+
+    let mut optimistic = forge_review(1, "Just-created PR", "new-pr");
+    optimistic.last_sync_at = chrono::DateTime::from_timestamp(3_000_000, 0)
+        .unwrap()
+        .naive_utc();
+    let vanished = forge_review(2, "Vanished PR", "gone");
+
+    db.forge_reviews_mut()?
+        .set_all(vec![optimistic.clone(), vanished])?;
+
+    let cutoff = chrono::DateTime::from_timestamp(2_000_000, 0)
+        .unwrap()
+        .naive_utc();
+    db.forge_reviews_mut()?
+        .reconcile_listed(vec![], cutoff, cutoff)?;
+
+    let reviews = db.forge_reviews().list_all()?;
+    assert_eq!(
+        reviews,
+        [optimistic],
+        "a recently-inserted open review must survive an empty list within the grace window"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn reconcile_listed_spares_recent_optimistic_inserts_with_non_empty_list() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+
+    // A brand-new PR cached optimistically (synced "just now"), not yet visible
+    // in the forge's list response.
+    let mut optimistic = forge_review(1, "Just-created PR", "new-pr");
+    optimistic.last_sync_at = chrono::DateTime::from_timestamp(3_000_000, 0)
+        .unwrap()
+        .naive_utc();
+    // An open PR that genuinely dropped off the forge, last synced long ago
+    // (the helper stamps `last_sync_at` at t=1_000_000).
+    let vanished = forge_review(2, "Vanished PR", "gone");
+    let listed = forge_review(3, "Listed PR", "listed");
+
+    db.forge_reviews_mut()?
+        .set_all(vec![optimistic.clone(), vanished.clone()])?;
+
+    // Reconcile against a non-empty list with the grace cutoff between the two
+    // sync times: the recent optimistic insert survives, the long-absent one is
+    // pruned, and the listed review is inserted.
+    let cutoff = chrono::DateTime::from_timestamp(2_000_000, 0)
+        .unwrap()
+        .naive_utc();
+    db.forge_reviews_mut()?
+        .reconcile_listed(vec![listed.clone()], cutoff, cutoff)?;
+
+    let reviews = db.forge_reviews().list_all()?;
+    assert_eq!(
+        reviews.len(),
+        2,
+        "only the recent optimistic and listed reviews should remain"
+    );
+    assert!(
+        reviews.contains(&optimistic),
+        "a recently-inserted open review must survive within the grace window"
+    );
+    assert!(
+        reviews.contains(&listed),
+        "a review returned by the forge must be retained"
+    );
+    assert!(
+        !reviews.contains(&vanished),
+        "a stale open review absent from the forge list must be pruned"
     );
 
     Ok(())

--- a/crates/but-forge/src/db.rs
+++ b/crates/but-forge/src/db.rs
@@ -1,6 +1,7 @@
 use super::ForgeReview;
 
 const MERGED_REVIEW_RETENTION_DAYS: i64 = 15;
+const ABSENT_OPEN_REVIEW_GRACE_SECONDS: i64 = 60;
 
 impl TryFrom<ForgeReview> for but_db::ForgeReview {
     type Error = anyhow::Error;
@@ -109,14 +110,15 @@ pub(crate) fn cache_reviews(
     db: &mut but_db::DbHandle,
     reviews: &[ForgeReview],
 ) -> anyhow::Result<()> {
-    let cutoff =
-        chrono::Local::now().naive_local() - chrono::Duration::days(MERGED_REVIEW_RETENTION_DAYS);
+    let now = chrono::Local::now().naive_local();
+    let merged_cutoff = now - chrono::Duration::days(MERGED_REVIEW_RETENTION_DAYS);
+    let absent_open_cutoff = now - chrono::Duration::seconds(ABSENT_OPEN_REVIEW_GRACE_SECONDS);
     let db_reviews = reviews
         .iter()
         .map(|review| review.clone().try_into())
         .collect::<anyhow::Result<Vec<_>>>()?;
     db.forge_reviews_mut()?
-        .reconcile_listed(db_reviews, cutoff)
+        .reconcile_listed(db_reviews, merged_cutoff, absent_open_cutoff)
         .map_err(anyhow::Error::from)?;
     Ok(())
 }


### PR DESCRIPTION
Update the reconciliation algorithm, to keep recently created PRs in the
cache long enough for eventual consistency in GitHub to hit.

- Saves every review returned by the forge, updating existing cache
entries where necessary.
- Removes cached open reviews that the forge did not return, unless they
  were added very recently. That short grace period prevents a newly
  created review from briefly disappearing while
the forge catches up.
- Removes merged reviews older than the retention period.
  Closed-but-unmerged reviews remain cached because other features may
  still need them.If any step fails, none of the changes are committed.

---

### Why

After we create a PR through the application. If we were to store that in the cache, and then immediately after list the reviews, the GitHub API might not contain the new PR yet. In that period of time, we need to ideally keep the PR in the cache, so that we can read from it.