### PR TITLE
Project cache-derived PR associations into workspace state

### DIFF
--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -790,6 +790,7 @@ pub fn branch_create_with_perm(
         DryRun::No,
     );
 
+    let prs_by_head = crate::workspace_state::forge_prs_by_head(ctx)?;
     let mut meta = ctx.meta()?;
     let (repo, mut ws, _db) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let checkout_after_create = checkout_anchor_ref.as_ref().is_some_and(|anchor_ref| {
@@ -812,7 +813,8 @@ pub fn branch_create_with_perm(
         snapshot.commit(ctx, perm).ok();
     }
 
-    let workspace = WorkspaceState::from_workspace(&new_ws, &mut meta, &repo, BTreeMap::new())?;
+    let workspace =
+        WorkspaceState::from_workspace(&new_ws, &mut meta, &repo, BTreeMap::new(), &prs_by_head)?;
     *ws = new_ws.into_owned();
     drop(ws);
     drop(repo);
@@ -966,9 +968,11 @@ pub fn branch_remove_with_perm(
         snapshot.commit(ctx, perm).ok();
     }
 
+    let prs_by_head = crate::workspace_state::forge_prs_by_head(ctx)?;
     let mut meta = ctx.meta()?;
     let (repo, ws, _db) = ctx.workspace_mut_and_db_with_perm(perm)?;
-    let workspace = WorkspaceState::from_workspace(&ws, &mut meta, &repo, BTreeMap::new())?;
+    let workspace =
+        WorkspaceState::from_workspace(&ws, &mut meta, &repo, BTreeMap::new(), &prs_by_head)?;
     Ok(BranchRemoveResult { workspace })
 }
 
@@ -1022,11 +1026,13 @@ pub fn branch_rename_with_perm(
 
     // Renaming onto the same name is a no-op that still returns the current view.
     if ref_name.as_ref() == new_ref.as_ref() {
+        let prs_by_head = crate::workspace_state::forge_prs_by_head(ctx)?;
         let mut meta = ctx.meta()?;
         let (repo, ws, _db) = ctx.workspace_mut_and_db_with_perm(perm)?;
         repo.find_reference(ref_name.as_ref())
             .with_context(|| format!("Branch '{}' does not exist", ref_name.shorten()))?;
-        let workspace = WorkspaceState::from_workspace(&ws, &mut meta, &repo, BTreeMap::new())?;
+        let workspace =
+            WorkspaceState::from_workspace(&ws, &mut meta, &repo, BTreeMap::new(), &prs_by_head)?;
         return Ok(BranchRenameResult { workspace, new_ref });
     }
 
@@ -1248,9 +1254,11 @@ pub fn branch_rename_with_perm(
         snapshot.commit(ctx, perm).ok();
     }
 
+    let prs_by_head = crate::workspace_state::forge_prs_by_head(ctx)?;
     let mut meta = ctx.meta()?;
     let (repo, ws, _db) = ctx.workspace_mut_and_db_with_perm(perm)?;
-    let workspace = WorkspaceState::from_workspace(&ws, &mut meta, &repo, BTreeMap::new())?;
+    let workspace =
+        WorkspaceState::from_workspace(&ws, &mut meta, &repo, BTreeMap::new(), &prs_by_head)?;
     Ok(BranchRenameResult { workspace, new_ref })
 }
 
@@ -1423,9 +1431,11 @@ fn checkout_ref_with_perm(
     }
 
     ctx.reload_repo_and_invalidate_workspace(perm)?;
+    let prs_by_head = crate::workspace_state::forge_prs_by_head(ctx)?;
     let mut meta = ctx.meta()?;
     let (repo, ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
-    let workspace = WorkspaceState::from_workspace(&ws, &mut meta, &repo, BTreeMap::new())?;
+    let workspace =
+        WorkspaceState::from_workspace(&ws, &mut meta, &repo, BTreeMap::new(), &prs_by_head)?;
     Ok(BranchCheckoutResult { workspace })
 }
 
@@ -1500,6 +1510,7 @@ pub fn apply_branch_integration_with_perm(
         OperationKind::GenericBranchUpdate,
         dry_run,
         |ctx, perm| {
+            let prs_by_head = crate::workspace_state::forge_prs_by_head(ctx)?;
             let mut meta = ctx.meta()?;
             let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
             let rebase = but_workspace::branch::integrate_branch_with_steps(
@@ -1511,7 +1522,12 @@ pub fn apply_branch_integration_with_perm(
             )?;
 
             Ok(IntegrateBranchResult {
-                workspace: WorkspaceState::from_successful_rebase(rebase, &repo, dry_run)?,
+                workspace: WorkspaceState::from_successful_rebase(
+                    rebase,
+                    &repo,
+                    dry_run,
+                    &prs_by_head,
+                )?,
             })
         },
     )
@@ -1564,6 +1580,7 @@ pub fn move_branch_with_perm(
         OperationKind::MoveBranch,
         dry_run,
         |ctx, perm| {
+            let prs_by_head = crate::workspace_state::forge_prs_by_head(ctx)?;
             let mut meta = ctx.meta()?;
             let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
             let editor = Editor::create(&mut ws, &mut meta, &repo)?;
@@ -1583,7 +1600,13 @@ pub fn move_branch_with_perm(
             }
 
             let result = MoveBranchResult {
-                workspace: branch_workspace_from_rebase(rebase, ws_meta, &repo, dry_run)?,
+                workspace: branch_workspace_from_rebase(
+                    rebase,
+                    ws_meta,
+                    &repo,
+                    dry_run,
+                    &prs_by_head,
+                )?,
             };
             Ok((result, new_tip))
         },
@@ -1644,6 +1667,7 @@ pub fn tear_off_branch_with_perm(
         OperationKind::TearOffBranch,
         dry_run,
         |ctx, perm| {
+            let prs_by_head = crate::workspace_state::forge_prs_by_head(ctx)?;
             let mut meta = ctx.meta()?;
             let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
             let editor = Editor::create(&mut ws, &mut meta, &repo)?;
@@ -1652,7 +1676,13 @@ pub fn tear_off_branch_with_perm(
             } = but_workspace::branch::tear_off_branch(editor, subject_branch, None)?;
 
             Ok(MoveBranchResult {
-                workspace: branch_workspace_from_rebase(rebase, ws_meta, &repo, dry_run)?,
+                workspace: branch_workspace_from_rebase(
+                    rebase,
+                    ws_meta,
+                    &repo,
+                    dry_run,
+                    &prs_by_head,
+                )?,
             })
         },
     )
@@ -1690,9 +1720,10 @@ fn branch_workspace_from_rebase<M: but_core::RefMetadata>(
     ws_meta: Option<but_core::ref_metadata::Workspace>,
     repo: &gix::Repository,
     dry_run: DryRun,
+    prs_by_head: &std::collections::HashMap<String, usize>,
 ) -> anyhow::Result<WorkspaceState> {
     if dry_run.into() {
-        return WorkspaceState::from_successful_rebase(rebase, repo, dry_run);
+        return WorkspaceState::from_successful_rebase(rebase, repo, dry_run, prs_by_head);
     }
 
     let materialized = rebase.materialize()?;
@@ -1708,5 +1739,6 @@ fn branch_workspace_from_rebase<M: but_core::RefMetadata>(
         materialized.meta,
         repo,
         materialized.history.commit_mappings(),
+        prs_by_head,
     )
 }

--- a/crates/but-api/src/commit/amend.rs
+++ b/crates/but-api/src/commit/amend.rs
@@ -40,6 +40,7 @@ pub(crate) fn commit_amend_only_impl(
     context_lines: u32,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitCreateResult> {
+    let prs_by_head = crate::workspace_state::forge_prs_by_head(ctx)?;
     let mut meta = ctx.meta()?;
     let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
@@ -53,7 +54,7 @@ pub(crate) fn commit_amend_only_impl(
     let new_commit = commit_selector
         .map(|commit_selector| rebase.lookup_pick(commit_selector))
         .transpose()?;
-    let workspace = WorkspaceState::from_successful_rebase(rebase, &repo, dry_run)?;
+    let workspace = WorkspaceState::from_successful_rebase(rebase, &repo, dry_run, &prs_by_head)?;
 
     Ok(CommitCreateResult {
         new_commit,

--- a/crates/but-api/src/commit/create.rs
+++ b/crates/but-api/src/commit/create.rs
@@ -57,6 +57,7 @@ pub(crate) fn commit_create_only_impl(
     context_lines: u32,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitCreateResult> {
+    let prs_by_head = crate::workspace_state::forge_prs_by_head(ctx)?;
     let mut meta = ctx.meta()?;
     let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
@@ -77,7 +78,7 @@ pub(crate) fn commit_create_only_impl(
     let new_commit = commit_selector
         .map(|commit_selector| rebase.lookup_pick(commit_selector))
         .transpose()?;
-    let workspace = WorkspaceState::from_successful_rebase(rebase, &repo, dry_run)?;
+    let workspace = WorkspaceState::from_successful_rebase(rebase, &repo, dry_run, &prs_by_head)?;
 
     Ok(CommitCreateResult {
         new_commit,

--- a/crates/but-api/src/commit/discard_commit.rs
+++ b/crates/but-api/src/commit/discard_commit.rs
@@ -37,13 +37,14 @@ pub fn commit_discard_only_with_perm(
     dry_run: DryRun,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitDiscardResult> {
+    let prs_by_head = crate::workspace_state::forge_prs_by_head(ctx)?;
     let mut meta = ctx.meta()?;
     let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
 
     let rebase = but_workspace::commit::discard_commits(editor, [subject_commit_id])?;
 
-    let workspace = WorkspaceState::from_successful_rebase(rebase, &repo, dry_run)?;
+    let workspace = WorkspaceState::from_successful_rebase(rebase, &repo, dry_run, &prs_by_head)?;
 
     Ok(CommitDiscardResult {
         discarded_commit: subject_commit_id,
@@ -140,13 +141,15 @@ pub fn commit_discard_changes_only_with_perm(
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<MoveChangesResult> {
     let context_lines = ctx.settings.context_lines;
+    let prs_by_head = crate::workspace_state::forge_prs_by_head(ctx)?;
     let mut meta = ctx.meta()?;
     let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
 
     let outcome =
         but_workspace::commit::uncommit_changes(editor, commit_id, changes, context_lines)?;
-    let workspace = WorkspaceState::from_successful_rebase(outcome.rebase, &repo, dry_run)?;
+    let workspace =
+        WorkspaceState::from_successful_rebase(outcome.rebase, &repo, dry_run, &prs_by_head)?;
 
     Ok(MoveChangesResult { workspace })
 }

--- a/crates/but-api/src/commit/insert_blank.rs
+++ b/crates/but-api/src/commit/insert_blank.rs
@@ -39,6 +39,7 @@ pub(crate) fn commit_insert_blank_only_impl(
     dry_run: DryRun,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitInsertBlankResult> {
+    let prs_by_head = crate::workspace_state::forge_prs_by_head(ctx)?;
     let mut meta = ctx.meta()?;
     let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
@@ -46,7 +47,7 @@ pub(crate) fn commit_insert_blank_only_impl(
     let (rebase, blank_commit_selector) =
         but_workspace::commit::insert_blank_commit(editor, side, relative_to)?;
     let new_commit = rebase.lookup_pick(blank_commit_selector)?;
-    let workspace = WorkspaceState::from_successful_rebase(rebase, &repo, dry_run)?;
+    let workspace = WorkspaceState::from_successful_rebase(rebase, &repo, dry_run, &prs_by_head)?;
 
     Ok(CommitInsertBlankResult {
         new_commit,

--- a/crates/but-api/src/commit/move_changes.rs
+++ b/crates/but-api/src/commit/move_changes.rs
@@ -52,6 +52,7 @@ pub fn commit_move_changes_between_only_with_perm(
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<MoveChangesResult> {
     let context_lines = ctx.settings.context_lines;
+    let prs_by_head = crate::workspace_state::forge_prs_by_head(ctx)?;
     let mut meta = ctx.meta()?;
     let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
@@ -63,7 +64,8 @@ pub fn commit_move_changes_between_only_with_perm(
         changes,
         context_lines,
     )?;
-    let workspace = WorkspaceState::from_successful_rebase(outcome.rebase, &repo, dry_run)?;
+    let workspace =
+        WorkspaceState::from_successful_rebase(outcome.rebase, &repo, dry_run, &prs_by_head)?;
 
     Ok(MoveChangesResult { workspace })
 }

--- a/crates/but-api/src/commit/move_commit.rs
+++ b/crates/but-api/src/commit/move_commit.rs
@@ -50,6 +50,7 @@ pub fn commit_move_only_with_perm(
     dry_run: DryRun,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitMoveResult> {
+    let prs_by_head = crate::workspace_state::forge_prs_by_head(ctx)?;
     let mut meta = ctx.meta()?;
     let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let editor = but_rebase::graph_rebase::Editor::create(&mut ws, &mut meta, &repo)?;
@@ -57,7 +58,7 @@ pub fn commit_move_only_with_perm(
         but_workspace::commit::move_commits(editor, subject_commit_ids, relative_to, side)?;
 
     Ok(CommitMoveResult {
-        workspace: WorkspaceState::from_successful_rebase(rebase, &repo, dry_run)?,
+        workspace: WorkspaceState::from_successful_rebase(rebase, &repo, dry_run, &prs_by_head)?,
     })
 }
 

--- a/crates/but-api/src/commit/reword.rs
+++ b/crates/but-api/src/commit/reword.rs
@@ -45,6 +45,7 @@ pub fn commit_reword_only_with_perm(
     dry_run: DryRun,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitRewordResult> {
+    let prs_by_head = crate::workspace_state::forge_prs_by_head(ctx)?;
     let mut meta = ctx.meta()?;
     let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
@@ -52,7 +53,7 @@ pub fn commit_reword_only_with_perm(
     let (rebase, edited_commit_selector) =
         but_workspace::commit::reword(editor, commit_id, message.as_bstr())?;
     let new_commit = rebase.lookup_pick(edited_commit_selector)?;
-    let workspace = WorkspaceState::from_successful_rebase(rebase, &repo, dry_run)?;
+    let workspace = WorkspaceState::from_successful_rebase(rebase, &repo, dry_run, &prs_by_head)?;
 
     Ok(CommitRewordResult {
         new_commit,

--- a/crates/but-api/src/commit/squash.rs
+++ b/crates/but-api/src/commit/squash.rs
@@ -54,6 +54,7 @@ pub fn commit_squash_only_with_perm(
         anyhow::bail!("No commits were provided to squash")
     }
 
+    let prs_by_head = crate::workspace_state::forge_prs_by_head(ctx)?;
     let mut meta = ctx.meta()?;
     let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
@@ -67,7 +68,7 @@ pub fn commit_squash_only_with_perm(
         how_to_combine_messages,
     )?;
     let new_commit = rebase.lookup_pick(commit_selector)?;
-    let workspace = WorkspaceState::from_successful_rebase(rebase, &repo, dry_run)?;
+    let workspace = WorkspaceState::from_successful_rebase(rebase, &repo, dry_run, &prs_by_head)?;
 
     Ok(CommitSquashResult {
         new_commit,

--- a/crates/but-api/src/commit/uncommit.rs
+++ b/crates/but-api/src/commit/uncommit.rs
@@ -122,6 +122,7 @@ pub fn commit_uncommit_only_with_perm(
         anyhow::bail!("no commit IDs provided for uncommit");
     }
     let context_lines = ctx.settings.context_lines;
+    let prs_by_head = crate::workspace_state::forge_prs_by_head(ctx)?;
     let mut meta = ctx.meta()?;
     let (repo, mut ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
     let mut tx = db.transaction()?;
@@ -210,7 +211,13 @@ pub fn commit_uncommit_only_with_perm(
 
     Ok(UncommitResult {
         uncommitted_ids: subject_commit_ids,
-        workspace: WorkspaceState::from_workspace(workspace, meta, repo, replaced_commits)?,
+        workspace: WorkspaceState::from_workspace(
+            workspace,
+            meta,
+            repo,
+            replaced_commits,
+            &prs_by_head,
+        )?,
     })
 }
 
@@ -262,6 +269,7 @@ pub fn commit_uncommit_changes_only_with_perm(
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<MoveChangesResult> {
     let context_lines = ctx.settings.context_lines;
+    let prs_by_head = crate::workspace_state::forge_prs_by_head(ctx)?;
     let mut meta = ctx.meta()?;
     let (repo, mut ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
     let mut tx = db.transaction()?;
@@ -336,7 +344,13 @@ pub fn commit_uncommit_changes_only_with_perm(
     }
 
     Ok(MoveChangesResult {
-        workspace: WorkspaceState::from_workspace(workspace, meta, repo, replaced_commits)?,
+        workspace: WorkspaceState::from_workspace(
+            workspace,
+            meta,
+            repo,
+            replaced_commits,
+            &prs_by_head,
+        )?,
     })
 }
 
@@ -442,6 +456,7 @@ pub fn commit_uncommit_changes_from_commits_only_with_perm(
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<UncommitChangesFromCommitsResult> {
     let context_lines = ctx.settings.context_lines;
+    let prs_by_head = crate::workspace_state::forge_prs_by_head(ctx)?;
     let mut meta = ctx.meta()?;
     let (repo, mut ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
     let mut tx = db.transaction()?;
@@ -542,7 +557,13 @@ pub fn commit_uncommit_changes_from_commits_only_with_perm(
     }
 
     Ok(UncommitChangesFromCommitsResult {
-        workspace: WorkspaceState::from_workspace(workspace, meta, repo, replaced_commits)?,
+        workspace: WorkspaceState::from_workspace(
+            workspace,
+            meta,
+            repo,
+            replaced_commits,
+            &prs_by_head,
+        )?,
         failures,
     })
 }

--- a/crates/but-api/src/land/mod.rs
+++ b/crates/but-api/src/land/mod.rs
@@ -412,10 +412,17 @@ fn segment_short_name(segment: &but_workspace::ref_info::Segment) -> Option<Stri
 /// than the pre-fetch graph.
 fn current_workspace_state(ctx: &mut Context) -> anyhow::Result<WorkspaceState> {
     ctx.invalidate_workspace_cache()?;
+    let prs_by_head = crate::workspace_state::forge_prs_by_head(ctx)?;
     let mut meta = ctx.meta()?;
     let guard = ctx.exclusive_worktree_access();
     let (repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
-    WorkspaceState::from_workspace(&ws, &mut meta, &repo, std::collections::BTreeMap::new())
+    WorkspaceState::from_workspace(
+        &ws,
+        &mut meta,
+        &repo,
+        std::collections::BTreeMap::new(),
+        &prs_by_head,
+    )
 }
 
 /// Peel a ref to its commit id, or `None` if it doesn't exist.

--- a/crates/but-api/src/land/reconcile.rs
+++ b/crates/but-api/src/land/reconcile.rs
@@ -83,9 +83,10 @@ fn current_state(
     perm: &but_core::sync::RepoShared,
 ) -> anyhow::Result<WorkspaceState> {
     ctx.invalidate_workspace_cache()?;
+    let prs_by_head = crate::workspace_state::forge_prs_by_head(ctx)?;
     let mut meta = ctx.meta()?;
     let (repo, ws, _db) = ctx.workspace_and_db_with_perm(perm)?;
-    WorkspaceState::from_workspace(&ws, &mut meta, &repo, BTreeMap::new())
+    WorkspaceState::from_workspace(&ws, &mut meta, &repo, BTreeMap::new(), &prs_by_head)
 }
 
 /// Build one `Rebase` update per applied stack, selecting its bottom-most commit (or the bottom

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -38,7 +38,7 @@ pub fn head_info(ctx: &but_ctx::Context) -> Result<but_workspace::RefInfo> {
         Some(db) => but_workspace::ref_info::GerritMode::Enabled(db.gerrit_metadata()),
         None => but_workspace::ref_info::GerritMode::Disabled,
     };
-    but_workspace::head_info(
+    let mut info = but_workspace::head_info(
         &repo,
         &meta,
         but_workspace::ref_info::Options {
@@ -47,8 +47,14 @@ pub fn head_info(ctx: &but_ctx::Context) -> Result<but_workspace::RefInfo> {
             expensive_commit_info: true,
             gerrit_mode,
         },
-    )
-    .map(|info| info.pruned_to_entrypoint())
+    )?
+    .pruned_to_entrypoint();
+
+    // Resolve each segment's PR association from the forge review cache instead
+    // of stored branch metadata, keyed by the segment's remote/pushed short name.
+    info.apply_forge_review_associations(&repo, &crate::workspace_state::forge_prs_by_head(ctx)?);
+
+    Ok(info)
 }
 
 #[but_api]
@@ -224,6 +230,28 @@ pub fn branch_details(
     }?;
     let repo = ctx.repo.get()?;
     let db = ctx.db.get_cache()?;
+
+    // Derive the PR association from the forge cache rather than reading a stored
+    // number off branch metadata: match the branch's remote/pushed short name
+    // (what the forge records as a review's `source_branch`) against the cached
+    // reviews. `review_id` is no longer used, so it is always cleared.
+    details.review_id = None;
+    details.pr_number = {
+        let pushed_short_name = details
+            .remote_tracking_branch
+            .as_ref()
+            .and_then(|full| gix::refs::FullName::try_from(full.clone()).ok())
+            .and_then(|full| {
+                but_core::extract_remote_name_and_short_name(full.as_ref(), &repo.remote_names())
+                    .map(|(_, short)| short.to_string())
+            });
+        match pushed_short_name {
+            Some(short) => but_forge::review_for_head_ref(&db, &short)?
+                .and_then(|review| usize::try_from(review.number).ok()),
+            None => None,
+        }
+    };
+
     let gerrit_mode = ctx
         .repo
         .get()?

--- a/crates/but-api/src/resolve/apply.rs
+++ b/crates/but-api/src/resolve/apply.rs
@@ -203,6 +203,7 @@ pub(crate) fn apply(
     dry_run: DryRun,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<(gix::ObjectId, WorkspaceState)> {
+    let prs_by_head = crate::workspace_state::forge_prs_by_head(ctx)?;
     let mut meta = ctx.meta()?;
     let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
 
@@ -229,7 +230,7 @@ pub(crate) fn apply(
 
     let rebase = editor.rebase()?;
     let new_commit = rebase.lookup_pick(target_selector)?;
-    let workspace = WorkspaceState::from_successful_rebase(rebase, &repo, dry_run)?;
+    let workspace = WorkspaceState::from_successful_rebase(rebase, &repo, dry_run, &prs_by_head)?;
 
     Ok((new_commit, workspace))
 }

--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -321,6 +321,7 @@ pub fn workspace_integrate_upstream_only_with_perm(
     dry_run: DryRun,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<WorkspaceIntegrateUpstreamOutcome> {
+    let prs_by_head = crate::workspace_state::forge_prs_by_head(ctx)?;
     let mut meta = ctx.meta()?;
     let (workspace_state, worktree_conflicts) = {
         let (repo, mut ws, db) = ctx.workspace_mut_and_db_with_perm(perm)?;
@@ -352,7 +353,7 @@ pub fn workspace_integrate_upstream_only_with_perm(
         if dry_run.into() {
             let replaced_commits = rebase.history.commit_mappings();
             let workspace_state =
-                WorkspaceState::from_rebase_preview(&mut rebase, replaced_commits)?;
+                WorkspaceState::from_rebase_preview(&mut rebase, replaced_commits, &prs_by_head)?;
             return Ok(WorkspaceIntegrateUpstreamOutcome {
                 workspace_state,
                 worktree_conflicts,
@@ -377,6 +378,7 @@ pub fn workspace_integrate_upstream_only_with_perm(
             materialized.meta,
             &repo,
             materialized.history.commit_mappings(),
+            &prs_by_head,
         )?;
         (workspace_state, worktree_conflicts)
     };

--- a/crates/but-api/src/workspace_state.rs
+++ b/crates/but-api/src/workspace_state.rs
@@ -1,8 +1,22 @@
 use super::WorkspaceState;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use but_core::{DryRun, RefMetadata};
 use but_rebase::graph_rebase::{MaterializeOutcome, SuccessfulRebase};
+
+/// Build a `{ pushed short name -> PR number }` lookup from the forge review
+/// cache, for resolving branch PR associations at projection time.
+///
+/// This is the same view of forge truth the `head_info` read command uses, so
+/// that mutation responses — which the Lite app writes straight into its
+/// head_info cache without refetching — stay consistent with the query.
+pub(crate) fn forge_prs_by_head(ctx: &but_ctx::Context) -> anyhow::Result<HashMap<String, usize>> {
+    let db = ctx.db.get_cache()?;
+    Ok(but_forge::reviews_by_head(&db)?
+        .into_iter()
+        .filter_map(|(head, review)| usize::try_from(review.number).ok().map(|n| (head, n)))
+        .collect())
+}
 
 impl WorkspaceState {
     /// Whether any commit in the projected workspace is in a conflicted state.
@@ -47,11 +61,12 @@ impl WorkspaceState {
         meta: &mut M,
         repo: &gix::Repository,
         replaced_commits: BTreeMap<gix::ObjectId, gix::ObjectId>,
+        prs_by_head: &HashMap<String, usize>,
     ) -> anyhow::Result<WorkspaceState> {
         #[cfg(not(feature = "graph-workspace"))]
         {
             let _ = meta;
-            let head_info = but_workspace::graph_to_ref_info(
+            let mut head_info = but_workspace::graph_to_ref_info(
                 workspace,
                 repo,
                 but_workspace::ref_info::Options {
@@ -63,6 +78,10 @@ impl WorkspaceState {
             )?
             .pruned_to_entrypoint();
 
+            // Same pass the `head_info` read command runs, so mutation responses
+            // (which Lite renders directly) carry cache-derived PR associations.
+            head_info.apply_forge_review_associations(repo, prs_by_head);
+
             Ok(WorkspaceState {
                 replaced_commits,
                 head_info,
@@ -70,6 +89,9 @@ impl WorkspaceState {
         }
         #[cfg(feature = "graph-workspace")]
         {
+            // The graph_workspace projection needs its own equivalent enrichment;
+            // that is out of scope here.
+            let _ = prs_by_head;
             let mut workspace = workspace.clone();
             let graph_workspace =
                 but_workspace::workspace::detailed_graph_workspace(&mut workspace, meta, repo)?;
@@ -92,10 +114,11 @@ impl WorkspaceState {
     pub fn from_rebase_preview<M: RefMetadata>(
         rebase: &mut SuccessfulRebase<'_, '_, M>,
         replaced_commits: BTreeMap<gix::ObjectId, gix::ObjectId>,
+        prs_by_head: &HashMap<String, usize>,
     ) -> anyhow::Result<WorkspaceState> {
         let workspace = rebase.overlayed_graph()?.into_workspace()?;
         let (repo, meta) = rebase.repo_and_meta_mut();
-        Self::from_workspace(&workspace, meta, repo, replaced_commits)
+        Self::from_workspace(&workspace, meta, repo, replaced_commits, prs_by_head)
     }
 
     /// Build a [`WorkspaceState`] from an already-materialized rebase.
@@ -105,12 +128,14 @@ impl WorkspaceState {
     pub fn from_materialized_rebase<M: RefMetadata>(
         materialized: MaterializeOutcome<'_, '_, M>,
         repo: &gix::Repository,
+        prs_by_head: &HashMap<String, usize>,
     ) -> anyhow::Result<WorkspaceState> {
         Self::from_workspace(
             materialized.workspace,
             materialized.meta,
             repo,
             materialized.history.commit_mappings(),
+            prs_by_head,
         )
     }
 
@@ -126,11 +151,12 @@ impl WorkspaceState {
         rebase: SuccessfulRebase<'_, '_, M>,
         repo: &gix::Repository,
         dry_run: DryRun,
+        prs_by_head: &HashMap<String, usize>,
     ) -> anyhow::Result<WorkspaceState> {
         if dry_run.into() {
             let mut rebase = rebase;
             let replaced_commits = rebase.history.commit_mappings();
-            return Self::from_rebase_preview(&mut rebase, replaced_commits);
+            return Self::from_rebase_preview(&mut rebase, replaced_commits, prs_by_head);
         }
 
         let materialized = rebase.materialize()?;
@@ -139,6 +165,7 @@ impl WorkspaceState {
             materialized.meta,
             repo,
             materialized.history.commit_mappings(),
+            prs_by_head,
         )
     }
 }

--- a/crates/but-api/tests/api/forge_pr_association.rs
+++ b/crates/but-api/tests/api/forge_pr_association.rs
@@ -1,0 +1,169 @@
+use but_core::RefMetadata;
+use gix::refs::transaction::PreviousValue;
+
+const BRANCH: &str = "feature";
+const PR_NUMBER: usize = 42;
+
+#[test]
+fn managed_branch_gets_pr_from_forge_cache() -> anyhow::Result<()> {
+    let (mut ctx, _tmp) = context_with_remote_branch()?;
+    let branch: gix::refs::FullName = format!("refs/heads/{BRANCH}").try_into()?;
+    but_api::branch::apply_only(&mut ctx, branch.as_ref())?;
+    cache_review(&ctx, PR_NUMBER)?;
+
+    let info = but_api::legacy::workspace::head_info(&ctx)?;
+    let segment = segment(&info);
+    assert!(
+        segment.metadata.is_some(),
+        "applied branch should be managed"
+    );
+    assert_eq!(
+        segment
+            .metadata
+            .as_ref()
+            .and_then(|meta| meta.review.pull_request),
+        Some(PR_NUMBER),
+        "managed branch should resolve its PR from the forge cache"
+    );
+    Ok(())
+}
+
+#[test]
+fn single_branch_gets_pr_without_stored_metadata() -> anyhow::Result<()> {
+    let (mut ctx, _tmp) = context_with_remote_branch()?;
+    cache_review(&ctx, PR_NUMBER)?;
+
+    let result =
+        but_api::branch::branch_checkout(&mut ctx, format!("refs/heads/{BRANCH}").try_into()?)?;
+    let segment = segment(&result.workspace.head_info);
+    assert_eq!(
+        segment
+            .metadata
+            .as_ref()
+            .and_then(|meta| meta.review.pull_request),
+        Some(PR_NUMBER),
+        "a cache hit should synthesize projection metadata in single-branch mode"
+    );
+
+    let branch_name: gix::refs::FullName = format!("refs/heads/{BRANCH}").try_into()?;
+    let stored = ctx.meta()?.branch_opt(branch_name.as_ref())?;
+    assert!(
+        stored.is_none(),
+        "projection enrichment must not persist metadata for an ad-hoc branch"
+    );
+    Ok(())
+}
+
+#[test]
+fn empty_cache_clears_a_stale_stored_pr() -> anyhow::Result<()> {
+    let (mut ctx, _tmp) = context_with_remote_branch()?;
+    let branch_name: gix::refs::FullName = format!("refs/heads/{BRANCH}").try_into()?;
+    but_api::branch::apply_only(&mut ctx, branch_name.as_ref())?;
+
+    let mut meta = ctx.meta()?;
+    let mut branch = meta.branch(branch_name.as_ref())?;
+    branch.review.pull_request = Some(99);
+    meta.set_branch(&branch)?;
+    drop(meta);
+
+    let info = but_api::legacy::workspace::head_info(&ctx)?;
+    assert_eq!(
+        segment(&info)
+            .metadata
+            .as_ref()
+            .and_then(|meta| meta.review.pull_request),
+        None,
+        "an empty forge cache should clear stale persisted association in the projection"
+    );
+    Ok(())
+}
+
+#[test]
+fn optimistic_cache_insert_is_visible_on_the_next_projection() -> anyhow::Result<()> {
+    let (mut ctx, _tmp) = context_with_remote_branch()?;
+    let branch: gix::refs::FullName = format!("refs/heads/{BRANCH}").try_into()?;
+    but_api::branch::apply_only(&mut ctx, branch.as_ref())?;
+
+    assert_eq!(projected_pr(&ctx)?, None, "cache starts empty");
+    cache_review(&ctx, PR_NUMBER)?;
+    assert_eq!(
+        projected_pr(&ctx)?,
+        Some(PR_NUMBER),
+        "a single optimistic upsert should be visible without a list sync"
+    );
+    Ok(())
+}
+
+fn context_with_remote_branch() -> anyhow::Result<(
+    but_ctx::Context,
+    but_testsupport::gix_testtools::tempfile::TempDir,
+)> {
+    let (repo, tmp) = crate::support::writable_scenario("checkout-head-info");
+    crate::support::persist_default_target(&repo)?;
+
+    let branch_name: gix::refs::FullName = format!("refs/heads/{BRANCH}").try_into()?;
+    let branch_id = repo.find_reference(&branch_name)?.peel_to_id()?.detach();
+    repo.reference(
+        format!("refs/remotes/origin/{BRANCH}"),
+        branch_id,
+        PreviousValue::Any,
+        "test remote-tracking branch",
+    )?;
+
+    Ok((
+        but_ctx::Context::from_repo_for_testing(repo)?.with_memory_app_cache(),
+        tmp,
+    ))
+}
+
+fn cache_review(ctx: &but_ctx::Context, number: usize) -> anyhow::Result<()> {
+    let mut db = ctx.db.get_cache_mut()?;
+    but_forge::cache_review(&mut db, &review(number))
+}
+
+fn review(number: usize) -> but_forge::ForgeReview {
+    but_forge::ForgeReview {
+        html_url: format!("https://example.com/pull/{number}"),
+        number: number as i64,
+        title: "Cached review".into(),
+        body: None,
+        author: None,
+        labels: vec![],
+        draft: false,
+        source_branch: BRANCH.into(),
+        target_branch: "main".into(),
+        sha: String::new(),
+        integration_commit_shas: vec![],
+        created_at: None,
+        modified_at: None,
+        merged_at: None,
+        closed_at: None,
+        repository_ssh_url: None,
+        repository_https_url: None,
+        repo_owner: None,
+        head_repo_is_fork: false,
+        reviewers: vec![],
+        unit_symbol: "#".into(),
+        last_sync_at: Default::default(),
+    }
+}
+
+fn projected_pr(ctx: &but_ctx::Context) -> anyhow::Result<Option<usize>> {
+    Ok(segment(&but_api::legacy::workspace::head_info(ctx)?)
+        .metadata
+        .as_ref()
+        .and_then(|meta| meta.review.pull_request))
+}
+
+fn segment(info: &but_workspace::RefInfo) -> &but_workspace::ref_info::Segment {
+    info.stacks
+        .iter()
+        .flat_map(|stack| &stack.segments)
+        .find(|segment| {
+            segment
+                .ref_info
+                .as_ref()
+                .is_some_and(|info| info.ref_name.shorten() == BRANCH)
+        })
+        .expect("feature segment exists")
+}

--- a/crates/but-api/tests/api/main.rs
+++ b/crates/but-api/tests/api/main.rs
@@ -3,5 +3,7 @@ mod branch_checkout;
 mod branch_create;
 mod branch_remove;
 mod branch_rename;
+#[cfg(all(feature = "legacy", not(feature = "graph-workspace")))]
+mod forge_pr_association;
 mod resolve_ai;
 mod support;

--- a/crates/but-api/tests/api/support.rs
+++ b/crates/but-api/tests/api/support.rs
@@ -149,7 +149,7 @@ pub fn fresh_head_info(ctx: &but_ctx::Context) -> anyhow::Result<but_workspace::
     let project_meta = ctx.project_meta()?;
     let meta = ctx.meta()?;
     let repo = ctx.repo.get()?;
-    but_workspace::head_info(
+    let mut info = but_workspace::head_info(
         &repo,
         &meta,
         but_workspace::ref_info::Options {
@@ -158,8 +158,15 @@ pub fn fresh_head_info(ctx: &but_ctx::Context) -> anyhow::Result<but_workspace::
             expensive_commit_info: true,
             ..Default::default()
         },
-    )
-    .map(but_workspace::RefInfo::pruned_to_entrypoint)
+    )?
+    .pruned_to_entrypoint();
+    let db = ctx.db.get_cache()?;
+    let prs_by_head = but_forge::reviews_by_head(&db)?
+        .into_iter()
+        .filter_map(|(head, review)| usize::try_from(review.number).ok().map(|n| (head, n)))
+        .collect();
+    info.apply_forge_review_associations(&repo, &prs_by_head);
+    Ok(info)
 }
 
 #[cfg(feature = "graph-workspace")]

--- a/crates/but-transaction/src/lib.rs
+++ b/crates/but-transaction/src/lib.rs
@@ -1142,8 +1142,13 @@ fn workspace_state_from_rebase<M: RefMetadata>(
     pending_created_independent_refs: Vec<PendingCreatedIndependentRef>,
     dry_run: DryRun,
 ) -> anyhow::Result<WorkspaceState> {
+    // The forge PR association is a projection concern. Every consumer of this
+    // crate's `WorkspaceState` (the `but` CLI) discards it, so we skip the
+    // enrichment here and pass an empty map rather than pull a forge/db
+    // dependency into this transaction layer.
+    let prs_by_head = std::collections::HashMap::new();
     if dry_run.into() {
-        return WorkspaceState::from_successful_rebase(rebase, repo, dry_run);
+        return WorkspaceState::from_successful_rebase(rebase, repo, dry_run, &prs_by_head);
     }
 
     let materialized = rebase.materialize()?;
@@ -1185,7 +1190,7 @@ fn workspace_state_from_rebase<M: RefMetadata>(
         materialized.meta.remove(ref_name.as_ref())?;
     }
 
-    WorkspaceState::from_materialized_rebase(materialized, repo)
+    WorkspaceState::from_materialized_rebase(materialized, repo, &prs_by_head)
 }
 
 /// Intermediate outcome after creating a commit.

--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -83,10 +83,14 @@ pub fn list_branches(
             gerrit_mode,
         },
     )?;
+    // Resolve each segment's PR association from the forge review cache (keyed by
+    // the segment's remote/pushed short name) rather than from stored metadata.
+    let review_cache = ctx.db.get_cache()?;
+    let reviews_by_head = but_forge::reviews_by_head(&review_cache)?;
     let stacks = info
         .stacks
         .into_iter()
-        .filter_map(|s| GitButlerStack::try_new(s, &remote_names).transpose())
+        .filter_map(|s| GitButlerStack::try_new(s, &remote_names, &reviews_by_head).transpose())
         .collect::<Result<Vec<_>, _>>()?;
     let workspace_target_ref_name = info.target_ref.map(|r| r.ref_name);
 
@@ -407,6 +411,7 @@ impl GitButlerStack {
     fn try_new(
         stack: but_workspace::branch::Stack,
         names: &gix::remote::Names,
+        reviews_by_head: &HashMap<String, but_forge::ForgeReview>,
     ) -> anyhow::Result<Option<Self>> {
         let Some(id) = stack.id else { return Ok(None) };
         let first_segment = stack.segments.first();
@@ -446,7 +451,12 @@ impl GitButlerStack {
                         )
                         .expect("known to be valid statically")
                     }),
-                    pr_or_mr: s.metadata.as_ref().and_then(|md| md.review.pull_request),
+                    pr_or_mr: s
+                        .remote_tracking_ref_name
+                        .as_ref()
+                        .and_then(|rn| extract_remote_name_and_short_name(rn.as_ref(), names))
+                        .and_then(|(_, short)| reviews_by_head.get(&short.to_string()))
+                        .and_then(|review| usize::try_from(review.number).ok()),
                 })
                 .collect(),
         }))


### PR DESCRIPTION
## 🧢 Changes

Projects forge-cache review associations into branch details, stack segments, head info, and mutation responses, with focused API integration coverage.

## ☕️ Reasoning

Every workspace projection must expose the same live PR association without relying on persisted branch metadata.

## 🔗 Stack

| Layer | Pull request |
| --- | --- |
| 1 | #14733 |
| 2 | **#14734 (current)** |
| 3 | #14735 |
| 4 | #14736 |
| 5 | #14737 |