### PR TITLE
Lite misc

### DIFF
--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -1,5 +1,5 @@
 import { decodeBytes, encodeBytes } from "#ui/api/bytes.ts";
-import { getHeadInfoIndex, renameBranchInHeadInfo } from "#ui/api/ref-info.ts";
+import { renameBranchInHeadInfo } from "#ui/api/ref-info.ts";
 import {
 	changesInWorktreeQueryOptions,
 	getReviewMergeStatusQueryOptions,
@@ -56,7 +56,6 @@ export const syncCoreCaches = (
 		projectSlice.actions.updateRewrittenCommitReferences({
 			projectId,
 			replacedCommits: workspace.replacedCommits,
-			headInfo: workspace.headInfo,
 		}),
 	);
 };
@@ -525,17 +524,12 @@ export const useCommitInsertBlank = () => {
 		onSuccess: async (response, input, _context, mutation) => {
 			syncCoreCaches(mutation.client, dispatch, input.projectId, response);
 
-			const stackId = getHeadInfoIndex(response.workspace.headInfo).commitContextById(
-				response.newCommit,
-			)?.stack.id;
-			if (stackId != null) {
-				dispatch(
-					projectSlice.actions.selectOutline({
-						projectId: input.projectId,
-						selection: commitOperand({ stackId, commitId: response.newCommit }),
-					}),
-				);
-			}
+			dispatch(
+				projectSlice.actions.selectOutline({
+					projectId: input.projectId,
+					selection: commitOperand({ commitId: response.newCommit }),
+				}),
+			);
 		},
 		onError: (error) => {
 			// oxlint-disable-next-line no-console
@@ -814,12 +808,10 @@ export const useUnapplyStack = () => {
 
 export const useUpdateBranchName = ({
 	projectId,
-	stackId,
 	branchRef,
 	oldBranch,
 }: {
 	projectId: string;
-	stackId: string;
 	branchRef: Array<number>;
 	oldBranch: BranchOperand;
 }) => {
@@ -830,7 +822,6 @@ export const useUpdateBranchName = ({
 		mutationFn: window.lite.updateBranchName,
 		onSuccess: async (newRef, _input, _context, mutation) => {
 			const newBranch: BranchOperand = {
-				stackId,
 				branchRef: newRef.fullNameBytes,
 			};
 
@@ -839,7 +830,6 @@ export const useUpdateBranchName = ({
 
 				return renameBranchInHeadInfo({
 					headInfo,
-					stackId,
 					branchRef,
 					newName: newRef.displayName,
 					newBranchRef: newRef.fullNameBytes,

--- a/apps/lite/ui/src/api/ref-info.ts
+++ b/apps/lite/ui/src/api/ref-info.ts
@@ -75,38 +75,31 @@ export const getHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
 
 export const renameBranchInHeadInfo = ({
 	headInfo,
-	stackId,
 	branchRef,
 	newName,
 	newBranchRef,
 }: {
 	headInfo: RefInfo;
-	stackId: string;
 	branchRef: Array<number>;
 	newName: string;
 	newBranchRef: Array<number>;
 }): RefInfo => ({
 	...headInfo,
-	stacks: headInfo.stacks.map((stack) => {
-		if (stack.id !== stackId) return stack;
+	stacks: headInfo.stacks.map((stack) => ({
+		...stack,
+		segments: stack.segments.map((segment) => {
+			if (!segment.refName || !bytesEqual(segment.refName.fullNameBytes, branchRef)) return segment;
 
-		return {
-			...stack,
-			segments: stack.segments.map((segment) => {
-				if (!segment.refName || !bytesEqual(segment.refName.fullNameBytes, branchRef))
-					return segment;
-
-				return {
-					...segment,
-					refName: {
-						...segment.refName,
-						displayName: newName,
-						fullNameBytes: newBranchRef,
-					},
-				};
-			}),
-		};
-	}),
+			return {
+				...segment,
+				refName: {
+					...segment.refName,
+					displayName: newName,
+					fullNameBytes: newBranchRef,
+				},
+			};
+		}),
+	})),
 });
 
 export const resolveRelativeTo = ({

--- a/apps/lite/ui/src/commit.ts
+++ b/apps/lite/ui/src/commit.ts
@@ -1,6 +1,5 @@
-import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
 import { commitOperand, type CommitOperand, type Operand } from "#ui/operands.ts";
-import type { Commit, ForgeInfo, RefInfo } from "@gitbutler/but-sdk";
+import type { Commit, ForgeInfo } from "@gitbutler/but-sdk";
 
 export const shortCommitId = (commitId: string): string => commitId.slice(0, 7);
 
@@ -23,37 +22,29 @@ export const commitIsDiverged = (commit: Commit): boolean =>
 
 export const rewrittenCommitOperand = ({
 	commit,
-	headInfo,
 	replacedCommits,
 }: {
 	commit: CommitOperand;
-	headInfo: RefInfo;
 	replacedCommits: Record<string, string>;
 }): CommitOperand | null => {
 	const commitId = replacedCommits[commit.commitId];
 	if (commitId === undefined) return null;
 
-	const stackId = getHeadInfoIndex(headInfo).commitContextById(commitId)?.stack.id;
-	if (stackId == null) return null;
-
-	return { stackId, commitId };
+	return { commitId };
 };
 
 export const rewrittenCommitSelection = ({
 	selection,
 	replacedCommits,
-	headInfo,
 }: {
 	selection: Operand | null;
 	replacedCommits: Record<string, string>;
-	headInfo: RefInfo;
 }): Operand | null => {
 	if (selection?._tag !== "Commit") return selection;
 
 	const commit = rewrittenCommitOperand({
 		commit: selection,
 		replacedCommits,
-		headInfo,
 	});
 	if (!commit) return selection;
 

--- a/apps/lite/ui/src/hunk.ts
+++ b/apps/lite/ui/src/hunk.ts
@@ -69,8 +69,6 @@ export type HunkLineSelection = {
 	hunkHeader: HunkHeader;
 	/** Changed-line groups covered by the single visual range, in hunk order. */
 	lineGroups: Array<HunkLineSelectionGroup>;
-	/** The single CodeView selection range to show for this selection. */
-	range: SelectedLineRange;
 };
 
 const lineGroupsFromChangeContent = (
@@ -97,7 +95,7 @@ const lineGroupsFromChangeContent = (
 		: []),
 ];
 
-const rangeFromLineGroups = (
+export const rangeFromLineGroups = (
 	lineGroups: Array<HunkLineSelectionGroup>,
 ): SelectedLineRange | null => {
 	const first = lineGroups[0];
@@ -120,13 +118,11 @@ export const contiguousSelectionsFromHunk = (hunk: Hunk): Array<HunkLineSelectio
 		if (content.type !== "change") return [];
 
 		const lineGroups = lineGroupsFromChangeContent(hunk, content);
-		const range = rangeFromLineGroups(lineGroups);
-		if (!range) return [];
+		if (lineGroups.length === 0) return [];
 
 		return {
 			hunkHeader: hunkHeaderFromHunk(hunk),
 			lineGroups,
-			range,
 		};
 	});
 

--- a/apps/lite/ui/src/operands.ts
+++ b/apps/lite/ui/src/operands.ts
@@ -117,10 +117,6 @@ export const operandFileParent = (operand: Operand): FileParent | null =>
 	);
 
 export const operandContains = (a: Operand, b: Operand) => {
-	if (operandEquals(a, b)) return true;
-
 	const bFileParent = operandFileParent(b);
-	if (bFileParent && operandEquals(a, bFileParent)) return true;
-
-	return false;
+	return bFileParent && operandEquals(a, bFileParent);
 };

--- a/apps/lite/ui/src/operands.ts
+++ b/apps/lite/ui/src/operands.ts
@@ -2,9 +2,9 @@ import { Match } from "effect";
 import type { HunkLineSelection } from "#ui/hunk.ts";
 
 /** @public */
-export type BranchFileParent = { stackId: string; branchRef: Array<number> };
+export type BranchFileParent = { branchRef: Array<number> };
 /** @public */
-export type CommitFileParent = { stackId: string; commitId: string };
+export type CommitFileParent = { commitId: string };
 
 export type FileParent =
 	| { _tag: "UncommittedChanges" }
@@ -17,16 +17,14 @@ export const uncommittedChangesFileParent: FileParent = {
 };
 
 /** @public */
-export const branchFileParent = ({ stackId, branchRef }: BranchFileParent): FileParent => ({
+export const branchFileParent = ({ branchRef }: BranchFileParent): FileParent => ({
 	_tag: "Branch",
-	stackId,
 	branchRef,
 });
 
 /** @public */
-export const commitFileParent = ({ stackId, commitId }: CommitFileParent): FileParent => ({
+export const commitFileParent = ({ commitId }: CommitFileParent): FileParent => ({
 	_tag: "Commit",
-	stackId,
 	commitId,
 });
 
@@ -36,12 +34,12 @@ export type StackOperand = {
 };
 
 /** @public */
-export type BranchOperand = StackOperand & {
+export type BranchOperand = {
 	branchRef: Array<number>;
 };
 
 /** @public */
-export type CommitOperand = StackOperand & {
+export type CommitOperand = {
 	commitId: string;
 };
 
@@ -77,16 +75,14 @@ export const stackOperand = ({ stackId }: StackOperand): Operand => ({
 });
 
 /** @public */
-export const branchOperand = ({ stackId, branchRef }: BranchOperand): Operand => ({
+export const branchOperand = ({ branchRef }: BranchOperand): Operand => ({
 	_tag: "Branch",
-	stackId,
 	branchRef,
 });
 
 /** @public */
-export const commitOperand = ({ stackId, commitId }: CommitOperand): Operand => ({
+export const commitOperand = ({ commitId }: CommitOperand): Operand => ({
 	_tag: "Commit",
-	stackId,
 	commitId,
 });
 
@@ -115,15 +111,14 @@ export const operandIdentityKey = (operand: Operand): string =>
 			UncommittedChanges: () => JSON.stringify(["UncommittedChanges"]),
 			File: (x) => JSON.stringify(["File", x.parent, x.path]),
 			Stack: (x) => JSON.stringify(["Stack", x.stackId]),
-			Branch: (x) => JSON.stringify(["Branch", x.stackId, x.branchRef]),
-			Commit: (x) => JSON.stringify(["Commit", x.stackId, x.commitId]),
+			Branch: (x) => JSON.stringify(["Branch", x.branchRef]),
+			Commit: (x) => JSON.stringify(["Commit", x.commitId]),
 			Hunk: (x) =>
 				JSON.stringify([
 					"Hunk",
 					x.parent,
 					x.hunkHeader,
 					x.lineGroups,
-					x.range,
 					x.isResultOfBinaryToTextConversion,
 				]),
 		}),
@@ -147,8 +142,8 @@ const fileParentToOperand = (fileParent: FileParent): Operand =>
 	Match.value(fileParent).pipe(
 		Match.tagsExhaustive({
 			UncommittedChanges: () => uncommittedChangesOperand,
-			Branch: ({ stackId, branchRef }) => branchOperand({ stackId, branchRef }),
-			Commit: ({ stackId, commitId }) => commitOperand({ stackId, commitId }),
+			Branch: ({ branchRef }) => branchOperand({ branchRef }),
+			Commit: ({ commitId }) => commitOperand({ commitId }),
 		}),
 	);
 

--- a/apps/lite/ui/src/operands.ts
+++ b/apps/lite/ui/src/operands.ts
@@ -1,60 +1,6 @@
 import { Match } from "effect";
 import type { HunkLineSelection } from "#ui/hunk.ts";
 
-/** @public */
-export type BranchFileParent = { branchRef: Array<number> };
-/** @public */
-export type CommitFileParent = { commitId: string };
-
-export type FileParent =
-	| { _tag: "UncommittedChanges" }
-	| ({ _tag: "Branch" } & BranchFileParent)
-	| ({ _tag: "Commit" } & CommitFileParent);
-
-/** @public */
-export const uncommittedChangesFileParent: FileParent = {
-	_tag: "UncommittedChanges",
-};
-
-/** @public */
-export const branchFileParent = ({ branchRef }: BranchFileParent): FileParent => ({
-	_tag: "Branch",
-	branchRef,
-});
-
-/** @public */
-export const commitFileParent = ({ commitId }: CommitFileParent): FileParent => ({
-	_tag: "Commit",
-	commitId,
-});
-
-/** @public */
-export type StackOperand = {
-	stackId: string;
-};
-
-/** @public */
-export type BranchOperand = {
-	branchRef: Array<number>;
-};
-
-/** @public */
-export type CommitOperand = {
-	commitId: string;
-};
-
-/** @public */
-export type FileOperand = {
-	parent: FileParent;
-	path: string;
-};
-
-/** @public */
-export type HunkOperand = HunkLineSelection & {
-	parent: FileOperand;
-	isResultOfBinaryToTextConversion: boolean;
-};
-
 export type Operand =
 	| { _tag: "UncommittedChanges" }
 	| ({ _tag: "Stack" } & StackOperand)
@@ -63,37 +9,55 @@ export type Operand =
 	| ({ _tag: "File" } & FileOperand)
 	| ({ _tag: "Hunk" } & HunkOperand);
 
-/** @public */
+export type FileParent = Extract<Operand, { _tag: "UncommittedChanges" | "Branch" | "Commit" }>;
+
+export type StackOperand = {
+	stackId: string;
+};
+
+export type BranchOperand = {
+	branchRef: Array<number>;
+};
+
+export type CommitOperand = {
+	commitId: string;
+};
+
+export type FileOperand = {
+	parent: FileParent;
+	path: string;
+};
+
+export type HunkOperand = HunkLineSelection & {
+	parent: FileOperand;
+	isResultOfBinaryToTextConversion: boolean;
+};
+
 export const uncommittedChangesOperand: Operand = {
 	_tag: "UncommittedChanges",
 };
 
-/** @public */
 export const stackOperand = ({ stackId }: StackOperand): Operand => ({
 	_tag: "Stack",
 	stackId,
 });
 
-/** @public */
 export const branchOperand = ({ branchRef }: BranchOperand): Operand => ({
 	_tag: "Branch",
 	branchRef,
 });
 
-/** @public */
 export const commitOperand = ({ commitId }: CommitOperand): Operand => ({
 	_tag: "Commit",
 	commitId,
 });
 
-/** @public */
 export const fileOperand = ({ parent, path }: FileOperand): Operand => ({
 	_tag: "File",
 	parent,
 	path,
 });
 
-/** @public */
 export const hunkOperand = ({
 	parent,
 	isResultOfBinaryToTextConversion,
@@ -103,6 +67,20 @@ export const hunkOperand = ({
 	parent,
 	isResultOfBinaryToTextConversion,
 	...lineSelection,
+});
+
+export const uncommittedChangesFileParent: FileParent = {
+	_tag: "UncommittedChanges",
+};
+
+export const branchFileParent = ({ branchRef }: BranchOperand): FileParent => ({
+	_tag: "Branch",
+	branchRef,
+});
+
+export const commitFileParent = ({ commitId }: CommitOperand): FileParent => ({
+	_tag: "Commit",
+	commitId,
 });
 
 export const operandIdentityKey = (operand: Operand): string =>
@@ -132,26 +110,17 @@ export const operandFileParent = (operand: Operand): FileParent | null =>
 		Match.withReturnType<FileParent | null>(),
 		Match.tags({
 			File: ({ parent }) => parent,
-			UncommittedChanges: () => uncommittedChangesFileParent,
+			UncommittedChanges: () => uncommittedChangesOperand,
 			Hunk: ({ parent }) => parent.parent,
 		}),
 		Match.orElse(() => null),
-	);
-
-const fileParentToOperand = (fileParent: FileParent): Operand =>
-	Match.value(fileParent).pipe(
-		Match.tagsExhaustive({
-			UncommittedChanges: () => uncommittedChangesOperand,
-			Branch: ({ branchRef }) => branchOperand({ branchRef }),
-			Commit: ({ commitId }) => commitOperand({ commitId }),
-		}),
 	);
 
 export const operandContains = (a: Operand, b: Operand) => {
 	if (operandEquals(a, b)) return true;
 
 	const bFileParent = operandFileParent(b);
-	if (bFileParent && operandEquals(a, fileParentToOperand(bFileParent))) return true;
+	if (bFileParent && operandEquals(a, bFileParent)) return true;
 
 	return false;
 };

--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -25,7 +25,7 @@ import {
 	type TransferMode,
 } from "#ui/outline/mode.ts";
 import { navigationIndexIncludes, type NavigationIndex } from "#ui/workspace/navigation-index.ts";
-import type { AbsorptionTarget, RefInfo, RelativeTo } from "@gitbutler/but-sdk";
+import type { AbsorptionTarget, RelativeTo } from "@gitbutler/but-sdk";
 import { Match } from "effect";
 
 export type Dialog =
@@ -313,13 +313,12 @@ export const projectReducers = {
 	},
 	updateRewrittenCommitReferences: (
 		state: ProjectState,
-		{ replacedCommits, headInfo }: { replacedCommits: Record<string, string>; headInfo: RefInfo },
+		{ replacedCommits }: { replacedCommits: Record<string, string> },
 	) => {
 		const workspaceState = state.workspace;
 		const commit = rewrittenCommitSelection({
 			selection: workspaceState.selection.outline,
 			replacedCommits,
-			headInfo,
 		});
 		if (commit) workspaceState.selection.outline = commit;
 
@@ -341,7 +340,6 @@ export const projectReducers = {
 			const commit = rewrittenCommitOperand({
 				commit: workspaceState.mode.operand,
 				replacedCommits,
-				headInfo,
 			});
 			if (commit) workspaceState.mode = rewordCommitOutlineMode({ operand: commit });
 		}

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchPicker.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchPicker.tsx
@@ -20,29 +20,24 @@ type Props = {
 
 const segmentToBranchPickerOption = ({
 	segment,
-	stackId,
 }: {
 	segment: Segment;
-	stackId: string;
 }): BranchPickerOption | null => {
 	const refName = segment.refName;
 	if (!refName) return null;
 
 	return {
-		id: JSON.stringify([stackId, refName.fullNameBytes]),
+		id: refName.fullNameBytes.join(","),
 		label: refName.displayName,
-		branch: { stackId, branchRef: refName.fullNameBytes },
+		branch: { branchRef: refName.fullNameBytes },
 	};
 };
 
-const stackToBranchPickerOptions = (stack: Stack): Array<BranchPickerOption> => {
-	// oxlint-disable-next-line typescript/no-non-null-assertion -- [ref:stack-id-required]
-	const stackId = stack.id!;
-	return stack.segments.flatMap((segment): Array<BranchPickerOption> => {
-		const option = segmentToBranchPickerOption({ segment, stackId });
+const stackToBranchPickerOptions = (stack: Stack): Array<BranchPickerOption> =>
+	stack.segments.flatMap((segment): Array<BranchPickerOption> => {
+		const option = segmentToBranchPickerOption({ segment });
 		return option ? [option] : [];
 	});
-};
 
 export const BranchPicker: FC<Props> = ({ open, onOpenChange, onSelectBranch }) => {
 	const { id: projectId } = useParams({ from: "/project/$id/workspace" });

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -987,10 +987,10 @@ const Diff: FC<{
 	);
 	const fileParent = Match.value(outlineSelection).pipe(
 		Match.tags({
-			Branch: ({ branchRef, stackId }) => branchFileParent({ branchRef, stackId }),
+			Branch: ({ branchRef }) => branchFileParent({ branchRef }),
 			UncommittedChanges: () => uncommittedChangesFileParent,
 			File: ({ parent }) => parent,
-			Commit: ({ commitId, stackId }) => commitFileParent({ commitId, stackId }),
+			Commit: ({ commitId }) => commitFileParent({ commitId }),
 		}),
 		Match.orElseAbsurd,
 	);

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -98,6 +98,7 @@ import {
 import {
 	contiguousSelectionByLine,
 	contiguousSelectionsFromHunk,
+	rangeFromLineGroups,
 	synthesizeFilePatch,
 } from "#ui/hunk.ts";
 import { buildIndexByKey, NavigationIndex } from "#ui/workspace/navigation-index.ts";
@@ -272,6 +273,9 @@ const getDiffView = ({
 		if (mdiff?.type === "Patch") {
 			for (const hunk of item.fileDiff.hunks) {
 				for (const selection of contiguousSelectionsFromHunk(hunk)) {
+					const range = rangeFromLineGroups(selection.lineGroups);
+					if (!range) continue;
+
 					const hunkOperand: HunkOperand = {
 						parent: file,
 						...selection,
@@ -286,7 +290,7 @@ const getDiffView = ({
 						operand: hunkOperand,
 						selectedLines: {
 							id: item.id,
-							range: hunkOperand.range,
+							range,
 						},
 					};
 					diffViewFile.hunks.push(diffViewHunk);

--- a/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
@@ -90,12 +90,7 @@ export const Outline: FC<
 			},
 			{
 				onSuccess: (response) => {
-					const newBranchStack = getHeadInfoIndex(
-						response.workspace.headInfo,
-					).branchContextByRefBytes(response.newRef.fullNameBytes)?.stack;
-
-					if (newBranchStack && newBranchStack.id !== null)
-						selectBranch({ stackId: newBranchStack.id, branchRef: response.newRef.fullNameBytes });
+					selectBranch({ branchRef: response.newRef.fullNameBytes });
 				},
 			},
 		);

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.tsx
@@ -8,7 +8,6 @@ import {
 	useWorkspaceBranchAndAncestorsPush,
 } from "#ui/api/mutations.ts";
 import { forgeInfoOptions, listCIChecksQueryOptions } from "#ui/api/queries.ts";
-import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
 import { decodeBytes } from "#ui/api/bytes.ts";
 import { Button, Toast, Tooltip } from "@base-ui/react";
 import { Toolbar } from "@base-ui/react/toolbar";
@@ -149,7 +148,6 @@ export const BranchRow: FC<
 
 	const dispatch = useAppDispatch();
 	const branchOperandV: BranchOperand = {
-		stackId,
 		branchRef: refName.fullNameBytes,
 	};
 	const operand = branchOperand(branchOperandV);
@@ -171,7 +169,6 @@ export const BranchRow: FC<
 
 	const { mutateAsync: updateBranchName } = useUpdateBranchName({
 		projectId,
-		stackId,
 		branchRef: refName.fullNameBytes,
 		oldBranch: branchOperandV,
 	});
@@ -272,21 +269,14 @@ export const BranchRow: FC<
 			},
 			{
 				onSuccess: (response) => {
-					const newBranchStack = getHeadInfoIndex(
-						response.workspace.headInfo,
-					).branchContextByRefBytes(response.newRef.fullNameBytes)?.stack;
-
-					if (newBranchStack && newBranchStack.id !== null) {
-						dispatch(
-							projectSlice.actions.selectOutline({
-								projectId,
-								selection: branchOperand({
-									stackId: newBranchStack.id,
-									branchRef: response.newRef.fullNameBytes,
-								}),
+					dispatch(
+						projectSlice.actions.selectOutline({
+							projectId,
+							selection: branchOperand({
+								branchRef: response.newRef.fullNameBytes,
 							}),
-						);
-					}
+						}),
+					);
 				},
 			},
 		);

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/CommitRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/CommitRow.tsx
@@ -8,7 +8,6 @@ import {
 	useCommitUncommit,
 } from "#ui/api/mutations.ts";
 import { forgeInfoOptions } from "#ui/api/queries.ts";
-import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
 import { classes } from "#ui/components/classes.ts";
 import { GraphSegment } from "#ui/components/GraphSegment.tsx";
 import { Icon } from "#ui/components/Icon.tsx";
@@ -57,11 +56,10 @@ export const CommitRow: FC<
 	{
 		commit: Commit;
 		projectId: string;
-		stackId: string;
 		isCommitTarget: boolean;
 		dryRunCommit: Commit | null;
 	} & ComponentProps<"div">
-> = ({ commit, projectId, stackId, isCommitTarget, dryRunCommit, ...restProps }) => {
+> = ({ commit, projectId, isCommitTarget, dryRunCommit, ...restProps }) => {
 	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
 	const mforgeUrl = forgeInfo && commitForgeUrl(commit, forgeInfo);
 
@@ -75,7 +73,6 @@ export const CommitRow: FC<
 	const dispatch = useAppDispatch();
 	const navigationIndex = assert(use(NavigationIndexContext));
 	const commitOperandV: CommitOperand = {
-		stackId,
 		commitId: commit.id,
 	};
 	const operand = commitOperand(commitOperandV);
@@ -132,21 +129,14 @@ export const CommitRow: FC<
 			},
 			{
 				onSuccess: (response) => {
-					const newBranchStack = getHeadInfoIndex(
-						response.workspace.headInfo,
-					).branchContextByRefBytes(response.newRef.fullNameBytes)?.stack;
-
-					if (newBranchStack && newBranchStack.id !== null) {
-						dispatch(
-							projectSlice.actions.selectOutline({
-								projectId,
-								selection: branchOperand({
-									stackId: newBranchStack.id,
-									branchRef: response.newRef.fullNameBytes,
-								}),
+					dispatch(
+						projectSlice.actions.selectOutline({
+							projectId,
+							selection: branchOperand({
+								branchRef: response.newRef.fullNameBytes,
 							}),
-						);
-					}
+						}),
+					);
 				},
 			},
 		);
@@ -172,7 +162,6 @@ export const CommitRow: FC<
 							selection: rewrittenCommitSelection({
 								selection: selectionAfterDiscard,
 								replacedCommits: response.workspace.replacedCommits,
-								headInfo: response.workspace.headInfo,
 							}),
 						}),
 					);

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -288,7 +288,7 @@ const BranchSegment: FC<{
 	downstackPushStatus,
 	isTopSegment,
 }) => {
-	const operand = branchOperand({ stackId, branchRef: refName.fullNameBytes });
+	const operand = branchOperand({ branchRef: refName.fullNameBytes });
 
 	return (
 		<TreeItem
@@ -322,12 +322,7 @@ const BranchSegment: FC<{
 
 			{/* oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- Tree items need ARIA group semantics. */}
 			<div role="group">
-				<SegmentContent
-					projectId={projectId}
-					segment={segment}
-					stackId={stackId}
-					commitTarget={commitTarget}
-				/>
+				<SegmentContent projectId={projectId} segment={segment} commitTarget={commitTarget} />
 			</div>
 		</TreeItem>
 	);
@@ -335,14 +330,13 @@ const BranchSegment: FC<{
 
 const EmptySegmentContent: FC<{
 	segment: Segment;
-	stackId: string;
-}> = ({ segment, stackId }) => {
+}> = ({ segment }) => {
 	const navigationIndex = assert(use(NavigationIndexContext));
 
 	const refName = assert(segment.refName);
 	const inert = !navigationIndexIncludes(
 		navigationIndex,
-		branchOperand({ stackId, branchRef: refName.fullNameBytes }),
+		branchOperand({ branchRef: refName.fullNameBytes }),
 		operandIdentityKey,
 	);
 
@@ -364,11 +358,9 @@ const EmptySegmentContent: FC<{
 const SegmentContent: FC<{
 	projectId: string;
 	segment: Segment;
-	stackId: string;
 	commitTarget: RelativeTo | null;
-}> = ({ projectId, segment, stackId, commitTarget }) => {
-	if (segment.commits.length === 0)
-		return <EmptySegmentContent segment={segment} stackId={stackId} />;
+}> = ({ projectId, segment, commitTarget }) => {
+	if (segment.commits.length === 0) return <EmptySegmentContent segment={segment} />;
 
 	const dryRunWorkspace = use(DryRunWorkspaceContext);
 	const dryRunHeadInfoIndex = dryRunWorkspace ? getHeadInfoIndex(dryRunWorkspace.headInfo) : null;
@@ -376,7 +368,7 @@ const SegmentContent: FC<{
 	return (
 		<div>
 			{segment.commits.map((commit) => {
-				const operand = commitOperand({ stackId, commitId: commit.id });
+				const operand = commitOperand({ commitId: commit.id });
 				const dryRunCommitId = dryRunWorkspace?.replacedCommits[commit.id];
 				const dryRunCommit =
 					dryRunCommitId !== undefined
@@ -397,7 +389,6 @@ const SegmentContent: FC<{
 									<CommitRow
 										commit={commit}
 										projectId={projectId}
-										stackId={stackId}
 										isCommitTarget={
 											commitTarget
 												? relativeToEquals(commitTarget, {
@@ -478,7 +469,6 @@ const StackC: FC<{
 									<SegmentContent
 										projectId={projectId}
 										segment={segment}
-										stackId={stackId}
 										commitTarget={commitTarget}
 									/>
 								)}
@@ -490,8 +480,8 @@ const StackC: FC<{
 									!navigationIndexIncludes(
 										navigationIndex,
 										segment.commits.length === 0
-											? branchOperand({ stackId, branchRef: assert(segment.refName).fullNameBytes })
-											: commitOperand({ stackId, commitId: assert(segment.commits.at(-1)).id }),
+											? branchOperand({ branchRef: assert(segment.refName).fullNameBytes })
+											: commitOperand({ commitId: assert(segment.commits.at(-1)).id }),
 										operandIdentityKey,
 									)
 								}

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
@@ -89,10 +89,14 @@ export const useOutlineTreeHotkeys = ({
 		(state) => projectSlice.selectors.selectOutlineModeState(state, projectId)._tag === "Default",
 	);
 
-	const selectedStack =
-		selection && "stackId" in selection
-			? headInfoIndex?.stackContextById(selection.stackId)?.stack
-			: undefined;
+	const selectionStack = Match.value(selection).pipe(
+		Match.tags({
+			Stack: (stack) => headInfoIndex?.stackContextById(stack.stackId)?.stack,
+			Branch: (branch) => headInfoIndex?.branchContextByRefBytes(branch.branchRef)?.stack,
+			Commit: (commit) => headInfoIndex?.commitContextById(commit.commitId)?.stack,
+		}),
+		Match.orElse(() => undefined),
+	);
 	const selectedBranchSegment =
 		selection?._tag === "Branch"
 			? headInfoIndex?.branchContextByRefBytes(selection.branchRef)?.segment
@@ -208,21 +212,14 @@ export const useOutlineTreeHotkeys = ({
 			},
 			{
 				onSuccess: (response) => {
-					const newBranchStack = getHeadInfoIndex(
-						response.workspace.headInfo,
-					).branchContextByRefBytes(response.newRef.fullNameBytes)?.stack;
-
-					if (newBranchStack && newBranchStack.id !== null) {
-						dispatch(
-							projectSlice.actions.selectOutline({
-								projectId,
-								selection: branchOperand({
-									stackId: newBranchStack.id,
-									branchRef: response.newRef.fullNameBytes,
-								}),
+					dispatch(
+						projectSlice.actions.selectOutline({
+							projectId,
+							selection: branchOperand({
+								branchRef: response.newRef.fullNameBytes,
 							}),
-						);
-					}
+						}),
+					);
 				},
 			},
 		);
@@ -288,7 +285,7 @@ export const useOutlineTreeHotkeys = ({
 
 		const selectionAfterDiscard = selectAfterDiscardedCommit({
 			navigationIndex,
-			commit: { stackId: selection.stackId, commitId: selection.commitId },
+			commit: { commitId: selection.commitId },
 		});
 
 		commitDiscard(
@@ -305,7 +302,6 @@ export const useOutlineTreeHotkeys = ({
 							selection: rewrittenCommitSelection({
 								selection: selectionAfterDiscard,
 								replacedCommits: response.workspace.replacedCommits,
-								headInfo: response.workspace.headInfo,
 							}),
 						}),
 					);
@@ -322,13 +318,13 @@ export const useOutlineTreeHotkeys = ({
 				: undefined;
 
 	const selectedPushContext =
-		selectedStack && selectedSegmentIndex !== undefined
+		selectionStack && selectedSegmentIndex !== undefined
 			? pushContextForSegment({
-					segments: selectedStack.segments,
+					segments: selectionStack.segments,
 					segmentIndex: selectedSegmentIndex,
 				})
 			: null;
-	const selectedStackRelativeTo = selectedStack ? stackBottomRelativeTo(selectedStack) : null;
+	const selectedStackRelativeTo = selectionStack ? stackBottomRelativeTo(selectionStack) : null;
 	const selectedStackRebaseUpdate: BottomUpdate | null = selectedStackRelativeTo
 		? { kind: "rebase", selector: selectedStackRelativeTo }
 		: null;

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -211,10 +211,8 @@ const useOutlineNavigationIndex = ({
 						operandContains(operand, activeMode.value.source) ||
 						hasAnyOperation(activeMode.value.source, operand),
 				),
-			RenameBranch: (x) =>
-				items.filter((operand) => operandEquals(operand, branchOperand(x.operand))),
-			RewordCommit: (x) =>
-				items.filter((operand) => operandEquals(operand, commitOperand(x.operand))),
+			RenameBranch: (x) => [branchOperand(x.operand)],
+			RewordCommit: (x) => [commitOperand(x.operand)],
 		}),
 	);
 	const indexByKey = buildIndexByKey(filteredItems, operandIdentityKey);

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -200,12 +200,14 @@ const useOutlineNavigationIndex = ({
 			Absorb: (activeMode) =>
 				items.filter(
 					(operand) =>
+						operandEquals(operand, activeMode.source) ||
 						operandContains(operand, activeMode.source) ||
 						(operand._tag === "Commit" && absorptionTargetCommitIds.has(operand.commitId)),
 				),
 			Transfer: (activeMode) =>
 				items.filter(
 					(operand) =>
+						operandEquals(operand, activeMode.value.source) ||
 						operandContains(operand, activeMode.value.source) ||
 						hasAnyOperation(activeMode.value.source, operand),
 				),

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -154,11 +154,9 @@ const outlineNavigationItems = ({
 	headInfo: RefInfo | undefined;
 	uncommittedFilePaths: Array<string>;
 }): Array<Operand> => {
-	const segmentItems = (stackId: string, segment: Segment): Array<Operand> => [
-		...(segment.refName
-			? [branchOperand({ stackId, branchRef: segment.refName.fullNameBytes })]
-			: []),
-		...segment.commits.map((commit) => commitOperand({ stackId, commitId: commit.id })),
+	const segmentItems = (segment: Segment): Array<Operand> => [
+		...(segment.refName ? [branchOperand({ branchRef: segment.refName.fullNameBytes })] : []),
+		...segment.commits.map((commit) => commitOperand({ commitId: commit.id })),
 	];
 
 	return [
@@ -167,11 +165,9 @@ const outlineNavigationItems = ({
 			fileOperand({ parent: uncommittedChangesFileParent, path }),
 		),
 
-		...(headInfo?.stacks.toReversed() ?? []).flatMap((stack) => {
-			// oxlint-disable-next-line typescript/no-non-null-assertion -- [ref:stack-id-required]
-			const stackId = stack.id!;
-			return stack.segments.flatMap((segment) => segmentItems(stackId, segment));
-		}),
+		...(headInfo?.stacks.toReversed() ?? []).flatMap((stack) =>
+			stack.segments.flatMap(segmentItems),
+		),
 	];
 };
 


### PR DESCRIPTION
Tidy up operands a bit, most notably removing hierarchical IDs (primarily stack IDs). I toyed with stringly operands however they're not very ergonomic given a) we need file parents in identity and b) hunks carry additional information that's not necessary for identity.

cc @OliverJAsh for visibility