### PR TITLE
Use cache-derived PR associations in TUI and agent logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,6 +935,8 @@ dependencies = [
  "anyhow",
  "bstr",
  "but-core",
+ "but-db",
+ "but-forge",
  "but-meta",
  "but-testsupport",
  "but-workspace",

--- a/crates/but-agentlog/Cargo.toml
+++ b/crates/but-agentlog/Cargo.toml
@@ -11,6 +11,8 @@ description = "Capture coding-agent session logs into Git metadata"
 anyhow.workspace = true
 bstr.workspace = true
 but-core.workspace = true
+but-db.workspace = true
+but-forge.workspace = true
 but-meta = { workspace = true, features = ["legacy"] }
 but-workspace.workspace = true
 chrono = { workspace = true, features = ["clock"] }

--- a/crates/but-agentlog/src/environment.rs
+++ b/crates/but-agentlog/src/environment.rs
@@ -1,5 +1,6 @@
 use std::{
     any::Any,
+    collections::HashMap,
     ops::{Deref, DerefMut},
     path::Path,
 };
@@ -360,14 +361,14 @@ fn workspace_snapshot_with_current_branch_fallback(
     match workspace_snapshot_with_meta(repo, meta) {
         Ok(mut observation) => {
             if observation.observed_targets.is_empty()
-                && let Ok(fallback) = current_branch_targets(repo, meta)
+                && let Ok(fallback) = current_branch_targets(repo)
                 && !fallback.is_empty()
             {
                 observation.observed_targets = fallback;
             }
             Ok(observation)
         }
-        Err(error) => match current_branch_targets(repo, meta) {
+        Err(error) => match current_branch_targets(repo) {
             Ok(fallback) if !fallback.is_empty() => Ok(WorkspaceObservation {
                 stacks: Vec::new(),
                 observed_targets: fallback,
@@ -378,10 +379,7 @@ fn workspace_snapshot_with_current_branch_fallback(
     }
 }
 
-fn current_branch_targets(
-    repo: &gix::Repository,
-    meta: &impl RefMetadata,
-) -> anyhow::Result<ObservedTargets> {
+fn current_branch_targets(repo: &gix::Repository) -> anyhow::Result<ObservedTargets> {
     let head = repo.head()?;
     let Some(ref_name) = head.referent_name() else {
         anyhow::bail!("HEAD is detached");
@@ -397,12 +395,17 @@ fn current_branch_targets(
         key: format!("ref:{full_ref_name}"),
         name: ref_name.shorten().to_string(),
     };
-    let reviews = meta
-        .branch_opt(ref_name)
-        .ok()
-        .flatten()
-        .map(|branch_metadata| review_targets(&branch.key, Some(&branch_metadata)))
-        .unwrap_or_default();
+    // Derive the PR association from the forge review cache rather than stored
+    // metadata. Synthesize a metadata entry carrying the resolved number so a
+    // branch with a cached PR is reported even without stored branch metadata.
+    let reviews = match resolve_branch_pr(repo, ref_name, &forge_prs_by_head(repo)) {
+        Some(pull_request) => {
+            let mut metadata = Branch::default();
+            metadata.review.pull_request = Some(pull_request);
+            review_targets(&branch.key, Some(&metadata))
+        }
+        None => Vec::new(),
+    };
     let mut observed_targets = ObservedTargets {
         branches: vec![branch],
         reviews,
@@ -416,7 +419,7 @@ fn workspace_snapshot_with_meta(
     repo: &gix::Repository,
     meta: &impl RefMetadata,
 ) -> anyhow::Result<WorkspaceObservation> {
-    let info = but_workspace::head_info(
+    let mut info = but_workspace::head_info(
         repo,
         meta,
         but_workspace::ref_info::Options {
@@ -425,6 +428,10 @@ fn workspace_snapshot_with_meta(
             ..Default::default()
         },
     )?;
+
+    // Derive each segment's PR association from the forge review cache instead of
+    // stored branch metadata, so the observation records live associations.
+    info.apply_forge_review_associations(repo, &forge_prs_by_head(repo));
 
     let mut observed_targets = ObservedTargets::default();
     let mut stacks = Vec::new();
@@ -505,6 +512,40 @@ fn workspace_snapshot_with_meta(
             None
         },
     })
+}
+
+/// Best-effort forge PR association map (`pushed short name -> PR number`), read
+/// from the project's cached review list. Opened read-only and returns empty when
+/// the project database is absent or unreadable, so the observation degrades to
+/// "no reviews" rather than failing.
+fn forge_prs_by_head(repo: &gix::Repository) -> HashMap<String, usize> {
+    let Ok(storage_dir) = repo.gitbutler_storage_path() else {
+        return HashMap::new();
+    };
+    match but_db::DbHandle::open_existing_read_only_in_directory(&storage_dir) {
+        Ok(Some(db)) => but_forge::pr_numbers_by_head(&db).unwrap_or_default(),
+        _ => HashMap::new(),
+    }
+}
+
+/// Resolve the cache-derived PR number for a single local branch by matching its
+/// remote-tracking short name against `prs_by_head`, mirroring the projection
+/// resolver used for workspace segments.
+fn resolve_branch_pr(
+    repo: &gix::Repository,
+    ref_name: &gix::refs::FullNameRef,
+    prs_by_head: &HashMap<String, usize>,
+) -> Option<usize> {
+    let remote_tracking = repo
+        .branch_remote_tracking_ref_name(ref_name, gix::remote::Direction::Fetch)
+        .transpose()
+        .ok()
+        .flatten()?;
+    let (_, short) = but_core::extract_remote_name_and_short_name(
+        remote_tracking.as_ref(),
+        &repo.remote_names(),
+    )?;
+    prs_by_head.get(&short.to_string()).copied()
 }
 
 fn review_targets(branch_key: &str, metadata: Option<&Branch>) -> Vec<ReviewTarget> {

--- a/crates/but-api/src/workspace_state.rs
+++ b/crates/but-api/src/workspace_state.rs
@@ -12,10 +12,7 @@ use but_rebase::graph_rebase::{MaterializeOutcome, SuccessfulRebase};
 /// head_info cache without refetching — stay consistent with the query.
 pub(crate) fn forge_prs_by_head(ctx: &but_ctx::Context) -> anyhow::Result<HashMap<String, usize>> {
     let db = ctx.db.get_cache()?;
-    Ok(but_forge::reviews_by_head(&db)?
-        .into_iter()
-        .filter_map(|(head, review)| usize::try_from(review.number).ok().map(|n| (head, n)))
-        .collect())
+    but_forge::pr_numbers_by_head(&db)
 }
 
 impl WorkspaceState {

--- a/crates/but-forge/src/association.rs
+++ b/crates/but-forge/src/association.rs
@@ -31,6 +31,20 @@ pub fn review_for_head_ref(
 }
 
 /// Build a lookup from a branch's remote/pushed short name to its associated
+/// PR number, for enriching a workspace projection (see
+/// `but_workspace::RefInfo::apply_forge_pr_associations`) in one pass.
+///
+/// This is [`reviews_by_head`] reduced to just the number each projection needs,
+/// so callers across crates don't each re-implement the `ForgeReview -> usize`
+/// extraction.
+pub fn pr_numbers_by_head(db: &but_db::DbHandle) -> anyhow::Result<HashMap<String, usize>> {
+    Ok(reviews_by_head(db)?
+        .into_iter()
+        .filter_map(|(head, review)| usize::try_from(review.number).ok().map(|n| (head, n)))
+        .collect())
+}
+
+/// Build a lookup from a branch's remote/pushed short name to its associated
 /// review, so a projection can resolve many branches in one pass without a cache
 /// read per branch.
 ///

--- a/crates/but-forge/src/lib.rs
+++ b/crates/but-forge/src/lib.rs
@@ -9,7 +9,7 @@ mod db;
 mod forge_info;
 mod repo;
 mod review;
-pub use association::{review_for_head_ref, reviews_by_head};
+pub use association::{pr_numbers_by_head, review_for_head_ref, reviews_by_head};
 pub use ci::{CiCheck, CiConclusion, CiOutput, CiStatus, ci_checks_for_ref_with_cache};
 pub use forge_info::{ForgeCapabilities, ForgeInfo, ForgeUnitInfo, compare_branch_url, forge_info};
 pub use repo::{RepoInfo, RepoPermissions, get_repo_info};

--- a/crates/but/src/command/legacy/status/json.rs
+++ b/crates/but/src/command/legacy/status/json.rs
@@ -523,7 +523,8 @@ fn convert_branch_to_json(
 
     let review_numbers = crate::command::legacy::forge::review::get_review_numbers(
         &segment.branch_name().unwrap_or_default().to_string(),
-        &segment.pr_number(),
+        // Resolved by branch name from the cached review list; no stored PR number.
+        &None,
         &status_ctx.review_map,
     );
     let review_id = {

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -447,6 +447,7 @@ fn build_status_context<'a>(
         &cache_config,
         &stack_details,
         &push_statuses_by_segment_id,
+        &review_map,
     )?;
 
     // Calculate common_merge_base data and upstream state in a scope
@@ -782,7 +783,9 @@ fn branch_is_merged_upstream(
     segment
         .branch_name()
         .and_then(|branch_name| {
-            review::from_branch_details(&status_ctx.review_map, branch_name, segment.pr_number())
+            // Resolve by branch name from the cached review list; a stored PR
+            // number is no longer used to disambiguate.
+            review::from_branch_details(&status_ctx.review_map, branch_name, None)
         })
         .is_some_and(|review| review.is_merged_at_commit(&head_commit_id))
 }
@@ -1026,6 +1029,7 @@ fn ci_map(
     cache_config: &but_forge::CacheConfig,
     stack_details: &[StackEntry],
     push_statuses_by_segment_id: &HashMap<SegmentIndex, PushStatus>,
+    review_map: &HashMap<String, Vec<but_forge::ForgeReview>>,
 ) -> Result<BTreeMap<String, Vec<but_forge::CiCheck>>, anyhow::Error> {
     let mut ci_map = BTreeMap::new();
     for (_, (stack_with_id, _)) in stack_details {
@@ -1035,9 +1039,14 @@ fn ci_map(
                 if push_status.is_none() {
                     eprintln!("warning: head_info does not contain segment that graph has");
                 }
-                if segment.pr_number().is_some()
-                    && !matches!(push_status, Some(PushStatus::Integrated))
+                // Fetch CI only for branches that actually have a review on the
+                // forge, derived from the cached review list keyed by branch name
+                // rather than a stored PR number on branch metadata.
+                if !matches!(push_status, Some(PushStatus::Integrated))
                     && let Some(branch_name) = segment.branch_name()
+                    && review_map
+                        .get(&branch_name.to_string())
+                        .is_some_and(|reviews| !reviews.is_empty())
                     && let Ok(checks) = but_api::legacy::forge::list_ci_checks(
                         ctx,
                         branch_name.to_string(),
@@ -1204,11 +1213,7 @@ fn print_group(
             let review_spans: Vec<Span<'static>> = segment
                 .branch_name()
                 .and_then(|branch_name| {
-                    review::from_branch_details(
-                        &status_ctx.review_map,
-                        branch_name,
-                        segment.pr_number(),
-                    )
+                    review::from_branch_details(&status_ctx.review_map, branch_name, None)
                 })
                 .map(|r| {
                     [Span::raw(" ")]

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -444,14 +444,6 @@ impl SegmentWithId {
             None
         }
     }
-    /// Returns the PR number.
-    pub fn pr_number(&self) -> Option<usize> {
-        if let Some(metadata) = &self.inner.metadata {
-            metadata.review.pull_request
-        } else {
-            None
-        }
-    }
 }
 impl<'a> Node<'a> for &'a SegmentWithId {
     fn parse(

--- a/crates/but/src/legacy/workspace.rs
+++ b/crates/but/src/legacy/workspace.rs
@@ -69,13 +69,20 @@ fn head_info(
         expensive_commit_info,
         gerrit_mode,
     };
-    let info = match edit_mode_workspace_ref(&repo)? {
+    let mut info = match edit_mode_workspace_ref(&repo)? {
         Some(ref_name) => {
             but_workspace::ref_info(repo.find_reference(ref_name.as_ref())?, &meta, options)
         }
         None => but_workspace::head_info(&repo, &meta, options),
     }?
     .pruned_to_entrypoint();
+
+    // Derive each segment's PR association from the forge review cache instead of
+    // stored branch metadata, mirroring the desktop's `head_info` command.
+    let review_cache = ctx.db.get_cache()?;
+    let prs_by_head = but_forge::pr_numbers_by_head(&review_cache)?;
+    info.apply_forge_review_associations(&repo, &prs_by_head);
+
     Ok((info, object_hash))
 }
 


### PR DESCRIPTION
## 🧢 Changes

Uses forge-cache associations in TUI status output, workspace snapshots, agent logs, and transaction plumbing.

## ☕️ Reasoning

Non-desktop consumers must observe the same cache-derived associations as workspace APIs.

## 🔗 Stack

| Layer | Pull request |
| --- | --- |
| 1 | #14733 |
| 2 | #14734 |
| 3 | **#14735 (current)** |
| 4 | #14736 |
| 5 | #14737 |