### PR TITLE
feat(but): show committed file IDs using short change ID if available

### DIFF
--- a/crates/but/src/command/legacy/status/tui/tests/discard_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/discard_tests.rs
@@ -324,7 +324,7 @@ fn discard_individual_committed_files_from_local_file_list() {
         "snapshots/discard_individual_committed_files_from_local_file_list_002.svg"
     ]);
     tui.input('y')
-        .assert_current_line_eq(str!["┊│     5:o A three"])
+        .assert_current_line_eq(str!["┊│     1:o A three"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/discard_individual_committed_files_from_local_file_list_003.svg"
         ])
@@ -334,7 +334,7 @@ fn discard_individual_committed_files_from_local_file_list() {
         "snapshots/discard_individual_committed_files_from_local_file_list_004.svg"
     ]);
     tui.input('y')
-        .assert_current_line_eq(str!["┊│     c:t A two"])
+        .assert_current_line_eq(str!["┊│     1:t A two"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/discard_individual_committed_files_from_local_file_list_005.svg"
         ])
@@ -421,7 +421,7 @@ fn discard_marked_committed_files_from_local_file_list() {
         "snapshots/discard_marked_committed_files_from_local_file_list_003.svg"
     ]);
     tui.input('y')
-        .assert_current_line_eq(str!["┊│     c:t A two"])
+        .assert_current_line_eq(str!["┊│     1:t A two"])
         .assert_backstack_eq([BackstackEntry::ShowFileList])
         .assert_rendered_term_svg_eq(file![
             "snapshots/discard_marked_committed_files_from_local_file_list_004.svg"

--- a/crates/but/src/command/legacy/status/tui/tests/marking_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/marking_tests.rs
@@ -188,7 +188,7 @@ fn can_only_mark_files_from_one_commit() {
 
     tui.input('j');
     tui.input(' ')
-        .assert_current_line_eq(str!["┊│     b:t A two"])
+        .assert_current_line_eq(str!["┊│     1#0:t A two"])
         .assert_backstack_eq([BackstackEntry::Mark, BackstackEntry::ShowFileList])
         .assert_rendered_term_svg_eq(file![
             "snapshots/can_only_mark_files_from_one_commit_002.svg"
@@ -197,7 +197,7 @@ fn can_only_mark_files_from_one_commit() {
     // we shouldn't be allowed to select lines outside the commit files
     for _ in 0..10 {
         tui.input('j')
-            .assert_current_line_eq(str!["┊│     b:t A two"])
+            .assert_current_line_eq(str!["┊│     1#0:t A two"])
             .assert_backstack_eq([BackstackEntry::Mark, BackstackEntry::ShowFileList])
             .assert_rendered_term_svg_eq(file![
                 "snapshots/can_only_mark_files_from_one_commit_003.svg"
@@ -205,7 +205,7 @@ fn can_only_mark_files_from_one_commit() {
     }
     for _ in 0..10 {
         tui.input('k')
-            .assert_current_line_eq(str!["┊✔︎     b:o A three"])
+            .assert_current_line_eq(str!["┊✔︎     1#0:o A three"])
             .assert_backstack_eq([BackstackEntry::Mark, BackstackEntry::ShowFileList])
             .assert_rendered_term_svg_eq(file![
                 "snapshots/can_only_mark_files_from_one_commit_004.svg"

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_001.svg
@@ -24,13 +24,13 @@
     <text x="178 186 194 202 210 218" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
     <text x="234 242 250 258 266 274 282 290" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">b:o</text>
-    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130 138 146" y="96" style="fill:#00AA00;">three</text>
+    <text x="66 74 82 90 98" y="96" style="fill:#0000AA;font-weight:bold;">1#0:o</text>
+    <text x="114" y="96" style="fill:#CCCCCC;">A</text>
+    <text x="130 138 146 154 162" y="96" style="fill:#00AA00;">three</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">b:t</text>
-    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130" y="114" style="fill:#00AA00;">two</text>
+    <text x="66 74 82 90 98" y="114" style="fill:#0000AA;font-weight:bold;">1#0:t</text>
+    <text x="114" y="114" style="fill:#CCCCCC;">A</text>
+    <text x="130 138 146" y="114" style="fill:#00AA00;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58 66" y="132" style="fill:#AA00AA;">1#1</text>
     <text x="82" y="132" style="fill:#0000AA;font-weight:bold;">4</text>
@@ -39,13 +39,13 @@
     <text x="178 186 194 202 210 218" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="234 242 250 258 266 274 282 290" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="150" style="fill:#0000AA;font-weight:bold;">4:q</text>
-    <text x="98" y="150" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130 138" y="150" style="fill:#00AA00;">four</text>
+    <text x="66 74 82 90 98" y="150" style="fill:#0000AA;font-weight:bold;">1#1:q</text>
+    <text x="114" y="150" style="fill:#CCCCCC;">A</text>
+    <text x="130 138 146 154" y="150" style="fill:#00AA00;">four</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="168" style="fill:#0000AA;font-weight:bold;">4:k</text>
-    <text x="98" y="168" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130" y="168" style="fill:#00AA00;">one</text>
+    <text x="66 74 82 90 98" y="168" style="fill:#0000AA;font-weight:bold;">1#1:k</text>
+    <text x="114" y="168" style="fill:#CCCCCC;">A</text>
+    <text x="130 138 146" y="168" style="fill:#00AA00;">one</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_002.svg
@@ -26,13 +26,13 @@
     <text x="234 242 250 258 266 274 282 290" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">b:o</text>
-    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130 138 146" y="96" style="fill:#00AA00;">three</text>
+    <text x="66 74 82 90 98" y="96" style="fill:#0000AA;font-weight:bold;">1#0:o</text>
+    <text x="114" y="96" style="fill:#CCCCCC;">A</text>
+    <text x="130 138 146 154 162" y="96" style="fill:#00AA00;">three</text>
     <text x="10 18" y="114" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">b:t</text>
-    <text x="98" y="114" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114 122 130" y="114" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="66 74 82 90 98" y="114" style="fill:#0000AA;font-weight:bold;">1#0:t</text>
+    <text x="114" y="114" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="130 138 146" y="114" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58 66" y="132" style="fill:#AA00AA;opacity:0.75;">1#1</text>
     <text x="82" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">4</text>
@@ -41,13 +41,13 @@
     <text x="178 186 194 202 210 218" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="234 242 250 258 266 274 282 290" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">4:q</text>
-    <text x="98" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130 138" y="150" style="fill:#00AA00;opacity:0.75;">four</text>
+    <text x="66 74 82 90 98" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#1:q</text>
+    <text x="114" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="130 138 146 154" y="150" style="fill:#00AA00;opacity:0.75;">four</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="168" style="fill:#0000AA;font-weight:bold;opacity:0.75;">4:k</text>
-    <text x="98" y="168" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130" y="168" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="66 74 82 90 98" y="168" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#1:k</text>
+    <text x="114" y="168" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="130 138 146" y="168" style="fill:#00AA00;opacity:0.75;">one</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_003.svg
@@ -26,13 +26,13 @@
     <text x="234 242 250 258 266 274 282 290" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">b:o</text>
-    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130 138 146" y="96" style="fill:#00AA00;">three</text>
+    <text x="66 74 82 90 98" y="96" style="fill:#0000AA;font-weight:bold;">1#0:o</text>
+    <text x="114" y="96" style="fill:#CCCCCC;">A</text>
+    <text x="130 138 146 154 162" y="96" style="fill:#00AA00;">three</text>
     <text x="10 18" y="114" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">b:t</text>
-    <text x="98" y="114" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114 122 130" y="114" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="66 74 82 90 98" y="114" style="fill:#0000AA;font-weight:bold;">1#0:t</text>
+    <text x="114" y="114" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="130 138 146" y="114" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58 66" y="132" style="fill:#AA00AA;opacity:0.75;">1#1</text>
     <text x="82" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">4</text>
@@ -41,13 +41,13 @@
     <text x="178 186 194 202 210 218" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="234 242 250 258 266 274 282 290" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">4:q</text>
-    <text x="98" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130 138" y="150" style="fill:#00AA00;opacity:0.75;">four</text>
+    <text x="66 74 82 90 98" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#1:q</text>
+    <text x="114" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="130 138 146 154" y="150" style="fill:#00AA00;opacity:0.75;">four</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="168" style="fill:#0000AA;font-weight:bold;opacity:0.75;">4:k</text>
-    <text x="98" y="168" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130" y="168" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="66 74 82 90 98" y="168" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#1:k</text>
+    <text x="114" y="168" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="130 138 146" y="168" style="fill:#00AA00;opacity:0.75;">one</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_004.svg
@@ -27,13 +27,13 @@
     <text x="234 242 250 258 266 274 282 290" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="18" y="96" style="fill:#000000;font-weight:bold;">✔︎</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">b:o</text>
-    <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114 122 130 138 146" y="96" style="fill:#00AA00;font-weight:bold;">three</text>
+    <text x="66 74 82 90 98" y="96" style="fill:#0000AA;font-weight:bold;">1#0:o</text>
+    <text x="114" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="130 138 146 154 162" y="96" style="fill:#00AA00;font-weight:bold;">three</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">b:t</text>
-    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130" y="114" style="fill:#00AA00;">two</text>
+    <text x="66 74 82 90 98" y="114" style="fill:#0000AA;font-weight:bold;">1#0:t</text>
+    <text x="114" y="114" style="fill:#CCCCCC;">A</text>
+    <text x="130 138 146" y="114" style="fill:#00AA00;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58 66" y="132" style="fill:#AA00AA;opacity:0.75;">1#1</text>
     <text x="82" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">4</text>
@@ -42,13 +42,13 @@
     <text x="178 186 194 202 210 218" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="234 242 250 258 266 274 282 290" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">4:q</text>
-    <text x="98" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130 138" y="150" style="fill:#00AA00;opacity:0.75;">four</text>
+    <text x="66 74 82 90 98" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#1:q</text>
+    <text x="114" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="130 138 146 154" y="150" style="fill:#00AA00;opacity:0.75;">four</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="168" style="fill:#0000AA;font-weight:bold;opacity:0.75;">4:k</text>
-    <text x="98" y="168" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="114 122 130" y="168" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="66 74 82 90 98" y="168" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#1:k</text>
+    <text x="114" y="168" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="130 138 146" y="168" style="fill:#00AA00;opacity:0.75;">one</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_001.svg
@@ -24,15 +24,15 @@
     <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
     <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">b:k</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:k</text>
     <text x="98" y="96" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130" y="96" style="fill:#00AA00;">one</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">b:o</text>
+    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:o</text>
     <text x="98" y="114" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130 138 146" y="114" style="fill:#00AA00;">three</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">b:t</text>
+    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">1:t</text>
     <text x="98" y="132" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130" y="132" style="fill:#00AA00;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_002.svg
@@ -30,15 +30,15 @@
     <text x="66 74" y="96" style="fill:#000000;font-weight:bold;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130 138" y="96" style="fill:#000000;font-weight:bold;">discard</text>
     <text x="154 162" y="96" style="fill:#000000;font-weight:bold;">&gt;&gt;</text>
-    <text x="178 186 194" y="96" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">b:k</text>
+    <text x="178 186 194" y="96" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">1:k</text>
     <text x="210" y="96" style="fill:#FFFFFF;font-weight:bold;text-decoration:line-through;">A</text>
     <text x="226 234 242" y="96" style="fill:#00AA00;font-weight:bold;text-decoration:line-through;">one</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">b:o</text>
+    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:o</text>
     <text x="98" y="114" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130 138 146" y="114" style="fill:#00AA00;">three</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">b:t</text>
+    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">1:t</text>
     <text x="98" y="132" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130" y="132" style="fill:#00AA00;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_003.svg
@@ -24,11 +24,11 @@
     <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">5:o</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:o</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="114 122 130 138 146" y="96" style="fill:#00AA00;font-weight:bold;">three</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">5:t</text>
+    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:t</text>
     <text x="98" y="114" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130" y="114" style="fill:#00AA00;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_004.svg
@@ -24,7 +24,7 @@
     <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">c:t</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:t</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="114 122 130" y="96" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_001.svg
@@ -24,15 +24,15 @@
     <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">b:k</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:k</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="114 122 130" y="96" style="fill:#00AA00;font-weight:bold;">one</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">b:o</text>
+    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:o</text>
     <text x="98" y="114" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130 138 146" y="114" style="fill:#00AA00;">three</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">b:t</text>
+    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">1:t</text>
     <text x="98" y="132" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130" y="132" style="fill:#00AA00;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_002.svg
@@ -30,15 +30,15 @@
     <text x="66 74" y="96" style="fill:#000000;font-weight:bold;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130 138" y="96" style="fill:#000000;font-weight:bold;">discard</text>
     <text x="154 162" y="96" style="fill:#000000;font-weight:bold;">&gt;&gt;</text>
-    <text x="178 186 194" y="96" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">b:k</text>
+    <text x="178 186 194" y="96" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">1:k</text>
     <text x="210" y="96" style="fill:#FFFFFF;font-weight:bold;text-decoration:line-through;">A</text>
     <text x="226 234 242" y="96" style="fill:#00AA00;font-weight:bold;text-decoration:line-through;">one</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">b:o</text>
+    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:o</text>
     <text x="98" y="114" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130 138 146" y="114" style="fill:#00AA00;">three</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">b:t</text>
+    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">1:t</text>
     <text x="98" y="132" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130" y="132" style="fill:#00AA00;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_003.svg
@@ -24,11 +24,11 @@
     <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">5:o</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:o</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="114 122 130 138 146" y="96" style="fill:#00AA00;font-weight:bold;">three</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">5:t</text>
+    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:t</text>
     <text x="98" y="114" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130" y="114" style="fill:#00AA00;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_004.svg
@@ -25,11 +25,11 @@
     <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">5:o</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:o</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="114 122 130 138 146" y="96" style="fill:#00AA00;font-weight:bold;">three</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">5:t</text>
+    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:t</text>
     <text x="98" y="114" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130" y="114" style="fill:#00AA00;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_005.svg
@@ -24,7 +24,7 @@
     <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">c:t</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:t</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="114 122 130" y="96" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_006.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_006.svg
@@ -25,7 +25,7 @@
     <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">c:t</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:t</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="114 122 130" y="96" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_001.svg
@@ -24,15 +24,15 @@
     <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
     <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">b:k</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:k</text>
     <text x="98" y="96" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130" y="96" style="fill:#00AA00;">one</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">b:o</text>
+    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:o</text>
     <text x="98" y="114" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130 138 146" y="114" style="fill:#00AA00;">three</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">b:t</text>
+    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">1:t</text>
     <text x="98" y="132" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130" y="132" style="fill:#00AA00;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_002.svg
@@ -27,16 +27,16 @@
     <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">b:k</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:k</text>
     <text x="98" y="96" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130" y="96" style="fill:#00AA00;">one</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">b:o</text>
+    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:o</text>
     <text x="98" y="114" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130 138 146" y="114" style="fill:#00AA00;">three</text>
     <text x="10 18" y="132" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">b:t</text>
+    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">1:t</text>
     <text x="98" y="132" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="114 122 130" y="132" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_003.svg
@@ -33,7 +33,7 @@
     <text x="66 74" y="96" style="fill:#000000;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130 138" y="96" style="fill:#000000;">discard</text>
     <text x="154 162" y="96" style="fill:#000000;">&gt;&gt;</text>
-    <text x="178 186 194" y="96" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">b:k</text>
+    <text x="178 186 194" y="96" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">1:k</text>
     <text x="210" y="96" style="fill:#CCCCCC;text-decoration:line-through;">A</text>
     <text x="226 234 242" y="96" style="fill:#00AA00;text-decoration:line-through;">one</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
@@ -41,11 +41,11 @@
     <text x="66 74" y="114" style="fill:#000000;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130 138" y="114" style="fill:#000000;">discard</text>
     <text x="154 162" y="114" style="fill:#000000;">&gt;&gt;</text>
-    <text x="178 186 194" y="114" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">b:o</text>
+    <text x="178 186 194" y="114" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">1:o</text>
     <text x="210" y="114" style="fill:#CCCCCC;text-decoration:line-through;">A</text>
     <text x="226 234 242 250 258" y="114" style="fill:#00AA00;text-decoration:line-through;">three</text>
     <text x="10 18" y="132" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">b:t</text>
+    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">1:t</text>
     <text x="98" y="132" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="114 122 130" y="132" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_004.svg
@@ -24,7 +24,7 @@
     <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">c:t</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:t</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="114 122 130" y="96" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_005.svg
@@ -24,7 +24,7 @@
     <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
     <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">c:t</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:t</text>
     <text x="98" y="96" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130" y="96" style="fill:#00AA00;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_001.svg
@@ -24,15 +24,15 @@
     <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">b:k</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:k</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="114 122 130" y="96" style="fill:#00AA00;font-weight:bold;">one</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">b:o</text>
+    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:o</text>
     <text x="98" y="114" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130 138 146" y="114" style="fill:#00AA00;">three</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">b:t</text>
+    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">1:t</text>
     <text x="98" y="132" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130" y="132" style="fill:#00AA00;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_002.svg
@@ -27,16 +27,16 @@
     <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">b:k</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:k</text>
     <text x="98" y="96" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130" y="96" style="fill:#00AA00;">one</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">b:o</text>
+    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:o</text>
     <text x="98" y="114" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130 138 146" y="114" style="fill:#00AA00;">three</text>
     <text x="10 18" y="132" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">b:t</text>
+    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">1:t</text>
     <text x="98" y="132" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="114 122 130" y="132" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_003.svg
@@ -33,7 +33,7 @@
     <text x="66 74" y="96" style="fill:#000000;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130 138" y="96" style="fill:#000000;">discard</text>
     <text x="154 162" y="96" style="fill:#000000;">&gt;&gt;</text>
-    <text x="178 186 194" y="96" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">b:k</text>
+    <text x="178 186 194" y="96" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">1:k</text>
     <text x="210" y="96" style="fill:#CCCCCC;text-decoration:line-through;">A</text>
     <text x="226 234 242" y="96" style="fill:#00AA00;text-decoration:line-through;">one</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
@@ -41,11 +41,11 @@
     <text x="66 74" y="114" style="fill:#000000;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130 138" y="114" style="fill:#000000;">discard</text>
     <text x="154 162" y="114" style="fill:#000000;">&gt;&gt;</text>
-    <text x="178 186 194" y="114" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">b:o</text>
+    <text x="178 186 194" y="114" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">1:o</text>
     <text x="210" y="114" style="fill:#CCCCCC;text-decoration:line-through;">A</text>
     <text x="226 234 242 250 258" y="114" style="fill:#00AA00;text-decoration:line-through;">three</text>
     <text x="10 18" y="132" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">b:t</text>
+    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">1:t</text>
     <text x="98" y="132" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="114 122 130" y="132" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_004.svg
@@ -24,7 +24,7 @@
     <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">c:t</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:t</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="114 122 130" y="96" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/mark_and_commit_multiple_uncommitted_files_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/mark_and_commit_multiple_uncommitted_files_final.svg
@@ -26,11 +26,11 @@
     <text x="162 170 178 186 194 202" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
     <text x="218 226 234 242 250 258 266 274" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">f:k</text>
+    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:k</text>
     <text x="98" y="114" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130" y="114" style="fill:#00AA00;">one</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">f:o</text>
+    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">1:o</text>
     <text x="98" y="132" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130 138 146" y="132" style="fill:#00AA00;">three</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊●</text>

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -313,7 +313,14 @@ impl WorkspaceCommitWithId {
             .into_iter()
             .flat_map(|(changes, _change_id, short_id)| {
                 changes.into_iter().map(move |change| TreeChangeWithId {
-                    short_id: format!("{}:{}", self.short_id, short_id.clone()),
+                    short_id: format!(
+                        "{}:{}",
+                        self.change_id
+                            .as_ref()
+                            .map(|cid| &cid.short_id)
+                            .unwrap_or(&self.short_id),
+                        short_id.clone()
+                    ),
                     inner: change,
                 })
             })
@@ -350,7 +357,14 @@ impl<'a> Node<'a> for &'a WorkspaceCommitWithId {
                     cli_id: CliId::CommittedFile {
                         commit_id: self.commit_id(),
                         path: tree_changes.first().path.clone(),
-                        id: format!("{}:{}", self.short_id, short_id),
+                        id: format!(
+                            "{}:{}",
+                            self.change_id
+                                .as_ref()
+                                .map(|cid| &cid.short_id)
+                                .unwrap_or(&self.short_id),
+                            short_id
+                        ),
                     },
                 }));
             }

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -4,7 +4,7 @@ use but_core::{ChangeId, ref_metadata::StackId};
 use but_graph::workspace::Stack;
 use but_hunk_assignment::HunkAssignment;
 use but_testsupport::{hex_to_id, hunk_header};
-use snapbox::prelude::*;
+use snapbox::{assert_data_eq, prelude::*};
 
 use crate::{CliId, IdMap, id::id_usage::UintId};
 
@@ -1259,6 +1259,64 @@ fn committed_files_are_deduplicated_by_commit_oid_path() -> anyhow::Result<()> {
     );
 
     Ok(())
+}
+
+#[test]
+fn committed_file_can_be_referenced_by_either_change_id_or_commit_id() {
+    let id = id(1);
+    let stacks = vec![stack([segment("branch", [id], None, [])])];
+    let commit_id_to_change_id: gix::hashtable::HashMap<gix::ObjectId, ChangeId> = [
+        (id, ChangeId::from_bytes("sv".as_bytes())), // swstzzzz...
+    ]
+    .into_iter()
+    .collect();
+    let id_map = IdMap::new(stacks, Vec::new(), commit_id_to_change_id).unwrap();
+
+    let changed_paths_fn = |commit_id: gix::ObjectId,
+                            parent_id: Option<gix::ObjectId>|
+     -> anyhow::Result<Vec<but_core::TreeChange>> {
+        if commit_id == id {
+            Ok(vec![
+                tree_change_addition("file.txt"),
+                tree_change_addition("other_file.txt"),
+            ])
+        } else {
+            anyhow::bail!("unexpected IDs {commit_id} {parent_id:?}");
+        }
+    };
+
+    assert_data_eq!(
+        id_map
+            .parse("0:u", Box::new(changed_paths_fn))
+            .unwrap()
+            .to_debug(),
+        snapbox::str![[r#"
+[
+    CommittedFile {
+        commit_id: Sha1(0101010101010101010101010101010101010101),
+        path: "file.txt",
+        id: "s:u",
+    },
+]
+
+"#]]
+    );
+    assert_data_eq!(
+        id_map
+            .parse("s:u", Box::new(changed_paths_fn))
+            .unwrap()
+            .to_debug(),
+        snapbox::str![[r#"
+[
+    CommittedFile {
+        commit_id: Sha1(0101010101010101010101010101010101010101),
+        path: "file.txt",
+        id: "s:u",
+    },
+]
+
+"#]]
+    );
 }
 
 #[test]

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -310,13 +310,13 @@ n:5 a.txt│
 ┊
 ┊╭┄g0 [A]
 ┊●   1#0 a7aa4ef partial change to a.txt 3
-┊│     a:n M a.txt
+┊│     1#0:n M a.txt
 ┊●   1#1 889385c partial change to a.txt 2
-┊│     88:n M a.txt
+┊│     1#1:n M a.txt
 ┊●   1#2 8dc39e0 partial change to a.txt 1
-┊│     8d:n M a.txt
+┊│     1#2:n M a.txt
 ┊●   1#3 f4ea7f8 a.txt
-┊│     f:n A a.txt
+┊│     1#3:n A a.txt
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
@@ -361,13 +361,13 @@ Hint: you can run `but undo` to undo these changes
 ┊
 ┊╭┄g0 [A]
 ┊●   1#0 4822140 partial change to a.txt 3
-┊│     48:n M a.txt
+┊│     1#0:n M a.txt
 ┊●   1#1 4593422 partial change to a.txt 2
-┊│     45:n M a.txt
+┊│     1#1:n M a.txt
 ┊●   1#2 8dc39e0 partial change to a.txt 1
-┊│     8:n M a.txt
+┊│     1#2:n M a.txt
 ┊●   1#3 f4ea7f8 a.txt
-┊│     f:n A a.txt
+┊│     1#3:n A a.txt
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -19,8 +19,8 @@ fn commit_moved_file_replaced_by_directory() {
 ┊
 ┊╭┄g0 [A]
 ┊●   1 25c45c4 Commit everything
-┊│     2:q A A/file
-┊│     2:p R B
+┊│     1:q A A/file
+┊│     1:p R B
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
@@ -1569,7 +1569,7 @@ Created new independent branch 'a-branch-1'
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1 d215849 Add file
-┊│     d:q A file
+┊│     1:q A file
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M

--- a/crates/but/tests/but/command/commit2.rs
+++ b/crates/but/tests/but/command/commit2.rs
@@ -1076,7 +1076,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ┊
 ┊╭┄g0 [A]
 ┊●   1 f86bb7b (no commit message)
-┊│     f:k A one
+┊│     1:k A one
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
@@ -1134,9 +1134,9 @@ q:2 file│
 ┊
 ┊╭┄g0 [A]
 ┊●   1#0 f0a3edc (no commit message)
-┊│     f:q M file
+┊│     1#0:q M file
 ┊●   1#1 21b345e (no commit message)
-┊│     2:q A file
+┊│     1#1:q A file
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
@@ -1161,9 +1161,9 @@ Hint: run `but help` for all commands
 ┊
 ┊╭┄g0 [A]
 ┊●   1#0 f0a3edc (no commit message)
-┊│     f:q M file
+┊│     1#0:q M file
 ┊●   1#1 21b345e (no commit message)
-┊│     2:q A file
+┊│     1#1:q A file
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
@@ -1221,9 +1221,9 @@ q:2 file│
 ┊
 ┊╭┄g0 [A]
 ┊●   1#0 f0a3edc (no commit message)
-┊│     f:q M file
+┊│     1#0:q M file
 ┊●   1#1 21b345e (no commit message)
-┊│     2:q A file
+┊│     1#1:q A file
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
@@ -1248,9 +1248,9 @@ Hint: run `but help` for all commands
 ┊
 ┊╭┄g0 [A]
 ┊●   1#0 f0a3edc (no commit message)
-┊│     f:q M file
+┊│     1#0:q M file
 ┊●   1#1 21b345e (no commit message)
-┊│     2:q A file
+┊│     1#1:q A file
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
@@ -1317,8 +1317,8 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ┊
 ┊╭┄g0 [A]
 ┊●   1 e1c5473 (no commit message)
-┊│     e:m A path/to/first.txt
-┊│     e:r A path/to/second.txt
+┊│     1:m A path/to/first.txt
+┊│     1:r A path/to/second.txt
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
@@ -1359,9 +1359,9 @@ fn path_prefix_with_mix_of_modifications() {
 ┊
 ┊╭┄g0 [A]
 ┊●   1 d199c17 (no commit message)
-┊│     d:l A dir/to_delete.txt
-┊│     d:n A dir/to_empty.txt
-┊│     d:x A dir/to_modify.txt
+┊│     1:l A dir/to_delete.txt
+┊│     1:n A dir/to_empty.txt
+┊│     1:x A dir/to_modify.txt
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
@@ -1382,13 +1382,13 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ┊
 ┊╭┄g0 [A]
 ┊●   1#0 d1a6de8 (no commit message)
-┊│     d1a:l D dir/to_delete.txt
-┊│     d1a:n M dir/to_empty.txt
-┊│     d1a:x M dir/to_modify.txt
+┊│     1#0:l D dir/to_delete.txt
+┊│     1#0:n M dir/to_empty.txt
+┊│     1#0:x M dir/to_modify.txt
 ┊●   1#1 d199c17 (no commit message)
-┊│     d19:l A dir/to_delete.txt
-┊│     d19:n A dir/to_empty.txt
-┊│     d19:x A dir/to_modify.txt
+┊│     1#1:l A dir/to_delete.txt
+┊│     1#1:n A dir/to_empty.txt
+┊│     1#1:x A dir/to_modify.txt
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
@@ -1716,7 +1716,7 @@ q:3 file│
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1 d215849 Add file
-┊│     d:q A file
+┊│     1:q A file
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M

--- a/crates/but/tests/but/command/diff.rs
+++ b/crates/but/tests/but/command/diff.rs
@@ -330,8 +330,8 @@ fn json_target_committed_file() {
 ┊
 ┊╭┄g0 [A]
 ┊●   1 3f40d29 committed-file-target
-┊│     3:k A committed-other.txt
-┊│     3:w A committed-target.txt
+┊│     1:k A committed-other.txt
+┊│     1:w A committed-target.txt
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
@@ -611,14 +611,14 @@ fn json_commit_target_tree_change_statuses() -> anyhow::Result<()> {
 ┊
 ┊╭┄g0 [A]
 ┊●   1#0 dafe86a status-target
-┊│     da:nx A added.txt
-┊│     da:nm D deleted.txt
-┊│     da:u M modified.txt
-┊│     da:o R renamed-after.txt
+┊│     1#0:nx A added.txt
+┊│     1#0:nm D deleted.txt
+┊│     1#0:u M modified.txt
+┊│     1#0:o R renamed-after.txt
 ┊●   1#1 db7d00b status-base
-┊│     db:n A deleted.txt
-┊│     db:u A modified.txt
-┊│     db:z A renamed-before.txt
+┊│     1#1:n A deleted.txt
+┊│     1#1:u A modified.txt
+┊│     1#1:z A renamed-before.txt
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯

--- a/crates/but/tests/but/command/move2.rs
+++ b/crates/but/tests/but/command/move2.rs
@@ -976,9 +976,9 @@ Moved 1 changes from 9ac4652 to new commit 8e35f84 below commit fe12bcd
 ┊╭┄g0 [A]
 ┊●   ywx 01a55b8 add second (no changes)
 ┊●   zll 12b9152 add first
-┊│     1:l A first
+┊│     zl:l A first
 ┊●   1 8e35f84 (no commit message)
-┊│     8:w A second
+┊│     1:w A second
 ├╯
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
@@ -1028,9 +1028,9 @@ Moved 1 changes from fe12bcd to new commit c019027 above commit 9ac4652
 ┊
 ┊╭┄g0 [A]
 ┊●   1 c019027 (no commit message)
-┊│     c:l A first
+┊│     1:l A first
 ┊●   ywx 38b1f1a add second
-┊│     3:w A second
+┊│     y:w A second
 ┊●   d8dfd0f add first (no changes)
 ├╯
 ┊
@@ -1082,11 +1082,11 @@ Moved 1 changes from 9ac4652 to new commit 8e35f84 on new branch 'a-branch-1' be
 ┊╭┄g0 [A]
 ┊●   ywx 01a55b8 add second (no changes)
 ┊●   zll 12b9152 add first
-┊│     1:l A first
+┊│     zl:l A first
 ┊│
 ┊├┄br [a-branch-1]
 ┊●   1 8e35f84 (no commit message)
-┊│     8:w A second
+┊│     1:w A second
 ├╯
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
@@ -1136,11 +1136,11 @@ Moved 1 changes from fe12bcd to new commit c019027 on new branch 'a-branch-1' ab
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1 c019027 (no commit message)
-┊│     c:l A first
+┊│     1:l A first
 ┊│
 ┊├┄g0 [A]
 ┊●   ywx 38b1f1a add second
-┊│     3:w A second
+┊│     y:w A second
 ┊●   d8dfd0f add first (no changes)
 ├╯
 ┊
@@ -1194,7 +1194,7 @@ Moved 1 changes from d3e2ba3 to new commit be174de to the tip of branch 'A'
 ┊
 ┊╭┄g0 [A]
 ┊●   1 be174de (no commit message)
-┊│     b:p A B
+┊│     1:p A B
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
@@ -1250,7 +1250,7 @@ Moved 1 changes from 9ac4652 to new commit 8e35f84 on new branch 'new-branch'
 ┊
 ┊╭┄ne [new-branch]
 ┊●   1 8e35f84 (no commit message)
-┊│     8e:w A second
+┊│     1:w A second
 ├╯
 ┊
 ┊╭┄g0 [A]
@@ -1306,7 +1306,7 @@ Moved 1 changes from 9ac4652 to new commit 8e35f84 on new branch 'a-branch-1'
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1 8e35f84 (no commit message)
-┊│     8e:w A second
+┊│     1:w A second
 ├╯
 ┊
 ┊╭┄g0 [A]
@@ -1348,11 +1348,11 @@ fn move_file_should_be_order_independent() {
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1#0 e3d3e3a Prepare for moves!
-┊│     e:u R moved
-┊│     e:p A new/file
-┊│     e:t A unrelated
+┊│     1#0:u R moved
+┊│     1#0:p A new/file
+┊│     1#0:t A unrelated
 ┊●   1#1 24ac1e5 Add new file
-┊│     2:n A new
+┊│     1#1:n A new
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1377,12 +1377,12 @@ Moved 2 changes from e3d3e3a to new commit 99ef17e above commit e3d3e3a
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1#0 99ef17e (no commit message)
-┊│     9:u R moved
-┊│     9:p A new/file
+┊│     1#0:u R moved
+┊│     1#0:p A new/file
 ┊●   1#1 f94e59f Prepare for moves!
-┊│     f:t A unrelated
+┊│     1#1:t A unrelated
 ┊●   1#2 24ac1e5 Add new file
-┊│     2:n A new
+┊│     1#2:n A new
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1409,12 +1409,12 @@ Moved 2 changes from e3d3e3a to new commit 99ef17e above commit e3d3e3a
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1#0 99ef17e (no commit message)
-┊│     9:u R moved
-┊│     9:p A new/file
+┊│     1#0:u R moved
+┊│     1#0:p A new/file
 ┊●   1#1 f94e59f Prepare for moves!
-┊│     f:t A unrelated
+┊│     1#1:t A unrelated
 ┊●   1#2 24ac1e5 Add new file
-┊│     2:n A new
+┊│     1#2:n A new
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -210,12 +210,12 @@ fn committed_file_to_uncommitted_area() -> anyhow::Result<()> {
 ...
               "changes": [
                 {
-                  "cliId": "e:n",
+                  "cliId": "1#0:n",
                   "filePath": "a.txt",
                   "changeType": "modified"
                 },
                 {
-                  "cliId": "e:p",
+                  "cliId": "1#0:p",
                   "filePath": "b.txt",
                   "changeType": "modified"
                 }
@@ -225,12 +225,12 @@ fn committed_file_to_uncommitted_area() -> anyhow::Result<()> {
 ...
               "changes": [
                 {
-                  "cliId": "f:n",
+                  "cliId": "1#1:n",
                   "filePath": "a.txt",
                   "changeType": "added"
                 },
                 {
-                  "cliId": "f:p",
+                  "cliId": "1#1:p",
                   "filePath": "b.txt",
                   "changeType": "added"
                 }
@@ -287,7 +287,7 @@ Uncommitted changes
 ...
               "changes": [
                 {
-                  "cliId": "c:n",
+                  "cliId": "1#0:n",
                   "filePath": "a.txt",
                   "changeType": "modified"
                 }
@@ -297,12 +297,12 @@ Uncommitted changes
 ...
               "changes": [
                 {
-                  "cliId": "f:n",
+                  "cliId": "1#1:n",
                   "filePath": "a.txt",
                   "changeType": "added"
                 },
                 {
-                  "cliId": "f:p",
+                  "cliId": "1#1:p",
                   "filePath": "b.txt",
                   "changeType": "added"
                 }
@@ -733,8 +733,8 @@ fn uncommit_command_with_discard_on_commit() -> anyhow::Result<()> {
 ┊
 ┊╭┄g0 [A]
 ┊●   1 fce8ecc create a.txt and b.txt
-┊│     f:n A a.txt
-┊│     f:p A b.txt
+┊│     1:n A a.txt
+┊│     1:p A b.txt
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
@@ -817,8 +817,8 @@ fn uncommit_command_with_discard_on_committed_file() -> anyhow::Result<()> {
 ┊
 ┊╭┄g0 [A]
 ┊●   1 fce8ecc create a.txt and b.txt
-┊│     f:n A a.txt
-┊│     f:p A b.txt
+┊│     1:n A a.txt
+┊│     1:p A b.txt
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
@@ -861,7 +861,7 @@ Hint: run `but help` for all commands
 ┊
 ┊╭┄g0 [A]
 ┊●   1 993513d create a.txt and b.txt
-┊│     99:n A a.txt
+┊│     1:n A a.txt
 ┊●   9477ae7 add A
 ┊│     94:t A A
 ├╯
@@ -2235,8 +2235,8 @@ fn rubbing_modified_and_renamed_file() {
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1 e3f869d add files
-┊│     e:q A file
-┊│     e:k A file-2
+┊│     1:q A file
+┊│     1:k A file-2
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2258,8 +2258,8 @@ Hint: run `but help` for all commands
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1 e3f869d add files
-┊│     e:q A file
-┊│     e:k A file-2
+┊│     1:q A file
+┊│     1:k A file-2
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2278,7 +2278,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1 3a32c97 add files
-┊│     3:q A file
+┊│     1:q A file
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2306,8 +2306,8 @@ fn committing_modified_and_renamed_file() {
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1 e3f869d add files
-┊│     e:q A file
-┊│     e:k A file-2
+┊│     1:q A file
+┊│     1:k A file-2
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2329,8 +2329,8 @@ Hint: run `but help` for all commands
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1 e3f869d add files
-┊│     e:q A file
-┊│     e:k A file-2
+┊│     1:q A file
+┊│     1:k A file-2
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2349,11 +2349,11 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1#0 e419886 change file
-┊│     e4:q M file
-┊│     e4:k D file-2
+┊│     1#0:q M file
+┊│     1#0:k D file-2
 ┊●   1#1 e3f869d add files
-┊│     e3:q A file
-┊│     e3:k A file-2
+┊│     1#1:q A file
+┊│     1#1:k A file-2
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M

--- a/crates/but/tests/but/command/squash2.rs
+++ b/crates/but/tests/but/command/squash2.rs
@@ -66,11 +66,11 @@ fn squash_two_commits() {
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1#0 f55169f add three
-┊│     f5:o A three
+┊│     1#0:o A three
 ┊●   1#1 f63361f add two
-┊│     f6:t A two
+┊│     1#1:t A two
 ┊●   1#2 ea345ba add one
-┊│     e:k A one
+┊│     1#2:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -95,10 +95,10 @@ Squashed f55169f into f63361f to create 7251301
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1#0 7251301 squashed
-┊│     7:o A three
-┊│     7:t A two
+┊│     1#0:o A three
+┊│     1#0:t A two
 ┊●   1#1 ea345ba add one
-┊│     e:k A one
+┊│     1#1:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -150,9 +150,9 @@ Squashed f55169f, f63361f into ea345ba to create e355a10
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1 e355a10 squashed
-┊│     e:k A one
-┊│     e:o A three
-┊│     e:t A two
+┊│     1:k A one
+┊│     1:o A three
+┊│     1:t A two
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -179,11 +179,11 @@ fn use_target_message() {
 ┊╭┄br [a-branch-1]
 ┊● 1#0 5ab5165 author 2000-01-01 00:00:00 +0000
 ┊│     add two
-┊│     5:o A three
-┊│     5:t A two
+┊│     1#0:o A three
+┊│     1#0:t A two
 ┊● 1#1 ea345ba author 2000-01-01 00:00:00 +0000
 ┊│     add one
-┊│     e:k A one
+┊│     1#1:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -210,11 +210,11 @@ fn use_source_message() {
 ┊╭┄br [a-branch-1]
 ┊● 1#0 c441d34 author 2000-01-01 00:00:00 +0000
 ┊│     add three
-┊│     c:o A three
-┊│     c:t A two
+┊│     1#0:o A three
+┊│     1#0:t A two
 ┊● 1#1 ea345ba author 2000-01-01 00:00:00 +0000
 ┊│     add one
-┊│     e:k A one
+┊│     1#1:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -245,9 +245,9 @@ Squashed branch 'a-branch-1' to create commit a694042
 ┊╭┄br [a-branch-1]
 ┊● 1 a694042 author 2000-01-01 00:00:00 +0000
 ┊│     squashed a branch
-┊│     a:k A one
-┊│     a:o A three
-┊│     a:t A two
+┊│     1:k A one
+┊│     1:o A three
+┊│     1:t A two
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -312,7 +312,7 @@ fn squash_whole_branch_into_commit_on_other_branch() {
 ┊╭┄fi [add-file-branch]
 ┊● 1#0 e528488 author 2000-01-01 00:00:00 +0000
 ┊│     add file
-┊│     e5:q A file
+┊│     1#0:q A file
 ├╯
 ┊
 ┊╭┄ta [target-branch]
@@ -323,13 +323,13 @@ fn squash_whole_branch_into_commit_on_other_branch() {
 ┊╭┄br [a-branch-1]
 ┊● 1#2 f55169f author 2000-01-01 00:00:00 +0000
 ┊│     add three
-┊│     f5:o A three
+┊│     1#2:o A three
 ┊● 1#3 f63361f author 2000-01-01 00:00:00 +0000
 ┊│     add two
-┊│     f6:t A two
+┊│     1#3:t A two
 ┊● 1#4 ea345ba author 2000-01-01 00:00:00 +0000
 ┊│     add one
-┊│     ea:k A one
+┊│     1#4:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -355,10 +355,10 @@ Squashed branches 'a-branch-1', 'add-file-branch' to create commit 44aa30a
 ┊╭┄ta [target-branch]
 ┊● 1 44aa30a author 2000-01-01 00:00:00 +0000
 ┊│     new commit on new branch
-┊│     4:q A file
-┊│     4:k A one
-┊│     4:o A three
-┊│     4:t A two
+┊│     1:q A file
+┊│     1:k A one
+┊│     1:o A three
+┊│     1:t A two
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -393,7 +393,7 @@ fn squash_multiple_branches_into_commit_on_one_of_the_branch_sources() {
 ┊╭┄fi [add-file-branch]
 ┊● 1#0 e528488 author 2000-01-01 00:00:00 +0000
 ┊│     add file
-┊│     e5:q A file
+┊│     1#0:q A file
 ├╯
 ┊
 ┊╭┄ta [target-branch]
@@ -406,13 +406,13 @@ fn squash_multiple_branches_into_commit_on_one_of_the_branch_sources() {
 ┊╭┄br [a-branch-1]
 ┊● 1#3 f55169f author 2000-01-01 00:00:00 +0000
 ┊│     add three
-┊│     f5:o A three
+┊│     1#3:o A three
 ┊● 1#4 f63361f author 2000-01-01 00:00:00 +0000
 ┊│     add two
-┊│     f6:t A two
+┊│     1#4:t A two
 ┊● 1#5 ea345ba author 2000-01-01 00:00:00 +0000
 ┊│     add one
-┊│     ea:k A one
+┊│     1#5:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -438,10 +438,10 @@ Squashed branches 'target-branch', 'a-branch-1', 'add-file-branch' to create com
 ┊╭┄ta [target-branch]
 ┊● 1 0653794 author 2000-01-01 00:00:00 +0000
 ┊│     target commit
-┊│     0:q A file
-┊│     0:k A one
-┊│     0:o A three
-┊│     0:t A two
+┊│     1:q A file
+┊│     1:k A one
+┊│     1:o A three
+┊│     1:t A two
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -480,9 +480,9 @@ Squashed branch 'a-branch-1' to create commit 7b3d915
 ┊╭┄br [a-branch-1]
 ┊● 1 7b3d915 author 2000-01-01 00:00:00 +0000
 ┊│     message from editor
-┊│     7:k A one
-┊│     7:o A three
-┊│     7:t A two
+┊│     1:k A one
+┊│     1:o A three
+┊│     1:t A two
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -518,9 +518,9 @@ Squashed branch 'a-branch-1' to create commit abb21d9
 ┊╭┄br [a-branch-1]
 ┊● 1 abb21d9 author 2000-01-01 00:00:00 +0000
 ┊│     add one  add three  add two
-┊│     a:k A one
-┊│     a:o A three
-┊│     a:t A two
+┊│     1:k A one
+┊│     1:o A three
+┊│     1:t A two
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -697,11 +697,11 @@ fn aborts_on_conflicts() {
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1#0 d5e51af remove file
-┊│     d:u D file.txt
+┊│     1#0:u D file.txt
 ┊●   1#1 5b59611 change file
-┊│     5:u M file.txt
+┊│     1#1:u M file.txt
 ┊●   1#2 11a2a8a add file
-┊│     1:u A file.txt
+┊│     1#2:u A file.txt
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -731,16 +731,16 @@ fn cannot_squash_into_commits_on_unapplied_branches() {
 ┊
 ┊╭┄se [second]
 ┊●   1#0 d15f721 add four
-┊│     d:q A four
+┊│     1#0:q A four
 ┊●   1#1 66a5286 add three
-┊│     6:o A three
+┊│     1#1:o A three
 ├╯
 ┊
 ┊╭┄on [one]
 ┊●   1#2 f63361f add two
-┊│     f:t A two
+┊│     1#2:t A two
 ┊●   1#3 ea345ba add one
-┊│     e:k A one
+┊│     1#3:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -830,10 +830,10 @@ Squashed f55169f into f63361f to create 5ab5165
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1#0 5ab5165 add two
-┊│     5:o A three
-┊│     5:t A two
+┊│     1#0:o A three
+┊│     1#0:t A two
 ┊●   1#1 ea345ba add one
-┊│     e:k A one
+┊│     1#1:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -863,11 +863,11 @@ Squashed branch 'one' to create commit 00e6751
 ┊
 ┊╭┄se [second]
 ┊●   1#0 00e6751 add four
-┊│     0:q A four
-┊│     0:k A one
-┊│     0:t A two
+┊│     1#0:q A four
+┊│     1#0:k A one
+┊│     1#0:t A two
 ┊●   1#1 66a5286 add three
-┊│     6:o A three
+┊│     1#1:o A three
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -917,8 +917,8 @@ Amended 7adb8e6 to create d2f176a
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1 d2f176a (no commit message)
-┊│     d:k A one
-┊│     d:t A two
+┊│     1:k A one
+┊│     1:t A two
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -967,9 +967,9 @@ Amended 7adb8e6 to create 0e76889
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1 0e76889 (no commit message)
-┊│     0:k A one
-┊│     0:o A three
-┊│     0:t A two
+┊│     1:k A one
+┊│     1:o A three
+┊│     1:t A two
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1060,11 +1060,11 @@ Amended f55169f to create f55169f
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1#0 f55169f add three
-┊│     f5:o A three
+┊│     1#0:o A three
 ┊●   1#1 f63361f add two
-┊│     f6:t A two
+┊│     1#1:t A two
 ┊●   1#2 ea345ba add one
-┊│     e:k A one
+┊│     1#2:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1095,10 +1095,10 @@ Amended f63361f to create 5ab5165
 ┊╭┄br [a-branch-1]
 ┊●   1#0 bb84ecc add three (no changes)
 ┊●   1#1 5ab5165 add two
-┊│     5:o A three
-┊│     5:t A two
+┊│     1#1:o A three
+┊│     1#1:t A two
 ┊●   1#2 ea345ba add one
-┊│     e:k A one
+┊│     1#2:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1120,11 +1120,11 @@ fn cannot_amend_files_from_different_commits() {
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1#0 f55169f add three
-┊│     f5:o A three
+┊│     1#0:o A three
 ┊●   1#1 f63361f add two
-┊│     f6:t A two
+┊│     1#1:t A two
 ┊●   1#2 ea345ba add one
-┊│     e:k A one
+┊│     1#2:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1164,11 +1164,11 @@ fn cannot_amend_files_in_ways_that_cause_conflicts() {
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1#0 beafa55 remove file
-┊│     b:q D file
+┊│     1#0:q D file
 ┊●   1#1 623d399 change file
-┊│     6:q M file
+┊│     1#1:q M file
 ┊●   1#2 5c348d7 add file
-┊│     5:q A file
+┊│     1#2:q A file
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1208,12 +1208,12 @@ Amended f55169f to create 13baa98
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1#0 13baa98 add three
-┊│     1:q A file
-┊│     1:o A three
+┊│     1#0:q A file
+┊│     1#0:o A three
 ┊●   1#1 f63361f add two
-┊│     f:t A two
+┊│     1#1:t A two
 ┊●   1#2 ea345ba add one
-┊│     e:k A one
+┊│     1#2:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1326,9 +1326,9 @@ Uncommitted f55169f
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1#0 f63361f add two
-┊│     f:t A two
+┊│     1#0:t A two
 ┊●   1#1 ea345ba add one
-┊│     e:k A one
+┊│     1#1:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1357,11 +1357,11 @@ fn squash_into_zz_to_uncommit_file() {
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1#0 f55169f add three
-┊│     f5:o A three
+┊│     1#0:o A three
 ┊●   1#1 f63361f add two
-┊│     f6:t A two
+┊│     1#1:t A two
 ┊●   1#2 ea345ba add one
-┊│     e:k A one
+┊│     1#2:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1388,9 +1388,9 @@ Uncommitted from f55169f
 ┊╭┄br [a-branch-1]
 ┊●   1#0 aba928c add three (no changes)
 ┊●   1#1 f63361f add two
-┊│     f:t A two
+┊│     1#1:t A two
 ┊●   1#2 ea345ba add one
-┊│     e:k A one
+┊│     1#2:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1422,11 +1422,11 @@ fn cannot_uncommit_files_in_ways_that_cause_conflicts() {
 ┊
 ┊╭┄br [a-branch-1]
 ┊●   1#0 beafa55 remove file
-┊│     b:q D file
+┊│     1#0:q D file
 ┊●   1#1 623d399 change file
-┊│     6:q M file
+┊│     1#1:q M file
 ┊●   1#2 5c348d7 add file
-┊│     5:q A file
+┊│     1#2:q A file
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -1285,3 +1285,35 @@ fn status_in_edit_mode_delegates_to_resolve_status() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn status_file_prefixed_with_change_id_when_available_and_commit_id_otherwise() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    env.file("B", "Some content");
+    env.invoke_git("config --local gitbutler.testing.changeId 1234");
+
+    env.but("commit -m 'Commit with change ID'")
+        .assert()
+        .success();
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   123 e1db5a8 Commit with change ID
+┊│     1:p A B
+┊●   9477ae7 add A
+┊│     9:t A A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -284,12 +284,12 @@ fn uncommitted_and_committed_file_cli_ids() -> anyhow::Result<()> {
 ...
               "changes": [
                 {
-                  "cliId": "44:n",
+                  "cliId": "1#0:n",
                   "filePath": "a.txt",
                   "changeType": "modified"
                 },
                 {
-                  "cliId": "44:p",
+                  "cliId": "1#0:p",
                   "filePath": "b.txt",
                   "changeType": "modified"
                 }
@@ -299,12 +299,12 @@ fn uncommitted_and_committed_file_cli_ids() -> anyhow::Result<()> {
 ...
               "changes": [
                 {
-                  "cliId": "49:n",
+                  "cliId": "1#1:n",
                   "filePath": "a.txt",
                   "changeType": "added"
                 },
                 {
-                  "cliId": "49:p",
+                  "cliId": "1#1:p",
                   "filePath": "b.txt",
                   "changeType": "added"
                 }

--- a/crates/but/tests/but/command/uncommit.rs
+++ b/crates/but/tests/but/command/uncommit.rs
@@ -80,9 +80,9 @@ fn uncommit_different_files_from_different_commits_same_branch() -> anyhow::Resu
 ┊
 ┊╭┄g0 [A]
 ┊●   1#0 3d21fdd add c2
-┊│     3:w A c2.txt
+┊│     1#0:w A c2.txt
 ┊●   1#1 28b88fc add c1
-┊│     2:l A c1.txt
+┊│     1#1:l A c1.txt
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
@@ -290,11 +290,11 @@ fn uncommit_same_file_from_different_commits_same_branch() -> anyhow::Result<()>
 ┊
 ┊╭┄g0 [A]
 ┊●   1#0 485d867 write v3
-┊│     4:s M f.txt
+┊│     1#0:s M f.txt
 ┊●   1#1 adeaad7 write v2
-┊│     a:s M f.txt
+┊│     1#1:s M f.txt
 ┊●   1#2 825d09f write v1
-┊│     8:s A f.txt
+┊│     1#2:s A f.txt
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
@@ -400,14 +400,14 @@ fn uncommit_different_files_from_different_commits_different_branches() -> anyho
 ┊
 ┊╭┄g0 [A]
 ┊●   1#0 1675e0b add fa
-┊│     1:s A fa.txt
+┊│     1#0:s A fa.txt
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
 ┊
 ┊╭┄h0 [B]
 ┊●   1#1 30b330c add fb
-┊│     3:q A fb.txt
+┊│     1#1:q A fb.txt
 ┊●   d3e2ba3 add B
 ┊│     d:p A B
 ├╯


### PR DESCRIPTION
If unavailable, we fall back to the short commit ID.

The commit ID remains usable regardless of if the change ID is what's
printed or not.