### PR TITLE
fix(but-meta): collapse within-stack duplicate heads

### DIFF
--- a/crates/but-meta/src/legacy/mod.rs
+++ b/crates/but-meta/src/legacy/mod.rs
@@ -198,11 +198,20 @@ impl Snapshot {
                 }
             }
 
+            // A single stack must never list the same branch name twice: that's
+            // always corruption (e.g. from a racy write, #13345), never a legitimate
+            // shared segment. Drop within-stack repeats unconditionally - ahead of the
+            // cross-stack `preserve_duplicate` carve-out below, which only makes sense
+            // for two *different* stacks resolving to the same projected segment.
+            let mut seen_in_this_stack = HashSet::<String>::new();
             let head_indices_to_remove: Vec<_> = stack
                 .heads
                 .iter()
                 .enumerate()
                 .filter_map(|(head_idx, head)| {
+                    if !seen_in_this_stack.insert(head.name.clone()) {
+                        return Some(head_idx);
+                    }
                     let projected_segment_id = projected_segment_ids
                         .as_ref()
                         .and_then(|ids| ids.get(&head.name).copied());
@@ -225,7 +234,7 @@ impl Snapshot {
             for head_idx in head_indices_to_remove.into_iter().rev() {
                 let head = stack.heads.remove(head_idx);
                 tracing::warn!(
-                    "Removed '{head_name}' from stack {stack_id} as it was already used in another stack",
+                    "Removed duplicate head '{head_name}' from stack {stack_id}",
                     head_name = head.name
                 );
                 changed = true;

--- a/crates/but-meta/tests/meta/ref_metadata_legacy.rs
+++ b/crates/but-meta/tests/meta/ref_metadata_legacy.rs
@@ -1974,6 +1974,54 @@ fn preserves_duplicate_heads_if_they_map_to_the_same_workspace_segment() -> anyh
     Ok(())
 }
 
+#[test]
+fn removes_within_stack_duplicate_heads_even_when_mapped_to_a_segment() -> anyhow::Result<()> {
+    let repo = but_testsupport::read_only_in_memory_scenario("ws/multi-lane-with-shared-segment")?;
+    let (mut store, _tmp) = empty_vb_store_rw()?;
+    store.data_mut().default_target = Some(Target {
+        branch: RemoteRefname::new("origin", "main"),
+        remote_url: "https://example.com/example-org/example-repo".to_string(),
+        sha: gix::hash::Kind::Sha1.null(),
+        push_remote_name: Some("origin".into()),
+    });
+
+    // A single stack that lists "shared" twice - one of the corruption shapes in
+    // #13345. Even though "shared" maps to a real projected segment (which is what
+    // makes the cross-stack preserve carve-out fire), one stack must never repeat a
+    // branch.
+    let stack = LegacyStack::new_with_just_heads(
+        vec![
+            StackBranch::new_with_zero_head("shared".into(), None, None, false),
+            StackBranch::new_with_zero_head("shared".into(), None, None, false),
+            StackBranch::new_with_zero_head("A".into(), None, None, false),
+        ],
+        0,
+        true,
+    );
+    let stack_id = stack.id;
+    store.data_mut().branches.insert(stack_id, stack);
+    store.set_changed_to_necessitate_write();
+
+    let path = store.path().to_owned();
+    store.write_reconciled(&repo)?;
+
+    let store = VirtualBranchesTomlMetadata::from_path(path)?;
+    let shared_in_stack = store.data().branches.get(&stack_id).map(|stack| {
+        stack
+            .heads
+            .iter()
+            .filter(|head| head.name == "shared")
+            .count()
+    });
+    assert_eq!(
+        shared_in_stack,
+        Some(1),
+        "the stack must not keep the same branch twice, even when it maps to a projected segment",
+    );
+
+    Ok(())
+}
+
 #[cfg(unix)]
 #[test]
 fn falls_back_to_in_memory_db_when_persistent_db_open_fails() -> anyhow::Result<()> {

--- a/crates/but-meta/tests/meta/ref_metadata_legacy.rs
+++ b/crates/but-meta/tests/meta/ref_metadata_legacy.rs
@@ -1975,7 +1975,8 @@ fn preserves_duplicate_heads_if_they_map_to_the_same_workspace_segment() -> anyh
 }
 
 #[test]
-fn removes_within_stack_duplicate_heads_even_when_mapped_to_a_segment() -> anyhow::Result<()> {
+fn removes_within_stack_duplicate_heads_even_when_mapped_to_a_segment_13345() -> anyhow::Result<()>
+{
     let repo = but_testsupport::read_only_in_memory_scenario("ws/multi-lane-with-shared-segment")?;
     let (mut store, _tmp) = empty_vb_store_rw()?;
     store.data_mut().default_target = Some(Target {
@@ -1985,10 +1986,8 @@ fn removes_within_stack_duplicate_heads_even_when_mapped_to_a_segment() -> anyho
         push_remote_name: Some("origin".into()),
     });
 
-    // A single stack that lists "shared" twice - one of the corruption shapes in
-    // #13345. Even though "shared" maps to a real projected segment (which is what
-    // makes the cross-stack preserve carve-out fire), one stack must never repeat a
-    // branch.
+    // A single stack that lists "shared" twice.
+    // Even though "shared" maps to a real projected segment, one stack must never repeat a branch.
     let stack = LegacyStack::new_with_just_heads(
         vec![
             StackBranch::new_with_zero_head("shared".into(), None, None, false),


### PR DESCRIPTION
`enforce_constraints` (but-meta) dedups head names across stacks, but a *"preserve if they map to the same projected segment"* carve-out — meant for two **different** stacks legitimately sharing a segment — also fired for a **single stack repeating a branch name** (same name → same segment → preserved). So the duplicate-head corruption reported in #13345 survived cleanup, and `but status` showed the phantom "(no commits)" head entries.

This drops within-stack repeats unconditionally: a stack is a series of distinct branches and must never list the same one twice.

## Scope
This collapses the **duplicate heads** only. The `Really couldn't find <uuid>` wedge in #13345 also involves a shadow duplicate *stack*, which this does **not** remove — so this **Addresses** the issue rather than fully fixing it. I've opened a note on the issue to get direction on the shadow-stack part before the planned vb.toml removal.

## Tests (`crates/but-meta/tests/meta/ref_metadata_legacy.rs`)
- `removes_within_stack_duplicate_heads_even_when_mapped_to_a_segment` — one stack lists `shared` twice under a real projected segment (the exact condition that fires the carve-out); asserts it keeps `shared` once. Reverting only the fix makes it fail (the stack keeps `shared` twice).
- The existing `removes_duplicate_heads_…` and `preserves_duplicate_heads_…` still pass, so cross-stack behavior is unchanged.

Addresses #13345