### PR TITLE
add missing card wrap

### DIFF
--- a/apps/desktop/src/components/projectSettings/KeysForm.svelte
+++ b/apps/desktop/src/components/projectSettings/KeysForm.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
 	import CredentialCheck from "$components/projectSettings/CredentialCheck.svelte";
-	import ProjectNameLabel from "$components/shared/ProjectNameLabel.svelte";
 	import ReduxResult from "$components/shared/ReduxResult.svelte";
-	import SettingsSection from "$components/shared/SettingsSection.svelte";
 	import { BASE_BRANCH_SERVICE } from "$lib/baseBranch/baseBranchService.svelte";
 	import { PROJECTS_SERVICE } from "$lib/project/projectsService";
 	import { inject } from "@gitbutler/core/context";
+	import { CardGroup } from "@gitbutler/ui";
 
 	interface Props {
 		// Used by credential checker before target branch set
@@ -16,13 +15,7 @@
 		disabled?: boolean;
 	}
 
-	const {
-		projectId,
-		remoteName = "",
-		branchName = "",
-		showProjectName = false,
-		disabled = false,
-	}: Props = $props();
+	const { projectId, remoteName = "", branchName = "", disabled = false }: Props = $props();
 
 	const baseBranchService = inject(BASE_BRANCH_SERVICE);
 	const baseBranchQuery = $derived(baseBranchService.baseBranch(projectId));
@@ -31,17 +24,14 @@
 	const projectQuery = $derived(projectsService.getProject(projectId));
 </script>
 
-<div>
-	<ReduxResult {projectId} result={projectQuery.result}>
-		{#snippet children(project)}
-			<SettingsSection>
-				{#snippet top()}
-					{#if showProjectName}<ProjectNameLabel projectName={project.title} />{/if}
-				{/snippet}
+<ReduxResult {projectId} result={projectQuery.result}>
+	{#snippet children(project)}
+		<CardGroup>
+			<CardGroup.Item>
 				{#snippet title()}
 					Git authentication
 				{/snippet}
-				{#snippet description()}
+				{#snippet caption()}
 					GitButler authenticates with your Git remote provider through the Git executable available
 					on your PATH.
 				{/snippet}
@@ -51,7 +41,7 @@
 					remoteName={remoteName || baseBranch?.remoteName}
 					branchName={branchName || baseBranch?.shortName}
 				/>
-			</SettingsSection>
-		{/snippet}
-	</ReduxResult>
-</div>
+			</CardGroup.Item>
+		</CardGroup>
+	{/snippet}
+</ReduxResult>


### PR DESCRIPTION
Fixed a styling issue in the Git Credentials section where a card wrapper was missing. Someone had used the wrong wrapping component, which blended the backgrounds together and made it look like the styles weren't loading.

---

Before:

<img width="702" height="375" alt="Screenshot 2026-07-14 at 21 22 14" src="https://github.com/user-attachments/assets/5119835f-39db-4a9a-b139-63e5ccad63e1" />
<img width="754" height="437" alt="Screenshot 2026-07-14 at 21 22 24" src="https://github.com/user-attachments/assets/e067d695-5185-40d5-8a6e-4b8506f1ced9" />

---

After:

<img width="656" height="385" alt="Screenshot 2026-07-14 at 21 30 30" src="https://github.com/user-attachments/assets/b78da91a-2ed0-4677-b3ed-94fa11bc1a94" />

https://github.com/user-attachments/assets/1659b1b8-5f70-4cf8-887f-8c7f4e5a13bf

