### PR TITLE
fix(but): remove change ID from remote commits in `but`

### DIFF
--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -382,9 +382,6 @@ fn build_status_context<'a>(
                     local_commits_by_id.insert(local_commit.id, local_commit);
                 }
                 for remote_commit in commits_on_remote {
-                    if let Some(change_id) = &remote_commit.change_id {
-                        commit_id_to_change_id.insert(remote_commit.id, change_id.clone());
-                    }
                     remote_commits_by_id.insert(remote_commit.id, remote_commit);
                 }
                 push_statuses_by_segment_id.insert(segment.id, push_status);
@@ -1358,10 +1355,7 @@ fn print_group(
                     status_ctx,
                     stack_with_id.id,
                     commit.short_id.clone(),
-                    commit
-                        .change_id
-                        .as_ref()
-                        .map(|change_id| change_id.short_id.clone()),
+                    None,
                     inner,
                     CommitChanges::Remote(&details.diff_with_first_parent),
                     CommitClassification::Upstream,

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -390,8 +390,6 @@ impl<'a> Node<'a> for &'a WorkspaceCommitWithId {
 pub struct RemoteCommitWithId {
     /// The short ID.
     pub short_id: ShortId,
-    /// The change ID.
-    pub change_id: Option<ChangeIdWithShortId>,
     /// The original remote commit.
     pub inner: StackCommit,
 }
@@ -419,7 +417,7 @@ impl<'a> Node<'a> for &'a RemoteCommitWithId {
         Ok(Some(CliId::Commit {
             commit_id: self.commit_id(),
             id: self.short_id.clone(),
-            change_id: self.change_id.as_ref().map(|id| id.change_id.clone()),
+            change_id: None,
         }))
     }
 }
@@ -646,15 +644,10 @@ impl IdMap {
             .iter_mut()
             .flat_map(|stack| stack.segments.iter_mut())
             .flat_map(|segment| {
-                let ws_commits = segment
+                segment
                     .workspace_commits
                     .iter_mut()
-                    .filter_map(|c| c.change_id.as_mut());
-                let remote_commits = segment
-                    .remote_commits
-                    .iter_mut()
-                    .filter_map(|c| c.change_id.as_mut());
-                ws_commits.chain(remote_commits)
+                    .filter_map(|c| c.change_id.as_mut())
             })
         {
             reverse_hex_short_ids.push((change_id.change_id.clone(), Some(&mut change_id.short_id)))
@@ -844,12 +837,7 @@ impl IdMap {
             .stacks
             .iter()
             .flat_map(|stack| &stack.segments)
-            .flat_map(|segment| {
-                segment
-                    .commits
-                    .iter()
-                    .chain(segment.commits_on_remote.iter())
-            })
+            .flat_map(|segment| segment.commits.iter())
             .map(|c| c.id);
 
         let commit_id_to_change_id = commit_ids
@@ -1020,7 +1008,11 @@ impl IdMap {
                 for remote_commit_with_id in segment_with_id.remote_commits.iter() {
                     if element_matches_commit(
                         remote_commit_with_id.commit_id(),
-                        remote_commit_with_id.change_id.as_ref(),
+                        // We currently do not allow change ID matching against remote commits to
+                        // prevent unnecessary ambiguity with local commits. If we do want this
+                        // feature in the future, we should probably put remote commit change IDs in
+                        // a separate namespace by prefixing something to them.
+                        None,
                     ) {
                         matches.push(Box::new(remote_commit_with_id))
                     }

--- a/crates/but/src/id/stacks_info.rs
+++ b/crates/but/src/id/stacks_info.rs
@@ -39,10 +39,6 @@ fn stacks_info_without_short_ids(
                 .into_iter()
                 .map(|commit| RemoteCommitWithId {
                     short_id: ShortId::default(),
-                    change_id: commit_id_to_change_id
-                        .get(&commit.id)
-                        .cloned()
-                        .map(Into::into),
                     inner: commit,
                 })
                 .collect::<Vec<_>>();

--- a/crates/but/tests/but/command/expand.rs
+++ b/crates/but/tests/but/command/expand.rs
@@ -50,7 +50,6 @@ Matches: 0
 "#]]);
 }
 
-#[cfg(feature = "legacy")]
 #[test]
 fn resolves_duplicated_change_ids() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
@@ -79,7 +78,6 @@ commit: 1 71c4380695ab83fc7ff085860bb656ab27ed524e
 "#]]);
 }
 
-#[cfg(feature = "legacy")]
 #[test]
 fn resolves_distinct_change_id_prefixes() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
@@ -105,7 +103,70 @@ commit: 132 ea3b1e3ff9f628d463fc5d66a20a9d523fb9a95b
 "#]]);
 }
 
-#[cfg(feature = "legacy")]
+/// It's important for usability that change IDs on remote commits do not interfere with change IDs
+/// on local commits. At the time of writing this test we don't include change IDs for remote
+/// commits in ID resolution, but if we do in the future we should take care to put them in a
+/// separate namespace from local commits.
+#[test]
+fn changing_pushed_commit_does_not_cause_change_id_ambiguity() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    set_change_id(&env, "123");
+    env.file("file", "some content");
+    env.but("_commit2 -m first").assert().success();
+
+    env.file("file", "some other content");
+    env.but("_commit2 -m second").assert().success();
+
+    env.invoke_git("update-ref refs/remotes/origin/a-branch-1 refs/heads/a-branch-1");
+    env.invoke_git("config branch.a-branch-1.remote origin");
+    env.invoke_git("config branch.a-branch-1.merge refs/heads/a-branch-1");
+
+    // Undo to before the second commit
+    env.but("undo").assert().success();
+    env.but("discard zz").assert().success();
+
+    // now reword the first to properly diverge
+    env.but("reword 123 -m 'rewritten'").assert().success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄br [a-branch-1]
+┊┊
+┊╭┄┄(upstream: on origin/a-branch-1)
+┊●   a5caff1 second
+┊-
+┊◐   123 96b6213 rewritten
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+    assert_eq!(
+        env.invoke_git("rev-list --count refs/remotes/origin/a-branch-1 ^refs/heads/a-branch-1"),
+        "2",
+        "remote should have two divergent commits with the local commit's change ID"
+    );
+
+    // This should still unambiguously refer to the one local commit with that change ID
+    env.but("_expand 123")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Matches: 1
+
+commit: 123 96b6213[..]
+
+"#]]);
+}
+
 fn set_change_id(env: &Sandbox, change_id: &str) {
     env.invoke_git(&format!(
         "config --local gitbutler.testing.changeId {change_id}"

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -23,7 +23,7 @@ mod diff;
 mod diff2;
 #[cfg(feature = "legacy")]
 mod discard;
-#[cfg(feature = "but-2")]
+#[cfg(all(feature = "legacy", feature = "but-2"))]
 mod expand;
 #[cfg(unix)]
 mod external;


### PR DESCRIPTION
## 🧢 Changes
We were not doing the remote<->local commit reconciliation in `IdMap::new_from_context()`, so it didn't agree with `but status` about which remote commits were in view. This could cause a commit's change ID to become ambiguous, even though it looked distinct by `but status`. Here's an example:

```bash
$ but st
Initiated a background sync...
╭┄zz [uncommitted]
┊   p A B
┊
┊╭┄bo [bottom]
┊●   xpl 7c00a0f Add a
├╯
┊
┴ ea3c2a3 (common base) 2026-07-02 Add README.md

Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them

$ but _expand x
Matches: 1

commit: xplouoplruptsunqmtztzkrtvspluntz 7c00a0f20227e8f95d3acad1bfdf4c880fcd5bc8

$ but _squash2 p -t x
Initiated a background sync...
Amended 7c00a0f to create 984235f

$ but _expand x
Matches: 2

commit: xplouoplruptsunqmtztzkrtvspluntz 984235f196235aa1bc922a63e12267e449a3f91b
commit: xplouoplruptsunqmtztzkrtvspluntz 7c00a0f20227e8f95d3acad1bfdf4c880fcd5bc8
```

To fix this for the moment, we just get rid of change IDs for remote commits. They're rarely rendered anyway and we don't have a good use for them right now.