### PR TITLE
Group projects by recency in the header project selector

### DIFF
--- a/apps/desktop/src/components/views/AppHeader.svelte
+++ b/apps/desktop/src/components/views/AppHeader.svelte
@@ -74,6 +74,9 @@
 
 	const recentProjectIds = projectsService.recentProjectIds;
 
+	// Below this number of projects a flat list is easier to scan than groups.
+	const MIN_PROJECTS_FOR_GROUPING = 8;
+
 	const mappedProjects = $derived.by(() => {
 		const allProjects = projects.response ?? [];
 		const recentIds = $recentProjectIds;
@@ -83,8 +86,12 @@
 			.filter((project) => project !== undefined);
 		const others = allProjects.filter((project) => !recentIds.includes(project.id));
 
-		// No point in grouping if one of the groups is empty.
-		if (recent.length === 0 || others.length === 0) {
+		// No point in grouping small lists or if one of the groups is empty.
+		if (
+			allProjects.length < MIN_PROJECTS_FOR_GROUPING ||
+			recent.length === 0 ||
+			others.length === 0
+		) {
 			return allProjects.map((project) => ({ value: project.id, label: project.title }));
 		}
 

--- a/apps/desktop/src/components/views/AppHeader.svelte
+++ b/apps/desktop/src/components/views/AppHeader.svelte
@@ -72,12 +72,29 @@
 
 	const projects = $derived(projectsService.projects());
 
-	const mappedProjects = $derived(
-		projects.response?.map((project) => ({
-			value: project.id,
-			label: project.title,
-		})) || [],
-	);
+	const recentProjectIds = projectsService.recentProjectIds;
+
+	const mappedProjects = $derived.by(() => {
+		const allProjects = projects.response ?? [];
+		const recentIds = $recentProjectIds;
+
+		const recent = recentIds
+			.map((id) => allProjects.find((project) => project.id === id))
+			.filter((project) => project !== undefined);
+		const others = allProjects.filter((project) => !recentIds.includes(project.id));
+
+		// No point in grouping if one of the groups is empty.
+		if (recent.length === 0 || others.length === 0) {
+			return allProjects.map((project) => ({ value: project.id, label: project.title }));
+		}
+
+		return [
+			{ header: "Recent" },
+			...recent.map((project) => ({ value: project.id, label: project.title })),
+			{ header: "Other projects" },
+			...others.map((project) => ({ value: project.id, label: project.title })),
+		];
+	});
 
 	let newProjectLoading = $state(false);
 	let projectSelectorOpen = $state(false);

--- a/apps/desktop/src/lib/project/projectsService.ts
+++ b/apps/desktop/src/lib/project/projectsService.ts
@@ -14,8 +14,11 @@ import type { ForgeUser } from "@gitbutler/but-sdk";
 
 export const PROJECTS_SERVICE = new InjectionToken<ProjectsService>("ProjectsService");
 
+const MAX_RECENT_PROJECTS = 5;
+
 export class ProjectsService {
 	private persistedId = persisted<string | undefined>(undefined, "lastProject");
+	readonly recentProjectIds = persisted<string[]>([], "recentlyOpenedProjects");
 
 	constructor(
 		private backendApi: BackendApi,
@@ -70,6 +73,7 @@ export class ProjectsService {
 		if (this.getLastOpenedProject() === projectId) {
 			this.unsetLastOpenedProject();
 		}
+		this.recentProjectIds.set(get(this.recentProjectIds).filter((id) => id !== projectId));
 		return response;
 	}
 
@@ -202,6 +206,11 @@ export class ProjectsService {
 
 	setLastOpenedProject(projectId: string) {
 		this.persistedId.set(projectId);
+		const recentIds = get(this.recentProjectIds);
+		// Keep the order stable for projects already in the recents list.
+		if (!recentIds.includes(projectId)) {
+			this.recentProjectIds.set([projectId, ...recentIds].slice(0, MAX_RECENT_PROJECTS));
+		}
 	}
 
 	unsetLastOpenedProject() {

--- a/packages/ui/src/lib/components/select/OptionsGroup.svelte
+++ b/packages/ui/src/lib/components/select/OptionsGroup.svelte
@@ -2,13 +2,17 @@
 	import { type Snippet } from "svelte";
 
 	interface Props {
+		header?: string;
 		children: Snippet;
 	}
 
-	const { children }: Props = $props();
+	const { header, children }: Props = $props();
 </script>
 
 <div class="options__group">
+	{#if header}
+		<div class="options__group-header text-11 text-semibold">{header}</div>
+	{/if}
 	{@render children()}
 </div>
 
@@ -22,5 +26,13 @@
 		&:not(&:last-child) {
 			border-bottom: 1px solid var(--border-2);
 		}
+	}
+
+	.options__group-header {
+		padding: 8px 8px 2px;
+		color: var(--text-3);
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		user-select: none;
 	}
 </style>

--- a/packages/ui/src/lib/components/select/Select.svelte
+++ b/packages/ui/src/lib/components/select/Select.svelte
@@ -17,9 +17,11 @@
 		value?: T;
 		selectable?: boolean;
 		separator?: boolean; // When true, this item acts as a separator
+		header?: string; // When set, this item acts as a labeled section header/separator
 		[key: string]: any; // Allow additional properties for icons, emojis, etc.
 	} & (
 		| { separator: true } // Separator items don't need label or value
+		| { header: string } // Header items don't need label or value
 		| { label: string; value: T } // Regular items require label and value
 	);
 
@@ -89,28 +91,31 @@
 		options.filter(
 			(item) =>
 				item.separator ||
+				item.header !== undefined ||
 				(item.label && item.label.toLowerCase().includes(searchValue.toLowerCase())),
 		),
 	);
 
-	// Group options by separators
+	// Group options by separators and headers
 	const groupedOptions = $derived.by(() => {
-		const groups: SelectItem<T>[][] = [];
-		let currentGroup: SelectItem<T>[] = [];
+		const groups: { header?: string; items: SelectItem<T>[] }[] = [];
+		let currentItems: SelectItem<T>[] = [];
+		let currentHeader: string | undefined;
 
 		for (const option of filteredOptions) {
-			if (option.separator) {
-				if (currentGroup.length > 0) {
-					groups.push(currentGroup);
-					currentGroup = [];
+			if (option.separator || option.header !== undefined) {
+				if (currentItems.length > 0) {
+					groups.push({ header: currentHeader, items: currentItems });
+					currentItems = [];
 				}
+				currentHeader = option.header;
 			} else {
-				currentGroup.push(option as SelectItem<T>);
+				currentItems.push(option as SelectItem<T>);
 			}
 		}
 
-		if (currentGroup.length > 0) {
-			groups.push(currentGroup);
+		if (currentItems.length > 0) {
+			groups.push({ header: currentHeader, items: currentItems });
 		}
 
 		return groups;
@@ -118,7 +123,10 @@
 
 	// Flatten grouped options for navigation while preserving order
 	const selectableOptions = $derived.by(
-		() => filteredOptions.filter((item) => !item.separator) as SelectItem<T>[],
+		() =>
+			filteredOptions.filter(
+				(item) => !item.separator && item.header === undefined,
+			) as SelectItem<T>[],
 	);
 
 	// Auto-highlight first option when search results change, reset when search is cleared
@@ -207,7 +215,7 @@
 	}
 
 	function handleSelect(item: SelectItem<string>, event?: MouseEvent | KeyboardEvent) {
-		if (item.separator || !item.value) return;
+		if (item.separator || item.header !== undefined || !item.value) return;
 		const value = item.value as T;
 		const modifiers = event
 			? {
@@ -391,8 +399,8 @@
 						</OptionsGroup>
 					{:else}
 						{#each groupedOptions as group}
-							<OptionsGroup>
-								{#each group as item}
+							<OptionsGroup header={group.header}>
+								{#each group.items as item}
 									{@const selectableIdx = selectableOptions.findIndex(
 										(opt) => opt.value === item.value && item.value !== undefined,
 									)}

--- a/packages/ui/src/stories/components/Select.stories.svelte
+++ b/packages/ui/src/stories/components/Select.stories.svelte
@@ -279,6 +279,38 @@
 	{/snippet}
 </Story>
 
+<Story name="With Headers">
+	{#snippet template(_args)}
+		<div class="wrap">
+			<Select
+				searchable
+				options={[
+					{ header: "Repos" },
+					{ value: "origin-head", label: "origin/HEAD" },
+					{ value: "add-extra-check", label: "add-extra-check" },
+					{ value: "origin-css-fixes", label: "origin/css-fixes" },
+					{ value: "lucky-backend-api", label: "lucky/backend-API" },
+					{ value: "sera-payment", label: "sera/payment-features" },
+					{ header: "Options" },
+					{ value: "add-new", label: "Add new project" },
+					{ value: "clone", label: "Clone a repository" },
+				]}
+				value={selectedWithSeparators}
+				onselect={(value: string) => {
+					selectedWithSeparators = value;
+				}}
+				placeholder="Placeholder"
+			>
+				{#snippet itemSnippet({ item, highlighted })}
+					<SelectItem selected={item.value === selectedWithSeparators} {highlighted}>
+						{item.label}
+					</SelectItem>
+				{/snippet}
+			</Select>
+		</div>
+	{/snippet}
+</Story>
+
 <Story name="Complex Separators">
 	{#snippet template(_args)}
 		<div class="wrap">


### PR DESCRIPTION
The project selector in the app header showed all projects as one flat list, which gets hard to scan with many repos. This PR groups them into Recent and Other projects.

## Changes

* Select / OptionsGroup (UI package): added support for labeled section headers inside the options list
* ProjectsService: tracks up to 5 recently opened projects in localStorage; entries are removed on project deletion
* AppHeader: builds grouped options from the recents list

## Behavior details

* Grouping only kicks in with 8+ projects — smaller lists stay flat, since headers would just add noise
* Recents keep a stable order: opening a project already in the list doesn't reorder it, avoiding items jumping right after you click them
* Falls back to a flat list if either group would be empty

<img src="https://github.com/user-attachments/assets/6c191ea2-abf5-46e1-8875-e8ed30395055 " alt="image" width="1217" data-linear-height="775" />

https://github.com/user-attachments/assets/0969412b-c00a-4218-86fb-3f867377380b