### PR TITLE
Remove unused push base branch endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3877,7 +3877,6 @@ dependencies = [
  "git2",
  "gitbutler-branch",
  "gitbutler-commit",
- "gitbutler-git",
  "gitbutler-operating-modes",
  "gitbutler-oplog",
  "gitbutler-project",

--- a/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
+++ b/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
@@ -94,10 +94,6 @@ export default class BaseBranchService {
 		return this.backendApi.endpoints.switchBackToWorkspace.useMutation();
 	}
 
-	get push() {
-		return this.backendApi.endpoints.pushBaseBranch.useMutation();
-	}
-
 	remoteBranches(projectId: string) {
 		return this.backendApi.endpoints.remoteBranches.useQuery({ projectId });
 	}

--- a/apps/desktop/src/lib/branches/branchEndpoints.ts
+++ b/apps/desktop/src/lib/branches/branchEndpoints.ts
@@ -73,11 +73,6 @@ export function buildBranchEndpoints(build: BackendEndpointBuilder) {
 				invalidatesList(ReduxTag.StackDetails),
 			],
 		}),
-		pushBaseBranch: build.mutation<void, { projectId: string; withForce?: boolean }>({
-			extraOptions: { command: "push_base_branch" },
-			query: (args) => args,
-			invalidatesTags: [invalidatesType(ReduxTag.BaseBranchData)],
-		}),
 		remoteBranches: build.query<RemoteBranchInfo[], { projectId: string }>({
 			extraOptions: { command: "git_remote_branches" },
 			query: (args) => args,

--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -257,13 +257,6 @@ pub fn set_base_branch_with_perm(
 
 #[but_api]
 #[instrument(err(Debug))]
-pub fn push_base_branch(ctx: &mut but_ctx::Context, with_force: bool) -> Result<()> {
-    gitbutler_branch_actions::push_base_branch(ctx, with_force)?;
-    Ok(())
-}
-
-#[but_api]
-#[instrument(err(Debug))]
 pub fn update_stack_order(
     ctx: &mut but_ctx::Context,
     stacks: Vec<BranchUpdateRequest>,

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -700,10 +700,6 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
             but_post(legacy::virtual_branches::switch_back_to_workspace_cmd),
         )
         .route(
-            "/push_base_branch",
-            but_post(legacy::virtual_branches::push_base_branch_cmd),
-        )
-        .route(
             "/update_stack_order",
             but_post(legacy::virtual_branches::update_stack_order_cmd),
         )

--- a/crates/gitbutler-branch-actions/Cargo.toml
+++ b/crates/gitbutler-branch-actions/Cargo.toml
@@ -29,7 +29,6 @@ but-ctx = { workspace = true, features = ["legacy"] }
 but-meta = { workspace = true, features = ["legacy"] }
 
 gitbutler-oplog.workspace = true
-gitbutler-git.workspace = true
 gitbutler-repo.workspace = true
 gitbutler-repo-actions.workspace = true
 gitbutler-branch.workspace = true

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -21,10 +21,6 @@ pub fn set_target_push_remote(ctx: &mut Context, push_remote: &str) -> Result<()
     base::set_target_push_remote(ctx, push_remote)
 }
 
-pub fn push_base_branch(ctx: &Context, with_force: bool) -> Result<()> {
-    base::push(ctx, with_force)
-}
-
 pub(crate) trait Verify {
     fn verify(&self, perm: &mut RepoExclusive) -> Result<()>;
 }

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -10,7 +10,6 @@ use but_ctx::Context;
 use but_error::Code;
 use but_graph::FirstParent;
 use but_meta::virtual_branches_legacy_types::Target;
-use gitbutler_git::GitContextExt as _;
 use gitbutler_project::{FetchResult, Project};
 use gitbutler_reference::{Refname, RemoteRefname};
 use gitbutler_repo::first_parent_commit_ids_until;
@@ -486,21 +485,6 @@ fn first_parent_commit_ids_with_limit(
         .take(limit)
         .map(|info| Ok(info?.id))
         .collect()
-}
-
-pub(crate) fn push(ctx: &Context, with_force: bool) -> Result<()> {
-    let project_meta = ctx.project_meta()?;
-    let target_ref: RemoteRefname = project_meta.target_ref_or_err()?.to_string().parse()?;
-    let _ = ctx.push(
-        project_meta.target_commit_id_or_err()?,
-        &target_ref,
-        with_force,
-        ctx.legacy_project.force_push_protection,
-        None,
-        None,
-        vec![],
-    );
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/gitbutler-branch-actions/src/lib.rs
+++ b/crates/gitbutler-branch-actions/src/lib.rs
@@ -6,7 +6,7 @@
 
 mod actions;
 // This is our API
-pub use actions::{push_base_branch, set_base_branch, set_target_push_remote};
+pub use actions::{set_base_branch, set_target_push_remote};
 
 mod branch_manager;
 pub use branch_manager::BranchManagerExt;

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -357,7 +357,6 @@ fn main() -> anyhow::Result<()> {
                 legacy::virtual_branches::tauri_get_base_branch_data::get_base_branch_data,
                 legacy::virtual_branches::tauri_set_base_branch::set_base_branch,
                 legacy::virtual_branches::tauri_switch_back_to_workspace::switch_back_to_workspace,
-                legacy::virtual_branches::tauri_push_base_branch::push_base_branch,
                 legacy::virtual_branches::tauri_update_stack_order::update_stack_order,
                 legacy::virtual_branches::tauri_unapply_stack::unapply_stack,
                 legacy::virtual_branches::tauri_list_branches::list_branches,


### PR DESCRIPTION
Remove the unused push_base_branch endpoint across the desktop, Tauri, local server, but-api, and branch-actions layers. Drop the now-unused branch-actions dependency.