### PR TITLE
feat(but): add commit change IDs to `but`

### DIFF
--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -5,7 +5,7 @@ use assignment::FileAssignment;
 use bstr::{BStr, BString, ByteSlice};
 use but_api::diff::ComputeLineStats;
 use but_core::{
-    IgnoredWorktreeTreeChangeStatus, RepositoryExt, TreeStatus,
+    ChangeId, IgnoredWorktreeTreeChangeStatus, RepositoryExt, TreeStatus,
     ref_metadata::StackId,
     sync::{RepoExclusive, RepoExclusiveGuard},
     ui,
@@ -350,6 +350,7 @@ fn build_status_context<'a>(
         remote_commits_by_id,
         stacks,
         resolved_target,
+        commit_id_to_change_id,
     ) = {
         let (repo, ws, _db) = ctx.workspace_and_db_with_perm(perm.read_permission())?;
         let head_info = but_workspace::graph_to_ref_info(
@@ -364,6 +365,8 @@ fn build_status_context<'a>(
         let mut push_statuses_by_segment_id = HashMap::<SegmentIndex, PushStatus>::new();
         let mut local_commits_by_id = HashMap::<gix::ObjectId, LocalCommit>::new();
         let mut remote_commits_by_id = HashMap::<gix::ObjectId, Commit>::new();
+        let mut commit_id_to_change_id =
+            gix::hashtable::HashMap::<gix::ObjectId, ChangeId>::default();
         for stack in head_info.stacks {
             for segment in stack.segments {
                 let Segment {
@@ -373,9 +376,15 @@ fn build_status_context<'a>(
                     ..
                 } = segment;
                 for local_commit in commits {
+                    if let Some(change_id) = &local_commit.inner.change_id {
+                        commit_id_to_change_id.insert(local_commit.id, change_id.clone());
+                    }
                     local_commits_by_id.insert(local_commit.id, local_commit);
                 }
                 for remote_commit in commits_on_remote {
+                    if let Some(change_id) = &remote_commit.change_id {
+                        commit_id_to_change_id.insert(remote_commit.id, change_id.clone());
+                    }
                     remote_commits_by_id.insert(remote_commit.id, remote_commit);
                 }
                 push_statuses_by_segment_id.insert(segment.id, push_status);
@@ -389,6 +398,7 @@ fn build_status_context<'a>(
             remote_commits_by_id,
             ws.stacks.clone(),
             resolved_target,
+            commit_id_to_change_id,
         )
     };
 
@@ -411,7 +421,11 @@ fn build_status_context<'a>(
         .collect();
     conflicted_paths.sort();
 
-    let id_map = IdMap::new(stacks, worktree_changes.assignments.clone())?;
+    let id_map = IdMap::new(
+        stacks,
+        worktree_changes.assignments.clone(),
+        commit_id_to_change_id,
+    )?;
 
     let stacks = id_map.stacks();
     // Store the count of stacks for hint logic later

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -1354,6 +1354,10 @@ fn print_group(
                     status_ctx,
                     stack_with_id.id,
                     commit.short_id.clone(),
+                    commit
+                        .change_id
+                        .as_ref()
+                        .map(|change_id| change_id.short_id.clone()),
                     inner,
                     CommitChanges::Remote(&details.diff_with_first_parent),
                     CommitClassification::Upstream,
@@ -1383,6 +1387,10 @@ fn print_group(
                     status_ctx,
                     stack_with_id.id,
                     commit.short_id.clone(),
+                    commit
+                        .change_id
+                        .as_ref()
+                        .map(|change_id| change_id.short_id.clone()),
                     &inner.inner,
                     CommitChanges::Workspace(&commit.tree_changes_using_repo(&repo)?),
                     classification,
@@ -1510,6 +1518,7 @@ fn print_commit(
     status_ctx: &StatusContext<'_>,
     stack_id: Option<StackId>,
     short_id: ShortId,
+    short_change_id: Option<ShortId>,
     commit: &but_workspace::ref_info::Commit,
     commit_changes: CommitChanges,
     classification: CommitClassification,
@@ -1530,6 +1539,7 @@ fn print_commit(
     let (details_line, _) = display_cli_commit_details(
         repo,
         short_id.clone(),
+        short_change_id,
         commit,
         match commit_changes {
             CommitChanges::Workspace(tree_changes) => !tree_changes.is_empty(),
@@ -1557,6 +1567,7 @@ fn print_commit(
             Vec::from([Span::raw("┊"), dot, Span::raw(" ")]),
             CommitLineContent {
                 sha: details_line.sha,
+                change_id: details_line.change_id,
                 author: details_line.author,
                 message: details_line.message,
                 suffix: details_line
@@ -1599,6 +1610,7 @@ fn print_commit(
             Vec::from([Span::raw("┊"), dot, Span::raw("   ")]),
             CommitLineContent {
                 sha: details_line.sha,
+                change_id: details_line.change_id,
                 author: details_line.author,
                 message: details_line.message,
                 suffix: details_line
@@ -1691,6 +1703,7 @@ impl CliDisplay for but_core::TreeChange {
 fn display_cli_commit_details(
     repo: &gix::Repository,
     short_id: ShortId,
+    short_change_id: Option<ShortId>,
     commit: &but_workspace::ref_info::Commit,
     has_changes: bool,
     verbose: bool,
@@ -1711,6 +1724,23 @@ fn display_cli_commit_details(
     };
     let start_id = Span::styled(short_id.to_string(), t.cli_id);
 
+    let change_id =
+        if let (Some(short_change_id), Some(change_id)) = (short_change_id, &commit.change_id) {
+            let change_id_str = change_id.to_string();
+            let hint_end = 3.min(change_id_str.len());
+            let hint = change_id_str
+                .get(short_change_id.len()..hint_end)
+                .unwrap_or("")
+                .to_string();
+            vec![
+                Span::styled(short_change_id.to_string(), t.change_id),
+                Span::styled(hint, t.hint),
+                Span::raw(" "),
+            ]
+        } else {
+            vec![]
+        };
+
     let no_changes = if has_changes {
         None
     } else {
@@ -1729,6 +1759,7 @@ fn display_cli_commit_details(
         let formatted_time = created_at.format_or_unix(CLI_DATE);
         (
             CommitLineContent {
+                change_id,
                 sha: Vec::from_iter([start_id, end_id]),
                 author: Vec::from_iter([Span::raw(" "), Span::raw(commit.author.name.to_string())]),
                 message: Vec::new(),
@@ -1747,6 +1778,7 @@ fn display_cli_commit_details(
         (
             CommitLineContent {
                 sha: Vec::from([start_id, end_id]),
+                change_id,
                 author: Vec::new(),
                 message: Vec::from_iter([Span::raw(" "), message]),
                 suffix: maybe_with_leading_space(no_changes, conflicted),
@@ -1774,6 +1806,7 @@ fn maybe_with_leading_space(
 
 fn dim_commit_line_content(content: CommitLineContent) -> CommitLineContent {
     let sha = dim_spans(content.sha);
+    let change_id = dim_spans(content.change_id);
     let mut author = dim_spans(content.author);
     let message = dim_spans(content.message);
     let mut suffix = dim_spans(content.suffix);
@@ -1788,6 +1821,7 @@ fn dim_commit_line_content(content: CommitLineContent) -> CommitLineContent {
 
     CommitLineContent {
         sha,
+        change_id,
         author,
         message,
         suffix,

--- a/crates/but/src/command/legacy/status/output.rs
+++ b/crates/but/src/command/legacy/status/output.rs
@@ -269,6 +269,7 @@ pub(super) enum StatusOutputContent {
 
 #[derive(Debug, Default, Clone)]
 pub(super) struct CommitLineContent {
+    pub(super) change_id: Vec<Span<'static>>,
     pub(super) sha: Vec<Span<'static>>,
     pub(super) author: Vec<Span<'static>>,
     pub(super) message: Vec<Span<'static>>,

--- a/crates/but/src/command/legacy/status/render_oneshot.rs
+++ b/crates/but/src/command/legacy/status/render_oneshot.rs
@@ -32,10 +32,12 @@ pub(super) fn render_oneshot(
         }
         StatusOutputContent::Commit(CommitLineContent {
             mut sha,
+            mut change_id,
             mut author,
             mut message,
             mut suffix,
         }) => {
+            spans.append(&mut change_id);
             spans.append(&mut sha);
             spans.append(&mut author);
             spans.append(&mut message);

--- a/crates/but/src/command/legacy/status/tui/render.rs
+++ b/crates/but/src/command/legacy/status/tui/render.rs
@@ -592,10 +592,13 @@ fn render_status_list_item(
             }
             StatusOutputContent::Commit(CommitLineContent {
                 sha,
+                change_id,
                 author,
                 message,
                 suffix,
             }) => {
+                line.extend(change_id.iter().cloned());
+
                 if line_has_copied_highlight {
                     line.extend(sha.iter().cloned().map(with_highlight));
                 } else if let Mode::Jump(jump_mode) = &*app.mode {

--- a/crates/but/src/command/legacy/status/tui/tests/commit_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/commit_tests.rs
@@ -84,7 +84,7 @@ fn commiting_with_no_uncommitted_changes() {
         ]);
 
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   f184fc7 (no commit message) (no changes)"])
+        .assert_current_line_eq(str!["┊●   1 f184fc7 (no commit message) (no changes)"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/commiting_with_no_uncommitted_changes_003.svg"
         ]);
@@ -117,11 +117,11 @@ fn commit_from_unstaged_changes_creates_commit_visible_in_tui() {
 
     with_var("GIT_EDITOR", Some(editor_command), || {
         tui.input(KeyCode::Enter)
-            .assert_current_line_eq(str!["┊●   48fdc38 commit from tui test"]);
+            .assert_current_line_eq(str!["┊●   1 48fdc38 commit from tui test"]);
     });
 
     tui.reload()
-        .assert_current_line_eq(str!["┊●   48fdc38 commit from tui test"])
+        .assert_current_line_eq(str!["┊●   1 48fdc38 commit from tui test"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/commit_from_unstaged_changes_creates_commit_visible_in_tui_final.svg"
         ]);
@@ -154,11 +154,11 @@ fn commit_from_unstaged_changes_to_new_branch_creates_branch_and_commit() {
 
     with_var("GIT_EDITOR", Some(editor_command), || {
         tui.input('b')
-            .assert_current_line_eq(str!["┊●   48fdc38 commit from tui test"]);
+            .assert_current_line_eq(str!["┊●   1 48fdc38 commit from tui test"]);
     });
 
     tui.reload()
-        .assert_current_line_eq(str!["┊●   48fdc38 commit from tui test"])
+        .assert_current_line_eq(str!["┊●   1 48fdc38 commit from tui test"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/commit_from_unstaged_changes_to_new_branch_creates_branch_and_commit_final.svg"
         ]);
@@ -197,7 +197,7 @@ fn commit_from_unstaged_changes_with_multiple_hunks_in_same_file_commits_all_cha
 
     with_var("GIT_EDITOR", Some(editor_command.clone()), || {
         tui.input(KeyCode::Enter)
-            .assert_current_line_eq(str!["┊●   7f81dac commit from tui test"]);
+            .assert_current_line_eq(str!["┊●   1 7f81dac commit from tui test"]);
     });
 
     let changed = base
@@ -226,7 +226,7 @@ fn commit_from_unstaged_changes_with_multiple_hunks_in_same_file_commits_all_cha
 
     with_var("GIT_EDITOR", Some(editor_command), || {
         tui.input(KeyCode::Enter)
-            .assert_current_line_eq(str!["┊●   ab9015b commit from tui test"]);
+            .assert_current_line_eq(str!["┊●   1#0 ab9015b commit from tui test"]);
     });
 
     let status = tui.env().invoke_git("status --porcelain");
@@ -292,11 +292,11 @@ fn commit_to_commit_above_creates_commit_visible_in_tui() {
 
     with_var("GIT_EDITOR", Some(editor_command), || {
         tui.input(KeyCode::Enter)
-            .assert_current_line_eq(str!["┊●   48fdc38 commit from tui test"]);
+            .assert_current_line_eq(str!["┊●   1 48fdc38 commit from tui test"]);
     });
 
     tui.reload()
-        .assert_current_line_eq(str!["┊●   48fdc38 commit from tui test"])
+        .assert_current_line_eq(str!["┊●   1 48fdc38 commit from tui test"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/commit_to_commit_above_creates_commit_visible_in_tui_final_002.svg"
         ]);
@@ -333,11 +333,11 @@ fn commit_to_commit_below_creates_commit_visible_in_tui() {
 
     with_var("GIT_EDITOR", Some(editor_command), || {
         tui.input(KeyCode::Enter)
-            .assert_current_line_eq(str!["┊●   584b4d0 commit from tui test"]);
+            .assert_current_line_eq(str!["┊●   1 584b4d0 commit from tui test"]);
     });
 
     tui.reload()
-        .assert_current_line_eq(str!["┊●   584b4d0 commit from tui test"])
+        .assert_current_line_eq(str!["┊●   1 584b4d0 commit from tui test"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/commit_to_commit_below_creates_commit_visible_in_tui_final.svg"
         ]);
@@ -429,13 +429,13 @@ fn commit_with_inline_reword() {
         .assert_rendered_term_svg_eq(file!["snapshots/commit_with_inline_reword_004.svg"]);
 
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   6bdd3d2"]);
+        .assert_current_line_eq(str!["┊●   1 6bdd3d2"]);
 
     tui.input("commit message here")
-        .assert_current_line_eq(str!["┊●   6bdd3d2 commit message here"]);
+        .assert_current_line_eq(str!["┊●   1 6bdd3d2 commit message here"]);
 
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   072c144 commit message here"]);
+        .assert_current_line_eq(str!["┊●   1 072c144 commit message here"]);
 }
 
 #[test]

--- a/crates/but/src/command/legacy/status/tui/tests/discard_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/discard_tests.rs
@@ -125,10 +125,10 @@ fn discard_top_commit_selects_next_commit_in_branch() {
         .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   f184fc7 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1 f184fc7 (no commit message) (no changes)"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   9638f28 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1#0 9638f28 (no commit message) (no changes)"]);
 
     tui.input('x')
         .assert_rendered_contains("Discard commit")
@@ -137,7 +137,7 @@ fn discard_top_commit_selects_next_commit_in_branch() {
     tui.input('y');
 
     tui.reload()
-        .assert_current_line_eq(str!["┊●   f184fc7 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1 f184fc7 (no commit message) (no changes)"]);
 }
 
 #[test]
@@ -344,7 +344,7 @@ fn discard_individual_committed_files_from_local_file_list() {
         "snapshots/discard_individual_committed_files_from_local_file_list_006.svg"
     ]);
     tui.input('y')
-        .assert_current_line_eq(str![["┊●   0b42c46 (no commit message) (no changes)"]])
+        .assert_current_line_eq(str!["┊●   1 0b42c46 (no commit message) (no changes)"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/discard_individual_committed_files_from_local_file_list_007.svg"
         ])
@@ -432,7 +432,7 @@ fn discard_marked_committed_files_from_local_file_list() {
 
     tui.input('x');
     tui.input('y')
-        .assert_current_line_eq(str![["┊●   0b42c46 (no commit message) (no changes)"]])
+        .assert_current_line_eq(str!["┊●   1 0b42c46 (no commit message) (no changes)"])
         .assert_backstack_eq([])
         .assert_rendered_term_svg_eq(file![
             "snapshots/discard_marked_committed_files_from_local_file_list_005.svg"

--- a/crates/but/src/command/legacy/status/tui/tests/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/mod.rs
@@ -529,11 +529,11 @@ fn creating_empty_commits() {
 
     tui.input('n')
         .assert_rendered_term_svg_eq(file!["snapshots/creating_empty_commits_002.svg"])
-        .assert_current_line_eq(str!["┊●   f184fc7 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1 f184fc7 (no commit message) (no changes)"]);
 
     tui.input('n')
         .assert_rendered_term_svg_eq(file!["snapshots/creating_empty_commits_003.svg"])
-        .assert_current_line_eq(str!["┊●   9638f28 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1#0 9638f28 (no commit message) (no changes)"]);
 }
 
 #[test]
@@ -552,7 +552,7 @@ fn inline_reword() {
 
     tui.input('n')
         .assert_rendered_term_svg_eq(file!["snapshots/inline_reword_002.svg"])
-        .assert_current_line_eq(str!["┊●   f184fc7 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1 f184fc7 (no commit message) (no changes)"]);
 
     tui.input(KeyCode::Enter)
         .assert_rendered_term_svg_eq(file!["snapshots/inline_reword_003.svg"]);
@@ -562,7 +562,7 @@ fn inline_reword() {
 
     tui.input(KeyCode::Enter)
         .assert_rendered_term_svg_eq(file!["snapshots/inline_reword_005.svg"])
-        .assert_current_line_eq(str!["┊●   cb96911 foo (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1 cb96911 foo (no changes)"]);
 }
 
 #[test]
@@ -789,7 +789,7 @@ fn rubbing() {
         .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   f184fc7 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1 f184fc7 (no commit message) (no changes)"]);
 
     tui.input([KeyCode::Up, KeyCode::Up])
         .assert_current_line_eq(str!["┊   v A test.txt"]);
@@ -798,7 +798,7 @@ fn rubbing() {
         .assert_current_line_eq(str!["┊   << source >> << noop >> v A test.txt"]);
 
     tui.input(KeyCode::Down).assert_current_line_eq(str![
-        "┊●   << amend >> f184fc7 (no commit message) (no changes)"
+        "┊●   << amend >> 1 f184fc7 (no commit message) (no changes)"
     ]);
 
     tui.input(KeyCode::Down)
@@ -889,12 +889,12 @@ fn commit_file_toggle_on_commit_without_files_is_noop() {
     with_var("GIT_AUTHOR_DATE", Some("2000-01-01T00:00:00Z"), || {
         with_var("GIT_COMMITTER_DATE", Some("2000-01-01T00:00:00Z"), || {
             tui.input('n')
-                .assert_current_line_eq(str!["┊●   f184fc7 (no commit message) (no changes)"]);
+                .assert_current_line_eq(str!["┊●   1 f184fc7 (no commit message) (no changes)"]);
         });
     });
 
     tui.input('f')
-        .assert_current_line_eq(str!["┊●   f184fc7 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1 f184fc7 (no commit message) (no changes)"]);
 
     tui.input([KeyCode::Down, KeyCode::Down, KeyCode::Down])
         .assert_current_line_eq(str!["┴ 0dc3733 (common base) 2000-01-02 add M"])
@@ -1140,7 +1140,7 @@ fn consistent_commit_shas_in_tests() {
 
     tui.input('b');
     tui.input('n')
-        .assert_current_line_eq("┊●   0b42c46 (no commit message) (no changes)");
+        .assert_current_line_eq(str!["┊●   1 0b42c46 (no commit message) (no changes)"]);
 }
 
 #[test]
@@ -1159,12 +1159,12 @@ fn jumping_up_down() {
     }
 
     tui.reload()
-        .assert_current_line_eq("┊●   0856e2b commit #12 (no changes)");
+        .assert_current_line_eq("┊●   1#0 0856e2b commit #12 (no changes)");
 
     tui.input((KeyModifiers::CONTROL, 'd'))
-        .assert_current_line_eq("┊●   f2262ae commit #2 (no changes)");
+        .assert_current_line_eq("┊●   1#10 f2262ae commit #2 (no changes)");
     tui.input((KeyModifiers::CONTROL, 'u'))
-        .assert_current_line_eq("┊●   0856e2b commit #12 (no changes)");
+        .assert_current_line_eq("┊●   1#0 0856e2b commit #12 (no changes)");
 }
 
 #[test]
@@ -1189,7 +1189,7 @@ fn jumping_up_down_non_normal_mode() {
     tui.input('r');
 
     tui.input((KeyModifiers::CONTROL, 'd'))
-        .assert_current_line_eq("┊●   << amend >> 9a7be93 commit #3 (no changes)");
+        .assert_current_line_eq("┊●   << amend >> 1#9 9a7be93 commit #3 (no changes)");
     tui.input((KeyModifiers::CONTROL, 'u'))
         .assert_current_line_eq("╭┄<< source >> << noop >> zz [uncommitted]");
 }

--- a/crates/but/src/command/legacy/status/tui/tests/move_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/move_tests.rs
@@ -49,10 +49,10 @@ fn move_mode_keeps_selected_commit_and_extension_visible_when_scrolled() {
         .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   f184fc7 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1 f184fc7 (no commit message) (no changes)"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   9638f28 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1#0 9638f28 (no commit message) (no changes)"]);
 
     tui.input([KeyCode::Down, KeyCode::Down])
         .assert_current_line_eq(str!["┊●   9477ae7 add A"]);
@@ -80,10 +80,10 @@ fn move_commit_above_other_commit_reorders_tui() {
         .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   f184fc7 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1 f184fc7 (no commit message) (no changes)"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   9638f28 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1#0 9638f28 (no commit message) (no changes)"]);
 
     tui.input([KeyCode::Down, KeyCode::Down])
         .assert_current_line_eq(str!["┊●   9477ae7 add A"]);
@@ -98,7 +98,7 @@ fn move_commit_above_other_commit_reorders_tui() {
         .assert_current_line_eq(str!["┊│   << move commit above >>"]);
 
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   2c72e58 add A"]);
+        .assert_current_line_eq(str!["┊●   tpm 2c72e58 add A"]);
 
     tui = tui.recreate();
     tui.reload().assert_rendered_term_svg_eq(file![
@@ -117,16 +117,16 @@ fn move_commit_down_from_source_selects_next_commit() {
         .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   f184fc7 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1 f184fc7 (no commit message) (no changes)"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   9638f28 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1#0 9638f28 (no commit message) (no changes)"]);
 
     tui.input(KeyCode::Down)
-        .assert_current_line_eq(str!["┊●   f184fc7 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1#1 f184fc7 (no commit message) (no changes)"]);
 
     tui.input('m').assert_current_line_eq(str![
-        "┊●   << source >> << noop >> f184fc7 (no commit message) (no changes)"
+        "┊●   << source >> << noop >> 1#1 f184fc7 (no commit message) (no changes)"
     ]);
 
     tui.input(KeyCode::Down)

--- a/crates/but/src/command/legacy/status/tui/tests/rub_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/rub_tests.rs
@@ -27,7 +27,7 @@ fn rub_api_uncommitted_to_commit() {
         .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   f184fc7 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1 f184fc7 (no commit message) (no changes)"]);
 
     tui.input([KeyCode::Up, KeyCode::Up])
         .assert_current_line_eq(str!["┊   v A test.txt"]);
@@ -36,11 +36,11 @@ fn rub_api_uncommitted_to_commit() {
         .assert_current_line_eq(str!["┊   << source >> << noop >> v A test.txt"]);
 
     tui.input(KeyCode::Down).assert_current_line_eq(str![
-        "┊●   << amend >> f184fc7 (no commit message) (no changes)"
+        "┊●   << amend >> 1 f184fc7 (no commit message) (no changes)"
     ]);
 
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   6bdd3d2 (no commit message)"])
+        .assert_current_line_eq(str!["┊●   1 6bdd3d2 (no commit message)"])
         .assert_rendered_term_svg_eq(file!["snapshots/rub_api_uncommitted_to_commit.svg"]);
 }
 

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_001.svg
@@ -17,11 +17,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">b</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">df06f9</text>
-    <text x="114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="50 58 66" y="78" style="fill:#AA00AA;font-weight:bold;">1#0</text>
+    <text x="82" y="78" style="fill:#0000AA;font-weight:bold;">b</text>
+    <text x="90 98 106 114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">df06f9</text>
+    <text x="146 154 162" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">b:o</text>
     <text x="98" y="96" style="fill:#CCCCCC;">A</text>
@@ -31,11 +32,12 @@
     <text x="98" y="114" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130" y="114" style="fill:#00AA00;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="132" style="fill:#0000AA;font-weight:bold;">4</text>
-    <text x="58 66 74 82 90 98" y="132" style="fill:#CCCCCC;opacity:0.75;">fea983</text>
-    <text x="114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50 58 66" y="132" style="fill:#AA00AA;">1#1</text>
+    <text x="82" y="132" style="fill:#0000AA;font-weight:bold;">4</text>
+    <text x="90 98 106 114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">fea983</text>
+    <text x="146 154 162" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="150" style="fill:#0000AA;font-weight:bold;">4:q</text>
     <text x="98" y="150" style="fill:#CCCCCC;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_002.svg
@@ -18,11 +18,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">df06f9</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50 58 66" y="78" style="fill:#AA00AA;opacity:0.75;">1#0</text>
+    <text x="82" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
+    <text x="90 98 106 114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">df06f9</text>
+    <text x="146 154 162" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">b:o</text>
@@ -33,11 +34,12 @@
     <text x="98" y="114" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="114 122 130" y="114" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">4</text>
-    <text x="58 66 74 82 90 98" y="132" style="fill:#CCCCCC;opacity:0.75;">fea983</text>
-    <text x="114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50 58 66" y="132" style="fill:#AA00AA;opacity:0.75;">1#1</text>
+    <text x="82" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">4</text>
+    <text x="90 98 106 114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">fea983</text>
+    <text x="146 154 162" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">4:q</text>
     <text x="98" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_003.svg
@@ -18,11 +18,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">df06f9</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50 58 66" y="78" style="fill:#AA00AA;opacity:0.75;">1#0</text>
+    <text x="82" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
+    <text x="90 98 106 114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">df06f9</text>
+    <text x="146 154 162" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">b:o</text>
@@ -33,11 +34,12 @@
     <text x="98" y="114" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="114 122 130" y="114" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">4</text>
-    <text x="58 66 74 82 90 98" y="132" style="fill:#CCCCCC;opacity:0.75;">fea983</text>
-    <text x="114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50 58 66" y="132" style="fill:#AA00AA;opacity:0.75;">1#1</text>
+    <text x="82" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">4</text>
+    <text x="90 98 106 114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">fea983</text>
+    <text x="146 154 162" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">4:q</text>
     <text x="98" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_004.svg
@@ -19,11 +19,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">df06f9</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50 58 66" y="78" style="fill:#AA00AA;opacity:0.75;">1#0</text>
+    <text x="82" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
+    <text x="90 98 106 114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">df06f9</text>
+    <text x="146 154 162" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="18" y="96" style="fill:#000000;font-weight:bold;">✔︎</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">b:o</text>
@@ -34,11 +35,12 @@
     <text x="98" y="114" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130" y="114" style="fill:#00AA00;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">4</text>
-    <text x="58 66 74 82 90 98" y="132" style="fill:#CCCCCC;opacity:0.75;">fea983</text>
-    <text x="114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50 58 66" y="132" style="fill:#AA00AA;opacity:0.75;">1#1</text>
+    <text x="82" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">4</text>
+    <text x="90 98 106 114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">fea983</text>
+    <text x="146 154 162" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">4:q</text>
     <text x="98" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_file_toggle_on_commit_without_files_is_noop_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_file_toggle_on_commit_without_files_is_noop_final.svg
@@ -17,13 +17,14 @@
     <text x="66" y="60" style="fill:#00AA00;">A</text>
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">f</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">184fc7</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50" y="78" style="fill:#AA00AA;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">f</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">184fc7</text>
+    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="290 298 306" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="322 330 338 346 354 362 370 378" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">9</text>
     <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">477ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_from_unstaged_changes_creates_commit_visible_in_tui_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_from_unstaged_changes_creates_commit_visible_in_tui_final.svg
@@ -17,12 +17,13 @@
     <text x="66" y="60" style="fill:#00AA00;">A</text>
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">4</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">8fdc38</text>
-    <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;">commit</text>
-    <text x="170 178 186 194" y="78" style="fill:#FFFFFF;font-weight:bold;">from</text>
-    <text x="210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;">tui</text>
-    <text x="242 250 258 266" y="78" style="fill:#FFFFFF;font-weight:bold;">test</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">4</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">8fdc38</text>
+    <text x="130 138 146 154 162 170" y="78" style="fill:#FFFFFF;font-weight:bold;">commit</text>
+    <text x="186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;">from</text>
+    <text x="226 234 242" y="78" style="fill:#FFFFFF;font-weight:bold;">tui</text>
+    <text x="258 266 274 282" y="78" style="fill:#FFFFFF;font-weight:bold;">test</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">9</text>
     <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">477ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_from_unstaged_changes_to_new_branch_creates_branch_and_commit_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_from_unstaged_changes_to_new_branch_creates_branch_and_commit_final.svg
@@ -17,12 +17,13 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">4</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">8fdc38</text>
-    <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;">commit</text>
-    <text x="170 178 186 194" y="78" style="fill:#FFFFFF;font-weight:bold;">from</text>
-    <text x="210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;">tui</text>
-    <text x="242 250 258 266" y="78" style="fill:#FFFFFF;font-weight:bold;">test</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">4</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">8fdc38</text>
+    <text x="130 138 146 154 162 170" y="78" style="fill:#FFFFFF;font-weight:bold;">commit</text>
+    <text x="186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;">from</text>
+    <text x="226 234 242" y="78" style="fill:#FFFFFF;font-weight:bold;">tui</text>
+    <text x="258 266 274 282" y="78" style="fill:#FFFFFF;font-weight:bold;">test</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊├┄</text>
     <text x="34 42" y="114" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_commit_above_creates_commit_visible_in_tui_final_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_commit_above_creates_commit_visible_in_tui_final_002.svg
@@ -17,12 +17,13 @@
     <text x="66" y="60" style="fill:#00AA00;">A</text>
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">4</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">8fdc38</text>
-    <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;">commit</text>
-    <text x="170 178 186 194" y="78" style="fill:#FFFFFF;font-weight:bold;">from</text>
-    <text x="210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;">tui</text>
-    <text x="242 250 258 266" y="78" style="fill:#FFFFFF;font-weight:bold;">test</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">4</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">8fdc38</text>
+    <text x="130 138 146 154 162 170" y="78" style="fill:#FFFFFF;font-weight:bold;">commit</text>
+    <text x="186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;">from</text>
+    <text x="226 234 242" y="78" style="fill:#FFFFFF;font-weight:bold;">tui</text>
+    <text x="258 266 274 282" y="78" style="fill:#FFFFFF;font-weight:bold;">test</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">9</text>
     <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">477ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_commit_below_creates_commit_visible_in_tui_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_commit_below_creates_commit_visible_in_tui_final.svg
@@ -17,17 +17,20 @@
     <text x="66" y="60" style="fill:#00AA00;">A</text>
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">c</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">1d8a48</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;">add</text>
-    <text x="146" y="78" style="fill:#CCCCCC;">A</text>
+    <text x="50" y="78" style="fill:#AA00AA;">t</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">pm</text>
+    <text x="82" y="78" style="fill:#0000AA;font-weight:bold;">c</text>
+    <text x="90 98 106 114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">1d8a48</text>
+    <text x="146 154 162" y="78" style="fill:#CCCCCC;">add</text>
+    <text x="178" y="78" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">5</text>
-    <text x="58 66 74 82 90 98" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">84b4d0</text>
-    <text x="114 122 130 138 146 154" y="96" style="fill:#FFFFFF;font-weight:bold;">commit</text>
-    <text x="170 178 186 194" y="96" style="fill:#FFFFFF;font-weight:bold;">from</text>
-    <text x="210 218 226" y="96" style="fill:#FFFFFF;font-weight:bold;">tui</text>
-    <text x="242 250 258 266" y="96" style="fill:#FFFFFF;font-weight:bold;">test</text>
+    <text x="50" y="96" style="fill:#AA00AA;font-weight:bold;">1</text>
+    <text x="66" y="96" style="fill:#0000AA;font-weight:bold;">5</text>
+    <text x="74 82 90 98 106 114" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">84b4d0</text>
+    <text x="130 138 146 154 162 170" y="96" style="fill:#FFFFFF;font-weight:bold;">commit</text>
+    <text x="186 194 202 210" y="96" style="fill:#FFFFFF;font-weight:bold;">from</text>
+    <text x="226 234 242" y="96" style="fill:#FFFFFF;font-weight:bold;">tui</text>
+    <text x="258 266 274 282" y="96" style="fill:#FFFFFF;font-weight:bold;">test</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_new_branch_from_uncommitted_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_new_branch_from_uncommitted_001.svg
@@ -17,11 +17,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">2</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">d299ac</text>
-    <text x="114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">2</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">d299ac</text>
+    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commiting_with_no_uncommitted_changes_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commiting_with_no_uncommitted_changes_003.svg
@@ -17,13 +17,14 @@
     <text x="66" y="60" style="fill:#00AA00;">A</text>
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">f</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">184fc7</text>
-    <text x="114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">f</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">184fc7</text>
+    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="290 298 306" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="322 330 338 346 354 362 370 378" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">9</text>
     <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">477ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/creating_empty_commits_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/creating_empty_commits_002.svg
@@ -17,13 +17,14 @@
     <text x="66" y="60" style="fill:#00AA00;">A</text>
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">f</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">184fc7</text>
-    <text x="114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">f</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">184fc7</text>
+    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="290 298 306" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="322 330 338 346 354 362 370 378" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">9</text>
     <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">477ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/creating_empty_commits_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/creating_empty_commits_003.svg
@@ -17,21 +17,23 @@
     <text x="66" y="60" style="fill:#00AA00;">A</text>
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50 58" y="78" style="fill:#0000AA;font-weight:bold;">96</text>
-    <text x="66 74 82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">38f28</text>
-    <text x="114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="50 58 66" y="78" style="fill:#AA00AA;font-weight:bold;">1#0</text>
+    <text x="82 90" y="78" style="fill:#0000AA;font-weight:bold;">96</text>
+    <text x="98 106 114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">38f28</text>
+    <text x="146 154 162" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="306 314 322" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="338 346 354 362 370 378 386 394" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">f</text>
-    <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">184fc7</text>
-    <text x="114 122 130" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50 58 66" y="96" style="fill:#AA00AA;">1#1</text>
+    <text x="82" y="96" style="fill:#0000AA;font-weight:bold;">f</text>
+    <text x="90 98 106 114 122 130" y="96" style="fill:#CCCCCC;opacity:0.75;">184fc7</text>
+    <text x="146 154 162" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="306 314 322" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="338 346 354 362 370 378 386 394" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58" y="114" style="fill:#0000AA;font-weight:bold;">94</text>
     <text x="66 74 82 90 98" y="114" style="fill:#CCCCCC;opacity:0.75;">77ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_001.svg
@@ -31,11 +31,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="132" style="fill:#00AA00;">c-branch-1</text>
     <text x="146" y="132" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="150" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="150" style="fill:#0000AA;font-weight:bold;">0</text>
-    <text x="58 66 74 82 90 98" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">0d0cfb</text>
-    <text x="114 122 130" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="50" y="150" style="fill:#AA00AA;font-weight:bold;">1</text>
+    <text x="66" y="150" style="fill:#0000AA;font-weight:bold;">0</text>
+    <text x="74 82 90 98 106 114" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">0d0cfb</text>
+    <text x="130 138 146" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_002.svg
@@ -31,11 +31,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="132" style="fill:#00AA00;">c-branch-1</text>
     <text x="146" y="132" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="150" style="fill:#0000AA;font-weight:bold;">0</text>
-    <text x="58 66 74 82 90 98" y="150" style="fill:#CCCCCC;opacity:0.75;">0d0cfb</text>
-    <text x="114 122 130" y="150" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="150" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="150" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="150" style="fill:#AA00AA;">1</text>
+    <text x="66" y="150" style="fill:#0000AA;font-weight:bold;">0</text>
+    <text x="74 82 90 98 106 114" y="150" style="fill:#CCCCCC;opacity:0.75;">0d0cfb</text>
+    <text x="130 138 146" y="150" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="150" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="150" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_003.svg
@@ -54,11 +54,12 @@
     <text x="482 490 498 506" y="132" style="fill:#CCCCCC;opacity:0.75;">+1,4</text>
     <text x="522 530" y="132" style="fill:#CCCCCC;opacity:0.75;">@@</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="150" style="fill:#0000AA;font-weight:bold;">0</text>
-    <text x="58 66 74 82 90 98" y="150" style="fill:#CCCCCC;opacity:0.75;">0d0cfb</text>
-    <text x="114 122 130" y="150" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="150" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="150" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="150" style="fill:#AA00AA;">1</text>
+    <text x="66" y="150" style="fill:#0000AA;font-weight:bold;">0</text>
+    <text x="74 82 90 98 106 114" y="150" style="fill:#CCCCCC;opacity:0.75;">0d0cfb</text>
+    <text x="130 138 146" y="150" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="150" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="150" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="410" y="150" style="fill:#FFA500;">▌</text>
     <text x="418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="150" style="fill:#555555;">───────────────</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_004.svg
@@ -49,11 +49,12 @@
     <text x="410" y="114" style="fill:#555555;">│</text>
     <text x="802" y="114" style="fill:#555555;">█</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="132" style="fill:#0000AA;font-weight:bold;">0</text>
-    <text x="58 66 74 82 90 98" y="132" style="fill:#CCCCCC;opacity:0.75;">0d0cfb</text>
-    <text x="114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="132" style="fill:#AA00AA;">1</text>
+    <text x="66" y="132" style="fill:#0000AA;font-weight:bold;">0</text>
+    <text x="74 82 90 98 106 114" y="132" style="fill:#CCCCCC;opacity:0.75;">0d0cfb</text>
+    <text x="130 138 146" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="410" y="132" style="fill:#555555;">│</text>
     <text x="418 426" y="132" style="fill:#CCCCCC;opacity:0.75;">@@</text>
     <text x="442 450 458 466" y="132" style="fill:#CCCCCC;opacity:0.75;">-1,0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_001.svg
@@ -17,11 +17,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">b</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">1c0d33</text>
-    <text x="114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">b</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">1c0d33</text>
+    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">b:k</text>
     <text x="98" y="96" style="fill:#CCCCCC;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_002.svg
@@ -20,11 +20,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">b</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">1c0d33</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">b</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">1c0d33</text>
+    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74" y="96" style="fill:#000000;font-weight:bold;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130 138" y="96" style="fill:#000000;font-weight:bold;">discard</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_003.svg
@@ -17,11 +17,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">5</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">fbe863</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">5</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">fbe863</text>
+    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">5:o</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_004.svg
@@ -17,11 +17,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">c</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">0dfd4e</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">c</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">0dfd4e</text>
+    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">c:t</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_005.svg
@@ -17,13 +17,14 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">0</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">b42c46</text>
-    <text x="114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">0</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">b42c46</text>
+    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="290 298 306" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="322 330 338 346 354 362 370 378" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_001.svg
@@ -17,11 +17,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">1c0d33</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">1c0d33</text>
+    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">b:k</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_002.svg
@@ -20,11 +20,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">1c0d33</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">1c0d33</text>
+    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74" y="96" style="fill:#000000;font-weight:bold;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130 138" y="96" style="fill:#000000;font-weight:bold;">discard</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_003.svg
@@ -17,11 +17,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">5</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">fbe863</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">5</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">fbe863</text>
+    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">5:o</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_004.svg
@@ -18,11 +18,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">5</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">fbe863</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">5</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">fbe863</text>
+    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">5:o</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_005.svg
@@ -17,11 +17,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">c</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">0dfd4e</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">c</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">0dfd4e</text>
+    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">c:t</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_006.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_006.svg
@@ -18,11 +18,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">c</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">0dfd4e</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">c</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">0dfd4e</text>
+    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">c:t</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_007.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_007.svg
@@ -17,13 +17,14 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">0</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">b42c46</text>
-    <text x="114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">0</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">b42c46</text>
+    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="290 298 306" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="322 330 338 346 354 362 370 378" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_001.svg
@@ -17,11 +17,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">b</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">1c0d33</text>
-    <text x="114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">b</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">1c0d33</text>
+    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">b:k</text>
     <text x="98" y="96" style="fill:#CCCCCC;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_002.svg
@@ -19,11 +19,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">1c0d33</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">1c0d33</text>
+    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">b:k</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_003.svg
@@ -22,11 +22,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">1c0d33</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">1c0d33</text>
+    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="66 74" y="96" style="fill:#000000;">&lt;&lt;</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_004.svg
@@ -17,11 +17,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">c</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">0dfd4e</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">c</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">0dfd4e</text>
+    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">c:t</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_005.svg
@@ -17,11 +17,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">c</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">0dfd4e</text>
-    <text x="114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">c</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">0dfd4e</text>
+    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">c:t</text>
     <text x="98" y="96" style="fill:#CCCCCC;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_001.svg
@@ -17,11 +17,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">1c0d33</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">1c0d33</text>
+    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">b:k</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_002.svg
@@ -19,11 +19,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">1c0d33</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">1c0d33</text>
+    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">b:k</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_003.svg
@@ -22,11 +22,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">1c0d33</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">1c0d33</text>
+    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="66 74" y="96" style="fill:#000000;">&lt;&lt;</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_004.svg
@@ -17,11 +17,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">c</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">0dfd4e</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">c</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">0dfd4e</text>
+    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">c:t</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_005.svg
@@ -17,13 +17,14 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">0</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">b42c46</text>
-    <text x="114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">0</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">b42c46</text>
+    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="290 298 306" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="322 330 338 346 354 362 370 378" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_multiple_commits_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_multiple_commits_final.svg
@@ -17,11 +17,12 @@
     <text x="66 74 82 90 98 106 114 122 130 138" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">0</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">707139</text>
-    <text x="114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;">two</text>
-    <text x="146 154 162" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218 226 234" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">0</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">707139</text>
+    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;">two</text>
+    <text x="162 170 178" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="194 202 210 218 226 234 242 250" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/inline_reword_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/inline_reword_002.svg
@@ -17,13 +17,14 @@
     <text x="66" y="60" style="fill:#00AA00;">A</text>
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">f</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">184fc7</text>
-    <text x="114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">f</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">184fc7</text>
+    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="290 298 306" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="322 330 338 346 354 362 370 378" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">9</text>
     <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">477ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/inline_reword_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/inline_reword_003.svg
@@ -17,8 +17,9 @@
     <text x="66" y="60" style="fill:#00AA00;">A</text>
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">f</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">184fc7</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">f</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">184fc7</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">9</text>
     <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">477ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/inline_reword_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/inline_reword_004.svg
@@ -17,9 +17,10 @@
     <text x="66" y="60" style="fill:#00AA00;">A</text>
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">f</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">184fc7</text>
-    <text x="114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;">foo</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">f</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">184fc7</text>
+    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;">foo</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">9</text>
     <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">477ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/inline_reword_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/inline_reword_005.svg
@@ -17,11 +17,12 @@
     <text x="66" y="60" style="fill:#00AA00;">A</text>
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">c</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">b96911</text>
-    <text x="114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;">foo</text>
-    <text x="146 154 162" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218 226 234" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">c</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">b96911</text>
+    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;">foo</text>
+    <text x="162 170 178" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="194 202 210 218 226 234 242 250" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">9</text>
     <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">477ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/mark_and_commit_multiple_uncommitted_files_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/mark_and_commit_multiple_uncommitted_files_final.svg
@@ -19,11 +19,12 @@
     <text x="66" y="78" style="fill:#00AA00;">A</text>
     <text x="74" y="78" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">f</text>
-    <text x="58 66 74 82 90 98" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">4a3970</text>
-    <text x="114 122 130" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="50" y="96" style="fill:#AA00AA;font-weight:bold;">1</text>
+    <text x="66" y="96" style="fill:#0000AA;font-weight:bold;">f</text>
+    <text x="74 82 90 98 106 114" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">4a3970</text>
+    <text x="130 138 146" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">f:k</text>
     <text x="98" y="114" style="fill:#CCCCCC;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_are_maintained_after_leaving_rub_mode_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_are_maintained_after_leaving_rub_mode_001.svg
@@ -17,29 +17,32 @@
     <text x="66" y="60" style="fill:#00AA00;">A</text>
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50 58" y="78" style="fill:#0000AA;font-weight:bold;">fe</text>
-    <text x="66 74 82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">c7f68</text>
-    <text x="114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="50 58 66" y="78" style="fill:#AA00AA;font-weight:bold;">1#0</text>
+    <text x="82 90" y="78" style="fill:#0000AA;font-weight:bold;">fe</text>
+    <text x="98 106 114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">c7f68</text>
+    <text x="146 154 162" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="306 314 322" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="338 346 354 362 370 378 386 394" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58" y="96" style="fill:#0000AA;font-weight:bold;">96</text>
-    <text x="66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">38f28</text>
-    <text x="114 122 130" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50 58 66" y="96" style="fill:#AA00AA;">1#1</text>
+    <text x="82 90" y="96" style="fill:#0000AA;font-weight:bold;">96</text>
+    <text x="98 106 114 122 130" y="96" style="fill:#CCCCCC;opacity:0.75;">38f28</text>
+    <text x="146 154 162" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="306 314 322" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="338 346 354 362 370 378 386 394" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58" y="114" style="fill:#0000AA;font-weight:bold;">f1</text>
-    <text x="66 74 82 90 98" y="114" style="fill:#CCCCCC;opacity:0.75;">84fc7</text>
-    <text x="114 122 130" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50 58 66" y="114" style="fill:#AA00AA;">1#2</text>
+    <text x="82 90" y="114" style="fill:#0000AA;font-weight:bold;">f1</text>
+    <text x="98 106 114 122 130" y="114" style="fill:#CCCCCC;opacity:0.75;">84fc7</text>
+    <text x="146 154 162" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="306 314 322" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="338 346 354 362 370 378 386 394" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58" y="132" style="fill:#0000AA;font-weight:bold;">94</text>
     <text x="66 74 82 90 98" y="132" style="fill:#CCCCCC;opacity:0.75;">77ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_are_maintained_after_leaving_rub_mode_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_are_maintained_after_leaving_rub_mode_002.svg
@@ -21,31 +21,34 @@
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="78" style="fill:#000000;">✔︎</text>
-    <text x="50 58" y="78" style="fill:#0000AA;font-weight:bold;">fe</text>
-    <text x="66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">c7f68</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50 58 66" y="78" style="fill:#AA00AA;">1#0</text>
+    <text x="82 90" y="78" style="fill:#0000AA;font-weight:bold;">fe</text>
+    <text x="98 106 114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">c7f68</text>
+    <text x="146 154 162" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="306 314 322" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="338 346 354 362 370 378 386 394" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
-    <text x="50 58" y="96" style="fill:#0000AA;font-weight:bold;">96</text>
-    <text x="66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">38f28</text>
-    <text x="114 122 130" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50 58 66" y="96" style="fill:#AA00AA;">1#1</text>
+    <text x="82 90" y="96" style="fill:#0000AA;font-weight:bold;">96</text>
+    <text x="98 106 114 122 130" y="96" style="fill:#CCCCCC;opacity:0.75;">38f28</text>
+    <text x="146 154 162" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="306 314 322" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="338 346 354 362 370 378 386 394" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
-    <text x="50 58" y="114" style="fill:#0000AA;font-weight:bold;">f1</text>
-    <text x="66 74 82 90 98" y="114" style="fill:#CCCCCC;opacity:0.75;">84fc7</text>
-    <text x="114 122 130" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50 58 66" y="114" style="fill:#AA00AA;">1#2</text>
+    <text x="82 90" y="114" style="fill:#0000AA;font-weight:bold;">f1</text>
+    <text x="98 106 114 122 130" y="114" style="fill:#CCCCCC;opacity:0.75;">84fc7</text>
+    <text x="146 154 162" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="306 314 322" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="338 346 354 362 370 378 386 394" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="132" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50 58" y="132" style="fill:#0000AA;font-weight:bold;">94</text>
     <text x="66 74 82 90 98" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">77ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_are_maintained_after_leaving_rub_mode_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_are_maintained_after_leaving_rub_mode_003.svg
@@ -29,37 +29,40 @@
     <text x="50 58" y="78" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="78" style="fill:#FFFFFF;">&gt;&gt;</text>
-    <text x="154 162" y="78" style="fill:#0000AA;font-weight:bold;">fe</text>
-    <text x="170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">c7f68</text>
-    <text x="218 226 234" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="250 258 266 274 282 290" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="306 314 322 330 338 346 354 362" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="378 386 394" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="410 418 426 434 442 450 458 466" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="154 162 170" y="78" style="fill:#AA00AA;">1#0</text>
+    <text x="186 194" y="78" style="fill:#0000AA;font-weight:bold;">fe</text>
+    <text x="202 210 218 226 234" y="78" style="fill:#CCCCCC;opacity:0.75;">c7f68</text>
+    <text x="250 258 266" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="282 290 298 306 314 322" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="338 346 354 362 370 378 386 394" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="410 418 426" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="442 450 458 466 474 482 490 498" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="50 58" y="96" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="96" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="96" style="fill:#FFFFFF;">&gt;&gt;</text>
-    <text x="154 162" y="96" style="fill:#0000AA;font-weight:bold;">96</text>
-    <text x="170 178 186 194 202" y="96" style="fill:#CCCCCC;opacity:0.75;">38f28</text>
-    <text x="218 226 234" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="250 258 266 274 282 290" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="306 314 322 330 338 346 354 362" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="378 386 394" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="410 418 426 434 442 450 458 466" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="154 162 170" y="96" style="fill:#AA00AA;">1#1</text>
+    <text x="186 194" y="96" style="fill:#0000AA;font-weight:bold;">96</text>
+    <text x="202 210 218 226 234" y="96" style="fill:#CCCCCC;opacity:0.75;">38f28</text>
+    <text x="250 258 266" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="282 290 298 306 314 322" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="338 346 354 362 370 378 386 394" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="410 418 426" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="442 450 458 466 474 482 490 498" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
     <text x="50 58" y="114" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="114" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="114" style="fill:#FFFFFF;">&gt;&gt;</text>
-    <text x="154 162" y="114" style="fill:#0000AA;font-weight:bold;">f1</text>
-    <text x="170 178 186 194 202" y="114" style="fill:#CCCCCC;opacity:0.75;">84fc7</text>
-    <text x="218 226 234" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="250 258 266 274 282 290" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="306 314 322 330 338 346 354 362" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="378 386 394" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="410 418 426 434 442 450 458 466" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="154 162 170" y="114" style="fill:#AA00AA;">1#2</text>
+    <text x="186 194" y="114" style="fill:#0000AA;font-weight:bold;">f1</text>
+    <text x="202 210 218 226 234" y="114" style="fill:#CCCCCC;opacity:0.75;">84fc7</text>
+    <text x="250 258 266" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="282 290 298 306 314 322" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="338 346 354 362 370 378 386 394" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="410 418 426" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="442 450 458 466 474 482 490 498" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="132" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50 58" y="132" style="fill:#000000;font-weight:bold;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="132" style="fill:#000000;font-weight:bold;">squash</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_are_maintained_after_leaving_rub_mode_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_are_maintained_after_leaving_rub_mode_004.svg
@@ -21,31 +21,34 @@
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="78" style="fill:#000000;">✔︎</text>
-    <text x="50 58" y="78" style="fill:#0000AA;font-weight:bold;">fe</text>
-    <text x="66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">c7f68</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50 58 66" y="78" style="fill:#AA00AA;">1#0</text>
+    <text x="82 90" y="78" style="fill:#0000AA;font-weight:bold;">fe</text>
+    <text x="98 106 114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">c7f68</text>
+    <text x="146 154 162" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="306 314 322" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="338 346 354 362 370 378 386 394" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
-    <text x="50 58" y="96" style="fill:#0000AA;font-weight:bold;">96</text>
-    <text x="66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">38f28</text>
-    <text x="114 122 130" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50 58 66" y="96" style="fill:#AA00AA;">1#1</text>
+    <text x="82 90" y="96" style="fill:#0000AA;font-weight:bold;">96</text>
+    <text x="98 106 114 122 130" y="96" style="fill:#CCCCCC;opacity:0.75;">38f28</text>
+    <text x="146 154 162" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="306 314 322" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="338 346 354 362 370 378 386 394" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
-    <text x="50 58" y="114" style="fill:#0000AA;font-weight:bold;">f1</text>
-    <text x="66 74 82 90 98" y="114" style="fill:#CCCCCC;opacity:0.75;">84fc7</text>
-    <text x="114 122 130" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50 58 66" y="114" style="fill:#AA00AA;">1#2</text>
+    <text x="82 90" y="114" style="fill:#0000AA;font-weight:bold;">f1</text>
+    <text x="98 106 114 122 130" y="114" style="fill:#CCCCCC;opacity:0.75;">84fc7</text>
+    <text x="146 154 162" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="306 314 322" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="338 346 354 362 370 378 386 394" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="132" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50 58" y="132" style="fill:#0000AA;font-weight:bold;">94</text>
     <text x="66 74 82 90 98" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">77ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/move_branch_onto_other_branch_reorders_stacks_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/move_branch_onto_other_branch_reorders_stacks_final.svg
@@ -17,10 +17,12 @@
     <text x="66" y="60" style="fill:#00AA00;">C</text>
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">a</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">72ac5a</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;">add</text>
-    <text x="146" y="78" style="fill:#CCCCCC;">C</text>
+    <text x="50" y="78" style="fill:#AA00AA;">x</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">wn</text>
+    <text x="82" y="78" style="fill:#0000AA;font-weight:bold;">a</text>
+    <text x="90 98 106 114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">72ac5a</text>
+    <text x="146 154 162" y="78" style="fill:#CCCCCC;">add</text>
+    <text x="178" y="78" style="fill:#CCCCCC;">C</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊├┄</text>
     <text x="34 42" y="114" style="fill:#0000AA;font-weight:bold;">h0</text>
@@ -28,10 +30,12 @@
     <text x="66" y="114" style="fill:#00AA00;">A</text>
     <text x="74" y="114" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="132" style="fill:#0000AA;font-weight:bold;">b</text>
-    <text x="58 66 74 82 90 98" y="132" style="fill:#CCCCCC;opacity:0.75;">4162d1</text>
-    <text x="114 122 130" y="132" style="fill:#CCCCCC;">add</text>
-    <text x="146" y="132" style="fill:#CCCCCC;">A</text>
+    <text x="50" y="132" style="fill:#AA00AA;">t</text>
+    <text x="58 66" y="132" style="fill:#CCCCCC;opacity:0.75;">pm</text>
+    <text x="82" y="132" style="fill:#0000AA;font-weight:bold;">b</text>
+    <text x="90 98 106 114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">4162d1</text>
+    <text x="146 154 162" y="132" style="fill:#CCCCCC;">add</text>
+    <text x="178" y="132" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
     <text x="10 18 26" y="168" style="fill:#CCCCCC;">┊├┄</text>
     <text x="34 42" y="168" style="fill:#0000AA;font-weight:bold;">i0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/move_branch_to_merge_base_tears_off_branch_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/move_branch_to_merge_base_tears_off_branch_final.svg
@@ -41,10 +41,12 @@
     <text x="66" y="204" style="fill:#00AA00;">C</text>
     <text x="74" y="204" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="222" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="222" style="fill:#0000AA;font-weight:bold;">2</text>
-    <text x="58 66 74 82 90 98" y="222" style="fill:#CCCCCC;opacity:0.75;">0b5eda</text>
-    <text x="114 122 130" y="222" style="fill:#CCCCCC;">add</text>
-    <text x="146" y="222" style="fill:#CCCCCC;">C</text>
+    <text x="50" y="222" style="fill:#AA00AA;">x</text>
+    <text x="58 66" y="222" style="fill:#CCCCCC;opacity:0.75;">wn</text>
+    <text x="82" y="222" style="fill:#0000AA;font-weight:bold;">2</text>
+    <text x="90 98 106 114 122 130" y="222" style="fill:#CCCCCC;opacity:0.75;">0b5eda</text>
+    <text x="146 154 162" y="222" style="fill:#CCCCCC;">add</text>
+    <text x="178" y="222" style="fill:#CCCCCC;">C</text>
     <text x="10 18" y="240" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="258" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="276" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/move_commit_above_other_commit_reorders_tui_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/move_commit_above_other_commit_reorders_tui_final.svg
@@ -17,26 +17,30 @@
     <text x="66" y="60" style="fill:#00AA00;">A</text>
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">2</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">c72e58</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;">add</text>
-    <text x="146" y="78" style="fill:#CCCCCC;">A</text>
+    <text x="50" y="78" style="fill:#AA00AA;">t</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">pm</text>
+    <text x="82" y="78" style="fill:#0000AA;font-weight:bold;">2</text>
+    <text x="90 98 106 114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">c72e58</text>
+    <text x="146 154 162" y="78" style="fill:#CCCCCC;">add</text>
+    <text x="178" y="78" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">7</text>
-    <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">149602</text>
-    <text x="114 122 130" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50 58 66" y="96" style="fill:#AA00AA;">1#0</text>
+    <text x="82" y="96" style="fill:#0000AA;font-weight:bold;">7</text>
+    <text x="90 98 106 114 122 130" y="96" style="fill:#CCCCCC;opacity:0.75;">149602</text>
+    <text x="146 154 162" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="306 314 322" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="338 346 354 362 370 378 386 394" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="114" style="fill:#0000AA;font-weight:bold;">0</text>
-    <text x="58 66 74 82 90 98" y="114" style="fill:#CCCCCC;opacity:0.75;">b42c46</text>
-    <text x="114 122 130" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50 58 66" y="114" style="fill:#AA00AA;">1#1</text>
+    <text x="82" y="114" style="fill:#0000AA;font-weight:bold;">0</text>
+    <text x="90 98 106 114 122 130" y="114" style="fill:#CCCCCC;opacity:0.75;">b42c46</text>
+    <text x="146 154 162" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="306 314 322" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="338 346 354 362 370 378 386 394" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/moves_the_cursor_back_to_a_valid_location_when_going_back_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/moves_the_cursor_back_to_a_valid_location_when_going_back_001.svg
@@ -19,29 +19,32 @@
     <text x="66" y="78" style="fill:#00AA00;">A</text>
     <text x="74" y="78" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50 58" y="96" style="fill:#0000AA;font-weight:bold;">fe</text>
-    <text x="66 74 82 90 98" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">c7f68</text>
-    <text x="114 122 130" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="50 58 66" y="96" style="fill:#AA00AA;font-weight:bold;">1#0</text>
+    <text x="82 90" y="96" style="fill:#0000AA;font-weight:bold;">fe</text>
+    <text x="98 106 114 122 130" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">c7f68</text>
+    <text x="146 154 162" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="306 314 322" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="338 346 354 362 370 378 386 394" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58" y="114" style="fill:#0000AA;font-weight:bold;">96</text>
-    <text x="66 74 82 90 98" y="114" style="fill:#CCCCCC;opacity:0.75;">38f28</text>
-    <text x="114 122 130" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50 58 66" y="114" style="fill:#AA00AA;">1#1</text>
+    <text x="82 90" y="114" style="fill:#0000AA;font-weight:bold;">96</text>
+    <text x="98 106 114 122 130" y="114" style="fill:#CCCCCC;opacity:0.75;">38f28</text>
+    <text x="146 154 162" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="306 314 322" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="338 346 354 362 370 378 386 394" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58" y="132" style="fill:#0000AA;font-weight:bold;">f1</text>
-    <text x="66 74 82 90 98" y="132" style="fill:#CCCCCC;opacity:0.75;">84fc7</text>
-    <text x="114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="132" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50 58 66" y="132" style="fill:#AA00AA;">1#2</text>
+    <text x="82 90" y="132" style="fill:#0000AA;font-weight:bold;">f1</text>
+    <text x="98 106 114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">84fc7</text>
+    <text x="146 154 162" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="306 314 322" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="338 346 354 362 370 378 386 394" y="132" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58" y="150" style="fill:#0000AA;font-weight:bold;">94</text>
     <text x="66 74 82 90 98" y="150" style="fill:#CCCCCC;opacity:0.75;">77ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/moves_the_cursor_back_to_a_valid_location_when_going_back_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/moves_the_cursor_back_to_a_valid_location_when_going_back_002.svg
@@ -29,36 +29,39 @@
     <text x="50 58" y="96" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="96" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="96" style="fill:#FFFFFF;">&gt;&gt;</text>
-    <text x="154 162" y="96" style="fill:#0000AA;font-weight:bold;">fe</text>
-    <text x="170 178 186 194 202" y="96" style="fill:#CCCCCC;opacity:0.75;">c7f68</text>
-    <text x="218 226 234" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="250 258 266 274 282 290" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="306 314 322 330 338 346 354 362" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="378 386 394" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="410 418 426 434 442 450 458 466" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="154 162 170" y="96" style="fill:#AA00AA;">1#0</text>
+    <text x="186 194" y="96" style="fill:#0000AA;font-weight:bold;">fe</text>
+    <text x="202 210 218 226 234" y="96" style="fill:#CCCCCC;opacity:0.75;">c7f68</text>
+    <text x="250 258 266" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="282 290 298 306 314 322" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="338 346 354 362 370 378 386 394" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="410 418 426" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="442 450 458 466 474 482 490 498" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
     <text x="50 58" y="114" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="114" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="114" style="fill:#FFFFFF;">&gt;&gt;</text>
-    <text x="154 162" y="114" style="fill:#0000AA;font-weight:bold;">96</text>
-    <text x="170 178 186 194 202" y="114" style="fill:#CCCCCC;opacity:0.75;">38f28</text>
-    <text x="218 226 234" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="250 258 266 274 282 290" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="306 314 322 330 338 346 354 362" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="378 386 394" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="410 418 426 434 442 450 458 466" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="154 162 170" y="114" style="fill:#AA00AA;">1#1</text>
+    <text x="186 194" y="114" style="fill:#0000AA;font-weight:bold;">96</text>
+    <text x="202 210 218 226 234" y="114" style="fill:#CCCCCC;opacity:0.75;">38f28</text>
+    <text x="250 258 266" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="282 290 298 306 314 322" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="338 346 354 362 370 378 386 394" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="410 418 426" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="442 450 458 466 474 482 490 498" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="132" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50 58" y="132" style="fill:#000000;font-weight:bold;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="132" style="fill:#000000;font-weight:bold;">squash</text>
     <text x="130 138" y="132" style="fill:#000000;font-weight:bold;">&gt;&gt;</text>
-    <text x="154 162" y="132" style="fill:#0000AA;font-weight:bold;">f1</text>
-    <text x="170 178 186 194 202" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">84fc7</text>
-    <text x="218 226 234" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="250 258 266 274 282 290" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="306 314 322 330 338 346 354 362" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="378 386 394" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="410 418 426 434 442 450 458 466" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="154 162 170" y="132" style="fill:#AA00AA;font-weight:bold;">1#2</text>
+    <text x="186 194" y="132" style="fill:#0000AA;font-weight:bold;">f1</text>
+    <text x="202 210 218 226 234" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">84fc7</text>
+    <text x="250 258 266" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="282 290 298 306 314 322" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="338 346 354 362 370 378 386 394" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="410 418 426" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="442 450 458 466 474 482 490 498" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58" y="150" style="fill:#0000AA;font-weight:bold;">94</text>
     <text x="66 74 82 90 98" y="150" style="fill:#CCCCCC;opacity:0.75;">77ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/moves_the_cursor_back_to_a_valid_location_when_going_back_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/moves_the_cursor_back_to_a_valid_location_when_going_back_003.svg
@@ -33,33 +33,36 @@
     <text x="50 58" y="96" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="96" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="96" style="fill:#FFFFFF;">&gt;&gt;</text>
-    <text x="154 162" y="96" style="fill:#0000AA;font-weight:bold;">fe</text>
-    <text x="170 178 186 194 202" y="96" style="fill:#CCCCCC;opacity:0.75;">c7f68</text>
-    <text x="218 226 234" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="250 258 266 274 282 290" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="306 314 322 330 338 346 354 362" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="378 386 394" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="410 418 426 434 442 450 458 466" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="154 162 170" y="96" style="fill:#AA00AA;">1#0</text>
+    <text x="186 194" y="96" style="fill:#0000AA;font-weight:bold;">fe</text>
+    <text x="202 210 218 226 234" y="96" style="fill:#CCCCCC;opacity:0.75;">c7f68</text>
+    <text x="250 258 266" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="282 290 298 306 314 322" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="338 346 354 362 370 378 386 394" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="410 418 426" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="442 450 458 466 474 482 490 498" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
     <text x="50 58" y="114" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="114" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="114" style="fill:#FFFFFF;">&gt;&gt;</text>
-    <text x="154 162" y="114" style="fill:#0000AA;font-weight:bold;">96</text>
-    <text x="170 178 186 194 202" y="114" style="fill:#CCCCCC;opacity:0.75;">38f28</text>
-    <text x="218 226 234" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="250 258 266 274 282 290" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="306 314 322 330 338 346 354 362" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="378 386 394" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="410 418 426 434 442 450 458 466" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="154 162 170" y="114" style="fill:#AA00AA;">1#1</text>
+    <text x="186 194" y="114" style="fill:#0000AA;font-weight:bold;">96</text>
+    <text x="202 210 218 226 234" y="114" style="fill:#CCCCCC;opacity:0.75;">38f28</text>
+    <text x="250 258 266" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="282 290 298 306 314 322" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="338 346 354 362 370 378 386 394" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="410 418 426" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="442 450 458 466 474 482 490 498" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58" y="132" style="fill:#0000AA;font-weight:bold;">f1</text>
-    <text x="66 74 82 90 98" y="132" style="fill:#CCCCCC;opacity:0.75;">84fc7</text>
-    <text x="114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="132" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50 58 66" y="132" style="fill:#AA00AA;">1#2</text>
+    <text x="82 90" y="132" style="fill:#0000AA;font-weight:bold;">f1</text>
+    <text x="98 106 114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">84fc7</text>
+    <text x="146 154 162" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="306 314 322" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="338 346 354 362 370 378 386 394" y="132" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58" y="150" style="fill:#0000AA;font-weight:bold;">94</text>
     <text x="66 74 82 90 98" y="150" style="fill:#CCCCCC;opacity:0.75;">77ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/moves_the_cursor_back_to_a_valid_location_when_going_back_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/moves_the_cursor_back_to_a_valid_location_when_going_back_004.svg
@@ -22,30 +22,33 @@
     <text x="74" y="78" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
-    <text x="50 58" y="96" style="fill:#0000AA;font-weight:bold;">fe</text>
-    <text x="66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">c7f68</text>
-    <text x="114 122 130" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50 58 66" y="96" style="fill:#AA00AA;">1#0</text>
+    <text x="82 90" y="96" style="fill:#0000AA;font-weight:bold;">fe</text>
+    <text x="98 106 114 122 130" y="96" style="fill:#CCCCCC;opacity:0.75;">c7f68</text>
+    <text x="146 154 162" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="306 314 322" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="338 346 354 362 370 378 386 394" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
-    <text x="50 58" y="114" style="fill:#0000AA;font-weight:bold;">96</text>
-    <text x="66 74 82 90 98" y="114" style="fill:#CCCCCC;opacity:0.75;">38f28</text>
-    <text x="114 122 130" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50 58 66" y="114" style="fill:#AA00AA;">1#1</text>
+    <text x="82 90" y="114" style="fill:#0000AA;font-weight:bold;">96</text>
+    <text x="98 106 114 122 130" y="114" style="fill:#CCCCCC;opacity:0.75;">38f28</text>
+    <text x="146 154 162" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="306 314 322" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="338 346 354 362 370 378 386 394" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58" y="132" style="fill:#0000AA;font-weight:bold;">f1</text>
-    <text x="66 74 82 90 98" y="132" style="fill:#CCCCCC;opacity:0.75;">84fc7</text>
-    <text x="114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="132" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50 58 66" y="132" style="fill:#AA00AA;">1#2</text>
+    <text x="82 90" y="132" style="fill:#0000AA;font-weight:bold;">f1</text>
+    <text x="98 106 114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">84fc7</text>
+    <text x="146 154 162" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="178 186 194 202 210 218" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="234 242 250 258 266 274 282 290" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="306 314 322" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="338 346 354 362 370 378 386 394" y="132" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58" y="150" style="fill:#0000AA;font-weight:bold;">94</text>
     <text x="66 74 82 90 98" y="150" style="fill:#CCCCCC;opacity:0.75;">77ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/rub_api_uncommitted_to_commit.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/rub_api_uncommitted_to_commit.svg
@@ -17,11 +17,12 @@
     <text x="66" y="60" style="fill:#00AA00;">A</text>
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">6</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">bdd3d2</text>
-    <text x="114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">6</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">bdd3d2</text>
+    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">9</text>
     <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">477ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/rub_multiple_commits_into_uncommitted_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/rub_multiple_commits_into_uncommitted_001.svg
@@ -31,21 +31,23 @@
     <text x="50 58" y="78" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="78" style="fill:#FFFFFF;">&gt;&gt;</text>
-    <text x="154" y="78" style="fill:#0000AA;font-weight:bold;">a</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">6018af</text>
-    <text x="218 226 234" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="250 258 266 274 282 290" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="306 314 322 330 338 346 354 362" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="154 162 170" y="78" style="fill:#AA00AA;">1#0</text>
+    <text x="186" y="78" style="fill:#0000AA;font-weight:bold;">a</text>
+    <text x="194 202 210 218 226 234" y="78" style="fill:#CCCCCC;opacity:0.75;">6018af</text>
+    <text x="250 258 266" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="282 290 298 306 314 322" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="338 346 354 362 370 378 386 394" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="50 58" y="96" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="96" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="96" style="fill:#FFFFFF;">&gt;&gt;</text>
-    <text x="154" y="96" style="fill:#0000AA;font-weight:bold;">5</text>
-    <text x="162 170 178 186 194 202" y="96" style="fill:#CCCCCC;opacity:0.75;">bd308f</text>
-    <text x="218 226 234" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="250 258 266 274 282 290" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="306 314 322 330 338 346 354 362" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="154 162 170" y="96" style="fill:#AA00AA;">1#1</text>
+    <text x="186" y="96" style="fill:#0000AA;font-weight:bold;">5</text>
+    <text x="194 202 210 218 226 234" y="96" style="fill:#CCCCCC;opacity:0.75;">bd308f</text>
+    <text x="250 258 266" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="282 290 298 306 314 322" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="338 346 354 362 370 378 386 394" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/rubbing_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/rubbing_003.svg
@@ -17,13 +17,14 @@
     <text x="66" y="60" style="fill:#00AA00;">A</text>
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">6</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">78db78</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="274 282 290" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="306 314 322 330 338 346 354 362" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50" y="78" style="fill:#AA00AA;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">6</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">78db78</text>
+    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="290 298 306" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="322 330 338 346 354 362 370 378" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">8</text>
     <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">474410</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/undo_opens_confirm_for_latest_snapshot_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/undo_opens_confirm_for_latest_snapshot_001.svg
@@ -17,11 +17,12 @@
     <text x="66" y="60" style="fill:#00AA00;">A</text>
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#0000AA;font-weight:bold;">6</text>
-    <text x="58 66 74 82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">bdd3d2</text>
-    <text x="114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="146 154 162 170 178 186" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="202 210 218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;">1</text>
+    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">6</text>
+    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">bdd3d2</text>
+    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">9</text>
     <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">477ae7</text>

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -7,7 +7,7 @@
 #![forbid(missing_docs)]
 
 use std::collections::{BTreeMap, HashMap};
-use std::str::FromStr as _;
+use std::str::{self, FromStr as _};
 
 use bstr::{BStr, BString, ByteSlice};
 use but_core::sync::RepoShared;
@@ -38,7 +38,7 @@ pub(crate) type ShortId = String;
 
 pub(crate) const UNCOMMITTED: &str = "zz";
 
-const INDEX_SEPARATOR: &str = "#";
+const INDEX_SEPARATOR: char = '#';
 
 /// The ID of a hunk, without its namespace (file).
 #[derive(Debug, Clone, Default)]
@@ -120,25 +120,63 @@ fn create_reverse_hex_id(
     Ok(change_id)
 }
 
-/// Assign short IDs to each `Some` entry such that they are unambiguous with
-/// respect to every other entry. `reverse_hex_short_ids` must already be
-/// sorted.
+/// Assign short IDs to each `Some` entry such that they are unambiguous with respect to every other
+/// entry.
+///
+/// `None` entries represent reserved IDs that cannot be changed, such as filenames. They are only
+/// there to cause disambiguation with other IDs that we can change. There is currently no mechanism
+/// to deal with multiple colliding `None` entries. These will simply slip through.
+///
+/// Short IDs are disambiguated in two ways:
+///
+/// 1. By lengthening if the IDs match by prefix but are not identical.
+/// 2. By appending an index for collisions.
+///
+/// These two mechanisms interact. For example, given three IDs 123, 123 and 132, the output short
+/// IDs will be 12#0, 12#1 and 13. 123 and 132 are disambiguated against each other by lengthening
+/// both, and the duplicate 123 entries are then internally disambiguated by index.
+///
+/// Note that the algorithm only guarantees that the exact short IDs are distinct. Prefix matching
+/// with short IDs is therefore only advisable if the underlying IDs are known to not have cases
+/// where one ID is a prefix of another ID.
+///
+/// TODO Index disambiguation should be structured data. Right now we just append it to the short ID
+/// as a string, but that is rather inconvenient when it comes to rendering and matching. The
+/// [`ShortId`] type needs to carry collision information in the same way that [`UnqualifiedHunkId`]
+/// does.
 fn assign_short_ids(
-    reverse_hex_short_ids: &mut [(ChangeId, Option<&mut ShortId>)],
+    reverse_hex_short_ids: BTreeMap<ChangeId, Vec<Option<&mut ShortId>>>,
 ) -> anyhow::Result<()> {
     let mut common_with_previous_len = 0;
-    let mut remaining = reverse_hex_short_ids;
-    while let Some(((reverse_hex, short_id), rest)) = remaining.split_first_mut() {
+    let mut reverse_hex_short_ids: Vec<_> = reverse_hex_short_ids.into_iter().collect();
+    let mut remaining = reverse_hex_short_ids.as_mut_slice();
+
+    while let Some(((reverse_hex, short_ids), rest)) = remaining.split_first_mut() {
+        // TODO should compare UTF8 chars instead of bytes once we start putting full branch names
+        // in here. Otherwise we risk splitting in the middle of a UTF8 character.
         let common_with_next_len = rest
             .first()
             .map_or(0, |(next_reverse_hex, _next_short_id)| {
                 common_prefix_len(reverse_hex, next_reverse_hex)
             });
-        if let Some(short_id) = short_id {
+
+        let min_disambiguation_len = 1 + common_with_previous_len.max(common_with_next_len);
+
+        let num_conflicting_ids = short_ids.len();
+        for (i, short_id) in short_ids.iter_mut().flatten().enumerate() {
             short_id.clear();
-            short_id.push_str(str::from_utf8(
-                &reverse_hex[..(1 + common_with_previous_len.max(common_with_next_len))],
-            )?);
+
+            let reverse_hex_utf8 = str::from_utf8(reverse_hex)?;
+            if min_disambiguation_len > reverse_hex.len() {
+                short_id.push_str(reverse_hex_utf8);
+            } else {
+                short_id.push_str(str::from_utf8(&reverse_hex[..min_disambiguation_len])?);
+            }
+
+            if num_conflicting_ids > 1 {
+                short_id.push(INDEX_SEPARATOR);
+                short_id.push_str(&i.to_string());
+            }
         }
         common_with_previous_len = common_with_next_len;
         remaining = rest;
@@ -158,12 +196,16 @@ fn short_ids_from_tree_changes(
             ShortId::default(),
         ));
     }
-    let mut reverse_hex_short_ids: Vec<(ChangeId, Option<&mut ShortId>)> = short_ids
-        .iter_mut()
-        .map(|(_changes, reverse_hex, short_id)| (reverse_hex.clone(), Some(short_id)))
-        .collect();
-    reverse_hex_short_ids.sort();
-    assign_short_ids(reverse_hex_short_ids.as_mut_slice())?;
+    let mut reverse_hex_short_ids = BTreeMap::<ChangeId, Vec<_>>::new();
+
+    for (_, reverse_hex, short_id) in short_ids.iter_mut() {
+        reverse_hex_short_ids
+            .entry(reverse_hex.clone())
+            .or_default()
+            .push(Some(short_id));
+    }
+
+    assign_short_ids(reverse_hex_short_ids)?;
     Ok(short_ids)
 }
 
@@ -602,8 +644,15 @@ impl IdMap {
             reverse_hex_short_ids.push((change_id.change_id.clone(), Some(&mut change_id.short_id)))
         }
 
-        reverse_hex_short_ids.sort();
-        assign_short_ids(&mut reverse_hex_short_ids)?;
+        let mut mapped_reverse_hex_short_ids =
+            BTreeMap::<ChangeId, Vec<Option<&mut ShortId>>>::new();
+        for (id, short_id) in reverse_hex_short_ids {
+            mapped_reverse_hex_short_ids
+                .entry(id)
+                .or_default()
+                .push(short_id);
+        }
+        assign_short_ids(mapped_reverse_hex_short_ids)?;
 
         let mut uncommitted_hunks = HashMap::new();
         for uncommitted_file in uncommitted_files.values_mut() {
@@ -800,9 +849,7 @@ impl IdMap {
                             .map(|c| (c.id, c.change_id)),
                     )
             })
-            .filter_map(|(commit_id, change_id)| {
-                change_id.map(|change_id| (commit_id, change_id))
-            })
+            .filter_map(|(commit_id, change_id)| change_id.map(|change_id| (commit_id, change_id)))
             .collect();
 
         Self::new(ws.stacks.clone(), hunk_assignments, commit_id_to_change_id)
@@ -914,24 +961,30 @@ impl IdMap {
             None
         };
 
-        let matches_commit = |id: gix::ObjectId, maybe_change_id: Option<&ChangeId>| {
-            maybe_hex_prefix
-                .map(|hex_prefix| hex_prefix.cmp_oid(&id).is_eq())
-                .unwrap_or(false)
-                || maybe_change_id
-                    .map(|change_id| change_id.starts_with_str(element))
-                    .unwrap_or(false)
-        };
+        let element_matches_commit =
+            |id: gix::ObjectId, maybe_change_id: Option<&ChangeIdWithShortId>| {
+                if let Some(element_hex_prefix) = maybe_element_hex_prefix
+                    && element_hex_prefix.cmp_oid(&id).is_eq()
+                {
+                    return true;
+                }
+
+                if let Some(change_id) = maybe_change_id
+                    && (change_id.change_id.starts_with_str(element)
+                        || element == change_id.short_id)
+                {
+                    return true;
+                }
+
+                false
+            };
 
         for stack_with_id in self.indexed_stacks.borrow_owner().iter() {
             for segment_with_id in stack_with_id.segments.iter() {
                 for workspace_commit_with_id in segment_with_id.workspace_commits.iter() {
-                    if matches_commit(
+                    if element_matches_commit(
                         workspace_commit_with_id.commit_id(),
-                        workspace_commit_with_id
-                            .change_id
-                            .as_ref()
-                            .map(|cid| &cid.change_id),
+                        workspace_commit_with_id.change_id.as_ref(),
                     ) {
                         matches.push(Box::new(workspace_commit_with_id))
                     }
@@ -940,10 +993,7 @@ impl IdMap {
                 for remote_commit_with_id in segment_with_id.remote_commits.iter() {
                     if element_matches_commit(
                         remote_commit_with_id.commit_id(),
-                        remote_commit_with_id
-                            .change_id
-                            .as_ref()
-                            .map(|cid| &cid.change_id),
+                        remote_commit_with_id.change_id.as_ref(),
                     ) {
                         matches.push(Box::new(remote_commit_with_id))
                     }

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -135,6 +135,7 @@ fn assign_short_ids(
                 common_prefix_len(reverse_hex, next_reverse_hex)
             });
         if let Some(short_id) = short_id {
+            short_id.clear();
             short_id.push_str(str::from_utf8(
                 &reverse_hex[..(1 + common_with_previous_len.max(common_with_next_len))],
             )?);
@@ -213,14 +214,35 @@ pub struct TreeChangeWithId {
     pub inner: but_core::TreeChange,
 }
 
+/// A change ID with an accompanying distinct short ID
+#[derive(Debug, Clone)]
+pub struct ChangeIdWithShortId {
+    /// The full change ID
+    pub change_id: ChangeId,
+    /// The shortened version of [`Self::change_id`]
+    pub short_id: ShortId,
+}
+
+impl From<ChangeId> for ChangeIdWithShortId {
+    fn from(value: ChangeId) -> Self {
+        Self {
+            short_id: ShortId::default(),
+            change_id: value,
+        }
+    }
+}
+
 /// A workspace commit with its short ID.
 #[derive(Debug, Clone)]
 pub struct WorkspaceCommitWithId {
     /// The short ID.
     pub short_id: ShortId,
+    /// The change ID
+    pub change_id: Option<ChangeIdWithShortId>,
     /// The original workspace commit.
     pub inner: StackCommit,
 }
+
 impl WorkspaceCommitWithId {
     /// The object ID of the commit.
     pub fn commit_id(&self) -> gix::ObjectId {
@@ -311,6 +333,8 @@ impl<'a> Node<'a> for &'a WorkspaceCommitWithId {
 pub struct RemoteCommitWithId {
     /// The short ID.
     pub short_id: ShortId,
+    /// The change ID.
+    pub change_id: Option<ChangeIdWithShortId>,
     /// The original remote commit.
     pub inner: StackCommit,
 }
@@ -498,16 +522,24 @@ fn common_prefix_len(a: &[u8], b: &[u8]) -> usize {
 impl IdMap {
     /// Initializes CLI IDs for branches, commits, and uncommitted
     /// files/hunks.
-    pub fn new(stacks: Vec<Stack>, hunk_assignments: Vec<HunkAssignment>) -> anyhow::Result<Self> {
+    pub fn new(
+        stacks: Vec<Stack>,
+        hunk_assignments: Vec<HunkAssignment>,
+        commit_id_to_change_id: gix::hashtable::HashMap<gix::ObjectId, ChangeId>,
+    ) -> anyhow::Result<Self> {
         let UncommittedInfo {
             partitioned_hunks,
             uncommitted_short_filenames,
         } = UncommittedInfo::from_hunk_assignments(hunk_assignments)?;
         let StacksInfo {
-            stacks,
+            mut stacks,
             mut id_usage,
             non_hex_used_short_ids,
-        } = StacksInfo::new(stacks, &uncommitted_short_filenames)?;
+        } = StacksInfo::new(
+            stacks,
+            &uncommitted_short_filenames,
+            &commit_id_to_change_id,
+        )?;
 
         let mut uncommitted_files: BTreeMap<ChangeId, UncommittedFile> = BTreeMap::new();
         for hunk_assignments in partitioned_hunks {
@@ -551,6 +583,25 @@ impl IdMap {
         for short_id in non_hex_used_short_ids {
             reverse_hex_short_ids.push((ChangeId::from(BString::from(short_id.as_str())), None));
         }
+
+        for change_id in stacks
+            .iter_mut()
+            .flat_map(|stack| stack.segments.iter_mut())
+            .flat_map(|segment| {
+                let ws_commits = segment
+                    .workspace_commits
+                    .iter_mut()
+                    .filter_map(|c| c.change_id.as_mut());
+                let remote_commits = segment
+                    .remote_commits
+                    .iter_mut()
+                    .filter_map(|c| c.change_id.as_mut());
+                ws_commits.chain(remote_commits)
+            })
+        {
+            reverse_hex_short_ids.push((change_id.change_id.clone(), Some(&mut change_id.short_id)))
+        }
+
         reverse_hex_short_ids.sort();
         assign_short_ids(&mut reverse_hex_short_ids)?;
 
@@ -724,7 +775,37 @@ impl IdMap {
             }
         };
 
-        Self::new(ws.stacks.clone(), hunk_assignments)
+        let head_info = but_workspace::graph_to_ref_info(
+            &ws,
+            &repo,
+            but_workspace::ref_info::Options {
+                project_meta: ws.graph.project_meta.clone(),
+                ..Default::default()
+            },
+        )?;
+
+        let commit_id_to_change_id = head_info
+            .stacks
+            .into_iter()
+            .flat_map(|stack| stack.segments)
+            .flat_map(|segment| {
+                segment
+                    .commits
+                    .into_iter()
+                    .map(|c| (c.inner.id, c.inner.change_id))
+                    .chain(
+                        segment
+                            .commits_on_remote
+                            .into_iter()
+                            .map(|c| (c.id, c.change_id)),
+                    )
+            })
+            .filter_map(|(commit_id, change_id)| {
+                change_id.map(|change_id| (commit_id, change_id))
+            })
+            .collect();
+
+        Self::new(ws.stacks.clone(), hunk_assignments, commit_id_to_change_id)
     }
 }
 
@@ -823,26 +904,48 @@ impl IdMap {
             return Ok(matches);
         }
 
-        // Only try SHA matching if the input looks like a hex string
-        if element
+        // Match against commits
+        let maybe_element_hex_prefix = if element
             .chars()
             .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
-            && let Ok(prefix) = gix::hash::Prefix::from_hex_nonempty(element)
         {
-            for stack_with_id in self.indexed_stacks.borrow_owner().iter() {
-                for segment_with_id in stack_with_id.segments.iter() {
-                    for workspace_commit_with_id in segment_with_id.workspace_commits.iter() {
-                        if prefix
-                            .cmp_oid(&workspace_commit_with_id.commit_id())
-                            .is_eq()
-                        {
-                            matches.push(Box::new(workspace_commit_with_id));
-                        }
+            gix::hash::Prefix::from_hex_nonempty(element).ok()
+        } else {
+            None
+        };
+
+        let matches_commit = |id: gix::ObjectId, maybe_change_id: Option<&ChangeId>| {
+            maybe_hex_prefix
+                .map(|hex_prefix| hex_prefix.cmp_oid(&id).is_eq())
+                .unwrap_or(false)
+                || maybe_change_id
+                    .map(|change_id| change_id.starts_with_str(element))
+                    .unwrap_or(false)
+        };
+
+        for stack_with_id in self.indexed_stacks.borrow_owner().iter() {
+            for segment_with_id in stack_with_id.segments.iter() {
+                for workspace_commit_with_id in segment_with_id.workspace_commits.iter() {
+                    if matches_commit(
+                        workspace_commit_with_id.commit_id(),
+                        workspace_commit_with_id
+                            .change_id
+                            .as_ref()
+                            .map(|cid| &cid.change_id),
+                    ) {
+                        matches.push(Box::new(workspace_commit_with_id))
                     }
-                    for remote_commit_with_id in segment_with_id.remote_commits.iter() {
-                        if prefix.cmp_oid(&remote_commit_with_id.commit_id()).is_eq() {
-                            matches.push(Box::new(remote_commit_with_id));
-                        }
+                }
+
+                for remote_commit_with_id in segment_with_id.remote_commits.iter() {
+                    if element_matches_commit(
+                        remote_commit_with_id.commit_id(),
+                        remote_commit_with_id
+                            .change_id
+                            .as_ref()
+                            .map(|cid| &cid.change_id),
+                    ) {
+                        matches.push(Box::new(remote_commit_with_id))
                     }
                 }
             }

--- a/crates/but/src/id/stacks_info.rs
+++ b/crates/but/src/id/stacks_info.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, HashSet};
 
 use bstr::BString;
+use but_core::ChangeId;
 use but_graph::workspace::Stack;
 
 use crate::id::{
@@ -8,7 +9,10 @@ use crate::id::{
     id_usage::{IdUsage, UintId},
 };
 
-fn stacks_info_without_short_ids(stacks: Vec<Stack>) -> StacksInfo {
+fn stacks_info_without_short_ids(
+    stacks: Vec<Stack>,
+    commit_id_to_change_id: &gix::hashtable::HashMap<gix::ObjectId, ChangeId>,
+) -> StacksInfo {
     let mut stacks_info = StacksInfo {
         stacks: Vec::with_capacity(stacks.len()),
         id_usage: IdUsage::default(),
@@ -24,6 +28,10 @@ fn stacks_info_without_short_ids(stacks: Vec<Stack>) -> StacksInfo {
                 .into_iter()
                 .map(|commit| WorkspaceCommitWithId {
                     short_id: ShortId::default(),
+                    change_id: commit_id_to_change_id
+                        .get(&commit.id)
+                        .cloned()
+                        .map(Into::into),
                     inner: commit,
                 })
                 .collect::<Vec<_>>();
@@ -31,6 +39,10 @@ fn stacks_info_without_short_ids(stacks: Vec<Stack>) -> StacksInfo {
                 .into_iter()
                 .map(|commit| RemoteCommitWithId {
                     short_id: ShortId::default(),
+                    change_id: commit_id_to_change_id
+                        .get(&commit.id)
+                        .cloned()
+                        .map(Into::into),
                     inner: commit,
                 })
                 .collect::<Vec<_>>();
@@ -187,8 +199,9 @@ impl StacksInfo {
     pub(crate) fn new(
         stacks: Vec<Stack>,
         uncommitted_short_filenames: &HashSet<BString>,
+        commit_id_to_change_id: &gix::hashtable::HashMap<gix::ObjectId, ChangeId>,
     ) -> anyhow::Result<Self> {
-        let mut stacks_info = stacks_info_without_short_ids(stacks);
+        let mut stacks_info = stacks_info_without_short_ids(stacks, commit_id_to_change_id);
         populate_branch_short_ids(
             &mut stacks_info.stacks,
             &mut stacks_info.id_usage,

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -48,7 +48,7 @@ fn uint_id_to_short_id() {
 fn commit_id_works_with_two_or_more_characters() -> anyhow::Result<()> {
     let id1 = id(1);
     let stacks = vec![stack([segment("not-important", [id1], None, [])])];
-    let id_map = IdMap::new(stacks, Vec::new())?;
+    let id_map = IdMap::new(stacks, Vec::new(), gix::hashtable::HashMap::default())?;
     snapbox::assert_data_eq!(
         id_map.debug_state().to_debug(),
         snapbox::str![[r#"
@@ -88,7 +88,7 @@ fn commit_id_appearing_multiple_times() -> anyhow::Result<()> {
         stack([segment("branch1", [id(2), id1], None, [])]),
         stack([segment("branch2", [id(3), id1], None, [])]),
     ];
-    let id_map = IdMap::new(stacks, Vec::new())?;
+    let id_map = IdMap::new(stacks, Vec::new(), gix::hashtable::HashMap::default())?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
      -> anyhow::Result<Vec<but_core::TreeChange>> {
@@ -117,7 +117,7 @@ fn commit_ids_become_longer_if_ambiguous() -> anyhow::Result<()> {
     let id2 = hex_to_id("21bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
     let id3 = hex_to_id("21bccccccccccccccccccccccccccccccccccccc");
     let stacks = vec![stack([segment("not-important", [id1, id2, id3], None, [])])];
-    let id_map = IdMap::new(stacks, Vec::new())?;
+    let id_map = IdMap::new(stacks, Vec::new(), gix::hashtable::HashMap::default())?;
     snapbox::assert_data_eq!(
         id_map.debug_state().to_debug(),
         snapbox::str![[r#"
@@ -175,7 +175,7 @@ branches: [ no ]
 #[test]
 fn branches_work_with_single_character() -> anyhow::Result<()> {
     let stacks = vec![stack([segment("f", [id(1)], None, [])])];
-    let id_map = IdMap::new(stacks, Vec::new())?;
+    let id_map = IdMap::new(stacks, Vec::new(), gix::hashtable::HashMap::default())?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
      -> anyhow::Result<Vec<but_core::TreeChange>> {
@@ -212,7 +212,7 @@ branches: [ g0 ]
 #[test]
 fn branches_avoid_uncommitted_area_id() -> anyhow::Result<()> {
     let stacks = vec![stack([segment("zza", [id(1)], None, [])])];
-    let id_map = IdMap::new(stacks, Vec::new())?;
+    let id_map = IdMap::new(stacks, Vec::new(), gix::hashtable::HashMap::default())?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
      -> anyhow::Result<Vec<but_core::TreeChange>> {
@@ -247,7 +247,7 @@ fn branches_avoid_invalid_ids() -> anyhow::Result<()> {
         segment("x-yz_/hi", [id(1)], None, []),
         segment("0ax", [id(2)], None, []),
     ])];
-    let id_map = IdMap::new(stacks, Vec::new())?;
+    let id_map = IdMap::new(stacks, Vec::new(), gix::hashtable::HashMap::default())?;
     snapbox::assert_data_eq!(
         id_map.debug_state().to_debug(),
         snapbox::str![[r#"
@@ -290,7 +290,7 @@ branches: [ ax, yz ]
 fn branches_avoid_uncommitted_filenames() -> anyhow::Result<()> {
     let stacks = vec![stack([segment("ghij", [id(1)], None, [])])];
     let hunk_assignments = vec![hunk_assignment("gh", None), hunk_assignment("hi", None)];
-    let id_map = IdMap::new(stacks, hunk_assignments)?;
+    let id_map = IdMap::new(stacks, hunk_assignments, gix::hashtable::HashMap::default())?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
      -> anyhow::Result<Vec<but_core::TreeChange>> {
@@ -327,7 +327,7 @@ fn branch_that_is_substring_of_other_substring_still_gets_id() -> anyhow::Result
         stack([segment("substring", [id(1)], None, [])]),
         stack([segment("supersubstring", [id(2)], None, [])]),
     ];
-    let id_map = IdMap::new(stacks, Vec::new())?;
+    let id_map = IdMap::new(stacks, Vec::new(), gix::hashtable::HashMap::default())?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
      -> anyhow::Result<Vec<but_core::TreeChange>> {
@@ -379,7 +379,7 @@ fn non_commit_ids_do_not_collide() -> anyhow::Result<()> {
         },
         hunk_assignment("uncommitted2.txt", None),
     ];
-    let id_map = IdMap::new(stacks, hunk_assignments)?;
+    let id_map = IdMap::new(stacks, hunk_assignments, gix::hashtable::HashMap::default())?;
     snapbox::assert_data_eq!(
         id_map.debug_state().to_debug(),
         snapbox::str![[r#"
@@ -543,7 +543,7 @@ stacks: [ j0 ]
 fn ids_are_case_sensitive() -> anyhow::Result<()> {
     let stacks = vec![stack([segment("h0", [id(10)], Some(id(9)), [])])];
     let hunk_assignments = vec![hunk_assignment("uncommitted.txt", None)];
-    let id_map = IdMap::new(stacks, hunk_assignments)?;
+    let id_map = IdMap::new(stacks, hunk_assignments, gix::hashtable::HashMap::default())?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
      -> anyhow::Result<Vec<but_core::TreeChange>> {
@@ -667,7 +667,7 @@ fn uncommitted_files_disambiguate_between_themselves() -> anyhow::Result<()> {
         hunk_assignment("foo23", None),
         hunk_assignment("foo242", None),
     ];
-    let id_map = IdMap::new(stacks, hunk_assignments)?;
+    let id_map = IdMap::new(stacks, hunk_assignments, gix::hashtable::HashMap::default())?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
      -> anyhow::Result<Vec<but_core::TreeChange>> {
@@ -800,7 +800,7 @@ fn uncommitted_files_disambiguate_between_themselves() -> anyhow::Result<()> {
 fn uncommitted_files_disambiguate_with_branch() -> anyhow::Result<()> {
     let stacks = vec![stack([segment("qsy", [id(1)], None, [])])];
     let hunk_assignments = vec![hunk_assignment("file", None)];
-    let id_map = IdMap::new(stacks, hunk_assignments)?;
+    let id_map = IdMap::new(stacks, hunk_assignments, gix::hashtable::HashMap::default())?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
      -> anyhow::Result<Vec<but_core::TreeChange>> {
@@ -878,7 +878,7 @@ fn uncommitted_files_disambiguate_with_branch() -> anyhow::Result<()> {
 fn longer_id_is_ok() -> anyhow::Result<()> {
     let stacks = vec![stack([segment("foo", [id(1)], None, [])])];
     let hunk_assignments = vec![hunk_assignment("foo23", None)];
-    let id_map = IdMap::new(stacks, hunk_assignments)?;
+    let id_map = IdMap::new(stacks, hunk_assignments, gix::hashtable::HashMap::default())?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
      -> anyhow::Result<Vec<but_core::TreeChange>> {
@@ -926,7 +926,7 @@ fn longer_id_is_ok() -> anyhow::Result<()> {
 fn reverse_hex_filename_is_its_own_id() -> anyhow::Result<()> {
     let stacks = vec![stack([segment("foo", [id(1)], None, [])])];
     let hunk_assignments = vec![hunk_assignment("klmxyz", None)];
-    let id_map = IdMap::new(stacks, hunk_assignments)?;
+    let id_map = IdMap::new(stacks, hunk_assignments, gix::hashtable::HashMap::default())?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
      -> anyhow::Result<Vec<but_core::TreeChange>> {
@@ -974,7 +974,7 @@ fn reverse_hex_filename_is_its_own_id() -> anyhow::Result<()> {
 fn branch_and_file_by_name() -> anyhow::Result<()> {
     let stacks = vec![stack([segment("foo", [id(1)], None, [])])];
     let hunk_assignments = vec![hunk_assignment("foo", None)];
-    let id_map = IdMap::new(stacks, hunk_assignments)?;
+    let id_map = IdMap::new(stacks, hunk_assignments, gix::hashtable::HashMap::default())?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
      -> anyhow::Result<Vec<but_core::TreeChange>> {
@@ -1035,7 +1035,7 @@ fn colon_uncommitted_filename() -> anyhow::Result<()> {
         hunk_assignment("uncommitted", None),
         hunk_assignment("assigned", Some(StackId::from_number_for_testing(1))),
     ];
-    let id_map = IdMap::new(stacks, hunk_assignments)?;
+    let id_map = IdMap::new(stacks, hunk_assignments, gix::hashtable::HashMap::default())?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
      -> anyhow::Result<Vec<but_core::TreeChange>> {
@@ -1153,7 +1153,7 @@ fn uncommitted_path() -> anyhow::Result<()> {
         hunk_assignment("prefix/a", None),
         hunk_assignment("prefix/b", None),
     ];
-    let id_map = IdMap::new(stacks, hunk_assignments)?;
+    let id_map = IdMap::new(stacks, hunk_assignments, gix::hashtable::HashMap::default())?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
      -> anyhow::Result<Vec<but_core::TreeChange>> {
@@ -1224,7 +1224,7 @@ fn uncommitted_path() -> anyhow::Result<()> {
 #[test]
 fn committed_files_are_deduplicated_by_commit_oid_path() -> anyhow::Result<()> {
     let stacks = vec![stack([segment("branch", [id(2)], Some(id(1)), [])])];
-    let id_map = IdMap::new(stacks, Vec::new())?;
+    let id_map = IdMap::new(stacks, Vec::new(), gix::hashtable::HashMap::default())?;
 
     // Simulate a changed_paths function that returns the same file twice
     // (which could happen due to a bug in the caller or data source)
@@ -1269,7 +1269,7 @@ fn short_uncommitted_files_are_properly_reverse_hexed() -> anyhow::Result<()> {
         hunk_assignment("kl", None),
         hunk_assignment("klm", None),
     ];
-    let id_map = IdMap::new(stacks, hunk_assignments)?;
+    let id_map = IdMap::new(stacks, hunk_assignments, gix::hashtable::HashMap::default())?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
      -> anyhow::Result<Vec<but_core::TreeChange>> {
@@ -1386,7 +1386,7 @@ fn uncommitted_hunks_by_numeric_index() -> anyhow::Result<()> {
         },
         hunk_assignment("uncommitted2.txt", None),
     ];
-    let id_map = IdMap::new(stacks, hunk_assignments)?;
+    let id_map = IdMap::new(stacks, hunk_assignments, gix::hashtable::HashMap::default())?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
      -> anyhow::Result<Vec<but_core::TreeChange>> {
@@ -1534,7 +1534,7 @@ fn uncommitted_hunks_by_id() -> anyhow::Result<()> {
         hunk_assignment("hunk_without_diff.txt", None),
     ];
 
-    let id_map = IdMap::new(stacks, hunk_assignments)?;
+    let id_map = IdMap::new(stacks, hunk_assignments, gix::hashtable::HashMap::default())?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
      -> anyhow::Result<Vec<but_core::TreeChange>> {
@@ -1705,7 +1705,7 @@ fn uncommitted_hunks_by_id_increase_id_length_as_necessary() -> anyhow::Result<(
         },
     ];
 
-    let id_map = IdMap::new(stacks, hunk_assignments)?;
+    let id_map = IdMap::new(stacks, hunk_assignments, gix::hashtable::HashMap::default())?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
      -> anyhow::Result<Vec<but_core::TreeChange>> {
@@ -1812,7 +1812,7 @@ fn uncommitted_hunks_overspecifying_id_prefix() -> anyhow::Result<()> {
         ..hunk_assignment("uncommitted1.txt", None)
     }];
 
-    let id_map = IdMap::new(stacks, hunk_assignments)?;
+    let id_map = IdMap::new(stacks, hunk_assignments, gix::hashtable::HashMap::default())?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
      -> anyhow::Result<Vec<but_core::TreeChange>> {
@@ -1889,7 +1889,7 @@ fn uncommitted_hunks_overspecifying_id_prefix_with_collision_disambiguation() ->
         },
     ];
 
-    let id_map = IdMap::new(stacks, hunk_assignments)?;
+    let id_map = IdMap::new(stacks, hunk_assignments, gix::hashtable::HashMap::default())?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
      -> anyhow::Result<Vec<but_core::TreeChange>> {
@@ -1971,7 +1971,7 @@ fn underspecifying_hunk_ids() -> anyhow::Result<()> {
         },
     ];
 
-    let id_map = IdMap::new(stacks, hunk_assignments)?;
+    let id_map = IdMap::new(stacks, hunk_assignments, gix::hashtable::HashMap::default())?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
      -> anyhow::Result<Vec<but_core::TreeChange>> {
@@ -2149,7 +2149,7 @@ fn uncommitted_hunks_by_id_collision_handling() -> anyhow::Result<()> {
         },
     ];
 
-    let id_map = IdMap::new(stacks, hunk_assignments)?;
+    let id_map = IdMap::new(stacks, hunk_assignments, gix::hashtable::HashMap::default())?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
      -> anyhow::Result<Vec<but_core::TreeChange>> {
@@ -2240,7 +2240,7 @@ fn commit_matches_are_deduplicated_by_commit_oid() -> anyhow::Result<()> {
         Some(id(1)),
         [commit_id],
     )])];
-    let id_map = IdMap::new(stacks, Vec::new())?;
+    let id_map = IdMap::new(stacks, Vec::new(), gix::hashtable::HashMap::default())?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
      -> anyhow::Result<Vec<but_core::TreeChange>> {
@@ -2264,7 +2264,7 @@ fn dedupe_does_not_hide_ambiguity_between_distinct_commits() -> anyhow::Result<(
     let id1 = hex_to_id("21aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
     let id2 = hex_to_id("21bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
     let stacks = vec![stack([segment("branch", [id1, id2], None, [])])];
-    let id_map = IdMap::new(stacks, Vec::new())?;
+    let id_map = IdMap::new(stacks, Vec::new(), gix::hashtable::HashMap::default())?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
      -> anyhow::Result<Vec<but_core::TreeChange>> {
@@ -2303,7 +2303,7 @@ fn dedupe_does_not_hide_ambiguity_between_branches_in_different_stacks() -> anyh
             ..stack([segment("foo", [id(2)], None, [])])
         },
     ];
-    let id_map = IdMap::new(stacks, Vec::new())?;
+    let id_map = IdMap::new(stacks, Vec::new(), gix::hashtable::HashMap::default())?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
      -> anyhow::Result<Vec<but_core::TreeChange>> {
@@ -2339,7 +2339,7 @@ fn dedupe_does_not_hide_ambiguity_between_unmanaged_branches_with_same_name() ->
         stack([segment("foo", [id(1)], None, [])]),
         stack([segment("foo", [id(2)], None, [])]),
     ];
-    let id_map = IdMap::new(stacks, Vec::new())?;
+    let id_map = IdMap::new(stacks, Vec::new(), gix::hashtable::HashMap::default())?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
      -> anyhow::Result<Vec<but_core::TreeChange>> {

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -1,6 +1,6 @@
 use anyhow::bail;
 use bstr::BString;
-use but_core::ref_metadata::StackId;
+use but_core::{ChangeId, ref_metadata::StackId};
 use but_graph::workspace::Stack;
 use but_hunk_assignment::HunkAssignment;
 use but_testsupport::{hex_to_id, hunk_header};
@@ -2363,6 +2363,172 @@ fn dedupe_does_not_hide_ambiguity_between_unmanaged_branches_with_same_name() ->
         "the two unmanaged branches must stay distinct"
     );
     Ok(())
+}
+
+#[test]
+fn find_commits_by_change_id() {
+    let id1 = id(1);
+    let id2 = id(2);
+    let stacks = vec![stack([segment("not-important", [id1, id2], None, [])])];
+
+    let commit_id_to_change_id: gix::hashtable::HashMap<gix::ObjectId, ChangeId> = [
+        (id1, ChangeId::from_bytes("sv".as_bytes())), // swstzzzz...
+        (id2, ChangeId::from_bytes("sx".as_bytes())), // swsrzzzz...
+    ]
+    .into_iter()
+    .collect();
+
+    let id_map = IdMap::new(stacks, Vec::new(), commit_id_to_change_id).unwrap();
+    snapbox::assert_data_eq!(
+        id_map.debug_state().to_debug(),
+        snapbox::str![[r#"
+workspace_and_remote_commits_count: 2
+branches: [ no ]
+
+
+"#]]
+    );
+    let changed_paths_fn = |commit_id: gix::ObjectId,
+                            parent_id: Option<gix::ObjectId>|
+     -> anyhow::Result<Vec<but_core::TreeChange>> {
+        bail!("unexpected IDs {commit_id} {parent_id:?}");
+    };
+
+    // Should match both commits if we use a common prefix
+    snapbox::assert_data_eq!(
+        id_map
+            .parse("sws", Box::new(changed_paths_fn))
+            .unwrap()
+            .to_debug(),
+        snapbox::str![[r#"
+[
+    Commit {
+        commit_id: Sha1(0101010101010101010101010101010101010101),
+        id: "01",
+    },
+    Commit {
+        commit_id: Sha1(0202020202020202020202020202020202020202),
+        id: "02",
+    },
+]
+
+"#]],
+    );
+
+    snapbox::assert_data_eq!(
+        id_map
+            .parse("swst", Box::new(changed_paths_fn))
+            .unwrap()
+            .to_debug(),
+        snapbox::str![[r#"
+[
+    Commit {
+        commit_id: Sha1(0101010101010101010101010101010101010101),
+        id: "01",
+    },
+]
+
+"#]],
+    );
+
+    snapbox::assert_data_eq!(
+        id_map
+            .parse("swsr", Box::new(changed_paths_fn))
+            .unwrap()
+            .to_debug(),
+        snapbox::str![[r#"
+[
+    Commit {
+        commit_id: Sha1(0202020202020202020202020202020202020202),
+        id: "02",
+    },
+]
+
+"#]],
+    )
+}
+
+#[test]
+fn change_ids_are_disambiguated_on_collision() {
+    let id1 = id(1);
+    let id2 = id(2);
+    let stacks = vec![stack([segment("not-important", [id1, id2], None, [])])];
+
+    let commit_id_to_change_id: gix::hashtable::HashMap<gix::ObjectId, ChangeId> = [
+        (id1, ChangeId::from_bytes("sv".as_bytes())), // swstzzzz...
+        (id2, ChangeId::from_bytes("sv".as_bytes())), // swstzzzz...
+    ]
+    .into_iter()
+    .collect();
+
+    let id_map = IdMap::new(stacks, Vec::new(), commit_id_to_change_id).unwrap();
+    snapbox::assert_data_eq!(
+        id_map.debug_state().to_debug(),
+        snapbox::str![[r#"
+workspace_and_remote_commits_count: 2
+branches: [ no ]
+
+
+"#]]
+    );
+    let changed_paths_fn = |commit_id: gix::ObjectId,
+                            parent_id: Option<gix::ObjectId>|
+     -> anyhow::Result<Vec<but_core::TreeChange>> {
+        bail!("unexpected IDs {commit_id} {parent_id:?}");
+    };
+
+    // Should match both commits if we use a common prefix
+    snapbox::assert_data_eq!(
+        id_map
+            .parse("sws", Box::new(changed_paths_fn))
+            .unwrap()
+            .to_debug(),
+        snapbox::str![[r#"
+[
+    Commit {
+        commit_id: Sha1(0101010101010101010101010101010101010101),
+        id: "01",
+    },
+    Commit {
+        commit_id: Sha1(0202020202020202020202020202020202020202),
+        id: "02",
+    },
+]
+
+"#]],
+    );
+
+    snapbox::assert_data_eq!(
+        id_map
+            .parse("s#0", Box::new(changed_paths_fn))
+            .unwrap()
+            .to_debug(),
+        snapbox::str![[r#"
+[
+    Commit {
+        commit_id: Sha1(0101010101010101010101010101010101010101),
+        id: "01",
+    },
+]
+
+"#]],
+    );
+
+    snapbox::assert_data_eq!(
+        id_map
+            .parse("s#1", Box::new(changed_paths_fn))
+            .unwrap()
+            .to_debug(),
+        snapbox::str![[r#"
+[
+    Commit {
+        commit_id: Sha1(0202020202020202020202020202020202020202),
+        id: "02",
+    },
+]
+
+"#]],
+    )
 }
 
 mod util {

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -309,13 +309,13 @@ n:5 a.txt│
 ┊   n M a.txt
 ┊
 ┊╭┄g0 [A]
-┊●   a7aa4ef partial change to a.txt 3
+┊●   1#0 a7aa4ef partial change to a.txt 3
 ┊│     a:n M a.txt
-┊●   889385c partial change to a.txt 2
+┊●   1#1 889385c partial change to a.txt 2
 ┊│     88:n M a.txt
-┊●   8dc39e0 partial change to a.txt 1
+┊●   1#2 8dc39e0 partial change to a.txt 1
 ┊│     8d:n M a.txt
-┊●   f4ea7f8 a.txt
+┊●   1#3 f4ea7f8 a.txt
 ┊│     f:n A a.txt
 ┊●   9477ae7 add A
 ┊│     9:t A A
@@ -360,13 +360,13 @@ Hint: you can run `but undo` to undo these changes
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   4822140 partial change to a.txt 3
+┊●   1#0 4822140 partial change to a.txt 3
 ┊│     48:n M a.txt
-┊●   4593422 partial change to a.txt 2
+┊●   1#1 4593422 partial change to a.txt 2
 ┊│     45:n M a.txt
-┊●   8dc39e0 partial change to a.txt 1
+┊●   1#2 8dc39e0 partial change to a.txt 1
 ┊│     8:n M a.txt
-┊●   f4ea7f8 a.txt
+┊●   1#3 f4ea7f8 a.txt
 ┊│     f:n A a.txt
 ┊●   9477ae7 add A
 ┊│     9:t A A

--- a/crates/but/tests/but/command/branch/delete.rs
+++ b/crates/but/tests/but/command/branch/delete.rs
@@ -72,10 +72,10 @@ Deleted branch A
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [C]
-┊●   ec33a86 add C
+┊●   wlx ec33a86 add C
 ┊│
 ┊├┄h0 [B]
-┊●   05d3df1 add B
+┊●   wwm 05d3df1 add B
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -108,7 +108,7 @@ Deleted branch B
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [C]
-┊●   983f317 add C
+┊●   wlx 983f317 add C
 ┊│
 ┊├┄h0 [A]
 ┊●   9477ae7 add A

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -18,7 +18,7 @@ fn commit_moved_file_replaced_by_directory() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   25c45c4 Commit everything
+┊●   1 25c45c4 Commit everything
 ┊│     2:q A A/file
 ┊│     2:p R B
 ┊●   9477ae7 add A
@@ -380,7 +380,7 @@ Created blank commit at the tip of branch 'A'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   2594ce3 (no commit message) (no changes)
+┊●   1 2594ce3 (no commit message) (no changes)
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -586,8 +586,8 @@ Created blank commit above branch 'bottom'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   76b24fa add second
-┊●   32d198c (no commit message) (no changes)
+┊●   ywx 76b24fa add second
+┊●   1 32d198c (no commit message) (no changes)
 ┊│
 ┊├┄bo [bottom]
 ┊●   fe12bcd add first
@@ -632,7 +632,7 @@ Created blank commit at the tip of branch 'A'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   2594ce3 (no commit message) (no changes)
+┊●   1 2594ce3 (no commit message) (no changes)
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -1568,7 +1568,7 @@ Created new independent branch 'a-branch-1'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   d215849 Add file
+┊●   1 d215849 Add file
 ┊│     d:q A file
 ├╯
 ┊

--- a/crates/but/tests/but/command/commit2.rs
+++ b/crates/but/tests/but/command/commit2.rs
@@ -14,7 +14,7 @@ fn no_message_nothing_to_commit() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1049574 (no commit message) (no changes)
+┊●   1 1049574 (no commit message) (no changes)
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -47,7 +47,7 @@ Created commit 7bbfdca on branch 'A'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   7bbfdca (no commit message)
+┊●   1 7bbfdca (no commit message)
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -116,7 +116,7 @@ fn no_args_single_head_message_from_editor() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   d4e7c2a commit from editor
+┊●   1 d4e7c2a commit from editor
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -143,7 +143,7 @@ fn single_head_with_message() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   a41148c add file.txt
+┊●   1 a41148c add file.txt
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -172,7 +172,7 @@ fn can_repeat_message() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊● b141567 author 2000-01-01 00:00:00 +0000
+┊● 1 b141567 author 2000-01-01 00:00:00 +0000
 ┊│     add file.txt  with more  text lines
 ┊● 9477ae7 author 2000-01-01 00:00:00 +0000
 ┊│     add A 
@@ -229,7 +229,7 @@ fn editor_user_writes_no_message() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   3b915b5 (no commit message)
+┊●   1 3b915b5 (no commit message)
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -278,7 +278,7 @@ fn create_commit_on_new_branch() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   d4910f8 (no commit message)
+┊●   1 d4910f8 (no commit message)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -306,7 +306,7 @@ fn create_commit_on_user_provided_branch() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄fi [file]
-┊●   5a6fc56 add first
+┊●   1 5a6fc56 add first
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -328,8 +328,8 @@ Hint: run `but help` for all commands
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄fi [file]
-┊●   49fc2f0 add second
-┊●   5a6fc56 add first
+┊●   1#0 49fc2f0 add second
+┊●   1#1 5a6fc56 add first
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -351,12 +351,12 @@ Hint: run `but help` for all commands
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄ot [other]
-┊●   ed433d3 add third
+┊●   1#0 ed433d3 add third
 ├╯
 ┊
 ┊╭┄fi [file]
-┊●   49fc2f0 add second
-┊●   5a6fc56 add first
+┊●   1#1 49fc2f0 add second
+┊●   1#2 5a6fc56 add first
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -378,13 +378,13 @@ Hint: run `but help` for all commands
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄ot [other]
-┊●   81bd527 add fourth
-┊●   ed433d3 add third
+┊●   1#0 81bd527 add fourth
+┊●   1#1 ed433d3 add third
 ├╯
 ┊
 ┊╭┄fi [file]
-┊●   49fc2f0 add second
-┊●   5a6fc56 add first
+┊●   1#2 49fc2f0 add second
+┊●   1#3 5a6fc56 add first
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -410,7 +410,7 @@ fn create_commit_on_new_branch_with_canned_name() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   633b765 add file.txt
+┊●   1 633b765 add file.txt
 ├╯
 ┊
 ┊╭┄g0 [A]
@@ -505,7 +505,7 @@ fn empty_flag_to_force_empty_commit_when_changes_exist() {
 ┊   v A changes
 ┊
 ┊╭┄br [a-branch-1]
-┊●   341ce70 empty commit despite changes in worktree (no changes)
+┊●   1 341ce70 empty commit despite changes in worktree (no changes)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -548,8 +548,8 @@ Hint: run `but help` for all commands
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   955bee4 add second
-┊●   4400448 (no commit message) (no changes)
+┊●   ywx 955bee4 add second
+┊●   1 4400448 (no commit message) (no changes)
 ┊●   fe12bcd add first
 ├╯
 ┊
@@ -593,9 +593,9 @@ Hint: run `but help` for all commands
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   eee1eaf add second
-┊●   c149530 add first
-┊●   8b16ff4 (no commit message) (no changes)
+┊●   ywx eee1eaf add second
+┊●   zll c149530 add first
+┊●   1 8b16ff4 (no commit message) (no changes)
 ├╯
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
@@ -641,8 +641,8 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   e38b8f7 add second
-┊●   94fecae add file.txt
+┊●   ywx e38b8f7 add second
+┊●   1 94fecae add file.txt
 ┊●   fe12bcd add first
 ├╯
 ┊
@@ -688,7 +688,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   092d7a9 add file.txt
+┊●   1 092d7a9 add file.txt
 ┊│
 ┊├┄g0 [A]
 ┊●   9477ae7 add A
@@ -737,9 +737,9 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   d7e6d8f add second
-┊●   12982b7 add first
-┊●   bdfeaa4 add file.txt
+┊●   ywx d7e6d8f add second
+┊●   zll 12982b7 add first
+┊●   1 bdfeaa4 add file.txt
 ├╯
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
@@ -784,10 +784,10 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   8a3fbb3 add A
+┊●   tpm 8a3fbb3 add A
 ┊│
 ┊├┄br [a-branch-1]
-┊●   28e38bd add file.txt
+┊●   1 28e38bd add file.txt
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -833,11 +833,11 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   d7e6d8f add second
-┊●   12982b7 add first
+┊●   ywx d7e6d8f add second
+┊●   zll 12982b7 add first
 ┊│
 ┊├┄br [a-branch-1]
-┊●   bdfeaa4 add file.txt
+┊●   1 bdfeaa4 add file.txt
 ├╯
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
@@ -1075,7 +1075,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ┊   twop A two
 ┊
 ┊╭┄g0 [A]
-┊●   f86bb7b (no commit message)
+┊●   1 f86bb7b (no commit message)
 ┊│     f:k A one
 ┊●   9477ae7 add A
 ┊│     9:t A A
@@ -1133,9 +1133,9 @@ q:2 file│
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   f0a3edc (no commit message)
+┊●   1#0 f0a3edc (no commit message)
 ┊│     f:q M file
-┊●   21b345e (no commit message)
+┊●   1#1 21b345e (no commit message)
 ┊│     2:q A file
 ┊●   9477ae7 add A
 ┊│     9:t A A
@@ -1160,9 +1160,9 @@ Hint: run `but help` for all commands
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   f0a3edc (no commit message)
+┊●   1#0 f0a3edc (no commit message)
 ┊│     f:q M file
-┊●   21b345e (no commit message)
+┊●   1#1 21b345e (no commit message)
 ┊│     2:q A file
 ┊●   9477ae7 add A
 ┊│     9:t A A
@@ -1220,9 +1220,9 @@ q:2 file│
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   f0a3edc (no commit message)
+┊●   1#0 f0a3edc (no commit message)
 ┊│     f:q M file
-┊●   21b345e (no commit message)
+┊●   1#1 21b345e (no commit message)
 ┊│     2:q A file
 ┊●   9477ae7 add A
 ┊│     9:t A A
@@ -1247,9 +1247,9 @@ Hint: run `but help` for all commands
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   f0a3edc (no commit message)
+┊●   1#0 f0a3edc (no commit message)
 ┊│     f:q M file
-┊●   21b345e (no commit message)
+┊●   1#1 21b345e (no commit message)
 ┊│     2:q A file
 ┊●   9477ae7 add A
 ┊│     9:t A A
@@ -1316,7 +1316,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ┊   o A path/other/to/third.txt
 ┊
 ┊╭┄g0 [A]
-┊●   e1c5473 (no commit message)
+┊●   1 e1c5473 (no commit message)
 ┊│     e:m A path/to/first.txt
 ┊│     e:r A path/to/second.txt
 ┊●   9477ae7 add A
@@ -1358,7 +1358,7 @@ fn path_prefix_with_mix_of_modifications() {
 ┊   x M dir/to_modify.txt
 ┊
 ┊╭┄g0 [A]
-┊●   d199c17 (no commit message)
+┊●   1 d199c17 (no commit message)
 ┊│     d:l A dir/to_delete.txt
 ┊│     d:n A dir/to_empty.txt
 ┊│     d:x A dir/to_modify.txt
@@ -1381,11 +1381,11 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   d1a6de8 (no commit message)
+┊●   1#0 d1a6de8 (no commit message)
 ┊│     d1a:l D dir/to_delete.txt
 ┊│     d1a:n M dir/to_empty.txt
 ┊│     d1a:x M dir/to_modify.txt
-┊●   d199c17 (no commit message)
+┊●   1#1 d199c17 (no commit message)
 ┊│     d19:l A dir/to_delete.txt
 ┊│     d19:n A dir/to_empty.txt
 ┊│     d19:x A dir/to_modify.txt
@@ -1455,7 +1455,7 @@ fn committing_above_an_empty_branch() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   75b9f19 add one
+┊●   1 75b9f19 add one
 ┊│
 ┊├┄to [top] (no commits)
 ├╯
@@ -1489,7 +1489,7 @@ fn committing_below_empty_branch_with_empty_branch_below() {
 ┊╭┄to [top] (no commits)
 ┊│
 ┊├┄br [a-branch-1]
-┊●   75b9f19 add one
+┊●   1 75b9f19 add one
 ┊│
 ┊├┄mi [middle] (no commits)
 ├╯
@@ -1531,10 +1531,10 @@ fn committing_below_non_top_empty_branch() {
 ┊├┄mi [middle] (no commits)
 ┊│
 ┊├┄br [a-branch-1]
-┊●   af4ddbe add two
+┊●   1#0 af4ddbe add two
 ┊│
 ┊├┄bo [bottom]
-┊●   75b9f19 add one
+┊●   1#1 75b9f19 add one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1585,7 +1585,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ┊╭┄to [top] (no commits)
 ┊│
 ┊├┄br [a-branch-1]
-┊●   75b9f19 add one
+┊●   1 75b9f19 add one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1609,10 +1609,10 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ┊╭┄to [top] (no commits)
 ┊│
 ┊├┄br [a-branch-1]
-┊●   af4ddbe add two
+┊●   1#0 af4ddbe add two
 ┊│
 ┊├┄bo [bottom]
-┊●   75b9f19 add one
+┊●   1#1 75b9f19 add one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1650,7 +1650,7 @@ fn commit_to_existing_branch_via_short_code() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   2e0e1d8 new commit (no changes)
+┊●   1 2e0e1d8 new commit (no changes)
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -1677,7 +1677,7 @@ fn commit_to_new_branch_with_same_name_as_file() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄fi [file]
-┊●   46b0823 add file
+┊●   1 46b0823 add file
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1715,7 +1715,7 @@ q:3 file│
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   d215849 Add file
+┊●   1 d215849 Add file
 ┊│     d:q A file
 ├╯
 ┊
@@ -1825,7 +1825,7 @@ fn new_branches_are_created_on_top() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   7adb8e6 (no commit message) (no changes)
+┊●   1 7adb8e6 (no commit message) (no changes)
 ├╯
 ┊
 ┊╭┄g0 [A]

--- a/crates/but/tests/but/command/diff.rs
+++ b/crates/but/tests/but/command/diff.rs
@@ -329,7 +329,7 @@ fn json_target_committed_file() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   3f40d29 committed-file-target
+┊●   1 3f40d29 committed-file-target
 ┊│     3:k A committed-other.txt
 ┊│     3:w A committed-target.txt
 ┊●   9477ae7 add A
@@ -610,12 +610,12 @@ fn json_commit_target_tree_change_statuses() -> anyhow::Result<()> {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   dafe86a status-target
+┊●   1#0 dafe86a status-target
 ┊│     da:nx A added.txt
 ┊│     da:nm D deleted.txt
 ┊│     da:u M modified.txt
 ┊│     da:o R renamed-after.txt
-┊●   db7d00b status-base
+┊●   1#1 db7d00b status-base
 ┊│     db:n A deleted.txt
 ┊│     db:u A modified.txt
 ┊│     db:z A renamed-before.txt

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -49,6 +49,9 @@ mod reword;
 mod rub;
 #[cfg(feature = "legacy")]
 mod setup;
+#[cfg(feature = "but-2")]
+// behind but-2 feature flag as we use _commit2 in the tests for convenience
+mod show;
 mod skill;
 #[cfg(feature = "legacy")]
 mod squash;

--- a/crates/but/tests/but/command/move.rs
+++ b/crates/but/tests/but/command/move.rs
@@ -114,9 +114,9 @@ fn move_multiple_commits_before_another_commit() -> anyhow::Result<()> {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   23e1bf8 create e.txt and f.txt
-┊●   de41286 create c.txt and d.txt
-┊●   fce8ecc create a.txt and b.txt
+┊●   1#0 23e1bf8 create e.txt and f.txt
+┊●   1#1 de41286 create c.txt and d.txt
+┊●   1#2 fce8ecc create a.txt and b.txt
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -158,9 +158,9 @@ Moved 2 commits → before fce8ecc
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   0e08d58 create a.txt and b.txt
-┊●   7887784 create e.txt and f.txt
-┊●   078d9e6 create c.txt and d.txt
+┊●   1#0 0e08d58 create a.txt and b.txt
+┊●   1#1 7887784 create e.txt and f.txt
+┊●   1#2 078d9e6 create c.txt and d.txt
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -192,9 +192,9 @@ fn move_multiple_commits_after_another_commit() -> anyhow::Result<()> {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   23e1bf8 create e.txt and f.txt
-┊●   de41286 create c.txt and d.txt
-┊●   fce8ecc create a.txt and b.txt
+┊●   1#0 23e1bf8 create e.txt and f.txt
+┊●   1#1 de41286 create c.txt and d.txt
+┊●   1#2 fce8ecc create a.txt and b.txt
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -236,9 +236,9 @@ Moved 2 commits → after 23e1bf8
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   05b04e5 create c.txt and d.txt
-┊●   9f54aec create a.txt and b.txt
-┊●   d7e5fc7 create e.txt and f.txt
+┊●   1#0 05b04e5 create c.txt and d.txt
+┊●   1#1 9f54aec create a.txt and b.txt
+┊●   1#2 d7e5fc7 create e.txt and f.txt
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -376,10 +376,10 @@ Moved 4 commits → before [..]
 ┊
 ┊╭┄h0 [B]
 ┊●   [..] B: another 10 lines at the bottom
-┊●   c4ee0c5 C: add another 10 lines to new file
-┊●   4b3d452 C: add 10 lines to new file
-┊●   90250eb C: new file with 10 lines
-┊●   29bc6a0 A: 10 lines on top
+┊●   zmt c4ee0c5 C: add another 10 lines to new file
+┊●   xkt 4b3d452 C: add 10 lines to new file
+┊●   sxz 90250eb C: new file with 10 lines
+┊●   psr 29bc6a0 A: 10 lines on top
 ┊●   62e05ba B: 10 lines at the bottom
 ├╯
 ┊
@@ -519,10 +519,10 @@ Moved 4 commits → after a748762
 ├╯
 ┊
 ┊╭┄h0 [B]
-┊●   79860aa C: add another 10 lines to new file
-┊●   cb938a1 C: add 10 lines to new file
-┊●   87f25cc C: new file with 10 lines
-┊●   d2689e7 A: 10 lines on top
+┊●   zmt 79860aa C: add another 10 lines to new file
+┊●   xkt cb938a1 C: add 10 lines to new file
+┊●   sxz 87f25cc C: new file with 10 lines
+┊●   psr d2689e7 A: 10 lines on top
 ┊●   a748762 B: another 10 lines at the bottom
 ┊●   62e05ba B: 10 lines at the bottom
 ├╯
@@ -827,7 +827,7 @@ Moved branch A on top of C.
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   89a57fc add A
+┊●   tpm 89a57fc add A
 ┊│
 ┊├┄h0 [C]
 ┊●   3842fc0 add C
@@ -991,7 +991,7 @@ Moved branch A on top of C.
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   89a57fc add A
+┊●   tpm 89a57fc add A
 ┊│
 ┊├┄h0 [C]
 ┊●   3842fc0 add C
@@ -1081,7 +1081,7 @@ Unstacked branch C.
 ├╯
 ┊
 ┊╭┄i0 [C]
-┊●   661a9b6 add C
+┊●   xwn 661a9b6 add C
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M

--- a/crates/but/tests/but/command/move2.rs
+++ b/crates/but/tests/but/command/move2.rs
@@ -37,8 +37,8 @@ Moved fe12bcd above commit 9ac4652
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   c6224e6 add first
-┊●   ce8b324 add second
+┊●   zll c6224e6 add first
+┊●   ywx ce8b324 add second
 ├╯
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
@@ -85,8 +85,8 @@ Moved 9ac4652 below commit fe12bcd
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   c6224e6 add first
-┊●   ce8b324 add second
+┊●   zll c6224e6 add first
+┊●   ywx ce8b324 add second
 ├╯
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
@@ -147,13 +147,13 @@ Moved 2a98cfc, 769f4a8 [..]
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   86218a9 add A13
-┊●   4ba5683 add A12
-┊●   33c2cee add A11
-┊●   894e57b add A8
-┊●   1c425d1 add A7
-┊●   73d652c add A10
-┊●   a6a6cd1 add A9
+┊●   usn 86218a9 add A13
+┊●   opy 4ba5683 add A12
+┊●   opk 33c2cee add A11
+┊●   vmw 894e57b add A8
+┊●   tpw 1c425d1 add A7
+┊●   vvl 73d652c add A10
+┊●   mzz a6a6cd1 add A9
 ┊●   d60e311 add A6
 ┊●   c67c49e add A5
 ┊●   23c280d add A4
@@ -228,19 +228,19 @@ Moved 2a98cfc, 0748e42, c67c49e [..]
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   6f23074 add A13
-┊●   ae30331 add A12
-┊●   ad601eb add A11
-┊●   bfcf0d6 add A10
-┊●   a5511fb add A9
-┊●   79d9420 add A7
-┊●   651dbaf add A5
-┊●   33e2190 add A1
-┊●   ddfd694 add A8
-┊●   88fbf4b add A6
-┊●   4868a7b add A4
-┊●   c05b7a8 add A3
-┊●   b7e9e54 add A2
+┊●   usn 6f23074 add A13
+┊●   opy ae30331 add A12
+┊●   opk ad601eb add A11
+┊●   vvl bfcf0d6 add A10
+┊●   mzz a5511fb add A9
+┊●   tpw 79d9420 add A7
+┊●   pyq 651dbaf add A5
+┊●   zpl 33e2190 add A1
+┊●   vmw ddfd694 add A8
+┊●   lyq 88fbf4b add A6
+┊●   mvv 4868a7b add A4
+┊●   tvm c05b7a8 add A3
+┊●   sxq b7e9e54 add A2
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -290,10 +290,10 @@ Moved fe12bcd to new branch 'a-branch-1' above branch 'A'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   c6224e6 add first
+┊●   zll c6224e6 add first
 ┊│
 ┊├┄g0 [A]
-┊●   ce8b324 add second
+┊●   ywx ce8b324 add second
 ├╯
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
@@ -390,10 +390,10 @@ Moved 9ac4652 to new branch 'a-branch-1' below branch 'A'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   c6224e6 add first
+┊●   zll c6224e6 add first
 ┊│
 ┊├┄br [a-branch-1]
-┊●   ce8b324 add second
+┊●   ywx ce8b324 add second
 ├╯
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
@@ -770,7 +770,7 @@ Moved 9477ae7 to the tip of branch 'B'
 ├╯
 ┊
 ┊╭┄h0 [B]
-┊●   22c3ce2 add A
+┊●   tpm 22c3ce2 add A
 ┊●   d3e2ba3 add B
 ├╯
 ┊
@@ -870,7 +870,7 @@ Moved 9ac4652 to new branch 'new-branch'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄ne [new-branch]
-┊●   ce8b324 add second
+┊●   ywx ce8b324 add second
 ├╯
 ┊
 ┊╭┄g0 [A]
@@ -921,7 +921,7 @@ Moved 9ac4652 to new branch 'a-branch-1'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   ce8b324 add second
+┊●   ywx ce8b324 add second
 ├╯
 ┊
 ┊╭┄g0 [A]
@@ -974,10 +974,10 @@ Moved 1 changes from 9ac4652 to new commit 8e35f84 below commit fe12bcd
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   01a55b8 add second (no changes)
-┊●   12b9152 add first
+┊●   ywx 01a55b8 add second (no changes)
+┊●   zll 12b9152 add first
 ┊│     1:l A first
-┊●   8e35f84 (no commit message)
+┊●   1 8e35f84 (no commit message)
 ┊│     8:w A second
 ├╯
 ┊
@@ -1027,9 +1027,9 @@ Moved 1 changes from fe12bcd to new commit c019027 above commit 9ac4652
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   c019027 (no commit message)
+┊●   1 c019027 (no commit message)
 ┊│     c:l A first
-┊●   38b1f1a add second
+┊●   ywx 38b1f1a add second
 ┊│     3:w A second
 ┊●   d8dfd0f add first (no changes)
 ├╯
@@ -1080,12 +1080,12 @@ Moved 1 changes from 9ac4652 to new commit 8e35f84 on new branch 'a-branch-1' be
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   01a55b8 add second (no changes)
-┊●   12b9152 add first
+┊●   ywx 01a55b8 add second (no changes)
+┊●   zll 12b9152 add first
 ┊│     1:l A first
 ┊│
 ┊├┄br [a-branch-1]
-┊●   8e35f84 (no commit message)
+┊●   1 8e35f84 (no commit message)
 ┊│     8:w A second
 ├╯
 ┊
@@ -1135,11 +1135,11 @@ Moved 1 changes from fe12bcd to new commit c019027 on new branch 'a-branch-1' ab
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   c019027 (no commit message)
+┊●   1 c019027 (no commit message)
 ┊│     c:l A first
 ┊│
 ┊├┄g0 [A]
-┊●   38b1f1a add second
+┊●   ywx 38b1f1a add second
 ┊│     3:w A second
 ┊●   d8dfd0f add first (no changes)
 ├╯
@@ -1193,7 +1193,7 @@ Moved 1 changes from d3e2ba3 to new commit be174de to the tip of branch 'A'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   be174de (no commit message)
+┊●   1 be174de (no commit message)
 ┊│     b:p A B
 ┊●   9477ae7 add A
 ┊│     9:t A A
@@ -1249,7 +1249,7 @@ Moved 1 changes from 9ac4652 to new commit 8e35f84 on new branch 'new-branch'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄ne [new-branch]
-┊●   8e35f84 (no commit message)
+┊●   1 8e35f84 (no commit message)
 ┊│     8e:w A second
 ├╯
 ┊
@@ -1305,7 +1305,7 @@ Moved 1 changes from 9ac4652 to new commit 8e35f84 on new branch 'a-branch-1'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   8e35f84 (no commit message)
+┊●   1 8e35f84 (no commit message)
 ┊│     8e:w A second
 ├╯
 ┊
@@ -1347,11 +1347,11 @@ fn move_file_should_be_order_independent() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   e3d3e3a Prepare for moves!
+┊●   1#0 e3d3e3a Prepare for moves!
 ┊│     e:u R moved
 ┊│     e:p A new/file
 ┊│     e:t A unrelated
-┊●   24ac1e5 Add new file
+┊●   1#1 24ac1e5 Add new file
 ┊│     2:n A new
 ├╯
 ┊
@@ -1376,12 +1376,12 @@ Moved 2 changes from e3d3e3a to new commit 99ef17e above commit e3d3e3a
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   99ef17e (no commit message)
+┊●   1#0 99ef17e (no commit message)
 ┊│     9:u R moved
 ┊│     9:p A new/file
-┊●   f94e59f Prepare for moves!
+┊●   1#1 f94e59f Prepare for moves!
 ┊│     f:t A unrelated
-┊●   24ac1e5 Add new file
+┊●   1#2 24ac1e5 Add new file
 ┊│     2:n A new
 ├╯
 ┊
@@ -1408,12 +1408,12 @@ Moved 2 changes from e3d3e3a to new commit 99ef17e above commit e3d3e3a
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   99ef17e (no commit message)
+┊●   1#0 99ef17e (no commit message)
 ┊│     9:u R moved
 ┊│     9:p A new/file
-┊●   f94e59f Prepare for moves!
+┊●   1#1 f94e59f Prepare for moves!
 ┊│     f:t A unrelated
-┊●   24ac1e5 Add new file
+┊●   1#2 24ac1e5 Add new file
 ┊│     2:n A new
 ├╯
 ┊
@@ -1506,10 +1506,10 @@ Stacked branch 'B' on top of branch 'C'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [B]
-┊●   223f14d add B
+┊●   wwm 223f14d add B
 ┊│
 ┊├┄h0 [C]
-┊●   983f317 add C
+┊●   wlx 983f317 add C
 ┊│
 ┊├┄i0 [A]
 ┊●   9477ae7 add A
@@ -1623,7 +1623,7 @@ Stacked branch 'B' on top of branch 'A'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [B]
-┊●   e776549 add B
+┊●   lrm e776549 add B
 ┊│
 ┊├┄h0 [A]
 ┊●   9477ae7 add A
@@ -1792,7 +1792,7 @@ Unstacked branch 'C'
 ├╯
 ┊
 ┊╭┄i0 [C]
-┊●   db21ee2 add C
+┊●   wlx db21ee2 add C
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1846,11 +1846,11 @@ Unstacked branch 'B'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [B]
-┊●   05d3df1 add B
+┊●   wwm 05d3df1 add B
 ├╯
 ┊
 ┊╭┄h0 [C]
-┊●   983f317 add C
+┊●   wlx 983f317 add C
 ┊│
 ┊├┄i0 [A]
 ┊●   9477ae7 add A
@@ -1911,10 +1911,10 @@ Unstacked branch 'A'
 ├╯
 ┊
 ┊╭┄h0 [C]
-┊●   ec33a86 add C
+┊●   wlx ec33a86 add C
 ┊│
 ┊├┄i0 [B]
-┊●   05d3df1 add B
+┊●   wwm 05d3df1 add B
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2025,10 +2025,10 @@ Unstacked branch 'A'
 ├╯
 ┊
 ┊╭┄h0 [C]
-┊●   ec33a86 add C
+┊●   wlx ec33a86 add C
 ┊│
 ┊├┄i0 [B]
-┊●   05d3df1 add B
+┊●   wwm 05d3df1 add B
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -38,7 +38,7 @@ Hint: run `but help` for all commands
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [B]
-┊◐   5542cc3 add B
+┊◐   lrm 5542cc3 add B
 ├╯
 ┊
 ┴ 26ecc90 (common base) 2000-01-02 add upstream
@@ -111,7 +111,7 @@ Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove 
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊◐   3a110f4 add A
+┊◐   ozt 3a110f4 add A
 ├╯
 ┊
 ┴ d4cb681 (common base) 2000-01-02 add upstream
@@ -287,7 +287,7 @@ Hint: run `but help` for all commands
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊◐   6e0f28b A-change (no changes) {conflicted}
+┊◐   nyo 6e0f28b A-change (no changes) {conflicted}
 ├╯
 ┊
 ┴ bdfcf28 (common base) 2000-01-02 main-change
@@ -436,7 +436,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ┊   o M shared.txt
 ┊
 ┊╭┄g0 [A]
-┊◐   705b03e local change (no changes) {conflicted}
+┊◐   vun 705b03e local change (no changes) {conflicted}
 ├╯
 ┊
 ┴ 7f73771 (common base) 2000-01-02 upstream change
@@ -500,7 +500,7 @@ Hint: run `but help` for all commands
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊◐   705b03e local change (no changes) {conflicted}
+┊◐   vun 705b03e local change (no changes) {conflicted}
 ├╯
 ┊
 ┴ 7f73771 (common base) 2000-01-02 upstream change
@@ -565,10 +565,10 @@ To undo this operation:
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊◐   4a2dd6a top change
+┊◐   rvk 4a2dd6a top change
 ┊│
 ┊├┄h0 [B]
-┊◐   d5fa75c bottom change (no changes) {conflicted}
+┊◐   rou d5fa75c bottom change (no changes) {conflicted}
 ├╯
 ┊
 ┴ 7f73771 (common base) 2000-01-02 upstream change
@@ -633,10 +633,10 @@ To undo this operation:
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊◐   09bcfd9 top change (no changes) {conflicted}
+┊◐   wmr 09bcfd9 top change (no changes) {conflicted}
 ┊│
 ┊├┄h0 [B]
-┊◐   7ac1f5a bottom change (no changes) {conflicted}
+┊◐   trk 7ac1f5a bottom change (no changes) {conflicted}
 ├╯
 ┊
 ┴ e4933d8 (common base) 2000-01-02 upstream change

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -732,7 +732,7 @@ fn uncommit_command_with_discard_on_commit() -> anyhow::Result<()> {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   fce8ecc create a.txt and b.txt
+┊●   1 fce8ecc create a.txt and b.txt
 ┊│     f:n A a.txt
 ┊│     f:p A b.txt
 ┊●   9477ae7 add A
@@ -816,7 +816,7 @@ fn uncommit_command_with_discard_on_committed_file() -> anyhow::Result<()> {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   fce8ecc create a.txt and b.txt
+┊●   1 fce8ecc create a.txt and b.txt
 ┊│     f:n A a.txt
 ┊│     f:p A b.txt
 ┊●   9477ae7 add A
@@ -860,7 +860,7 @@ Hint: run `but help` for all commands
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   993513d create a.txt and b.txt
+┊●   1 993513d create a.txt and b.txt
 ┊│     99:n A a.txt
 ┊●   9477ae7 add A
 ┊│     94:t A A
@@ -1601,7 +1601,7 @@ fn rub_commit_without_message_to_commit() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   aec35ac add one.txt
+┊●   1 aec35ac add one.txt
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -1618,8 +1618,8 @@ fn rub_commit_without_message_to_commit() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   5e5c05a (no commit message) (no changes)
-┊●   aec35ac add one.txt
+┊●   1#0 5e5c05a (no commit message) (no changes)
+┊●   1#1 aec35ac add one.txt
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -1636,7 +1636,7 @@ fn rub_commit_without_message_to_commit() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   aec35ac add one.txt
+┊●   1 aec35ac add one.txt
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -2234,7 +2234,7 @@ fn rubbing_modified_and_renamed_file() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   e3f869d add files
+┊●   1 e3f869d add files
 ┊│     e:q A file
 ┊│     e:k A file-2
 ├╯
@@ -2257,7 +2257,7 @@ Hint: run `but help` for all commands
 ┊   k D file-2
 ┊
 ┊╭┄br [a-branch-1]
-┊●   e3f869d add files
+┊●   1 e3f869d add files
 ┊│     e:q A file
 ┊│     e:k A file-2
 ├╯
@@ -2277,7 +2277,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   3a32c97 add files
+┊●   1 3a32c97 add files
 ┊│     3:q A file
 ├╯
 ┊
@@ -2305,7 +2305,7 @@ fn committing_modified_and_renamed_file() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   e3f869d add files
+┊●   1 e3f869d add files
 ┊│     e:q A file
 ┊│     e:k A file-2
 ├╯
@@ -2328,7 +2328,7 @@ Hint: run `but help` for all commands
 ┊   k D file-2
 ┊
 ┊╭┄br [a-branch-1]
-┊●   e3f869d add files
+┊●   1 e3f869d add files
 ┊│     e:q A file
 ┊│     e:k A file-2
 ├╯
@@ -2348,10 +2348,10 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   e419886 change file
+┊●   1#0 e419886 change file
 ┊│     e4:q M file
 ┊│     e4:k D file-2
-┊●   e3f869d add files
+┊●   1#1 e3f869d add files
 ┊│     e3:q A file
 ┊│     e3:k A file-2
 ├╯

--- a/crates/but/tests/but/command/show.rs
+++ b/crates/but/tests/but/command/show.rs
@@ -1,0 +1,120 @@
+use crate::utils::Sandbox;
+
+#[test]
+fn can_show_by_duplicated_change_id() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.but("_commit2 -m first").assert().success();
+    env.but("_commit2 -m second").assert().success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄br [a-branch-1]
+┊●   1#0 e8564e1 second (no changes)
+┊●   1#1 71c4380 first (no changes)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("show 1#0")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Commit:    e8564e1938a8b7e00c0f3cf88d08f0687d6863d3
+Change-ID: 1
+Author:    author <author@example.com>
+Date:      2000-01-02 00:00:00 +0000 (26y ago)
+Committer: committer <committer@example.com>
+
+second
+
+
+"#]]);
+    env.but("show 1#1")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Commit:    71c4380695ab83fc7ff085860bb656ab27ed524e
+Change-ID: 1
+Author:    author <author@example.com>
+Date:      2000-01-02 00:00:00 +0000 (26y ago)
+Committer: committer <committer@example.com>
+
+first
+
+
+"#]]);
+}
+
+#[test]
+fn can_show_by_distinct_change_id() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    set_change_id(&env, "123");
+    env.but("_commit2 -m first").assert().success();
+
+    set_change_id(&env, "132");
+    env.but("_commit2 -m second").assert().success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄br [a-branch-1]
+┊●   132 ea3b1e3 second (no changes)
+┊●   123 a8954d4 first (no changes)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("show 12")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Commit:    a8954d4c8daf2bc64ad7a62a33dbbad7a920bdb7
+Change-ID: 123
+Author:    author <author@example.com>
+Date:      2000-01-02 00:00:00 +0000 (26y ago)
+Committer: committer <committer@example.com>
+
+first
+
+
+"#]]);
+    env.but("show 13")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Commit:    ea3b1e3ff9f628d463fc5d66a20a9d523fb9a95b
+Change-ID: 132
+Author:    author <author@example.com>
+Date:      2000-01-02 00:00:00 +0000 (26y ago)
+Committer: committer <committer@example.com>
+
+second
+
+
+"#]]);
+}
+
+fn set_change_id(env: &Sandbox, change_id: &str) {
+    env.invoke_git(&format!(
+        "config --local gitbutler.testing.changeId {change_id}"
+    ));
+}

--- a/crates/but/tests/but/command/squash2.rs
+++ b/crates/but/tests/but/command/squash2.rs
@@ -65,11 +65,11 @@ fn squash_two_commits() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   f55169f add three
+┊●   1#0 f55169f add three
 ┊│     f5:o A three
-┊●   f63361f add two
+┊●   1#1 f63361f add two
 ┊│     f6:t A two
-┊●   ea345ba add one
+┊●   1#2 ea345ba add one
 ┊│     e:k A one
 ├╯
 ┊
@@ -94,10 +94,10 @@ Squashed f55169f into f63361f to create 7251301
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   7251301 squashed
+┊●   1#0 7251301 squashed
 ┊│     7:o A three
 ┊│     7:t A two
-┊●   ea345ba add one
+┊●   1#1 ea345ba add one
 ┊│     e:k A one
 ├╯
 ┊
@@ -149,7 +149,7 @@ Squashed f55169f, f63361f into ea345ba to create e355a10
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   e355a10 squashed
+┊●   1 e355a10 squashed
 ┊│     e:k A one
 ┊│     e:o A three
 ┊│     e:t A two
@@ -177,11 +177,11 @@ fn use_target_message() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊● 5ab5165 author 2000-01-01 00:00:00 +0000
+┊● 1#0 5ab5165 author 2000-01-01 00:00:00 +0000
 ┊│     add two
 ┊│     5:o A three
 ┊│     5:t A two
-┊● ea345ba author 2000-01-01 00:00:00 +0000
+┊● 1#1 ea345ba author 2000-01-01 00:00:00 +0000
 ┊│     add one
 ┊│     e:k A one
 ├╯
@@ -208,11 +208,11 @@ fn use_source_message() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊● c441d34 author 2000-01-01 00:00:00 +0000
+┊● 1#0 c441d34 author 2000-01-01 00:00:00 +0000
 ┊│     add three
 ┊│     c:o A three
 ┊│     c:t A two
-┊● ea345ba author 2000-01-01 00:00:00 +0000
+┊● 1#1 ea345ba author 2000-01-01 00:00:00 +0000
 ┊│     add one
 ┊│     e:k A one
 ├╯
@@ -243,7 +243,7 @@ Squashed branch 'a-branch-1' to create commit a694042
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊● a694042 author 2000-01-01 00:00:00 +0000
+┊● 1 a694042 author 2000-01-01 00:00:00 +0000
 ┊│     squashed a branch
 ┊│     a:k A one
 ┊│     a:o A three
@@ -276,7 +276,7 @@ Squashed branch 'a-branch-1' to create commit 17b59a2
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊● 17b59a2 author 2000-01-01 00:00:00 +0000
+┊● 1 17b59a2 author 2000-01-01 00:00:00 +0000
 ┊│     add two
 ┊│     1:k A one
 ┊│     1:o A three
@@ -310,24 +310,24 @@ fn squash_whole_branch_into_commit_on_other_branch() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄fi [add-file-branch]
-┊● e528488 author 2000-01-01 00:00:00 +0000
+┊● 1#0 e528488 author 2000-01-01 00:00:00 +0000
 ┊│     add file
 ┊│     e5:q A file
 ├╯
 ┊
 ┊╭┄ta [target-branch]
-┊● d1d6a19 author 2000-01-01 00:00:00 +0000 (no changes)
+┊● 1#1 d1d6a19 author 2000-01-01 00:00:00 +0000 (no changes)
 ┊│     new commit on new branch
 ├╯
 ┊
 ┊╭┄br [a-branch-1]
-┊● f55169f author 2000-01-01 00:00:00 +0000
+┊● 1#2 f55169f author 2000-01-01 00:00:00 +0000
 ┊│     add three
 ┊│     f5:o A three
-┊● f63361f author 2000-01-01 00:00:00 +0000
+┊● 1#3 f63361f author 2000-01-01 00:00:00 +0000
 ┊│     add two
 ┊│     f6:t A two
-┊● ea345ba author 2000-01-01 00:00:00 +0000
+┊● 1#4 ea345ba author 2000-01-01 00:00:00 +0000
 ┊│     add one
 ┊│     ea:k A one
 ├╯
@@ -353,7 +353,7 @@ Squashed branches 'a-branch-1', 'add-file-branch' to create commit 44aa30a
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄ta [target-branch]
-┊● 44aa30a author 2000-01-01 00:00:00 +0000
+┊● 1 44aa30a author 2000-01-01 00:00:00 +0000
 ┊│     new commit on new branch
 ┊│     4:q A file
 ┊│     4:k A one
@@ -391,26 +391,26 @@ fn squash_multiple_branches_into_commit_on_one_of_the_branch_sources() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄fi [add-file-branch]
-┊● e528488 author 2000-01-01 00:00:00 +0000
+┊● 1#0 e528488 author 2000-01-01 00:00:00 +0000
 ┊│     add file
 ┊│     e5:q A file
 ├╯
 ┊
 ┊╭┄ta [target-branch]
-┊● a489b93 author 2000-01-01 00:00:00 +0000 (no changes)
+┊● 1#1 a489b93 author 2000-01-01 00:00:00 +0000 (no changes)
 ┊│     random commit on target-branch
-┊● 561a8d8 author 2000-01-01 00:00:00 +0000 (no changes)
+┊● 1#2 561a8d8 author 2000-01-01 00:00:00 +0000 (no changes)
 ┊│     target commit
 ├╯
 ┊
 ┊╭┄br [a-branch-1]
-┊● f55169f author 2000-01-01 00:00:00 +0000
+┊● 1#3 f55169f author 2000-01-01 00:00:00 +0000
 ┊│     add three
 ┊│     f5:o A three
-┊● f63361f author 2000-01-01 00:00:00 +0000
+┊● 1#4 f63361f author 2000-01-01 00:00:00 +0000
 ┊│     add two
 ┊│     f6:t A two
-┊● ea345ba author 2000-01-01 00:00:00 +0000
+┊● 1#5 ea345ba author 2000-01-01 00:00:00 +0000
 ┊│     add one
 ┊│     ea:k A one
 ├╯
@@ -436,7 +436,7 @@ Squashed branches 'target-branch', 'a-branch-1', 'add-file-branch' to create com
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄ta [target-branch]
-┊● 0653794 author 2000-01-01 00:00:00 +0000
+┊● 1 0653794 author 2000-01-01 00:00:00 +0000
 ┊│     target commit
 ┊│     0:q A file
 ┊│     0:k A one
@@ -478,7 +478,7 @@ Squashed branch 'a-branch-1' to create commit 7b3d915
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊● 7b3d915 author 2000-01-01 00:00:00 +0000
+┊● 1 7b3d915 author 2000-01-01 00:00:00 +0000
 ┊│     message from editor
 ┊│     7:k A one
 ┊│     7:o A three
@@ -516,7 +516,7 @@ Squashed branch 'a-branch-1' to create commit abb21d9
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊● abb21d9 author 2000-01-01 00:00:00 +0000
+┊● 1 abb21d9 author 2000-01-01 00:00:00 +0000
 ┊│     add one  add three  add two
 ┊│     a:k A one
 ┊│     a:o A three
@@ -696,11 +696,11 @@ fn aborts_on_conflicts() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   d5e51af remove file
+┊●   1#0 d5e51af remove file
 ┊│     d:u D file.txt
-┊●   5b59611 change file
+┊●   1#1 5b59611 change file
 ┊│     5:u M file.txt
-┊●   11a2a8a add file
+┊●   1#2 11a2a8a add file
 ┊│     1:u A file.txt
 ├╯
 ┊
@@ -730,16 +730,16 @@ fn cannot_squash_into_commits_on_unapplied_branches() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄se [second]
-┊●   d15f721 add four
+┊●   1#0 d15f721 add four
 ┊│     d:q A four
-┊●   66a5286 add three
+┊●   1#1 66a5286 add three
 ┊│     6:o A three
 ├╯
 ┊
 ┊╭┄on [one]
-┊●   f63361f add two
+┊●   1#2 f63361f add two
 ┊│     f:t A two
-┊●   ea345ba add one
+┊●   1#3 ea345ba add one
 ┊│     e:k A one
 ├╯
 ┊
@@ -829,10 +829,10 @@ Squashed f55169f into f63361f to create 5ab5165
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   5ab5165 add two
+┊●   1#0 5ab5165 add two
 ┊│     5:o A three
 ┊│     5:t A two
-┊●   ea345ba add one
+┊●   1#1 ea345ba add one
 ┊│     e:k A one
 ├╯
 ┊
@@ -862,11 +862,11 @@ Squashed branch 'one' to create commit 00e6751
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄se [second]
-┊●   00e6751 add four
+┊●   1#0 00e6751 add four
 ┊│     0:q A four
 ┊│     0:k A one
 ┊│     0:t A two
-┊●   66a5286 add three
+┊●   1#1 66a5286 add three
 ┊│     6:o A three
 ├╯
 ┊
@@ -891,7 +891,7 @@ fn amend_uncommitted_files_into_commit() {
 ┊   twop A two
 ┊
 ┊╭┄br [a-branch-1]
-┊●   7adb8e6 (no commit message) (no changes)
+┊●   1 7adb8e6 (no commit message) (no changes)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -916,7 +916,7 @@ Amended 7adb8e6 to create d2f176a
 ┊   o A three
 ┊
 ┊╭┄br [a-branch-1]
-┊●   d2f176a (no commit message)
+┊●   1 d2f176a (no commit message)
 ┊│     d:k A one
 ┊│     d:t A two
 ├╯
@@ -942,7 +942,7 @@ fn amend_all_uncommitted_changes_into_commit() {
 ┊   twop A two
 ┊
 ┊╭┄br [a-branch-1]
-┊●   7adb8e6 (no commit message) (no changes)
+┊●   1 7adb8e6 (no commit message) (no changes)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -966,7 +966,7 @@ Amended 7adb8e6 to create 0e76889
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   0e76889 (no commit message)
+┊●   1 0e76889 (no commit message)
 ┊│     0:k A one
 ┊│     0:o A three
 ┊│     0:t A two
@@ -1059,11 +1059,11 @@ Amended f55169f to create f55169f
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   f55169f add three
+┊●   1#0 f55169f add three
 ┊│     f5:o A three
-┊●   f63361f add two
+┊●   1#1 f63361f add two
 ┊│     f6:t A two
-┊●   ea345ba add one
+┊●   1#2 ea345ba add one
 ┊│     e:k A one
 ├╯
 ┊
@@ -1093,11 +1093,11 @@ Amended f63361f to create 5ab5165
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   bb84ecc add three (no changes)
-┊●   5ab5165 add two
+┊●   1#0 bb84ecc add three (no changes)
+┊●   1#1 5ab5165 add two
 ┊│     5:o A three
 ┊│     5:t A two
-┊●   ea345ba add one
+┊●   1#2 ea345ba add one
 ┊│     e:k A one
 ├╯
 ┊
@@ -1119,11 +1119,11 @@ fn cannot_amend_files_from_different_commits() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   f55169f add three
+┊●   1#0 f55169f add three
 ┊│     f5:o A three
-┊●   f63361f add two
+┊●   1#1 f63361f add two
 ┊│     f6:t A two
-┊●   ea345ba add one
+┊●   1#2 ea345ba add one
 ┊│     e:k A one
 ├╯
 ┊
@@ -1163,11 +1163,11 @@ fn cannot_amend_files_in_ways_that_cause_conflicts() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   beafa55 remove file
+┊●   1#0 beafa55 remove file
 ┊│     b:q D file
-┊●   623d399 change file
+┊●   1#1 623d399 change file
 ┊│     6:q M file
-┊●   5c348d7 add file
+┊●   1#2 5c348d7 add file
 ┊│     5:q A file
 ├╯
 ┊
@@ -1207,12 +1207,12 @@ Amended f55169f to create 13baa98
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   13baa98 add three
+┊●   1#0 13baa98 add three
 ┊│     1:q A file
 ┊│     1:o A three
-┊●   f63361f add two
+┊●   1#1 f63361f add two
 ┊│     f:t A two
-┊●   ea345ba add one
+┊●   1#2 ea345ba add one
 ┊│     e:k A one
 ├╯
 ┊
@@ -1269,7 +1269,7 @@ Error: --target cannot be an empty branch
 ┊╭┄mi [middle] (no commits)
 ┊│
 ┊├┄bo [bottom]
-┊●   7adb8e6 (no commit message) (no changes)
+┊●   1 7adb8e6 (no commit message) (no changes)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1325,9 +1325,9 @@ Uncommitted f55169f
 ┊   o A three
 ┊
 ┊╭┄br [a-branch-1]
-┊●   f63361f add two
+┊●   1#0 f63361f add two
 ┊│     f:t A two
-┊●   ea345ba add one
+┊●   1#1 ea345ba add one
 ┊│     e:k A one
 ├╯
 ┊
@@ -1356,11 +1356,11 @@ fn squash_into_zz_to_uncommit_file() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   f55169f add three
+┊●   1#0 f55169f add three
 ┊│     f5:o A three
-┊●   f63361f add two
+┊●   1#1 f63361f add two
 ┊│     f6:t A two
-┊●   ea345ba add one
+┊●   1#2 ea345ba add one
 ┊│     e:k A one
 ├╯
 ┊
@@ -1386,10 +1386,10 @@ Uncommitted from f55169f
 ┊   o A three
 ┊
 ┊╭┄br [a-branch-1]
-┊●   aba928c add three (no changes)
-┊●   f63361f add two
+┊●   1#0 aba928c add three (no changes)
+┊●   1#1 f63361f add two
 ┊│     f:t A two
-┊●   ea345ba add one
+┊●   1#2 ea345ba add one
 ┊│     e:k A one
 ├╯
 ┊
@@ -1421,11 +1421,11 @@ fn cannot_uncommit_files_in_ways_that_cause_conflicts() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   beafa55 remove file
+┊●   1#0 beafa55 remove file
 ┊│     b:q D file
-┊●   623d399 change file
+┊●   1#1 623d399 change file
 ┊│     6:q M file
-┊●   5c348d7 add file
+┊●   1#2 5c348d7 add file
 ┊│     5:q A file
 ├╯
 ┊

--- a/crates/but/tests/but/command/uncommit.rs
+++ b/crates/but/tests/but/command/uncommit.rs
@@ -79,9 +79,9 @@ fn uncommit_different_files_from_different_commits_same_branch() -> anyhow::Resu
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   3d21fdd add c2
+┊●   1#0 3d21fdd add c2
 ┊│     3:w A c2.txt
-┊●   28b88fc add c1
+┊●   1#1 28b88fc add c1
 ┊│     2:l A c1.txt
 ┊●   9477ae7 add A
 ┊│     9:t A A
@@ -136,8 +136,8 @@ Uncommitted changes
 ┊   w A c2.txt
 ┊
 ┊╭┄g0 [A]
-┊●   01fc011 add c2 (no changes)
-┊●   5682e2a add c1 (no changes)
+┊●   1#0 01fc011 add c2 (no changes)
+┊●   1#1 5682e2a add c1 (no changes)
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
@@ -185,7 +185,7 @@ fn uncommit_different_files_from_the_same_commit() -> anyhow::Result<()> {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   191c6ed add c1 and c2
+┊●   1 191c6ed add c1 and c2
 ┊│     1:l A c1.txt
 ┊│     1:w A c2.txt
 ┊●   9477ae7 add A
@@ -239,7 +239,7 @@ Uncommitted changes
 ┊   w A c2.txt
 ┊
 ┊╭┄g0 [A]
-┊●   3d256e6 add c1 and c2 (no changes)
+┊●   1 3d256e6 add c1 and c2 (no changes)
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
@@ -289,11 +289,11 @@ fn uncommit_same_file_from_different_commits_same_branch() -> anyhow::Result<()>
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   485d867 write v3
+┊●   1#0 485d867 write v3
 ┊│     4:s M f.txt
-┊●   adeaad7 write v2
+┊●   1#1 adeaad7 write v2
 ┊│     a:s M f.txt
-┊●   825d09f write v1
+┊●   1#2 825d09f write v1
 ┊│     8:s A f.txt
 ┊●   9477ae7 add A
 ┊│     9:t A A
@@ -349,9 +349,9 @@ Uncommitted changes
 ┊   s A f.txt
 ┊
 ┊╭┄g0 [A]
-┊●   ddf33f2 write v3 (no changes)
-┊●   3212a72 write v2 (no changes)
-┊●   637ac90 write v1 (no changes)
+┊●   1#0 ddf33f2 write v3 (no changes)
+┊●   1#1 3212a72 write v2 (no changes)
+┊●   1#2 637ac90 write v1 (no changes)
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
@@ -399,14 +399,14 @@ fn uncommit_different_files_from_different_commits_different_branches() -> anyho
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1675e0b add fa
+┊●   1#0 1675e0b add fa
 ┊│     1:s A fa.txt
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
 ┊
 ┊╭┄h0 [B]
-┊●   30b330c add fb
+┊●   1#1 30b330c add fb
 ┊│     3:q A fb.txt
 ┊●   d3e2ba3 add B
 ┊│     d:p A B
@@ -451,13 +451,13 @@ Uncommitted changes
 ┊   q A fb.txt
 ┊
 ┊╭┄g0 [A]
-┊●   3bbaec6 add fa (no changes)
+┊●   1#0 3bbaec6 add fa (no changes)
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
 ┊
 ┊╭┄h0 [B]
-┊●   0596eed add fb (no changes)
+┊●   1#1 0596eed add fb (no changes)
 ┊●   d3e2ba3 add B
 ┊│     d:p A B
 ├╯


### PR DESCRIPTION
## 🧢 Changes
This PR introduces change IDs to the `but` CLI. As change IDs are inherently "duplicable" in a single workspace, this also forces the introduction of index deduplication on the level of assigning short IDs.

There are some known shortcomings with this implementation that will be fixed in upcoming PRs.

1. Collision indexes are simply appended to the string representation of the "short change ID", which is generally quite undesirable both from a presentation and parsing perspective.
    - I will attempt to structure the collision information in the same way it is currently structured for hunks, so we can do proper prefix matching and also ensure that rendering looks good. 
    - Currently, rendering looks good as we render a minimum of 3 characters and a collision forces at least 3 characters to accomodate the `#<n>` disambiguation. If we were to render e.g. a minimum of 4 characters, then a collision on an ID like `ztrs` could cause output to look like `z#0s` instead of the correct `zs#0`.
2. Change IDs are not currently disambiguated against full branch names. A full branch name can therefore cause ambiguity with both full change IDs and short-form change IDs.
3. Change IDs are not currently disambiguated against uncommitted files unless those files are reverse hexes themselves.
4. Change IDs are not currently disambiguated against commit IDs. This is generally not an issue as our change IDs are reverse hex, but it's a strong assumption that we probably shouldn't make. This will be fixed in an upcoming PR.

Commit IDs _also_ suffer from problems 2 and 3, so all of 2, 3 and 4 are closely related.