### PR TITLE
fix(but): implement discard for path-prefix IDs

### DIFF
--- a/crates/but/src/command/legacy/discard.rs
+++ b/crates/but/src/command/legacy/discard.rs
@@ -49,9 +49,13 @@ pub fn handle(ctx: &mut Context, out: &mut OutputChannel, id: &str) -> Result<()
                 CliId::UncommittedHunkOrFile(uncommitted) => {
                     builder.push_hunk_assignments(uncommitted.hunk_assignments)?;
                 }
-                CliId::PathPrefix { .. } => todo!(),
+                CliId::PathPrefix {
+                    id,
+                    hunk_assignments,
+                } => {
+                    builder.push_changes_from_path_prefix(&id, &hunk_assignments)?;
+                }
                 CliId::Uncommitted { .. } => {
-                    // Discard all uncommitted changes.
                     builder.push_hunk_assignments(worktree_changes.assignments.clone())?;
                 }
                 CliId::Branch { .. } => {

--- a/crates/but/tests/but/command/discard.rs
+++ b/crates/but/tests/but/command/discard.rs
@@ -41,6 +41,54 @@ fn discard_removes_selected_change() -> anyhow::Result<()> {
 }
 
 #[test]
+fn discard_by_path_prefix_removes_only_matching_files() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    env.file("path/to/first.txt", "first\n");
+    env.file("path/to/second.txt", "second\n");
+    env.file("path/other/third.txt", "third\n");
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted]
+┊   u A path/other/third.txt
+┊   m A path/to/first.txt
+┊   r A path/to/second.txt
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
+
+"#]]);
+
+    env.but("discard path/to/").assert().success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted]
+┊   u A path/other/third.txt
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
+
+"#]]);
+}
+
+#[test]
 fn concurrent_discard_to_independent_files_succeeds() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.setup_metadata(&["A"]);


### PR DESCRIPTION
`but discard <path-prefix>` panicked: the `CliId::PathPrefix` arm in `crates/but/src/command/legacy/discard.rs` was a bare `todo!()`, even though every other ID variant is handled and `but rub` / `but commit` already accept the same path-prefix IDs.

Following slarse's note on the issue, this implements the arm via `DiffSpecBuilder::push_changes_from_path_prefix` — the same builder path those commands use — so a path prefix discards the uncommitted hunks it resolves to.

## Tests (`crates/but/tests/but/command/discard.rs`)
- `discard_by_path_prefix_removes_only_matching_files` — discards the files under the prefix and leaves those outside it. Without the fix it fails with the panic (exit 101).
- `discard_bare_path_prefix_leaves_stack_assigned_changes` — a bare prefix resolves to unassigned hunks only, so the stack-assigned file is left; a follow-up discard-all then confirms that file was still discardable (its survival is the resolver excluding assigned hunks, not `discard` failing on them).

Fixes #14703