### PR TITLE
Remove persisted PR-association write paths

### DIFF
--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -3,7 +3,7 @@ use anyhow::{Context as _, Result};
 use bstr::ByteSlice;
 use but_api_macros::but_api;
 use but_core::{
-    RefMetadata as _, RepositoryExt,
+    RepositoryExt,
     git_config::{edit_repo_config, ensure_config_value},
     ref_metadata::ProjectMeta,
 };
@@ -299,13 +299,10 @@ pub fn review_apply(
             })?;
 
     let out = crate::branch::apply_with_perm(ctx, remote_ref.as_ref(), guard.write_permission())?;
-    if out.status.persisted_mutation()
-        && let Some(applied_branch_ref) = out.applied_branches.last()
-    {
-        let mut meta = ctx.meta()?;
-        let mut branch = meta.branch(applied_branch_ref.as_ref())?;
-        branch.review.pull_request = Some(review_id);
-        meta.set_branch(&branch)?;
+    if out.status.persisted_mutation() {
+        // The applied review is already in the forge cache (it was just fetched
+        // to be applied), so its PR association is derived at projection time.
+        // Invalidate the workspace cache so the next projection reflects it.
         ctx.invalidate_workspace_cache()?;
     }
     Ok(out)

--- a/crates/but-api/src/legacy/stack.rs
+++ b/crates/but-api/src/legacy/stack.rs
@@ -336,23 +336,6 @@ pub fn update_branch_name_with_perm(
     Ok(full_name.into())
 }
 
-#[but_api]
-#[instrument(err(Debug))]
-pub fn update_branch_pr_number(
-    ctx: &mut Context,
-    stack_id: StackId,
-    branch_name: String,
-    pr_number: Option<usize>,
-) -> Result<()> {
-    gitbutler_branch_actions::stack::update_branch_pr_number(
-        ctx,
-        stack_id,
-        branch_name,
-        pr_number,
-    )?;
-    Ok(())
-}
-
 pub mod json {
     use serde::Serialize;
 

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -805,10 +805,6 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
             "/update_branch_name",
             but_post(legacy::stack::update_branch_name_cmd),
         )
-        .route(
-            "/update_branch_pr_number",
-            but_post(legacy::stack::update_branch_pr_number_cmd),
-        )
         .route("/push_stack", but_post(legacy::stack::push_stack_cmd))
         // Undo/Snapshot commands
         .route(

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -927,19 +927,10 @@ async fn publish_review_for_branch(
         },
     )
     .await
-    .map(|review| {
-        if let Some(stack_id) = stack_id {
-            let review_number = review.number.try_into().ok();
-            but_api::legacy::stack::update_branch_pr_number(
-                ctx,
-                stack_id,
-                branch_name.to_string(),
-                review_number,
-            )
-            .ok();
-        }
-        PublishReviewResult::Published(Box::new(review))
-    })
+    // The PR association is derived from the forge review cache; `publish_review`
+    // optimistically caches the created review, so there is no PR number to
+    // persist onto branch metadata here.
+    .map(|review| PublishReviewResult::Published(Box::new(review)))
 }
 
 /// Get the default commit for the branch, if it has exactly one commit.

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -2,11 +2,8 @@ use anyhow::{Context as _, Result};
 use but_core::{RepositoryExt, extract_remote_name_and_short_name, ref_metadata::StackId};
 use but_ctx::{Context, access::RepoShared};
 use gitbutler_git::{GitContextExt as _, PushResult};
-use gitbutler_operating_modes::{ensure_open_workspace_mode, in_open_workspace_mode};
-use gitbutler_oplog::{
-    OplogExt, SnapshotExt,
-    entry::{OperationKind, SnapshotDetails},
-};
+use gitbutler_operating_modes::ensure_open_workspace_mode;
+use gitbutler_oplog::SnapshotExt;
 use gitbutler_reference::{RemoteRefname, normalize_branch_name};
 use gitbutler_repo::hooks;
 use gitbutler_stack::{PatchReferenceUpdate, Stack, StackBranch};
@@ -110,38 +107,6 @@ pub fn update_branch_name_with_perm(
         },
     )?;
     Ok(normalized_head_name)
-}
-
-/// Sets the forge identifier for a given series/branch. Existing value is overwritten.
-///
-/// # Errors
-/// This method will return an error if:
-///  - The series does not exist
-///  - The stack can't be found
-///  - The stack has not been initialized
-///  - The project is not in workspace mode
-///  - Persisting the changes failed
-pub fn update_branch_pr_number(
-    ctx: &mut Context,
-    stack_id: StackId,
-    branch_name: String,
-    pr_number: Option<usize>,
-) -> Result<()> {
-    let mut guard = ctx.exclusive_worktree_access();
-    // In single branch mode there's no open workspace, so there's no stack
-    // metadata to update — just no-op instead of erroring out.
-    if !in_open_workspace_mode(ctx, guard.read_permission())? {
-        // TODO: Write the metadata somewhere else.
-        return Ok(());
-    }
-    // Pure metadata write — skip verify so background syncs aren't
-    // blocked when HEAD is off the workspace ref (e.g. edit mode).
-    let _ = ctx.create_snapshot(
-        SnapshotDetails::new(OperationKind::UpdateDependentBranchPrNumber),
-        guard.write_permission(),
-    );
-    let mut stack = ctx.virtual_branches().get_stack(stack_id)?;
-    stack.set_pr_number(ctx, &branch_name, pr_number)
 }
 
 /// Pushes all series in the stack to the remote.

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -851,15 +851,9 @@ pub(crate) fn integrate_upstream(
                 stack.set_heads_from_rebase_output(ctx, active_references)?;
             }
 
-            // Dissociate closed reviews
-            for head in stack.clone().heads.iter() {
-                let branch_name = head.name.to_string();
-                if let Some(review) = review_map.get(&branch_name)
-                    && !review.is_open()
-                {
-                    stack.set_pr_number(ctx, &branch_name, None)?;
-                }
-            }
+            // A closed review no longer needs to be dissociated from its branch:
+            // the PR association is derived from the forge review cache at
+            // projection time, which already reflects the closed/merged state.
 
             stack.set_stack_head(&mut virtual_branches_state, &repo, *head)?;
         }

--- a/crates/gitbutler-stack/src/stack.rs
+++ b/crates/gitbutler-stack/src/stack.rs
@@ -644,33 +644,6 @@ impl Stack {
         self.set_all_heads(&*ctx.repo.get()?, &ctx.project_data_dir(), new_heads)
     }
 
-    /// Sets the forge identifier for a given series/branch.
-    /// Existing value is overwritten - passing `None` sets the forge identifier to `None`.
-    ///
-    /// # Errors
-    /// If the series does not exist, this method will return an error.
-    /// If the stack has not been initialized, this method will return an error.
-    pub fn set_pr_number(
-        &mut self,
-        ctx: &Context,
-        branch_name: &str,
-        new_pr_number: Option<usize>,
-    ) -> Result<()> {
-        self.ensure_initialized()?;
-        match self.heads.iter_mut().find(|r| r.name() == branch_name) {
-            Some(head) => {
-                head.pr_number = new_pr_number;
-                let mut state = branch_state(ctx);
-                state.set_stack(self.clone())
-            }
-            None => bail!(
-                "Series {} does not exist on stack {}",
-                branch_name,
-                self.name()
-            ),
-        }
-    }
-
     pub fn heads(&self, exclude_archived: bool) -> Vec<String> {
         if !exclude_archived {
             self.heads.iter().map(|h| h.name().clone()).collect()

--- a/crates/gitbutler-stack/src/stack_branch.rs
+++ b/crates/gitbutler-stack/src/stack_branch.rs
@@ -23,12 +23,21 @@ pub struct StackBranch {
     /// The name of the reference e.g. `master` or `feature/branch`. This should **NOT** include the `refs/heads/` prefix.
     /// The name must be unique within the repository.
     pub name: String,
-    /// The pull request associated with the branch, or None if a pull request has not been created.
+    /// Legacy persisted pull-request association.
+    ///
+    /// PR associations are now derived from the forge review cache when projecting branch data.
+    /// This field remains only for backwards-compatible snapshot and storage handling.
+    #[deprecated(note = "derive PR associations from the forge review cache instead")]
     pub pr_number: Option<usize>,
     /// Archived represents the state when series/branch has been integrated and is below the merge base of the branch.
     /// This would occur when the branch has been merged at the remote and the workspace has been updated with that change.
     pub archived: bool,
 
+    /// Legacy persisted GitButler review identifier.
+    ///
+    /// Review identifiers are no longer populated. This field remains only for
+    /// backwards-compatible snapshot and storage handling.
+    #[deprecated(note = "review identifiers are no longer persisted or populated")]
     pub review_id: Option<String>,
 }
 

--- a/crates/gitbutler-stack/tests/stack.rs
+++ b/crates/gitbutler-stack/tests/stack.rs
@@ -404,29 +404,6 @@ fn update_branch_name_success() -> Result<()> {
 }
 
 #[test]
-fn update_branch_name_resets_pr_number() -> Result<()> {
-    let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
-    let mut test_ctx = test_ctx(&ctx)?;
-    let pr_number = 123;
-    test_ctx
-        .stack
-        .set_pr_number(&ctx, "virtual", Some(pr_number))?;
-    assert_eq!(test_ctx.stack.heads[0].pr_number, Some(pr_number));
-    let update = PatchReferenceUpdate {
-        name: Some("new-name".into()),
-    };
-    test_ctx
-        .stack
-        .update_branch(&ctx, "virtual".into(), &update)?;
-    assert_eq!(test_ctx.stack.heads[0].pr_number, None);
-    assert_eq!(
-        test_ctx.stack,
-        test_ctx.handle.get_stack(test_ctx.stack.id)?
-    );
-    Ok(())
-}
-
-#[test]
 fn push_series_success() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let test_ctx = test_ctx(&ctx)?;
@@ -677,38 +654,6 @@ fn archive_heads_success() -> Result<()> {
 //     );
 //     Ok(())
 // }
-
-#[test]
-fn set_pr_numberentifiers_success() -> Result<()> {
-    let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
-    let mut test_ctx = test_ctx(&ctx)?;
-    let result = test_ctx.stack.set_pr_number(&ctx, "virtual", Some(123));
-    assert!(result.is_ok());
-    assert_eq!(test_ctx.stack.heads[0].pr_number, Some(123));
-    // Assert persisted
-    assert_eq!(
-        test_ctx.stack,
-        test_ctx.handle.get_stack(test_ctx.stack.id)?
-    );
-    Ok(())
-}
-
-#[test]
-fn set_pr_numberentifiers_series_not_found_fails() -> Result<()> {
-    let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
-    let mut test_ctx = test_ctx(&ctx)?;
-    let result = test_ctx
-        .stack
-        .set_pr_number(&ctx, "does-not-exist", Some(123));
-    assert_eq!(
-        result.err().unwrap().to_string(),
-        format!(
-            "Series does-not-exist does not exist on stack {}",
-            test_ctx.stack.name()
-        )
-    );
-    Ok(())
-}
 
 #[test]
 fn add_head_with_archived_bottom_head() -> Result<()> {

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -378,7 +378,6 @@ fn main() -> anyhow::Result<()> {
                 legacy::stack::tauri_create_branch::create_branch,
                 legacy::stack::tauri_remove_branch::remove_branch,
                 legacy::stack::tauri_update_branch_name::update_branch_name,
-                legacy::stack::tauri_update_branch_pr_number::update_branch_pr_number,
                 legacy::stack::tauri_push_stack::push_stack,
                 legacy::secret::tauri_secret_get_global::secret_get_global,
                 legacy::secret::tauri_secret_set_global::secret_set_global,


### PR DESCRIPTION
## 🧢 Changes

Removes the remaining persisted PR-number mutation paths and marks legacy association fields as deprecated while retaining read compatibility.

## ☕️ Reasoning

Once every reader derives associations from forge cache state, metadata writeback becomes redundant and risks stale values.

## 🔗 Stack

| Layer | Pull request |
| --- | --- |
| 1 | #14733 |
| 2 | #14734 |
| 3 | #14735 |
| 4 | #14736 |
| 5 | **#14737 (current)** |