### PR TITLE
fix(skill): Update installs only on setup

### DIFF
--- a/crates/but/src/command/skill/freshness.rs
+++ b/crates/but/src/command/skill/freshness.rs
@@ -38,12 +38,7 @@ impl AgentSkillNotice {
 }
 
 pub(crate) fn agent_skill_notice(current_dir: &std::path::Path) -> Option<AgentSkillNotice> {
-    let update = agent_skill_freshness_check();
-    let hint = agent_skill_install_hint(current_dir);
-    match update {
-        Some(failed @ AgentSkillNotice::UpdateFailed(_)) => Some(failed),
-        update => hint.or(update),
-    }
+    agent_skill_install_hint(current_dir)
 }
 
 pub(crate) fn agent_skill_update_notice() -> Option<String> {

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -1349,10 +1349,21 @@ async fn match_subcommand(
             };
             let mut ctx = but_ctx::Context::from_repo_with_settings(repo, app_settings.clone())?;
             let mut guard = ctx.exclusive_worktree_access();
-            command::legacy::setup::repo(&mut ctx, &args.current_dir, out, guard.write_permission())
-                .context("Failed to set up GitButler project.")
-                .emit_metrics(metrics_ctx)
-                .map_err(CliError::from)
+            let result = command::legacy::setup::repo(
+                &mut ctx,
+                &args.current_dir,
+                out,
+                guard.write_permission(),
+            )
+            .context("Failed to set up GitButler project.");
+            if result.is_ok()
+                && let Some(notice) = command::skill::agent_skill_update_notice()
+                && let Some(human) = out.for_human()
+            {
+                writeln!(human, "{notice}").ok();
+                writeln!(human).ok();
+            }
+            result.emit_metrics(metrics_ctx).map_err(CliError::from)
         }
         #[cfg(feature = "legacy")]
         Subcommands::Teardown { checkout_to } => {
@@ -1930,8 +1941,6 @@ async fn maybe_run_status_after<T, E>(
 /// In human mode, prints a blank line then full status.
 /// In JSON mode, combines the mutation's buffered JSON with status JSON into
 /// `{"result": <mutation_output>, "status": <workspace_status>}`.
-/// For JSON commands, reconciles stale skill installations and includes an
-/// update announcement or failure notice under `agent_skill_notice`.
 /// This function only runs when the CLI caller was detected as an agent.
 ///
 /// Status errors are handled gracefully: in JSON mode the mutation result is
@@ -1945,12 +1954,6 @@ async fn run_status_after(
 ) {
     use crate::command::legacy::status::StatusFlags;
 
-    let agent_skill_notice = out
-        .format()
-        .is_json()
-        .then(command::skill::agent_skill_update_notice)
-        .flatten();
-
     if out.is_json() {
         out.start_json_buffering();
         let status_result = command::legacy::status::worktree(
@@ -1962,7 +1965,7 @@ async fn run_status_after(
         .await;
         let status_json = out.take_json_buffer().unwrap_or(serde_json::Value::Null);
 
-        let mut combined = match status_result {
+        let combined = match status_result {
             Ok(()) => serde_json::json!({
                 "result": mutation_json.unwrap_or(serde_json::Value::Null),
                 "status": status_json,
@@ -1977,14 +1980,6 @@ async fn run_status_after(
                 })
             }
         };
-        if let Some(notice) = agent_skill_notice
-            && let Some(object) = combined.as_object_mut()
-        {
-            object.insert(
-                "agent_skill_notice".to_string(),
-                serde_json::Value::String(notice),
-            );
-        }
         if let Err(err) = out.write_value(combined) {
             eprintln!("warning: failed to write status after mutation: {err}");
         }

--- a/crates/but/tests/but/command/skill.rs
+++ b/crates/but/tests/but/command/skill.rs
@@ -284,7 +284,7 @@ fn agent_skill_notice_reports_a_stale_local_skill_despite_a_current_global_copy(
 }
 
 #[test]
-fn agent_skill_notice_repairs_a_stale_global_skill() {
+fn agent_skill_notice_never_repairs_stale_global_skill_implicitly() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
     env.setup_metadata(&[]);
     env.but("skill install")
@@ -305,10 +305,48 @@ fn agent_skill_notice_repairs_a_stale_global_skill() {
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     assert!(
-        stdout.contains("was out of date and was updated")
-            && !stdout.contains("but skill check --update"),
-        "a stale global skill should be repaired before a read-only command, got: {stdout}"
+        stdout.contains("but skill check --update")
+            && !stdout.contains("was out of date and was updated"),
+        "an ordinary read-only command should only report the stale skill, got: {stdout}"
     );
+    let skill_path = env.home_dir().join(".codex/skills/gitbutler/SKILL.md");
+    assert!(
+        std::fs::read_to_string(&skill_path)
+            .unwrap()
+            .contains("version: old"),
+        "an ordinary read-only command must not rewrite the skill"
+    );
+
+    env.but("alias add inspect status")
+        .env("AI_AGENT", "codex")
+        .assert()
+        .success();
+    assert!(
+        std::fs::read_to_string(&skill_path)
+            .unwrap()
+            .contains("version: old"),
+        "an ordinary mutation must not rewrite the skill"
+    );
+
+    #[cfg(feature = "legacy")]
+    {
+        let setup = env
+            .but("setup")
+            .env("AI_AGENT", "codex")
+            .output()
+            .expect("setup runs");
+        assert!(setup.status.success());
+        assert!(
+            String::from_utf8_lossy(&setup.stdout).contains("was out of date and was updated"),
+            "successful setup should report the explicit update"
+        );
+        assert!(
+            !std::fs::read_to_string(skill_path)
+                .unwrap()
+                .contains("version: old"),
+            "successful setup should update the installed skill"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## 🧢 Changes

- Make ordinary commands report stale agent skills without rewriting them.
- Run the automatic skill update only after successful explicit project setup.
- Remove implicit updates from status-after-mutation JSON handling.
- Cover read-only commands, ordinary mutations, and successful setup.

## ☕️ Reasoning

Agent-skill repair changes global configuration and therefore belongs at an explicit lifecycle boundary. Inspection and unrelated mutations should report stale state without silently repairing it; successful setup is where installation repair is expected and can be reported clearly.

Concrete read-only examples are `but alias list`, `but config user`, and `but config target` when the latter is called without a branch or `--push-remote`. These inspection forms may report that an agent skill is stale, but they do not repair or rewrite it. Their corresponding add, set, unset, or target-changing forms remain mutations.

For agentic coding, keeping that boundary explicit prevents ordinary commands from unexpectedly requiring permission to modify global tooling state.

## 🧪 Reproduction

With an installed GitButler agent skill older than the bundled version:

```sh
but alias list
```

Before this fix, listing aliases silently rewrote the stale global skill instead of only reporting that an update was available.

## ✅ Verification

- Focused agent-skill notice tests: 5 passed, 0 failed.
- Tests prove ordinary observation and mutation preserve the stale file while successful setup updates it.
- The exact regression passed with default features and `--no-default-features`; the latter proves the test no longer invokes unavailable legacy setup.
- `cargo fmt --check --all` passed.

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>
