### PR TITLE
Review-to-ref association primitives

### DIFF
--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -684,6 +684,8 @@ pub async fn publish_review(
     ctx: ThreadSafeContext,
     params: but_forge::CreateForgeReviewParams,
 ) -> Result<but_forge::ForgeReview> {
+    // Kept for the optimistic cache insert after the (non-`Send`) forge call.
+    let cache_ctx = ctx.clone();
     let (storage, forge_repo_info, forge_push_repo_info, preferred_forge_user) = {
         let ctx = ctx.into_thread_local();
         let project_meta = ctx.project_meta()?;
@@ -709,14 +711,28 @@ pub async fn publish_review(
         )
     };
 
-    but_forge::create_forge_review(
+    let review = but_forge::create_forge_review(
         &preferred_forge_user,
         &forge_repo_info,
         &forge_push_repo_info,
         &params,
         &storage,
     )
-    .await
+    .await?;
+
+    // Optimistically insert the new review into the cache so the next projection
+    // shows it immediately, rather than waiting for a full review-list sync. The
+    // returned review's `source_branch` is the forge's own head-ref name, which
+    // is exactly the key the projection resolver matches against. Best-effort:
+    // a failed insert only delays the association until the next sync.
+    {
+        let ctx = cache_ctx.into_thread_local();
+        if let Ok(mut db) = ctx.db.get_cache_mut() {
+            but_forge::cache_review(&mut db, &review).ok();
+        }
+    }
+
+    Ok(review)
 }
 
 /// Merge a review on the forge.

--- a/crates/but-forge/src/association.rs
+++ b/crates/but-forge/src/association.rs
@@ -1,0 +1,190 @@
+//! Resolve which forge review (PR/MR) is associated with a local branch by
+//! matching the branch against the cached review list, instead of reading a
+//! stored PR number off branch metadata.
+//!
+//! The join key is the branch's remote/pushed short name (e.g. `"my-feature"`),
+//! which is exactly [`ForgeReview::source_branch`]. Callers derive that key from
+//! the branch's remote-tracking ref (see
+//! `but_core::extract_remote_name_and_short_name`) so the association follows the
+//! branch that was actually pushed, which can differ from the local branch name.
+//!
+//! Everything here reads only from the cache: it never performs network I/O and
+//! is safe to call inside a workspace projection. A `None` result means nothing
+//! in the cache matches — no PR yet, forge not connected, or the branch simply
+//! isn't published. That is a correct "not published" answer, not an error.
+
+use std::collections::HashMap;
+
+use crate::ForgeReview;
+
+/// Resolve the forge review associated with a branch whose remote/pushed head
+/// short name is `head_ref_short`, reading only from the cache.
+///
+/// When several cached reviews share a `source_branch`, `preference` decides
+/// the winner.
+pub fn review_for_head_ref(
+    db: &but_db::DbHandle,
+    head_ref_short: &str,
+) -> anyhow::Result<Option<ForgeReview>> {
+    let reviews = crate::db::reviews_from_cache(db)?;
+    Ok(best_match(&reviews, head_ref_short).cloned())
+}
+
+/// Build a lookup from a branch's remote/pushed short name to its associated
+/// review, so a projection can resolve many branches in one pass without a cache
+/// read per branch.
+///
+/// When several cached reviews share a `source_branch`, `preference` decides
+/// which one the key maps to.
+pub fn reviews_by_head(db: &but_db::DbHandle) -> anyhow::Result<HashMap<String, ForgeReview>> {
+    let reviews = crate::db::reviews_from_cache(db)?;
+    let mut map: HashMap<String, ForgeReview> = HashMap::new();
+    for review in reviews {
+        let replace = map
+            .get(&review.source_branch)
+            .is_none_or(|existing| preference(&review) >= preference(existing));
+        if replace {
+            map.insert(review.source_branch.clone(), review);
+        }
+    }
+    Ok(map)
+}
+
+/// Ranking used to pick between multiple cached reviews that share a
+/// `source_branch` (a closed PR plus a freshly opened one, or a same-named
+/// branch on a fork). Higher is preferred:
+///
+/// 1. an open review over a merged/closed one, and
+/// 2. a review whose head is in the base repo over one in a fork — a local
+///    branch normally pushes to the base repo, so this avoids latching onto a
+///    fork's same-named branch when a base-repo review also exists.
+fn preference(review: &ForgeReview) -> (bool, bool) {
+    (review.is_open(), !review.head_repo_is_fork)
+}
+
+/// Pick the best cached review whose `source_branch` equals `head_ref_short`,
+/// or `None` if none match. Ties resolve to the last such review in `reviews`.
+fn best_match<'a>(reviews: &'a [ForgeReview], head_ref_short: &str) -> Option<&'a ForgeReview> {
+    reviews
+        .iter()
+        .filter(|review| review.source_branch == head_ref_short)
+        .max_by_key(|review| preference(review))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{best_match, review_for_head_ref, reviews_by_head};
+    use crate::ForgeReview;
+
+    /// An open, non-fork review on `source_branch` with the given `number`.
+    fn review(number: i64, source_branch: &str) -> ForgeReview {
+        ForgeReview {
+            html_url: String::new(),
+            number,
+            title: String::new(),
+            body: None,
+            author: None,
+            labels: Vec::new(),
+            draft: false,
+            source_branch: source_branch.to_string(),
+            target_branch: "main".to_string(),
+            sha: String::new(),
+            integration_commit_shas: Vec::new(),
+            created_at: None,
+            modified_at: None,
+            merged_at: None,
+            closed_at: None,
+            repository_ssh_url: None,
+            repository_https_url: None,
+            repo_owner: None,
+            head_repo_is_fork: false,
+            reviewers: Vec::new(),
+            unit_symbol: "#".to_string(),
+            last_sync_at: chrono::Local::now().naive_local(),
+        }
+    }
+
+    fn merged(mut review: ForgeReview) -> ForgeReview {
+        review.merged_at = Some("2026-01-01T00:00:00Z".to_string());
+        review
+    }
+
+    fn from_fork(mut review: ForgeReview) -> ForgeReview {
+        review.head_repo_is_fork = true;
+        review
+    }
+
+    #[test]
+    fn matches_by_source_branch() {
+        let reviews = vec![review(1, "other"), review(2, "feature")];
+        assert_eq!(best_match(&reviews, "feature").map(|r| r.number), Some(2));
+    }
+
+    #[test]
+    fn no_match_returns_none() {
+        let reviews = vec![review(1, "other"), review(2, "feature")];
+        assert!(best_match(&reviews, "missing").is_none());
+    }
+
+    #[test]
+    fn empty_cache_returns_none() {
+        assert!(best_match(&[], "feature").is_none());
+    }
+
+    #[test]
+    fn prefers_open_over_merged() {
+        let reviews = vec![merged(review(1, "feature")), review(2, "feature")];
+        assert_eq!(best_match(&reviews, "feature").map(|r| r.number), Some(2));
+    }
+
+    #[test]
+    fn prefers_base_repo_over_fork() {
+        let reviews = vec![from_fork(review(1, "feature")), review(2, "feature")];
+        assert_eq!(best_match(&reviews, "feature").map(|r| r.number), Some(2));
+    }
+
+    #[test]
+    fn falls_back_to_a_fork_match_when_only_one_exists() {
+        let reviews = vec![from_fork(review(1, "feature"))];
+        assert_eq!(best_match(&reviews, "feature").map(|r| r.number), Some(1));
+    }
+
+    fn test_db() -> (tempfile::TempDir, but_db::DbHandle) {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = but_db::DbHandle::new_in_directory(tmp.path()).unwrap();
+        (tmp, db)
+    }
+
+    #[test]
+    fn resolves_from_the_cache() {
+        let (_tmp, mut db) = test_db();
+        crate::db::cache_reviews(&mut db, &[review(7, "feature")]).unwrap();
+
+        let resolved = review_for_head_ref(&db, "feature").unwrap();
+        assert_eq!(resolved.map(|r| r.number), Some(7));
+
+        assert!(
+            review_for_head_ref(&db, "missing").unwrap().is_none(),
+            "an unpublished branch resolves to no review"
+        );
+    }
+
+    #[test]
+    fn empty_cache_resolves_to_none() {
+        let (_tmp, db) = test_db();
+        assert!(review_for_head_ref(&db, "feature").unwrap().is_none());
+    }
+
+    #[test]
+    fn reviews_by_head_dedups_preferring_open() {
+        let (_tmp, mut db) = test_db();
+        crate::db::cache_reviews(
+            &mut db,
+            &[merged(review(1, "feature")), review(2, "feature")],
+        )
+        .unwrap();
+
+        let map = reviews_by_head(&db).unwrap();
+        assert_eq!(map.get("feature").map(|r| r.number), Some(2));
+    }
+}

--- a/crates/but-forge/src/association.rs
+++ b/crates/but-forge/src/association.rs
@@ -58,12 +58,14 @@ pub fn reviews_by_head(db: &but_db::DbHandle) -> anyhow::Result<HashMap<String, 
 /// 2. a review whose head is in the base repo over one in a fork — a local
 ///    branch normally pushes to the base repo, so this avoids latching onto a
 ///    fork's same-named branch when a base-repo review also exists.
-fn preference(review: &ForgeReview) -> (bool, bool) {
-    (review.is_open(), !review.head_repo_is_fork)
+/// 3. the highest review number, which is deterministic and usually the newest
+///    review among otherwise equivalent matches.
+fn preference(review: &ForgeReview) -> (bool, bool, i64) {
+    (review.is_open(), !review.head_repo_is_fork, review.number)
 }
 
 /// Pick the best cached review whose `source_branch` equals `head_ref_short`,
-/// or `None` if none match. Ties resolve to the last such review in `reviews`.
+/// or `None` if none match.
 fn best_match<'a>(reviews: &'a [ForgeReview], head_ref_short: &str) -> Option<&'a ForgeReview> {
     reviews
         .iter()
@@ -149,6 +151,12 @@ mod tests {
         assert_eq!(best_match(&reviews, "feature").map(|r| r.number), Some(1));
     }
 
+    #[test]
+    fn prefers_highest_number_when_other_preferences_match() {
+        let reviews = vec![review(2, "feature"), review(1, "feature")];
+        assert_eq!(best_match(&reviews, "feature").map(|r| r.number), Some(2));
+    }
+
     fn test_db() -> (tempfile::TempDir, but_db::DbHandle) {
         let tmp = tempfile::tempdir().unwrap();
         let db = but_db::DbHandle::new_in_directory(tmp.path()).unwrap();
@@ -183,6 +191,15 @@ mod tests {
             &[merged(review(1, "feature")), review(2, "feature")],
         )
         .unwrap();
+
+        let map = reviews_by_head(&db).unwrap();
+        assert_eq!(map.get("feature").map(|r| r.number), Some(2));
+    }
+
+    #[test]
+    fn reviews_by_head_dedups_preferring_highest_number() {
+        let (_tmp, mut db) = test_db();
+        crate::db::cache_reviews(&mut db, &[review(2, "feature"), review(1, "feature")]).unwrap();
 
         let map = reviews_by_head(&db).unwrap();
         assert_eq!(map.get("feature").map(|r| r.number), Some(2));

--- a/crates/but-forge/src/lib.rs
+++ b/crates/but-forge/src/lib.rs
@@ -3,11 +3,13 @@ use git_url_parse::{GitUrl, types::provider::GenericProvider};
 mod forge;
 pub use crate::forge::{ForgeName, ForgeRepoInfo, ForgeUser, deserialize_preferred_forge_user_opt};
 
+mod association;
 mod ci;
 mod db;
 mod forge_info;
 mod repo;
 mod review;
+pub use association::{review_for_head_ref, reviews_by_head};
 pub use ci::{CiCheck, CiConclusion, CiOutput, CiStatus, ci_checks_for_ref_with_cache};
 pub use forge_info::{ForgeCapabilities, ForgeInfo, ForgeUnitInfo, compare_branch_url, forge_info};
 pub use repo::{RepoInfo, RepoPermissions, get_repo_info};

--- a/crates/but-forge/src/lib.rs
+++ b/crates/but-forge/src/lib.rs
@@ -16,7 +16,7 @@ pub use repo::{RepoInfo, RepoPermissions, get_repo_info};
 pub use review::{
     CacheConfig, CreateForgeReviewParams, ForgeAccountValidity, ForgeReview, ForgeReviewFilter,
     ForgeReviewTargetUpdate, ForgeReviewUpdate, ReviewMergeMethod, ReviewMergeStatus, ReviewState,
-    ReviewTemplateFunctions, ReviewUpdatePayload, available_review_templates,
+    ReviewTemplateFunctions, ReviewUpdatePayload, available_review_templates, cache_review,
     check_forge_account_is_valid, compute_review_target_updates, create_forge_review,
     get_forge_review, get_review_base_repo_url, get_review_merge_status,
     get_review_template_functions, list_forge_reviews_for_branch, list_forge_reviews_with_cache,

--- a/crates/but-forge/src/review.rs
+++ b/crates/but-forge/src/review.rs
@@ -538,6 +538,18 @@ pub fn list_forge_reviews_with_cache(
     Ok(reviews)
 }
 
+/// Optimistically cache a single review — e.g. one just created via
+/// [`create_forge_review`] — so it appears in cache-only projections before the
+/// next full review-list sync.
+///
+/// Unlike [`list_forge_reviews_with_cache`], this upserts a single row and never
+/// deletes other cached reviews. The reconcile pass protects such a freshly
+/// written row from deletion for a short grace window, so it survives even if the
+/// forge's own list endpoint hasn't caught up to the new review yet.
+pub fn cache_review(db: &mut but_db::DbHandle, review: &ForgeReview) -> Result<()> {
+    crate::db::upsert_review(db, review)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum ForgeAccountValidity {


### PR DESCRIPTION
Adds cache-derived review association resolution, optimistic PR insertion, and reconciliation grace behavior.

---

### Why?

After we create a PR, we should add it to the cache, so that readers have the most up-to-date information. This makes the review cache authoritative.
